### PR TITLE
Improve temporary file behavior when fork is used

### DIFF
--- a/M2/Macaulay2/m2/files.m2
+++ b/M2/Macaulay2/m2/files.m2
@@ -192,14 +192,17 @@ String << Thing := File => (filename,x) -> (
 
 temporaryDirectoryName = null
 temporaryDirectoryCounter = 0
+-- Track the process ID: if we fork, then the child should (lazily) get a new temp dir and not clean up the parent's temp dir
+temporaryDirectoryProcessID = -1
 temporaryFilenameCounter = 0
 addStartFunction( () -> (
 	  temporaryDirectoryCounter = 0;
 	  temporaryFilenameCounter = 0;
 	  temporaryDirectoryName = null;
+	  temporaryDirectoryProcessID = -1;
 	  ))
 addEndFunction( () -> (
-	  if temporaryDirectoryName =!= null 
+	  if (temporaryDirectoryName =!= null and temporaryDirectoryProcessID === processID())
 	  then scan(reverse findFiles temporaryDirectoryName, 
 	       fn -> (
 		    if isDirectory fn then (
@@ -212,7 +215,7 @@ addEndFunction( () -> (
 			 )))))
 
 temporaryDirectory = () -> (
-     if temporaryDirectoryName === null 
+     if (temporaryDirectoryName === null or temporaryDirectoryProcessID =!= processID())
      then temporaryDirectoryName = (
 	  tmp := (
 	       if getenv "TMPDIR" === ""
@@ -223,8 +226,9 @@ temporaryDirectory = () -> (
 	  if not isDirectory tmp then error("expected a directory: ", tmp);
 	  if not fileExecutable tmp then error("expected a executable directory: ", tmp);
 	  if not fileWritable tmp then error("expected a writable directory: ", tmp);
+	  temporaryDirectoryProcessID=processID();
 	  while true do (
-	       fn := tmp | "M2-" | toString processID() | "-" | toString temporaryDirectoryCounter | "/";
+	       fn := tmp | "M2-" | toString temporaryDirectoryProcessID | "-" | toString temporaryDirectoryCounter | "/";
 	       temporaryDirectoryCounter = temporaryDirectoryCounter + 1;
 	       try mkdir fn else continue;
 	       break fn

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
@@ -1465,6 +1465,11 @@ document {
      PARA {
 	  "The temporary file name is derived from the value of the environment variable ", TT "TMPDIR", ", if it has one."
 	  },
+     PARA {
+	  "If ", TO "fork", " is used, then the parent and child Macaulay2 processes will each remove their
+	  own temporary files upon termination, with the parent removing any files created before ", TO "fork",
+	  " was called.",
+	  },
      SeeAlso => {File, "rootPath", "rootURI"}
      }
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/test/file-fork.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/test/file-fork.m2
@@ -1,0 +1,20 @@
+-- Check fixes to https://github.com/Macaulay2/M2/issues/296
+
+f1=rootPath|temporaryFileName();
+f2=rootPath|temporaryFileName();
+f2<<"2"<<close;
+t=fork();
+if (t==0) then (
+  -- Is the child
+  f1<<toString(1)<<close;
+  exit(0);
+) else (
+  -- is the parent
+  wait(t);
+  assert(1===value get(f1));
+  assert(2===value get(f2));
+  f3=rootPath|temporaryFileName();
+  f3<<"3"<<close;
+  assert(3===value get(f3));
+);
+


### PR DESCRIPTION
This should close github issue #296, adds a test for this new behavior, and describes this behavior in  the documentation of temporaryFileName().