### PR TITLE
Fix homogenize(Ideal,RingElement) to homogenize the ideal.

### DIFF
--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -426,7 +426,10 @@ homogenize(Module,RingElement) := Module => (M,z) -> (
 	  if M.?generators then homogenize(M.generators,z),
 	  if M.?relations then homogenize(M.relations,z)))
 
-homogenize(Ideal,RingElement) := Ideal => (I,z) -> ideal homogenize(module I, z)
+homogenize(Ideal,RingElement) := Ideal => (I,z) -> (
+    if I == 0 then I
+    else ideal homogenize (gens gb I, z)
+    )
 
 homogenize(Module,RingElement,List) := Module => (M,z,wts) -> (
      if isFreeModule M then M


### PR DESCRIPTION
This changes the behavior of `homogenize(Ideal, RingElement)` to the mathematically right thing.

This should not be merged until we have discussed the following things:
- I could not run make check because make fails (I've e-mailed Dan about it)
- There may be code outside of the M2 repository that uses the old behavior
- There may be code in the Macaulay2 repository that works around the old behavior, that code would call "gb" twice now.

What I have done instead of actual testing is to run `grep -r "homogenize(" *` on the repository to see all occurrences of homogenize.

There are a number of places where it is not clear if the authors assumed that homogenize would homogenize the ideal.  Some are in old bug reports from 2000, some are in the singular book code.
