### PR TITLE
Additional Makefile fix for optional submodules

### DIFF
--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -179,7 +179,7 @@ else
 M2_LIBRARIES := $(M2_LIBRARIES) -L../d -lM2inits2
 endif
 M2_LIBDEPS += ../d/libM2inits2.a				\
-	$(foreach S, @BUILDSUBLIST@, @abs_top_builddir@/submodules/$S/lib$S.a)
+	$(foreach S, @BUILDSUBLIST@, @abs_top_builddir@/submodules/$S/.libs/lib$S.a)
 ifeq (@CONSTRUCTOR_ORDER_OBJ@,LR)
 M2_OBJECTS := ../d/M2inits.o $(M2_OBJECTS)
 else

--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -179,9 +179,7 @@ else
 M2_LIBRARIES := $(M2_LIBRARIES) -L../d -lM2inits2
 endif
 M2_LIBDEPS += ../d/libM2inits2.a				\
-	@abs_top_builddir@/submodules/memtailor/.libs/libmemtailor.a	\
-	@abs_top_builddir@/submodules/mathic/.libs/libmathic.a	\
-	@abs_top_builddir@/submodules/mathicgb/.libs/libmathicgb.a
+	$(foreach S, @BUILDSUBLIST@, @abs_top_builddir@/submodules/$S/lib$S.a)
 ifeq (@CONSTRUCTOR_ORDER_OBJ@,LR)
 M2_OBJECTS := ../d/M2inits.o $(M2_OBJECTS)
 else


### PR DESCRIPTION
Somehow I missed this when I was testing the earlier commits.