### PR TITLE
enable parallel build and parallel check for flint

### DIFF
--- a/M2/include/config.Makefile.in
+++ b/M2/include/config.Makefile.in
@@ -8,6 +8,18 @@ all:
 
 SHELL = /bin/sh
 
+NPROCS:=1
+OS:=$(shell uname -s)
+
+ifeq ($(OS),Linux)
+  NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
+endif
+ifeq ($(OS),Darwin) # Assume Mac Os X
+  NPROCS:=$(shell system_profiler | awk '/Number Of CPUs/{print $4}{next;}'}
+endif
+
+
+
 .DELETE_ON_ERROR:
 
 # here we set the variables that "make" uses

--- a/M2/libraries/flint/Makefile.in
+++ b/M2/libraries/flint/Makefile.in
@@ -13,6 +13,8 @@ ifeq (@DEBUG@,yes)
 CFLAGS += -O0 -fno-unroll-loops 
 endif
 CONFIGURECMD =  LIB_DIRS=$(LIBRARIESDIR)/lib ./configure  --with-gc --with-blas --disable-tls --prefix='$(PREFIX)' --disable-shared CC='$(CC)' CFLAGS='$(CPPFLAGS) $(CFLAGS)' 
+BUILDCMD= $(MAKE) -j$(NPROCS) prefix=$(LIBRARIESDIR) $(BUILDOPTIONS) $(BUILDTARGET)
+CHECKCMD = time $(MAKE) -j$(NPROCS) check
 include ../Makefile.library
 Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/flint/Makefile
 # Local Variables:


### PR DESCRIPTION
flint supports parallel build and check. This is a proposal to enable it.
Consider, that the check output is not synchronized
 (this is possible to achieve with  make versions >=4.0, which are too new for now)

Comments/suggestions?
