### PR TITLE
Document a caveat of isHomogeneous

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/isHomogeneous-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/isHomogeneous-doc.m2
@@ -73,6 +73,14 @@ document {
 	  "isHomogeneous(a*M)",
      	  "isHomogeneous((a+1)*M)"
 	  },
+     PARA{},
+    "Note that no implicit simplification is done.",
+     EXAMPLE {
+	 "R = QQ[x]",
+	 "isHomogeneous ideal(x+x^2, x^2)"
+	 },
+     Caveat => {"No computation on the generators and relations is performed.
+	 For example, if inhomogeneous generators of a homogeneous ideal are given, then the return value is ", TO false, "."},
      SeeAlso => {degree, "graded and multigraded polynomial rings"}
      }
 


### PR DESCRIPTION
isHomogeneous only looks at the given generators and relations of a
module.  Therefore it can return the value false even for homogeneous
modules.  Extend the documentation to highlight this.

Maybe we have discussed this in person at some point? I somehow remember that the behaviour should not be changed for performance reasons.  In any case, I was recently bitten by it, so it should be documented properly.