### PR TITLE
Add meta tag to HTML docs to force UTF-8 on offline HTML documentation

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -204,6 +204,11 @@ links := tag -> (
      LINK { "href" => toURL doccss, "rel" => "stylesheet", "type" => "text/css" }
      )
 
+-- Also set the character encoding with a meta http-equiv statement. (Sometimes XHTML
+-- is parsed as HTML, and then the HTTP header or a meta tag is used to determine the
+-- character encoding.  Locally-stored documentation does not have an HTTP header.)
+defaultCharSet := () -> META { "http-equiv" => "Content-Type", "content" => "text/html; charset=utf-8" }
+
 BUTTON := (s,alt) -> (
      s = toURL s;
      if alt === null
@@ -408,7 +413,7 @@ makeMasterIndex := (keylist,verbose) -> (
      title := DocumentTag.FormattedKey topDocumentTag | " : Index";
      if verbose then stderr << "--making '" << title << "' in " << fn << endl;
      r := HTML {
-	  HEAD splice { TITLE title, links() },
+	  HEAD splice { TITLE title, defaultCharSet(), links() },
 	  BODY nonnull {
 	       DIV { topNodeButton, " | ", tocButton, {* " | ", directoryButton, *} " | ", homeButton },
 	       HR{},
@@ -430,7 +435,7 @@ maketableOfContents := (verbose) -> (
      if verbose then stderr << "--making  " << title << "' in " << fn << endl;
      fn
      << html HTML {
-	  HEAD splice { TITLE title, links() },
+	  HEAD splice { TITLE title, defaultCharSet(), links() },
 	  BODY {
 	       DIV { topNodeButton, " | ", masterIndexButton, {* " | ", directoryButton, *} " | ", homeButton },
 	       HR{},
@@ -991,6 +996,7 @@ installPackage Package := opts -> pkg -> (
 	       << html HTML { 
 		    HEAD splice {
 			 TITLE {fkey, commentize headline fkey}, -- I hope this works...
+			 defaultCharSet(),
 			 links tag
 			 },
 		    BODY { 
@@ -1177,6 +1183,7 @@ makePackageIndex List := path -> (
      fn << html HTML { 
 	  HEAD splice {
 	       TITLE {key, commentize headline key},
+	       defaultCharSet(),
 	       links()
 	       },
 	  BODY { 
@@ -1284,7 +1291,8 @@ showHtml = show Hypertext := x -> (
      fn := temporaryFileName() | ".html";
      fn << html HTML {
 	  HEAD {
-	       TITLE "Macaulay2 Output"
+	       TITLE "Macaulay2 Output",
+	       defaultCharSet()
 	       },
      	  BODY {
 	       x


### PR DESCRIPTION
This change adds `<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>` to the header of the HTML files containing M2's documentation.  No change should be visible in the online documentation at `www.math.uiuc.edu`, which already sends the HTTP header `Content-Type: text/html; charset=utf-8`.  However, this should fix a problem I encountered when viewing local (offline) documentation using my web browser (Firefox 45 on Debian), namely, characters such as "ö" display as gibberish (a pair of extended ASCII characters) unless I manually switch Firefox's 'text encoding' setting to unicode.

Validating the product produces the same 2 warnings that apply to the current online documentation (see [this](https://validator.w3.org/check?uri=http%3A%2F%2Fwww.math.uiuc.edu%2FMacaulay2%2Fdoc%2FMacaulay2-1.8.2%2Fshare%2Fdoc%2FMacaulay2%2FMacaulay2Doc%2Fhtml%2F_gb.html&charset=%28detect+automatically%29&doctype=Inline&group=0), for example).

Feel free to delay this change until after the release.