### PR TITLE
Add support for localization of polynomial rings with respect to prime ideals.

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1044,6 +1044,7 @@ tostringfun(e:Expr):Expr := (
      is x:RawFreeModuleCell do toExpr(Ccode(string, "IM2_FreeModule_to_string(",x.p,")" ))
      is x:RawMatrixCell do toExpr(Ccode(string, "IM2_Matrix_to_string(",x.p,")" ))
      is x:RawMutableMatrixCell do toExpr(Ccode(string, "IM2_MutableMatrix_to_string(",x.p,")" ))
+     is x:RawMutableComplexCell do toExpr(Ccode(string, "rawMutableComplexToString(",x.p,")" ))
      -- NAG stuff begin
      is x:RawHomotopyCell do toExpr(Ccode(string, "rawHomotopyToString(",x.p,")" ))
      is x:RawSLEvaluatorCell do toExpr(Ccode(string, "rawSLEvaluatorToString(",x.p,")" ))

--- a/M2/Macaulay2/d/basic.d
+++ b/M2/Macaulay2/d/basic.d
@@ -50,6 +50,7 @@ export hash(e:Expr):int := (
      is x:RawMonoidCell do int(Ccode(uint, "rawMonoidHash(",x.p,")" ))
      is x:RawMatrixCell do int(Ccode(uint, "rawMatrixHash(",x.p,")" ))
      is x:RawMutableMatrixCell do int(Ccode(uint, "rawMutableMatrixHash(",x.p,")" ))
+     is x:RawMutableComplexCell do int(Ccode(uint, "rawMutableComplexHash(",x.p,")" ))
      -- NAG begin
      is x:RawHomotopyCell do int(Ccode(uint, "rawHomotopyHash(",x.p,")" ))
      is x:RawSLEvaluatorCell do int(Ccode(uint, "rawSLEvaluatorHash(",x.p,")" ))

--- a/M2/Macaulay2/d/classes.dd
+++ b/M2/Macaulay2/d/classes.dd
@@ -33,6 +33,7 @@ setupconst("RawRing",Expr(rawRingClass));
 setupconst("RawFreeModule",Expr(rawFreeModuleClass));
 setupconst("RawMatrix",Expr(rawMatrixClass));
 setupconst("RawMutableMatrix",Expr(rawMutableMatrixClass));
+setupconst("RawMutableComplex",Expr(rawMutableComplexClass));
 -- NAG begin
 setupconst("RawHomotopy",Expr(rawHomotopyClass));
 setupconst("RawSLEvaluator",Expr(rawSLEvaluatorClass));
@@ -154,6 +155,7 @@ export Class(e:Expr):HashTable := (
      is RawFreeModuleCell do rawFreeModuleClass
      is RawMatrixCell do rawMatrixClass
      is RawMutableMatrixCell do rawMutableMatrixClass
+     is RawMutableComplexCell do rawMutableComplexClass
      -- NAG begin
      is RawHomotopyCell do rawHomotopyClass
      is RawSLEvaluatorCell do rawSLEvaluatorClass

--- a/M2/Macaulay2/d/engine.dd
+++ b/M2/Macaulay2/d/engine.dd
@@ -40,6 +40,8 @@ export RawPointArrayOrNull := RawPointArray or null;
 -- NAG end
 export RawMutableMatrix := Pointer "struct MutableMatrix *";
 export RawMutableMatrixOrNull := RawMutableMatrix or null;
+export RawMutableComplex := Pointer "struct MutableComplex *";
+export RawMutableComplexOrNull := RawMutableComplex or null;
 export RawMonomialOrderingArray := array(RawMonomialOrdering);
 
 export RawArrayIntPair := { a:RawArrayInt, b:RawArrayInt };
@@ -49,6 +51,8 @@ export RawMatrixPair := { a:RawMatrix, b:RawMatrix };
 export RawMatrixPairOrNull := RawMatrixPair or null;
 export RawMatrixArray := array(RawMatrix);
 export RawMatrixArrayOrNull := array(RawMatrix) or null;
+export RawMutableMatrixArray := array(RawMutableMatrix);
+export RawMutableMatrixArrayOrNull := array(RawMutableMatrix) or null;
 export RawRingElementArray := array(RawRingElement);
 export RawRingElementArrayOrNull := array(RawRingElement) or null;
 export RawArrayPair := { monoms:array(RawMonomial), coeffs:array(RawRingElement) };
@@ -68,6 +72,7 @@ export RawMonomialCell := {+ p:RawMonomial };
 export RawMonomialIdealCell := {+ p:RawMonomialIdeal };
 export RawMonomialOrderingCell := {+ p:RawMonomialOrdering };
 export RawMutableMatrixCell := {+ p:RawMutableMatrix };
+export RawMutableComplexCell := {+ p:RawMutableComplex };
 -- NAG begin
 export RawHomotopyCell := {+ p:RawHomotopy };
 export RawSLEvaluatorCell := {+ p:RawSLEvaluator };

--- a/M2/Macaulay2/d/equality.dd
+++ b/M2/Macaulay2/d/equality.dd
@@ -198,6 +198,7 @@ export equal(lhs:Expr,rhs:Expr):Expr := (
      is MysqlFieldWrapper do False
      is MysqlResultWrapper do False
      is RawMutableMatrixCell do False			    -- mutable matrices may not stay equal, so they aren't equal
+     is RawMutableComplexCell do False			    -- mutable matrices may not stay equal, so they aren't equal
      -- NAG begin
      is RawHomotopyCell do False
      is RawSLEvaluatorCell do False

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -325,6 +325,7 @@ export rawSLEvaluatorClass := newtypeof(rawObjectClass);    -- RawSLEvaluator
 export rawSLProgramClass := newtypeof(rawObjectClass);    -- RawSLProgram
 export rawPointArrayClass := newtypeof(rawObjectClass);    -- RawPointArray
 -- NAG end
+export rawMutableComplexClass := newtypeof(rawObjectClass);	    -- RawMutableComplex
 -- all new types, dictionaries, and classes go just above this line, if possible, so hash codes don't change gratuitously!
 
 

--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -1,7 +1,7 @@
 --		Copyright 1994-2004 by Daniel R. Grayson
 
 -- this file contains top level routines that call the C++ code in the engine
- 
+
 use engine;
 use common;
 use hashtables;
@@ -753,16 +753,20 @@ export rawSolvableAlgebra(e:Expr):Expr := (
 setupfun("rawSolvableAlgebra",rawSolvableAlgebra);
 
 export rawLocalRing(e:Expr):Expr := (			    -- localization at a prime ideal
-     when e is a:Sequence do 
-     if length(a) == 2 then 
-     when a.0 is R:RawRingCell do 
-     when a.1 is P:RawMatrixCell do toExpr(Ccode(RawRingOrNull, "IM2_Ring_localization(", R.p, ",",
- 	       P.p,				    -- 1 by n matrix generating the prime ideal
- 	       ")" ))
-     else WrongArgMatrix(2)
-     else WrongArg(1,"a raw ring")
-     else WrongNumArgs(2)
-     else WrongNumArgs(2));
+  when e is s:Sequence do (
+  if length(s) == 2 then (
+  when s.0 is R:RawRingCell do (
+  when s.1 is P:RawComputationCell do (			    -- Grobner basis of prime ideal
+    toExpr(Ccode(RawRingOrNull,
+      "IM2_Ring_localization(",
+        R.p, ",", P.p,
+      ")"
+    ))
+  ) else WrongArg(2,"a raw computation")
+  ) else WrongArg(1,"a raw ring")
+  ) else WrongNumArgs(2)
+  ) else WrongNumArgs(2)
+  );
 setupfun("rawLocalRing",rawLocalRing);
 
 export rawQuotientRing(e:Expr):Expr := (
@@ -1340,7 +1344,7 @@ export rawLift(e:Expr):Expr := (
 		             R.p,
 		             ",", x.p, ")" );
 	           if success == 0 then nullE else toExpr(m))
-	  else WrongArg(2,"a raw ring element or rae mutable matrix"))
+	  else WrongArg(2,"a raw ring element or raw mutable matrix"))
      is M:RawFreeModuleCell do (				    -- M is the new target free module
 	  when a.1 is f:RawMatrixCell do (
 	       m := Ccode(RawMatrixOrNull, 
@@ -4236,6 +4240,113 @@ ConstantII(e:Expr):Expr := (
      else toExpr(toCC(0,1,toULong(prec)))
      else WrongArgZZ(1));
 setupfun("ConstantII",ConstantII);
+
+export rawMutableComplex(e:Expr):Expr := (			    -- returns a mutable chain complex
+     if isSequenceOfMutableMatrices(e) then
+     toExpr(Ccode(RawMutableComplexOrNull,
+	       "rawMutableComplex(",
+	       getSequenceOfMutableMatrices(e),
+	       ")"))
+     else WrongArg(1,"a sequence of raw mutable matrices")
+     );
+setupfun("rawMutableComplex",rawMutableComplex);
+
+export rawPruneComplex(e:Expr):Expr := (			    -- prunes a mutable chain complex
+  when e is s:Sequence do (
+  if length(s) == 3 then (
+  when s.0 is wC:RawMutableComplexCell do (C := wC.p;
+  when s.1 is wnsteps:ZZcell do (
+  if isInt(wnsteps) then (nsteps := toInt(wnsteps);
+  when s.2 is wflags:ZZcell do (
+  if isInt(wflags) then (flags := toInt(wflags);
+    toExpr(Ccode(RawMutableComplexOrNull,
+      "rawPruneComplex(",
+        C, ",", nsteps, ",", flags,
+      ")"
+    ))
+  ) else WrongArgSmallInteger(2)
+  ) else WrongArgZZ(2)
+  ) else WrongArgSmallInteger(1)
+  ) else WrongArgZZ(1)
+  ) else WrongArg(0,"a raw mutable complex")
+  ) else WrongNumArgs(3)
+  ) else WrongNumArgs(3)
+  );
+setupfun("rawPruneComplex",rawPruneComplex);
+
+export rawPruneBetti(e:Expr):Expr := (				    -- returns the betti numbers
+  when e is s:Sequence do (
+  if length(s) == 3 then (
+  when s.0 is wC:RawMutableComplexCell do (C := wC.p;
+  when s.1 is wnsteps:ZZcell do (
+  if isInt(wnsteps) then (nsteps := toInt(wnsteps);
+  when s.2 is wflags:ZZcell do (
+  if isInt(wflags) then (flags := toInt(wflags);
+    toExpr(Ccode(RawArrayIntOrNull,
+      "rawPruneBetti(",
+        C, ",", nsteps, ",", flags,
+      ")"
+    ))
+  ) else WrongArgSmallInteger(2)
+  ) else WrongArgZZ(2)
+  ) else WrongArgSmallInteger(1)
+  ) else WrongArgZZ(1)
+  ) else WrongArg(0,"a raw mutable complex")
+  ) else WrongNumArgs(3)
+  ) else WrongNumArgs(3)
+  );
+setupfun("rawPruneBetti",rawPruneBetti);
+
+export rawPruningMorphism(e:Expr):Expr := (			    -- returns the pruning maps
+  when e is s:Sequence do (
+  if length(s) == 3 then (
+  when s.0 is wC:RawMutableComplexCell do (C := wC.p;
+  when s.1 is wnsteps:ZZcell do (
+  if isInt(wnsteps) then (nsteps := toInt(wnsteps);
+  when s.2 is wflags:ZZcell do (
+  if isInt(wflags) then (flags := toInt(wflags);
+    toExpr(Ccode(RawMutableMatrixArrayOrNull,
+      "rawPruningMorphism(",
+        C, ",", nsteps, ",", flags,
+      ")"
+    ))
+  ) else WrongArgSmallInteger(2)
+  ) else WrongArgZZ(2)
+  ) else WrongArgSmallInteger(1)
+  ) else WrongArgZZ(1)
+  ) else WrongArg(0,"a raw mutable complex")
+  ) else WrongNumArgs(3)
+  ) else WrongNumArgs(3)
+  );
+setupfun("rawPruningMorphism",rawPruningMorphism);
+
+export rawLiftLocalMatrix(e:Expr):Expr := (                         -- clears denominators
+  when e is s:Sequence do (
+  if length(s) == 2 then (
+  when s.0 is R:RawRingCell do (
+  when s.1 is m:RawMatrixCell do (
+    toExpr(Ccode(RawMatrixOrNull,
+      "rawLiftLocalMatrix(",
+        R.p, ",", m.p,
+      ")"
+    ))
+  ) else WrongArg(2,"a raw matrix")
+  ) else WrongArg(1,"a raw ring")
+  ) else WrongNumArgs(2)
+  ) else WrongNumArgs(2)
+  );
+setupfun("rawLiftLocalMatrix", rawLiftLocalMatrix);
+
+export rawIsLocalUnit(e:Expr):Expr := (                             -- true for units in local rings
+  when e is f:RawRingElementCell do (
+    toExpr(Ccode(bool,
+      "rawIsLocalUnit(",
+        f.p,
+      ")"
+    ))
+  ) else WrongArg(1,"a raw ring element")
+  );
+setupfun("rawIsLocalUnit",rawIsLocalUnit);
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d interface.o "

--- a/M2/Macaulay2/d/parse.d
+++ b/M2/Macaulay2/d/parse.d
@@ -390,6 +390,7 @@ export Expr := (
      RawMonomialIdealCell or
      RawMonomialOrderingCell or
      RawMutableMatrixCell or
+     RawMutableComplexCell or
      -- NAG begin
      RawHomotopyCell or
      RawSLEvaluatorCell or

--- a/M2/Macaulay2/d/util.d
+++ b/M2/Macaulay2/d/util.d
@@ -170,6 +170,23 @@ export getSequenceOfMatrices(e:Expr) : RawMatrixArray := (
      is a:RawMatrixCell do RawMatrixArray(a.p)
      else RawMatrixArray());
 
+export isSequenceOfMutableMatrices(e:Expr) : bool := (
+     when e is s:Sequence do (
+	  foreach i in s do when i is RawMutableMatrixCell do nothing else return false;
+	  true)
+     is RawMutableMatrixCell do true
+     else false);
+export getSequenceOfMutableMatrices(e:Expr) : RawMutableMatrixArray := (
+     when e
+     is s:Sequence do (
+	  new RawMutableMatrixArray len length(s) do (
+	       foreach i in s do
+	       when i
+	       is a:RawMutableMatrixCell do provide a.p
+	       else anywhereAbort("internal error : getSequenceOfMutableMatrices")))
+     is a:RawMutableMatrixCell do RawMutableMatrixArray(a.p)
+     else RawMutableMatrixArray());
+
 -----------------------------------------------------------------------------
 -- helper routines for checking and converting return values
 
@@ -200,6 +217,7 @@ export toExpr(x:RawMonomial):Expr := Expr(RawMonomialCell(x));
 export toExpr(x:RawMonomialIdeal):Expr := Expr(RawMonomialIdealCell(x));
 export toExpr(x:RawMonomialOrdering):Expr := Expr(RawMonomialOrderingCell(x));
 export toExpr(x:RawMutableMatrix):Expr := Expr(RawMutableMatrixCell(x));
+export toExpr(x:RawMutableComplex):Expr := Expr(RawMutableComplexCell(x));
 -- NAG begin
 export toExpr(x:RawHomotopy):Expr := Expr(RawHomotopyCell(x));
 export toExpr(x:RawSLEvaluator):Expr := Expr(RawSLEvaluatorCell(x));
@@ -230,6 +248,7 @@ export toExpr(x:RawRingElementOrNull):Expr := when x is r:RawRingElement do Expr
 export toExpr(x:RawFreeModuleOrNull):Expr := when x is r:RawFreeModule do Expr(RawFreeModuleCell(r)) is null do engineErrorMessage();
 export toExpr(x:RawMatrixOrNull):Expr := when x is r:RawMatrix do Expr(RawMatrixCell(r)) is null do engineErrorMessage();
 export toExpr(x:RawMutableMatrixOrNull):Expr := when x is r:RawMutableMatrix do Expr(RawMutableMatrixCell(r)) is null do engineErrorMessage();
+export toExpr(x:RawMutableComplexOrNull):Expr := when x is r:RawMutableComplex do Expr(RawMutableComplexCell(r)) is null do engineErrorMessage();
 -- NAG begin
 export toExpr(x:RawHomotopyOrNull):Expr := when x is r:RawHomotopy do Expr(RawHomotopyCell(r)) is null do engineErrorMessage();
 export toExpr(x:RawSLEvaluatorOrNull):Expr := when x is r:RawSLEvaluator do Expr(RawSLEvaluatorCell(r)) is null do engineErrorMessage();
@@ -245,6 +264,8 @@ export toExpr(x:CCorNull):Expr := when x is i:CC do Expr(CCcell(i)) is null do e
 export toExpr(x:RawMatrixPairOrNull):Expr := when x is p:RawMatrixPair do seq(Expr(RawMatrixCell(p.a)),Expr(RawMatrixCell(p.b))) is null do engineErrorMessage();
 export toExpr(x:RawMatrixArray):Expr := Expr( list( new Sequence len length(x) do foreach m in x do provide Expr(RawMatrixCell(m)) ) );
 export toExpr(x:RawMatrixArrayOrNull):Expr := when x is r:RawMatrixArray do toExpr(r) is null do engineErrorMessage();
+export toExpr(x:RawMutableMatrixArray):Expr := Expr( list( new Sequence len length(x) do foreach m in x do provide Expr(RawMutableMatrixCell(m)) ) );
+export toExpr(x:RawMutableMatrixArrayOrNull):Expr := when x is r:RawMutableMatrixArray do toExpr(r) is null do engineErrorMessage();
 export toExpr(x:array(string)):Expr := Expr( list( new Sequence len length(x) do foreach s in x do provide Expr(stringCell(s)) ) );
 export toExpr(x:RawComputationOrNull):Expr := when x is r:RawComputation do Expr(RawComputationCell(r)) is null do engineErrorMessage();
 export toExpr(x:RawArrayPairOrNull):Expr := (

--- a/M2/Macaulay2/e/Makefile.files
+++ b/M2/Macaulay2/e/Makefile.files
@@ -11,6 +11,8 @@ INTERFACE2 = \
 	newdelete \
 
 INTERFACE = \
+	mutablecomplex \
+	localring \
 	f4/res-varpower-monomial \
 	f4/res-f4-monlookup \
 	f4/res-moninfo-dense \

--- a/M2/Macaulay2/e/engine.h
+++ b/M2/Macaulay2/e/engine.h
@@ -22,6 +22,7 @@ class RingElement;
 class RingMap;
 class Computation;
 class EngineComputation;
+class MutableComplex;
 // NAG begin
 class SLEvaluator;
 class Homotopy;
@@ -46,6 +47,7 @@ typedef struct Computation Computation;
 typedef struct EngineComputation EngineComputation;
 typedef struct MonomialOrdering MonomialOrdering;
 typedef struct MonomialIdeal MonomialIdeal;
+typedef struct MutableComplex MutableComplex;
 // NAG begin
 typedef struct SLEvaluator SLEvaluator;
 typedef struct Homotopy Homotopy;
@@ -296,7 +298,7 @@ extern "C" {
   const Ring /* or null */ *IM2_Ring_frac(const Ring *R); /* drg: connected rawFractionRing*/
 
   const Ring /* or null */ *IM2_Ring_localization(const Ring *R,
-                                          const Matrix *P); /* drg: connected rawLocalRing */
+                                          Computation *P); /* drg: connected rawLocalRing */
   /* Create the localization of R.
      R should be a COMMUTATIVE ring.  P should be a one row matrix
      whose entries generate a prime ideal of R.
@@ -1505,6 +1507,29 @@ extern "C" {
      and the multipliers tau_i will appear in R.
      MES TODO: be more specific here, once we know the exact format!
   */
+
+  /**************************************************/
+  /**** Mutable Complex routines ********************/
+  /**************************************************/
+
+  M2_string rawMutableComplexToString(const MutableComplex *M);
+
+  unsigned int  rawMutableComplexHash(const MutableComplex *M);
+
+  MutableComplex* rawMutableComplex(const engine_RawMutableMatrixArray M);
+
+  M2_arrayint rawPruneBetti(MutableComplex* C, int n, int f);
+
+  MutableComplex* rawPruneComplex(MutableComplex* C, int n, int f);
+
+  engine_RawMutableMatrixArray rawPruningMorphism(MutableComplex* C, int n, int f);
+
+  /**************************************************/
+  /**** Local Ring routines *************************/
+  /**************************************************/
+
+  Matrix * rawLiftLocalMatrix(const Ring * R, const Matrix *m);
+  M2_bool  rawIsLocalUnit(const RingElement *f);
 
   /**************************************************/
   /**** Monomial ideal routines *********************/

--- a/M2/Macaulay2/e/localring.cpp
+++ b/M2/Macaulay2/e/localring.cpp
@@ -1,0 +1,774 @@
+/* Copyright 2017 Mahrud Sayrafi and Michael E. Stillman
+   Mahrud Sayrafi's code in this file is in the public domain. */
+
+#include "text-io.hpp"
+#include "ringmap.hpp"
+#include "monoid.hpp"
+#include "gbring.hpp"
+#include "relem.hpp"
+#include "debug.hpp"
+#include "matrix.hpp"
+#include "matrix-con.hpp"
+#include "localring.hpp"
+#include "mutablecomplex.hpp"
+
+LocalRing *LocalRing::create(const PolyRing *R, GBComputation *P)
+{
+  LocalRing *result = new LocalRing;
+  result->initialize_local(R, P);
+  return result;
+}
+
+bool LocalRing::initialize_local(const PolyRing *R, GBComputation *P)
+{
+  initialize_ring(
+      R->characteristic(), R->get_degree_ring(), R->get_heft_vector());
+
+  mRing = R;
+  mPrime = P;
+
+  oneV = from_long(1);
+  zeroV = from_long(0);
+  minus_oneV = from_long(-1);
+
+  /*
+  if (R->n_quotients() > 0 ||
+      R->getCoefficients()
+          ->cast_to_LocalRing()  // disallowed in x-relem.cpp
+      ||
+      R->getMonoid()->getNonTermOrderVariables()->len >
+          0)  // disallowed in x-relem.cpp
+    use_gcd_simplify = false;
+  else
+    use_gcd_simplify = true;
+  */
+
+  return true;
+}
+
+local_elem *LocalRing::make_elem(ring_elem a, ring_elem b) const
+{
+  local_elem *result = new_local_elem();
+  result->numer = a;
+  result->denom = b;
+  simplify(result);
+  return result;
+}
+
+local_elem *LocalRing::new_local_elem() const { return newitem(local_elem); }
+
+bool LocalRing::is_in_prime(const ring_elem f) const
+{
+  MatrixConstructor mat(mRing->make_FreeModule(1), 1);
+  mat.set_entry(0, 0, f);
+  Matrix *M = mat.to_matrix();
+  bool res = (mPrime->contains(M) == -1);
+  delete M;
+  return res;
+}
+
+void LocalRing::simplify(local_elem *f) const
+{
+  ring_elem x, y;
+  if (use_gcd_simplify)
+    {
+      y = f->denom;
+      if (mRing->is_equal(y, mRing->one())) return;
+      x = f->numer;
+      const RingElement *a = RingElement::make_raw(mRing, x);
+      const RingElement *b = RingElement::make_raw(mRing, y);
+      const RingElement *c = rawGCDRingElement(a, b, NULL, false);
+
+#if 0
+      // Debugging code
+            buffer o;
+            o << newline;
+            o << "a = ";
+            a->text_out(o);
+            o << "  b = ";
+            b->text_out(o);
+            o << " gcd = ";
+            c->text_out(o);
+            o << newline;
+            emit(o.str());
+#endif
+      if (!mRing->is_equal(c->get_value(), mRing->one()))
+        {
+          f->numer = mRing->divide(f->numer, c->get_value());
+          f->denom = mRing->divide(f->denom, c->get_value());
+        }
+      // Now, let's take the content of the denominator, and divide the
+      // numerator
+      // and denominator by this value.
+      ring_elem ct = mRing->content(
+          f->denom, f->numer);  // result is in mRing->getCoefficients()
+
+#if 0
+            o.reset();
+            o << "f->numer = ";
+            mRing->elem_text_out(o,f->numer);
+            o << "  f->denom = ";
+            mRing->elem_text_out(o,f->denom);
+            o << " ass= ";
+            mRing->getCoefficients()->elem_text_out(o,ct);
+            o << newline;
+            emit(o.str());
+#endif
+
+      if (!mRing->getCoefficients()->is_equal(ct,
+                                              mRing->getCoefficients()->one()))
+        {
+          f->numer = mRing->divide_by_given_content(f->numer, ct);
+          f->denom = mRing->divide_by_given_content(f->denom, ct);
+        }
+    }
+  else
+    {
+      mRing->syzygy(f->numer, f->denom, x, y);
+      if (mRing->is_zero(x))
+        {
+          mRing->remove(x);
+          set_non_unit_frac(f->denom);
+          f->numer = mRing->zero();
+          f->denom = mRing->one();
+          return;
+        }
+      mRing->negate_to(y);
+      mRing->remove(f->numer);
+      mRing->remove(f->denom);
+      f->numer = y;
+      f->denom = x;
+    }
+}
+
+ring_elem LocalRing::set_non_unit_frac(ring_elem top) const
+{
+  // Sets the non unit to be top/1 (which flags an error)
+  // flags an error
+  // returns 0/1
+
+  std::cout << "set_non_unit_frac is called!" << std::endl;
+
+  local_elem *f = new_local_elem();
+  f->numer = top;
+  f->denom = mRing->one();
+  set_non_unit(ring_elem(f));
+  return zero();
+}
+
+Ring::CoefficientType LocalRing::coefficient_type() const
+{
+  const PolynomialRing *A = mRing->cast_to_PolynomialRing();
+  assert(A != 0);
+  const Ring *K = A->getCoefficientRing();
+  if (K->coefficient_type() == COEFF_ZZ) return COEFF_QQ;
+  return K->coefficient_type();
+}
+
+// TODO: extend to arbitrary multiplicative sets
+bool LocalRing::is_unit(const ring_elem f) const
+{
+  // TODO: make sure f is a local ring element
+  return (!is_in_prime(f.local_val->numer));
+}
+
+bool LocalRing::is_zero(const ring_elem f) const
+{
+  return (mRing->is_zero(f.local_val->numer));
+}
+
+bool LocalRing::is_equal(const ring_elem a, const ring_elem b) const
+{
+  local_elem *f = a.local_val;
+  local_elem *g = b.local_val;
+  if (mRing->is_equal(f->denom, g->denom))
+    {
+      return mRing->is_equal(f->numer, g->numer);
+    }
+  else
+    {
+      ring_elem h = subtract(a, b);
+      bool result = is_zero(h);
+      remove(h);
+      return result;
+    }
+}
+
+int LocalRing::compare_elems(const ring_elem a, const ring_elem b) const
+{
+  local_elem *f = a.local_val;
+  local_elem *g = b.local_val;
+  int cmp = mRing->compare_elems(f->numer, g->numer);
+  if (cmp != 0) return cmp;
+  return mRing->compare_elems(f->denom, g->denom);
+}
+
+ring_elem LocalRing::numerator(ring_elem f) const
+{
+  local_elem *g = f.local_val;
+  return mRing->copy(g->numer);
+}
+
+ring_elem LocalRing::denominator(ring_elem f) const
+{
+  local_elem *g = f.local_val;
+  return mRing->copy(g->denom);
+}
+
+ring_elem LocalRing::fraction(const ring_elem top, const ring_elem bottom) const
+{
+  return ring_elem(make_elem(mRing->copy(top), mRing->copy(bottom)));
+}
+
+// TODO: implement for MutableMatrix
+void LocalRing::lift_up(const Ring *R, const Matrix *m, Matrix *&result) const
+{
+  local_elem *f;
+  const RingElement *a, *b, *d;
+  MatrixConstructor mat(mRing->make_FreeModule(m->n_rows()), m->n_cols());
+  Matrix::column_iterator i(m), end(m);
+  for (int c = 0; c < m->n_cols(); c++)
+    {
+      // TODO: make this into a routine for vector LCM
+      a = RingElement::make_raw(mRing, mRing->from_long(1));
+      for (i = Matrix::column_iterator(m, c); i != end; ++i)
+        {
+          f = ((*i)->coeff).local_val;
+          b = RingElement::make_raw(mRing, f->denom);
+          d = rawGCDRingElement(a, b, NULL, false);
+#if 0 // FIXME: GCD(8,2)=1 apparently ...
+          drelem(a);
+          std::cout<<" ";
+          drelem(b);
+          std::cout<<" ";
+          drelem(d);
+          std::cout<<std::endl;
+#endif
+          d = *b / *d;
+          a = *a * *d;
+        }
+      for (i = Matrix::column_iterator(m, c); i != end; ++i)
+        {
+          f = ((*i)->coeff).local_val;
+          mat.set_entry(
+              (*i)->comp,
+              c,
+              mRing->mult(f->numer, mRing->divide(a->get_value(), f->denom)));
+        }
+    }
+  mat.compute_column_degrees();
+  result = mat.to_matrix();
+}
+
+bool LocalRing::lift(const Ring *Rg, const ring_elem f, ring_elem &result) const
+{
+  // Rg = R ---> frac R
+  // f is an element of frac R.
+
+  ring_elem
+      hdenom;  // used in the case when the denominator can be a unit, but not 1
+               // e.g. when this = frac (QQ[x,y,z]).  Is an element of
+  if (Rg == mRing)
+    {
+      local_elem *h = f.local_val;
+      if (mRing->is_equal(h->denom, mRing->one()))
+        {
+          result = mRing->copy(h->numer);
+          return true;
+        }
+      else
+        {
+          if (mRing->is_field())
+            {
+              // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+              // try to lift denominator.  If can, can lift, otherwise not.
+              if (mRing->lift(mRing, h->denom, hdenom))
+                {
+                  ring_elem hinv = mRing->invert(hdenom);
+                  result = mRing->mult(hinv, h->numer);
+                  return true;
+                }
+            }
+        }
+    }
+  return false;
+}
+
+bool LocalRing::promote(const Ring *Rf,
+                        const ring_elem f,
+                        ring_elem &result) const
+{
+  // Rf = R ---> frac R
+  if (Rf == mRing)
+    {
+      local_elem *g = new_local_elem();
+      g->numer = mRing->copy(f);
+      g->denom = mRing->from_long(1);
+      result = ring_elem(g);
+      return true;
+    }
+
+  return false;
+}
+
+bool LocalRing::from_rational(mpq_ptr n, ring_elem &result) const
+{
+  local_elem *f = new_local_elem();
+  f->numer = mRing->from_int(mpq_numref(n));
+  f->denom = mRing->from_int(mpq_denref(n));
+  bool ok = not mRing->is_zero(f->denom);
+  if (ok) result = ring_elem(f);
+  return ok;
+}
+
+ring_elem LocalRing::from_long(long n) const
+{
+  local_elem *f = new_local_elem();
+  f->numer = mRing->from_long(n);
+  f->denom = mRing->from_long(1);
+  return ring_elem(f);
+}
+
+ring_elem LocalRing::from_int(mpz_ptr n) const
+{
+  local_elem *f = new_local_elem();
+  f->numer = mRing->from_int(n);
+  f->denom = mRing->from_long(1);
+  return ring_elem(f);
+}
+
+ring_elem LocalRing::var(int v) const
+{
+  local_elem *f = new_local_elem();
+  f->numer = mRing->var(v);
+  f->denom = mRing->from_long(1);
+  return ring_elem(f);
+}
+
+int LocalRing::index_of_var(const ring_elem a) const
+{
+  const local_elem *f = a.local_val;
+  if (!mRing->is_unit(f->denom))
+    // If so, a cannot be a variable, otherwise, by 'simplify', f->denom == 1.
+    return -1;
+  return mRing->index_of_var(f->numer);
+}
+
+M2_arrayint LocalRing::support(const ring_elem a) const
+{
+  const local_elem *f = a.local_val;
+  M2_arrayint result1 = mRing->support(f->numer);
+  M2_arrayint result2 = mRing->support(f->denom);
+  M2_arrayint result = M2_makearrayint(result1->len + result2->len);
+  for (int i = 0; i < result1->len; i++) result->array[i] = result1->array[i];
+  for (int i = 0; i < result2->len; i++)
+    result->array[result1->len + i] = result2->array[i];
+  return result;
+}
+
+void LocalRing::lower_content(ring_elem &c, const ring_elem g) const
+{
+  if (!use_gcd_simplify) return;
+  if (is_zero(c))
+    {
+      c = g;
+      return;
+    }
+
+  local_elem *cf = c.local_val;
+  local_elem *gf = g.local_val;
+  const RingElement *c1 = RingElement::make_raw(mRing, cf->numer);
+  const RingElement *c2 = RingElement::make_raw(mRing, cf->denom);
+  const RingElement *g1 = RingElement::make_raw(mRing, gf->numer);
+  const RingElement *g2 = RingElement::make_raw(mRing, gf->denom);
+
+  c1 = rawGCDRingElement(c1, g1, NULL, false);
+
+  const RingElement *cc2 = rawGCDRingElement(c2, g2, NULL, false);
+  const RingElement *cc3 = (*c2) * (*g2);
+  const RingElement *cc4 = (*cc3) / (*cc2);
+
+  local_elem *result = new_local_elem();
+  result->numer = c1->get_value();
+  result->denom = cc4->get_value();
+
+  c = ring_elem(result);
+}
+
+bool LocalRing::is_homogeneous(const ring_elem a) const
+{
+  if (is_zero(a)) return true;
+  const local_elem *f = a.local_val;
+  if (!mRing->is_homogeneous(f->numer) || !mRing->is_homogeneous(f->denom))
+    return false;
+  return true;
+}
+
+void LocalRing::degree(const ring_elem a, int *d) const
+{
+  const local_elem *f = a.local_val;
+  mRing->degree(f->numer, d);
+  int *e = degree_monoid()->make_one();
+  mRing->degree(f->denom, e);
+  degree_monoid()->divide(d, e, d);
+  degree_monoid()->remove(e);
+}
+
+bool LocalRing::multi_degree(const ring_elem a, int *d) const
+{
+  const local_elem *f = a.local_val;
+  bool tophom = mRing->multi_degree(f->numer, d);
+  int *e = degree_monoid()->make_one();
+  bool bottomhom = mRing->multi_degree(f->denom, e);
+  degree_monoid()->divide(d, e, d);
+  degree_monoid()->remove(e);
+  return tophom && bottomhom;
+}
+
+void LocalRing::degree_weights(const ring_elem,
+                               M2_arrayint,
+                               int &lo,
+                               int &hi) const
+{
+  assert(0);
+  // MES: what should this do?
+  lo = hi = 0;
+}
+
+ring_elem LocalRing::homogenize(const ring_elem a,
+                                int v,
+                                int deg,
+                                M2_arrayint wts) const
+{
+  int d1, d2, lo1, lo2;
+  ring_elem top, bottom;
+  const local_elem *f = a.local_val;
+  mRing->degree_weights(f->numer, wts, lo1, d1);
+  mRing->degree_weights(f->denom, wts, lo2, d2);
+  if (deg >= d1 - d2)
+    {
+      top = mRing->homogenize(f->numer, v, deg + d2, wts);
+      bottom = mRing->homogenize(f->denom, v, d2, wts);
+    }
+  else
+    {
+      top = mRing->homogenize(f->numer, v, d1, wts);
+      bottom = mRing->homogenize(f->denom, v, -deg + d1, wts);
+    }
+  local_elem *result = make_elem(top, bottom);
+  return ring_elem(result);
+}
+
+ring_elem LocalRing::homogenize(const ring_elem a, int v, M2_arrayint wts) const
+{
+  const local_elem *f = a.local_val;
+  ring_elem top = mRing->homogenize(f->numer, v, wts);
+  ring_elem bottom = mRing->homogenize(f->denom, v, wts);
+  local_elem *result = make_elem(top, bottom);
+  return ring_elem(result);
+}
+
+ring_elem LocalRing::copy(const ring_elem a) const
+{
+  local_elem *f = a.local_val;
+  local_elem *g = new_local_elem();
+  g->numer = mRing->copy(f->numer);
+  g->denom = mRing->copy(f->denom);
+  return ring_elem(g);
+}
+
+void LocalRing::remove(ring_elem &a) const {}
+
+ring_elem LocalRing::negate(const ring_elem a) const
+{
+  const local_elem *f = a.local_val;
+  local_elem *result = new_local_elem();
+  result->numer = mRing->negate(f->numer);
+  result->denom = mRing->copy(f->denom);
+  return ring_elem(result);
+}
+
+ring_elem LocalRing::add(const ring_elem a, const ring_elem b) const
+{
+  const local_elem *f = a.local_val;
+  const local_elem *g = b.local_val;
+  ring_elem top, bottom;
+
+  if (mRing->is_equal(f->denom, g->denom))
+    {
+      top = mRing->add(f->numer, g->numer);
+      bottom = mRing->copy(f->denom);
+    }
+  else
+    {
+      top = mRing->mult(f->numer, g->denom);
+      ring_elem tmp = mRing->mult(f->denom, g->numer);
+      mRing->add_to(top, tmp);
+      bottom = mRing->mult(f->denom, g->denom);
+      if (mRing->is_zero(bottom)) return set_non_unit_frac(f->denom);
+    }
+  local_elem *result = make_elem(top, bottom);
+  return ring_elem(result);
+}
+
+ring_elem LocalRing::subtract(const ring_elem a, const ring_elem b) const
+{
+  const local_elem *f = a.local_val;
+  const local_elem *g = b.local_val;
+  ring_elem top, bottom;
+
+  if (mRing->is_equal(f->denom, g->denom))
+    {
+      top = mRing->subtract(f->numer, g->numer);
+      bottom = mRing->copy(f->denom);
+    }
+  else
+    {
+      top = mRing->mult(f->numer, g->denom);
+      ring_elem tmp = mRing->mult(f->denom, g->numer);
+      mRing->subtract_to(top, tmp);
+      bottom = mRing->mult(f->denom, g->denom);
+      if (mRing->is_zero(bottom)) return set_non_unit_frac(f->denom);
+    }
+  local_elem *result = make_elem(top, bottom);
+  return ring_elem(result);
+}
+
+ring_elem LocalRing::mult(const ring_elem a, const ring_elem b) const
+{
+  local_elem *f = a.local_val;
+  local_elem *g = b.local_val;
+  ring_elem top = mRing->mult(f->numer, g->numer);
+  ring_elem bottom = mRing->mult(f->denom, g->denom);
+  if (mRing->is_zero(bottom)) return set_non_unit_frac(f->denom);
+  return ring_elem(make_elem(top, bottom));
+}
+
+ring_elem LocalRing::power(const ring_elem a, int n) const
+{
+  local_elem *f = a.local_val;
+  ring_elem top, bottom;
+  if (n >= 0)
+    {
+      top = mRing->power(f->numer, n);
+      bottom = mRing->power(f->denom, n);
+
+      if (mRing->is_zero(bottom)) return set_non_unit_frac(f->denom);
+    }
+  else
+    {
+      if (is_unit(a))
+        {
+          top = mRing->power(f->denom, -n);
+          bottom = mRing->power(f->numer, -n);
+        }
+      else
+        {
+          ERROR("attempt to divide by non-unit");
+          return zero();
+        }
+
+      if (mRing->is_zero(bottom)) return set_non_unit_frac(f->numer);
+    }
+  return ring_elem(make_elem(top, bottom));
+}
+ring_elem LocalRing::power(const ring_elem a, mpz_t n) const
+{
+  local_elem *f = a.local_val;
+  ring_elem top, bottom;
+  if (mpz_sgn(n) >= 0)
+    {
+      top = mRing->power(f->numer, n);
+      bottom = mRing->power(f->denom, n);
+
+      if (mRing->is_zero(bottom)) return set_non_unit_frac(f->denom);
+    }
+  else
+    {
+      mpz_neg(n, n);
+      if (is_unit(a))
+        {
+          top = mRing->power(f->denom, n);
+          bottom = mRing->power(f->numer, n);
+        }
+      else
+        {
+          ERROR("attempt to divide by non-unit");
+          return zero();
+        }
+      mpz_neg(n, n);
+
+      if (mRing->is_zero(bottom)) return set_non_unit_frac(f->numer);
+    }
+  return ring_elem(make_elem(top, bottom));
+}
+
+ring_elem LocalRing::invert(const ring_elem a) const
+{
+  local_elem *f = a.local_val;
+  if (mRing->is_zero(f->numer) || !is_unit(a))
+    {
+      ERROR("attempt to invert a non-unit");
+      return zero();
+    }
+  ring_elem top = mRing->copy(f->denom);
+  ring_elem bottom = mRing->copy(f->numer);
+  return ring_elem(make_elem(top, bottom));
+}
+
+ring_elem LocalRing::divide(const ring_elem a, const ring_elem b) const
+{
+  local_elem *f = a.local_val;
+  local_elem *g = b.local_val;
+  ring_elem top, bottom;
+  if (is_unit(b))
+    {
+      top = mRing->mult(f->numer, g->denom);
+      bottom = mRing->mult(f->denom, g->numer);
+    }
+  else
+    {
+      ERROR("attempt to divide by non-unit");
+      return zero();
+    }
+  return ring_elem(make_elem(top, bottom));
+}
+
+void LocalRing::syzygy(const ring_elem a,
+                       const ring_elem b,
+                       ring_elem &x,
+                       ring_elem &y) const
+{
+  x = LocalRing::from_long(1);
+  y = LocalRing::divide(a, b);
+  y = LocalRing::negate(y);
+}
+
+ring_elem LocalRing::random() const
+{
+  ring_elem a = mRing->random();
+  ring_elem b = mRing->random();
+  if (mRing->is_zero(b))
+    {
+      mRing->remove(b);
+      b = mRing->from_long(1);
+    }
+  return ring_elem(make_elem(a, b));
+}
+
+ring_elem LocalRing::eval(const RingMap *map,
+                          const ring_elem a,
+                          int first_var) const
+{
+  ring_elem top, bottom, result;
+  const Ring *S = map->get_ring();
+  const local_elem *f = a.local_val;
+  top = mRing->eval(map, f->numer, first_var);
+  if (S->is_zero(top)) return top;
+  bottom = mRing->eval(map, f->denom, first_var);
+  if (S->is_unit(bottom))
+    result = S->divide(top, bottom);
+  else
+    {
+      if (not error())  // FIXME: keep this?
+        ERROR("attempt to divide by non-unit");
+      result = S->from_long(0);
+    }
+  S->remove(top);
+  S->remove(bottom);
+  return result;
+}
+
+int LocalRing::n_fraction_vars() const { return mRing->n_vars(); }
+int LocalRing::n_terms(const ring_elem a) const
+{
+  return mRing->n_terms(a.local_val->numer);
+}
+ring_elem LocalRing::term(const ring_elem a, const int *) const
+{
+  return copy(a);
+}
+ring_elem LocalRing::lead_coeff(const ring_elem f) const { return f; }
+ring_elem LocalRing::get_coeff(const ring_elem f, const int *) const
+{
+  return f;
+}
+ring_elem LocalRing::get_terms(int nvars0, const ring_elem f, int, int) const
+{
+  return f;
+}
+
+void LocalRing::text_out(buffer &o) const
+{
+  o << "LocalRing(";
+  mRing->text_out(o);
+  o << ", Prime ideal => ";
+  mPrime->get_mingens()->text_out(o);
+  o << ")";
+}
+
+void LocalRing::elem_text_out(buffer &o,
+                              const ring_elem a,
+                              bool p_one,
+                              bool p_plus,
+                              bool p_parens) const
+{
+  local_elem *f = a.local_val;
+  int denom_one = mRing->is_equal(f->denom, mRing->one());
+
+  p_one = p_one || !denom_one;
+  p_parens = p_parens || !denom_one;
+  mRing->elem_text_out(o, f->numer, p_one, p_plus, p_parens);
+  if (!denom_one)
+    {
+      o << "/";
+      p_plus = false;
+      mRing->elem_text_out(o, f->denom, p_one, p_plus, p_parens);
+    }
+}
+
+unsigned int LocalRing::computeHashValue(const ring_elem f) const
+{
+  local_elem *g = f.local_val;
+  return (16473 * mRing->computeHashValue(g->numer) +
+          7698908 * mRing->computeHashValue(g->denom));
+}
+
+/********************************************************************************/
+/*                               Global functions */
+/********************************************************************************/
+
+Matrix *rawLiftLocalMatrix(const Ring *R, const Matrix *f)
+{
+  const LocalRing *L = f->get_ring()->cast_to_LocalRing();
+  if (L == 0)
+    {
+      ERROR("expected an object over a local ring");
+      return nullptr;
+    }
+  // TODO: Check that f is over a localization of R
+  if (R != L->get_ring())
+    {
+      ERROR("expected an object over a localization of the first argument");
+      return nullptr;
+    }
+  Matrix *result;
+  L->lift_up(R, f, result);
+  return result;
+}
+
+M2_bool rawIsLocalUnit(const RingElement *f)
+{
+  const LocalRing *L = f->get_ring()->cast_to_LocalRing();
+  if (L == 0)
+    {
+      ERROR("expected an object over a local ring");
+      return false;
+    }
+  return L->is_unit(f->get_value());
+}
+
+// Local Variables:
+// compile-command: "make -C $M2BUILDDIR/Macaulay2/e "
+// indent-tabs-mode: nil
+// End:

--- a/M2/Macaulay2/e/localring.hpp
+++ b/M2/Macaulay2/e/localring.hpp
@@ -1,0 +1,136 @@
+/* Copyright 2017 Mahrud Sayrafi and Michael E. Stillman
+   Mahrud Sayrafi's code in this file is in the public domain. */
+
+#ifndef _localring_hh_
+#define _localring_hh_
+
+#include "ring.hpp"
+#include "poly.hpp"
+#include "polyring.hpp"
+#include "comp-gb.hpp"
+
+struct local_elem
+{
+  ring_elem numer;
+  ring_elem denom;
+};
+
+class LocalRing : public Ring
+{
+ private:
+  const PolyRing *mRing;
+  GBComputation *mPrime;
+
+  LocalRing() {}
+  virtual ~LocalRing() {}
+
+  bool initialize_local(const PolyRing *R, GBComputation *P);
+  local_elem *make_elem(ring_elem a, ring_elem b) const;
+  local_elem *new_local_elem() const;
+
+  bool is_in_prime(const ring_elem f) const;
+  void simplify(local_elem *f) const;
+
+  // FIXME remove:
+  bool use_gcd_simplify = true;
+  ring_elem set_non_unit_frac(ring_elem top) const;
+
+ public:
+  LocalRing *cast_to_LocalRing() { return this; }
+  const LocalRing *cast_to_LocalRing() const { return this; }
+
+  const PolyRing *get_ring() const { return mRing; }
+  unsigned long get_precision() const { return mRing->get_precision(); }
+
+  virtual bool is_local_ring() const { return true; }
+  virtual bool is_graded() const { return mRing->is_graded(); }
+  virtual CoefficientType coefficient_type() const;
+
+  static LocalRing *create(const PolyRing *R, GBComputation *P);
+
+  virtual bool is_unit(const ring_elem f) const;
+  virtual bool is_zero(const ring_elem f) const;
+  virtual bool is_equal(const ring_elem f, const ring_elem g) const;
+  virtual int compare_elems(const ring_elem f, const ring_elem g) const;
+
+  ring_elem numerator(ring_elem f) const;
+  ring_elem denominator(ring_elem f) const;
+  ring_elem fraction(const ring_elem top, const ring_elem bottom) const;
+
+  virtual void lift_up(const Ring *R, const Matrix *m, Matrix *&result) const;
+  virtual bool lift(const Ring *R, const ring_elem f, ring_elem &result) const;
+  virtual bool promote(const Ring *R,
+                       const ring_elem f,
+                       ring_elem &result) const;
+
+  virtual bool from_rational(mpq_ptr n, ring_elem &result) const;
+  virtual ring_elem from_long(long n) const;
+  virtual ring_elem from_int(mpz_ptr n) const;
+  virtual ring_elem var(int v) const;
+
+  virtual int index_of_var(const ring_elem a) const;
+  virtual M2_arrayint support(const ring_elem a) const;
+
+  void lower_content(ring_elem &c, const ring_elem g) const;
+
+  virtual bool is_homogeneous(const ring_elem f) const;
+  virtual void degree(const ring_elem f, int *d) const;
+  virtual bool multi_degree(const ring_elem f, int *d) const;
+  virtual void degree_weights(const ring_elem f,
+                              M2_arrayint wts,
+                              int &lo,
+                              int &hi) const;
+  virtual ring_elem homogenize(const ring_elem f,
+                               int v,
+                               int deg,
+                               M2_arrayint wts) const;
+  virtual ring_elem homogenize(const ring_elem f, int v, M2_arrayint wts) const;
+
+  virtual ring_elem copy(const ring_elem f) const;
+  virtual void remove(ring_elem &f) const;
+
+  virtual ring_elem negate(const ring_elem f) const;
+  virtual ring_elem add(const ring_elem f, const ring_elem g) const;
+  virtual ring_elem subtract(const ring_elem f, const ring_elem g) const;
+  virtual ring_elem mult(const ring_elem f, const ring_elem g) const;
+  virtual ring_elem power(const ring_elem f, mpz_t n) const;
+  virtual ring_elem power(const ring_elem f, int n) const;
+  virtual ring_elem invert(const ring_elem f) const;
+  virtual ring_elem divide(const ring_elem f, const ring_elem g) const;
+
+  virtual void syzygy(const ring_elem a,
+                      const ring_elem b,
+                      ring_elem &x,
+                      ring_elem &y) const;
+
+  virtual ring_elem random() const;
+
+  virtual ring_elem eval(const RingMap *map,
+                         const ring_elem f,
+                         int first_var) const;
+
+  virtual int n_fraction_vars() const;  // FIXME
+  virtual int n_terms(const ring_elem f) const;
+  virtual ring_elem term(const ring_elem a, const int *m) const;
+  virtual ring_elem lead_coeff(const ring_elem f) const;
+  virtual ring_elem get_coeff(const ring_elem f, const int *m) const;
+  virtual ring_elem get_terms(int nvars0,
+                              const ring_elem f,
+                              int lo,
+                              int hi) const;
+
+  virtual void text_out(buffer &o) const;
+  virtual void elem_text_out(buffer &o,
+                             const ring_elem f,
+                             bool p_one = true,
+                             bool p_plus = false,
+                             bool p_parens = false) const;
+  virtual unsigned int computeHashValue(const ring_elem a) const;
+};
+
+#endif
+
+// Local Variables:
+// compile-command: "make -C $M2BUILDDIR/Macaulay2/e "
+// indent-tabs-mode: nil
+// End:

--- a/M2/Macaulay2/e/matrix.hpp
+++ b/M2/Macaulay2/e/matrix.hpp
@@ -255,6 +255,18 @@ class Matrix : public EngineObject
     int row() { return v->comp; }
     ring_elem entry() { return v->coeff; }
   };
+
+  class column_iterator
+  {
+    const vecterm * v;
+  public:
+    column_iterator(const Matrix *M, int c) : v(M->elem(c)) {}
+    column_iterator(const Matrix *M) : v(nullptr) {}
+
+    column_iterator& operator++() { v = v->next; return *this; }
+    const vecterm* operator *() { return v; }
+    bool operator!=(const column_iterator b) { return v != b.v; }
+  };
 };
 
 #endif

--- a/M2/Macaulay2/e/mutablecomplex.cpp
+++ b/M2/Macaulay2/e/mutablecomplex.cpp
@@ -1,0 +1,297 @@
+/* Copyright 2017 Mahrud Sayrafi and Michael E. Stillman
+   Mahrud Sayrafi's code in this file is in the public domain. */
+
+#include "mutablecomplex.hpp"
+#include "engine-includes.hpp"
+#include "debug.hpp"
+#include "ring.hpp"
+#include "polyring.hpp"
+#include <utility>
+#include <iostream>
+#include <algorithm>
+
+// TODO: make enums class
+#define FLAG_TRACE_MORPHISMS 1  // See `help pruningMap` in M2
+#define FLAG_TRIM_COMPLEX 2     // Delete pruned rows and columns
+#define FLAG_PRUNE_PMONE 4      // Only prune -1,+1
+#define FLAG_PRUNE_SCALARS 8    // Only prune constants
+#define FLAG_PRUNE_ORIGIN 16    // Only prune functions with constants
+#define FLAG_PRUNE_MAXIMAL 32   // Pruning for maximal ideal
+#define FLAG_PRUNE_PRIME 64     // Pruning for prime ideal
+#define FLAG_BEST_UNIT 1024     // Prune sparsest unit first
+#define FLAG_BEST_MATRIX 2048   // Prune best matrix first
+#define FLAG_REV_ORDER 65536    // Prune the matrices in reverse order
+
+size_t MutableComplex::complexity(const iterator &i, const size_t flags) const
+// Heuristics
+// TODO: save row/column totals in a separate vector and only update when
+// pruning a unit
+{
+  ring_elem e;
+  const size_t n = i.index();
+  const std::pair<size_t, size_t> u = *i;
+  mDifferential[n]->get_entry(u.first, u.second, e);
+  // Count terms in the column
+  int s = 0;
+  if (mLocalRing == 0)
+    s = mPolynomialRing->n_terms(e);
+  else
+    s = mLocalRing->n_terms(e);
+  for (size_t r = 0; r < mBetti[n]; ++r)
+    {
+      if (r == u.first) continue;
+      mDifferential[n]->get_entry(r, u.second, e);
+      if (mRing->is_zero(e)) continue;
+      if (mLocalRing == 0)
+        s += mPolynomialRing->n_terms(e);
+      else
+        s += mLocalRing->n_terms(e);
+    }
+  // Count terms in the row
+  for (size_t c = 0; c < mBetti[n + 1]; ++c)
+    {
+      if (c == u.second) continue;
+      mDifferential[n]->get_entry(u.first, c, e);
+      if (mRing->is_zero(e)) continue;
+      if (mLocalRing == 0)
+        s += mPolynomialRing->n_terms(e);
+      else
+        s += mLocalRing->n_terms(e);
+    }
+  // std::cout<<s<<std::endl;
+  // Local case: (size numerator elt) * (row/numerator/size//sum) *
+  // (col/numerator/size//sum)
+  return static_cast<size_t>(s);
+}
+
+bool MutableComplex::next_unit(iterator &i, const size_t flags) const
+{
+  ring_elem e;
+  for (; i < i.end(); ++i)
+    {
+      mDifferential[i.index()]->get_entry((*i).first, (*i).second, e);
+      if (mRing->is_unit(e)) return true;
+    }
+  return false;
+}
+
+bool MutableComplex::find_unit(iterator &i, const size_t flags) const
+{
+  if (!(flags & FLAG_BEST_UNIT)) return next_unit(i, flags);
+
+  iterator j(*this, i.index());
+  if (!next_unit(j, flags)) return false;
+  size_t t = -1, s = complexity(j, flags);
+  while (next_unit(j, flags))
+    {
+      s = complexity(j, flags);
+      if (s < t)
+        {
+          t = s;
+          *i = *j;
+        }
+      ++j;
+    }
+  return true;
+}
+
+// bool MutableComplex::unit_cmp(const iterator &a, const iterator &b);
+
+std::vector<MutableComplex::iterator> MutableComplex::list_units(
+    size_t n,
+    const size_t flags) const
+{
+  iterator i(*this, n);
+  std::vector<iterator> units;
+  while (next_unit(i, flags))
+    {
+      units.push_back(i);
+      ++i;
+    }
+  // sort units here?
+  // std::sort(units.begin(), units.end(), unit_cmp());
+  return units;
+}
+
+void MutableComplex::prune_unit(const iterator &i, const size_t flags)
+{
+  const size_t n = i.index();
+  const std::pair<size_t, size_t> u = *i;
+  const bool trace = flags & FLAG_TRACE_MORPHISMS;
+  /* There is some redundancy here, can set some stuff to zero.
+     TODO: Maybe check to see which is more efficient?
+           Compare with using rawReduceByPivot
+  */
+  // Move to last row
+  mDifferential[n]->interchange_rows(u.first, mBetti[n] - 1);
+  if (0 < n) mDifferential[n - 1]->interchange_columns(u.first, mBetti[n] - 1);
+  if (trace) mMorphisms[n]->interchange_columns(u.first, mBetti[n] - 1);
+  // Move to last column
+  mDifferential[n]->interchange_columns(u.second, mBetti[n + 1] - 1);
+  if (n < mDifferential.size() - 1)
+    mDifferential[n + 1]->interchange_rows(u.second, mBetti[n + 1] - 1);
+  if (trace)
+    mMorphisms[n + 1]->interchange_columns(u.second, mBetti[n + 1] - 1);
+  // Get the pivot
+  ring_elem p, q, f;
+  mDifferential[n]->get_entry(mBetti[n] - 1, mBetti[n + 1] - 1, p);
+  p = mRing->invert(p);
+  q = mRing->negate(p);
+  // Clear the column
+  for (size_t r = 0; r < mBetti[n] - 1; ++r)
+    {
+      mDifferential[n]->get_entry(r, mBetti[n + 1] - 1, f);
+      mDifferential[n]->row_op(r, mRing->mult(f, q), mBetti[n] - 1);
+      if (0 < n)
+        mDifferential[n - 1]->column_op(mBetti[n] - 1, mRing->mult(f, p), r);
+      if (trace) mMorphisms[n]->column_op(mBetti[n] - 1, mRing->mult(f, p), r);
+    }
+  // Clear the row
+  for (size_t c = 0; c < mBetti[n + 1] - 1; ++c)
+    {
+      mDifferential[n]->get_entry(mBetti[n] - 1, c, f);
+      mDifferential[n]->column_op(c, mRing->mult(f, q), mBetti[n + 1] - 1);
+      if (n < mDifferential.size() - 1)
+        mDifferential[n + 1]->row_op(mBetti[n + 1] - 1, mRing->mult(f, p), c);
+      if (trace)
+        mMorphisms[n + 1]->column_op(c, mRing->mult(f, q), mBetti[n + 1] - 1);
+    }
+  --mBetti[n];
+  --mBetti[n + 1];
+}
+
+// Prunes a single matrix by reducing the units
+void MutableComplex::prune_matrix(size_t n, size_t flags)
+{
+  iterator i(*this, n);
+  while (find_unit(i, flags))
+    {
+      prune_unit(i, flags);
+      *i = *iterator(*this, n);
+    }
+}
+
+void MutableComplex::prune_complex(size_t nsteps, size_t flags)
+{
+  // Initialize pruning maps
+  const bool dense = mDifferential[0]->is_dense();
+  if (flags & FLAG_TRACE_MORPHISMS)
+    for (size_t n = 0; n < mDifferential.size() + 1; ++n)
+      mMorphisms.push_back(MutableMatrix::identity(mRing, mBetti[n], dense));
+  for (size_t n = 0; n < mDifferential.size() && n < nsteps; n++)
+    {
+      if (flags & FLAG_REV_ORDER)
+        prune_matrix(mDifferential.size() - n - 1, flags);
+      else
+        prune_matrix(n, flags);
+    }
+}
+
+std::vector<size_t> MutableComplex::prune_betti(size_t nsteps, size_t flags)
+{
+  /* TODO:
+   * separate all units into a square matrix (efficiently?)
+   * start with the ones in sparcest row/column.
+   */
+  //  prune_complex(nsteps, flags);
+  return mBetti;
+}
+
+VECTOR(MutableMatrix *)
+MutableComplex::prune_morphisms(size_t nsteps, size_t flags)
+{
+  for (size_t n = 0; n < mMorphisms.size(); ++n)
+    if (flags & FLAG_TRACE_MORPHISMS)
+      if (mBetti[n] < mMorphisms[n]->n_cols())
+        mMorphisms[n]->delete_columns(mBetti[n], mMorphisms[n]->n_cols() - 1);
+  return mMorphisms;
+}
+
+/*
+MutableComplex* MutableComplex::trim_complex(size_t nsteps, size_t flags)
+{
+  M2_arrayint rows, cols;
+  VECTOR(MutableMatrix *) D;
+  for(size_t n = 0; n < mDifferential.size(); n++)
+    {
+      rows = M2_makearrayint(mBetti[n]);
+      for(int i = 0; i < mBetti[n]; ++i) rows->array[i] = i;
+      cols = M2_makearrayint(mBetti[n+1]);
+      for(int i = 0; i < mBetti[n+1]; ++i) cols->array[i] = i;
+
+      D.push_back(mDifferential[n]->submatrix(rows, cols));
+    }
+  // FIXME how to access the matrices?
+  return new MutableComplex(D);
+}
+*/
+
+void MutableComplex::text_out(buffer &o) const
+{
+  for (size_t i = 0; i < mDifferential.size(); i++) o << mBetti[i] << " <-- ";
+  o << mBetti[mDifferential.size()];
+
+  // auto C = const_cast <MutableComplex *> (this);
+}
+
+/********************************************************************************/
+/*                               Global functions */
+/********************************************************************************/
+
+engine_RawMutableMatrixArray rawPruningMorphism(MutableComplex *C, int n, int f)
+{
+  size_t nsteps = static_cast<size_t>(n), flags = static_cast<size_t>(f);
+  //  std::min(static_cast<int>(C->mMorphisms.size()),
+  //  static_cast<int>(nsteps));
+  VECTOR(MutableMatrix *) M = C->prune_morphisms(nsteps, flags);
+  int N = static_cast<int>(M.size());
+  engine_RawMutableMatrixArray A =
+      getmemarraytype(engine_RawMutableMatrixArray, N);
+  A->len = N;
+  for (int i = 0; i < N; ++i) A->array[i] = M[i];
+  return A;
+}
+
+M2_arrayint rawPruneBetti(MutableComplex *C, int n, int f)
+{
+  size_t nsteps = static_cast<size_t>(n), flags = static_cast<size_t>(f);
+  std::vector<size_t> betti = C->prune_betti(nsteps, flags);
+  //  std::min(static_cast<int>(betti.size()), static_cast<int>(nsteps));
+  int N = static_cast<int>(betti.size());
+  M2_arrayint B = M2_makearrayint(N);
+  for (int i = 0; i < N; ++i) B->array[i] = static_cast<int>(betti[i]);
+  return B;
+}
+
+MutableComplex *rawPruneComplex(MutableComplex *C, int n, int f)
+{
+  size_t nsteps = static_cast<size_t>(n), flags = static_cast<size_t>(f);
+  C->prune_complex(nsteps, flags);
+  //  if (flags & FLAG_TRIM_COMPLEX)
+  //    C = C->trim_complex(nsteps, flags);
+  return C;
+}
+
+MutableComplex *rawMutableComplex(const engine_RawMutableMatrixArray M)
+{
+  VECTOR(MutableMatrix *) D;
+  for (int i = 0; i < M->len; ++i) D.push_back(M->array[i]);
+  return new MutableComplex(D);
+}
+
+M2_string rawMutableComplexToString(const MutableComplex *M)
+{
+  buffer o;
+  M->text_out(o);
+  return o.to_string();
+}
+
+unsigned int rawMutableComplexHash(const MutableComplex *M)
+{
+  return M->hash();
+}
+
+// Local Variables:
+// compile-command: "make -C $M2BUILDDIR/Macaulay2/e "
+// indent-tabs-mode: nil
+// End:

--- a/M2/Macaulay2/e/mutablecomplex.hpp
+++ b/M2/Macaulay2/e/mutablecomplex.hpp
@@ -1,0 +1,122 @@
+/* Copyright 2017 Mahrud Sayrafi and Michael E. Stillman
+   Mahrud Sayrafi's code in this file is in the public domain. */
+
+#ifndef _mutablecomplex_hpp_
+#define _mutablecomplex_hpp_
+
+#include "localring.hpp"
+#include "style.hpp"
+#include "hash.hpp"
+#include "mat.hpp"
+#include "debug.hpp"
+#include <iostream>
+
+// TODO how to seamlessly use sparse or dense mutable matrices?
+// template <typename MutableMatrix>
+class MutableComplex : public MutableEngineObject
+{
+ public:
+  MutableComplex() {}
+  MutableComplex(VECTOR(MutableMatrix *) & D)
+      : mRing(D[0]->get_ring()),
+        mLocalRing(mRing->cast_to_LocalRing()),
+        mPolynomialRing(mLocalRing == 0 ? mRing->cast_to_PolynomialRing()
+                                        : mLocalRing->get_ring()),
+        mDifferential(D)
+  {
+#if 0
+    if (mLocalRing != 0)
+      std::cout << "Got a mutable complex over a local ring." << std::endl;
+    if (mPolynomialRing == 0)
+      std::cout << "Not a polynomial ring or local ring." << std::endl;
+#endif
+    for (size_t i = 0; i < D.size(); ++i) mBetti.push_back(D[i]->n_rows());
+    mBetti.push_back(D[D.size() - 1]->n_cols());
+    // TODO: Check to make sure mBetti's are compatible, or define isWellDefined
+  }
+  virtual ~MutableComplex() {}  // destructor
+
+  class iterator;
+
+  size_t complexity(const iterator &i, const size_t flags) const;
+  bool next_unit(iterator &i, const size_t flags) const;
+  bool find_unit(iterator &i, const size_t flags) const;
+  // TODO improve list_units to move all units in a square
+  std::vector<iterator> list_units(size_t n, const size_t flags) const;
+
+  void prune_unit(const iterator &i, const size_t flags);
+  void prune_matrix(size_t n, const size_t flags);
+  void prune_complex(const size_t nsteps, const size_t flags);
+  std::vector<size_t> prune_betti(const size_t nsteps, const size_t flags);
+  VECTOR(MutableMatrix *)
+  prune_morphisms(const size_t nsteps, const size_t flags);
+  //  MutableComplex* trim_complex(const size_t nsteps, const size_t flags)
+
+  class iterator
+  {
+   public:
+    iterator(const MutableComplex &C,
+             const size_t n,
+             std::pair<size_t, size_t> m)
+        : mComplex(C), mIndex(n), mAddr(m)
+    {
+    }
+    iterator(const MutableComplex &C, const size_t n)
+        : mComplex(C), mIndex(n), mAddr(std::pair<size_t, size_t>(0, 0))
+    {
+    }
+    iterator(const iterator &i, std::pair<size_t, size_t> m)
+        : mComplex(i.mComplex), mIndex(i.mIndex), mAddr(m)
+    {
+    }
+
+    size_t index() const { return mIndex; }
+
+    std::pair<size_t, size_t> &operator*() { return mAddr; }
+    const std::pair<size_t, size_t> &operator*() const { return mAddr; }
+
+    iterator &operator++()
+    {
+      ++mAddr.second;
+      if (mAddr.second >= mComplex.mBetti[mIndex + 1])
+        {
+          ++mAddr.first;
+          mAddr.second = 0;
+        }
+      return *this;
+    }
+    // TODO: define != instead
+    bool operator<(const iterator &o) const
+    {
+      return mIndex < o.mIndex || mAddr < o.mAddr;
+    }
+    iterator end() const
+    {
+      return iterator(*this,
+                      std::pair<size_t, size_t>(mComplex.mBetti[mIndex], 0));
+    }
+
+   private:
+    const MutableComplex &mComplex;
+    const size_t mIndex;
+    std::pair<size_t, size_t> mAddr;
+  };
+
+  void text_out(buffer &o) const;
+
+ private:
+  const Ring *mRing;
+  const LocalRing *mLocalRing;
+  const PolynomialRing *mPolynomialRing;  // FIXME change to PolyRing?
+  VECTOR(MutableMatrix *) mDifferential;
+  VECTOR(MutableMatrix *) mMorphisms;
+  VECTOR(MutableMatrix *) mDegrees; // TODO keep track of the degree changes
+  std::vector<size_t> mBetti;
+};
+
+#endif
+
+// Local Variables:
+// compile-command: "make -C $M2BUILDDIR/Macaulay2/e "
+// indent-tabs-mode: nil
+// End:

--- a/M2/Macaulay2/e/ring.hpp
+++ b/M2/Macaulay2/e/ring.hpp
@@ -18,6 +18,7 @@ class Z_mod;
 class GF;
 class Tower;
 class FractionField;
+class LocalRing;
 class PolynomialRing;
 class PolyRing;
 class PolyRingFlat;
@@ -191,6 +192,9 @@ class Ring : public MutableEngineObject
   virtual PolyRingFlat *cast_to_PolyRingFlat() { return 0; }
   virtual const FractionField *cast_to_FractionField() const { return 0; }
   virtual FractionField *cast_to_FractionField() { return 0; }
+  virtual const LocalRing *cast_to_LocalRing() const { return 0; }
+  virtual LocalRing *cast_to_LocalRing() { return 0; }
+
   virtual const SchurRing *cast_to_SchurRing() const { return 0; }
   virtual SchurRing *cast_to_SchurRing() { return 0; }
   virtual const SchurRing2 *cast_to_SchurRing2() const { return 0; }

--- a/M2/Macaulay2/e/ringelem.hpp
+++ b/M2/Macaulay2/e/ringelem.hpp
@@ -12,6 +12,7 @@ struct Nterm;
 
 typedef Nterm *tpoly;
 class schur_poly;
+struct local_elem;
 
 union ring_elem
 {
@@ -19,6 +20,7 @@ union ring_elem
   Nterm *poly_val;
   schur_poly *schur_poly_val;
   mpfr_ptr mpfr_val;
+  local_elem* local_val;
 
  private:  // move this line up to the top eventually
   mpz_ptr mpz_val;
@@ -29,6 +31,8 @@ union ring_elem
   ring_elem(int a) : int_val(a) {}
   ring_elem(Nterm *a) : poly_val(a) {}
   ring_elem(mpz_ptr a) : mpz_val(a) {}
+  explicit ring_elem(local_elem* a) : local_val(a) {}
+
   operator int() const { return int_val; }
   operator tpoly() const { return poly_val; }
   int get_int() const { return int_val; }

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1,6 +1,9 @@
 --		Copyright 2004,2005,2006,2007,2008 by Daniel R. Grayson
 
 export {
+    "LocalRing",
+    "localRing",
+    "MaximalIdeal",
 	"!",
 	"!=",
 	"#",

--- a/M2/Macaulay2/m2/loadsequence
+++ b/M2/Macaulay2/m2/loadsequence
@@ -40,6 +40,7 @@ modules.m2
 matrix.m2
 matrix1.m2
 mutablemat.m2
+localring.m2
 quotring.m2
 multilin.m2
 flint.m2

--- a/M2/Macaulay2/m2/localring.m2
+++ b/M2/Macaulay2/m2/localring.m2
@@ -1,0 +1,92 @@
+--------------------------------------------------------------------------
+-- PURPOSE : Compute localization of rings with respect to prime ideals.
+--
+-- PROGRAMMERs : Localization at a maximal ideal was implemented by Mike Stillman and David Eisenbud.
+--               Support for prime ideals added by Mike Stillman and Mahrud Sayrafi.
+--
+-- UPDATE HISTORY : created 1      July 2008 as packages/LocalRings.m2
+-- 	     	    updated 4   January 2017 as packages/Localization.m2
+-- 	     	    updated 12 November 2017 as m2/localring.m2
+--
+-- TODO : Add ZZ#(localRing, ideal(0)) := QQ
+--        Localization at arbitrary multiplicatively closed sets
+--        Localization at a function
+--        Implement a prime filtration
+--        symbol%, symbol// for the case when f != g * (f // g)
+--        leadCoefficient, perhaps using the part with zero filtration?
+--
+-- NOTE : Elementary operations in a local ring are defined in e/localring.hpp and handled here.
+--        Most operations (syz, res, mingens, etc.) are in packages/LocalRings.m2 and rely heavily
+--        on liftUp in packages/LocalRings.m2 and on pruneComplex from packages/PruneComplex.m2
+--        Legacy code from 2008 is stored in packages/LocalRings/legacy.m2 and is still loaded.
+---------------------------------------------------------------------------
+
+LocalRing = new Type of EngineRing
+LocalRing.synonym = "Local ring"
+
+localRing = method(TypicalValue => LocalRing)
+      localRing LocalRing := identity
+     expression LocalRing := RP -> (expression localRing) (expression ring RP.MaximalIdeal, expression max RP)
+       describe LocalRing := RP -> net expression RP
+       toString LocalRing := RP -> (if hasAttribute(RP, ReverseDictionary)
+                                    then toString getAttribute(RP, ReverseDictionary)
+                                    else "localRing(" | toString ring RP.MaximalIdeal | ", " | toString RP.MaximalIdeal | ")")
+            net LocalRing := RP -> (if hasAttribute(RP, ReverseDictionary)
+                                    then toString getAttribute(RP, ReverseDictionary)
+                                    else net new FunctionApplication from { localRing, (ring RP.MaximalIdeal, RP.MaximalIdeal)})
+coefficientRing LocalRing := RP -> coefficientRing ring RP.MaximalIdeal
+  isWellDefined LocalRing := RP -> isPrime RP.MaximalIdeal
+  isCommutative LocalRing := RP -> isCommutative ring RP.MaximalIdeal -- FIXME make sure this is correct
+   degreeLength LocalRing := RP -> degreeLength ring RP.MaximalIdeal
+   presentation LocalRing := RP -> map(RP^1, RP^0, 0)
+     generators LocalRing := opts ->
+                             RP -> (if opts.CoefficientRing =!= RP
+                                    then generators(ring RP.MaximalIdeal, opts) / (r -> promote(r, RP)) else {})
+      precision LocalRing := RP -> precision ring RP.MaximalIdeal
+        degrees LocalRing := RP -> degrees ring RP.MaximalIdeal
+        numgens LocalRing := RP -> numgens ring RP.MaximalIdeal
+           frac LocalRing := RP -> frac ring RP.MaximalIdeal
+           char LocalRing := RP -> char ring RP.MaximalIdeal
+            dim LocalRing := RP -> codim RP.MaximalIdeal
+            max LocalRing := RP -> promote(RP.MaximalIdeal, RP)
+       Ideal ** LocalRing := Ideal => (I, RP) -> ideal(generators I ** RP)
+
+localRing(Ring, Ideal) := (R, P) ->
+    if R#?(localRing, P) then R#(localRing, P) else error "No method found"
+localRing(EngineRing, Ideal) := (R, P) ->
+    if isField R then R else if R#?(localRing,P) then R#(localRing,P) else (
+        if ring P =!= R then error "expected ideal of the same ring";
+        RP := new LocalRing from rawLocalRing(raw R, raw gb P);
+        RP.baseRings = append(R.baseRings, R);
+        R#(localRing,P) = RP;
+        RP.localRing    = RP;
+        RP.MaximalIdeal =  P;
+        commonEngineRingInitializations RP;
+         expression RP := r -> expression numerator r / expression denominator r;
+           toString RP := r -> toString expression r;
+           baseName RP := r -> if denominator r == 1 then baseName numerator r
+                               else error "expected a generator";
+    leadCoefficient RP := r -> error "not implemented for local rings";
+        denominator RP := r -> new R from rawDenominator raw r;
+          numerator RP := r -> new R from rawNumerator   raw r;
+             isUnit RP := r -> rawIsLocalUnit raw r;
+             factor RP := r -> factor numerator r / factor denominator r;
+                net RP := r -> net expression r;
+                RP%RP  := (r,s) -> error "not implemented for local rings";
+                RP/RP  :=
+       fraction(RP,RP) := (r,s) -> if isUnit s then r * s^-1
+                                   else if s != 0 then new frac R from
+                                     rawFraction(raw frac R,
+                                         raw (numerator r * denominator s),
+                                         raw (denominator r * numerator s))
+                                   else error "expected a unit or nonzero element in the denominator";
+        if R.?generators           then RP.generators = apply(R.generators, r -> promote(r, RP));
+        if R.?generatorSymbols     then RP.generatorSymbols     = R.generatorSymbols;
+        if R.?generatorExpressions then RP.generatorExpressions = R.generatorExpressions;
+        if R.?indexSymbols then RP.indexSymbols = applyValues(R.indexSymbols, r -> promote(r,RP));
+        if R.?indexStrings then RP.indexStrings = applyValues(R.indexStrings, r -> promote(r,RP));
+        RP
+        )
+
+--##################### Documentation & Tests ########################--
+-- See LocalRings/doc.m2

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -64,9 +64,25 @@ numeric(ZZ, Matrix) := (prec,f) -> (
      )
 numeric Matrix := f -> numeric(defaultPrecision,f)
 
-reduce = (tar,f) -> (
-     if isFreeModule tar then f
-     else f % raw gb presentation tar)
+-- Warning: does not return a normal form over local rings
+reduce = (tar,rawF) -> (
+    if isFreeModule tar then return rawF;
+    RP := ring tar;
+    G := presentation tar;
+    if instance(RP, LocalRing) then (
+        F := map(RP, rawF);
+        cols := for i from 0 to numColumns F - 1 list F_{i};
+        mat  := for col in cols list (
+            LocalRings := needsPackage "LocalRings";
+            liftUp := value LocalRings.Dictionary#"liftUp";
+            L := flatten entries syz(liftUp(col | G), SyzygyRows => 1);
+            if any(L, u -> isUnit promote(u, RP))
+              then map(tar, RP^1, 0)
+              else col
+              );
+        rawMatrixRemake2(raw cover tar, rawSource rawF, degree rawF, raw matrix{mat}, 0)
+        )
+    else rawF % raw gb G)
 protect symbol reduce					    -- we won't export this
 
 Matrix * Number := Matrix * ZZ := (m,i) -> i * m

--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -77,10 +77,9 @@ map(Module,Module,Matrix) := Matrix => o -> (M,N,f) -> (
 	  )
      else (
 	  R := ring M;
-	  N' := cover N;
 	  deg := if o.Degree === null then (degreeLength R : 0) else o.Degree;
 	  deg = degreeCheck(deg,R);
-	  map(M,N,reduce(M,rawMatrixRemake2(raw cover M, raw N', deg, raw f,0)))))
+	  map(M,N,reduce(M,rawMatrixRemake2(raw cover M, raw cover N, deg, raw f,0)))))
 
 -- combine the one above with the one below
 map(Module,ZZ,List) := 

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -168,6 +168,7 @@ setupMethods := (args, symbols) -> (
 	  )))
 
 setupMethods((), { 
+      localRing,
 	  entries, borel, gcdCoefficients, singularLocus, replace,
 	  Hom, diff, diff', contract, contract', subsets, partitions, member,
 	  koszul, symmetricPower, trace, target, source,

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -293,16 +293,29 @@ hilbertPolynomial Ring := ProjectiveHilbertPolynomial => options -> (R) -> hilbe
 Ideal * Ring := Ideal => (I,S) -> if ring I === S then I else ideal(I.generators ** S)
 Ring * Ideal := Ideal => (S,I) -> if ring I === S then I else ideal(I.generators ** S)
 
+issub := (f, g) -> (
+    RP := ring f;
+    if ring g =!= RP then error "expected objects of the same ring";
+    if instance(RP, LocalRing) then (
+        for i from 0 to numColumns f - 1 do (
+            LocalRings := needsPackage "LocalRings";
+            liftUp := value LocalRings.Dictionary#"liftUp";
+            L := flatten entries syz(liftUp(f_{i} | g), SyzygyRows => 1);
+            if not any(L, u -> isUnit promote(u, RP)) then return false;
+            );
+        true
+        )
+    else -1 === rawGBContains(raw gb g, raw f)    -- we can do better in the homogeneous case!
+    )
+
 ZZ == Ideal := (n,I) -> I == n
 Ideal == ZZ := (I,n) -> (
      if n === 0
      then I.generators == 0
      else if n === 1
-     then 1_(ring I) % I == 0
+     then issub(matrix {{1_(ring I)}}, generators I)
      else error "attempted to compare ideal to integer not 0 or 1"
      )
-
-issub := (f,g) -> -1 === rawGBContains(raw gb g,raw f)	    -- we can do better in the homogeneous case!
 
 ZZ == Module := (n,M) -> M == n
 Module == ZZ := (M,n) -> (

--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -32,6 +32,7 @@ ChainComplexExtras
 Schubert2
 PushForward
 LocalRings
+PruneComplex
 BoijSoederberg
 BGG
 Bruns

--- a/M2/Macaulay2/packages/LocalRings.m2
+++ b/M2/Macaulay2/packages/LocalRings.m2
@@ -1,497 +1,535 @@
--- -*- coding: utf-8 -*-
+---------------------------------------------------------------------------
+-- PURPOSE : Compute elementary operations of ideals, modules, and chain
+--           complexes over local rings. The main lemma involves lifting
+--           the objects from R_P back to R, performing the operation, then
+--           localizing by tensoring with R_P and pruning the resolution.
+--
+-- PROGRAMMERS : Localization at a maximal ideal was implemented by Mike Stillman
+--               and David Eisenbud (legacy code was moved to LocalRings/legacy.m2).
+--               Support for prime ideals added by Mahrud Sayrafi and Mike Stillman.
+--
+-- UPDATE HISTORY : created 1 July 2008;
+-- 	     	    updated 4 January 2017; last update 25 October 2017.
+--
+-- TODO : 1. Hilbert-Samuel Polynomial
+--        2. Implement a prime filtration
+--        3. Define a variety over an open cover:
+-- Given C in Proj R = Proj kk[x_0,...,x_n]
+-- Store L = {R_(x_0),...,R_(x_n)}
+-- along with generators of C_(x_0),...,C_(x_n)
+-- and gluing maps from C_(x_i) <-- C_(x_j)
+---------------------------------------------------------------------------
 newPackage(
-	"LocalRings",
-    	Version => "1.0", 
-    	Date => "July 1, 2008",
-    	Authors => {
-	     {Name => "David Eisenbud", Email => "de@msri.org", HomePage => "http://www.msri.org/~de/"},
-	     {Name => "Mike Stillman", Email => "mike@math.cornell.edu", HomePage => "http://www.math.cornell.edu/~mike/"}
-	     },
-    	Headline => "Local rings at the origin",
-    	DebuggingMode => false
-    	)
+    "LocalRings",
+    Version => "2.0",
+    Date => "January 14, 2017",
+    Authors => {
+        {Name => "Mahrud Sayrafi", Email => "mahrud@berkeley.edu",   HomePage => "http://ocf.berkeley.edu/~mahrud/"},
+        {Name => "Mike Stillman",  Email => "mike@math.cornell.edu", HomePage => "http://www.math.cornell.edu/~mike/"},
+        {Name => "David Eisenbud", Email => "de@msri.org",           HomePage => "http://www.msri.org/~de/"}
+        },
+    Headline => "Operations over a local ring (R, P)",
+    PackageExports => {"PruneComplex"},
+    DebuggingMode => true,
+    AuxiliaryFiles => true
+    )
 
 export {
-     "setMaxIdeal",
-     "localComplement",
-     "localsyz",
-     "localMingens",
-     "localModulo",
-     "localPrune",
-     "localResolution",
-     "residueMap",
-     "maxIdeal"
-     }
+    "liftUp",
+    "presentationComplex",
+    "hilbertSamuelFunction",
+    -- Legacy
+    "setMaxIdeal",
+    "localComplement",
+    "localsyz",
+    "localMingens",
+    "localModulo",
+    "localPrune",
+    "localResolution",
+    "residueMap",
+    "maxIdeal"
+    }
 
--- This routine, localRing, is not functional yet -----
---localRing = new method(
---     Options => {
---	  MonomialOrder => null
---	  }
---     )
---localRing Ring := R -> localRing(R, ideal vars R)
---localRing(Ring,Ideal) := (R,P) -> (
---     R	-- at first, we do nothing
---     )
---------------------------------------------------------
-setMaxIdeal = method()
-setMaxIdeal(Ideal) := (maxI) -> (
-     R := ring maxI;
-     R.residueMap = map(R,R,vars R % maxI);
-     R.maxIdeal = maxI
-     )
+<< "--------------------------------------------------------------------------------------" << endl;
+<< "-- The LocalRings package is experimental, but old methods are still available.     --" << endl;
+<< "-- See the documentation and comments in the package to learn more.                 --" << endl;
+<< "--------------------------------------------------------------------------------------" << endl;
 
-localComplement = method()
-localComplement Matrix := Matrix => (m) -> (
-     n := transpose syz transpose ((ring m).residueMap m);
-     id_(target n) // n)
+debug Core;
 
-defaultResolutionLength := (R) -> (
-     numgens R + 1 + if ZZ === ultimate(coefficientRing, R) then 1 else 0
-     )
+--==================================== Basic Operations ====================================--
+-- Note: The following methods are extended to local rings in this package:
+-- syz                 -> localSyzHook,
+-- mingens             -> localMingensHook,
+-- minimalPresentation -> localMinimalPresentationHook,
+-- length              -> localLengthHook,
+-- trim
+-- resolution
+-- symbol// (quotient)
+-- inducedMap
+-- symbol:             -> localQuotient -- Note: quotient does not work as a synonym of symbol:
+-- saturate            -> localSaturate
+-- annihilator
+-- Note: various elementary operations are defined in m2/localring.m2.
+-- Note: isSubset symbol== are fixed in m2/modules2.m2 and reduce is fixed in m2/matrix.m2.
+-- Note: map, modulo, subquotient, kernel, cokernel, image, homology, Hom, Ext, Tor, and many
+--       other methods that rely only on the methods above work for local rings automatically.
+-- Note: certain methods, such as symbol%, radical, minimalPrimes, etc. are not yet implemented.
+--       If you need specific methods that do not work, please inform Mahrud Sayrafi.
 
-resolutionLength := (R,options) -> (
-     if options.LengthLimit == infinity then defaultResolutionLength R else
-options.LengthLimit
-     )
+-- Lifts objects over R_P to an object over R such that tensoring with R_P results
+-- in the original object.
+-- TODO: implement this in engine for mutable matrices as well
+-- TODO: add option to return a row of common denominators to be used in syz
+liftUp = method()
+liftUp Thing                :=  T     -> liftUp(T, last (ring T).baseRings)
+liftUp(Ideal, Ring)         := (I, R) -> ideal liftUp(gens I, R)
+liftUp(Module, Ring)        := (M, R) -> (
+    g := generators M;
+    r := relations  M;
+    c := (if M.?generators then 1 else 0) +
+         (if M.?relations  then 1 else 0) * 2;
+    if c == 0 then return R^(-degrees M);                          --freemodule
+    if c == 1 then return subquotient(liftUp(g, R),             ); --image
+    if c == 2 then return subquotient(            , liftUp(r, R)); --coker
+    if c == 3 then return subquotient(liftUp(g, R), liftUp(r, R)); --subquotient
+    )
+liftUp(Matrix, Ring)        := (m, R) ->
+    map(liftUp(target m, R),
+        liftUp(source m, R),
+        rawLiftLocalMatrix(raw R, raw m))
+liftUp(MutableMatrix, Ring) := (m, R) -> mutableMatrix liftUp(matrix m, R)
 
-localsyz = method()
-localsyz(Matrix) := (m) -> (
-     localMingens syz m
-     --C = res(coker m,LengthLimit=>3);
-     --C.dd_2 * localComplement(C.dd_3)
-     )
+-- Computes syzygies of a matrix over local rings
+localSyzHook = method(Options => options syz)
+localSyzHook Matrix := Matrix => opts -> m -> (
+    RP := ring m;
+    f' := liftUp m;
+    g' := syz f';
+    h' := syz g';
+    g := g' ** RP;
+    h := h' ** RP;
+    C := {g, h};
+    C = first pruneComplex(C, 1, Direction => "right");
+    f := C#0;
+    -- Dot product with the denominators of lift
+    N := transpose entries m;
+    for i from 0 to numcols m - 1 do
+      rowMult(f, i, N_i/denominator//lcm);
+    -- TODO make sure other options are treated correctly
+    if opts.SyzygyRows < numrows f then (
+        f = submatrix(f, 0..(opts.SyzygyRows-1),);
+        matrix f
+        )
+    else map(source m, , matrix f)
+    )
 
-localMingens = method()
-localMingens(Matrix) := Matrix => (m) -> (
-     -- warning: this routine should perhaps take a Module...
-     m * localComplement syz m
-     )
+-- Computes mingens of modules over local rings
+-- TODO: if presentationComplex exists, skip some steps
+localMingensHook = method(Options => options mingens)
+localMingensHook Module := Matrix => opts -> M -> (
+    RP := ring M;
+    F := ambient M;
+    c := (if M.?generators then 1 else 0) + 2 * (if M.?relations then 1 else 0);
+    if c == 0 then return id_F; --freemodule
+    if c == 1 then (            --image
+        f := generators M;
+        f' := liftUp f;
+        g' := syz f';
+        g := g' ** RP;
+        C := {f, g};
+        C = first pruneComplex(C, 1, Direction => "right");
+        return map(F, , matrix C#0);
+        );
+    if c == 2 then (            --coker
+        f = id_F;
+        g = relations M;
+        C = {f, g};
+        C = first pruneComplex(C, 1, Direction => "right");
+        return map(F, , matrix C#0);
+        );
+    if c == 3 then (            --subquotient
+        f = generators M;
+        g = relations M;
+        f' = liftUp f;
+        g' = liftUp g;
+        h' := modulo (f', g');
+        h := h' ** RP;
+        C = {f, h};
+        C = first pruneComplex(C, 1, Direction => "right");
+        return map(F, , matrix C#0);
+        );
+    )
 
-localModulo = method()
-localModulo(Matrix,Matrix) := Matrix => (m,n) -> (
-     P := target m;
-     Q := target n;
-     if P != Q then error "expected maps with the same target";
-     if not isFreeModule P or not isFreeModule Q
-     or not isFreeModule source m or not isFreeModule source n
-     then error "expected maps between free modules";
-     localMingens syz(m|n, SyzygyRows => numgens source m)
-     )
+-- Computes minimalPresentation of modules over local rings
+-- TODO: if presentationComplex exists, skip stuff
+localMinimalPresentationHook = method(Options => options minimalPresentation ++ {PruningMaps => true})
+localMinimalPresentationHook Module := Module => opts -> M -> (
+    RP := ring M;
+    c := (if M.?generators then 1 else 0) + 2 * (if M.?relations then 1 else 0);
+    if c == 0 then return M; --freemodule
+    if c == 1 then (         --image
+        f := generators M;
+        f' := liftUp f;
+        g' := syz f';
+        h' := syz g';
+        g := g' ** RP;
+        h := h' ** RP;
+        (C, P) := ({g, h}, null);
+        (C, P)  = pruneComplex(C, PruningMaps => true);
+        phi := map(M, , matrix P#0);
+        N := coker map(source phi, , matrix C#0);
+        phi = map(M, N, phi);
+        N.cache.pruningMap = phi;
+        M.cache.presentationComplex = toChainComplex C;
+        return N;
+        );
+    if c == 2 then (         --coker
+        f = relations M;
+        f' = liftUp f;
+        g' = syz f';
+        g = g' ** RP;
+        C = {f, g};
+        (C, P) = pruneComplex(C, PruningMaps => true);
+        phi = map(M, , matrix P#0);
+        N = coker map(source phi, , matrix C#0);
+        phi = map(M, N, phi);
+        N.cache.pruningMap = phi;
+        M.cache.presentationComplex = toChainComplex C;
+        return N;
+        );
+    if c == 3 then (         --subquotient
+        f = generators M;
+        g = relations M;
+        f' = liftUp f;
+        g' = liftUp g;
+        h' = modulo (f', g');
+        e' := syz h';
+        h = h' ** RP;
+        e := e' ** RP;
+        C = {h, e};
+        (C, P) = pruneComplex(C, PruningMaps => true);
+        phi = map(M, , matrix P#0);
+        N = coker map(source phi, , matrix C#0);
+        phi = map(M, N, phi);
+        N.cache.pruningMap = phi;
+        M.cache.presentationComplex = toChainComplex C;
+        return N;
+        );
+    )
 
+--===================== Length and Hilbert-Samuel Polynomial Polynomial =====================--
 
-localPrune = method()
-localPrune Module := (M) -> (
-     p := presentation M;
-     p1 := localComplement p;
-     p2 := localModulo(p1,p);
-     N := coker(p2);
-     N.cache.pruningMap = map(M,N,p1);
-     N
-     )
+-- Computes the length of an ideal or module over local rings
+-- Note: If computing length is slow, try summing hilbertSamuelFunction for short ranges
+-- TODO: check that it's Artinian first
+-- test based on when hilbertSamuelFunction(M, n) == 0?
+-- Maybe http://stacks.math.columbia.edu/tag/00IW ?
+localLengthHook = method(Options => {Strategy => null, Limit => 1000})
+localLengthHook Ideal  := ZZ => opts -> I -> localLengthHook(opts, module I)
+localLengthHook Module := ZZ => opts -> M -> (
+    RP := ring M;
+    m := max RP;
+    if class RP =!= LocalRing then error "expected objects over a local ring";
+--    if not isFiniteLength M   then return -1;
+    if debugLevel >= 1        then  << "isFiniteLength is not implemented" << endl;
+    sum for i from 0 to opts.Limit list (
+        if debugLevel >= 1    then  << i << endl;
+        if opts.Limit == i    then (<< "maximum limit for computing length is reached" << endl; break);
+        if opts.Strategy === Hilbert
+        then n := hilbertSamuelFunction(M, i) -- really should be M/mM, but by Nakayama it's the same
+        else (
+            M = localMinimalPresentationHook(M, PruningMaps => false);
+            n = numgens M;
+            M = m * M;
+            n
+            );
+        if n == 0 then break else n
+        )
+    )
 
-localResolution = method(Options => options resolution)
-localResolution Ideal := options -> (I) -> localResolution coker gens I
-localResolution Module := options -> (M) -> (
-     R := ring M;
-     if not R.?maxIdeal then error "use setMaxIdeal first!";
-     maxlength := resolutionLength(R,options);
-     if M.cache.?localResolution
-     then (C := M.cache.localResolution;
-     C.length = length C)
-     else (
-	  C = new ChainComplex;
-	  C.ring = R;
-	  -- f := presentation M;
-	  -- we have replaced presentation in the previous line by minimalPresentation. This has fixed a reported bug where 
-	  -- localResolution returned a non-minimal presentation.
-	  -- We have included the above mentioned example in the tests section.
-	  f := relations minimalPresentation M;
-	  C#0 = target f;
-	  C#1 = source f;
-	  C.dd#1 = f;
-	  M.cache.localResolution = C;
-	  C.length = 1;
-	  );
-     i := C.length;
-     while i < maxlength and C.dd_i != 0 do (
-	  g := localsyz C.dd_i;
-	  shield (
-	       i = i+1;
-	       C.dd#i = g;
-	       C#i = source g;
-	       C.length = i;
-	       );
-	  );
-     C)
+-- Computes the Hilbert-Samuel function for modules over local ring, possibly using a parameter ideal.
+-- Note:
+--   If computing at index n is fast but slows down at n+1, try computing at range (n, n+1).
+--   On the other hand, if computing at range (n, n+m) is slow, break up the range.
+-- TODO: implement the fast powering algorithm
+hilbertSamuelFunction = method()
+hilbertSamuelFunction (Module, ZZ)            := ZZ   => (M, n) -> first hilbertSamuelFunction(M,n,n)
+-- Eisenbud 1995, Chapter 12:
+-- Input:  finitely generated (R,m)-module M, integer n0, n1
+-- Output: H_M(i) := dim_{R/q}( m^n M / m^{n+1} M ) for i from n0 to n1
+hilbertSamuelFunction (Module, ZZ, ZZ)        := List => (M, n0, n1) -> (
+    RP := ring M;
+    if class RP =!= LocalRing then error "expected objects over a local ring";
+    m := max RP;
+    M = m^n0 * M;
+    for i from n0 to n1 list (
+        if debugLevel >= 1 then << i << endl;
+        N := localMinimalPresentationHook(M, PruningMaps => false);  -- really should be N/mN, but by Nakayama it's the same
+        if i < n1 then M = m * N;
+        numgens N
+        )
+    )
+hilbertSamuelFunction (Ideal, Module, ZZ)     := ZZ   => (q, M, n) -> first hilbertSamuelFunction(q,M,n,n)
+-- Eisenbud 1995, Section 12.1:
+-- Input:  parameter ideal q, finitely generated (R,m)-module M, integers n0, n1
+-- Output: H_{q, M}(i) := length( q^n M / q^{n+1} M ) for i from n0 to n1
+hilbertSamuelFunction (Ideal, Module, ZZ, ZZ) := List => (q, M, n0, n1) -> (
+    RP := ring M;
+    if class RP =!= LocalRing then error "expected objects over a local ring";
+    if ring q =!= RP          then error "expected objects over the same ring";
+    if q == max RP            then return hilbertSamuelFunction(M, n0, n1);
+    M = localMinimalPresentationHook(M, PruningMaps => false);
+    M = q^n0 * M;
+    for i from n0 to n1 list (
+        if debugLevel >= 1 then << i << endl;
+        N := localMinimalPresentationHook(M, PruningMaps => false);  -- really should be N/mN, but by Nakayama it's the same
+        if i < n1 then M = q * N;
+        localLengthHook (N/(q * N))
+        )
+    )
 
+--===================================== addHooks Section =====================================--
+
+-- syz
+-- this method doesn't have hooks so we redefine it to allow runHooks
+oldSyz = lookup(syz, Matrix)
+syz Matrix := Matrix => opts -> m -> (
+    c := runHooks(Matrix, symbol syz, (opts,m));
+    if c =!= null then return c;
+    error "syz: no method implemented for this type of matrix"
+    )
+
+addHook(Matrix, symbol syz, (opts,m) -> break (oldSyz opts)(m))
+
+addHook(Matrix, symbol syz, (opts,m) -> (
+        if instance(ring m, LocalRing) then break localSyzHook(opts,m)
+        ))
+
+-- res, resolution
+-- this method already has hooks installed, so we can simply add a new one
+addHook(Module, symbol resolution, (opts,M) -> (
+        RP := ring M;
+        if instance(RP, LocalRing) then (
+            M' := liftUp M;
+            C := resolution(M', opts);
+            CP := C ** RP;
+            CP = if isHomogeneous M'
+              then pruneComplex(CP, UnitTest => isScalar)
+              else pruneComplex CP;
+            break CP)
+        ))
+
+-- mingens
+-- this method doesn't have hooks so we redefine it to allow runHooks
+oldMingens = lookup(mingens, Module)
+mingens Module := Matrix => opts -> (cacheValue symbol mingens) (M -> (
+        c := runHooks(Module, symbol mingens, (opts, M));
+        if c =!= null then return c;
+        error "mingens: no method implemented for this type of module"
+        ))
+
+addHook(Module, symbol mingens, (opts,M) -> break (oldMingens opts)(M))
+
+addHook(Module, symbol mingens, (opts,M) -> (
+        if instance(ring M, LocalRing) then break localMingensHook(opts,M)
+        ))
+
+-- minimalPresentation
+-- this method already has hooks installed, so we can simply add a new one
+addHook(Module, symbol minimalPresentation, (opts,M) -> (
+        if instance(ring M, LocalRing) then break localMinimalPresentationHook(opts,M)
+        ))
+
+-- length
+-- this method doesn't have hooks so we redefine it to allow runHooks
+oldLength = lookup(length, Module)
+length Module := ZZ => (cacheValue symbol trim) (M -> (
+    c := runHooks(Module, symbol length, M);
+    if c =!= null then return c;
+    error "length: no method implemented for this type of module"
+    ))
+
+addHook(Module, symbol length, M -> break oldLength M)
+
+addHook(Module, symbol length, M -> (
+        if instance(ring M, LocalRing) then break (localLengthHook M)
+        ))
+
+-- trim
+-- this method doesn't have hooks so we redefine it to allow runHooks
+oldTrim = lookup(trim, Module)
+trim Module := Module => opts -> (cacheValue symbol trim) (M -> (
+    c := runHooks(Module, symbol trim, (opts,M));
+    if c =!= null then return c;
+    error "trim: no method implemented for this type of module"
+    ))
+
+addHook(Module, symbol trim, (opts,M) -> break (oldTrim opts)(M))
+
+addHook(Module, symbol trim, (opts,M) -> (
+        if instance(ring M, LocalRing) then (
+            if isFreeModule M then break M;
+            N := subquotient(mingens M, if M.?relations then mingens image relations M);
+            N.cache.trim = N;
+            break N)
+        ))
+
+-- (symbol//, Matrix, Matrix)
+-- Caution: this method is only correct when f = g * (f//g),
+--          otherwise may not be the correct reduction of f modulo image of g
+-- Here is the algorithm:
+--   Given two matrices F = [f1 ... fn], G = [g1 ... gm] with the same target,
+--   we wish to computer F // G such that F = G * (F // G).
+--   We compute H = syz(F | G). Each column looks like H_j = [h_1 .. h_n .. h_(n+m)]^T.
+--   Now for each column F_i of F, look for a unit in the i-th row of H.
+--   (Question: if there are multiple units, which one to choose?)
+--   Let's say in the unit u in the column H_j, then we replace F_i by -1/u times the column
+--   [h_(n+1) h_(n+2) ... h_(n+m)]^T, remove the column H_j from H, and move on to F_(i+1).
+--   If there aren't any units in the i-th column, we replace F_i by a 0 column and move on to F_(i+1)
+oldQuotient = lookup(quotient, Matrix, Matrix)
+quotient(Matrix,Matrix) := Matrix => opts -> (f, g) -> (
+    RP := ring f;
+    if ring g =!= RP then error "expected objects of the same ring";
+    if target f =!= target g then error "expected maps with the same target";
+    if instance(RP, LocalRing) then (
+        G := syz liftUp(f | g);
+        mat := for i from 0 to numColumns f - 1 list (
+            col := f_{i};
+            n := scan(numColumns G, j -> if isUnit promote(G_(i,j), RP) then break j);
+            if n === null then matrix map(source g, RP^1, 0) else (
+                col = -submatrix(G,{numColumns f..numRows G-1},{n}) * G_(i,n)^-1;
+                G = submatrix(G, ,{0..n-1, n+1..numColumns G-1});
+                (col ** RP)
+                )
+            );
+        m := if mat === {} then 0_RP else raw matrix{mat};
+        map(source g, source f, m,
+	    Degree => degree matrix f - degree matrix g)  -- set the degree in the engine instead
+        )
+    else (oldQuotient opts)(f, g)
+    )
+
+-- inducedMap
+-- TODO: verification of induced maps over local rings when opts.Verify = true
+oldInducedMap = lookup(inducedMap,Module,Module,Matrix)
+inducedMap(Module,Module,Matrix) := Matrix => opts -> (N',M',f) -> (
+    RP := ring f;
+    if ring N' =!= RP or ring M' =!= RP then error "inducedMap: expected modules and map over the same ring";
+    if instance(RP, LocalRing) then (
+        N := target f;
+        M := source f;
+        if isFreeModule N and isFreeModule M and (N =!= ambient N' and rank N === rank ambient N' or M =!= ambient M' and rank M === rank ambient M')
+        then f = map(N = ambient N', M = ambient M', f)
+        else (
+	    if ambient N' =!= ambient N then error "inducedMap: expected new target and target of map provided to be subquotients of same free module";
+	    if ambient M' =!= ambient M then error "inducedMap: expected new source and source of map provided to be subquotients of same free module";
+	    );
+        g := generators N * cover f * (generators M' // mingens image generators M);
+        f' := g // mingens image generators N';
+        f' = map(N',M',f',Degree => if opts.Degree === null then degree f else opts.Degree);
+        if false and opts.Verify then ( -- FIXME this is set to false because % doesn't work over local rings
+            if relations M % relations M' != 0 then error "inducedMap: expected new source not to have fewer relations";
+            if relations N % relations N' != 0 then error "inducedMap: expected new target not to have fewer relations";
+            if generators M' % mingens M != 0 then error "inducedMap: expected new source not to have more generators";
+            if g % mingens N' != 0 then error "inducedMap: expected matrix to induce a map";
+            if not isWellDefined f' then error "inducedMap: expected matrix to induce a well-defined map";
+            );
+        f')
+    else (oldInducedMap opts)(N',M',f)
+    )
+
+--======================================= Experimental =======================================--
+
+-- (symbol:, Thing, Thing)
+-- We rely on the fact that ideal and module quotients commute with localization
+-- TODO: find a way to handle the options from quotient
+localQuotient = (A, B) -> (
+    RP := ring A;
+    if ring B =!= RP then error "expected objects of the same ring";
+    if instance(RP, LocalRing) then (
+        if isSubset(B, A) then (
+            if class A === Ideal or class B === Module
+            then return ideal 1_RP
+            else return ambient A;
+            );
+        R := RP;
+        while class R === LocalRing do R = last R.baseRings;
+        A' := liftUp(A, R);
+        B' := liftUp(B, R);
+        C' := quotient(A', B');
+        C' ** RP
+        )
+    else quotient(A, B)
+    )
+
+--FIXME: get quotient to work, currently A:B works
+--quotient(Ideal ,Ideal      ) := Ideal  => opts -> (I,J) -> (quotientIdeal opts)(I,J)
+--quotient(Ideal ,RingElement) := Ideal  => opts -> (I,f) -> (quotientIdeal opts)(I,ideal(f))
+--quotient(Module,Ideal      ) := Module => opts -> (M,I) -> (quotientModule opts)(M,I)
+--quotient(Module,RingElement) := Module => opts -> (M,f) -> (quotientModule opts)(M,ideal(f))
+--quotient(Module,Module     ) := Ideal  => opts -> (M,N) -> (quotientAnn opts)(M,N)
+
+Ideal  : Ideal       := Ideal  => (I,J) -> localQuotient(I,J)
+Ideal  : RingElement := Ideal  => (I,r) -> localQuotient(I,ideal(r))
+Module : Ideal       := Module => (M,I) -> localQuotient(M,I)
+Module : RingElement := Module => (M,r) -> localQuotient(M,ideal(r))
+Module : Module      := Ideal  => (M,N) -> localQuotient(M,N)
+
+-- annihilator
+-- We rely on the fact that ideal and module annihilators commute with localization
+oldAnnihilator = lookup(annihilator, Module)
+annihilator Module := Ideal => opts -> (cacheValue symbol annihilator) (M -> (
+    RP := ring M;
+    if instance(RP, LocalRing) then (
+        if M == 0 then return ideal 1_RP;
+        R := RP;
+        while class R === LocalRing do R = last R.baseRings;
+        -- Does this theoretically work?
+        M' := liftUp(M, R);
+        N' := annihilator(M', opts);             -- Any options we need to care about?
+        N' ** RP
+        )
+    else (oldAnnihilator opts)(M)
+    ))
+
+-- saturate
+-- We rely on the fact that ideal and module saturations commute with localization
+oldSaturateIdeal  = lookup(saturate, Ideal,  Ideal)
+oldSaturateModule = lookup(saturate, Module, Ideal)
+localSaturate := opts -> (A, B) -> (
+    RP := ring A;
+    if ring B =!= RP then error "expected objects of the same ring";
+    if instance(RP, LocalRing) then (
+        if isSubset(B, A) then (
+            if class A === Ideal
+            then return ideal 1_RP
+            else return ambient A;
+            );
+        R := RP;
+        while class R === LocalRing do R = last R.baseRings;
+        A' := liftUp(A, R);
+        B' := liftUp(B, R);
+        C' := saturate(A', B', opts);
+        C' ** RP             -- Any options we need to care about?
+        )
+    else if class A === Ideal
+    then (oldSaturateIdeal  opts)(A, B)
+    else (oldSaturateModule opts)(A, B)
+    )
+
+saturate Ideal                := Ideal  => opts ->  I     -> (localSaturate opts)(I, ideal vars ring I)
+saturate(Ideal, Ideal)        := Ideal  => opts -> (I, J) -> (localSaturate opts)(I, J)
+saturate(Ideal, RingElement)  := Ideal  => opts -> (I, f) -> (localSaturate opts)(I, ideal(f))
+saturate Module               := Module => opts ->  M     -> (localSaturate opts)(M, ideal vars ring M)
+saturate(Module, Ideal)       := Module => opts -> (M, I) -> (localSaturate opts)(M, I)
+saturate(Module, RingElement) := Module => opts -> (M, f) -> (localSaturate opts)(M, ideal(f))
+
+--================================= Tests and Documentation =================================--
+
+load ("./LocalRings/legacy.m2")
+load ("./LocalRings/tests.m2")
 beginDocumentation()
+load ("./LocalRings/doc.m2")
 
-document { Key => LocalRings,
-     Headline => "Polynomial rings localized at a maximal ideal",
-     EM "LocalRings", " is a package for finding minimal generators, syzygies and resolutions
-     for polynomial rings localized at a maximal ideal.",
-     }
-
-document { 
-     Key => {setMaxIdeal, (setMaxIdeal,Ideal)},
-     Headline => "set the maximal ideal for local ring methods",
-     Usage => "setMaxIdeal I",
-     Inputs => {
-	  "I" => {ofClass Ideal, ", a maximal ideal of the ring R"}
-	  },
-     Outputs => {
-	  Ideal => {"same ideal as input"}
-	  },
-     "The function adds new structure to the ring which specifies a maximal ideal which allows the user to employ local ring methods.",
-     EXAMPLE lines ///
-	  R = ZZ/32003[x,y,z,w,SkewCommutative=>true]
-	  setMaxIdeal(ideal(x,y,z,w))
-	  ///,
-     Caveat => {},
-     SeeAlso => {localComplement, localsyz, localMingens, localModulo, localPrune, localResolution, residueMap, maxIdeal}
-     }
-
-document { 
-     Key => {localComplement, (localComplement,Matrix)},
-     Headline => "find the splitting of the target of a map",
-     Usage => "localComplement m",
-     Inputs => { 
-	  "m" => {ofClass Matrix, ", representing a homomorphism of free modules over a local ring"},
-	  },
-     Outputs => {
-	  Matrix => {"the complement of the image of the homomorphism represented by m"}
-	  },
-     "The function finds a splitting of the target of m as a direct sum of the image of m and the image of the output.",
-     EXAMPLE lines ///
-	  R = ZZ/32003[x,y]
-	  m = matrix{{x,y-1},{0,x}}
-	  setMaxIdeal(ideal(x,y))
-	  localComplement m
-	  ///,
-     Caveat => {},
-     SeeAlso => {setMaxIdeal, localsyz, localMingens, localModulo, localPrune, localResolution, residueMap, maxIdeal}
-     }
-
-document { 
-     Key => {localsyz, (localsyz,Matrix)},
-     Headline => "find syzygies",
-     Usage => "localsyz m",
-     Inputs => {
-	  "m" => {ofClass Matrix}
-	  },
-     Outputs => {
-	  Matrix => {"giving minimal generators of the syzygies taking into account the local structure"}
-	  },
-     EXAMPLE lines ///
-	  R = ZZ/32003[x,y,z,w,SkewCommutative=>true]
-	  m = matrix{{x,y*z},{z*w,x}}
-	  setMaxIdeal(ideal(x,y,z,w))
-     	  localsyz m
-	  m * localsyz m
-	  ///,
-     Caveat => {},
-     SeeAlso => {setMaxIdeal, localComplement, localMingens, localModulo, localPrune, localResolution, residueMap, maxIdeal}
-     }
-
-document { 
-     Key => {localMingens, (localMingens,Matrix)},
-     Headline => "finds a minimal set of generators",
-     Usage => "localMingens m",
-     Inputs => {
-	  "m" => {ofClass Matrix}
-	  },
-     Outputs => {
-	  Matrix => {"the matrix of minimal generators"}
-	  },
-     "We get a minimal set for the homogeneous case, but not necessarily otherwise.",
-     EXAMPLE lines ///
-	  R=QQ[a,b]
-	  setMaxIdeal ideal gens R
-	  mingens image matrix{{a-1,a,b},{a-1,a,b}}
-	  localMingens matrix {{a-1,a,b},{a-1,a,b}}
-	  ///,
-     Caveat => {},
-     SeeAlso => {setMaxIdeal, localComplement, localsyz, localModulo, localPrune, localResolution, residueMap, maxIdeal}
-     }
-
-document { 
-     Key => {localModulo, (localModulo,Matrix,Matrix)},
-     Headline => "find the pre-image (pullback) of image of a map over a local ring",
-     Usage => "localModulo(m,n)",
-     Inputs => {
-	  "m" => {ofClass Matrix},
-	  "n" => {ofClass Matrix}
-	  },
-     Outputs => {
-	  Matrix => {"whose image is the pre-image (pullback) of the image of n under m"}
-	  },
-     "The maps m and n must have the same target, and their sources and targets must be free. If m is null, then it is taken to be the identity. If n is null, it is taken to be zero.",
-     EXAMPLE lines ///
-	  R = QQ[x,y,z]
-	  setMaxIdeal ideal vars R
-	  m = matrix {{x-1, y}}
-	  n = matrix {{y,z}}
-	  modulo (m,n)
-	  localModulo (m,n)
-	  ///,
-          Caveat => {},
-     SeeAlso => {setMaxIdeal, localComplement, localsyz, localMingens, localPrune, localResolution, residueMap, maxIdeal}
-     }
-
-document { 
-     Key => {localPrune, (localPrune,Module)},
-     Headline => "find a minimal presentation",
-     Usage => "localPrune M",
-     Inputs => {
-	  "M" => {ofClass Module}
-	  },
-     Outputs => {
-	  Module
-	  },
-     "The output is a minimal presentation of the input.",
-     EXAMPLE lines ///
-	  R=QQ[a,b]
-	  setMaxIdeal ideal gens R
-	  m = matrix{{a-1,a,b},{a-1,a,b}}
-	  prune m
-	  localPrune image m
-	  ///,
-     Caveat => {},
-     SeeAlso => {setMaxIdeal, localComplement, localsyz, localMingens, localModulo, localResolution, residueMap, maxIdeal}
-     }
-
-document { 
-     Key => {localResolution, (localResolution,Module), (localResolution,Ideal)},
-     Headline => "find a resolution over a local ring",
-     Usage => "localResolution M",
-     Inputs => {
-	  "M" => {ofClass Module}, " or ", {ofClass Ideal},
-      	  },
-     PARA "This method has option inputs that it inherits from ", TO resolution, ".",
-     Outputs => {
-	  ChainComplex
-	  },
-     PARA "This function iterates ", TO localsyz, " to obtain a resolution over the local ring.",
-     EXAMPLE lines ///
-	  R = ZZ/32003[x,y,z,w,SkewCommutative=>true]
-	  m = matrix{{x,y*z},{z*w,x}}
-	  setMaxIdeal(ideal(x,y,z,w))
-	  C = localResolution(coker m, LengthLimit=>10)
-	  C = localResolution(coker m)
-	  C^2
-	  C.dd_4
-	  ///,
-     EXAMPLE lines ///
-     	  R = QQ[x,y,z]
-	  setMaxIdeal ideal vars R
-	  m = matrix {{x-1, y, z-1}}
-	  C = resolution coker m
-	  C.dd
-	  LC = localResolution coker m
-	  LC.dd
-          ///,
-
-     Caveat => {},
-     SeeAlso => {setMaxIdeal, localComplement, localsyz, localMingens, localModulo, localPrune, residueMap, maxIdeal}
-     }
-
-
-
-TEST ///
-     --loadPackage "LocalRings"
-     R = QQ[x,y,z]
-     setMaxIdeal ideal vars R
-     m = matrix {{x-1, y, z-1}}
-     LC = localResolution coker m
-     LC.dd
-     assert (length LC == 2)
-     ///
-
-TEST ///
-     --loadPackage "LocalRings"
-     S=ZZ/101[t,x,y,z]
-     setMaxIdeal ideal vars S
-     assert(S.residueMap === map(S,S,{0,0,0,0}))
-     m=matrix"x,y2;z3,x4"
-     M=coker m
-     assert(localsyz m == 0)
-     ///
-     
-TEST ///
-     --loadPackage "LocalRings"
-     R = QQ[a,b,c,d]
-     setMaxIdeal(ideal(a-1,b-2,c-3,d-4))
-     I = ideal((1+a), (1+b))
-     G = localMingens gens I
-     assert(numgens source G == 1)
-     ///
-     
-TEST ///
-     --loadPackage "LocalRings"
-     kk = ZZ/32003
-     R = kk[x,y,z,w,SkewCommutative=>true]
-     m = matrix{{x,y*z},{z*w,x}}
-     setMaxIdeal(ideal(x,y,z,w))
-     C = localResolution(coker m, LengthLimit=>10)
-     C = localResolution(coker m)
-     for i from 1 to 10 do
-     	  assert(zero(C.dd_(i-1) * C.dd_i))
-     ///     
-     
-     
-end
--- ###
-restart
-loadPackage "LocalRings"
-kk=ZZ/101
-S=kk[t,x,y,z]
-setMaxIdeal ideal vars S
-assert(S.residueMap === map(S,S,{0,0,0,0}))
-
-m=matrix"x,y2;z3,x4"
-M=coker m
-assert(localsyz m == 0)
-C = localResolution M -- wrong answer, OK now: MES
-
-N=coker map (S^{-2,0},S^{-3,-4}, m)
---betti res N --without this line some further errors are produced below, different than with this line!
-localResolution N -- gives error msg "key not found in hash table", OK mow: MES
-
-
-betti (FFM=res (M, LengthLimit => 4)) -- correct, nonminimal
-FFM.dd
-betti (FF=localResolution M)
-FF.dd -- this is WRONG, not even composable maps
-localResolution M
-
-betti res N --without the res N line above, this doesn't work! -- MES: YET TO BE FIXED
-betti (FF=localResolution N) -- same for this, MES: THIS SEEMS TO WORK NOW
-localResolution N -- and this MES: WORKING NOW
-NN=coker map (S^2, S^2, m)
-resolution NN
-localResolution NN
-
-
-
-
-restart
-loadPackage "LocalRings"
-kk=ZZ/101
-S=kk[t,x,y,z]
-setMaxIdeal ideal vars S
-m=matrix"x,y2;z3,x4"
-M=coker m
-C = localResolution M -- wrong answer, OK now: MES
-N=coker map (S^{-2,0},S^{-3,-4}, m)
-
-localResolution N
-errorDepth = 0
-res N
-
-
-
-
-
-
-restart
-loadPackage "LocalRings"
-kk = ZZ/32003
-R = kk[x,y,z,w,SkewCommutative=>true]
-m = matrix{{x,y*z},{z*w,x}}
-setMaxIdeal(ideal(x,y,z,w))
-C = localResolution(coker m, LengthLimit=>10)
-C = localResolution(coker m)
-C^2
-C.dd_4
-
-kk = QQ
-R = kk[a,b,c,d]
-setMaxIdeal(ideal(a-1,b-2,c-3,d-4))
-R.residueMap
-I = ideal(a*(1+a), a*(1+b))
-I = ideal(a*(a-1), a*(b-2))
-I = ideal((1+a), (1+b))
-localResolution coker gens I
-module I
-localPrune module I
-localMingens gens I
-decompose I
-
----------------------------------------
--- MES: tests of local ring routines --
----------------------------------------
-restart
-R = ZZ/32003[a,b,c,Weights=>{-1,-1,-1},Global=>false]
-I = ideal(a^2-b^3+a*c^4, a*b-c^3-b^4)
-gens gb I
-mingens I
-J = I + ideal((1+a-b^2)*I_0)
-mingens J
-res J
-
-restart
-loadPackage "BGG"
-loadPackage "LocalRings"
-A=ZZ/101[a,Weights=>{-1},Global=>false]/a^2
-S=ZZ/101[a,x,y,Weights=>{-1,1,1},Global=>false,Degrees=>{0,1,1}]/a^2
-F = map(S,A)
-m=matrix"ay,0;x,0;-y,x;0,-y"
-isHomogeneous m
-E=setupBGG(F,{e,f})
-describe E
-F = symmetricToExterior m
---E = (ZZ/101 [a, e, f, Weights=>{-1,1,1},Global=>false,Degrees => {{0}, {1}, {1}}, SkewCommutative => {1, 2}])/(a^2)
-setMaxIdeal(ideal(a,e,f))
-F = substitute(F,E)
-sF = matrix entries syz F
-sF = localMingens sF
-localResolution(coker sF, LengthLimit=>10)
-
-syz oo
-ker F
-prune F
-res coker oo
-
-A = ZZ/101[a,MonomialOrder=>Weights=>{-1},Global=>false]
-B = A[x,y,z]
-
-----------------------------
--- below this is possibly:
--- under development by dan
---------------------------------
-
-newPackage "LocalRings"
-export {"LocalRing","localRing","ambientRing","maxIdeal"}
-LocalRing = new Type of EngineRing
-debug Core
-presentation LocalRing := (R) -> presentation R.ambientRing
-generators LocalRing := opts -> (R) -> generators R.ambientRing
-isCommutative LocalRing := (R) -> isCommutative R.ambientRing
-degreeLength LocalRing := (R) -> degreeLength R.ambientRing
-numgens LocalRing := (R) -> numgens R.ambientRing
--- promote(ZZ,LocalRing) := promote(RingElement,LocalRing) := (r,R) -> promote(r,R.ambientRing)
-
-localRing = method()
-
-localRing(EngineRing,Ideal) := (R,m) -> (					    -- R = poly ring, m = max ideal
-     S := new LocalRing from raw R;
-     S.ambientRing = R;
-     S.maxIdeal = m;
-     S.baseRings = append(R.baseRings, R);
-     commonEngineRingInitializations S;
-     expression S := s -> expression lift(s,R);
-     S)
-endPackage "LocalRings"
-
--- end
--- try it out immediately
-
-errorDepth = 0
-R = localRing (QQ[x,y], ideal(x,y))
-M = R^4
-C = res M
-
--- Local Variables:
--- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages PACKAGES=Local pre-install"
--- End:
+end--

--- a/M2/Macaulay2/packages/LocalRings/doc.m2
+++ b/M2/Macaulay2/packages/LocalRings/doc.m2
@@ -1,0 +1,201 @@
+doc ///
+Key
+  LocalRings
+  (localRing, Ring, Ideal)
+Headline
+  Localizing polynomial rings at a prime ideal
+Description
+  Text
+    The basic definition of localization of polynomial rings at prime ideals along with various
+    elementary operations are defined in m2/localring.m2, which in turn depends on a raw local ring
+    type defined in e/localrings.hpp. This package extends the following methods to such local rings:
+    syz, resolution, length, trim, mingens, minimalPresentation, symbol//, inducedMap, symbol:,
+    saturate, annihilate.
+
+    Note: Methods isSubset and symbol== are fixed in m2/modules2.m2 and reduce is fixed in m2/matrix.m2.
+    Many other methods that only rely on the methods above, such as map, modulo, subquotient, kernel,
+    cokernel, image, homology, Hom, Ext, Tor, etc. work for local rings automatically.
+
+    If you need specific methods that do not work, please inform Mahrud Sayrafi.
+  Example
+    R = ZZ/32003[a..d];
+    "rational quartic curve in P^3:";
+    I = monomialCurveIdeal(R,{1,3,4})
+    C = res I
+    M = ideal"a,b,c,d"; "maximal ideal at the origin";
+    P = ideal"a,b,c"; "prime ideal";
+    RM = localRing(R, M);
+    D = C ** RM;
+    E = pruneComplex D
+    "That is to say, the rational quartic curve is not locally Cohen-Macaulay at the origin";
+    "Therefore the curve is not Cohen-Macaulay";
+    RP = localRing(R, P);
+    D' = C ** RP;
+    E' = pruneComplex D'
+    "However, the curve is Cohen-Macaulay at the prime ideal P (and in fact any other prime ideal)";
+Caveat
+  Currently limited to localization at prime ideals rather than any multiplicatively closed set.
+  Quotients of local rings are not implemented yet. Moreover, certain functions (such as symbol%,
+  radical, minimalPrimes, leadingCoefficient) are ambiguous or not yet defined.
+SeeAlso
+  PruneComplex
+///
+
+doc ///
+Key
+   liftUp
+  (liftUp, Thing)
+  (liftUp, Ideal, Ring)
+  (liftUp, Module, Ring)
+  (liftUp, Matrix, Ring)
+  (liftUp, MutableMatrix, Ring)
+Headline
+  Lifts various objects over R_P to R.
+Usage
+  I = liftUp IP
+  M = liftUp(MP, R)
+Inputs
+  MP: Matrix
+    a matrix, module, or ideal over a local ring RP
+  R: Ring
+    a ring, RP is a localization of R
+Outputs
+  M: Matrix
+    a matrix, module, or ideal over the ring R
+Description
+  Text
+    Given an object, for instance an ideal IP, over a local ring (RP, P), this method returns the
+    preimage of that object under the cannonical map R -> RP after clearing denominators of IP.
+
+    For matrices (hence most other objects as well), clearing denominators is performed columnwise.
+
+    In conjunction with pruneComplex, liftUp is used to implement many of the elementary operations
+    over local rings such as syz (see the example below).
+  Example
+    "Computing the syzygy over a local ring using liftUp and pruneComplex";
+    R = ZZ/32003[vars(0..5)];
+    I = ideal"abc-def,ab2-cd2-c,-b3+acd";
+    C = res I;
+    M = ideal gens R;
+    RM = localRing(R, M);
+    F = C.dd_2;
+    FM = F ** RM
+    "This is the process for finding the syzygy of FM:";
+    f = liftUp FM;
+    g = syz f;
+    h = syz g;
+    C = {g ** RM, h ** RM};
+    "Now we prune the map h, which is the first map from the right:";
+    C = first pruneComplex(C, 1, Direction => "right");
+    g' = C#0;
+    "Scale each row with the common denominator of the corresponding column in FM:";
+    N = transpose entries FM;
+    for i from 0 to numcols FM - 1 do
+      rowMult(g', i, N_i/denominator//lcm);
+    "The syzygy of FM is:";
+    GM = map(source FM, , matrix g')
+    kernel FM == image GM
+Caveat
+  This is NOT the same as lift.
+  Not tested with quotients properly.
+SeeAlso
+  pruneComplex
+///
+
+doc ///
+Key
+   hilbertSamuelFunction
+  (hilbertSamuelFunction, Module, ZZ)
+  (hilbertSamuelFunction, Module, ZZ, ZZ)
+  (hilbertSamuelFunction, Ideal, Module, ZZ)
+  (hilbertSamuelFunction, Ideal, Module, ZZ, ZZ)
+Headline
+  Computes the Hilbert-Samuel Function of Modules over Local Rings
+Usage
+  h = hilbertSamuelFunction(M, n)
+  L = hilbertSamuelFunction(M, n0, n1)
+  h = hilbertSamuelFunction(q, M, n)
+  L = hilbertSamuelFunction(q, M, n0, n1)
+Inputs
+  M: Module
+    a module over a local ring
+  n:  ZZ
+    single input to the function
+  n0: ZZ
+    first input to the function
+  n1: ZZ
+    last input to the function
+  q: Ideal
+    a parameter ideal
+Outputs
+  h: ZZ
+    the integer output of the Hilbert-Samuel function
+  L: Sequence
+    an sequence of integer outputs of the Hilbert-Samuel function
+Description
+  Text
+    Given a module over a local ring, a parameter ideal, and an integer, this method computes the
+    Hilbert-Samuel function for the module. If parameter ideal is not given, the maximal ideal is
+    assumed.
+
+    Note:
+     If computing at index n is fast but slows down at n+1, try computing at range (n, n+1).
+     On the other hand, if computing at range (n, n+m) is slow, try breaking up the range.
+
+    To learn more read Eisenbud, Commutative Algebra, Chapter 12.
+  Example
+    "Example from Computations in Algebraic Geometry with Macaulay2, pp. 61:";
+    R = QQ[x,y,z];
+    RP = localRing(R, ideal gens R);
+    I = ideal"x5+y3+z3,x3+y5+z3,x3+y3+z5"
+    M = RP^1/I
+    elapsedTime length M -- 0.55 seconds
+    elapsedTime hilbertSamuelFunction(M, 0, 6) -- 0.55 seconds
+    oo//sum
+
+    "An example of using a parameter ideal:";
+    R = ZZ/32003[x,y];
+    RP = localRing(R, ideal gens R);
+    N = RP^1
+    q = ideal"x2,y3"
+    elapsedTime hilbertSamuelFunction(N, 0, 5) -- n+1 -- 0.02 seconds
+    elapsedTime hilbertSamuelFunction(q, N, 0, 5) -- 6(n+1) -- 0.32 seconds
+Caveat
+  Hilbert-Samuel function with respect to a parameter ideal other than the maximal ideal can be slower.
+SeeAlso
+  (length, Module)
+///
+
+///
+Key
+   length
+  (length, Module)
+Headline
+  Computes the length of modules over local rings
+Usage
+Inputs
+Outputs
+Description
+  Text
+  Example
+Consequences
+  Item
+    If the algorithm terminates, the length of the module is stored in M.cache.length.
+Caveat
+SeeAlso
+///
+
+end--
+
+doc ///
+Key
+Headline
+Usage
+Inputs
+Outputs
+Description
+  Text
+  Example
+Caveat
+SeeAlso
+///

--- a/M2/Macaulay2/packages/LocalRings/examples.m2
+++ b/M2/Macaulay2/packages/LocalRings/examples.m2
@@ -1,0 +1,536 @@
+---------------------------------------------------------------------------
+-- PURPOSE : Contains examples of computations involving local rings from
+--           various sources in the literature.
+--           See: https://www.ocf.berkeley.edu/~mahrud/thesis/examples.m2
+---------------------------------------------------------------------------
+
+-- I. Examples in the handout:
+-- https://www.ocf.berkeley.edu/~mahrud/thesis/handout.pdf
+
+-- Source: https://www.singular.uni-kl.de/Manual/4-0-3/sing_2278.htm#SEC2353
+restart
+needsPackage "LocalRings"
+R = QQ[x,y,z,w];
+I = ideal( (x-1)^2 + y^2 - 1) -- Circle of radius one centered at (1,0)
+J = ideal"xz-y2,yw-z2,xw-yz"; -- The twisted cubic curve
+primaryDecomposition (I+J)
+P = radical (primaryDecomposition (I+J))#0
+Q = radical (primaryDecomposition (I+J))#1
+
+RP = localRing(R, P);
+RQ = localRing(R, Q);
+length (RP^1/promote(I+J, RP))
+length (RQ^1/promote(I+J, RQ))
+
+use R
+K = intersect(I, J)+ideal"z"; -- 4 inhomogeneous generators
+C' = res K
+C'.dd_1
+
+RP = localRing(R, K+ideal(x-1));
+CP = res (R^1/K ** RP)
+CP.dd_1
+factor (entries liftUp CP.dd_1)_0_1
+ideal((x-1)^2+y^2-1)== ideal entries {CP.dd_1}_0_1 -- Indeed, we get back the circle
+
+-- II. Examples in the paper:
+
+-- Example II.3: A Gorenstein ideal of homological dimension 2 with 5 generators
+-- Some Structure Theorems for Finite Free Resolutions, Example 5, pp. 127
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y,z];
+P = ideal"x,y,z";
+RP = localRing(R, P);
+I = ideal(x^3+y^3,x^3+z^3,x*y/(z+1),x*z/(y+1),y*z/(x+1));
+C = res I;
+CP = C ** RP
+pruneComplex CP -- FIXME this is surjective, so why isn't the complex complete
+assert(liftUp ideal CP.dd_1 == liftUp ideal transpose(CP.dd_3))
+-- FIXME can we have f_1=f_3* and f_2=-f_2* ?
+
+
+-- Example II.9: Is the smooth rational quartic a Cohen-Macaulay curve?
+restart
+needsPackage "LocalRings";
+R = ZZ/32003[a..d];
+-- rational quartic curve in P^3:
+I = monomialCurveIdeal(R,{1,3,4})
+C = res I
+M = ideal"a,b,c,d"; -- maximal ideal at the origin
+P = ideal"a,b,c";   -- prime ideal
+RM = localRing(R, M);
+D = C ** RM;
+E = pruneComplex D
+-- That is to say, the rational quartic curve is not locally Cohen-Macaulay at the origin
+-- Therefore the curve is not Cohen-Macaulay
+RP = localRing(R, P);
+D' = C ** RP;
+E' = pruneComplex D'
+-- However, the curve is Cohen-Macaulay at the prime ideal P (and in fact any other prime ideal)
+
+-- Example II.11: Computing the syzygy over a local ring using liftUp and pruneDiff
+restart
+needsPackage "LocalRings";
+R = ZZ/32003[vars(0..5)];
+I = ideal"abc-def,ab2-cd2-c,-b3+acd";
+C = res I;
+C = pruneComplex(C, UnitTest => isScalar);
+M = ideal"a,b,c,d,e,f";
+RM = localRing(R, M);
+F = C.dd_2;
+FM = F ** RM
+--GM = syz FM
+ f' = liftUp FM;
+ g' = syz f';
+ h' = syz g';
+ g = g' ** RM;
+ h = h' ** RM;
+ C = {mutableMatrix g, mutableMatrix h};
+ pruneDiff(C, 1);
+ toChainComplex C
+GM = matrix C#0
+assert(image GM == kernel FM)
+
+-- Intersection Theory: Geometric Multiplicity
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y];
+C = ideal"y-x2"; -- parabola
+D = ideal"y-1";  -- line
+E = ideal"y";    -- line
+
+use R;
+P = ideal"y-1,x-1";
+RP = localRing(R, P);
+assert(length (RP^1/promote(C+D, RP)) == 1)
+assert(length (RP^1/promote(C+E, RP)) == 0)
+
+use R;
+P = ideal"x,y";  -- origin
+RP = localRing(R, P);
+assert(length(RP^1/promote(C+D, RP)) == 0)
+assert(length(RP^1/promote(C+E, RP)) == 2)
+
+
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y];
+C = ideal"y-x3";
+D = ideal"y-x2";
+E = ideal"y";
+
+use R;
+P = ideal"x,y";
+RP = localRing(R, P);
+assert(length(RP^1/promote(C+D, RP)) == 2)
+assert(length(RP^1/promote(C+E, RP)) == 3)
+
+use R;
+P = ideal"x-1,y-1";
+RP = localRing(R, P);
+assert(length(RP^1/promote(C+D, RP)) == 1)
+assert(length(RP^1/promote(C+E, RP)) == 0)
+
+-- Hilbert-Samuel Function
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y];
+RP = localRing(R, ideal gens R);
+N = RP^1
+q = ideal"x2,y3"
+elapsedTime assert({1,2,3,4,5,6} == hilbertSamuelFunction(N, 0, 5)) -- n+1
+elapsedTime assert({6,12,18,24,30,36} == hilbertSamuelFunction(q, N, 0, 5)) -- 6(n+1)
+
+-- What is happening around the singularity of the Seepferdchen surface?
+-- Idea from the 2017 SIAM Applied Algebraic Geometry Conference in Atlanta
+-- see http://wiki.siam.org/siag-ag/index.php/Early_Career_Prize#Award_Type
+-- and https://homepage.univie.ac.at/herwig.hauser/gallery.html
+restart
+needsPackage "LocalRings"
+R = QQ[x,y,z]
+I = ideal(x^4 - 5/2*x^2*y^3 - x*z^3 + y^6 - y^2*z^3)
+assert(isPrime I);
+J = ideal jacobian I
+D = (primaryDecomposition J) / radical
+-- Which one is the cute self-intersection singularity?
+P = D#1
+assert(isPrime P);
+RP = localRing(R, P);
+M = RP^1/promote(J, RP)
+debugLevel = 1
+-- The multiplicity of the singularity of the Seepferdchen surface is 45
+--time length(M) -- this is too slow, so we break it up:
+time A = hilbertSamuelFunction(M, 0, 5)  -- 1 3 6 8 8 6 -- 1.2 seconds
+time B = hilbertSamuelFunction(M, 6, 10) -- 5 4 3 1 0 -- 1.2 seconds
+sum A + sum B
+
+M = RP^1/promote(I, RP)
+time A = hilbertSamuelFunction(M, 0, 4)  -- 1 3 6 8 8 6 -- 1.2 seconds
+time A = hilbertSamuelFunction(M, 5, 5)  -- 1 3 6 8 8 6 -- 1.2 seconds
+time A = hilbertSamuelFunction(M, 6, 6)  -- 1 3 6 8 8 6 -- 1.2 seconds
+time B = hilbertSamuelFunction(M, 7, 7) -- 5 4 3 1 0 -- 1.2 seconds
+time B = hilbertSamuelFunction(M, 8, 8) -- 5 4 3 1 0 -- 1.2 seconds
+time B = hilbertSamuelFunction(M, 9, 9) -- 5 4 3 1 0 -- 1.2 seconds
+time B = hilbertSamuelFunction(M, 10, 10) -- 5 4 3 1 0 -- 1.2 seconds
+
+-- Computations in Algebraic Geometry with Macaulay2 pp 61
+restart
+needsPackage "LocalRings"
+R = QQ[x,y,z];
+RP = localRing(R, ideal gens R);
+I = ideal"x5+y3+z3,x3+y5+z3,x3+y3+z5"
+M = RP^1/I
+elapsedTime assert(length(RP^1/I) == 27) -- 0.5 seconds
+elapsedTime assert((hilbertSamuelFunction(M, 0, 6))//sum == 27) -- 0.54 seconds
+elapsedTime assert((hilbertSamuelFunction(max ring M, M, 0, 6))//sum == 27) -- 0.55 seconds
+-- alternate method to get these numbers
+R = QQ[h,x,y,z,MonomialOrder=>Eliminate 1];
+I = ideal homogenize(matrix "x5+y3+z3,x3+y5+z3,x3+y3+z5",h)
+elapsedTime degree monomialIdeal sub(leadTerm gens gb I, h=>1)
+elapsedTime reduceHilbert hilbertSeries monomialIdeal sub(leadTerm gens gb I, h=>1)
+
+--TODO Computations in Algebraic Geometry with Macaulay2 pp 26-27
+
+
+-- Test from Mengyuan Zhang
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y,z,w];
+P = ideal "  yw-z2,   xw-yz,  xz-y2"
+I = ideal "z(yw-z2)-w(xw-yz), xz-y2"
+codim I == codim P --Hence this is finite, thus I is artinian in R_P, i.e. RP/IP is an artinian ring.
+radical I == P
+
+RP = localRing(R, P)
+N = RP^1/promote(I, RP)
+assert(length(N) == 2)
+assert(length(N) == degree I / degree P)
+
+assert({1,1,0,0} == for i from 0 to 3 list hilbertSamuelFunction(N, i))
+assert({1,1,0,0} == for i from 0 to 3 list hilbertSamuelFunction(max RP, N, i))
+
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+
+-- III. Additional examples:
+
+restart
+debug needsPackage "PruneComplex"
+needsPackage "LocalRings"
+R = ZZ/32003[a..f]
+I = ideal"abc-def,ab2-cd2-c,acd-b3-1"
+C = freeRes I
+D = pruneComplex(C, UnitTest => isScalar, Strategy => null, Direction => "both")
+--Not necessarily minimal!!
+C.dd
+D.dd
+
+-- 1506.06480.pdf Ex. 3.2
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y,z]
+P = ideal"x,y,z"
+RP = localRing(R, P) -- really we want R=kk[[x,y,z]] with infinite kk though
+I = ideal"x2y,y2z,z2x,xyz"
+Q = ideal"x2y,y2z,z2x"
+                     -- Q is a minimal reduction of I with red_Q(I)=2
+C = res I            -- presentation of I
+C = pruneComplex C   -- just to make sure it's minimal
+C.dd
+
+
+restart
+needsPackage "LocalRings";
+S = ZZ/32003[t]
+R = ZZ/32003[x,y]
+f = map(S, R, {t^4, t^6 + t^7})
+I = kernel f
+C = res I
+C.dd
+M = ideal"x,y"; -- maximal ideal at the origin
+P = ideal"x";   -- prime ideal
+RM = localRing(R, M);
+D = C ** RM;
+E = pruneComplex(D, UnitTest => isUnit)
+E.dd#1
+RP = localRing(R, P);
+D' = C ** RP;
+E' = pruneComplex(D', UnitTest => isUnit)
+
+------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------
+
+-- IV. Under development:
+
+-- TODO Hilbert-Samuel Polynomial
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y,z,w]
+-- Rational quartic, see Eisenbyd Ex. 12.4
+I = monomialCurveIdeal(R, {1, 3, 4})
+RM = localRing(R, ideal gens R)
+
+q = ideal"x,w"
+N = RM^1/promote(I, RM)
+
+for i from 0 to 3 list hilbertSamuelFunction(q, N, i)
+-- increasing linearly so degree is 1,
+-- hence the difference is the leading coefficient of the hilbert-samuel polynomial
+-- which is 4.
+
+-- TODO Geometric multiplicity != Algebraic multiplicity
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y]
+I = ideal"x2,xy,y2"
+RM = localRing(R, ideal gens R)
+
+N = RM^1/promote(I, RM)
+length(N) -- geometric multiplicity = 3, also computed by sum(HSF(N, i))
+
+for i from 0 to 3 list hilbertSamuelFunction(promote(I, RM), RM^1, i)
+-- algebraic multiplicity = 4, is the coefficient of HSP.
+
+-- TODO Smooth curves and differentials!!
+
+
+-- TODO blow-ups and resolution of singularities using reesAlgebra
+restart
+needsPackage "ReesAlgebra"
+needsPackage "LocalRings"
+R = ZZ/32003[x,y,z]
+I = ideal "y2z-x3-x2z"
+Q = reesIdeal I
+describe Q
+QP = localRing(Q, ideal"x,y,z")
+
+-- Projective Resolutions of Cohen-Macaulay Algebras
+-- 1981-002.pdf Ex. 4.2
+restart
+needsPackage "LocalRings"
+k = ZZ/32003 -- really wanted CC
+S = k[s,t, x,y,z]
+SP = localRing(S, ideal gens S)
+I = ideal"x2-st, y2-s(s2+t2), z2-t(s2+t2), xy-sz, xz-ty, yz-(s2+t2)x"
+C = res I
+C.dd
+-- TODO do a blow up of this
+
+--Syzygies of Multiplier Ideals on Singular Varieties
+-- 0804.4188.pdf Ex. 3.1
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y,z]
+RP = localRing(R, ideal gens R)
+n = 3
+I = ideal(x^n+y^n+z^n)
+res I
+oo.dd
+-- TODO blow this up
+
+-- Algebra Structures for Finite Free Resolution, and Some Structure Theorems for Ideals of Codimension 3
+-- Buchsbaum, Eisenbud
+-- 1977-002.pdf, pp 476
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[w,x,y,z]
+RP = localRing(R, ideal gens R)
+I = ideal"x2-wy,yz-w3,z2-wxy,xy2-w2z,y3-wxz"
+-- 5-generator perfect ideal of grade 3, with type 3
+-- kernel of R->k[[t]] obtained from {7,8,9,12}
+C = res I
+C.dd
+f3 = C.dd_3
+minors(2, f3)
+--this doesn't contain four elements from a minimal generating set for I
+--hence I is not of the form (I_0, x)
+
+-- FIXME: A TEST LIKE ABOVE FOR HIGHER DIMENSION
+-- TODO:  Do we need to use Serre's alternating sums? See
+restart
+needsPackage "LocalRings"
+R = ZZ/32003[x,y,z]
+C = ideal"x2+y2-z" -- paraboloid
+D = ideal"x2+y2-2" -- circle
+E = ideal"x,y"     -- line
+F = ideal"z"       -- plane
+
+use R
+P = ideal"x,y,z"   -- origin
+RP = localRing(R, P)
+length(RP^1/promote(C+D, RP)) == 0
+length(RP^1/promote(C+E, RP)) == 1 -- FIXME
+length(RP^1/promote(C+F, RP)) == 2 -- FIXME
+
+use R
+P = ideal"x-1,y-1"
+RP = localRing(R, P)
+length(RP^1/promote(C+D, RP)) == 1 -- FIXME
+length(RP^1/promote(C+E, RP)) == 0
+length(RP^1/promote(C+F, RP)) == 0
+
+
+-- 1403.3599.pdf Ex 3.14
+-- r(R) = l_R(Ext_R^d(R/m, R)) -- Cohen-Macaulay type of R??
+restart
+needsPackage "LocalRings"
+n = 4
+S = ZZ/32003[x_1..x_n,  dx_1..dx_n]
+A = matrix({{x_1..x_n},{dx_1..dx_n}})
+I = minors(2,A)
+R = S/I
+P = ideal(x_1..x_n,dx_1..dx_n)
+d = dim R - n -- dim RP = n+1, so d=1
+Ext^(n)(R^1/P, R^1)
+length oo -- FIXME this should be n-1=3
+RP = localRing(R, P)
+M = promote(P, RP)
+-- Then R/(X_i-Y_(i-1) : 0<1<n+1)R  \cong k[[X_1..X_n]]/minor(2,({{X1..Xn},{X2..Xn,X1}}))
+-- this is a cohen macaulay local ring of dim 1, also almost gorenstein local rings
+
+
+-- TODO
+-- 1403.3599.pdf Ex 7.6
+restart
+needsPackage "LocalRings"
+S = ZZ/32003[x,y]
+R = kk[x4,x3y,x2y2,xy3,y4]
+
+
+-- 1403.3599.pdf Ex 7.11
+restart
+needsPackage "LocalRings"
+V = ZZ/32003[t]
+S = ZZ/32003[x,y,z,w]
+F = map(V, S,{t^5,t^6,t^7,t^9})
+f = matrix F
+g = gens ker F
+h = syz g
+i = syz h
+j = syz i
+C = {mutableMatrix g, mutableMatrix h, mutableMatrix i, mutableMatrix j}
+(C1, P1) = pruneDiff(C, 0, PruningMaps => true)
+(C2, P2) = pruneDiff(C, 1, PruningMaps => P1)
+(C3, P3) = pruneDiff(C, 2, PruningMaps => P2)
+(C4, P4) = pruneDiff(C, 3, PruningMaps => P3)
+C' = chainComplex for M in C4 list  map(S^(numrows M), S^(numcols M), matrix M)
+C'.dd
+
+VP = localRing(V, ideal"t")
+SP = localRing(S, ideal"x,y,z,w")
+FP = map(VP, SP,{t^5,t^6,t^7,t^9})
+fp = matrix FP
+gp = g ** SP
+hp = syz gp
+ip = syz hp
+jp = syz ip
+CP = {mutableMatrix gp, mutableMatrix hp, mutableMatrix ip, mutableMatrix jp}
+(C1, P1) = pruneDiff(CP, 0, PruningMaps => true)
+(C2, P2) = pruneDiff(CP, 1, PruningMaps => P1)
+(C3, P3) = pruneDiff(CP, 2, PruningMaps => P2)
+(C4, P4) = pruneDiff(CP, 3, PruningMaps => P3)
+CP' = chainComplex for M in C4 list  map(SP^(numrows M), SP^(numcols M), matrix M)
+CP'.dd
+
+
+-------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
+-- V. Exercises from Commutative Algebra with a view towards algebraic geometry
+
+restart
+needsPackage "LocalRings"
+-- Eisenbud 12.2 exercises
+R = ZZ/32003[x,y,z]
+RP = localRing(R, ideal gens R)
+M = ideal"x,y,z"
+A = ideal"y,z"
+B = ideal"y2,z2"
+C = A^2
+-- Show these are parameter ideals of R/(f) where f is homogeneous form of degree d, monic in x
+-- Compute HS functions
+
+
+-- TODO Quotient
+-- Eisenbud 12.2 exercises
+exit
+make -j4 all-in-d all-in-e all-in-bin
+../M2
+restart
+debug Core
+debug needsPackage "LocalRings"
+R = ZZ/32003[x,y,z,w]
+RP = localRing(R, ideal gens R)
+M = matrix{{x,y,z},{y,z,w}}
+I = minors(2, M)
+SP = RP/I
+q = ideal"x,w"
+-- TODO Show that q is parameter ideal of R?
+isSubset(m^n, q)
+-- FIXME Compute HS function with respect to q, for which module? RP^1? RP^1/q?
+for i from 0 to 3 do << hilbertSamuelFunction(q, RP^1/q, i) << endl
+-- TODO Compute HS polynomial of it
+-- Compute length of RP/q
+N = RP^1/q
+for i from 0 to 3 do << hilbertSamuelFunction(N, i) << endl
+length N
+-- TODO IS THIS CORRECT?
+
+
+-- there are more examples in Section 12.2
+
+-------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
+restart
+needsPackage "LocalRings"
+needsPackage "PruneComplex"
+debugLevel=1
+debug PruneComplex
+debug LocalRings
+elapsedTime check PruneComplex -- 17
+elapsedTime check LocalRings -- 15
+
+uninstallPackage "PruneComplex"
+uninstallPackage "LocalRings"
+
+installPackage "PruneComplex"
+installPackage "LocalRings"
+
+-------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
+-- Local Rings in Engine
+exit
+make -j4 all-in-d all-in-e all-in-bin
+../M2
+
+restart
+debug Core
+debug needsPackage "PruneComplex"
+debug needsPackage "LocalRings"
+  R = ZZ/32003[vars(0..3)]
+  I = monomialCurveIdeal(R, {1, 3, 4})
+  C = res I
+  P = ideal"a,b,c";
+  RP = localRing(R, P);
+  J = ideal(gens I ** RP)
+  D = res J
+
+-- TODO look at rawMatrixRowScale(raw D_1,raw f,2,false)
+-- TODO first do isScalar, then do isUnit
+-- FIXME is the size of output of enginePruneComplex changing?
+-- TODO compute filtration degree for local rings
+-- TODO deal with degrees in the engine
+
+----------
+-- This shouldn't crash, it should give an error.
+restart
+debug Core
+debug needsPackage "LocalRings"
+  R = ZZ/32003[vars(0..4)]
+  P = ideal"a,b,c,d";
+  RP = localRing(R, P);
+  f = transpose matrix{{a, 0, c}, {0, b, 0}}
+  g = transpose matrix{{a, b, c}}
+  G := syz(f | g)
+  toChainComplex {f|g, G}
+  pruneComplex {G, f|g}

--- a/M2/Macaulay2/packages/LocalRings/legacy.m2
+++ b/M2/Macaulay2/packages/LocalRings/legacy.m2
@@ -1,0 +1,495 @@
+--##################### Legacy Code ##########################--
+--newPackage(
+--	"LocalRings",
+--    	Version => "1.0",
+--    	Date => "July 1, 2008",
+--    	Authors => {
+--	     {Name => "David Eisenbud", Email => "de@msri.org", HomePage => "http://www.msri.org/~de/"},
+--	     {Name => "Mike Stillman", Email => "mike@math.cornell.edu", HomePage => "http://www.math.cornell.edu/~mike/"}
+--	     },
+--    	Headline => "Local rings at the origin",
+--    	DebuggingMode => false
+--    	)
+
+--export {
+--     "setMaxIdeal",
+--     "localComplement",
+--     "localsyz",
+--     "localMingens",
+--     "localModulo",
+--     "localPrune",
+--     "localResolution",
+--     "residueMap",
+--     "maxIdeal"
+--     }
+
+-- This routine, localRing, is not functional yet -----
+--localRing = new method(
+--     Options => {
+--	  MonomialOrder => null
+--	  }
+--     )
+--localRing Ring := R -> localRing(R, ideal vars R)
+--localRing(Ring,Ideal) := (R,P) -> (
+--     R	-- at first, we do nothing
+--     )
+--------------------------------------------------------
+setMaxIdeal = method()
+setMaxIdeal(Ideal) := (maxI) -> (
+     R := ring maxI;
+     R.residueMap = map(R,R,vars R % maxI);
+     R.maxIdeal = maxI
+     )
+
+localComplement = method()
+localComplement Matrix := Matrix => (m) -> (
+     n := transpose syz transpose ((ring m).residueMap m);
+     id_(target n) // n)
+
+defaultResolutionLength := (R) -> (
+     numgens R + 1 + if ZZ === ultimate(coefficientRing, R) then 1 else 0
+     )
+
+resolutionLength := (R,options) -> (
+     if options.LengthLimit == infinity then defaultResolutionLength R else
+options.LengthLimit
+     )
+
+localsyz = method()
+localsyz(Matrix) := (m) -> (
+     localMingens syz m
+     --C = res(coker m,LengthLimit=>3);
+     --C.dd_2 * localComplement(C.dd_3)
+     )
+
+localMingens = method()
+localMingens(Matrix) := Matrix => (m) -> (
+     -- warning: this routine should perhaps take a Module...
+     m * localComplement syz m
+     )
+
+localModulo = method()
+localModulo(Matrix,Matrix) := Matrix => (m,n) -> (
+     P := target m;
+     Q := target n;
+     if P != Q then error "expected maps with the same target";
+     if not isFreeModule P or not isFreeModule Q
+     or not isFreeModule source m or not isFreeModule source n
+     then error "expected maps between free modules";
+     localMingens syz(m|n, SyzygyRows => numgens source m)
+     )
+
+
+localPrune = method()
+localPrune Module := (M) -> (
+     p := presentation M;
+     p1 := localComplement p;
+     p2 := localModulo(p1,p);
+     N := coker(p2);
+     N.cache.pruningMap = map(M,N,p1);
+     N
+     )
+
+localResolution = method(Options => options resolution)
+localResolution Ideal := options -> (I) -> localResolution coker gens I
+localResolution Module := options -> (M) -> (
+     R := ring M;
+     if not R.?maxIdeal then error "use setMaxIdeal first!";
+     maxlength := resolutionLength(R,options);
+     if M.cache.?localResolution
+     then (C := M.cache.localResolution;
+     C.length = length C)
+     else (
+	  C = new ChainComplex;
+	  C.ring = R;
+	  -- f := presentation M;
+	  -- we have replaced presentation in the previous line by minimalPresentation. This has fixed a reported bug where
+	  -- localResolution returned a non-minimal presentation.
+	  -- We have included the above mentioned example in the tests section.
+	  f := relations minimalPresentation M;
+	  C#0 = target f;
+	  C#1 = source f;
+	  C.dd#1 = f;
+	  M.cache.localResolution = C;
+	  C.length = 1;
+	  );
+     i := C.length;
+     while i < maxlength and C.dd_i != 0 do (
+	  g := localsyz C.dd_i;
+	  shield (
+	       i = i+1;
+	       C.dd#i = g;
+	       C#i = source g;
+	       C.length = i;
+	       );
+	  );
+     C)
+
+end--
+
+beginDocumentation()
+
+document { Key => LocalRings,
+     Headline => "Polynomial rings localized at a maximal ideal",
+     EM "LocalRings", " is a package for finding minimal generators, syzygies and resolutions
+     for polynomial rings localized at a maximal ideal.",
+     }
+
+document {
+     Key => {setMaxIdeal, (setMaxIdeal,Ideal)},
+     Headline => "set the maximal ideal for local ring methods",
+     Usage => "setMaxIdeal I",
+     Inputs => {
+	  "I" => {ofClass Ideal, ", a maximal ideal of the ring R"}
+	  },
+     Outputs => {
+	  Ideal => {"same ideal as input"}
+	  },
+     "The function adds new structure to the ring which specifies a maximal ideal which allows the user to employ local ring methods.",
+     EXAMPLE lines ///
+	  R = ZZ/32003[x,y,z,w,SkewCommutative=>true]
+	  setMaxIdeal(ideal(x,y,z,w))
+	  ///,
+     Caveat => {},
+     SeeAlso => {localComplement, localsyz, localMingens, localModulo, localPrune, localResolution, residueMap, maxIdeal}
+     }
+
+document {
+     Key => {localComplement, (localComplement,Matrix)},
+     Headline => "find the splitting of the target of a map",
+     Usage => "localComplement m",
+     Inputs => {
+	  "m" => {ofClass Matrix, ", representing a homomorphism of free modules over a local ring"},
+	  },
+     Outputs => {
+	  Matrix => {"the complement of the image of the homomorphism represented by m"}
+	  },
+     "The function finds a splitting of the target of m as a direct sum of the image of m and the image of the output.",
+     EXAMPLE lines ///
+	  R = ZZ/32003[x,y]
+	  m = matrix{{x,y-1},{0,x}}
+	  setMaxIdeal(ideal(x,y))
+	  localComplement m
+	  ///,
+     Caveat => {},
+     SeeAlso => {setMaxIdeal, localsyz, localMingens, localModulo, localPrune, localResolution, residueMap, maxIdeal}
+     }
+
+document {
+     Key => {localsyz, (localsyz,Matrix)},
+     Headline => "find syzygies",
+     Usage => "localsyz m",
+     Inputs => {
+	  "m" => {ofClass Matrix}
+	  },
+     Outputs => {
+	  Matrix => {"giving minimal generators of the syzygies taking into account the local structure"}
+	  },
+     EXAMPLE lines ///
+	  R = ZZ/32003[x,y,z,w,SkewCommutative=>true]
+	  m = matrix{{x,y*z},{z*w,x}}
+	  setMaxIdeal(ideal(x,y,z,w))
+	  localsyz m
+	  m * localsyz m
+	  ///,
+     Caveat => {},
+     SeeAlso => {setMaxIdeal, localComplement, localMingens, localModulo, localPrune, localResolution, residueMap, maxIdeal}
+     }
+
+document {
+     Key => {localMingens, (localMingens,Matrix)},
+     Headline => "finds a minimal set of generators",
+     Usage => "localMingens m",
+     Inputs => {
+	  "m" => {ofClass Matrix}
+	  },
+     Outputs => {
+	  Matrix => {"the matrix of minimal generators"}
+	  },
+     "We get a minimal set for the homogeneous case, but not necessarily otherwise.",
+     EXAMPLE lines ///
+	  R=QQ[a,b]
+	  setMaxIdeal ideal gens R
+	  mingens image matrix{{a-1,a,b},{a-1,a,b}}
+	  localMingens matrix {{a-1,a,b},{a-1,a,b}}
+	  ///,
+     Caveat => {},
+     SeeAlso => {setMaxIdeal, localComplement, localsyz, localModulo, localPrune, localResolution, residueMap, maxIdeal}
+     }
+
+document {
+     Key => {localModulo, (localModulo,Matrix,Matrix)},
+     Headline => "find the pre-image (pullback) of image of a map over a local ring",
+     Usage => "localModulo(m,n)",
+     Inputs => {
+	  "m" => {ofClass Matrix},
+	  "n" => {ofClass Matrix}
+	  },
+     Outputs => {
+	  Matrix => {"whose image is the pre-image (pullback) of the image of n under m"}
+	  },
+     "The maps m and n must have the same target, and their sources and targets must be free. If m is null, then it is taken to be the identity. If n is null, it is taken to be zero.",
+     EXAMPLE lines ///
+	  R = QQ[x,y,z]
+	  setMaxIdeal ideal vars R
+	  m = matrix {{x-1, y}}
+	  n = matrix {{y,z}}
+	  modulo (m,n)
+	  localModulo (m,n)
+	  ///,
+          Caveat => {},
+     SeeAlso => {setMaxIdeal, localComplement, localsyz, localMingens, localPrune, localResolution, residueMap, maxIdeal}
+     }
+
+document {
+     Key => {localPrune, (localPrune,Module)},
+     Headline => "find a minimal presentation",
+     Usage => "localPrune M",
+     Inputs => {
+	  "M" => {ofClass Module}
+	  },
+     Outputs => {
+	  Module
+	  },
+     "The output is a minimal presentation of the input.",
+     EXAMPLE lines ///
+	  R=QQ[a,b]
+	  setMaxIdeal ideal gens R
+	  m = matrix{{a-1,a,b},{a-1,a,b}}
+	  prune m
+	  localPrune image m
+	  ///,
+     Caveat => {},
+     SeeAlso => {setMaxIdeal, localComplement, localsyz, localMingens, localModulo, localResolution, residueMap, maxIdeal}
+     }
+
+document {
+     Key => {localResolution, (localResolution,Module), (localResolution,Ideal)},
+     Headline => "find a resolution over a local ring",
+     Usage => "localResolution M",
+     Inputs => {
+	  "M" => {ofClass Module}, " or ", {ofClass Ideal},
+	  },
+     PARA "This method has option inputs that it inherits from ", TO resolution, ".",
+     Outputs => {
+	  ChainComplex
+	  },
+     PARA "This function iterates ", TO localsyz, " to obtain a resolution over the local ring.",
+     EXAMPLE lines ///
+	  R = ZZ/32003[x,y,z,w,SkewCommutative=>true]
+	  m = matrix{{x,y*z},{z*w,x}}
+	  setMaxIdeal(ideal(x,y,z,w))
+	  C = localResolution(coker m, LengthLimit=>10)
+	  C = localResolution(coker m)
+	  C^2
+	  C.dd_4
+	  ///,
+     EXAMPLE lines ///
+	  R = QQ[x,y,z]
+	  setMaxIdeal ideal vars R
+	  m = matrix {{x-1, y, z-1}}
+	  C = resolution coker m
+	  C.dd
+	  LC = localResolution coker m
+	  LC.dd
+          ///,
+
+     Caveat => {},
+     SeeAlso => {setMaxIdeal, localComplement, localsyz, localMingens, localModulo, localPrune, residueMap, maxIdeal}
+     }
+
+
+
+TEST ///
+     --loadPackage "LocalRings"
+     R = QQ[x,y,z]
+     setMaxIdeal ideal vars R
+     m = matrix {{x-1, y, z-1}}
+     LC = localResolution coker m
+     LC.dd
+     assert (length LC == 2)
+     ///
+
+TEST ///
+     --loadPackage "LocalRings"
+     S=ZZ/101[t,x,y,z]
+     setMaxIdeal ideal vars S
+     assert(S.residueMap === map(S,S,{0,0,0,0}))
+     m=matrix"x,y2;z3,x4"
+     M=coker m
+     assert(localsyz m == 0)
+     ///
+
+TEST ///
+     --loadPackage "LocalRings"
+     R = QQ[a,b,c,d]
+     setMaxIdeal(ideal(a-1,b-2,c-3,d-4))
+     I = ideal((1+a), (1+b))
+     G = localMingens gens I
+     assert(numgens source G == 1)
+     ///
+
+TEST ///
+     --loadPackage "LocalRings"
+     kk = ZZ/32003
+     R = kk[x,y,z,w,SkewCommutative=>true]
+     m = matrix{{x,y*z},{z*w,x}}
+     setMaxIdeal(ideal(x,y,z,w))
+     C = localResolution(coker m, LengthLimit=>10)
+     C = localResolution(coker m)
+     for i from 1 to 10 do
+	  assert(zero(C.dd_(i-1) * C.dd_i))
+     ///
+
+
+end--
+-- ###
+restart
+loadPackage "LocalRings"
+kk=ZZ/101
+S=kk[t,x,y,z]
+setMaxIdeal ideal vars S
+assert(S.residueMap === map(S,S,{0,0,0,0}))
+
+m=matrix"x,y2;z3,x4"
+M=coker m
+assert(localsyz m == 0)
+C = localResolution M -- wrong answer, OK now: MES
+
+N=coker map (S^{-2,0},S^{-3,-4}, m)
+--betti res N --without this line some further errors are produced below, different than with this line!
+localResolution N -- gives error msg "key not found in hash table", OK mow: MES
+
+
+betti (FFM=res (M, LengthLimit => 4)) -- correct, nonminimal
+FFM.dd
+betti (FF=localResolution M)
+FF.dd -- this is WRONG, not even composable maps
+localResolution M
+
+betti res N --without the res N line above, this doesn't work! -- MES: YET TO BE FIXED
+betti (FF=localResolution N) -- same for this, MES: THIS SEEMS TO WORK NOW
+localResolution N -- and this MES: WORKING NOW
+NN=coker map (S^2, S^2, m)
+resolution NN
+localResolution NN
+
+
+
+
+restart
+loadPackage "LocalRings"
+kk=ZZ/101
+S=kk[t,x,y,z]
+setMaxIdeal ideal vars S
+m=matrix"x,y2;z3,x4"
+M=coker m
+C = localResolution M -- wrong answer, OK now: MES
+N=coker map (S^{-2,0},S^{-3,-4}, m)
+
+localResolution N
+errorDepth = 0
+res N
+
+
+
+
+
+
+restart
+loadPackage "LocalRings"
+kk = ZZ/32003
+R = kk[x,y,z,w,SkewCommutative=>true]
+m = matrix{{x,y*z},{z*w,x}}
+setMaxIdeal(ideal(x,y,z,w))
+C = localResolution(coker m, LengthLimit=>10)
+C = localResolution(coker m)
+C^2
+C.dd_4
+
+kk = QQ
+R = kk[a,b,c,d]
+setMaxIdeal(ideal(a-1,b-2,c-3,d-4))
+R.residueMap
+I = ideal(a*(1+a), a*(1+b))
+I = ideal(a*(a-1), a*(b-2))
+I = ideal((1+a), (1+b))
+localResolution coker gens I
+module I
+localPrune module I
+localMingens gens I
+decompose I
+
+---------------------------------------
+-- MES: tests of local ring routines --
+---------------------------------------
+restart
+R = ZZ/32003[a,b,c,Weights=>{-1,-1,-1},Global=>false]
+I = ideal(a^2-b^3+a*c^4, a*b-c^3-b^4)
+gens gb I
+mingens I
+J = I + ideal((1+a-b^2)*I_0)
+mingens J
+res J
+
+restart
+loadPackage "BGG"
+loadPackage "LocalRings"
+A=ZZ/101[a,Weights=>{-1},Global=>false]/a^2
+S=ZZ/101[a,x,y,Weights=>{-1,1,1},Global=>false,Degrees=>{0,1,1}]/a^2
+F = map(S,A)
+m=matrix"ay,0;x,0;-y,x;0,-y"
+isHomogeneous m
+E=setupBGG(F,{e,f})
+describe E
+F = symmetricToExterior m
+--E = (ZZ/101 [a, e, f, Weights=>{-1,1,1},Global=>false,Degrees => {{0}, {1}, {1}}, SkewCommutative => {1, 2}])/(a^2)
+setMaxIdeal(ideal(a,e,f))
+F = substitute(F,E)
+sF = matrix entries syz F
+sF = localMingens sF
+localResolution(coker sF, LengthLimit=>10)
+
+syz oo
+ker F
+prune F
+res coker oo
+
+A = ZZ/101[a,MonomialOrder=>Weights=>{-1},Global=>false]
+B = A[x,y,z]
+
+----------------------------
+-- below this is possibly:
+-- under development by dan
+--------------------------------
+
+newPackage "LocalRings"
+export {"LocalRing","localRing","ambientRing","maxIdeal"}
+LocalRing = new Type of EngineRing
+debug Core
+presentation LocalRing := (R) -> presentation R.ambientRing
+generators LocalRing := opts -> (R) -> generators R.ambientRing
+isCommutative LocalRing := (R) -> isCommutative R.ambientRing
+degreeLength LocalRing := (R) -> degreeLength R.ambientRing
+numgens LocalRing := (R) -> numgens R.ambientRing
+-- promote(ZZ,LocalRing) := promote(RingElement,LocalRing) := (r,R) -> promote(r,R.ambientRing)
+
+localRing = method()
+
+localRing(EngineRing,Ideal) := (R,m) -> (					    -- R = poly ring, m = max ideal
+     S := new LocalRing from raw R;
+     S.ambientRing = R;
+     S.maxIdeal = m;
+     S.baseRings = append(R.baseRings, R);
+     commonEngineRingInitializations S;
+     expression S := s -> expression lift(s,R);
+     S)
+endPackage "LocalRings"
+
+-- end
+-- try it out immediately
+
+errorDepth = 0
+R = localRing (QQ[x,y], ideal(x,y))
+M = R^4
+C = res M

--- a/M2/Macaulay2/packages/LocalRings/tests.m2
+++ b/M2/Macaulay2/packages/LocalRings/tests.m2
@@ -1,0 +1,586 @@
+--============================ Tests Sections ===================================--
+
+TEST /// -- test for localRing, res, **, ==
+  debug needsPackage "PruneComplex"
+  R = ZZ/32003[vars(0..3)]
+  I = monomialCurveIdeal(R, {1, 3, 4})
+  CI = res I
+  P = ideal"a,b,c";
+  RP = localRing(R, P);
+  J = ideal(gens I ** RP)
+  CJ = res J
+  CP = CJ++CJ[-10]
+  DJ = CI ** RP
+  DP = pruneComplex(DJ++DJ[-10], PruningMaps=>true)
+  f = DP.cache.pruningMap
+  assert(DP.dd^2 == 0)
+  assert(DP == CP)
+  assert(isMinimal DP)
+  assert(isCommutative f)
+  assert(isQuasiIsomorphism f)
+///
+
+TEST /// -- test for liftUp and //
+  R = QQ[vars(0..4)]
+  f = matrix{{-1/2 *b^2,c,a,0},{-1/2*a*c,d,b,0},{-1/2*b*d,0,-c,a},{-1/2*c^2,0,-d,b}}
+  RP = localRing(R, ideal"a,b,c,d")
+  f' = matrix{{-1/e *b^2,c,a,0},{-1/e*a*c,d,b,0},{-1/e*b*d,0,-c,a},{-1/e*c^2,0,-d,b}}
+  f' = matrix{{-1/2 *b^2,c,a,0},{-1/2*a*c,d,b,0},{-1/2*b*d,0,-c,a},{-1/2*c^2,0,-d,b}}
+  f'' = f ** RP
+--  assert(liftUp f' == liftUp f'') -- FIXME in the engine. GCD(4, 2) is not 1!
+--  assert(liftUp (f' // id_(target f')) == f // id_(target f)) -- FIXME also in the engine
+  assert(liftUp (f'' // id_(target f'')) == f // id_(target f)) -- good
+  assert(f'_(0,0) == f''_(0,0)) -- good
+  assert(f' - f'' == 0) -- good
+--  assert(raw f' == raw f'') --FIXME this is bad, but it happens in other places too
+///
+
+TEST /// -- test for syz, liftUp, **, modulo, inducedMap
+  R = ZZ/32003[a..d]
+  P = ideal gens R;
+  RP = localRing(R, P);
+  I = monomialCurveIdeal(R, {1,3,4})
+  C = res I
+  IP = monomialCurveIdeal(RP, {1,3,4})
+  CP = res IP
+  -- syz
+  f = syz transpose CP.dd_3
+  g = transpose CP.dd_2
+  assert(image syz f == kernel f)
+  -- liftUp
+  f' = syz transpose C.dd_3
+  g' = transpose C.dd_2
+  assert(f' == liftUp f)
+  assert(g' == liftUp g)
+  -- inducedMap
+  assert(inducedMap(coker f, target f) * f == 0)
+  assert(kernel(inducedMap(coker f, target f)) == image f)
+  assert(kernel(inducedMap(coker g, target g) * f) == image modulo (f, g))
+  -- modulo
+  A = modulo(f', g')
+  A' = A ** RP
+  B = modulo(f, g)
+  C = subquotient(f', g')
+  C' = C ** RP
+  D = subquotient(f, g)
+  -- image
+  assert(image A == liftUp image B)
+  assert(image A' == image B)
+  -- coker
+  assert(coker A == liftUp coker B)
+  assert(coker A' == coker B)
+  -- subquotient
+  assert(C == liftUp D)
+--  assert(C' == D) -- FIXME: Module ** LocalRing minimizes
+  assert(subquotient(A, liftUp B) == 0)
+  assert(subquotient(liftUp B, A) == 0)
+  -- trim
+  assert(trim image A == liftUp trim image B)
+  assert(trim image A' == trim image B)
+  assert(trim coker A == liftUp trim coker B)
+  assert(trim coker A' == trim coker B)
+  assert(trim C == liftUp trim D)
+--  assert(trim C' == trim D) -- FIXME: why does this fail?
+  -- cover
+  assert(cover coker A == liftUp cover coker B)
+  assert(cover coker A' == cover coker B)
+-- The following two fail because degrees on the source aren't the same
+-- FIXME when source degree of modulo is fixed
+--  assert(cover image A == liftUp cover image B)
+--  assert(cover image A' == cover image B)
+  assert(cover C == liftUp cover D)
+  assert(cover C' == cover D)
+  -- ambient
+  assert(ambient coker A == liftUp ambient coker B)
+  assert(ambient coker A' == ambient coker B)
+  assert(ambient image A == liftUp ambient image B)
+  assert(ambient image A' == ambient image B)
+  assert(ambient C == liftUp ambient D)
+--  assert(ambient C' == ambient D) -- FIXME: why does this fail?
+-- TODO:
+  -- mingens
+  -- minimalPresentation: how to make this work?
+--  minimalPresentation coker modulo(f, g) ==  minimalPresentation subquotient(f, g)
+///
+
+TEST ///
+  R = ZZ/32003[a..d]
+  P = ideal gens R;
+  RP = localRing(R, P);
+  I = monomialCurveIdeal(RP, {1,3,4})
+  C = res I
+  F = syz transpose C.dd_3
+  G = transpose C.dd_2
+   -- free module
+  M = RP^{-1,-2,-3,0,4,5}
+  N = minimalPresentation M
+  assert(N == M)
+  assert(mingens M == id_M)
+  f = N.cache.pruningMap
+  assert(isIsomorphism f)
+  assert(isHomogeneous f)
+  assert(target f === M and source f === N)
+  -- image module
+  M = image F
+  N = minimalPresentation M
+  f = N.cache.pruningMap
+  assert(isIsomorphism f)
+  assert(target f === M and source f === N)
+  -- cokernel module
+  M = coker F
+  N = minimalPresentation M
+  assert(presentation N == mingens image F)
+  f = N.cache.pruningMap
+  assert(isIsomorphism f)
+  assert(target f === M and source f === N)
+  -- subquotient module
+  M = subquotient(F, G)
+  N = minimalPresentation M
+  f = N.cache.pruningMap
+  assert(isIsomorphism f)
+  assert(target f === M and source f === N)
+///
+
+TEST ///
+  S = ZZ/32003[s,t]
+  R = ZZ/32003[a..d]
+  phi = map(S,R,{s^2*t-t, s*t-s, t^3-s*t^2-s, s^2*t^2})
+  I = ker phi
+  C = pruneComplex res I
+  RP = localRing(R, ideal gens R)
+  C' = pruneComplex(C ** RP)
+
+  IP = ideal(gens I ** RP)
+  elapsedTime m1 = mingens image gens IP
+  elapsedTime m2 = presentation minimalPresentation image m1
+  assert(m1 * m2 == 0)
+///
+
+TEST ///
+  R = ZZ/32003[vars(0..4)]
+  P = ideal"a,b,c,d";
+  RP = localRing(R, P);
+
+  f = transpose matrix{{a, 0, c}, {0, b, 0}}
+  g = transpose matrix{{a, b, c}}
+  h = subquotient(f, g)
+  assert(image mingens liftUp h == liftUp image mingens h)
+  assert(image(RP ** mingens liftUp h) == image mingens h)
+  assert(mingens h == mingens image (f - g * (f // g)))
+  assert(liftUp f // liftUp g - liftUp (f // g) == 0)
+
+  f = transpose matrix{{e*a, 0, e*c}, {0, b, 0}}
+  -- FIXME when degrees are given by prime filtration
+--  h = subquotient(f, g)
+  -- Work around:
+  h = subquotient(map(RP^3, RP^2, f), map(RP^3,RP^1,g))
+  assert(image mingens liftUp h == liftUp image mingens h)
+  assert(image(RP ** mingens liftUp h) == image mingens h)
+///
+
+TEST ///
+  R = ZZ/32003[vars(0..3)]
+  P = ideal"a,b,c,d";
+  RP = localRing(R, P);
+
+  C =  res monomialCurveIdeal(R,  {1, 3, 4})
+  CP = res monomialCurveIdeal(RP, {1, 3, 4})
+  F = ker   transpose C.dd_3;
+  G = image transpose C.dd_2;
+  H = subquotient(gens F, gens G)
+  FP = ker   transpose CP.dd_3;
+  GP = image transpose CP.dd_2;
+  HP = subquotient(gens FP, gens GP)
+  assert(image mingens HP == image(RP ** mingens H))
+  assert(image liftUp mingens HP == image mingens H)
+///
+
+
+TEST /// -- test for // -- TODO add more
+  R = ZZ/32003[a..d]
+  P = ideal gens R;
+  RP = localRing(R, P);
+  I = monomialCurveIdeal(RP, {1,3,4})
+  C = res I
+  f = syz transpose C.dd_3
+  g = transpose C.dd_2
+  f' = liftUp f
+  g' = liftUp g
+  use R
+  g' = f'
+  f' = f' ** a
+  g = f
+  f = f ** a
+  assert(f === g  * (f//g))
+///
+
+TEST ///
+  -- by hand compute Ext^1(RP/IP,RP) == 0
+  R = ZZ/32003[a..c]
+  RP = localRing(R, ideal gens R)
+  f = matrix for i from 0 to 2 list for j from 0 to 2 list (random(2, R)+random(1,R))
+  I = minors(2, f)
+  IP = ideal(gens I ** RP);
+  C = pruneComplex res IP
+  assert(coker C.dd_1 == RP^1/IP)
+  assert(image C.dd_1 == module IP)
+  f1 = relations minimalPresentation image transpose C.dd_2
+  f2 = transpose C.dd_1
+  f1 = map(target f2,,f1)
+  M = subquotient(f1,f2)
+  assert(minimalPresentation M == 0)
+  assert(mingens M == 0)
+  -- by hand compute Ext^2(RP/IP,RP) == 0
+  f1 = relations minimalPresentation image transpose C.dd_3
+  f2 = transpose C.dd_2
+  f1 = map(target f2,,f1)
+  M = subquotient(f1,f2)
+  assert(mingens M == 0)
+  assert(minimalPresentation M == 0)
+
+  M = ker transpose C.dd_3 / image transpose C.dd_2
+  assert(prune M == 0)
+///
+
+------------------------- length and hilbertSamuelPolynomial ---------------------------
+
+TEST /// -- Intersection Theory: Geometric Multiplicity
+  R = ZZ/32003[x,y];
+  C = ideal"y-x2"; -- parabola
+  D = ideal"y-x";  -- line
+  E = ideal"y";    -- line
+
+  use R;
+  P = ideal"y-1,x-1";
+  RP = localRing(R, P);
+  assert(length (RP^1/promote(C+D, RP)) == 1)
+  assert(length (RP^1/promote(C+E, RP)) == 0)
+
+  use R;
+  P = ideal"x,y";  -- origin
+  RP = localRing(R, P);
+  assert(length(RP^1/promote(C+D, RP)) == 1)
+  assert(length(RP^1/promote(C+E, RP)) == 2)
+///
+
+TEST ///
+  R = ZZ/32003[x,y];
+  C = ideal"y-x3";
+  D = ideal"y-x2";
+  E = ideal"y";
+
+  use R;
+  P = ideal"x,y";
+  RP = localRing(R, P);
+  assert(length(RP^1/promote(C+D, RP)) == 2)
+  assert(length(RP^1/promote(C+E, RP)) == 3)
+
+  use R;
+  P = ideal"x-1,y-1";
+  RP = localRing(R, P);
+  assert(length(RP^1/promote(C+D, RP)) == 1)
+  assert(length(RP^1/promote(C+E, RP)) == 0)
+///
+
+TEST /// -- Hilbert-Samuel Function
+  R = ZZ/32003[x,y];
+  RP = localRing(R, ideal gens R);
+  N = RP^1
+  q = ideal"x2,y3"
+  time assert({1,2,3,4,5,6} == hilbertSamuelFunction(N, 0, 5)) -- n+1 -- 0.02 seconds
+  time assert({6,12,18,24,30,36} == hilbertSamuelFunction(q, N, 0, 5)) -- 6(n+1) -- 0.3 seconds
+///
+
+TEST ///-- Computations in Algebraic Geometry with Macaulay2 pp 61
+  R = QQ[x,y,z];
+  RP = localRing(R, ideal gens R);
+  I = ideal"x5+y3+z3,x3+y5+z3,x3+y3+z5"
+  M = RP^1/I
+  time assert(length M == 27) -- 0.55 seconds
+  time assert((hilbertSamuelFunction(M, 0, 6))//sum == 27) -- 0.55 seconds
+  time assert((hilbertSamuelFunction(max ring M, M, 0, 6))//sum == 27) -- 0.56 seconds
+///
+
+TEST /// -- test from Mengyuan
+  R = ZZ/32003[x,y,z,w]
+  P = ideal "  yw-z2,   xw-yz,  xz-y2"
+  I = ideal "z(yw-z2)-w(xw-yz), xz-y2"
+  codim I == codim P
+  -- Hence this is finite, thus I is artinian in R_P, i.e. RP/IP is an artinian ring.
+  C = res I
+  radical I == P
+
+  RP = localRing(R, P)
+  IP = promote(I, RP)
+  N = RP^1/IP
+  M = promote(P, RP)
+
+  assert(length N == 2)
+  assert(length N == degree I / degree P)
+
+  assert({1,1,0} == hilbertSamuelFunction(N, 0, 2))
+  assert({1,1,0} == hilbertSamuelFunction(max RP, N, 0, 2))
+  -- TODO: Find the polynomial from this
+///
+
+-- #################################### Subfunctions #################################### --
+
+TEST ///
+  R = ZZ/32003[a,b,c];
+  P = ideal"a,b"
+  RP = localRing(R, P);
+  I = ideal(a/(a+1)-b/(b+1), a/(a+1)+b/(b+1))
+
+  assert(ideal"a,b" == I)
+  assert(ideal"a,b+1" != I)
+  assert(ideal"a2-a" == ideal "a")
+
+  assert(ideal"a" != I)
+  assert(isSubset(ideal"a", I))
+  assert(not isSubset(I, ideal"a"))
+
+  assert(ideal"(a-b)(b2+1)c" != I)
+  assert(isSubset(ideal"(a-b)(b2+1)c", I))
+  assert(not isSubset(I, ideal"(a-b)(b2+1)c"))
+///
+
+TEST ///
+  R = ZZ/32003[vars(0..8)]
+  RP = localRing(R, ideal"a,b,c")
+  M = genericMatrix(R,3,3)
+  I = minors(2,M)
+
+  IP = promote(I,RP)
+  assert(IP == 1)
+  assert(mingens IP == matrix{{d*i-f*g}})
+  -- FIXME technically correct, but how to get matrix{{1}}?
+
+  use R
+  RM = localRing(R, ideal"a,b,c,d,e,f")
+  IM = promote(I,RM)
+  assert(IM != 1)
+  assert not isSubset(ideal(a_RM), IM)
+  assert isSubset(ideal(a_RM), ideal(b_RM) + IM)
+///
+
+TEST ///
+  R = ZZ/32003[a..f];
+  P = ideal"a,b"
+  RP = localRing(R, P);
+
+  phi = map(RP, RP, {a/c, 0, c, d, e, a*f})
+  assert(phi((a+b)/(c+b*(a+1))) == a/c^2)
+  assert(sub(a+b+c, b=>0) == a+c)
+  assert(phi matrix {{a,b,c}, {d,e,f}} - matrix {{a/c, 0, c}, {d, e, a*f}} == 0)
+///
+
+-- ###################################### Other Tests ###################################### --
+
+TEST /// -- Legacy test
+  R = ZZ/32003[a..f]
+  I = ideal"abc-def,ab2-cd2,-b3+acd";
+  C = res I
+  -- legacy
+  setMaxIdeal ideal gens R
+  E = localResolution coker C.dd_1
+  assert(betti C == betti E)
+///
+
+TEST ///
+  S = ZZ/32003[r,s,t]
+  R = ZZ/32003[a..e]
+  phi = map(S,R,{r^3, s^3, t^3-1, r*s*t-r^2-s, s^2*t^2})
+  I = ker phi
+  assert not isHomogeneous I
+
+  C = res I
+  f = syz transpose C.dd_3;
+  g = transpose C.dd_2;
+  modulo(f,g);
+  prune coker oo
+///
+
+-- ##################################### Experimental ##################################### --
+-- ############################### Colon ideals and modules ############################### --
+-- ############################# Saturations and annihilators ############################# --
+
+-- FIXME commented lines give error: unable to flatten ring over given coefficient ring
+TEST /// -- I:J -> I
+  R = ZZ/32003[x,y,z,w,u]
+  RP = localRing(R, ideal"x,y,z,w")
+  S = ZZ/32003[r,t,s]
+--  J = ker map(S, RP, {s^4*t^2, s^2, t^2, s^2*t^4})
+  I = ker map(S, R, {s^4*t^2*r^5, s^2, t^2*r^7, s^2*t^4*r^11,r}) -- TODO come up with a more complicated map
+  mingens I
+  J = promote(I, RP)
+  mingens J
+--  radical J
+--  minimalPrimes J
+  assert(J : ideal"y2z-xu2" == 1)
+  -- TODO expand this test
+///
+
+TEST /// -- test for I:f -> I
+  R = ZZ/32003[a,b,c,d,e,f]
+  I = ideal"abc,abd,ade,def" : ideal"abf"
+  RP = localRing(R, ideal gens R)
+  J = ideal"abc,abd,ade,def" : ideal"abf"
+  J' = ideal"abc,abd,ade,def" : (a*b*f)
+  assert(J === J')
+  assert(liftUp J === I)
+  assert(J === promote(I, RP))
+///
+
+TEST /// -- from Macaulay2Docs/tests/quotient.m2
+  R = ZZ[x,y];
+  RP = localRing(R, ideal gens R)
+  i = ideal(6*x^3, 9*x*y, 8*y^2);
+  j = ideal(-3, x^2, 4*y);
+  j1 = ideal(-3, x^2);
+  j2 = ideal(4*y);
+  A = i:j
+  A' = liftUp i : liftUp j
+  assert(liftUp A === A')
+  B = i:j1
+  B' = liftUp i : liftUp j1
+  assert(liftUp B === B')
+  C = i:j2
+  C' = liftUp i : liftUp j2
+  assert(liftUp C === C')
+  C'' = i : (4*y)
+  assert(C === C'')
+--  intersect(B, C) -- FIXME two of the generators are just zero!
+--  assert(liftUp intersect(B, C) === intersect(B', C'))
+  assert(liftUp intersect(B, C) == intersect(B', C'))
+///
+
+TEST /// -- M:N -> I, annihilator
+  S = ZZ/32003[r,t,s]
+  SP = localRing(S, ideal"s,t")
+  phi = map(SP^1, , matrix{{s^4-t^2-1, s^2, t^2-r^7, s^2-t^4+r^11,r}})
+  M = coker phi
+  assert(ann liftUp M == liftUp ann M) -- 1_S
+  assert(ann M == image matrix{0_M}:M )
+  assert(mingens M == 0)
+-- TODO expand this test
+///
+
+TEST /// -- Compute the annihilator of the canonical module of the rational quartic curve.
+  R = QQ[a..d];
+  RP = localRing(R, ideal gens R)
+  I = monomialCurveIdeal(RP,{1,3,4})
+  assert(saturate I == promote(saturate I, RP))
+  assert(liftUp saturate I == saturate liftUp I)
+  assert(saturate module I == promote(saturate module I, RP))
+-- FIXME saturate uses Module ** LocalRing, which unfortunately automatically minimizes the module
+  assert(liftUp saturate module I == minimalPresentation saturate module liftUp I)
+  M =  Ext^2(RP^1/I, RP)
+  assert(annihilator M == I)
+///
+
+TEST /// -- test for saturate
+  S = QQ[u,v,a,c,Degrees=>{2,3,1,2}];
+  SP = localRing(S, ideal gens S)
+  P = ideal(v^3-u^3*a^3,u*v^2-c^2*a^4);
+  Q = saturate(P,a)
+  assert( Q == Q:a )
+///
+
+end--
+
+--============================ Tests Under Development ===================================--
+
+/// -- XXX TODO: This is a comparison of new methods, old methods, and Mora.
+  R = ZZ/32003[a..c]
+  RP = localRing(R, ideal gens R)
+  f = matrix for i from 0 to 2 list for j from 0 to 2 list (random(2, R)+random(1,R))
+  I = minors(2, f)
+  IP = ideal(gens I ** RP);
+  C = pruneComplex res IP
+--  IP = liftUp IP -- uncomment this line to compare speed with the nonlocal case
+  elapsedTime m1 = mingens image gens IP;
+  elapsedTime m2 = presentation minimalPresentation image m1;
+  elapsedTime m3 = presentation minimalPresentation image m2;
+  elapsedTime m4 = presentation minimalPresentation image m3;
+  assert(m1 * m2 == 0)
+  assert(m2 * m3 == 0) -- FIXME why not composable?
+  assert(m3 * m4 == 0)
+///
+
+/// -- Same as above using old LocalRing methods
+  R = ZZ/32003[a..c]
+  f = matrix for i from 0 to 2 list for j from 0 to 2 list (random(2, R)+random(1,R))
+  I = minors(2, f)
+  setMaxIdeal ideal gens R
+  elapsedTime localResolution I -- how long does this even take?
+  elapsedTime m1 = localMingens gens I;
+  elapsedTime m2 = localsyz m1;
+  elapsedTime m3 = localsyz m2;
+  elapsedTime m4 = localsyz m3; -- this is the one that takes almost all of the time
+///
+
+/// -- Now try Mora algorithm
+  A = (ZZ/32003){a..d}
+  IA = sub(I,A);
+  m1 = gens gb IA;
+  ideal m1
+  m1 = mingens gb IA;
+  m2 = mingens gb syz m1; -- not good.  Is this easy to fix in engine code?
+///
+
+/// --XXX Here are two similar examples
+  kk = ZZ/32003
+  S = kk[t]
+  R = kk[a..d]
+  phi = map(S,R,{t^2-t^4, t-t^7, t^2+2*t^5, t^8})
+  I = ker phi
+  psi = map(S,R,{t^2-t^4, t^3-t^4-t^7, t^5+2*t^6, t^8})
+  J = ker psi
+
+  RP = localRing(R, ideal gens R)
+
+  C = res J
+  C1 = pruneComplex C
+  C2 = C1 ** RP
+  elapsedTime pruneComplex(C2, UnitTest => isScalar) -- very slow
+
+  IP = ideal(gens I ** RP)
+--  IP = liftUp IP -- uncomment this line to compare speed with the nonlocal case
+  elapsedTime m1 = mingens image gens IP -- very slow
+  elapsedTime m2 = presentation minimalPresentation image m1
+  elapsedTime m3 = presentation minimalPresentation image m2
+  elapsedTime m4 = presentation minimalPresentation image m3
+  assert(m1 * m2 == 0) -- FIXME why not composable?
+  assert(m2 * m3 == 0)
+  assert(m3 * m4 == 0)
+///
+
+/// --XXX
+  R = ZZ/32003[a..d]
+  F = (a^3-b*c*d-3*b*c)^3-a^3-b^2-(b+d)^4-c^5
+  I = ideal jacobian matrix{{F}}
+  C = res I
+  RP = localRing(R, ideal gens R)
+  elapsedTime C1 = pruneComplex C
+  elapsedTime C2 = pruneComplex(C ** RP) -- how long does this even take?
+  --
+  Rloc = (ZZ/32003){a,b,c,d}
+  Iloc = sub(I, Rloc)
+  m1 = mingens Iloc
+  m2 = syz m1 -- how long does this take?
+  gens gb Iloc
+///
+
+end--
+
+--  Development stuff
+--  path = prepend("~/src/m2/M2-local-rings/M2/Macaulay2/packages/", path) -- Mike
+restart
+needsPackage "LocalRings"
+elapsedTime check LocalRings -- 17 seconds
+
+restart
+uninstallPackage "LocalRings"
+restart
+installPackage "LocalRings"
+viewHelp "LocalRings"

--- a/M2/Macaulay2/packages/PruneComplex.m2
+++ b/M2/Macaulay2/packages/PruneComplex.m2
@@ -1,0 +1,432 @@
+---------------------------------------------------------------------------
+-- PURPOSE : Pruning chain complexes over polynomial and local rings.
+--
+-- PROGRAMMERS : Mahrud Sayrafi and Mike Stillman.
+--
+-- UPDATE HISTORY : created 4 January 2017; last update 25 October 2017.
+--
+-- NOTE : Everything here works in the local, graded, and inhomogeneous case.
+--        Algorithms are implemented in both the Macaulay2 language and C++ for speed.
+--        pruneComplex may not treat degrees of free modules correctly when working
+--        on a free chain complex rather than a free resolution.
+---------------------------------------------------------------------------
+newPackage(
+    "PruneComplex",
+    Version => "1.0",
+    Date => "January 14th, 2017",
+    Authors => {
+        {Name => "Mahrud Sayrafi", Email => "mahrud@berkeley.edu",   HomePage => "http://ocf.berkeley.edu/~mahrud/"},
+        {Name => "Mike Stillman",  Email => "mike@math.cornell.edu", HomePage => "http://www.math.cornell.edu/~mike/"}
+        },
+    Headline => "Prunes a given complex over R, R_m, and R_p",
+    DebuggingMode => true,
+    AuxiliaryFiles => true
+    )
+
+export {
+    "toMutableComplex",
+    "toChainComplex",
+    "pruneComplex",
+    "pruneUnit",
+    "pruneDiff",
+    "isScalar",
+--    "findUnit",
+--    "findAllUnits",
+--    "findSparseUnit",
+--    "isQuasiIsomorphism", -- see ChainComplexExtras.m2
+--    "isCommutative",
+--    "isAcyclic",
+--    "isMinimal",
+--    "freeRes",
+--    "testM2",
+--    "testEngine",
+--  Options:
+    "Direction", "PruningMaps", "UnitTest"
+    }
+
+<< "--------------------------------------------------------------------------------------" << endl;
+<< "-- The PruneComplex package is experimental: if the input is not a free resolution, --" << endl;
+<< "-- the map degrees of the resulting chain complex may not be correct,               --" << endl;
+<< "-- See the documentation and comments in the package to learn more.                 --" << endl;
+<< "--------------------------------------------------------------------------------------" << endl;
+
+debug Core;
+
+--=================================== Chain Complex Operations ===================================--
+-- TODO see if the new Chain Complexes package can be incorporated
+
+-- converts a ChainComplex into a list of mutable matrices
+-- TODO: take an option to make sparse mutable matrices here
+toMutableComplex = method()
+toMutableComplex ChainComplex := C -> for i from min C to max C list mutableMatrix C.dd_(i+1)
+
+-- Converts a list of mutable matrices into a ChainComplex.
+-- TODO: make sure the information about source and target modules for general complexes are kept
+toChainComplex = method()
+toChainComplex List          :=  mComplex     -> (
+    if #mComplex == 0 then error "toChainComplex: cannot build a chain complex without a ring.";
+    toChainComplex(mComplex, target matrix (mComplex#0))
+    )
+toChainComplex(List, Module) := (mComplex, F) -> (
+    chainComplex for M in mComplex list (
+        m := map(F, , matrix M);
+        F = source m; m)
+    )
+
+--=================================== Unit Finding Operations  ===================================--
+
+isScalar = method()
+isScalar RingElement := f -> f != 0 and liftable(f, coefficientRing ring f)
+
+-- Returns the first unit in M after pos
+-- A mutable matrix and a pair of coordinates -> a pair of coordinates for a unit or null
+-- start scanning at this location, row by row, return the coordinates of the first unit or scalar
+-- start from the beginning if no coordinate is given
+-- caveat: how to find bigger than 1x1 units?
+findUnit = method(Options => {UnitTest => isUnit})
+findUnit Matrix                   :=
+findUnit MutableMatrix            := opts ->  M                  -> findUnit(M, (0, 0), opts)
+findUnit(Matrix, Sequence)        :=
+findUnit(MutableMatrix, Sequence) := opts -> (M, pos) -> (
+    -- start scanning at this location, row by row
+    -- return the coordinates of the first unit or scalar
+    (r, c) := pos;
+    numrow := numRows M;
+    numcol := numColumns M;
+    if numcol == 0 or numrow == 0 then return null;
+    func := opts.UnitTest;
+    dl := debugLevel >= 3;
+    for i from c to numcol - 1 do
+      if func M_(r, i) then (if dl then <<"Unit "<<M_(r, i)<<" at "<<(r, i)<<endl; return (r, i));
+    for j from r+1 to numrow - 1 do
+      for i from 0 to numcol - 1 do
+        if func M_(j, i) then (if dl then <<"Unit "<<M_(j, i)<<" at "<<(j, i)<<endl; return (j, i));
+    )
+
+-- Returns a list of all units
+-- A mutable matrix -> List (of coordinates for all units or scalars in a matrix)
+findAllUnits = method(Options => options findUnit)
+findAllUnits Matrix        :=
+findAllUnits MutableMatrix := opts -> M -> (
+    -- return all units or scalars in a matrix
+    lastpos := (0, -1);
+    if numcols M == 0 or numrows M == 0 then return {};
+    while (pos := findUnit(M, (lastpos_0, lastpos_1 + 1), opts)) =!= null list (lastpos = pos; pos)
+    )
+
+-- If matrix is over a local ring, return a matrix of number of terms in the numerator of each element;
+-- if matrix is over a poly ring, return a matrix of number of terms of each element
+sizeMatrix = method()
+sizeMatrix Matrix        :=
+sizeMatrix MutableMatrix := M -> (
+    if instance(ring M, LocalRing)
+      then matrix (entries M / (e->e/numerator/size))
+      else matrix (entries M / (e->e/size))
+    )
+
+-- Returns the coordinates of the unit or scalar with the sparsest row and column in a matrix
+-- A mutable matrix -> a coordinate pair and a complexity integer
+-- lists all units, uses heuristics to calculate a complexity for each unit, then returns the simplest
+-- uses different measures for poly ring and local ring; for poly ring returns the coordinates of the
+-- unit with the sparsest row and column in a matrix; for local ring takes into account the sum of
+-- number of terms in the numerators for all elements in row and column as well.
+-- caveat: super time intensive
+-- Note: if no unit found, returns ((-1,-1), infinity)
+findSparseUnit = method(Options => {UnitTest => isUnit, Strategy => "NoSort"})
+findSparseUnit Matrix :=
+findSparseUnit MutableMatrix := opts -> M -> (
+    if opts.Strategy =!= "NoSort" then (
+      c := runHooks(MutableMatrix, symbol findSparseUnit, (opts, M));
+      if c =!= null then return c;
+      );
+    unit := findUnit (M, UnitTest => opts.UnitTest);
+    if unit === null then (
+      if debugLevel >= 3 then << "No units found." << endl;
+      return ((-1, -1), infinity);
+      );
+    (unit, 0)
+    )
+
+-- A heuristic measure to find the easiest unit to prune first
+-- TODO this could be made more efficient
+complexity := (elt, row, col) -> (
+    if instance(ring elt, LocalRing) then
+      (size numerator elt) * (row/numerator/size//sum) * (col/numerator/size//sum)
+    else
+      (#(for i in row list if i != 0 then 1 else continue)-1) *
+      (#(for j in col list if j != 0 then 1 else continue)-1)
+    )
+
+-- TODO this could be made more efficient.
+addHook(MutableMatrix, symbol findSparseUnit, (opts, M) -> (
+        units := for unit in findAllUnits (M, UnitTest => opts.UnitTest) list (
+            (r, c) := unit;
+            elt := M_unit;
+            row := flatten entries submatrix(M, {r},    );
+            col := flatten entries submatrix(M,    , {c});
+            cmp := complexity(elt, row, col);
+            unit, cmp
+            );
+        if #units == 0 then (
+            if debugLevel >= 3 then << "No unit found." << endl;
+            return ((-1,-1),infinity);
+            );
+        argMin := minPosition (units/last);
+        unit := first units#argMin;
+        cmp := last units#argMin;
+        if debugLevel >= 3 then
+          << "Found sparse unit of complexity " << cmp << " at " << unit << ": " << M_unit << endl;
+        break (unit, cmp)))
+
+--============================ Pruning Operations ===================================--
+
+deleteRows =    (M, rfirst, rlast) -> ( rawDeleteRows(raw M, rfirst, rlast); M )
+deleteColumns = (M, cfirst, clast) -> ( rawDeleteColumns(raw M, cfirst, clast); M )
+
+-- Moves a given row and column to the end while keeping the neighbouring differentials compatible
+-- Then reduces mComplex#n using the unit in the last row and column
+-- Input: a list of mutable matrices mComplex followed by an iterator n
+-- Output: a list of mutable matrices mComplex of smaller size
+pruneUnit = method(Options => {PruningMaps => false, UnitTest => isUnit})
+pruneUnit(List, ZZ, Sequence, List) := opts -> (mComplex, n, unit, pruningMorph) -> (
+    if debugLevel >= 3 then
+      <<"   Removing a unit from differential #"<<n<<endl;
+    if n < 0 or n >= #mComplex then error "out of range";
+    (r,c) := unit;
+    R := ring mComplex#n;
+    -- Initialize pruning maps if needed
+    if opts.PruningMaps =!= false then (
+        if pruningMorph#n     === null then pruningMorph#n     = mutableIdentity(R, numRows mComplex#n);
+        if pruningMorph#(n+1) === null then pruningMorph#(n+1) = mutableIdentity(R, numColumns mComplex#n);
+        );
+    -- Move to last row
+    r2 := numRows mComplex#n - 1;
+    rowSwap(mComplex#n, r, r2);
+    if 0 < n then
+      columnSwap(mComplex#(n-1), r, r2);
+    if opts.PruningMaps =!= false then
+      columnSwap(pruningMorph#n, r, r2);
+    -- Move to last column
+    c2 := numColumns mComplex#n - 1;
+    columnSwap(mComplex#n, c, c2);
+    if n < #mComplex - 1 then
+      rowSwap(mComplex#(n+1), c, c2);
+    if opts.PruningMaps =!= false then
+      columnSwap(pruningMorph#(n+1), c, c2);
+    -- Get the pivot
+    inversePivot := if instance(R, LocalRing) then (mComplex#n_(r2, c2))^-1 else (leadCoefficient mComplex#n_(r2, c2))^-1;
+    -- Clear the column
+    for r from 0 to r2 do (
+        f := (mComplex#n)_(r, c2);
+        rowAdd(mComplex#n, r, -f * inversePivot, r2);
+        if 0 < n then
+            columnAdd(mComplex#(n-1), r2, f * inversePivot, r);
+        if opts.PruningMaps =!= false then
+            columnAdd(pruningMorph#n, r2, f * inversePivot, r);
+        );
+    -- Clear the row
+    for c from 0 to c2 do (
+        f := (mComplex#n)_(r2, c);
+        columnAdd(mComplex#n, c, -f * inversePivot, c2);
+        if n < #mComplex - 1 then
+            rowAdd(mComplex#(n+1), c2, f * inversePivot, c);
+        if opts.PruningMaps =!= false then
+            columnAdd(pruningMorph#(n+1), c, -f * inversePivot, c2);
+        );
+    -- delete rows/columns
+    deleteColumns(mComplex#n, c2, c2);
+    if n < #mComplex-1 then
+       deleteRows(mComplex#(n+1), c2, c2);
+    if opts.PruningMaps =!= false then
+        deleteColumns(pruningMorph#(n+1), c2, c2);
+
+    deleteRows(mComplex#n, r2, r2);
+    if 0 < n then
+        deleteColumns(mComplex#(n-1), r2, r2);
+    if opts.PruningMaps =!= false then
+        deleteColumns(pruningMorph#n, r2, r2);
+
+    mComplex
+    )
+
+-- Prunes a single differential by reducing the units in a while loop, starting with the ones in
+-- sparcest row/column. Uses pruneUnit.
+-- TODO: handle the case of twisted complexes and free modules with degrees (both are OK in the engine)
+pruneDiff = method(Options => {PruningMaps => false, UnitTest => isUnit})
+pruneDiff(ChainComplex, ZZ) := opts -> (C, n) -> (
+    if opts.PruningMaps === true then (
+        (D, pruningMorph) := pruneDiff(toMutableComplex C, n, opts);
+        return (toChainComplex D, pruningMorph);
+        );
+    toChainComplex pruneDiff(toMutableComplex C, n, opts)
+    )
+pruneDiff(ChainComplex, ZZ, List) := opts -> (C, n, M) -> (
+    if opts.PruningMaps === true then (
+        (D, pruningMorph) := pruneDiff(toMutableComplex C, n, M, opts);
+        return (toChainComplex D, pruningMorph);
+        );
+    toChainComplex pruneDiff(toMutableComplex C, n, M, opts)
+    )
+pruneDiff(List, ZZ)         := opts -> (mComplex, n) -> (
+    pruningMorph := new MutableList;
+    if opts.PruningMaps === true then (
+        for i from 0 to #mComplex - 1 do pruningMorph#i = mutableIdentity(ring mComplex#0, numRows mComplex#i);
+        pruningMorph#(#mComplex) = mutableIdentity(ring mComplex#0, numColumns mComplex#(#mComplex - 1));
+        );
+    pruningMorph = new List from pruningMorph;
+    pruneDiff(mComplex, n, pruningMorph, opts)
+    )
+pruneDiff(List, ZZ, List)         := opts -> (mComplex, n, pruningMorph) -> (
+    M := mComplex#n;
+    if debugLevel >= 2 then
+      << "Pruning differential #" << n << " of size " << (numRows M, numColumns M) << endl;
+    while (
+        unit := findSparseUnit(M, UnitTest => opts.UnitTest);
+        last unit =!= infinity
+        ) do pruneUnit(mComplex, n, first unit, pruningMorph, opts);
+    if debugLevel >= 2 then
+      << "\tDifferential reduced to => " << (numRows M, numColumns M) << endl;
+    if opts.PruningMaps === true then return (mComplex, pruningMorph);
+    mComplex
+    )
+
+-- Prune a chain complex C into a free resolution by removing unit elements from the differentials
+-- TODO: keep track of degrees of the free modules in M2 and in the Engine
+-- TODO: give error if not given a free chain complex
+pruneComplex = method(
+    Options => {
+        Strategy => Engine, -- set to null to use the methods above
+        Direction => "left",
+        PruningMaps => false,
+        UnitTest => isUnit -- TODO: detect when all units are scalars and choose that
+        })
+pruneComplex ChainComplex      := opts ->  C          -> pruneComplex(C, -1, opts)
+pruneComplex(ChainComplex, ZZ) := opts -> (C, nsteps) -> (
+    m := min C;
+    mComplex := toMutableComplex C;
+    (D, M) := pruneComplex(mComplex, nsteps, opts);
+    F := if opts.PruningMaps == true
+    then source map(target C.dd_(m+1), , matrix M#0)
+    else target matrix D#0;
+    D = (toChainComplex(D, F))[-m];
+    R := ring D;
+    if opts.PruningMaps == true then
+      D.cache.pruningMap = map(C, D, i -> M#(i-m)//matrix);
+    D
+    )
+pruneComplex List      := opts ->  mComplex          -> pruneComplex(mComplex, -1, opts)
+pruneComplex(List, ZZ) := opts -> (mComplex, nsteps) -> (
+    len := length mComplex;
+    mComplex = mComplex/mutableMatrix;
+    if nsteps == -1 then nsteps = len;
+    pruningMorph := new MutableList;
+    if opts.PruningMaps === true then (
+        for i from 0 to #mComplex - 1 do pruningMorph#i = mutableIdentity(ring mComplex#0, numRows mComplex#i);
+        pruningMorph#(#mComplex) = mutableIdentity(ring mComplex#0, numColumns mComplex#(#mComplex - 1));
+        );
+    pruningMorph = new List from pruningMorph;
+    if      opts.Strategy === Engine  then                              -- call rawPruneComplex
+      return enginePruneComplex(mComplex, nsteps, opts)
+    else if opts.Direction == "left"  then                              -- pruning the left one first
+      for i from 0 to nsteps-1 do
+        pruneDiff(mComplex,       i, pruningMorph, PruningMaps => opts.PruningMaps, UnitTest => opts.UnitTest)
+    else if opts.Direction == "right" then                              -- pruning the right one first
+      for i from 0 to nsteps-1 do
+        pruneDiff(mComplex, len-i-1, pruningMorph, PruningMaps => opts.PruningMaps, UnitTest => opts.UnitTest)
+    else if opts.Direction == "both"  then                              -- pruning outside-in
+      (unique splice for i from 1 to lift((nsteps - nsteps % 2)/2, ZZ) list (i, len-i)) /
+      (n -> pruneDiff(mComplex,   n, pruningMorph, PruningMaps => opts.PruningMaps, UnitTest => opts.UnitTest))
+    else if opts.Direction == "best"  then                              -- pruning the sparsest unit
+      while (
+        units := for i from 0 to nsteps - 1 list (
+          M := mComplex#i;
+          if debugLevel >= 3 then << "Looking for sparsest unit in differential #" << i << endl;
+          findSparseUnit(M, UnitTest => opts.UnitTest)               --TODO only recheck the neighbours
+          );
+        n := minPosition(units/last);
+        unit := units#n;
+        last unit != infinity
+        ) do pruneUnit(mComplex, n, first unit, pruningMorph, PruningMaps => opts.PruningMaps, UnitTest => opts.UnitTest);
+    (mComplex, pruningMorph)
+    )
+
+enginePruneComplex = method(Options => options pruneComplex) -- ++ {...}
+enginePruneComplex List      := opts ->  C          -> enginePruneComplex(C, -1, opts)
+enginePruneComplex(List, ZZ) := opts -> (C, nsteps) -> (
+    R := ring C#0;
+    flag := 0;
+    -- See e/mutablecomplex.cpp for reference
+    flag = flag | (if opts.PruningMaps           then     1 else 0); -- See `help pruningMap` in M2
+    flag = flag | (if false                      then     2 else 0); -- Delete pruned rows and columns
+    flag = flag | (if false                      then     4 else 0); -- Only prune -1,+1
+    flag = flag | (if opts.UnitTest === isScalar then     8 else 0); -- Only prune constants
+    flag = flag | (if false                      then    16 else 0); -- Only prune functions with constants
+    flag = flag | (if false                      then    32 else 0); -- Pruning for maximal ideal
+    flag = flag | (if false                      then    64 else 0); -- Pruning for prime ideal
+    flag = flag | (if true                       then  1024 else 0); -- Prune sparsest unit first
+    flag = flag | (if opts.PruningMaps           then  2048 else 0); -- Prune best matrix first
+    flag = flag | (if opts.Direction === "right" then 65536 else 0); -- Prune the matrices in reverse order
+    -- create the raw chain complex
+    if debugLevel >= 2 then << "Using enginePruneComplex." << endl;
+    A := rawMutableComplex(C/raw//toSequence);
+    if debugLevel >= 2 then << A << endl;
+    L := rawPruneBetti(A, nsteps, flag) // sum;
+    -- prune the raw chain complex
+    rawPruneComplex(A, nsteps, flag);
+    if debugLevel >= 2 then << A << endl;
+    B := rawPruneBetti(A, nsteps, flag);
+    -- trim the complex
+    D := apply(length C, i -> submatrix(C#i, 0..B#i-1, 0..B#(i+1)-1));
+    if debugLevel >= 2 then << L - B//sum << endl;
+    -- retrieve the pruning maps
+    M := null;
+    if flag & 1 == 1 then M = rawPruningMorphism(A, nsteps, flag)/map_R;
+    (D, M)
+    )
+
+--================================= Testing and Checking Operations =================================--
+
+-- Checks that source phi is quasi-isomorphic to target phi
+-- Source: ChainComplexExtras.m2
+isQuasiIsomorphism = method(Options => {LengthLimit => infinity})
+isQuasiIsomorphism ChainComplexMap := Boolean => opts -> phi -> (
+    C := cone phi;
+    if all((min C,min(max C, opts.LengthLimit)), i -> (prune HH_i(C) == 0)) then true else false
+    )
+-- Checks that C is a resolution of N
+isQuasiIsomorphism(ChainComplex, Ideal)  := Boolean => opts -> (C, I) -> isQuasiIsomorphism(C, coker gens I)
+isQuasiIsomorphism(ChainComplex, Module) := Boolean => opts -> (C, N) -> (
+    R := ring N;
+    D := chainComplex map(N, R^0, 0);
+    if C == 0 then return D == 0;
+    M := {map(D_0, C_0, 1)} | for i from 1 to max(length C, length D) list map(D_i, C_i, 0);
+    isQuasiIsomorphism map(D, C, i -> M#i)
+    )
+
+-- Checks that C is an acyclic chain complex
+isAcyclic = C -> isQuasiIsomorphism(C, 0)
+
+-- Checks whether there are any more units are left in the complex
+-- Note: this only implies that the resolution is minimal in the local and graded case
+isMinimal = method(Options => options findUnit)
+isMinimal Matrix        :=
+isMinimal MutableMatrix := Boolean => opts -> M -> 0 == #findAllUnits(M, opts)
+isMinimal ChainComplex  := Boolean => opts -> C -> (
+    if any(length C + 1, i -> not isMinimal(matrix (C.dd_i), opts)) then false else true
+    )
+
+-- Checks commutativity of chain complexes C and D with chain complex map M
+isCommutative ChainComplexMap := Boolean => f -> (
+    D := source f;
+    C := target f;
+    for i from 1 to max(length C, length D) do
+      if C.dd_i * f_i - f_(i-1) * D.dd_i != 0 then
+        return false;
+    true
+    )
+
+load ("./PruneComplex/tests.m2")
+beginDocumentation()
+load ("./PruneComplex/doc.m2")
+
+end--

--- a/M2/Macaulay2/packages/PruneComplex/doc.m2
+++ b/M2/Macaulay2/packages/PruneComplex/doc.m2
@@ -1,0 +1,360 @@
+doc ///
+Key
+  PruneComplex
+Headline
+  Pruning chain complexes over polynomial and local rings
+Description
+  Text
+    This package includes various methods for pruning chain complexes over polynomial and local rings.
+    In particular, in the local or graded case the output is guaranteed to be a minimal free resolution.
+
+    Algorithms in this package are also implemented using C++ in e/mutablecomplex.hpp for speed.
+  Example
+    debug needsPackage "PruneComplex";
+    R = ZZ/32003[vars(0..17)];
+    m1 = genericMatrix(R,a,3,3)
+    m2 = genericMatrix(R,j,3,3)
+    I = ideal(m1*m2-m2*m1)
+    C = freeRes I
+    elapsedTime D = pruneComplex(C, PruningMaps => true, UnitTest => isScalar)
+    isCommutative D.cache.pruningMap
+    betti D == betti res I
+Caveat
+  Only supports localization at prime ideals.
+SeeAlso
+  "LocalRings"
+///
+
+doc ///
+Key
+   pruneComplex
+  (pruneComplex, List)
+  (pruneComplex, List, ZZ)
+  (pruneComplex, ChainComplex)
+  (pruneComplex, ChainComplex, ZZ)
+Headline
+  Prunes a chain complex or list of mutable matrices
+Usage
+  D = pruneComplex(C, nsteps)
+Inputs
+  C: ChainComplex
+    or a list of mutable matrices defining the differentials of a complex
+  nsteps: ZZ
+    the number of maps in the complex that will be pruned
+Outputs
+  D: ChainComplex
+    or the list of modified mutable matrices
+Description
+  Text
+    Prune a chain complex {C} into a free resolution by removing unit elements from the differentials.
+  Example
+    debug needsPackage "PruneComplex"
+    R = ZZ/32003[a..f]
+    I = ideal"abc-def,ab2-cd2-c,acd-b3-1"
+    C = (freeRes I)[-10]
+    D = pruneComplex(C, Strategy => null, UnitTest => isScalar, Direction => "both")
+    C.dd
+    D.dd
+Consequences
+  Item
+    If PruningMaps is true, D.cache.pruningMap will be updated to a chain complex map {f: C <-- D}.
+Caveat
+  For inhomogeneous input the resulting complex is not guaranteed to be minimal, particularly because
+  minimality is not well-defined in that case. If the input is a general chain complex, rather than a
+  free resolution, the degree of the maps will not be accurate.
+SeeAlso
+  pruneDiff
+  pruningMap
+///
+
+doc ///
+Key
+   pruneDiff
+  (pruneDiff, List, ZZ)
+  (pruneDiff, List, ZZ, List)
+  (pruneDiff, ChainComplex, ZZ)
+  (pruneDiff, ChainComplex, ZZ, List)
+Headline
+  Prunes a single differential in a chain complex or list of mutable matrices
+Usage
+  D = pruneDiff(C, n)
+  D = pruneDiff(C, n, M)
+Inputs
+  C: ChainComplex
+    or a list of mutable matrices defining the differentials of a complex
+  n: ZZ
+    the index of the differential in C
+  M: List
+    if provided, will initialize the list of pruning maps back to the old complex
+Outputs
+  D: ChainComplex
+    or the list of modified mutable matrices
+  M: List
+    if PruningMaps is true, will contain the pruning maps back to the old complex
+Description
+  Text
+    Completely prunes the n-th differential of the chain complex C by removing unit elements.
+  Example
+    "Computing the syzygy over a local ring using liftUp and pruneDiff";
+    needsPackage "LocalRings";
+    R = ZZ/32003[vars(0..5)];
+    I = ideal"abc-def,ab2-cd2-c,-b3+acd";
+    C = res I;
+    M = ideal gens R;
+    RM = localRing(R, M);
+    F = C.dd_2;
+    FM = F ** RM
+    "This is the process for finding the syzygy of FM:";
+    f = liftUp FM;
+    g = syz f;
+    h = syz g;
+    C = {g ** RM, h ** RM}/mutableMatrix;
+    "Now we prune the map h, which is the first map from the right:";
+    C = pruneDiff(C, 1)
+    g' = C#0;
+    "Scale each row with the common denominator of the corresponding column in FM:";
+    N = transpose entries FM;
+    for i from 0 to numcols FM - 1 do
+      rowMult(g', i, N_i/denominator//lcm);
+    "The syzygy of FM is:";
+    GM = map(source FM, , matrix g')
+    kernel FM == image GM
+Caveat
+  This method does not use the algorithms in the engine, hence it might be slow.
+SeeAlso
+  pruneUnit
+  pruneComplex
+--  findSparseUnit
+///
+
+doc ///
+Key
+   pruneUnit
+  (pruneUnit, List, ZZ, Sequence, List)
+Headline
+  Prunes a unit of a differential in a list of mutable matrices
+Usage
+  D = pruneUnit(C, n, u, M)
+Inputs
+  C: List
+    a list of mutable matrices defining the differentials of a complex
+  n: ZZ
+    the index of the differential in C
+  u: Sequence
+    the coordinates of the unit in the differential
+  M: List
+    if provided, will initialize the list of pruning maps back to the original complex
+Outputs
+  D: List
+    a list of modified mutable matrices
+Description
+  Text
+    Prune the unit in location {u} of the {n}-th differential in chain complex {C}.
+    Moves the unit to the end, clears row and column, while keeping the neighboring differentials compatible.
+Caveat
+  Currently only works with 1x1 units.
+SeeAlso
+  pruningMap
+  pruneDiff
+///
+
+doc ///
+Key
+   toChainComplex
+  (toChainComplex, List)
+  (toChainComplex, List, Module)
+Headline
+  Converts a list of mutable matrices into a ChainComplex.
+Usage
+  C = toChainComplex(M, F)
+Inputs
+  M: List
+    a list of MutableMatrix type
+  F: Module
+    the initial free module in the resolution. This is used to calculate the degrees in the maps.
+Outputs
+  C: ChainComplex
+Description
+  Example
+    debug needsPackage "PruneComplex"
+    R = ZZ/32003[vars(0..17)];
+    m1 = genericMatrix(R,a,3,3)
+    m2 = genericMatrix(R,j,3,3)
+    I = ideal(m1*m2-m2*m1)
+    C = res I;
+    D = C[-10]
+    MC = toMutableComplex D;
+    elapsedTime MC = first pruneComplex MC; -- 0.001 seconds
+    D' = toChainComplex MC
+    assert(betti D == betti D'[-10])
+Caveat
+  Does not keep the information about source of target of maps for general complexes.
+SeeAlso
+  toMutableComplex
+///
+
+doc ///
+Key
+   toMutableComplex
+  (toMutableComplex, ChainComplex)
+Headline
+  Converts a chain complex into a list of mutable matrices.
+Usage
+  M = toMutableComplex C
+Inputs
+  C: ChainComplex
+Outputs
+  M: List
+    a list of MutableMatrix type
+Description
+  Example
+    needsPackage "LocalRings"
+    R = ZZ/32003[vars(0..3)]
+    I = monomialCurveIdeal(R, {1, 3, 4})
+    C = res I
+    RP = localRing(R, ideal"a,b,c");
+    D = (C ++ C[-5]) ** RP
+    MD = toMutableComplex D
+    elapsedTime pruneComplex MD
+Caveat
+  The nonzero terms in the chain complex must be in a series, otherwise may not work correctly.
+SeeAlso
+  toChainComplex
+///
+
+///
+Key
+   findUnit
+  (findUnit, Matrix)
+  (findUnit, MutableMatrix)
+  (findUnit, Matrix, Sequence)
+  (findUnit, MutableMatrix, Sequence)
+///
+
+///
+Key
+   findAllUnits
+  (findAllUnits, Matrix)
+  (findAllUnits, MutableMatrix)
+///
+
+-- option: Strategy: NoSort
+///
+Key
+   findSparseUnit
+  (findSparseUnit, Matrix)
+  (findSparseUnit, MutableMatrix)
+///
+
+-- uses liftable(f, coefficientRing ring f)
+doc ///
+Key
+  isScalar
+  (isScalar, RingElement)
+Headline
+  check whether a ring element is a scalar
+Usage
+  b = isScalar(f)
+Inputs
+  f: RingElement
+    a ring element
+Outputs
+  b: Boolean
+    true if f is a scalar, false otherwise.
+Description
+  Text
+    A synonym for liftable(f, coefficientRing ring f).
+SeeAlso
+  isUnit
+  UnitTest
+  liftable
+///
+
+doc ///
+Key
+  PruningMaps
+  [pruneUnit, PruningMaps]
+  [pruneDiff, PruningMaps]
+  [pruneComplex, PruningMaps]
+Headline
+  Whether to compute a morphism of complexes
+Description
+  Text
+    If true, the pruning maps to the old complex will be stored in C.cache.pruningMap.
+SeeAlso
+  pruningMap
+  pruneUnit
+  pruneDiff
+  pruneComplex
+///
+
+doc ///
+Key
+  UnitTest
+  [pruneUnit, UnitTest]
+  [pruneDiff, UnitTest]
+  [pruneComplex, UnitTest]
+Headline
+  Limit which units are to be pruned
+Description
+  Text
+    Possible values: isUnit, isScalar
+SeeAlso
+  pruneComplex
+  pruneDiff
+  pruneUnit
+  isScalar
+  isUnit
+///
+
+doc ///
+Key
+  Direction
+  [pruneComplex, Direction]
+Headline
+  Determines the direction with which the matrices in the complex is pruned
+Description
+  Text
+    Possible values:
+
+    "left": Prune the differentials from lower indices.
+
+    "right": Prune the differentials from higher indices.
+
+    "both": Alternate between pruning the lower and higher indices.
+
+    "best": Use heuristics to prune the best unit in the whole complex first.
+SeeAlso
+  pruneComplex
+///
+
+doc ///
+Key
+  [pruneComplex, Strategy]
+Headline
+  Whether to use the methods in the package or C++ algorithms in the engine
+Description
+  Text
+    Possible values:
+
+      null: use the algorithms written using the Macaulay2 language;
+
+      Engine: use the algorithms implemented using C++ in the Engine (version 1.11 and up).
+SeeAlso
+  pruneComplex
+///
+
+end--
+
+doc ///
+Key
+Headline
+Usage
+Inputs
+Outputs
+Description
+  Text
+  Example
+Caveat
+SeeAlso
+///

--- a/M2/Macaulay2/packages/PruneComplex/tests.m2
+++ b/M2/Macaulay2/packages/PruneComplex/tests.m2
@@ -1,0 +1,347 @@
+--============================ Tests Sections ===================================--
+
+-- Returns a non-minimal free resolution, for testing purposes.
+-- Homogenizes the ideal w.r.t. a new variable, calculates a free resolution
+-- using res with option FastNonminimal, then dehomogenizes
+-- Warning: only works for finite fields
+freeRes = I -> (
+    -- Warning: only works for finite fields
+    R := ring I;
+    homogvar := local homogvar;
+    S := (coefficientRing R)(monoid [gens R, homogvar]);
+    Ih := ideal homogenize(sub(gens gb I, S), S_(numgens R));
+    C1 := res(Ih, FastNonminimal=>true);
+    phi := map(R,S,gens R | {1});
+    phi C1
+    )
+
+-- Runs various sanity checks using M2 code
+testM2 = (I, P) -> (
+    R := ring I;
+    if not instance(R, LocalRing) then (
+        C := freeRes I;
+        assert(C.dd^2 == 0);
+        time D := pruneComplex(C, Strategy => null, Direction => "left", PruningMaps => true);
+        assert(D.dd^2 == 0);
+        if isHomogeneous I then assert(betti D == betti res I);
+        assert(isCommutative D.cache.pruningMap);
+        assert(isQuasiIsomorphism(D, I));
+        E := D ** localRing(R, P);
+        ) else E = res I;
+    RP := ring E;
+    assert(E.dd^2 == 0);
+    time F := pruneComplex(E, Strategy => null, Direction => "left", PruningMaps => true);
+    return (
+        F.dd^2 == 0 and isMinimal F and
+        isCommutative F.cache.pruningMap and
+        isQuasiIsomorphism(F, ideal(gens I ** RP)))
+    )
+
+-- Runs various sanity checks using engine code
+testEngine = (I, P) -> (
+    R := ring I;
+    if not instance(R, LocalRing) then (
+        C := freeRes I;
+        assert(C.dd^2 == 0);
+        time D := pruneComplex(C, Strategy => Engine, Direction => "left", PruningMaps => true);
+        assert(D.dd^2 == 0);
+        if isHomogeneous I then assert(betti D == betti res I);
+        assert(isCommutative D.cache.pruningMap);
+        assert(isQuasiIsomorphism(D, I));
+        E := D ** localRing(R, P);
+        ) else E = res I;
+    RP := ring E;
+    assert(E.dd^2 == 0);
+    time F := pruneComplex(E, Strategy => Engine, Direction => "left", PruningMaps => true);
+    return (
+        F.dd^2 == 0 and isMinimal F and
+        isCommutative F.cache.pruningMap and
+        isQuasiIsomorphism(F, ideal(gens I ** RP)))
+    )
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  R = ZZ/32003[vars(0..17)]
+  m1 = genericMatrix(R,a,3,3)
+  m2 = genericMatrix(R,j,3,3)
+  I = ideal(m1*m2-m2*m1)
+  C = res I;
+  C' = freeRes I;
+  C' = C'[-10]
+  C'' = C'[20]
+  MC' = toMutableComplex C';
+  MC'' = toMutableComplex C'';
+  elapsedTime C1 = pruneComplex(C', Strategy => Engine, PruningMaps => true); -- TODO: consider using sparse matrices
+  assert(isCommutative C1.cache.pruningMap);
+  assert(betti C[-10] == betti C1)
+  elapsedTime (MC, M) = pruneComplex(MC'', Strategy => null, UnitTest => isScalar, PruningMaps => true); -- FIXME very slow
+  C2 = toChainComplex MC;
+  assert(isCommutative map(C'', C2, i -> M#(i+ min C'' +1)//matrix));
+  assert(betti C[10] == betti C2[10])
+///
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  needsPackage "ChainComplexExtras"
+  R = ZZ/32003[vars(0..8)]
+  M = genericMatrix(R,3,3)
+  I = minors(2, M)
+  C = freeRes I
+  elapsedTime C0 = pruneComplex(C); -- fast
+  elapsedTime C1 = pruneComplex(C, UnitTest => isScalar); -- fastest
+  elapsedTime C2 = pruneComplex(C, Strategy=>null); -- FIXME far too slow
+  elapsedTime C3 = pruneComplex(C, Strategy=>null, UnitTest => isScalar); -- okay
+  elapsedTime C4 = target minimize C; -- slow
+  assert({res I, C0, C1, C2, C3, C4}/betti//same)
+
+  needsPackage "LocalRings"
+  P = ideal gens R
+  RP = localRing(R,P)
+  IP = promote(I, RP)
+  C' = C ** RP
+  elapsedTime B0 = betti pruneComplex(C'); -- fastest
+  elapsedTime B1 = betti pruneComplex(C', UnitTest => isScalar); -- fast
+  elapsedTime B2 = betti pruneComplex(C', Strategy=>null); -- slow
+  elapsedTime B3 = betti pruneComplex(C', Strategy=>null, UnitTest => isScalar); -- slow
+  assert(same {betti res IP, B0, B1, B2, B3})
+///
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  R = ZZ/32003[a..f]
+
+  --
+  I = ideal"abc-def,ab2-cd2-c,acd-b3-1"
+  C = freeRes I -- 1 9 15 8 1
+
+  D = pruneComplex(C, UnitTest => isScalar, Strategy => null, Direction => "whole") -- 1 4 4 1
+  assert(D.dd^2 == 0)
+  assert(isQuasiIsomorphism(D,I))
+
+  D' = pruneComplex(C, UnitTest => isScalar, Strategy => null, Direction => "both") -- 1 4 4 1
+  assert(D'.dd^2 == 0)
+  assert(isQuasiIsomorphism(D',I))
+
+  --
+  I = ideal"abc-def,ab2-cd2,acd-b3"
+  C = freeRes I -- 1 8 13 7 1
+
+  D = pruneComplex(C, UnitTest => isScalar) -- 1 3 4 2
+  assert(D.dd^2 == 0)
+  assert(isQuasiIsomorphism(D,I))
+///
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  needsPackage "LocalRings"
+  R = ZZ/32003[a..f]
+  P = ideal gens R
+
+  I = ideal"abc-def,ab2-cd2-c,acd-b3-1"; -- Now: 0.0005 vs. 0.01 -- 1 3 3 1
+  assert testM2(I, P)
+
+  I = ideal"abc-def,ab2-cd2,acd-b3"; -- Now: 0.0003 vs 0.008 -- 1 3 4 2
+  assert testM2(I, P)
+
+  I = ideal"abc-def,ab2-cd2,acd-d3-a2c"; -- Now: 0.0018 vs. 0.0133 -- 1 3 4 2
+  assert testM2(I, P)
+///
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  R = ZZ/32003[x,y,z]
+
+  I = ideal"xyz+z5,2x2+y3+z7,3z5+y5"
+  C = freeRes I -- 1 15 38 34 10
+
+  checker = (D, I) -> (
+      assert(D.dd^2 == 0);
+      assert(isMinimal(D, UnitTest => isScalar));
+      assert(isCommutative D.cache.pruningMap);
+      assert(isQuasiIsomorphism(D, I));)
+
+  D = pruneComplex(C, PruningMaps => true, UnitTest => isScalar, Strategy => Engine) -- 1 3 4 2
+  checker(D, I)
+
+  D = pruneComplex(C, PruningMaps => true, UnitTest => isScalar, Strategy => Engine, Direction => "right") -- 1 4 5 2
+  checker(D, I)
+
+  D = pruneComplex(C, PruningMaps => true, Strategy => null, UnitTest => isScalar, Direction => "right") -- 1 7 9 3
+  checker(D, I)
+
+  -- FIXME these three strategies return terribly ugly stuff
+  D = pruneComplex(C, PruningMaps => true, Strategy => null, UnitTest => isScalar, Direction => "left") -- 1 6 9 5 1
+  checker(D, I)
+
+  D = pruneComplex(C, PruningMaps => true, Strategy => null, UnitTest => isScalar, Direction => "both") -- 1 6 11 6
+  checker(D, I)
+
+  D = pruneComplex(C, PruningMaps => true, Strategy => null, UnitTest => isScalar, Direction => "best") -- 1 6 9 5 1
+  checker(D, I)
+///
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  needsPackage "LocalRings"
+
+  R = ZZ/32003[a..f]
+  P = ideal"a,b,c,d,e,f"
+  I = ideal"abc-def,ab2-cd2-c,-b3+acd"
+  assert testM2(I, P)
+  assert testEngine(I, P)
+
+--  use R
+--  setMaxIdeal ideal gens R
+--  L = localResolution I
+--  L**RP == F
+///
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  needsPackage "LocalRings"
+  R = ZZ/32003[a..d]
+
+  I = monomialCurveIdeal(R,{1,3,4})
+  P = ideal"a,b,c"
+  assert testM2(I, P)
+  assert testEngine(I, P)
+  M = ideal"a,b,c,d"
+  assert testM2(I, M)
+  assert testEngine(I, P)
+
+--  use R
+--  setMaxIdeal ideal gens R
+--  L = localResolution I
+--  assert(isQuasiIsomorphism(L**RM, E'))
+///
+
+TEST /// -- An example for comparison with Singular
+  needsPackage "LocalRings"
+  R = ZZ/32003[a..d]
+  I = ideal"d3+3bd2+3b2d+b3-7994b3c3-15997b3c3d-8000b3c3d2+15997a3b2c2+16000a3b2c2d-8000a6bc, a2,
+  c4-12785b3c2-12785b3c2d+6406b3c2d2-6400b3c2d3-12812a3b2c+12794a3b2cd+12800a3b2cd2+12803a6b-6400a6bd,
+  b-15961b2c3-15961b2c3d-15988b2c3d2-16000b2c3d3+15988b3c3-9b3c3d+16000b3c3d2-27a3bc2-18a3bc2d-3a3bc2d2+9a3b2c2+3a3b2c2d-15997a6c-16000a6cd+16000a6bc"
+  RP = localRing(R, ideal gens R)
+  IP = promote(I, RP)
+  C = pruneComplex res I
+  elapsedTime CP = pruneComplex res IP -- 0.17
+///
+
+/// -- Singular code for the above example, this gives a resolution with no real effort.
+  -- This is at least partly because the initial ideal in the local ring is (b, a^2, d^3, c^4),
+  -- so the Schreyer frame gives a minimal resolution
+  ring R1 = 32003,(a,b,c,d),ls;
+  ideal I1 = 9*a^8-18*a^5*b*c*d+9*a^2*b^2*c^2*d^2-54*a^5*b*c+54*a^2*b^2*c^2*d+81*a^2*b^2*c^2-3*a^2,
+         -3*a^6*c*d+6*a^3*b*c^2*d^2-3*b^2*c^3*d^3-9*a^6*c+36*a^3*b*c^2*d-27*b^2*c^3*d^2+54*a^3*b*c^2-81*b^2*c^3*d-81*b^2*c^3-4*b^3-12*b^2*d-12*b*d^2-4*d^3-2*b,
+         -3*a^6*b*d+6*a^3*b^2*c*d^2-3*b^3*c^2*d^3-9*a^6*b+36*a^3*b^2*c*d-27*b^3*c^2*d^2+54*a^3*b^2*c-81*b^3*c^2*d-81*b^3*c^2-5*c^4,
+         -3*a^6*b*c+6*a^3*b^2*c^2*d-3*b^3*c^3*d^2+18*a^3*b^2*c^2-18*b^3*c^3*d-27*b^3*c^3-4*b^3-12*b^2*d-12*b*d^2-4*d^3;
+  ideal J = std(I1);
+  resolution rI = sres(J,0);
+  resolution minI = minres(rI);
+  print(list(minI));
+///
+
+--============================ Engine Tests Sections ===================================--
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  debug needsPackage "LocalRings"
+  R = ZZ/32003[a..f];
+  P = ideal gens R;
+
+  I = ideal"abc-def,ab2-cd2,acd-d3-a2c"; -- Now: 0.0018 vs. 0.0133 -- 1 3 4 2
+  assert testEngine(I, P)
+
+  I = ideal"abc-def,ab2-cd2-c,acd-b3-1"; -- Now: 0.0005 vs. 0.01 -- 1 3 3 1
+  assert testEngine(I, P)
+
+  I = ideal"abc-def,ab2-cd2,acd-b3"; -- Now: 0.0003 vs 0.008 -- 1 3 4 2
+  assert testEngine(I, P)
+
+  I = ideal"abc+c5,2a2+b3+c7,3c5+b5" -- Now: 0.0161 vs 0.022 -- 1 3 4 2
+  assert testEngine(I, P)
+///
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  needsPackage "LocalRings"
+  R = ZZ/32003[a..d]
+  P = ideal"a,b,c"
+  RP = localRing(R, P)
+  I = ideal(a/d, b/d^2, c/d^2)
+  assert testM2(I, P)
+  assert testEngine(I, P)
+///
+
+TEST ///
+  debug needsPackage "PruneComplex"
+  needsPackage "LocalRings"
+  R = ZZ/32003[x,y,z]
+  I = ideal"xyz+z5,2x2+y3+z7,3z5+y5"
+  C = freeRes I -- 1 15 38 34 10
+  D = pruneComplex(C, PruningMaps => true) -- 1 3 4 2
+  f = D.cache.pruningMap;
+
+  assert(D.dd^2 == 0)
+  assert(isCommutative f)
+  assert(isQuasiIsomorphism f)
+  assert(isMinimal(D, UnitTest => isScalar));
+
+  h = nullhomotopy(f)
+  f' = h * D.dd + C.dd * h;
+  assert(isCommutative f')
+  assert(nullhomotopy(f - f') == 0)
+  -- TODO what does this tell me? hahaha
+--  prune HH f -- what to do with this?
+
+  RP = localRing(R, ideal gens R)
+  C' = C ** RP
+  D' = pruneComplex(C', PruningMaps => true) -- 1 3 3 1
+  g = D'.cache.pruningMap;
+
+  assert(D'.dd^2 == 0)
+  assert(isCommutative g)
+--  assert(isQuasiIsomorphism g) -- FIXME THIS IS VERRRY SLOW
+  assert(isMinimal D');
+
+  h' = nullhomotopy(g) -- FIXME what does it mean that h' is zero?
+  g' = h' * D'.dd + C'.dd * h';
+  assert(isCommutative g')
+  assert(nullhomotopy(g - g') == 0)
+--  prune HH f -- To slow, probably why isQuasiIsomorphism is slow
+///
+
+end--
+
+-------------------------------------------------------------------------------------------------------
+-- Stress Test for Pruning Complexes in the Engine
+restart
+debug needsPackage "PruneComplex"
+needsPackage "RandomIdeals"
+R = ZZ/32003[a..f];
+
+randomCombo = (n, d) -> (
+--    ideal for i from 1 to n list (random(2, R) - random(3, R))
+    L := (randomMonomialIdeal(apply(2 + random 3, i-> 2 + random d), R))_*;
+    ideal apply(n, i -> sum(L, j -> random(coefficientRing ring L#0) * j + random 3))
+    )
+
+(nstep, flag) = (-1, 1025);
+(i, m) = (0, 50); time tally while i < m list (
+    I = randomCombo(3, 10);
+    try ( alarm (1); testEngine I; )
+    then (i = i + 1) else ( print "Lookit!"; break; );
+    );
+
+-------------------------------------------------------------------------------------------------------
+--  Development stuff
+--  path = prepend("~/src/m2/M2-local-rings/M2/Macaulay2/packages/", path) -- Mike
+restart
+needsPackage "PruneComplex"
+elapsedTime check PruneComplex -- 17 sec
+
+restart
+uninstallPackage "PruneComplex"
+restart
+installPackage "PruneComplex"
+viewHelp "PruneComplex"


### PR DESCRIPTION
This commit introduces changes in the core and in the engine, includes a new package, PruneComplex, and updates the LocalRings package. A new raw engine type LocalRing for localizations of polynomial rings at prime ideals, along with arithmetic operations for such rings, is defined in **e/localring.hpp**. The **m2/localring.m2** file in the core utilizes that type, allowing for making local rings as:
  ```RP = localRing(ZZ/32003[x,y,z,w], ideal"xy-zw")```

The **PruneComplex** package includes various methods for pruning chain complexes over polynomial and local rings. In particular, in the local or graded case, the output is guaranteed to be a minimal free resolution. Algorithms in this package are also implemented using C++ in **e/mutablecomplex.hpp** for speed. This introduces a new type MutableComplex in the engine.

The **LocalRings** package uses the package above to extend the following methods to such local rings: syz, res, trim, mingens, minimalPresentation, symbol//, inducedMap, symbol:, saturate, annihilate. This package now also includes a new method for computing **length** of modules over local rings and the **Hilbert-Samuel function** of modules over local rings, optionally given a parameter ideal. See [arXiv:1710.09830](https://arxiv.org/abs/1710.09830) for reference.

**Note**: Methods isSubset and symbol== are fixed in m2/modules2.m2 and reduce is fixed in m2/matrix.m2. Many other methods that only rely on the methods above, such as map, modulo, subquotient, kernel, cokernel, image, homology, Hom, Ext, Tor, etc. work for local rings automatically.

**Note**: The old LocalRings.m2 package from 2008 is stored in packages/LocalRings/legacy.m2 and is still usable, though it is slower and incompatible with new operations.

If you need specific methods that do not work, please email Mahrud Sayrafi. 