### PR TITLE
In PruneComplex, PruningMap => true by default; documentation fixes

### DIFF
--- a/M2/Macaulay2/packages/LocalRings.m2
+++ b/M2/Macaulay2/packages/LocalRings.m2
@@ -110,7 +110,7 @@ localSyzHook Matrix := Matrix => opts -> m -> (
     g := g' ** RP;
     h := h' ** RP;
     C := {g, h};
-    C = first pruneComplex(C, 1, Direction => "right");
+    C = first pruneComplex(C, 1, Direction => "right", PruningMap => false);
     f := C#0;
     -- Dot product with the denominators of lift
     N := transpose entries m;
@@ -138,14 +138,14 @@ localMingensHook Module := Matrix => opts -> M -> (
         g' := syz f';
         g := g' ** RP;
         C := {f, g};
-        C = first pruneComplex(C, 1, Direction => "right");
+        C = first pruneComplex(C, 1, Direction => "right", PruningMap => false);
         return map(F, , matrix C#0);
         );
     if c == 2 then (            --coker
         f = id_F;
         g = relations M;
         C = {f, g};
-        C = first pruneComplex(C, 1, Direction => "right");
+        C = first pruneComplex(C, 1, Direction => "right", PruningMap => false);
         return map(F, , matrix C#0);
         );
     if c == 3 then (            --subquotient
@@ -156,14 +156,14 @@ localMingensHook Module := Matrix => opts -> M -> (
         h' := modulo (f', g');
         h := h' ** RP;
         C = {f, h};
-        C = first pruneComplex(C, 1, Direction => "right");
+        C = first pruneComplex(C, 1, Direction => "right", PruningMap => false);
         return map(F, , matrix C#0);
         );
     )
 
 -- Computes minimalPresentation of modules over local rings
 -- TODO: if presentationComplex exists, skip stuff
-localMinimalPresentationHook = method(Options => options minimalPresentation ++ {PruningMaps => true})
+localMinimalPresentationHook = method(Options => options minimalPresentation ++ {PruningMap => true})
 localMinimalPresentationHook Module := Module => opts -> M -> (
     RP := ring M;
     c := (if M.?generators then 1 else 0) + 2 * (if M.?relations then 1 else 0);
@@ -176,7 +176,7 @@ localMinimalPresentationHook Module := Module => opts -> M -> (
         g := g' ** RP;
         h := h' ** RP;
         (C, P) := ({g, h}, null);
-        (C, P)  = pruneComplex(C, PruningMaps => true);
+        (C, P)  = pruneComplex(C, PruningMap => true);
         phi := map(M, , matrix P#0);
         N := coker map(source phi, , matrix C#0);
         phi = map(M, N, phi);
@@ -190,7 +190,7 @@ localMinimalPresentationHook Module := Module => opts -> M -> (
         g' = syz f';
         g = g' ** RP;
         C = {f, g};
-        (C, P) = pruneComplex(C, PruningMaps => true);
+        (C, P) = pruneComplex(C, PruningMap => true);
         phi = map(M, , matrix P#0);
         N = coker map(source phi, , matrix C#0);
         phi = map(M, N, phi);
@@ -208,7 +208,7 @@ localMinimalPresentationHook Module := Module => opts -> M -> (
         h = h' ** RP;
         e := e' ** RP;
         C = {h, e};
-        (C, P) = pruneComplex(C, PruningMaps => true);
+        (C, P) = pruneComplex(C, PruningMap => true);
         phi = map(M, , matrix P#0);
         N = coker map(source phi, , matrix C#0);
         phi = map(M, N, phi);
@@ -239,7 +239,7 @@ localLengthHook Module := ZZ => opts -> M -> (
         if opts.Strategy === Hilbert
         then n := hilbertSamuelFunction(M, i) -- really should be M/mM, but by Nakayama it's the same
         else (
-            M = localMinimalPresentationHook(M, PruningMaps => false);
+            M = localMinimalPresentationHook(M, PruningMap => false);
             n = numgens M;
             M = m * M;
             n
@@ -265,7 +265,7 @@ hilbertSamuelFunction (Module, ZZ, ZZ)        := List => (M, n0, n1) -> (
     M = m^n0 * M;
     for i from n0 to n1 list (
         if debugLevel >= 1 then << i << endl;
-        N := localMinimalPresentationHook(M, PruningMaps => false);  -- really should be N/mN, but by Nakayama it's the same
+        N := localMinimalPresentationHook(M, PruningMap => false);  -- really should be N/mN, but by Nakayama it's the same
         if i < n1 then M = m * N;
         numgens N
         )
@@ -279,11 +279,11 @@ hilbertSamuelFunction (Ideal, Module, ZZ, ZZ) := List => (q, M, n0, n1) -> (
     if class RP =!= LocalRing then error "expected objects over a local ring";
     if ring q =!= RP          then error "expected objects over the same ring";
     if q == max RP            then return hilbertSamuelFunction(M, n0, n1);
-    M = localMinimalPresentationHook(M, PruningMaps => false);
+    M = localMinimalPresentationHook(M, PruningMap => false);
     M = q^n0 * M;
     for i from n0 to n1 list (
         if debugLevel >= 1 then << i << endl;
-        N := localMinimalPresentationHook(M, PruningMaps => false);  -- really should be N/mN, but by Nakayama it's the same
+        N := localMinimalPresentationHook(M, PruningMap => false);  -- really should be N/mN, but by Nakayama it's the same
         if i < n1 then M = q * N;
         localLengthHook (N/(q * N))
         )
@@ -315,8 +315,8 @@ addHook(Module, symbol resolution, (opts,M) -> (
             C := resolution(M', opts);
             CP := C ** RP;
             CP = if isHomogeneous M'
-              then pruneComplex(CP, UnitTest => isScalar)
-              else pruneComplex CP;
+              then pruneComplex(CP, UnitTest => isScalar, PruningMap => false)
+              else pruneComplex(CP, PruningMap => false);
             break CP)
         ))
 

--- a/M2/Macaulay2/packages/LocalRings/doc.m2
+++ b/M2/Macaulay2/packages/LocalRings/doc.m2
@@ -19,7 +19,9 @@ Description
     If you need specific methods that do not work, please inform Mahrud Sayrafi.
   Example
     R = ZZ/32003[a..d];
-    "rational quartic curve in P^3:";
+  Text
+    Rational quartic curve in P^3:
+  Example
     I = monomialCurveIdeal(R,{1,3,4})
     C = res I
     M = ideal"a,b,c,d"; "maximal ideal at the origin";
@@ -27,12 +29,15 @@ Description
     RM = localRing(R, M);
     D = C ** RM;
     E = pruneComplex D
-    "That is to say, the rational quartic curve is not locally Cohen-Macaulay at the origin";
-    "Therefore the curve is not Cohen-Macaulay";
+  Text
+    That is to say, the rational quartic curve is not locally Cohen-Macaulay at the origin
+    Therefore the curve is not Cohen-Macaulay
+  Example
     RP = localRing(R, P);
     D' = C ** RP;
     E' = pruneComplex D'
-    "However, the curve is Cohen-Macaulay at the prime ideal P (and in fact any other prime ideal)";
+  Text
+    However, the curve is Cohen-Macaulay at the prime ideal P (and in fact any other prime ideal)
 Caveat
   Currently limited to localization at prime ideals rather than any multiplicatively closed set.
   Quotients of local rings are not implemented yet. Moreover, certain functions (such as symbol%,
@@ -70,9 +75,10 @@ Description
     For matrices (hence most other objects as well), clearing denominators is performed columnwise.
 
     In conjunction with pruneComplex, liftUp is used to implement many of the elementary operations
-    over local rings such as syz (see the example below).
+    over local rings such as syz.
+
+    Here is an example of computing the syzygy over a local ring using liftUp and pruneComplex:
   Example
-    "Computing the syzygy over a local ring using liftUp and pruneComplex";
     R = ZZ/32003[vars(0..5)];
     I = ideal"abc-def,ab2-cd2-c,-b3+acd";
     C = res I;
@@ -80,19 +86,27 @@ Description
     RM = localRing(R, M);
     F = C.dd_2;
     FM = F ** RM
-    "This is the process for finding the syzygy of FM:";
+  Text
+    This is the process for finding the syzygy of FM:
+  Example
     f = liftUp FM;
     g = syz f;
     h = syz g;
     C = {g ** RM, h ** RM};
-    "Now we prune the map h, which is the first map from the right:";
+  Text
+    Now we prune the map h, which is the first map from the right:
+  Example
     C = first pruneComplex(C, 1, Direction => "right");
     g' = C#0;
-    "Scale each row with the common denominator of the corresponding column in FM:";
+  Text
+    Scale each row with the common denominator of the corresponding column in FM:
+  Example
     N = transpose entries FM;
     for i from 0 to numcols FM - 1 do
       rowMult(g', i, N_i/denominator//lcm);
-    "The syzygy of FM is:";
+  Text
+    The syzygy of FM is:
+  Example
     GM = map(source FM, , matrix g')
     kernel FM == image GM
 Caveat
@@ -143,8 +157,9 @@ Description
      On the other hand, if computing at range (n, n+m) is slow, try breaking up the range.
 
     To learn more read Eisenbud, Commutative Algebra, Chapter 12.
+
+    Here is an example from Computations in Algebraic Geometry with Macaulay2, pp. 61:
   Example
-    "Example from Computations in Algebraic Geometry with Macaulay2, pp. 61:";
     R = QQ[x,y,z];
     RP = localRing(R, ideal gens R);
     I = ideal"x5+y3+z3,x3+y5+z3,x3+y3+z5"
@@ -153,7 +168,9 @@ Description
     elapsedTime hilbertSamuelFunction(M, 0, 6) -- 0.55 seconds
     oo//sum
 
-    "An example of using a parameter ideal:";
+  Text
+    An example of using a parameter ideal:
+  Example
     R = ZZ/32003[x,y];
     RP = localRing(R, ideal gens R);
     N = RP^1

--- a/M2/Macaulay2/packages/LocalRings/examples.m2
+++ b/M2/Macaulay2/packages/LocalRings/examples.m2
@@ -89,7 +89,7 @@ FM = F ** RM
  C = {mutableMatrix g, mutableMatrix h};
  pruneDiff(C, 1);
  toChainComplex C
-GM = matrix C#0
+GM = map(ambient image g, , matrix C#0)
 assert(image GM == kernel FM)
 
 -- Intersection Theory: Geometric Multiplicity

--- a/M2/Macaulay2/packages/LocalRings/examples.m2
+++ b/M2/Macaulay2/packages/LocalRings/examples.m2
@@ -267,7 +267,7 @@ E' = pruneComplex(D', UnitTest => isUnit)
 restart
 needsPackage "LocalRings"
 R = ZZ/32003[x,y,z,w]
--- Rational quartic, see Eisenbyd Ex. 12.4
+-- Rational quartic, see Eisenbud Ex. 12.4
 I = monomialCurveIdeal(R, {1, 3, 4})
 RM = localRing(R, ideal gens R)
 
@@ -410,10 +410,10 @@ h = syz g
 i = syz h
 j = syz i
 C = {mutableMatrix g, mutableMatrix h, mutableMatrix i, mutableMatrix j}
-(C1, P1) = pruneDiff(C, 0, PruningMaps => true)
-(C2, P2) = pruneDiff(C, 1, PruningMaps => P1)
-(C3, P3) = pruneDiff(C, 2, PruningMaps => P2)
-(C4, P4) = pruneDiff(C, 3, PruningMaps => P3)
+(C1, P1) = pruneDiff(C, 0, PruningMap => true)
+(C2, P2) = pruneDiff(C, 1, PruningMap => P1)
+(C3, P3) = pruneDiff(C, 2, PruningMap => P2)
+(C4, P4) = pruneDiff(C, 3, PruningMap => P3)
 C' = chainComplex for M in C4 list  map(S^(numrows M), S^(numcols M), matrix M)
 C'.dd
 
@@ -426,10 +426,10 @@ hp = syz gp
 ip = syz hp
 jp = syz ip
 CP = {mutableMatrix gp, mutableMatrix hp, mutableMatrix ip, mutableMatrix jp}
-(C1, P1) = pruneDiff(CP, 0, PruningMaps => true)
-(C2, P2) = pruneDiff(CP, 1, PruningMaps => P1)
-(C3, P3) = pruneDiff(CP, 2, PruningMaps => P2)
-(C4, P4) = pruneDiff(CP, 3, PruningMaps => P3)
+(C1, P1) = pruneDiff(CP, 0, PruningMap => true)
+(C2, P2) = pruneDiff(CP, 1, PruningMap => P1)
+(C3, P3) = pruneDiff(CP, 2, PruningMap => P2)
+(C4, P4) = pruneDiff(CP, 3, PruningMap => P3)
 CP' = chainComplex for M in C4 list  map(SP^(numrows M), SP^(numcols M), matrix M)
 CP'.dd
 

--- a/M2/Macaulay2/packages/LocalRings/tests.m2
+++ b/M2/Macaulay2/packages/LocalRings/tests.m2
@@ -11,7 +11,7 @@ TEST /// -- test for localRing, res, **, ==
   CJ = res J
   CP = CJ++CJ[-10]
   DJ = CI ** RP
-  DP = pruneComplex(DJ++DJ[-10], PruningMaps=>true)
+  DP = pruneComplex(DJ++DJ[-10], PruningMap=>true)
   f = DP.cache.pruningMap
   assert(DP.dd^2 == 0)
   assert(DP == CP)
@@ -542,7 +542,7 @@ end--
   C = res J
   C1 = pruneComplex C
   C2 = C1 ** RP
-  elapsedTime pruneComplex(C2, UnitTest => isScalar) -- very slow
+  elapsedTime pruneComplex(C2, UnitTest => isScalar, PruningMap => false) -- very slow
 
   IP = ideal(gens I ** RP)
 --  IP = liftUp IP -- uncomment this line to compare speed with the nonlocal case
@@ -561,8 +561,8 @@ end--
   I = ideal jacobian matrix{{F}}
   C = res I
   RP = localRing(R, ideal gens R)
-  elapsedTime C1 = pruneComplex C
-  elapsedTime C2 = pruneComplex(C ** RP) -- how long does this even take?
+  elapsedTime C1 = pruneComplex(C, PruningMap => false)
+  elapsedTime C2 = pruneComplex(C ** RP, PruningMap => false) -- how long does this even take?
   --
   Rloc = (ZZ/32003){a,b,c,d}
   Iloc = sub(I, Rloc)
@@ -577,7 +577,7 @@ end--
 --  path = prepend("~/src/m2/M2-local-rings/M2/Macaulay2/packages/", path) -- Mike
 restart
 needsPackage "LocalRings"
-elapsedTime check LocalRings -- 17 seconds
+elapsedTime check LocalRings -- 15.5 seconds
 
 restart
 uninstallPackage "LocalRings"

--- a/M2/Macaulay2/packages/PruneComplex.m2
+++ b/M2/Macaulay2/packages/PruneComplex.m2
@@ -363,7 +363,7 @@ enginePruneComplex(List, ZZ) := opts -> (C, nsteps) -> (
     flag = flag | (if false                      then    32 else 0); -- Pruning for maximal ideal
     flag = flag | (if false                      then    64 else 0); -- Pruning for prime ideal
     flag = flag | (if true                       then  1024 else 0); -- Prune sparsest unit first
-    flag = flag | (if opts.PruningMap            then  2048 else 0); -- Prune best matrix first
+    flag = flag | (if false                      then  2048 else 0); -- Prune best matrix first
     flag = flag | (if opts.Direction === "right" then 65536 else 0); -- Prune the matrices in reverse order
     -- create the raw chain complex
     if debugLevel >= 2 then << "Using enginePruneComplex." << endl;

--- a/M2/Macaulay2/packages/PruneComplex.m2
+++ b/M2/Macaulay2/packages/PruneComplex.m2
@@ -63,12 +63,15 @@ toMutableComplex ChainComplex := C -> for i from min C to max C list mutableMatr
 -- TODO: make sure the information about source and target modules for general complexes are kept
 toChainComplex = method()
 toChainComplex List          :=  mComplex     -> (
-    if #mComplex == 0 then error "toChainComplex: cannot build a chain complex without a ring.";
+    if #mComplex == 0 then error "toChainComplex: expected at least one differential map.";
     toChainComplex(mComplex, target matrix (mComplex#0))
     )
 toChainComplex(List, Module) := (mComplex, F) -> (
-    chainComplex for M in mComplex list (
-        m := map(F, , matrix M);
+    if #mComplex == 0 then error "toChainComplex: expected at least one differential map.";
+    places := select(0..(length mComplex)-1, i -> mComplex_i != 0);
+    len := if #places === 0 then 0 else max places - min places;
+    chainComplex for i from 0 to len list (
+        m := map(F, , matrix mComplex_i);
         F = source m; m)
     )
 

--- a/M2/Macaulay2/packages/PruneComplex.m2
+++ b/M2/Macaulay2/packages/PruneComplex.m2
@@ -41,12 +41,11 @@ export {
 --    "testM2",
 --    "testEngine",
 --  Options:
-    "Direction", "PruningMaps", "UnitTest"
+    "Direction", "PruningMap", "UnitTest"
     }
 
 << "--------------------------------------------------------------------------------------" << endl;
-<< "-- The PruneComplex package is experimental: if the input is not a free resolution, --" << endl;
-<< "-- the map degrees of the resulting chain complex may not be correct,               --" << endl;
+<< "-- The PruneComplex package is experimental.                                        --" << endl;
 << "-- See the documentation and comments in the package to learn more.                 --" << endl;
 << "--------------------------------------------------------------------------------------" << endl;
 
@@ -187,7 +186,7 @@ deleteColumns = (M, cfirst, clast) -> ( rawDeleteColumns(raw M, cfirst, clast); 
 -- Then reduces mComplex#n using the unit in the last row and column
 -- Input: a list of mutable matrices mComplex followed by an iterator n
 -- Output: a list of mutable matrices mComplex of smaller size
-pruneUnit = method(Options => {PruningMaps => false, UnitTest => isUnit})
+pruneUnit = method(Options => {PruningMap => true, UnitTest => isUnit})
 pruneUnit(List, ZZ, Sequence, List) := opts -> (mComplex, n, unit, pruningMorph) -> (
     if debugLevel >= 3 then
       <<"   Removing a unit from differential #"<<n<<endl;
@@ -195,7 +194,7 @@ pruneUnit(List, ZZ, Sequence, List) := opts -> (mComplex, n, unit, pruningMorph)
     (r,c) := unit;
     R := ring mComplex#n;
     -- Initialize pruning maps if needed
-    if opts.PruningMaps =!= false then (
+    if opts.PruningMap =!= false then (
         if pruningMorph#n     === null then pruningMorph#n     = mutableIdentity(R, numRows mComplex#n);
         if pruningMorph#(n+1) === null then pruningMorph#(n+1) = mutableIdentity(R, numColumns mComplex#n);
         );
@@ -204,14 +203,14 @@ pruneUnit(List, ZZ, Sequence, List) := opts -> (mComplex, n, unit, pruningMorph)
     rowSwap(mComplex#n, r, r2);
     if 0 < n then
       columnSwap(mComplex#(n-1), r, r2);
-    if opts.PruningMaps =!= false then
+    if opts.PruningMap =!= false then
       columnSwap(pruningMorph#n, r, r2);
     -- Move to last column
     c2 := numColumns mComplex#n - 1;
     columnSwap(mComplex#n, c, c2);
     if n < #mComplex - 1 then
       rowSwap(mComplex#(n+1), c, c2);
-    if opts.PruningMaps =!= false then
+    if opts.PruningMap =!= false then
       columnSwap(pruningMorph#(n+1), c, c2);
     -- Get the pivot
     inversePivot := if instance(R, LocalRing) then (mComplex#n_(r2, c2))^-1 else (leadCoefficient mComplex#n_(r2, c2))^-1;
@@ -221,7 +220,7 @@ pruneUnit(List, ZZ, Sequence, List) := opts -> (mComplex, n, unit, pruningMorph)
         rowAdd(mComplex#n, r, -f * inversePivot, r2);
         if 0 < n then
             columnAdd(mComplex#(n-1), r2, f * inversePivot, r);
-        if opts.PruningMaps =!= false then
+        if opts.PruningMap =!= false then
             columnAdd(pruningMorph#n, r2, f * inversePivot, r);
         );
     -- Clear the row
@@ -230,20 +229,20 @@ pruneUnit(List, ZZ, Sequence, List) := opts -> (mComplex, n, unit, pruningMorph)
         columnAdd(mComplex#n, c, -f * inversePivot, c2);
         if n < #mComplex - 1 then
             rowAdd(mComplex#(n+1), c2, f * inversePivot, c);
-        if opts.PruningMaps =!= false then
+        if opts.PruningMap =!= false then
             columnAdd(pruningMorph#(n+1), c, -f * inversePivot, c2);
         );
     -- delete rows/columns
     deleteColumns(mComplex#n, c2, c2);
     if n < #mComplex-1 then
        deleteRows(mComplex#(n+1), c2, c2);
-    if opts.PruningMaps =!= false then
+    if opts.PruningMap =!= false then
         deleteColumns(pruningMorph#(n+1), c2, c2);
 
     deleteRows(mComplex#n, r2, r2);
     if 0 < n then
         deleteColumns(mComplex#(n-1), r2, r2);
-    if opts.PruningMaps =!= false then
+    if opts.PruningMap =!= false then
         deleteColumns(pruningMorph#n, r2, r2);
 
     mComplex
@@ -252,16 +251,16 @@ pruneUnit(List, ZZ, Sequence, List) := opts -> (mComplex, n, unit, pruningMorph)
 -- Prunes a single differential by reducing the units in a while loop, starting with the ones in
 -- sparcest row/column. Uses pruneUnit.
 -- TODO: handle the case of twisted complexes and free modules with degrees (both are OK in the engine)
-pruneDiff = method(Options => {PruningMaps => false, UnitTest => isUnit})
+pruneDiff = method(Options => {PruningMap => true, UnitTest => isUnit})
 pruneDiff(ChainComplex, ZZ) := opts -> (C, n) -> (
-    if opts.PruningMaps === true then (
+    if opts.PruningMap === true then (
         (D, pruningMorph) := pruneDiff(toMutableComplex C, n, opts);
         return (toChainComplex D, pruningMorph);
         );
     toChainComplex pruneDiff(toMutableComplex C, n, opts)
     )
 pruneDiff(ChainComplex, ZZ, List) := opts -> (C, n, M) -> (
-    if opts.PruningMaps === true then (
+    if opts.PruningMap === true then (
         (D, pruningMorph) := pruneDiff(toMutableComplex C, n, M, opts);
         return (toChainComplex D, pruningMorph);
         );
@@ -269,7 +268,7 @@ pruneDiff(ChainComplex, ZZ, List) := opts -> (C, n, M) -> (
     )
 pruneDiff(List, ZZ)         := opts -> (mComplex, n) -> (
     pruningMorph := new MutableList;
-    if opts.PruningMaps === true then (
+    if opts.PruningMap === true then (
         for i from 0 to #mComplex - 1 do pruningMorph#i = mutableIdentity(ring mComplex#0, numRows mComplex#i);
         pruningMorph#(#mComplex) = mutableIdentity(ring mComplex#0, numColumns mComplex#(#mComplex - 1));
         );
@@ -286,7 +285,7 @@ pruneDiff(List, ZZ, List)         := opts -> (mComplex, n, pruningMorph) -> (
         ) do pruneUnit(mComplex, n, first unit, pruningMorph, opts);
     if debugLevel >= 2 then
       << "\tDifferential reduced to => " << (numRows M, numColumns M) << endl;
-    if opts.PruningMaps === true then return (mComplex, pruningMorph);
+    if opts.PruningMap === true then return (mComplex, pruningMorph);
     mComplex
     )
 
@@ -297,7 +296,7 @@ pruneComplex = method(
     Options => {
         Strategy => Engine, -- set to null to use the methods above
         Direction => "left",
-        PruningMaps => false,
+        PruningMap => true, -- TODO: grading may be incorrect if this is set to false
         UnitTest => isUnit -- TODO: detect when all units are scalars and choose that
         })
 pruneComplex ChainComplex      := opts ->  C          -> pruneComplex(C, -1, opts)
@@ -305,12 +304,12 @@ pruneComplex(ChainComplex, ZZ) := opts -> (C, nsteps) -> (
     m := min C;
     mComplex := toMutableComplex C;
     (D, M) := pruneComplex(mComplex, nsteps, opts);
-    F := if opts.PruningMaps == true
+    F := if opts.PruningMap == true
     then source map(target C.dd_(m+1), , matrix M#0)
     else target matrix D#0;
     D = (toChainComplex(D, F))[-m];
     R := ring D;
-    if opts.PruningMaps == true then
+    if opts.PruningMap == true then
       D.cache.pruningMap = map(C, D, i -> M#(i-m)//matrix);
     D
     )
@@ -320,7 +319,7 @@ pruneComplex(List, ZZ) := opts -> (mComplex, nsteps) -> (
     mComplex = mComplex/mutableMatrix;
     if nsteps == -1 then nsteps = len;
     pruningMorph := new MutableList;
-    if opts.PruningMaps === true then (
+    if opts.PruningMap === true then (
         for i from 0 to #mComplex - 1 do pruningMorph#i = mutableIdentity(ring mComplex#0, numRows mComplex#i);
         pruningMorph#(#mComplex) = mutableIdentity(ring mComplex#0, numColumns mComplex#(#mComplex - 1));
         );
@@ -329,13 +328,13 @@ pruneComplex(List, ZZ) := opts -> (mComplex, nsteps) -> (
       return enginePruneComplex(mComplex, nsteps, opts)
     else if opts.Direction == "left"  then                              -- pruning the left one first
       for i from 0 to nsteps-1 do
-        pruneDiff(mComplex,       i, pruningMorph, PruningMaps => opts.PruningMaps, UnitTest => opts.UnitTest)
+        pruneDiff(mComplex,       i, pruningMorph, PruningMap => opts.PruningMap, UnitTest => opts.UnitTest)
     else if opts.Direction == "right" then                              -- pruning the right one first
       for i from 0 to nsteps-1 do
-        pruneDiff(mComplex, len-i-1, pruningMorph, PruningMaps => opts.PruningMaps, UnitTest => opts.UnitTest)
+        pruneDiff(mComplex, len-i-1, pruningMorph, PruningMap => opts.PruningMap, UnitTest => opts.UnitTest)
     else if opts.Direction == "both"  then                              -- pruning outside-in
       (unique splice for i from 1 to lift((nsteps - nsteps % 2)/2, ZZ) list (i, len-i)) /
-      (n -> pruneDiff(mComplex,   n, pruningMorph, PruningMaps => opts.PruningMaps, UnitTest => opts.UnitTest))
+      (n -> pruneDiff(mComplex,   n, pruningMorph, PruningMap => opts.PruningMap, UnitTest => opts.UnitTest))
     else if opts.Direction == "best"  then                              -- pruning the sparsest unit
       while (
         units := for i from 0 to nsteps - 1 list (
@@ -346,7 +345,7 @@ pruneComplex(List, ZZ) := opts -> (mComplex, nsteps) -> (
         n := minPosition(units/last);
         unit := units#n;
         last unit != infinity
-        ) do pruneUnit(mComplex, n, first unit, pruningMorph, PruningMaps => opts.PruningMaps, UnitTest => opts.UnitTest);
+        ) do pruneUnit(mComplex, n, first unit, pruningMorph, PruningMap => opts.PruningMap, UnitTest => opts.UnitTest);
     (mComplex, pruningMorph)
     )
 
@@ -356,7 +355,7 @@ enginePruneComplex(List, ZZ) := opts -> (C, nsteps) -> (
     R := ring C#0;
     flag := 0;
     -- See e/mutablecomplex.cpp for reference
-    flag = flag | (if opts.PruningMaps           then     1 else 0); -- See `help pruningMap` in M2
+    flag = flag | (if opts.PruningMap            then     1 else 0); -- See `help pruningMap` in M2
     flag = flag | (if false                      then     2 else 0); -- Delete pruned rows and columns
     flag = flag | (if false                      then     4 else 0); -- Only prune -1,+1
     flag = flag | (if opts.UnitTest === isScalar then     8 else 0); -- Only prune constants
@@ -364,7 +363,7 @@ enginePruneComplex(List, ZZ) := opts -> (C, nsteps) -> (
     flag = flag | (if false                      then    32 else 0); -- Pruning for maximal ideal
     flag = flag | (if false                      then    64 else 0); -- Pruning for prime ideal
     flag = flag | (if true                       then  1024 else 0); -- Prune sparsest unit first
-    flag = flag | (if opts.PruningMaps           then  2048 else 0); -- Prune best matrix first
+    flag = flag | (if opts.PruningMap            then  2048 else 0); -- Prune best matrix first
     flag = flag | (if opts.Direction === "right" then 65536 else 0); -- Prune the matrices in reverse order
     -- create the raw chain complex
     if debugLevel >= 2 then << "Using enginePruneComplex." << endl;

--- a/M2/Macaulay2/packages/PruneComplex/doc.m2
+++ b/M2/Macaulay2/packages/PruneComplex/doc.m2
@@ -14,13 +14,14 @@ Description
     m1 = genericMatrix(R,a,3,3)
     m2 = genericMatrix(R,j,3,3)
     I = ideal(m1*m2-m2*m1)
-    "Here we produce an intentionally nonminimal resolution:";
-    S = (coefficientRing R)(monoid [gens R, local h]);
-    Ihom = ideal homogenize(sub(gens gb I, S), S_(numgens R));
-    Chom = res(Ihom, FastNonminimal=>true);
-    C = (map(R, S, gens R | {1})) Chom
-    "Now we prune the resolution above to get a minimal resolution:";
-    elapsedTime D = pruneComplex(C, PruningMaps => true, UnitTest => isScalar) -- 1.379s
+  Text
+    Here we produce an intentionally nonminimal resolution:
+  Example
+    C = res(I, FastNonminimal=>true)
+  Text
+    Now we prune the resolution above to get a minimal resolution:
+  Example
+    D = pruneComplex(C, UnitTest => isScalar)
     isCommutative D.cache.pruningMap
     betti D == betti res I
 Caveat
@@ -39,6 +40,7 @@ Key
 Headline
   Prunes a chain complex or list of mutable matrices
 Usage
+  D = pruneComplex C
   D = pruneComplex(C, nsteps)
 Inputs
   C: ChainComplex
@@ -54,22 +56,28 @@ Description
   Example
     R = ZZ/32003[a..f]
     I = ideal"abc-def,ab2-cd2-c,acd-b3-1"
-    "Here we produce an intentionally nonminimal resolution:";
+  Text
+    Here we produce an intentionally nonminimal resolution from a non-homogeneous ideal:
+  Example
     S = (coefficientRing R)(monoid [gens R, local h]);
     Ihom = ideal homogenize(sub(gens gb I, S), S_(numgens R));
     Chom = (res(Ihom, FastNonminimal=>true))[-10];
     C = (map(R, S, gens R | {1})) Chom
-    "Now we prune the resolution above to get a minimal resolution:";
-    D = pruneComplex(C, Strategy => null, UnitTest => isScalar, Direction => "both")
+  Text
+    Now we prune the resolution above to get a minimal resolution:
+  Example
+    D = pruneComplex C
     C.dd
     D.dd
 Consequences
   Item
-    If PruningMaps is true, D.cache.pruningMap will be updated to a chain complex map {f: C <-- D}.
+    Unless PruningMap is false, D.cache.pruningMap will be updated to a chain complex map {f: C <-- D}.
 Caveat
   For inhomogeneous input the resulting complex is not guaranteed to be minimal, particularly because
-  minimality is not well-defined in that case. If the input is a general chain complex, rather than a
-  free resolution, the degree of the maps will not be accurate.
+  minimality is not well-defined in that case.
+
+  If PruningMap is false and the input is not the resolution of a graded ideal, the grading of the
+  resulting complex may be incorrect.
 SeeAlso
   pruneDiff
   pruningMap
@@ -93,17 +101,18 @@ Inputs
   n: ZZ
     the index of the differential in C
   M: List
-    if provided, will initialize the list of pruning maps back to the old complex
+    if provided, will initialize the map back to the original complex
 Outputs
   D: ChainComplex
     or the list of modified mutable matrices
   M: List
-    if PruningMaps is true, will contain the pruning maps back to the old complex
+    unless PruningMap is false, will contain the map back to the original complex
 Description
   Text
     Completely prunes the n-th differential of the chain complex C by removing unit elements.
+  Text
+    Computing the syzygy over a local ring using liftUp and pruneDiff:
   Example
-    "Computing the syzygy over a local ring using liftUp and pruneDiff";
     needsPackage "LocalRings";
     R = ZZ/32003[vars(0..5)];
     I = ideal"abc-def,ab2-cd2-c,-b3+acd";
@@ -112,19 +121,27 @@ Description
     RM = localRing(R, M);
     F = C.dd_2;
     FM = F ** RM
-    "This is the process for finding the syzygy of FM:";
+  Text
+    This is the process for finding the syzygy of FM:
+  Example
     f = liftUp FM;
     g = syz f;
     h = syz g;
     C = {g ** RM, h ** RM}/mutableMatrix;
-    "Now we prune the map h, which is the first map from the right:";
+  Text
+    Now we prune the map h, which is the first map from the right:
+  Example
     C = pruneDiff(C, 1)
     g' = C#0;
-    "Scale each row with the common denominator of the corresponding column in FM:";
+  Text
+    Scale each row with the common denominator of the corresponding column in FM:
+  Example
     N = transpose entries FM;
     for i from 0 to numcols FM - 1 do
       rowMult(g', i, N_i/denominator//lcm);
-    "The syzygy of FM is:";
+  Text
+    The syzygy of FM is:
+  Example
     GM = map(source FM, , matrix g')
     kernel FM == image GM
 Caveat
@@ -151,7 +168,7 @@ Inputs
   u: Sequence
     the coordinates of the unit in the differential
   M: List
-    if provided, will initialize the list of pruning maps back to the original complex
+    if provided, will initialize the list of map back to the original complex
 Outputs
   D: List
     a list of modified mutable matrices
@@ -195,7 +212,8 @@ Description
     D' = toChainComplex MC
     assert(betti D == betti D'[-10])
 Caveat
-  Does not keep the information about source of target of maps for general complexes.
+  Since the information about source of target of maps is not available, the grading may be incorrect
+  for general complexes.
 SeeAlso
   toMutableComplex
 ///
@@ -279,15 +297,18 @@ SeeAlso
 
 doc ///
 Key
-  PruningMaps
-  [pruneUnit, PruningMaps]
-  [pruneDiff, PruningMaps]
-  [pruneComplex, PruningMaps]
+  PruningMap
+  [pruneUnit, PruningMap]
+  [pruneDiff, PruningMap]
+  [pruneComplex, PruningMap]
 Headline
   Whether to compute a morphism of complexes
 Description
   Text
-    If true, the pruning maps to the old complex will be stored in C.cache.pruningMap.
+    When true, the pruning map to the original complex will be stored in C.cache.pruningMap.
+Caveat
+  Setting PruningMap to false will improve performance, but in some cases the grading of the
+  resulting object may be incorrect.
 SeeAlso
   pruningMap
   pruneUnit

--- a/M2/Macaulay2/packages/PruneComplex/doc.m2
+++ b/M2/Macaulay2/packages/PruneComplex/doc.m2
@@ -57,18 +57,34 @@ Description
     R = ZZ/32003[a..f]
     I = ideal"abc-def,ab2-cd2-c,acd-b3-1"
   Text
-    Here we produce an intentionally nonminimal resolution from a non-homogeneous ideal:
+    Here we produce an intentionally nonminimal resolution from a inhomogeneous ideal:
   Example
     S = (coefficientRing R)(monoid [gens R, local h]);
     Ihom = ideal homogenize(sub(gens gb I, S), S_(numgens R));
     Chom = (res(Ihom, FastNonminimal=>true))[-10];
     C = (map(R, S, gens R | {1})) Chom
   Text
-    Now we prune the resolution above to get a minimal resolution:
+    Now we prune the resolution above to prune the resolution:
   Example
     D = pruneComplex C
-    C.dd
     D.dd
+  Text
+    Note that in general the resolution is not minimal. In this case, sometimes changing the direction
+    of pruning can lead to different results. To do so, set Strategy => null to avoid using the engine
+    procedures:
+  Example
+    D1 = pruneComplex(C, Strategy => null, Direction => "both")
+    D1.dd
+  Text
+    To improve speed for larger resolutions over local rings, one can first start with pruning all
+    scalars from the maps by setting UnitTest => isScalar, then proceed to other units using
+    UnitTest => isUnit.
+
+    Another trick is to turn off computation of the pruning map. Note, however, that this may result in
+    incorrect degrees in the graded case:
+  Example
+    D2 = pruneComplex(C, PruningMap => false)
+    D2.dd
 Consequences
   Item
     Unless PruningMap is false, D.cache.pruningMap will be updated to a chain complex map {f: C <-- D}.
@@ -131,7 +147,7 @@ Description
   Text
     Now we prune the map h, which is the first map from the right:
   Example
-    C = pruneDiff(C, 1)
+    C = pruneDiff(C, 1, PruningMap => false)
     g' = C#0;
   Text
     Scale each row with the common denominator of the corresponding column in FM:
@@ -208,7 +224,7 @@ Description
     C = res I;
     D = C[-10]
     MC = toMutableComplex D;
-    elapsedTime MC = first pruneComplex MC; -- 0.001 seconds
+    MC = first pruneComplex MC;
     D' = toChainComplex MC
     assert(betti D == betti D'[-10])
 Caveat
@@ -240,7 +256,7 @@ Description
     RP = localRing(R, ideal"a,b,c");
     D = (C ++ C[-5]) ** RP
     MD = toMutableComplex D
-    elapsedTime pruneComplex MD
+    pruneComplex MD
 Caveat
   The nonzero terms in the chain complex must be in a series, otherwise may not work correctly.
 SeeAlso

--- a/M2/Macaulay2/packages/PruneComplex/tests.m2
+++ b/M2/Macaulay2/packages/PruneComplex/tests.m2
@@ -21,7 +21,7 @@ testM2 = (I, P) -> (
     if not instance(R, LocalRing) then (
         C := freeRes I;
         assert(C.dd^2 == 0);
-        time D := pruneComplex(C, Strategy => null, Direction => "left", PruningMaps => true);
+        time D := pruneComplex(C, Strategy => null, Direction => "left", PruningMap => true);
         assert(D.dd^2 == 0);
         if isHomogeneous I then assert(betti D == betti res I);
         assert(isCommutative D.cache.pruningMap);
@@ -30,7 +30,7 @@ testM2 = (I, P) -> (
         ) else E = res I;
     RP := ring E;
     assert(E.dd^2 == 0);
-    time F := pruneComplex(E, Strategy => null, Direction => "left", PruningMaps => true);
+    time F := pruneComplex(E, Strategy => null, Direction => "left", PruningMap => true);
     return (
         F.dd^2 == 0 and isMinimal F and
         isCommutative F.cache.pruningMap and
@@ -43,7 +43,7 @@ testEngine = (I, P) -> (
     if not instance(R, LocalRing) then (
         C := freeRes I;
         assert(C.dd^2 == 0);
-        time D := pruneComplex(C, Strategy => Engine, Direction => "left", PruningMaps => true);
+        time D := pruneComplex(C, Strategy => Engine, Direction => "left", PruningMap => true);
         assert(D.dd^2 == 0);
         if isHomogeneous I then assert(betti D == betti res I);
         assert(isCommutative D.cache.pruningMap);
@@ -52,12 +52,24 @@ testEngine = (I, P) -> (
         ) else E = res I;
     RP := ring E;
     assert(E.dd^2 == 0);
-    time F := pruneComplex(E, Strategy => Engine, Direction => "left", PruningMaps => true);
+    time F := pruneComplex(E, Strategy => Engine, Direction => "left", PruningMap => true);
     return (
         F.dd^2 == 0 and isMinimal F and
         isCommutative F.cache.pruningMap and
         isQuasiIsomorphism(F, ideal(gens I ** RP)))
     )
+
+-- Given a homogeneous module, with a non-minimal resolution, the pruned complex should be homogeneous.
+TEST ///
+  R = ZZ/32003[x,y,z]
+  M = coker random(R^{1, 2, -1}, R^{-1, -2, -3, -4})
+  assert isHomogeneous M
+  C = res M
+  assert isHomogeneous C
+  C' = pruneComplex C
+  assert(C'.dd^2 == 0)
+  assert isHomogeneous C'
+///
 
 TEST ///
   debug needsPackage "PruneComplex"
@@ -71,10 +83,10 @@ TEST ///
   C'' = C'[20]
   MC' = toMutableComplex C';
   MC'' = toMutableComplex C'';
-  elapsedTime C1 = pruneComplex(C', Strategy => Engine, PruningMaps => true); -- TODO: consider using sparse matrices
+  elapsedTime C1 = pruneComplex(C', Strategy => Engine, PruningMap => true); -- TODO: consider using sparse matrices
   assert(isCommutative C1.cache.pruningMap);
   assert(betti C[-10] == betti C1)
-  elapsedTime (MC, M) = pruneComplex(MC'', Strategy => null, UnitTest => isScalar, PruningMaps => true); -- FIXME very slow
+  elapsedTime (MC, M) = pruneComplex(MC'', Strategy => null, UnitTest => isScalar, PruningMap => true); -- FIXME very slow
   C2 = toChainComplex MC;
   assert(isCommutative map(C'', C2, i -> M#(i+ min C'' +1)//matrix));
   assert(betti C[10] == betti C2[10])
@@ -160,23 +172,23 @@ TEST ///
       assert(isCommutative D.cache.pruningMap);
       assert(isQuasiIsomorphism(D, I));)
 
-  D = pruneComplex(C, PruningMaps => true, UnitTest => isScalar, Strategy => Engine) -- 1 3 4 2
+  D = pruneComplex(C, PruningMap => true, UnitTest => isScalar, Strategy => Engine) -- 1 3 4 2
   checker(D, I)
 
-  D = pruneComplex(C, PruningMaps => true, UnitTest => isScalar, Strategy => Engine, Direction => "right") -- 1 4 5 2
+  D = pruneComplex(C, PruningMap => true, UnitTest => isScalar, Strategy => Engine, Direction => "right") -- 1 4 5 2
   checker(D, I)
 
-  D = pruneComplex(C, PruningMaps => true, Strategy => null, UnitTest => isScalar, Direction => "right") -- 1 7 9 3
+  D = pruneComplex(C, PruningMap => true, Strategy => null, UnitTest => isScalar, Direction => "right") -- 1 7 9 3
   checker(D, I)
 
   -- FIXME these three strategies return terribly ugly stuff
-  D = pruneComplex(C, PruningMaps => true, Strategy => null, UnitTest => isScalar, Direction => "left") -- 1 6 9 5 1
+  D = pruneComplex(C, PruningMap => true, Strategy => null, UnitTest => isScalar, Direction => "left") -- 1 6 9 5 1
   checker(D, I)
 
-  D = pruneComplex(C, PruningMaps => true, Strategy => null, UnitTest => isScalar, Direction => "both") -- 1 6 11 6
+  D = pruneComplex(C, PruningMap => true, Strategy => null, UnitTest => isScalar, Direction => "both") -- 1 6 11 6
   checker(D, I)
 
-  D = pruneComplex(C, PruningMaps => true, Strategy => null, UnitTest => isScalar, Direction => "best") -- 1 6 9 5 1
+  D = pruneComplex(C, PruningMap => true, Strategy => null, UnitTest => isScalar, Direction => "best") -- 1 6 9 5 1
   checker(D, I)
 ///
 
@@ -279,7 +291,7 @@ TEST ///
   R = ZZ/32003[x,y,z]
   I = ideal"xyz+z5,2x2+y3+z7,3z5+y5"
   C = freeRes I -- 1 15 38 34 10
-  D = pruneComplex(C, PruningMaps => true) -- 1 3 4 2
+  D = pruneComplex(C, PruningMap => true) -- 1 3 4 2
   f = D.cache.pruningMap;
 
   assert(D.dd^2 == 0)
@@ -296,7 +308,7 @@ TEST ///
 
   RP = localRing(R, ideal gens R)
   C' = C ** RP
-  D' = pruneComplex(C', PruningMaps => true) -- 1 3 3 1
+  D' = pruneComplex(C', PruningMap => true) -- 1 3 3 1
   g = D'.cache.pruningMap;
 
   assert(D'.dd^2 == 0)
@@ -338,7 +350,7 @@ randomCombo = (n, d) -> (
 --  path = prepend("~/src/m2/M2-local-rings/M2/Macaulay2/packages/", path) -- Mike
 restart
 needsPackage "PruneComplex"
-elapsedTime check PruneComplex -- 17 sec
+elapsedTime check PruneComplex -- 18 sec
 
 restart
 uninstallPackage "PruneComplex"


### PR DESCRIPTION
This is to fix the grading when pruning non-minimal resolutions of homogeneous modules (a test is added in `PruneComplex/tests.m2`).

Also PruningMaps is renamed to PruningMap.

Please don't merge yet, I will push one more commit later today that adds more examples for pruneComplex to demonstrate when and why the options may be useful.