### PR TITLE
Remove stray equals sign in M2_CPPFLAGS when system fflas-ffpack is used.

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1279,7 +1279,7 @@ then AC_MSG_CHECKING(for fflas_ffpack library)
      FFLAS_FFPACK_CPPFLAGS=`fflas-ffpack-config --cflags 2>&1`
      if test $? = 0
      then AC_MSG_RESULT(found)
-          M2_CPPFLAGS="$M2_CPPFLAGS $FFLAS_FFPACK_CPPFLAGS="
+          M2_CPPFLAGS="$M2_CPPFLAGS $FFLAS_FFPACK_CPPFLAGS"
      else AC_MSG_RESULT(not found, will build)
           BUILD_fflas_ffpack=yes
      fi


### PR DESCRIPTION
This may result in errors like:

    gcc: error: unrecognized command line option '-fopenmp='; did you mean
    '-fopenmp'?