### PR TITLE
FastLinearAlgebra: fixed issue for characteristic 2 FFPACK field

### DIFF
--- a/M2/Macaulay2/e/aring-ffpack.cpp
+++ b/M2/Macaulay2/e/aring-ffpack.cpp
@@ -36,8 +36,8 @@ namespace M2 {
 
   /**  @todo Remove this function?  IE: rewrite it?
    //  http://www.johnkerl.org/doc/ffcomp.pdf
-   */
-
+   */ 
+ 
   ARingZZpFFPACK::ElementType ARingZZpFFPACK::computeGenerator() const
   {
     for (UTT currIntElem=2; currIntElem < mCharac; currIntElem++)
@@ -98,8 +98,8 @@ namespace M2 {
   void ARingZZpFFPACK::clear(ElementType &result) const
   { 
     /* nothing */
-  }
-  
+  }  
+   
   void ARingZZpFFPACK::set_zero(ElementType &result) const
   { 
     // M2_ASSERT(0 == mFfpackField.zero);
@@ -114,13 +114,13 @@ namespace M2 {
   /// @todo possible problem if type UTT is smaller than an int?
   void ARingZZpFFPACK::set_from_int(ElementType &result, int a) const
   {
-    mFfpackField.init(result, a);
+    mFfpackField.init(result, static_cast<long>(a));
   }
   
   void ARingZZpFFPACK::set_from_mpz(ElementType &result, const mpz_ptr a) const
   {
-    UTT b = static_cast<UTT>(mpz_fdiv_ui(a, mCharac));
-    mFfpackField.init(result,  b);
+    unsigned long b = static_cast<UTT>(mpz_fdiv_ui(a, mCharac));
+    mFfpackField.init(result,  b ); 
   }
   
   /// @Mike: change all uses of set_from_mpq to return bool

--- a/M2/Macaulay2/e/aring-ffpack.hpp
+++ b/M2/Macaulay2/e/aring-ffpack.hpp
@@ -28,6 +28,7 @@ namespace M2 {
 };
 #else
 #include <fflas-ffpack/field/modular-balanced.h>
+#include <fflas-ffpack/field/modular-double.h>
 #include <fflas-ffpack/ffpack/ffpack.h>
 //#include <givaro/givgfq.h>
 
@@ -37,7 +38,7 @@ namespace M2 {
      @ingroup rings
      
      @brief wrapper for the FFPACK::ModularBalanced<double> field implementation
-  */
+  */ 
   
   class ARingZZpFFPACK : public RingInterface
   {
@@ -48,7 +49,8 @@ namespace M2 {
     // problem: givaro isn't necessarily defined here
     static const RingID ringID = ring_FFPACK;
     
-    typedef FFPACK::ModularBalanced<double> FieldType;
+    //typedef FFPACK::ModularBalanced<double> FieldType;
+    typedef FFPACK::Modular<double> FieldType;
 
     typedef FieldType::Element ElementType;
     typedef ElementType elem;
@@ -210,6 +212,10 @@ namespace M2 {
     
     static inline double getMaxModulus() 
     {
+      if  (std::is_same<FFPACK::Modular<double> , FieldType>::value)
+      {
+	    return FieldType::getMaxModulus()/2;
+      }
       return FieldType::getMaxModulus();
     }
   /** @} */

--- a/M2/Macaulay2/e/unit-tests/ARingTest.hpp
+++ b/M2/Macaulay2/e/unit-tests/ARingTest.hpp
@@ -2,6 +2,7 @@
 #define __ring_test_hpp__
 
 const int ntrials = 1000;
+//const int ntrials = 1000000; // not good for the ssd - system swaps memory....
 
 template <typename RingType>
 void getElement(const RingType& R, int index, typename RingType::ElementType &result);

--- a/M2/Macaulay2/e/unit-tests/ARingZZpTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingZZpTest.cpp
@@ -144,10 +144,11 @@ TEST(ARingZZpFFPACK, arithmetic101) {
 }
 
 //TODO: commented out because it appears wrong.  Perhaps p=2 isn't allowed here?
-//TEST(ARingZZpFFPACK, arithmetic2) {
-//  M2::ARingZZpFFPACK R(2);
-//  testFiniteField(R);
-//}
+// strange: does not fail on my thinkpad...
+TEST(ARingZZpFFPACK, arithmetic2) {
+  M2::ARingZZpFFPACK R(2);
+  testFiniteField(R,ntrials);
+}
 
 TEST(ARingZZpFFPACK, arithmetic3) {
   M2::ARingZZpFFPACK R(3);
@@ -171,7 +172,7 @@ TEST(ARingZZpFFPACK, arithmetic66000007) {
 //TODO: commented out because it takes too long:
 // Actually: now this characteristic seems too big?!
 TEST(ARingZZpFFPACK, arithmetic67108859) {
-  M2::ARingZZpFFPACK R(67108859);
+  M2::ARingZZpFFPACK R(67108859);  
 
   testCoercions(R);
   testNegate(R, ntrials);
@@ -183,6 +184,21 @@ TEST(ARingZZpFFPACK, arithmetic67108859) {
   testPower(R, ntrials);
   testAxioms(R, ntrials);
 }
+
+TEST(ARingZZpFFPACK, arithmetic33500479) {
+  M2::ARingZZpFFPACK R(33500479);  
+
+  testCoercions(R);
+  testNegate(R, ntrials);
+  testAdd(R, ntrials);
+  testSubtract(R, ntrials);
+  testMultiply(R, ntrials);
+  testDivide(R, ntrials);
+  testReciprocal(R, ntrials);
+  testPower(R, ntrials);
+  testAxioms(R, ntrials);
+}
+
 #endif 
 
 

--- a/M2/Macaulay2/e/unit-tests/Makefile.files
+++ b/M2/Macaulay2/e/unit-tests/Makefile.files
@@ -1,8 +1,12 @@
-UNITTEST_CCFILES := \
-    testMain \
+SHARED_UNITTEST_CCFILES := \
+  testMain \
     M2-cpp-replacement \
     M2mem-replacement \
     basics-test \
+    fromStream
+
+UNITTEST_CCFILES := \
+    $(SHARED_UNITTEST_CCFILES) \
     ARingRRRTest \
     ARingZZpTest \
     ARingGFTest \
@@ -13,11 +17,14 @@ UNITTEST_CCFILES := \
     RingCCCTest \
     RingTowerTest \
     DMatZZpTest \
-    SubsetTest \
-    fromStream
+    SubsetTest  
+     
+
+SHARED_UNITTEST_CFILES += \
+    M2-replacement
 
 UNITTEST_CFILES += \
-    M2-replacement
+    $(SHARED_UNITTEST_CFILES)
 
 UNITTEST_TARGET := testMain
 
@@ -28,7 +35,12 @@ F4_FILES := $(addprefix ../f4/, $(F4_CCFILES))
 E_OBJECT_FILES := $(addsuffix .o, $(E_FILES) $(F4_FILES))
 
 UNITTEST_FILES := $(UNITTEST_CCFILES) $(UNITTEST_CFILES)
+UNITTEST_SHARED_FILES := $(SHARED_UNITTEST_CCFILES) $(SHARED_UNITTEST_CFILES)
+
 UNITTEST_OBJECT_FILES :=  $(addsuffix .o, $(UNITTEST_FILES))
+UNITTEST_SHARED_OBJECT_FILES :=  $(addsuffix .o, $(UNITTEST_SHARED_FILES))
+
+
 
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/e/unit-tests check"

--- a/M2/Macaulay2/e/unit-tests/Makefile.in
+++ b/M2/Macaulay2/e/unit-tests/Makefile.in
@@ -31,11 +31,45 @@ all: $(UNITTEST_OBJECT_FILES) $(E_OBJECT_FILES)
 
 check: runtests
 
+fullCheck: $(UNITTEST_TARGET)
+	valgrind --track-origins=yes ./$(UNITTEST_TARGET)
+
 $(UNITTEST_TARGET) : gtest-include.o $(UNITTEST_OBJECT_FILES) $(E_OBJECT_FILES)
 	@CC@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
 
 runtests: $(UNITTEST_TARGET)
 	time ./$(UNITTEST_TARGET)
+
+ARingRRRTest :  gtest-include.o ARingRRRTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(E_OBJECT_FILES)
+	@CC@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
+
+ARingGFTest :  gtest-include.o ARingGFTest.o $(UNITTEST_SHARED_OBJECT_FILES) $(E_OBJECT_FILES)
+	@CC@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
+
+ARingRRRZZpTest :  gtest-include.o  \
+    ARingZZpTest.o  \
+    ARingRRRTest.o \
+    ARingZZpTest.o \
+    RingZZTest.o \
+    RingZZpTest.o \
+    RingQQTest.o \
+    RingRRRTest.o \
+    RingCCCTest.o \
+    $(UNITTEST_SHARED_OBJECT_FILES) $(E_OBJECT_FILES)
+	@CC@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
+
+ 
+checkRingRRR: ARingRRRTest
+	time ./ARingRRRTest
+
+#fails for whatever reasins
+checkRingRRRZZp: ARingRRRZZpTest
+	time ./ARingRRRZZpTest
+
+
+# fails on my 32-bit fedora 14 , gcc is 4.5.1. 
+failing: checkRingRRRZZp
+
 
 %.s : %.c; $(COMPILE.cc) -S $< $(OUTPUT_OPTION)
 

--- a/M2/Macaulay2/packages/FastLinearAlgebra.m2
+++ b/M2/Macaulay2/packages/FastLinearAlgebra.m2
@@ -498,11 +498,8 @@ testAddMultipleTo(MutableMatrix, MutableMatrix, MutableMatrix) := (M3,M1,M2) -> 
      addMultipleTo(A, transpose M1, transpose M2, TransposeA=>true, TransposeB=>true);
      assert(A == M3 + M1*M2);
 
-     A = mutableMatrix matrix M3;  -- 'copy' should work here!!
-     a := 2_kk;
-     b := 3_kk;
-     addMultipleTo(A, M1, M2, Alpha=>a, Beta=>b);
-     assert(A == b*M3 + a*M1*M2);
+     a := 0_kk;
+     b := 0_kk;
 
      A = mutableMatrix matrix M3;  -- 'copy' should work here!!
      a = 0_kk;
@@ -515,6 +512,54 @@ testAddMultipleTo(MutableMatrix, MutableMatrix, MutableMatrix) := (M3,M1,M2) -> 
      b = 0_kk;
      addMultipleTo(A, M1, M2, Alpha=>a, Beta=>b);
      assert(A == b*M3 + a*M1*M2);
+
+     A = mutableMatrix matrix M3;  -- 'copy' should work here!!
+     a = 2_kk;
+     b = 0_kk;
+     addMultipleTo(A, M1, M2, Alpha=>a, Beta=>b);
+     assert(A == b*M3 + a*M1*M2);
+
+     A = mutableMatrix matrix M3;  -- 'copy' should work here!!
+     a = 1_kk;
+     b = 1_kk;
+     addMultipleTo(A, M1, M2, Alpha=>a, Beta=>b);
+     assert(A == b*M3 + a*M1*M2);
+
+     A = mutableMatrix matrix M3;  -- 'copy' should work here!!
+     a = 2_kk;
+     b = 1_kk;
+     addMultipleTo(A, M1, M2, Alpha=>a, Beta=>b);
+     assert(A == b*M3 + a*M1*M2);
+
+     A = mutableMatrix matrix M3;  -- 'copy' should work here!!
+     a = 2_kk;
+     b = 2_kk;
+     addMultipleTo(A, M1, M2, Alpha=>a, Beta=>b);
+     assert(A == b*M3 + a*M1*M2);
+
+
+     A = mutableMatrix matrix M3;  -- 'copy' should work here!!
+     a = 2_kk;
+     b = 3_kk;
+     addMultipleTo(A, M1, M2, Alpha=>a, Beta=>b);
+     if not (A == b*M3 + a*M1*M2) then
+     (
+         --print "A != b*M3 + a*M1*M2";
+         --print (A-b*M3 + a*M1*M2);
+     );
+     assert(A == b*M3 + a*M1*M2);
+
+   A = mutableMatrix matrix M3;  -- 'copy' should work here!!
+     a = (char ring M3 -1)_kk;
+     b = 1_kk;
+     addMultipleTo(A, M1, M2, Alpha=>a, Beta=>b);
+     if not (A == b*M3 + a*M1*M2) then
+     (
+         --print "A != b*M3 + a*M1*M2";
+         --print (A-b*M3 + a*M1*M2);
+     );
+     assert(A == b*M3 + a*M1*M2);
+
      )
 
 
@@ -530,7 +575,32 @@ NONTEST = (str) -> null
 -- Linear algebra tests -----------
 -----------------------------------
 TEST ///
+-- addMultipleTo
+    debug Core
+    kk = ZZp 33500479
+    M1 = mutableMatrix random(kk^300, kk^500)
+    M2 = mutableMatrix random(kk^200, kk^300)
+    M3 = mutableMatrix random(kk^200, kk^500)
+
+    testAddMultipleTo(M3,M2,M1)
+///
+
+TEST ///
+-- addMultipleTo
+    debug Core
+    kk = ZZp 67000993
+    M1 = mutableMatrix random(kk^300, kk^100);
+    M2 = mutableMatrix random(kk^200, kk^300);
+    M3 = mutableMatrix random(kk^200, kk^100);
+
+    testAddMultipleTo(M3,M2,M1)
+    time addMultipleTo(M3, M2, M1);
+///
+
+TEST ///
+restart
 loadPackage "FastLinearAlgebra"
+debug Core
     kk = ZZp 101
 
     M3 = mutableMatrix(kk, 200, 200)
@@ -590,6 +660,7 @@ TEST ///
     -- test of routines involving modules (subquotients especially) over ZZp
     restart
     loadPackage "FastLinearAlgebra"
+debug Core
     R = ZZp 101
     N = 1000
     f = random(R^N, R^(N//2));
@@ -623,6 +694,7 @@ TEST ///
 TEST ///
     restart
     loadPackage "FastLinearAlgebra"
+    debug Core
     R = ZZp 101
     f = matrix{{1_R,2},{3,4}}
     g = matrix{{1_R},{1_R}}
@@ -639,6 +711,7 @@ TEST ///
 TEST ///  -- CRASHING TEST 19 Dec 2012 Jakob+Mike    
     restart
     loadPackage "FastLinearAlgebra"
+    debug Core
     R = ZZp 101
 
     N = 700
@@ -649,7 +722,7 @@ TEST ///  -- CRASHING TEST 19 Dec 2012 Jakob+Mike
 ///
 
 TEST ///
-
+    debug Core
     kk = ZZp 101
     R = kk[t]
     M1 = mutableMatrix matrix(kk, {{2, 16, 29}, {-18, 24, 12}, {-41, 7, -31}})
@@ -701,6 +774,7 @@ TEST ///
 
 TEST ///
 -- addMultipleTo
+    debug Core
     kk = ZZp 101
     M1 = mutableMatrix random(kk^3, kk^5)
     M2 = mutableMatrix random(kk^2, kk^3)
@@ -709,8 +783,11 @@ TEST ///
     testAddMultipleTo(M3,M2,M1)
 ///
 
+
+
 TEST ///
 -- addMultipleTo
+    debug Core
     kk = ZZp 67000993
     M1 = mutableMatrix random(kk^3, kk^5)
     M2 = mutableMatrix random(kk^2, kk^3)
@@ -721,6 +798,7 @@ TEST ///
 
 TEST ///
 -- addMultipleTo
+    debug Core
     kk = ZZp 101
     M1 = mutableMatrix random(kk^300, kk^500);
     M2 = mutableMatrix random(kk^200, kk^300);
@@ -732,6 +810,7 @@ TEST ///
 
 TEST ///
 -- addMultipleTo
+    debug Core
     kk = ZZp 67000993
     M1 = mutableMatrix random(kk^300, kk^500);
     M2 = mutableMatrix random(kk^200, kk^300);
@@ -742,6 +821,7 @@ TEST ///
 ///
 
 TEST ///
+    debug Core
     kk = ZZp 101;
     A = mutableMatrix matrix(kk, {{23, -35, -29, 33}, {22, 7, -25, 11}})
     B = mutableMatrix matrix(kk, {{-36, -40}, {-15, -43}, {-16, -43}, {15, 32}, {6, -14}})
@@ -755,6 +835,7 @@ TEST ///
 ///
 
 TEST ///
+    debug Core
     N = 10
     kk = ZZp 101
     time A = mutableMatrix(kk, N, N, Dense=>true);
@@ -768,6 +849,7 @@ TEST ///
 ///
 
 TEST ///
+  debug Core
   R = ZZp 5
   Rt = R[t]
   jordanBlock = (R, diag, n) -> (
@@ -824,6 +906,7 @@ TEST ///
 ///
 
 TEST ///
+  debug Core
   kk = ZZp 67108859
   M = mutableMatrix(kk, 10, 10, Dense=>true)
   fillMatrix M
@@ -878,6 +961,7 @@ TEST ///
 ///
 
 TEST ///
+    debug Core
     kk = ZZp 101
     M = mutableMatrix(kk,5000,5000);
     N = mutableMatrix(kk,5000,5000);


### PR DESCRIPTION
Hello Mike,

i fixed the fixed issue for the characteristic 2 FFPACK field by using Modular<double>
instead of ModularBalanced<double> .
On my machine I also observe some failing unit tests
(
cd Macaulay2/e/unit_test
make failing # ARingRRR.multDivide fails
)

Best,

Jakob
