### PR TITLE
fixes 3 bugs, and implements 1 suggestion (factor, Laurent polynomials):

### DIFF
--- a/M2/Macaulay2/m2/orderedmonoidrings.m2
+++ b/M2/Macaulay2/m2/orderedmonoidrings.m2
@@ -261,33 +261,38 @@ Ring OrderedMonoid := PolynomialRing => (			  -- no memoize
 --	       f}
 	  );
      	  if M.Options.Inverses === true then (
-	       denominator RM := f -> RM_( - min \ transpose exponents f );
+	       denominator RM := f -> RM_( - min \ apply(transpose exponents f,x->x|{0}) );
 	       numerator RM := f -> f * denominator f;
 	       );
 	  factor RM := opts -> f -> (
-	       if (options RM).Inverses then error "expected a polynomial ring without inverses";
-	       c := 1;
-	       (facs,exps) := rawFactor raw f;	-- example value: ((11, x+1, x-1, 2x+3), (1, 1, 1, 1)); constant term is first, if there is one
-     	       facs = apply(facs, p -> new RM from p);
+	       c := 1; ff:=f;
+	       if (options RM).Inverses then (
+		   minexps:=min \ transpose exponents f;
+		   ff=f*RM_(-minexps); -- get rid of monomial in factor if f Laurent polynomial
+		   c=RM_minexps;
+		   );
+	       (facs,exps) := rawFactor raw ff;	-- example value: ((11, x+1, x-1, 2x+3), (1, 1, 1, 1)); constant term is first, if there is one
+--     	       facs = apply(facs, p -> new RM from p);
+     	       facs = apply(facs, p -> (pp:=new RM from p; if leadCoefficient pp>0 then pp else (c=-c; -pp)));
 	       if liftable(facs#0,R) then (
 		    -- factory returns the possible constant factor in front
 	       	    assert(exps#0 == 1);
-		    c = facs#0;
+		    c = c*(facs#0);
 		    facs = drop(facs,1);
 		    exps = drop(exps,1);
 		    );
 	       if #facs != 0 then (facs,exps) = toSequence transpose sort transpose {toList facs, toList exps};
 	       if c != 1 then (
-		    -- we put the possible constant factor at the end
+		    -- we put the possible constant (and monomial for Laurent polynomials) at the end
 		    facs = append(facs,c);
 		    exps = append(exps,1);
 		    );
 	       new Product from apply(facs,exps,(p,n) -> new Power from {p,n}));
 	  isPrime RM := f -> (
-	       v := factor f;				    -- constant term last
-	       #v === 1 and last v#0 === 1 and not isConstant first v#0
-	       or
-	       #v === 2 and v#0#1 === 1 and isConstant first v#0 and v#1#1 === 1
+	      v := factor f;
+	      cnt := 0; -- counts number of factors
+	      scan(v, x -> ( if not isUnit(x#0) then cnt=cnt+x#1 ));
+	      cnt == 1 -- cnt=0 is invertible element; cnt>1 is composite element; cnt=1 is prime element
 	       );
 	  RM.generatorSymbols = M.generatorSymbols;
 	  RM.generators = apply(num, i -> RM_i);

--- a/M2/Macaulay2/packages/Macaulay2Doc/test/factor.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/test/factor.m2
@@ -35,3 +35,22 @@ ZZ/101[x,a]
 debug Core
 t = rawFactor ( raw(x^4 - 2), raw(a^2 - 2) )
 assert( t === ((raw (x^2-a), raw (x^2+a)), (1,1)))
+
+
+-- factoring a Laurent polynomial
+R=ZZ[x,MonomialOrder=>Lex,Inverses=>true];
+b=(x+1+x^(-1))*(2+x^(-2)+x^(-1));
+factor b
+assert (# factor b == 3 )
+
+-- isPrime
+
+R=ZZ[x];
+
+assert(isPrime x);
+assert(isPrime (3_R));
+assert(not isPrime (3*x));
+
+R=QQ[x];
+assert(isPrime (3*x));
+assert(not isPrime (3_R));


### PR DESCRIPTION
- bug #98. factoring Laurent polynomial now works properly.
- related bug. numerator / denominator now work on Laurent polynomials and provide sensible answers.
- isPrime has been rewritten in a clean, factor-order-agnostic way. fixes such bugs as "3*x is not prime in QQ[x]".
- #39. factor now chooses the sign of each factor so that its leading monomial has positive coefficient (if basering is ZZ or QQ; behavior undefined for other baserings)
