### PR TITLE
Use existing gtest package if available.

### DIFF
--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -121,7 +121,7 @@ submodules/$1/Makefile:@srcdir@/submodules/$1/configure @srcdir@/submodules/$1/M
 		--prefix=$(BUILTLIBPATH)						\
 		--with-gtest=yes							\
 		PKG_CONFIG_PATH="$(BUILTLIBPATH)/lib/pkgconfig:$(PKG_CONFIG_PATH)"	\
-		GTEST_PATH=$(BUILTLIBPATH)/include/gtest				\
+		GTEST_PATH=@GTEST_PATH@							\
 		AR=@AR@									\
 		AS=@AS@									\
 		DLLTOOL=@DLLTOOL@							\

--- a/M2/config/gtest.m4
+++ b/M2/config/gtest.m4
@@ -1,0 +1,73 @@
+# Copyright (C) 2012 Canonical, Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice (including the next
+# paragraph) shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Checks whether the gtest source is available on the system. Allows for
+# adjusting the include and source path. Sets have_gtest=yes if the source is
+# present. Sets GTEST_CPPFLAGS and GTEST_SOURCE to the preprocessor flags and
+# source location respectively.
+AC_DEFUN([CHECK_GTEST],
+[
+  AC_ARG_WITH([gtest-source-path],
+              [AS_HELP_STRING([--with-gtest-source-path],
+                              [location of the Google test sources, defaults to /usr/src/gtest])],
+              [GTEST_SOURCE="$withval"; GTEST_CPPFLAGS="-I$withval/include";
+               case "$withval" in
+                  /*) ;;
+                  *) AC_MSG_ERROR([gtest source path must be an absolute path ('$withval')]) ;;
+               esac
+              ],
+              [GTEST_SOURCE="/usr/src/gtest"])
+
+  AC_ARG_WITH([gtest-include-path],
+              [AS_HELP_STRING([--with-gtest-include-path],
+                              [location of the Google test headers])],
+              [GTEST_CPPFLAGS="-I$withval";
+               case "$withval" in
+                  /*) ;;
+                  *) AC_MSG_ERROR([gtest-include-path must be an absolute path ('$withval')]) ;;
+               esac
+               ])
+
+  GTEST_CPPFLAGS="$GTEST_CPPFLAGS -I$GTEST_SOURCE"
+
+  AC_LANG_PUSH([C++])
+
+  tmp_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $GTEST_CPPFLAGS"
+
+  AC_CHECK_HEADER([gtest/gtest.h])
+
+  CPPFLAGS="$tmp_CPPFLAGS"
+
+  AC_LANG_POP
+
+  AC_CHECK_FILES([$GTEST_SOURCE/src/gtest-all.cc]
+                 [$GTEST_SOURCE/src/gtest_main.cc],
+                 [have_gtest_source=yes],
+                 [have_gtest_source=no])
+
+  AS_IF([test "x$ac_cv_header_gtest_gtest_h" = xyes -a \
+              "x$have_gtest_source" = xyes],
+        [have_gtest=yes]
+        [AC_SUBST(GTEST_CPPFLAGS)]
+        [AC_SUBST(GTEST_SOURCE)],
+        [have_gtest=no])
+]) # CHECK_GTEST

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -31,6 +31,7 @@ AC_CONFIG_MACRO_DIR([config])	dnl can't get this to work
 m4_include(config/ax_prog_cc_for_build.m4)
 m4_include(config/ax_func_accept_argtypes.m4)
 m4_include(config/relpaths.m4)
+m4_include(config/gtest.m4)
 
 dnl define(TO_UPPER,[translit($1, [a-z], [A-Z])])
 
@@ -806,7 +807,7 @@ AC_SUBST(SUBLIST, " memtailor mathic mathicgb ")
 
 # a library is listed in BUILD_ALWAYS if and only if we *always* build it, 
 # even if the option "--disable-building" is specified:
-BUILD_ALWAYS=" gtest "
+BUILD_ALWAYS=""
 
 for i in $LIBLIST $SUBLIST
 do eval BUILD_$i=no
@@ -862,7 +863,21 @@ AC_ARG_ENABLE(fflas-ffpack,
     ENABLE_GIVARO=yes
     )
 
-BUILD_gtest=yes
+if test $BUILD_gtest = no
+then
+    CHECK_GTEST
+    if test $have_gtest = yes
+    then
+        CPPFLAGS="$GTEST_CPPFLAGS $CPPFLAGS"
+        GTEST_PATH=$GTEST_SOURCE
+    else
+        BUILD_gtest=yes
+        GTEST_PATH="\$(BUILTLIBPATH)/include/gtest"
+    fi
+else
+    GTEST_PATH="\$(BUILTLIBPATH)/include/gtest"
+fi
+AC_SUBST(GTEST_PATH)
 
 PROGLIST=" $PROGLIST "
 AC_ARG_WITH(unbuilt-programs, 


### PR DESCRIPTION
We use the CHECK_GTEST autoconf macro distributed by the xorg-gtest
project [1].  By default, it checks in /usr/src/gtest (this is the path
used by the Debian/Ubuntu libgtest-dev package).  Users may also specify
a path with the --with-gtest-source-path and --with-gtest-include-path
configure options.

This closes #195.

[1] https://cgit.freedesktop.org/xorg/test/xorg-gtest/tree/m4/gtest.m4