### PR TITLE
Fix makefiles, now that memtailor uses libtool again (v2)

### DIFF
--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -180,7 +180,7 @@ else
 M2_LIBRARIES := $(M2_LIBRARIES) -L../d -lM2inits2
 endif
 M2_LIBDEPS += ../d/libM2inits2.a				\
-	@abs_top_builddir@/submodules/memtailor/libmemtailor.a	\
+	@abs_top_builddir@/submodules/memtailor/.libs/libmemtailor.a	\
 	@abs_top_builddir@/submodules/mathic/libmathic.a	\
 	@abs_top_builddir@/submodules/mathicgb/.libs/libmathicgb.a
 ifeq (@CONSTRUCTOR_ORDER_OBJ@,LR)

--- a/M2/include/config.Makefile.in
+++ b/M2/include/config.Makefile.in
@@ -74,13 +74,13 @@ endif
 vpath %.h $(BUILTLIBPATH)/include
 LDFLAGS :=						\
 	-L$(BUILTLIBPATH)/lib				\
-	-L@abs_top_builddir@/submodules/memtailor	\
+	-L@abs_top_builddir@/submodules/memtailor/.libs	\
 	-L@abs_top_builddir@/submodules/mathic		\
 	-L@abs_top_builddir@/submodules/mathicgb/.libs	\
 	$(LDFLAGS)
 LDFLAGS_FOR_BUILD :=					\
 	-L$(BUILTLIBPATH)/lib				\
-	-L@abs_top_builddir@/submodules/memtailor	\
+	-L@abs_top_builddir@/submodules/memtailor/.libs	\
 	-L@abs_top_builddir@/submodules/mathic		\
 	-L@abs_top_builddir@/submodules/mathicgb/.libs	\
 	$(LDFLAGS_FOR_BUILD)


### PR DESCRIPTION
This commit was previously applied, but then reverted because the
corresponding commit in the memtailor submodule was not updated
(see [1]).

Note that we have updated M2/submodules/memtailor to point to [2], one
commit earlier than the current HEAD of the master branch.  It may be
preferable to merge [3] first and use that commit instead.

[1] https://github.com/Macaulay2/M2/pull/343
[2] https://github.com/Macaulay2/memtailor/commit/a8212c6
[3] https://github.com/Macaulay2/memtailor/pull/3