### PR TITLE
fix for #737

### DIFF
--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -365,7 +365,7 @@ multidegree Module := M -> (
      A := degreesRing M;
      onem := map(A,A,apply(generators A, t -> 1-t));
      c := codim M;
-     if c === infinity then 0_A else part(c,onem numerator poincare M))
+     if c === infinity then 0_A else part(c,numgens A:1,onem numerator poincare M))
 multidegree Ring := R -> multidegree R^1
 multidegree Ideal := I -> multidegree cokernel generators I
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/test/multidegree.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/test/multidegree.m2
@@ -1,5 +1,5 @@
 S = QQ[a..d, Degrees => {{2,-1},{1,0},{0,1},{ -1,2}}];
-A=degreesRing S;
+A = degreesRing S;
 assert( heft S == {1,1} )
 M = S^1/(b^2,b*c,c^2)
 assert ( 3 == degree M )
@@ -11,6 +11,6 @@ M' = S^1/(a^2,a*b,b^2);
 assert( 6*T_0^2-3*T_0*T_1 == multidegree M' )
 assert ( 3 == degree M' )
 -- now a case where heft *isn't* {1...1} but post-#737-fix should still work
-R=QQ[x,y,Degrees=>{{1,-1},{1,1}}];
-B=degreesRing R;
+R = QQ[x,y,Degrees=>{{1,-1},{1,1}}];
+B = degreesRing R;
 assert(multidegree ideal(x,y) == (T_0+T_1)*(T_0-T_1))

--- a/M2/Macaulay2/packages/Macaulay2Doc/test/multidegree.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/test/multidegree.m2
@@ -1,4 +1,5 @@
 S = QQ[a..d, Degrees => {{2,-1},{1,0},{0,1},{ -1,2}}];
+A=degreesRing S;
 assert( heft S == {1,1} )
 M = S^1/(b^2,b*c,c^2)
 assert ( 3 == degree M )
@@ -11,4 +12,5 @@ assert( 6*T_0^2-3*T_0*T_1 == multidegree M' )
 assert ( 3 == degree M' )
 -- now a case where heft *isn't* {1...1} but post-#737-fix should still work
 R=QQ[x,y,Degrees=>{{1,-1},{1,1}}];
+B=degreesRing R;
 assert(multidegree ideal(x,y) == (T_0+T_1)*(T_0-T_1))

--- a/M2/Macaulay2/packages/Macaulay2Doc/test/multidegree.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/test/multidegree.m2
@@ -1,6 +1,4 @@
 S = QQ[a..d, Degrees => {{2,-1},{1,0},{0,1},{ -1,2}}];
-A = degreesRing S;
-onem = map(A,A,apply(gens A, t -> 1-t));
 assert( heft S == {1,1} )
 M = S^1/(b^2,b*c,c^2)
 assert ( 3 == degree M )
@@ -11,3 +9,6 @@ assert( 1 == degree N )
 M' = S^1/(a^2,a*b,b^2);
 assert( 6*T_0^2-3*T_0*T_1 == multidegree M' )
 assert ( 3 == degree M' )
+-- now a case where heft *isn't* {1...1} but post-#737-fix should still work
+R=QQ[x,y,Degrees=>{{1,-1},{1,1}}];
+assert(multidegree ideal(x,y) == (T_0+T_1)*(T_0-T_1))


### PR DESCRIPTION
Multidegree now correctly assigns degree 1 to variables when expanding at lowest order.
A test has been added.