### PR TITLE
Use gftables from factory if factory is not built.

### DIFF
--- a/M2/Macaulay2/d/startup.m2.in
+++ b/M2/Macaulay2/d/startup.m2.in
@@ -284,7 +284,7 @@ if firstTime then (
 	       "programs" => "@programsdir@/",
 	       "program licenses" => "@licensesdir@/",
 	       "package" => "@packagesdir@/PKG/",
-	       "factory gftables" =>  "@packagesdir@/Core/factory/",
+	       "factory gftables" =>  "@gftablesdir@",
 	       "packagedoc" => "@docdir@/PKG/",
 	       "packageimages" => "@docdir@/PKG/images/",
 	       "packagetests" => "@docdir@/PKG/tests/",

--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -51,11 +51,15 @@ inversePermutation = v -> ( w := new MutableList from #v:null; scan(#v, i -> w#(
 -- We mimic the procedure for finding a finite field addition table used in the routine gf_get_table
 -- for building the file name in "gffilename", in the file BUILD_DIR/libraries/factory/build/factory/gfops.cc .
 -- Reminder: the contents of currentLayout are determined by the file ../d/startup.m2.in .
-gfdir = prefixDirectory | currentLayout#"factory gftables"
-gftestfile = gfdir | "gftables/961" -- 961==31^2
-if not fileExists gftestfile
-then error ("sample Factory finite field addition table file missing, needed for factorization: ", gftestfile)
-setFactoryGFtableDirectory gfdir
+gfdirs = {prefixDirectory | currentLayout#"factory gftables",
+	  currentLayout#"factory gftables"}
+i = position(gfdirs, gfdir -> fileExists(gfdir | "gftables/961")) -- 961==31^2
+if i === null
+then error ("sample Factory finite field addition table file missing, needed for factorization: ",
+    prefixDirectory, currentLayout#"factory gftables",
+    " or ",
+    currentLayout#"factory gftables")
+setFactoryGFtableDirectory gfdirs_i
 
 irreducibleCharacteristicSeries = method()
 irreducibleCharacteristicSeries Ideal := I -> (		    -- rawCharSeries

--- a/M2/config/relpaths.m4
+++ b/M2/config/relpaths.m4
@@ -1,0 +1,155 @@
+dnl @synopsis adl_COMPUTE_RELATIVE_PATHS(PATH_LIST)
+dnl
+dnl PATH_LIST is a space-separated list of colon-separated triplets of
+dnl the form 'FROM:TO:RESULT'. This function iterates over these
+dnl triplets and set $RESULT to the relative path from $FROM to $TO.
+dnl Note that $FROM and $TO needs to be absolute filenames for this
+dnl macro to success.
+dnl
+dnl For instance,
+dnl
+dnl    first=/usr/local/bin
+dnl    second=/usr/local/share
+dnl    adl_COMPUTE_RELATIVE_PATHS([first:second:fs second:first:sf])
+dnl    # $fs is set to ../share
+dnl    # $sf is set to ../bin
+dnl
+dnl $FROM and $TO are both eval'ed recursively and normalized, this
+dnl means that you can call this macro with autoconf's dirnames like
+dnl `prefix' or `datadir'. For example:
+dnl
+dnl    adl_COMPUTE_RELATIVE_PATHS([bindir:datadir:bin_to_data])
+dnl
+dnl adl_COMPUTE_RELATIVE_PATHS should also works with DOS filenames.
+dnl
+dnl You may want to use this macro in order to make your package
+dnl relocatable. Instead of hardcoding $datadir into your programs just
+dnl encode $bin_to_data and try to determine $bindir at run-time.
+dnl
+dnl This macro requires adl_NORMALIZE_PATH.
+dnl
+dnl @category Misc
+dnl @author Alexandre Duret-Lutz <duret_g@epita.fr>
+dnl @version 2001-05-25
+dnl @license GPLWithACException
+
+AC_DEFUN([adl_COMPUTE_RELATIVE_PATHS],
+[for _lcl_i in $1; do
+  _lcl_from=\[$]`echo "[$]_lcl_i" | sed 's,:.*$,,'`
+  _lcl_to=\[$]`echo "[$]_lcl_i" | sed 's,^[[^:]]*:,,' | sed 's,:[[^:]]*$,,'`
+  _lcl_result_var=`echo "[$]_lcl_i" | sed 's,^.*:,,'`
+  adl_RECURSIVE_EVAL([[$]_lcl_from], [_lcl_from])
+  adl_RECURSIVE_EVAL([[$]_lcl_to], [_lcl_to])
+  _lcl_notation="$_lcl_from$_lcl_to"
+  adl_NORMALIZE_PATH([_lcl_from],['/'])
+  adl_NORMALIZE_PATH([_lcl_to],['/'])
+  adl_COMPUTE_RELATIVE_PATH([_lcl_from], [_lcl_to], [_lcl_result_tmp])
+  adl_NORMALIZE_PATH([_lcl_result_tmp],["[$]_lcl_notation"])
+  eval $_lcl_result_var='[$]_lcl_result_tmp'
+done])
+
+## Note:
+## *****
+## The following helper macros are too fragile to be used out
+## of adl_COMPUTE_RELATIVE_PATHS (mainly because they assume that
+## paths are normalized), that's why I'm keeping them in the same file.
+## Still, some of them maybe worth to reuse.
+
+dnl adl_COMPUTE_RELATIVE_PATH(FROM, TO, RESULT)
+dnl ===========================================
+dnl Compute the relative path to go from $FROM to $TO and set the value
+dnl of $RESULT to that value.  This function work on raw filenames
+dnl (for instead it will considerate /usr//local and /usr/local as
+dnl two distinct paths), you should really use adl_COMPUTE_REALTIVE_PATHS
+dnl instead to have the paths sanitized automatically.
+dnl
+dnl For instance:
+dnl    first_dir=/somewhere/on/my/disk/bin
+dnl    second_dir=/somewhere/on/another/disk/share
+dnl    adl_COMPUTE_RELATIVE_PATH(first_dir, second_dir, first_to_second)
+dnl will set $first_to_second to '../../../another/disk/share'.
+AC_DEFUN([adl_COMPUTE_RELATIVE_PATH],
+[adl_COMPUTE_COMMON_PATH([$1], [$2], [_lcl_common_prefix])
+adl_COMPUTE_BACK_PATH([$1], [_lcl_common_prefix], [_lcl_first_rel])
+adl_COMPUTE_SUFFIX_PATH([$2], [_lcl_common_prefix], [_lcl_second_suffix])
+$3="[$]_lcl_first_rel[$]_lcl_second_suffix"])
+
+dnl adl_COMPUTE_COMMON_PATH(LEFT, RIGHT, RESULT)
+dnl ============================================
+dnl Compute the common path to $LEFT and $RIGHT and set the result to $RESULT.
+dnl
+dnl For instance:
+dnl    first_path=/somewhere/on/my/disk/bin
+dnl    second_path=/somewhere/on/another/disk/share
+dnl    adl_COMPUTE_COMMON_PATH(first_path, second_path, common_path)
+dnl will set $common_path to '/somewhere/on'.
+AC_DEFUN([adl_COMPUTE_COMMON_PATH],
+[$3=''
+_lcl_second_prefix_match=''
+while test "[$]_lcl_second_prefix_match" != 0; do
+  _lcl_first_prefix=`expr "x[$]$1" : "x\([$]$3/*[[^/]]*\)"`
+  _lcl_second_prefix_match=`expr "x[$]$2" : "x[$]_lcl_first_prefix"`
+  if test "[$]_lcl_second_prefix_match" != 0; then
+    if test "[$]_lcl_first_prefix" != "[$]$3"; then
+      $3="[$]_lcl_first_prefix"
+    else
+      _lcl_second_prefix_match=0
+    fi
+  fi
+done])
+
+dnl adl_COMPUTE_SUFFIX_PATH(PATH, SUBPATH, RESULT)
+dnl ==============================================
+dnl Substrack $SUBPATH from $PATH, and set the resulting suffix
+dnl (or the empty string if $SUBPATH is not a subpath of $PATH)
+dnl to $RESULT.
+dnl
+dnl For instace:
+dnl    first_path=/somewhere/on/my/disk/bin
+dnl    second_path=/somewhere/on
+dnl    adl_COMPUTE_SUFFIX_PATH(first_path, second_path, common_path)
+dnl will set $common_path to '/my/disk/bin'.
+AC_DEFUN([adl_COMPUTE_SUFFIX_PATH],
+[$3=`expr "x[$]$1" : "x[$]$2/*\(.*\)"`])
+
+dnl adl_COMPUTE_BACK_PATH(PATH, SUBPATH, RESULT)
+dnl ============================================
+dnl Compute the relative path to go from $PATH to $SUBPATH, knowing that
+dnl $SUBPATH is a subpath of $PATH (any other words, only repeated '../'
+dnl should be needed to move from $PATH to $SUBPATH) and set the value
+dnl of $RESULT to that value.  If $SUBPATH is not a subpath of PATH,
+dnl set $RESULT to the empty string.
+dnl
+dnl For instance:
+dnl    first_path=/somewhere/on/my/disk/bin
+dnl    second_path=/somewhere/on
+dnl    adl_COMPUTE_BACK_PATH(first_path, second_path, back_path)
+dnl will set $back_path to '../../../'.
+AC_DEFUN([adl_COMPUTE_BACK_PATH],
+[adl_COMPUTE_SUFFIX_PATH([$1], [$2], [_lcl_first_suffix])
+$3=''
+_lcl_tmp='xxx'
+while test "[$]_lcl_tmp" != ''; do
+  _lcl_tmp=`expr "x[$]_lcl_first_suffix" : "x[[^/]]*/*\(.*\)"`
+  if test "[$]_lcl_first_suffix" != ''; then
+     _lcl_first_suffix="[$]_lcl_tmp"
+     $3="../[$]$3"
+  fi
+done])
+
+
+dnl adl_RECURSIVE_EVAL(VALUE, RESULT)
+dnl =================================
+dnl Interpolate the VALUE in loop until it doesn't change,
+dnl and set the result to $RESULT.
+dnl WARNING: It's easy to get an infinite loop with some unsane input.
+AC_DEFUN([adl_RECURSIVE_EVAL],
+[_lcl_receval="$1"
+$2=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "[$]_lcl_receval_old" != "[$]_lcl_receval"; do
+       _lcl_receval_old="[$]_lcl_receval"
+       eval _lcl_receval="\"[$]_lcl_receval\""
+     done
+     echo "[$]_lcl_receval")`])

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -30,6 +30,7 @@ AC_SUBST(CONFIG_CMD,"'$0' $ac_configure_args")
 AC_CONFIG_MACRO_DIR([config])	dnl can't get this to work
 m4_include(config/ax_prog_cc_for_build.m4)
 m4_include(config/ax_func_accept_argtypes.m4)
+m4_include(config/relpaths.m4)
 
 dnl define(TO_UPPER,[translit($1, [a-z], [A-Z])])
 
@@ -1269,8 +1270,6 @@ AC_ARG_WITH(lapack, AS_HELP_STRING(--without-lapack,[compile and link without la
 test "$LAPACK" = no; val=$?
 AC_DEFINE_UNQUOTED(LAPACK,$val,whether to link with lapack)
 
-BUILD_gftables=yes		dnl it seems that factory now includes gftables, and installs it
-
 SINGULARLIBS="-lfactory  "
 if test $BUILD_factory = no
 then
@@ -1299,6 +1298,29 @@ then
      CPPFLAGS="`$PKG_CONFIG --cflags $FACTORY_NAME` $CPPFLAGS"
 else
      BUILTLIBS="$SINGULARLIBS $BUILTLIBS"
+fi
+
+AC_ARG_VAR([GFTABLESDIR],
+    [path to gftables directory if factory is already installed])
+if test $BUILD_factory = yes
+then
+    BUILD_gftables=yes
+    AC_SUBST([gftablesdir], [${datadir}/Macaulay2/Core/factory/])
+else
+    BUILD_gftables=no
+    if test x$GFTABLESDIR = x
+    then
+	if test $FACTORY_NAME = factory
+	then
+	    GFTABLESDIR="${datadir}/factory/"
+	else
+	    GFTABLESDIR="${datadir}/singular/factory/"
+	fi
+    fi
+    adl_RECURSIVE_EVAL([$GFTABLESDIR], [GFTABLESDIR])
+    AC_CHECK_FILE([${GFTABLESDIR}gftables/961],
+	[AC_SUBST([gftablesdir], [$GFTABLESDIR])],
+	[AC_MSG_ERROR([could not find gftables but we are not building factory; try specifying the directory with GFTABLESDIR])])
 fi
 
 # we need to do the fortran library testing last, in case AC_SEARCH_LIBS adds
@@ -1666,7 +1688,7 @@ sysconfdir=/nowhere
 sharedstatedir=/nowhere
 localstatedir=/nowhere
 for i in bindir datadir includedir infodir libdir libexecdir mandir sbindir \
-         psdir pdfdir dvidir htmldir localedir docdir datarootdir
+         psdir pdfdir dvidir htmldir localedir gftablesdir docdir datarootdir
 do eval w=\$$i ; eval v="$w" ; eval v="$v" ; eval v="$v" ; eval v="$v" ; eval v="$v"
    case $v in
      "$exec_prefix"|"$exec_prefix"/*)
@@ -1679,7 +1701,9 @@ do eval w=\$$i ; eval v="$w" ; eval v="$v" ; eval v="$v" ; eval v="$v" ; eval v=
 	   eval  pre_${i}=`echo $v | sed s,"^$prefix","'\\${pre_prefix}'",`
 	   eval      ${i}=`echo $v | sed s,"^$prefix","'\\${prefix}'",`
 	   ;;
-     *) AC_MSG_ERROR([expected "\${$i}" => "$w" to start with "\${prefix}" or with "\${exec_prefix}"]) ;;
+     *) if test $i != gftablesdir #only needs normalized if we build factory
+	then AC_MSG_ERROR([expected "\${$i}" => "$w" to start with "\${prefix}" or with "\${exec_prefix}"])
+	fi ;;
    esac
 done
 prefix=$save_prefix


### PR DESCRIPTION
The configure script checks in the expected location for the gftables
directory or it may be specified using GFTABLESDIR.  Note that we must
expand the ${datadir} variable recursively in order for AC_CHECK_FILE
to work.  For this, we use the adl_RECURSIVE_EVAL macro from the Autoconf
Archive [1].

This fixes #375.

[1] http://ac-archive.sourceforge.net/adl/relpaths.html