### PR TITLE
Change homogenization behaviour to do mathematically correct thing.

### DIFF
--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -423,8 +423,8 @@ homogenize(Matrix, RingElement) := Matrix => (f,n) -> (
 homogenize(Module,RingElement) := Module => (M,z) -> (
      if isFreeModule M then M
      else subquotient(
-	  if M.?generators then homogenize(M.generators,z),
-	  if M.?relations then homogenize(M.relations,z)))
+	  if M.?generators then homogenize(generators gb M.generators,z),
+	  if M.?relations then homogenize(generators gb M.relations,z)))
 
 homogenize(Ideal,RingElement) := Ideal => (I,z) -> ideal homogenize(module I, z)
 


### PR DESCRIPTION
Changes the behavior of homogenize(Module, RingElement) so that it
homogenizes Groebner bases of generators and relations instead of
just the generators and relations.  Consquently homogenizing an
ideal will homogenize the ideal isntead of just the generators.

This is a new pull request since I messed up with my fork and could not modify the other pull request.

I have now run make check with the new patch and it passed.
