### PR TITLE
Use pkg-config to detect factory.

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1271,20 +1271,32 @@ AC_DEFINE_UNQUOTED(LAPACK,$val,whether to link with lapack)
 
 BUILD_gftables=yes		dnl it seems that factory now includes gftables, and installs it
 
+AC_MSG_CHECKING([whether factory library is installed])
 SINGULARLIBS="-lfactory  "
+FACTORY_MINVERSION=4.0.0
 if test $BUILD_factory = no
 then
-   PKG_CHECK_MODULES(FACTORY, factory >= 4.0.0, , BUILD_factory=maybe)
-   if test $BUILD_factory = maybe
-   then
-	BUILD_factory=no
-	PKG_CHECK_MODULES(FACTORY, singular-factory >= 4.0.0, , BUILD_factory=yes)
-   fi
+    if $PKG_CONFIG --exists "factory >= $FACTORY_MINVERSION"
+    then
+	FACTORY_NAME=factory
+	AC_MSG_RESULT([yes ($FACTORY_NAME)])
+    elif $PKG_CONFIG --exists "singular-factory >= $FACTORY_MINVERSION"
+    then
+	FACTORY_NAME=singular-factory
+	AC_MSG_RESULT([yes ($FACTORY_NAME)])
+    elif $PKG_CONFIG --exists factory || $PKG_CONFIG --exists singular-factory
+    then
+	BUILD_factory=yes
+	AC_MSG_RESULT([yes, but version $FACTORY_MINVERSION required; will build])
+    else
+	BUILD_factory=yes
+	AC_MSG_RESULT([no; will build])
+    fi
 fi
 if test $BUILD_factory = no
 then
-     LIBS="$FACTORY_LIBS $LIBS"
-     CPPFLAGS="$FACTORY_CFLAGS $CPPFLAGS"
+     LIBS="`$PKG_CONFIG --libs $FACTORY_NAME` $LIBS"
+     CPPFLAGS="`$PKG_CONFIG --cflags $FACTORY_NAME` $CPPFLAGS"
 else
      BUILTLIBS="$SINGULARLIBS $BUILTLIBS"
 fi

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1271,11 +1271,11 @@ AC_DEFINE_UNQUOTED(LAPACK,$val,whether to link with lapack)
 
 BUILD_gftables=yes		dnl it seems that factory now includes gftables, and installs it
 
-AC_MSG_CHECKING([whether factory library is installed])
 SINGULARLIBS="-lfactory  "
-FACTORY_MINVERSION=4.0.0
 if test $BUILD_factory = no
 then
+    AC_MSG_CHECKING([whether factory library is installed])
+    FACTORY_MINVERSION=4.0.0
     if $PKG_CONFIG --exists "factory >= $FACTORY_MINVERSION"
     then
 	FACTORY_NAME=factory

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1271,45 +1271,23 @@ AC_DEFINE_UNQUOTED(LAPACK,$val,whether to link with lapack)
 
 BUILD_gftables=yes		dnl it seems that factory now includes gftables, and installs it
 
-if test "$DEBUG" = yes
-then SINGULARLIBS="-lfactory  "
-else SINGULARLIBS="-lfactory  "
+SINGULARLIBS="-lfactory  "
+if test $BUILD_factory = no
+then
+   PKG_CHECK_MODULES(FACTORY, factory >= 4.0.0, , BUILD_factory=maybe)
+   if test $BUILD_factory = maybe
+   then
+	BUILD_factory=no
+	PKG_CHECK_MODULES(FACTORY, singular-factory >= 4.0.0, , BUILD_factory=yes)
+   fi
 fi
-while test $BUILD_factory = no 
-do AC_LANG(C++)
-   AC_CHECK_HEADER(factory/factory.h,,BUILD_factory=yes; break)
-   SAVELIBS=$LIBS
-   LIBS="$SINGULARLIBS $LIBS"
-   AC_MSG_CHECKING([whether factory library is installed ($SINGULARLIBS)])
-   dnl if -lntl is needed, it's been added to $LIBS above
-   AC_LINK_IFELSE([AC_LANG_SOURCE([[ #undef NOSTREAMIO
-	              #include <factory/factory.h>
-		      int main () { return 0 ; } ]])],
-       [AC_MSG_RESULT(yes)],
-       [AC_MSG_RESULT([no, will build factory]) ; BUILD_factory=yes  LIBS=$SAVELIBS ; break] )
-   AC_MSG_CHECKING([whether up-to-date factory libraries are installed])
-   AC_RUN_IFELSE([AC_LANG_SOURCE([[
-	   #include <stdio.h>
-	   #include <string.h>
-           #undef NOSTREAMIO
-	   #undef PACKAGE_VERSION /* so we can get PACKAGE_VERSION from factoryconf.h */
-	   #include <factory/factory.h>
-	   int main () {
-		FILE *msg = fdopen(]]AS_MESSAGE_FD[[,"w");
-		static int factoryV[3], fV[3] = {4,0,0}, fOK;
-		sscanf(PACKAGE_VERSION,"%d.%d.%d", &factoryV[0], &factoryV[1], &factoryV[2]);
-		fOK = factoryV[0] > fV[0] ||
-		      factoryV[0] == fV[0] && factoryV[1] > fV[1] ||
-		      factoryV[0] == fV[0] && factoryV[1] == fV[1] && factoryV[2] >= fV[2];
-		fprintf(msg,"(factory-%s %s %d.%d.%d) ", PACKAGE_VERSION, fOK ? ">=" : "<", fV[0], fV[1], fV[2]);
-		return fOK ? 0 : 1;
-		}
-	   ]])],
-	[AC_MSG_RESULT(yes)],
-	[AC_MSG_RESULT([no, will build factory ]); BUILD_factory=yes LIBS=$SAVELIBS])
-   break
-done
-test $BUILD_factory = yes && BUILTLIBS="$SINGULARLIBS $BUILTLIBS"
+if test $BUILD_factory = no
+then
+     LIBS="$FACTORY_LIBS $LIBS"
+     CPPFLAGS="$FACTORY_CFLAGS $CPPFLAGS"
+else
+     BUILTLIBS="$SINGULARLIBS $BUILTLIBS"
+fi
 
 # we need to do the fortran library testing last, in case AC_SEARCH_LIBS adds
 # one of them to $LIBS, making it impossible to check for the presence of C or


### PR DESCRIPTION
This is motivated by the Debian singular package's choice to rename factory
to singular-factory and put the headers inside a singular/ directory, as
pkg-config gives us the necessary CPPFLAGS to find these headers.

It also has the advantage of simplifying the check for version >= 4.0.0.