### PR TITLE
proposal for replacing factory by a recent version from Singular github snapshot

### DIFF
--- a/M2/Macaulay2/d/M2-factory.cpp
+++ b/M2/Macaulay2/d/M2-factory.cpp
@@ -1,6 +1,7 @@
 #include <M2/config.h>
+#define Matrix MaTrIx
 #include <factory/factory.h>		// to get definition of factoryseed()
-
+#undef Matrix
 // extern "C" void actors5_setFactorySeed(int s) { 
 //   factoryseed(s);
 // }
@@ -9,9 +10,9 @@ void factory_setup_1() {
   On(SW_USE_NTL);		/* tell factory to use NTL */
 }
 
-#define Matrix MaTrIx
-#include <factor.h>		// from Messollen's libfac
-#undef Matrix
+
+
+
 
 // Local Variables:
 // compile-command: "make -C $M2BUILDDIR/Macaulay2/d "

--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -53,10 +53,12 @@ static void putstderr(const char *m) {
 
 static void ignore(int x) { }
 
+/*
 void WerrorS(const char *m) {
   putstderr(m);
   exit(1);
 }
+*/
 
 void WarnS(const char *m) {
   putstderr(m);

--- a/M2/Macaulay2/d/startup.m2.in
+++ b/M2/Macaulay2/d/startup.m2.in
@@ -160,7 +160,6 @@ if firstTime then (
      	  | "Compiled with the following libraries:" | newline
 	  | "  GC " | version#"gc version" | ", by H. Boehm and Alan J. Demers" | newline
 	  | "  Singular-Factory " | version#"factory version" | ", by G.-M. Greuel et al." | newline
-	  | "  Singular-Libfac " | version#"libfac version" | ", by M. Messollen" | newline
 	  |    ( 
 	       if version#"frobby version" =!= "not present" 
 	       then ("  frobby " | version#"frobby version" | ", by B. H. Roune" | newline)
@@ -187,7 +186,7 @@ if firstTime then (
 	  );
 
      scan(
-	  { ("factory version", "3.0.2"), ("libfac version", "3.0.1") },
+	  { ("factory version", "3.0.2") },
 	  (k,v) -> if version#k < v then stderr << "--warning: old " << k << " " << version#k << " < " << v << endl);
 
      use = x -> x;				  -- temporary, until methods.m2

--- a/M2/Macaulay2/d/types.h
+++ b/M2/Macaulay2/d/types.h
@@ -22,7 +22,7 @@
 #define NEWLINE "\n"
 #endif
 
-extern char *libfac_version;
+//extern char *libfac_version;
 
 #include "../c/compat.h"
 

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -21,10 +21,8 @@ header "
    #define stringize0(a) #a
    #define stringize(a) stringize0(a)
    #define Matrix FactoryMatrix
-   #include <factor.h>
    #undef Matrix
    extern char timestamp[];
-   #include <factor.h>
    #undef ASSERT
    #ifdef HAVE_FROBBY
      #include <stdinc.h>		// to get version number of frobby
@@ -181,7 +179,6 @@ setupconst("version", Expr(toHashTable(Sequence(
 	#endif
 	"),
    "ntl version" => Ccode(constcharstar,"NTL_VERSION"),
-   "libfac version" => Ccode(constcharstar,"libfac_version"),
    "frobby version" => Ccode(constcharstar,"FROBBY_VERSION"),
    "pari version" => Ccode(constcharstar,"
 	 #if HAVE_PARI

--- a/M2/Macaulay2/e/x-factor.cpp
+++ b/M2/Macaulay2/e/x-factor.cpp
@@ -6,13 +6,14 @@
 #include <M2/config.h>
 #include <assert.h>
 #include <iostream>
-using std::cout;
-using std::endl;
 #include <cstdio>
 
 #define Matrix MaTrIx
-#include <factor.h>             // from Messollen's libfac
+#include <factory/libfac/libfac.h>             // from Messollen's libfac
 #undef Matrix
+// hack to define newfactoras from Messollen's libfac, since the header is 'factor.h' is gone..
+CFFList newfactoras( const CanonicalForm & f, const CFList & as, int &success);
+
 #undef ASSERT
 #include <NTL/ZZ.h>
 
@@ -29,7 +30,6 @@ using std::endl;
 
 #include "tower.hpp"
 
-using namespace NTL;
 
 const bool notInExtension = false;
 
@@ -53,7 +53,7 @@ int debugging
     ;
 
 static void init_seeds() {
-     SetSeed(ZZ::zero());       // NTL
+     NTL::SetSeed(NTL::ZZ::zero());       // NTL
      factoryseed(0);            // factory (which uses NTL, as we've compiled it)
 }
 
@@ -225,13 +225,13 @@ static struct enter_factory foo1;
 
     // debugging display routines to be called from gdb
     // needs factory to be configured without option --disable-streamio
-#if 1
-void showvar(Variable &t) { cout << t << endl; }
-void showcf(CanonicalForm &t) { cout << t << endl; }
-void showcfl(CFList &t) { cout << t << endl; }
-void showcffl(CFFList &t) { cout << t << endl; }
-void showmpint(gmp_ZZ p) { mpz_out_str (stdout, 10, p); cout << endl; }
-void showmpz(mpz_t p) { mpz_out_str (stdout, 10, p); cout << endl; }
+#if 0
+void showvar(Variable &t) { std::cout << t << std::endl; }
+void showcf(CanonicalForm &t) { std::cout << t << std::endl; }
+void showcfl(CFList &t) { std::cout << t << std::endl; }
+void showcffl(CFFList &t) { std::cout << t << std::endl; }
+void showmpint(gmp_ZZ p) { mpz_out_str (stdout, 10, p); std::cout << std::endl; }
+void showmpz(mpz_t p) { mpz_out_str (stdout, 10, p); std::cout << std::endl; }
 #endif
 
 static struct enter_factory foo2;

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview3.m2
@@ -276,7 +276,7 @@ document {
 document {
      Key => "Singular-Libfac",
      "With the kind permission of the author, Michael Messollen, Macaulay2
-     incorporates ", TT "Singular-Libfac", ", version ", version#"libfac version", ",
+     incorporates ", TT "Singular-Libfac", ",
      a free library of routines, depending on ", TO "Singular-Factory", ", that provides
      factorization of multivariate polynomials over finite fields and computation of the minimal associated primes 
      of ideals via characteristic sets.  It is distributed under the terms of the

--- a/M2/Macaulay2/packages/Macaulay2Doc/test/engine/factor.cc
+++ b/M2/Macaulay2/packages/Macaulay2Doc/test/engine/factor.cc
@@ -6,7 +6,9 @@
 
 #include "config.h"
 #include <gc/gc.h>
-#include <factory.h>
+#define Matrix MaTrIx
+#include <factory.h>              
+#undef Matrix
 #include <templates/ftmpl_inst.cc>
 
 extern "C" void factory_setup() { On(SW_USE_NTL); }

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -697,7 +697,6 @@ AC_SUBST(BUILTLIBS,)
 # it reflects dependencies, with prerequisites listed first
 # in particular, there are the following dependencies:
 #    factory needs gftables, ntl and gmp
-#    libfac needs factory
 #    ntl needs gmp
 #    lapack includes blas, makes both libblas and liblapack
 #    mpfr needs gmp
@@ -731,7 +730,7 @@ AC_SUBST(BUILTLIBS,)
 #	we always build it, and every program should link with it
 #	"gdbm" calls sync(), so its test programs need to link with it
 AC_SUBST(PROGLIST, "4ti2 gfan normaliz nauty cddplus lrslib gftables")
-AC_SUBST(LIBLIST, " missing gc gdbm mpir mpfr pari readline ntl factory libfac lapack frobby glpk cddlib fplll givaro fflas_ffpack linbox boost mpc qd mpack flint gtest memtailor mathic mathicgb ")
+AC_SUBST(LIBLIST, " missing gc gdbm mpir mpfr pari readline ntl factory lapack frobby glpk cddlib fplll givaro fflas_ffpack linbox boost mpc qd mpack flint gtest memtailor mathic mathicgb ")
 
 # a library is listed in BUILD_ALWAYS if and only if we *always* build it, 
 # even if the option "--disable-building" is specified:
@@ -747,7 +746,7 @@ done
 BUILD_missing=yes
 
 LIBLIST=" $LIBLIST "
-AC_ARG_ENABLE(build-libraries, AS_HELP_STRING(--enable-build-libraries=...,[list of libraries and programs to build from downloaded source code (e.g., gc gdbm mpir mpfr pari readline ntl gftables factory libfac lapack frobby glpk cddlib givaro fflas_ffpack linbox boost mpc qd mpack 4ti2 gfan normaliz nauty cddplus lrslib)]),
+AC_ARG_ENABLE(build-libraries, AS_HELP_STRING(--enable-build-libraries=...,[list of libraries and programs to build from downloaded source code (e.g., gc gdbm mpir mpfr pari readline ntl gftables factory lapack frobby glpk cddlib givaro fflas_ffpack linbox boost mpc qd mpack 4ti2 gfan normaliz nauty cddplus lrslib)]),
     [for i in $enableval
     do case $LIBLIST in
 	    *" $i "*) 
@@ -1168,16 +1167,13 @@ AC_DEFINE_UNQUOTED(LAPACK,$val,whether to link with lapack)
 
 BUILD_gftables=yes
 
-# the instantiations needed by an initialization in libcf are in libfac,
-# and libfac depends on libcf, so we mention libfac twice:
 if test "$DEBUG" = yes
-then SINGULARLIBS="-lfac -lcf -lfac -lcfmem"
-else SINGULARLIBS="-lfac -lcf -lfac -lcfmem"
+then SINGULARLIBS="-lfactory -lomalloc -lresources "
+else SINGULARLIBS="-lfactory -lomalloc -lresources "
 fi
-while test $BUILD_factory = no -o $BUILD_libfac = no
+while test $BUILD_factory = no
 do AC_LANG(C++)
-   AC_CHECK_HEADER(factory/factory.h,,BUILD_factory=yes BUILD_libfac=yes ; break)
-   AC_CHECK_HEADER(factor.h,,BUILD_factory=yes BUILD_libfac=yes ; break)
+   AC_CHECK_HEADER(factory/factory.h,,BUILD_factory=yes ; break)
    SAVELIBS=$LIBS
    LIBS="$SINGULARLIBS $LIBS"
    AC_MSG_CHECKING([whether factory library is installed ($SINGULARLIBS)])
@@ -1186,36 +1182,28 @@ do AC_LANG(C++)
 	              #include <factory/factory.h>
 		      int main () { return 0 ; } ]])],
        [AC_MSG_RESULT(yes)],
-       [AC_MSG_RESULT([no, will build factory and libfac]) ; BUILD_factory=yes BUILD_libfac=yes LIBS=$SAVELIBS ; break] )
-   AC_MSG_CHECKING([whether up-to-date libfac and factory libraries are installed])
+       [AC_MSG_RESULT([no, will build factory]) ; BUILD_factory=yes LIBS=$SAVELIBS ; break] )
+   AC_MSG_CHECKING([whether up-to-date factory libraries are installed])
    AC_RUN_IFELSE([AC_LANG_SOURCE([[
 	   #include <stdio.h>
 	   #include <string.h>
            #undef NOSTREAMIO
 	   #include <factory/factory.h>
-	   #include <factor.h>
-	   extern const char * libfac_version;
 	   int main () {
 		FILE *msg = fdopen(]]AS_MESSAGE_FD[[,"w");
-		static int factoryV[3], fV[3] = {3,1,0}, fOK;
-		static int  libfacV[3], lV[3] = {3,1,0}, lOK;
+		static int factoryV[3], fV[3] = {4,0,0}, fOK;
 		sscanf(FACTORYVERSION,"%d.%d.%d", &factoryV[0], &factoryV[1], &factoryV[2]);
-		sscanf(libfac_version,"%d.%d.%d", &libfacV[0], &libfacV[1], &libfacV[2]);
 		fOK = factoryV[0] > fV[0] ||
 		      factoryV[0] == fV[0] && factoryV[1] > fV[1] ||
 		      factoryV[0] == fV[0] && factoryV[1] == fV[1] && factoryV[2] >= fV[2];
-		lOK = libfacV[0] > lV[0] ||
-		      libfacV[0] == lV[0] && libfacV[1] > lV[1] ||
-		      libfacV[0] == lV[0] && libfacV[1] == lV[1] && libfacV[2] >= lV[2];
-		fprintf(msg,"(factory-%s %s %d.%d.%d, libfac-%s %s %d.%d.%d) ",
-		    FACTORYVERSION, fOK ? ">=" : "<", fV[0], fV[1], fV[2],
-		    libfac_version, lOK ? ">=" : "<", lV[0], lV[1], lV[2]
+		fprintf(msg,"(factory-%s %s %d.%d.%d) ",
+		    FACTORYVERSION, fOK ? ">=" : "<", fV[0], fV[1], fV[2]
 		    );
-		return !( lOK && fOK );
+		return !( fOK );
 		}
 	   ]])],
 	[AC_MSG_RESULT(yes)],
-	[AC_MSG_RESULT([no, will build factory and libfac]); BUILD_factory=yes BUILD_libfac=yes LIBS=$SAVELIBS])
+	[AC_MSG_RESULT([no, will build factory ]); BUILD_factory=yes LIBS=$SAVELIBS])
    break
 done
 test $BUILD_factory = yes && BUILTLIBS="$SINGULARLIBS $BUILTLIBS"

--- a/M2/libraries/factory/Makefile.in
+++ b/M2/libraries/factory/Makefile.in
@@ -6,11 +6,12 @@
 
 # URL = ftp://www.mathematik.uni-kl.de/pub/Math/Singular/Factory
 URL = http://www.math.uiuc.edu/Macaulay2/Downloads/OtherSourceCode/trunk
-VERSION = 3.1.6
+VERSION = 59817e0d039428e1e6d9217750a5c22464d4b321
 VERSIONH := $(shell echo $(VERSION) | sed 's/\./-/g')
-TARFILE = factory-$(VERSIONH).tar.gz
+#TARFILE = factory-$(VERSIONH).tar.gz
+TARFILE = factory-$(VERSION).tar.gz
 TARDIR = factory
-# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 
 BUILDTARGET = all ftmpl_inst.o
 LIBRARIES = ftmpl_inst.o
@@ -19,8 +20,13 @@ LICENSEFILES = INSTALL COPYING
 
 # this doesn't work, because autoheader fails with factory
 # PRECONFIGURE = autoreconf -vi
-CONFIGOPTIONS += --enable-NTL
-CONFIGOPTIONS += --includedir='$(LIBRARIESDIR)/include/'factory
+
+# works, but only for case flint is build in $(LIBRARIESDIR). better solution?
+CONFIGOPTIONS += --with-flint='$(LIBRARIESDIR)'
+
+CONFIGOPTIONS += --disable-omalloc --enable-streamio --with-ntl 
+CONFIGOPTIONS += --includedir='$(LIBRARIESDIR)/include/'
+CONFIGOPTIONS += --disable-shared
 
 ifeq (@DEBUG@,yes)
 CONFIGOPTIONS += --enable-assertions
@@ -42,12 +48,14 @@ endif
 
 BUILDOPTIONS += WARNFLAGS='$(WARNFLAGS)'
 
-CPPFLAGS += -DMP_INT=__mpz_struct
+CPPFLAGS += -DMP_INT=__mpz_struct -DHAVE_CONFIG_H
 
 # These are old routines, long deprecated, missing in mpir 1.3.0
 # but mpfr 2.4.2 still uses them, try removing them with 2.4.3:
 CPPFLAGS += -Dmpz_div_2exp=mpz_fdiv_q_2exp -Dmpz_div_ui=mpz_fdiv_q_ui -Dmpz_div=mpz_fdiv_q
-CFLAGS += -Wimplicit -Werror
+CFLAGS += -Wimplicit -Werror -DHAVE_CONFIG_H
+CXXFLAGS += -DHAVE_CONFIG_H
+CONFIGURECMD =  ./configure $(CONFIGOPTIONS) && cd omalloc && ./configure $(CONFIGOPTIONS) && cd ../resources && ./configure $(CONFIGOPTIONS)
 
 Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/factory/Makefile
 # HINT:
@@ -57,9 +65,9 @@ Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/factory/M
 #      #include <wchar.h>
 #    }
 
-.installed-$(VERSION) : $(LIBRARIESDIR)/include/factory/assert.h \
+.installed-$(VERSION) : $(LIBRARIESDIR)/include/factory/cf_assert.h \
 			$(LIBRARIESDIR)/include/factory/templates/ftmpl_list.cc
-$(LIBRARIESDIR)/include/factory/assert.h : $(BUILDDIR)/assert.h .compiled-$(VERSION) 
+$(LIBRARIESDIR)/include/factory/cf_assert.h : $(BUILDDIR)/cf_assert.h .compiled-$(VERSION) 
 	$(MKDIR_P) $(LIBRARIESDIR)/include/factory
 	@INSTALL_DATA@ $< $@
 $(LIBRARIESDIR)/include/factory/templates/ftmpl_list.cc : $(BUILDDIR)/templates/ftmpl_list.cc .compiled-$(VERSION) 
@@ -69,14 +77,13 @@ $(LIBRARIESDIR)/include/factory/templates/ftmpl_list.cc : $(BUILDDIR)/templates/
 uninstall clean ::
 	if [ -d $(LIBRARIESDIR) ] ;\
 	then cd $(LIBRARIESDIR) && rm -rf \
-		include/factory.h include/factoryconf.h include/cf_gmp.h include/templates/ftmpl_* include/factory \
-		lib/libcf.a lib/libcfmem.a ;\
+		include/factory.h include/factoryconf.h include/cf_gmp.h include/templates/ftmpl_* include/factory ; \
 	fi
 
-post-install: $(LIBRARIESDIR)/lib/libcfmem-newdelete-removed
-$(LIBRARIESDIR)/lib/libcfmem-newdelete-removed : $(LIBRARIESDIR)/lib/libcfmem.a
-	ar -d "$^" newdelete.o
-	touch "$@"
+#post-install: $(LIBRARIESDIR)/lib/libcfmem-newdelete-removed
+#$(LIBRARIESDIR)/lib/libcfmem-newdelete-removed : $(LIBRARIESDIR)/lib/libcfmem.a
+#	ar -d "$^" newdelete.o
+#	touch "$@"
 
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/libraries/factory "

--- a/M2/libraries/factory/factory-59817e0d039428e1e6d9217750a5c22464d4b321.Makefile.am.diff
+++ b/M2/libraries/factory/factory-59817e0d039428e1e6d9217750a5c22464d4b321.Makefile.am.diff
@@ -1,0 +1,28 @@
+diff --git a/factory/Makefile.am b/factory/Makefile.am
+index 540d3bf..c4f7c38 100644
+--- a/factory/Makefile.am
++++ b/factory/Makefile.am
+@@ -1,13 +1,13 @@
+ ACLOCAL_AMFLAGS = -I ../m4
+ 
+-SUBDIRS=include/factory libfac
++SUBDIRS=include/factory libfac omalloc resources
+ 
+ AM_CPPFLAGS = -I${builddir}/include -I${srcdir}/include $(FLINT_CFLAGS) ${GMP_CFLAGS} ${NTL_CFLAGS} ${OMALLOC_CFLAGS} 
+ 
+ lib_LTLIBRARIES = libfactory.la
+ 
+ libfactory_la_LIBADD     = ${builddir}/libfac/libfac.la \
+-${builddir}/../omalloc/libomalloc.la ${builddir}/../resources/libresources.la \
++${builddir}/omalloc/libomalloc.la ${builddir}/resources/libresources.la \
+ $(FLINT_LIBS) ${GMP_LIBS} ${NTL_LIBS}
+ 
+ libfactory_la_LDFLAGS    = -release ${PACKAGE_VERSION}
+@@ -76,6 +76,7 @@ SOURCES = \
+ 		int_poly.cc \
+ 		int_pp.cc \
+ 		int_rat.cc \
++		initgmp.cc \
+ 		variable.cc \
+ 		NTLconvert.cc \
+ 		singext.cc \

--- a/M2/libraries/factory/patch-546e3e4eb7aba52cab2eb659c027866693024f3c
+++ b/M2/libraries/factory/patch-546e3e4eb7aba52cab2eb659c027866693024f3c
@@ -1,0 +1,22 @@
+--- factory/initgmp.cc	1970-01-01 01:00:00.000000000 +0100
++++ factory/initgmp.cc	2014-03-02 15:52:08.124641882 +0100
+@@ -0,0 +1,18 @@
++/* emacs edit mode for this file is -*- C++ -*- */
++
++#define HAVE_CONFIG_H
++#include <factory/factory.h>
++#include <omalloc/omalloc.h>
++
++int initializeGMP()
++{
++#if defined(OMALLOC_USES_MALLOC) || defined(X_OMALLOC)
++    /* in mmstd.c, for some architectures freeSize() unconditionally uses the *system* free() */
++    /* sage ticket 5344: http://trac.sagemath.org/sage_trac/ticket/5344 */
++    /* do not rely on the default in Singular as libsingular may be different */
++    mp_set_memory_functions(omMallocFunc,omReallocSizeFunc,omFreeSizeFunc);
++#else
++    mp_set_memory_functions(malloc,reallocSize,freeSize);
++#endif
++  return 1;
++}
+

--- a/M2/libraries/factory/patch-59817e0d039428e1e6d9217750a5c22464d4b321
+++ b/M2/libraries/factory/patch-59817e0d039428e1e6d9217750a5c22464d4b321
@@ -1,0 +1,22 @@
+--- factory/initgmp.cc	1970-01-01 01:00:00.000000000 +0100
++++ factory/initgmp.cc	2014-03-02 15:52:08.124641882 +0100
+@@ -0,0 +1,18 @@
++/* emacs edit mode for this file is -*- C++ -*- */
++
++#define HAVE_CONFIG_H
++#include <factory/factory.h>
++#include <omalloc/omalloc.h>
++
++int initializeGMP()
++{
++#if defined(OMALLOC_USES_MALLOC) || defined(X_OMALLOC)
++    /* in mmstd.c, for some architectures freeSize() unconditionally uses the *system* free() */
++    /* sage ticket 5344: http://trac.sagemath.org/sage_trac/ticket/5344 */
++    /* do not rely on the default in Singular as libsingular may be different */
++    mp_set_memory_functions(omMallocFunc,omReallocSizeFunc,omFreeSizeFunc);
++#else
++    mp_set_memory_functions(malloc,reallocSize,freeSize);
++#endif
++  return 1;
++}
+


### PR DESCRIPTION
-requires recent factory snapshot ( tarball sent to Dan)

update reason: bugfixes.

remaining issues:
- find out how to avoid HAVE_CONFIG_H defines (currently required for building factory)
- repair and enable broken showvar,showcf,...
- pass correct FLINT location to libfactory in all cases (not only in case Flint is build by M2)

comments/suggestions?
