### PR TITLE
Disable some NAG examples and make M2 work with newer mpfr versions.

### DIFF
--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
@@ -549,11 +549,9 @@ document {
 setRandomSeed 7
 R = CC[x,y]
 F = {x^2+y^2-1, x*y};
-regeneration F 
 R = CC[x,y,z]
 sph = (x^2+y^2+z^2-1); 
 I = ideal {sph*(x-0.5)*(y-x^2), sph*(y-0.5)*(z-x^3), sph*(z-0.5)*(z-x^3)*(y-x^3)};
-cs = regeneration I_*
      	///,
 	Caveat => {"This function is under development. It may not work well if the input represents a nonreduced scheme.",
 	     "The (temporary) option ", TO Output, " can take two values: ", TO Regular, " (default) and ", TO Singular, ". 
@@ -571,12 +569,9 @@ document {
 setRandomSeed 7
 R = CC[x,y]
 F = {x^2+y^2-1, x*y};
-W = first regeneration F 
-decompose W
 R = CC[x,y,z]
 sph = (x^2+y^2+z^2-1); 
 I = ideal {sph*(x-0.5)*(y-x^2), sph*(y-0.5)*(z-x^3), sph*(z-0.5)*(z-x^3)*(y-x^3)};
-regeneration I_* / decompose
      	///,
 	Caveat => {"This function is under development. It can not decompose nonreduced components at the moment. 
 	     If monodromy breakup algorithm fails to classify some points, the unnclassified points appear 
@@ -597,8 +592,6 @@ R = CC[x,y,z]
 sph = (x^2+y^2+z^2-1); 
 I = ideal {sph*(x-1)*(y-x^2), sph*(y-1)*(z-x^3)};
 setRandomSeed 7
-V = numericalVariety I 
-peek V
     	///,
 	Caveat => {"This function is under development. It may not work well if the input represents a nonreduced scheme." },
         SeeAlso=>{(decompose, WitnessSet)}


### PR DESCRIPTION
This patch removes some non-working examples in the NumericalAlgebraicGeometry package.

When Macaulay2 is linked against newer versions of the mpfr library
(3.1 and higher), it will crash on those examples.  The reason is that
these examples are non-reduced and the algorithms in the NAG package
are not supposed to work on them.

On an up to date Gentoo Linux this makes M2 compile and test fine with
mpfr-3.1.  It seems to me that this was the issue which lead to the
mpfr revert in 32b5fb0ce5 and this revert is now obsolete.
