### PR TITLE
Add shebang line to to hom4ps2_in_out script in NAG4M2.

### DIFF
--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/hom4ps2_in_out
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/hom4ps2_in_out
@@ -1,3 +1,4 @@
+#!/bin/sh
 cd HOM4PS2
 ./bin/sym2num < $1 > ./bin/input.num
 echo "2" | ./bin/flwcrv


### PR DESCRIPTION
This prevents an "executable-not-elf-or-script" Lintian warning in the
Debian package.