### PR TITLE
Addition of two new packages

### DIFF
--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -169,3 +169,5 @@ RandomMonomialIdeals
 Matroids
 NumericalImplicitization
 NonminimalComplexes
+StronglyStableIdeals
+SLnEquivariantMatrices

--- a/M2/Macaulay2/packages/SLnEquivariantMatrices.m2
+++ b/M2/Macaulay2/packages/SLnEquivariantMatrices.m2
@@ -1,0 +1,969 @@
+-- Copyright 2017-2018: Paolo Lella.
+-- You may redistribute this file under the terms of the GNU General Public
+-- License as published by the Free Software Foundation, either version 2
+-- of the License, or any later version.
+
+newPackage("SLnEquivariantMatrices",
+           Version => "1.0", 
+     	   Date => "April 10, 2018",
+     	   Authors => {
+	               {Name => "Ada Boralevi", 
+			   Email => "ada.boralevi@polito.it",
+			       HomePage => "http://www.adaboralevi.com"},
+	               {Name => "Daniele Faenzi",
+			   Email => "daniele.faenzi@u-bourgogne.fr",
+			       HomePage => "http://dfaenzi.perso.math.cnrs.fr"},
+		       {Name => "Paolo Lella",
+			   Email => "paolo.lella@polimi.it",
+			       HomePage => "http://www.paololella.it"}
+		      },
+     	   Headline => "Ancillary file to the paper \"A construction of equivariant bundles 
+	               on the space of symmetric forms\"",
+	   DebuggingMode => false
+     	  )
+     
+export {
+        "slIrreducibleRepresentationsTensorProduct",
+   	"slEquivariantConstantRankMatrix",
+   	"slEquivariantVectorBundle",
+	"sl2EquivariantConstantRankMatrix",
+	"sl2EquivariantVectorBundle"
+       }
+
+
+--------------------------------------------------------------------------------
+--
+-- FUNCTIONS
+--
+--------------------------------------------------------------------------------
+   
+slIrreducibleRepresentationsTensorProduct = method(TypicalValue=>List)
+slIrreducibleRepresentationsTensorProduct (ZZ,ZZ,ZZ) := (n,a,b) -> (
+    
+    if n <= 0 then error "\targument 1 : expected a positive integer";
+    if a <= 0 then error "\targument 2 : expected a positive integer";
+    if b <= 0 then error "\targument 3 : expected a positive integer";
+    
+    v := getSymbol "v";
+    w := getSymbol "w";
+    R := QQ(monoid[v_0..v_n]);
+    
+    return slIrreducibleRepresentationsTensorProduct (R,a,b);
+)
+
+slIrreducibleRepresentationsTensorProduct (PolynomialRing,ZZ,ZZ) := (R,a,b) -> (
+    n := numgens R - 1;
+    if n <= 0 then error "\targument 1 : expected a ring with at least 2 variables";
+    if a <= 0 then error "\targument 2 : expected a positive integer";
+    if b <= 0 then error "\targument 3 : expected a positive integer";
+    
+    RotimesR := R**R;
+    L := getSymbol "L";
+    C := QQ(monoid[L_0..L_n]);
+    S := C[gens RotimesR];
+        
+    fromStoRotimesR := map(RotimesR,S,gens RotimesR);
+    fromRotimesRtoS := map(S,RotimesR,gens S);   
+    firstFactor := map(S,R,for i from 0 to n list S_i);
+    secondFactor := map(S,R,for i from 0 to n list S_(n+i+1));
+        
+    Va := rsort flatten entries basis(a,R);
+    Vb := rsort flatten entries basis(b,R);
+    eigenValues := {};
+    eigenSpaces := new MutableList from {};    
+    for f in Va do
+    (
+    	for g in Vb do
+	(
+	    fg := (firstFactor f)*(secondFactor g);
+	    e := leadCoefficient((slActionH fg)//fg);
+	    p := position(eigenValues, x -> x == e);
+	    if p === null then
+	    (
+	    	eigenValues = append(eigenValues,e);
+		eigenSpaces = append(eigenSpaces,{fromStoRotimesR fg});	
+	    )
+	    else
+	    (
+	       eigenSpaces#p = append(eigenSpaces#p,fromStoRotimesR fg);
+	    );
+	);	
+    );
+    l := weightOrder (C,eigenValues);
+    (eigenValues,eigenSpaces) = sortEigenspaces(eigenValues, eigenSpaces, l);
+    dimensions := new MutableList from for e in eigenSpaces list #e;
+    irreducible := {};
+    maxWeightPos := 0;
+    while maxWeightPos < #eigenSpaces do
+    (
+       maxWeightVector := {};
+       currentEigenSpace := eigenSpaces#maxWeightPos;
+       if (d := #currentEigenSpace) > 1 then
+       (
+       	   A := QQ[Variables=>d];
+	   ARotimesR := A[gens RotimesR];
+       	   fromAtoARotimesR := map(ARotimesR,A);
+       	   fromRotimesRtoARotimesR := map(ARotimesR,RotimesR, gens ARotimesR);
+       	   fromARotimesRtoRotimesR := map(RotimesR,ARotimesR, gens RotimesR);
+       	   genericElement := sum(for i from 0 to d-1 list A_i*fromRotimesRtoARotimesR(currentEigenSpace#i));
+	   toVanish := {};
+	   for i from 0 to n-1 do
+	   (
+	       for j from i+1 to n do
+	       (
+		   toVanish = toVanish | for t in terms slActionE(n,i,j,genericElement) list leadCoefficient t;
+	       );        
+	   );
+           toVanish = rsort (trim ideal toVanish)_*;
+	   parameters := gens A;
+	   eliminable := {};
+	   for eq in toVanish do
+	   (
+	       parameters = delete(leadMonomial eq, parameters);
+	       eliminable = append(eliminable, leadMonomial eq => (leadTerm eq-eq)/(leadCoefficient eq)); 
+	   );
+           genericElement = sub(genericElement,eliminable);
+	   for par in parameters do
+	   (
+	       specializationMap := map(RotimesR,ARotimesR,gens RotimesR | (for a in gens A list if a == par then 1 else 0)); 
+    	       maxWeightVector = append(maxWeightVector, (eigenValues#maxWeightPos,specializationMap genericElement));
+	   );
+       )
+       else
+       (
+	   maxWeightVector = append(maxWeightVector, (eigenValues#maxWeightPos, currentEigenSpace#0));
+       );
+       	      
+       for highestWeightVector in maxWeightVector do
+       (
+       	   newRepresentationWeights := {};
+       	   newRepresentationBases := new MutableList from {};
+	   queue := {highestWeightVector};
+       	   control := 0;
+       	   while #queue > 0 do
+       	   (
+       	       head := first queue;
+	       queue = delete(head,queue);
+	       vect := head#1;
+	       weight := head#0;
+	   
+	       j := position(newRepresentationWeights, x -> x == weight);
+	       pos := position(eigenValues, x -> x == weight);
+	       if j === null then
+	       (
+	       	   newRepresentationWeights = append(newRepresentationWeights,weight);
+	       	   newRepresentationBases = append(newRepresentationBases,{vect});
+	       	   dimensions#pos = dimensions#pos-1;	      
+	       )
+               else
+	       (
+		   currentDim := numgens trim ideal (newRepresentationBases#j);
+	       	   newDim := numgens trim (ideal (newRepresentationBases#j) + ideal(vect));
+	       	   if newDim > currentDim then 
+	       	   (
+		       newRepresentationBases#j = append(newRepresentationBases#j,vect);
+		       dimensions#pos = dimensions#pos-1;
+	       	   );
+	       );
+	   
+	       for i from 0 to n-1 do
+	       (
+	       	   for j from i+1 to n do
+	       	   (
+		       newWeight := weight + C_j - C_i;
+		       if (newV := slActionE(n,j,i,vect)) != 0 then
+		       (
+		       	   newPair := (newWeight,(trim ideal newV)_0);
+			   if not member(newPair,queue) then queue = append(queue, newPair);	   
+		       );
+	       	   );    
+	       );
+       	   ); 
+       	   (newRepresentationWeights,newRepresentationBases) = sortEigenspaces(newRepresentationWeights,newRepresentationBases,l);
+           irreducible = append(irreducible,flatten for i from 0 to #newRepresentationBases-1 list rsort flatten entries gens trim ideal newRepresentationBases#i);
+	);
+	while maxWeightPos < #eigenSpaces and dimensions#maxWeightPos == 0 do maxWeightPos=maxWeightPos+1;       
+    	
+    );    
+    return irreducible;
+)
+
+slEquivariantConstantRankMatrix = method(TypicalValue => Matrix, Options => {CoefficientRing => QQ})
+slEquivariantConstantRankMatrix (ZZ,ZZ,ZZ) := opts -> (n,d,m) -> (
+    if n <= 0 then error "\targument 1 : expected a positive integer";
+    if d <= 0 then error "\targument 2 : expected a positive integer";
+    if m <= 1 then error "\targument 3 : expected a integer greater than 1";
+    
+    v := getSymbol "v";
+    R := QQ(monoid[v_0..v_n]);
+
+    return slEquivariantConstantRankMatrix(R,d,m,CoefficientRing=>opts.CoefficientRing);
+)
+
+slEquivariantConstantRankMatrix (PolynomialRing,ZZ,ZZ) := opts -> (R,d,m) -> (
+    n := numgens R - 1;
+    if n <= 0 then error "\targument 1 : expected a ring with at least 2 variables";
+    if d <= 0 then error "\targument 2 : expected a positive integer";
+    if m <= 1 then error "\targument 3 : expected a integer greater than 1";
+    
+    RotimesR := QQ(monoid[gens (R**R)]);
+    firstFactor := map(RotimesR,R, for i from 0 to n list RotimesR_i);
+    projFirstFactor := map(R,RotimesR, gens R | toList(n+1:0));
+    secondFactor := map(RotimesR,R, for i from 0 to n list RotimesR_(n+i+1));
+    V := rsort flatten entries basis(d,R);
+    W := rsort flatten entries basis((m-1)*d,R); 
+    
+    L := getSymbol "L";
+    C := QQ(monoid[L_0..L_n]);
+       
+    highestWeight := (m*d-1)*C_0 + C_1;
+    highestWeightVector := (firstFactor V#0)*(secondFactor W#1) - (firstFactor V#1)*(secondFactor W#0);
+    irreducibleRepresentationWeights := {};
+    irreducibleRepresentationVectors := new MutableList from {};
+    queue := {(highestWeight,highestWeightVector)};
+    while #queue > 0 do
+    (
+       	head := first queue;
+	queue = delete(head,queue);
+	vect := head#1;
+	weight := head#0;
+	   
+	j := position(irreducibleRepresentationWeights, x -> x == weight);
+	if j === null then
+	(
+	    irreducibleRepresentationWeights = append(irreducibleRepresentationWeights,weight);
+	    irreducibleRepresentationVectors = append(irreducibleRepresentationVectors,{vect});
+       	)
+        else
+	(
+	    currentDim := numgens trim ideal (irreducibleRepresentationVectors#j);
+	    newDim := numgens trim (ideal (irreducibleRepresentationVectors#j) + ideal(vect));
+	    if newDim > currentDim then 
+	    (
+	       	irreducibleRepresentationVectors#j = append(irreducibleRepresentationVectors#j,vect);
+	    );
+        );
+	   
+	for i from 0 to n-1 do
+	(
+	    for j from i+1 to n do
+	    (
+	    	newWeight := weight + C_j - C_i;
+		if (newV := slActionE(n,j,i,vect)) != 0 then
+		(
+		    newPair := (newWeight,(trim ideal newV)_0);
+		    if not member(newPair,queue) then queue = append(queue, newPair);	   
+		);
+	    );    
+	);
+    ); 
+    (irreducibleRepresentationWeights,irreducibleRepresentationVectors) = sortEigenspaces(irreducibleRepresentationWeights,irreducibleRepresentationVectors,weightOrder (C,irreducibleRepresentationWeights));
+    irreducibleRepresentationBasis := flatten for i from 0 to #irreducibleRepresentationVectors-1 list irreducibleRepresentationVectors#i;
+    
+    N := #V-1;
+    x := getSymbol "x";
+    X := QQ(monoid[x_0..x_N]);
+     
+    M := {};
+    for vw in irreducibleRepresentationBasis do
+    (
+       column := {};
+       for w in W do
+       (
+	   c := vw//(secondFactor w);
+	   if c == 0 then
+	   (
+	       column = column | {0_X};	   
+	   )	 
+           else
+	   (
+	       column = column | {(leadCoefficient c)*X_(position(V, x-> x == (projFirstFactor leadMonomial c)))};	   
+	   );	
+       );
+       M = M | {column};	    
+   );
+   
+   M = transpose matrix M;
+   if opts.CoefficientRing =!= QQ then
+   (
+       newX := opts.CoefficientRing(monoid[gens X]);
+       phi := map(newX,X);
+       M = matrix for i in entries M list for j in i list phi j; 
+       M = M**newX^{1};   
+   );
+
+   return M;
+)
+
+slEquivariantConstantRankMatrix (ZZ,ZZ,ZZ,PolynomialRing) := opts -> (n,d,m,X) -> (
+    if n <= 0 then error "\targument 1 : expected a positive integer";
+    if d <= 0 then error "\targument 2 : expected a positive integer";
+    if m <= 1 then error "\targument 3 : expected a integer greater than 1";
+    if numgens X != (N := binomial(n+d,n)) then error ("\targument 4 : expected a polymial ring with " | toString(N) | " variables");
+
+    M := slEquivariantConstantRankMatrix (n,d,m);
+    phi := map(X,ring M,gens X);
+    return (matrix for r in entries M list for c in r list phi c)**X^{1};
+)
+
+slEquivariantConstantRankMatrix (PolynomialRing,ZZ,ZZ,PolynomialRing) := opts -> (R,d,m,X) -> (
+    n := numgens R - 1;
+    if n <= 0 then error "\targument 1 : expected a ring with at least 2 variables";
+    if d <= 0 then error "\targument 2 : expected a positive integer";
+    if m <= 1 then error "\targument 3 : expected a integer greater than 1";
+    if numgens X != (N := binomial(n+d,n)) then error ("\targument 4 : expected a polymial ring with " | toString(N) | " variables");
+
+    M := slEquivariantConstantRankMatrix (R,d,m);
+    phi := map(X,ring M,gens X);
+    return (matrix for r in entries M list for c in r list phi c)**X^{1};
+)
+
+slEquivariantVectorBundle = method(TypicalValue => CoherentSheaf, Options => {CoefficientRing => QQ})
+slEquivariantVectorBundle (ZZ,ZZ,ZZ) := opts -> (n,d,m) -> (
+    if n <= 0 then error "\targument 1 : expected a positive integer";
+    if d <= 0 then error "\targument 2 : expected a positive integer";
+    if m <= 1 then error "\targument 3 : expected a integer greater than 1";
+    
+    return sheaf minimalPresentation ker slEquivariantConstantRankMatrix(n,d,m,CoefficientRing=>opts.CoefficientRing);  
+)
+
+slEquivariantVectorBundle (PolynomialRing,ZZ,ZZ) := opts -> (R,d,m) -> (
+    n := numgens R - 1;
+    if n <= 0 then error "\targument 1 : expected a ring with at least 2 variables";
+    if d <= 0 then error "\targument 2 : expected a positive integer";
+    if m <= 1 then error "\targument 3 : expected a integer greater than 1";
+    
+    return sheaf minimalPresentation ker slEquivariantConstantRankMatrix(R,d,m,CoefficientRing=>opts.CoefficientRing);  
+)
+
+slEquivariantVectorBundle (ZZ,ZZ,ZZ,PolynomialRing) := opts -> (n,d,m,X) -> (
+    if n <= 0 then error "\targument 1 : expected a positive integer";
+    if d <= 0 then error "\targument 2 : expected a positive integer";
+    if m <= 1 then error "\targument 3 : expected an integer greater than 1";
+    if numgens X != (N := binomial(n+d,n)) then error ("\targument 4 : expected a polymial ring with " | toString(N) | " variables");
+
+    return sheaf minimalPresentation ker slEquivariantConstantRankMatrix(n,d,m,X);  
+)
+
+slEquivariantVectorBundle (PolynomialRing,ZZ,ZZ,PolynomialRing) := opts -> (R,d,m,X) -> (
+    n := numgens R - 1;
+    if n <= 0 then error "\targument 1 : expected a ring with at least 2 variables";
+    if d <= 0 then error "\targument 2 : expected a positive integer";
+    if m <= 1 then error "\targument 3 : expected an integer greater than 1";
+    if numgens X != (N := binomial(n+d,n)) then error ("\targument 4 : expected a polymial ring with " | toString(N) | " variables");
+
+    return sheaf minimalPresentation ker slEquivariantConstantRankMatrix(R,d,m,X);  
+)
+
+sl2EquivariantConstantRankMatrix = method(TypicalValue => Matrix, Options => {CoefficientRing => QQ})
+sl2EquivariantConstantRankMatrix (ZZ,ZZ) := opts -> (d,m) -> (
+    if d <= 0 then error "\targument 1 : expected a positive integer";
+    if m <= 1 then error "\targument 2 : expected a integer greater than 1";
+    
+    x := getSymbol "x";
+    R := opts.CoefficientRing(monoid[x_0..x_d]);
+
+    return sl2EquivariantConstantRankMatrix(R,m);
+)
+
+sl2EquivariantConstantRankMatrix (PolynomialRing,ZZ) := opts -> (R,m) -> (
+    if m <= 1 then error "\targument 2 : expected a integer greater than 1";
+    d := numgens R - 1;
+    
+    mutableM := mutableMatrix(R,(m-1)*d+1,m*d-1);
+    for j from 0 to m*d-2 do 
+    (
+	coeff := for i from max(0,j+1-d) to min(j+1,(m-1)*d) list matrixCoefficient(i+1,j+1,d,m);
+	gcdCoeff := gcd coeff;
+	h := 0;
+	for i from max(0,j+1-d) to min(j+1,(m-1)*d) do
+	(
+	    mutableM_(i,j) = (coeff#h//gcdCoeff)*R_(j-i+1);
+	    h = h+1;
+	);	
+    );
+
+    return (matrix mutableM)**R^{-1};
+)
+
+sl2EquivariantVectorBundle = method(TypicalValue => CoherentSheaf, Options => {CoefficientRing => QQ})
+sl2EquivariantVectorBundle (ZZ,ZZ) := opts -> (d,m) -> (
+    if d <= 0 then error "\targument 1 : expected a positive integer";
+    if m <= 1 then error "\targument 2 : expected a integer greater than 1";
+
+    return sheaf minimalPresentation ker sl2EquivariantConstantRankMatrix (d,m,CoefficientRing => opts.CoefficientRing);    
+)
+
+sl2EquivariantVectorBundle (PolynomialRing,ZZ) := opts -> (R,m) -> (
+    if m <= 1 then error "\targument 2 : expected a integer greater than 1";  
+    
+    return sheaf minimalPresentation ker sl2EquivariantConstantRankMatrix(R,m);
+)
+
+--------------------------------------------------------------------------------
+--
+-- AUXILIARY FUNCTIONS (unexported)
+--
+--------------------------------------------------------------------------------
+slActionE = method(TypicalValue=>RingElement)
+slActionE (ZZ,ZZ,ZZ,RingElement) := (n,i,j,v) -> (
+    R := ring v;
+    if first degree v == 0 then
+    (
+	return 1_R; 	  
+    )
+    else
+    (
+	return sum(for t in terms v list R_i*(diff_(R_j) t) + R_(n+i+1)*(diff_(R_(n+j+1)) t) );
+    );
+)
+
+
+slActionH = method(TypicalValue=>RingElement)
+slActionH (ZZ,ZZ,ZZ,RingElement) := (n,i,j,v) ->  (
+    return slActionE(n,j,i,slActionE(n,i,j,v)) - slActionE(n,i,j,slActionE(n,j,i,v));
+)
+
+slActionH RingElement := v -> (
+    R := ring v;
+    C := coefficientRing R;
+    n := numgens C - 1;
+    
+    if first degree v == 0 then
+    (
+        return 1_R; 	  
+    )
+    else
+    (
+    	return sum (for t in terms v list (sum (for i from 0 to n list (degree(R_i,t)+degree(R_(i+n+1),t))*C_i))*t);	
+    ); 
+)
+
+weightOrder = method(TypicalValue => RingMap, Options => {Height=>8})
+weightOrder (PolynomialRing,List) := opts -> (C,L) -> (
+    
+    n := numgens C;
+    if n == 2 then return map(QQ,C,{1,-1});
+    
+    W := rsort for i from 1 to n-1 list random(QQ,Height=>opts.Height);
+    if #(unique W) < #W then return weightOrder(C,L,Height=>opts.Height);
+    
+    wn := -sum W;
+    W = W | {wn};
+    
+    eval := map(QQ,C,W);
+    evalL := unique for l in L list eval l;
+    if #evalL < #L then return weightOrder(C,L,Height=>2*opts.Height);
+    
+    return eval;
+)
+
+sortEigenspaces = method(TypicalValue => Sequence)
+sortEigenspaces (List, MutableList, RingMap) := (eigenValues,eigenSpaces,eval) -> (
+    
+    orderedEigenValues := {};
+    orderedEigenSpaces := {};
+    for i from 0 to #eigenValues-1 do
+    (
+    	pos := 0;
+	while pos < #orderedEigenValues and eval eigenValues#i < eval orderedEigenValues#pos do pos = pos+1;
+	orderedEigenValues = insert(pos,eigenValues#i,orderedEigenValues);	
+	orderedEigenSpaces = insert(pos,eigenSpaces#i,orderedEigenSpaces);	
+    );
+    return (orderedEigenValues,orderedEigenSpaces);
+)
+
+sortEigenspaces (List, List, RingMap) := (eigenValues,eigenSpaces,eval) -> (
+    
+    orderedEigenValues := {};
+    orderedEigenSpaces := {};
+    for i from 0 to #eigenValues-1 do
+    (
+    	pos := 0;
+	while pos < #orderedEigenValues and eval eigenValues#i < eval orderedEigenValues#pos do pos = pos+1;
+	orderedEigenValues = insert(pos,eigenValues#i,orderedEigenValues);	
+	orderedEigenSpaces = insert(pos,eigenSpaces#i,orderedEigenSpaces);	
+    );
+    return (orderedEigenValues,orderedEigenSpaces);
+)
+
+
+matrixCoefficient = method(TypicalValue => ZZ)
+matrixCoefficient(ZZ,ZZ,ZZ,ZZ) := (i,j,d,m) -> (
+
+    if i == 1 then return -product(for k from 2 to j list d-k+1);
+    
+    if j > ceiling((m*d-1)/2) then return -matrixCoefficient((m-1)*d+2-i,m*d-j,d,m);
+      
+    output := -product(for k from max(1,j-d) to i-2 list (m-1)*d-k);
+    output = output*product(for k from 1 to j-i+1 list d-k+1);
+    output = output*(binomial(j-1,i-1)*m - binomial(j,i-1));
+    return output;        
+)
+
+--****************************************************************************--
+-- DOCUMENTATION FOR PACKAGE
+--****************************************************************************--
+beginDocumentation()
+
+doc ///
+    Key
+    	SLnEquivariantMatrices
+    Headline
+    	Ancillary file to the paper "A construction of equivariant bundles on the space of symmetric forms"
+    Description
+    	Text
+	    In the paper "A construction of equivariant bundles on the space of symmetric forms" (@HREF "https://arxiv.org"@),
+	    the authors construct stable vector bundles on the space $\mathbb{P}(S^d{\bf C}^{n+1})$ of symmetric forms of degree $d$
+	    in $n + 1$ variables which are equivariant for the action of $SL_{n+1}({\bf C})$ ,and admit an equivariant free 
+	    resolution of length 2.
+	    
+	    Take two integers $d \ge 1$ and $m \ge 2$ and a vector spave $V = {\bf C}^{n+1}$. For $n=2$, we have
+	    
+	    $S^dV \otimes S^{(m-1)d}V = S^{md}V \oplus S^{md-2}V \oplus S^{md-4}V \oplus \dots$,
+	     
+	    while for $n > 1$,
+	    
+	    $S^dV \otimes S^{(m-1)d}V = S^{md}V \oplus V_{(md-2)\lambda_1+\lambda_2} \oplus V_{(md-4)\lambda_1+2\lambda_2} \oplus \dots$,
+		
+	    where $\lambda_1$ and $\lambda_2$ are the two greatest fundamental weights of the Lie group $SL_{n+1}(\bf C)$ and $V_{i\lambda_1+j\lambda_2}$ is the irreducible representation of highest weight $i\lambda_1+j\lambda_2$.
+	    
+	    The projection of the tensor product onto the second summand induces a $SL_{2}({\bf C})$-equivariant morphism
+	    
+	    $\Phi: S^{md-2}V \otimes O_{\mathbb{P}(S^dV)} \to S^{(m-1)d}V \otimes O_{\mathbb{P}(S^dV)}(1)$
+	    
+	    or a $SL_{n+1}({\bf C})$-equivariant morphism
+	    
+	    $\Phi: V_{(md-2)\lambda_1 + \lambda_2} \otimes O_{\mathbb{P}(S^dV)} \to S^{(m-1)d}V \otimes O_{\mathbb{P}(S^dV)}(1)$
+	    
+	    with constant co-rank 1, and thus gives an exact sequence of vector bundles on $\mathbb{P}(S^dV)$:
+	    	    
+	    $0 \to W_{2,d,m} \to S^{md-2}V \otimes \mathcal{O}_{\mathbb{P}(S^dV)} \to S^{(m-1)d}V \otimes \mathcal{O}_{\mathbb{P}(S^dV)}(1) \to \mathcal{O}_{\mathbb{P}(S^dV)}(m) \to 0$,
+	    
+	    $0 \to W_{n,d,m} \to V_{(md-2)\lambda_1 + \lambda_2} \otimes \mathcal{O}_{\mathbb{P}(S^dV)} \to S^{(m-1)d}V \otimes \mathcal{O}_{\mathbb{P}(S^dV)}(1) \to \mathcal{O}_{\mathbb{P}(S^dV)}(m) \to 0$.	     
+	    
+	    The package allows to compute 
+	    
+	    (1) the decomposition into irreducible $SL_{n+1}(\bf C)$-representations of the
+	    tensor product of two symmetric powers $S^a{\bf C}^{n+1}$ and $S^b{\bf C}^{n+1}$;
+	    
+	    (2) the matrix representing the morphism $\Phi$;	    
+	    
+	    (3) the vector bundle $W_{n,d,m}$.
+///
+
+doc /// 
+    Key
+	slIrreducibleRepresentationsTensorProduct
+	(slIrreducibleRepresentationsTensorProduct, ZZ, ZZ, ZZ)
+	(slIrreducibleRepresentationsTensorProduct, PolynomialRing, ZZ, ZZ)
+    Headline 
+    	computes the the irreducible SL-subrepresentations of the tensor product of two symmetric products
+    Usage
+    	D = slIrreducibleRepresentationsTensorProduct(n,a,b)
+	D = slIrreducibleRepresentationsTensorProduct(R,a,b)	 
+    Inputs
+    	n:ZZ
+	    positive
+	R:PolynomialRing 	    
+	a:ZZ
+	    positive
+	b:ZZ
+	    positive
+    Outputs 
+    	D:List
+	    of irreducible representations
+    Description
+        Text 
+	    This function computes the decomposition in irreducible $SL(n+1)$-representations of the tensor product $S^aV \otimes S^bV$, where $V = <v_0,\ldots,v_n>$ and $a \leq b$.
+	    
+	    If $n = 1$, the decomposition is
+	    
+	    $S^aV \otimes S^bV = S^{a+b}V \oplus S^{a+b-2}V \oplus S^{a+b-4}V \oplus \dots \oplus S^{b-a}V$,
+	    
+	    while if $n > 1$, the decomposition is
+	    
+	    $S^aV \otimes S^bV = S^{a+b}V \oplus V_{(a+b-2)\lambda_1 + \lambda_2} \oplus V_{(a+b-4)\lambda_1 + 2\lambda_2} \oplus \dots \oplus V_{(b-a)\lambda_1 + a\lambda_2}$,
+	    
+	    where $\lambda_1$ and $\lambda_2$ are the two greatest fundamental weights of the Lie group $SL(n+1)$ and $V_{i\lambda_1+j\lambda_2}$ is the irreducible representation of highest weight $i\lambda_1+j\lambda_2$.
+	Example
+	    n = 2
+	    a = 1, b = 2
+	    D = slIrreducibleRepresentationsTensorProduct(n,a,b);
+	    #D
+	    D#0
+	    D#1
+	Text
+    	    If a polynomial ring {\tt R} is given, then {\tt n = numgens R - 1} and $V = <R_0,\ldots,R_n>$.
+	Example
+	    R = QQ[x_0,x_1,x_2]; 
+	    a = 2, b = 3
+	    D = slIrreducibleRepresentationsTensorProduct(R,a,b);
+	    #D
+	    D#0
+	    D#1
+	    D#2
+///
+
+doc /// 
+    Key
+   	slEquivariantConstantRankMatrix
+	(slEquivariantConstantRankMatrix, ZZ, ZZ, ZZ)
+	(slEquivariantConstantRankMatrix, PolynomialRing, ZZ, ZZ)
+	(slEquivariantConstantRankMatrix, ZZ, ZZ, ZZ, PolynomialRing)
+	(slEquivariantConstantRankMatrix, PolynomialRing, ZZ, ZZ, PolynomialRing) 
+    Headline 
+    	computes a SL-equivariant constant rank matrix
+    Usage
+    	M = slEquivariantConstantRankMatrix(n,d,m)
+	M = slEquivariantConstantRankMatrix(n,d,m,CoefficientRing=>C)
+    	M = slEquivariantConstantRankMatrix(R,d,m)
+	M = slEquivariantConstantRankMatrix(n,d,m,X)
+	M = slEquivariantConstantRankMatrix(R,d,m,X)
+    Inputs
+    	n:ZZ
+	    positive
+	R:PolynomialRing 
+	    with at least two variables
+	d:ZZ
+	    positive
+	m:ZZ
+	    at least 2
+	X:PolynomialRing 
+	    with {\tt binomial(n+d,n)} or {\tt binomial(numgens R-1+d,numgens R-1)} variables
+	C:Ring 
+    Outputs  
+    	M:Matrix  
+    Description
+        Text 
+	    This function returns a constant rank matrix of linear forms. For $n=1$, the matrix describes the morphism
+	    
+	    $\Phi: S^{md-2}V \otimes O_{\mathbb{P}^d} \to S^{(m-1)d}V \otimes O_{\mathbb{P}^d)}(1)$
+	    
+	    given by the projection
+	    
+	    $S^dV \otimes S^{(m-1)d}V \to S^{md-2}V$
+	    
+	    of the irreducible $SL(2)$-subrepresentation of highest weight $md-2$, where $\mathbb{P}^d = \mathbb{P}(S^dV)$ as $V=<v_0,v_1>$.
+	
+	    For $n>1$, the matrix describes the morphism	    
+	    
+	    $\Phi: V_{(md-2)\lambda_1 + \lambda_2} \otimes O_{\mathbb{P}(S^dV)} \to S^{(m-1)d}V \otimes O_{\mathbb{P}(S^dV)}(1)$
+	    
+	    given by the projection
+	    
+	    $S^dV \otimes S^{(m-1)d}V \to V_{(md-2)\lambda_1 + \lambda_2}$
+	    
+	    of the irreducible $SL(n+1)$-subrepresentation $V_{(md-2)\lambda_1 + \lambda_2}$ of highest weight 
+	    $(md-2)\lambda_1 + \lambda_2 = (md-1)L_1 + L_2$ in the tensor product $S^dV \otimes S^{(m-1)d}V$, where $V = {\bf C}^{n+1}$ and
+	    $\lambda_1$ and $\lambda_2$ are the two greatest fundamental weights of the Lie group $SL(n+1)$.
+	Example
+	    n = 1, d = 3, m = 3 
+	    M = slEquivariantConstantRankMatrix(n,d,m)
+	Text
+	    By default, @TO slEquivariantConstantRankMatrix@ defines the matrix over a polynomial ring with rational coefficients. 
+	    The optional argument @TO CoefficientRing@ allows one to change the coefficient ring.
+	Example
+	    n = 1, d = 3, m = 3 
+	    M = slEquivariantConstantRankMatrix(n,d,m,CoefficientRing=>ZZ/10007)
+	Text
+	    If the first argument is a polynomial ring {\tt R}, then {\tt n = numgens R-1}.
+	Example
+	    R = QQ[y_0,y_1];
+	    d = 2, m = 3 
+	    M = slEquivariantConstantRankMatrix(R,d,m)
+	Text
+	    If the last argument is polynomial ring {\tt X} (and {\tt X} has the same number of variables of the coordinate ring of $\mathbb{P}(S^d{\bf C}^{n+1})$),
+	    then the matrix is defined over the polynomial ring {\tt X}.
+	Example
+	    n = 1, d = 3, m = 3 
+	    X = ZZ/7[z_0,z_1,z_2,z_3];
+	    M = slEquivariantConstantRankMatrix(n,d,m,X)
+	    R = QQ[y_0,y_1];
+	    d = 3, m = 2 
+	    M = slEquivariantConstantRankMatrix(R,d,m,X)
+///
+
+doc /// 
+    Key
+    	slEquivariantVectorBundle
+	(slEquivariantVectorBundle, ZZ, ZZ, ZZ)
+	(slEquivariantVectorBundle, ZZ, ZZ, ZZ, PolynomialRing) 
+	(slEquivariantVectorBundle, PolynomialRing, ZZ, ZZ)
+	(slEquivariantVectorBundle, PolynomialRing, ZZ, ZZ, PolynomialRing) 
+    Headline 
+    	computes a SL-equivariant vector bundle over some projective space
+    Usage
+    	W = slEquivariantVectorBundle(n,d,m)
+	W = slEquivariantVectorBundle(n,d,m,CoefficientRing=>C)
+    	W = slEquivariantVectorBundle(R,d,m)
+    	W = slEquivariantVectorBundle(n,d,m,X)
+    	W = slEquivariantVectorBundle(R,d,m,X)
+    Inputs
+    	n:ZZ
+	    positive
+	R:PolynomialRing 
+	    with at least two variables
+	d:ZZ
+	    positive
+	m:ZZ
+	    at least 2
+	X:PolynomialRing 
+	    with {\tt binomial(n+d,n)} or {\tt binomial(numgens R-1+d,numgens R-1)} variables
+	C:Ring 
+    Outputs 
+    	W:CoherentSheaf
+	    vector bundle
+    Description
+        Text 
+    	    For $n=1$, this function returns the kernel of the matrix describing the morphism
+	    
+	    $\Phi: S^{md-2}V \otimes O_{\mathbb{P}^d} \to S^{(m-1)d}V \otimes O_{\mathbb{P}^d)}(1)$
+	    
+	    given by the projection
+	    
+	    $S^dV \otimes S^{(m-1)d}V \to S^{md-2}V$
+	    
+	    of the irreducible $SL(2)$-subrepresentation of highest weight $md-2$, where $\mathbb{P}^d = \mathbb{P}(S^dV)$ as $V=<v_0,v_1>$,
+	    while for $n>1$, the function returns the kernel of the matrix describing the morphism   
+	    
+	    $\Phi: V_{(md-2)\lambda_1 + \lambda_2} \otimes O_{\mathbb{P}(S^dV)} \to S^{(m-1)d}V \otimes O_{\mathbb{P}(S^dV)}(1)$
+	    
+	    given by the projection
+	    
+	    $S^dV \otimes S^{(m-1)d}V \to V_{(md-2)\lambda_1 + \lambda_2}$
+	    
+	    of the irreducible $SL(n+1)$-subrepresentation $V_{(md-2)\lambda_1 + \lambda_2}$ of highest weight 
+	    $(md-2)\lambda_1 + \lambda_2 = (md-1)L_1 + L_2$ in the tensor product $S^dV \otimes S^{(m-1)d}V$, where $V = {\bf C}^{n+1}$ and
+	    $\lambda_1$ and $\lambda_2$ are the two greatest fundamental weights of the Lie group $SL(n+1)$. 
+	    
+	    In the paper {\em A construction of equivariant bundles on the space of symmetric forms}, it is proved that the matrix $\Phi$ has constant co-rank 1, 
+	    so that the kernel $W = ker \Phi$ turns out to be a vector bundle.	
+	Example
+	    n = 1, d = 3, m = 3 
+	    W = slEquivariantVectorBundle(n,d,m)
+	Text
+	    By default, @TO slEquivariantVectorBundle@ defines the vector bundle over a projective space whose coordinate ring has rational coefficients. 
+	    The optional argument @TO CoefficientRing@ allows one to change the coefficient ring.
+	Example
+	    n = 1, d = 3, m = 3 
+	    W = slEquivariantVectorBundle(n,d,m,CoefficientRing=>ZZ/10007)
+	Text
+	    If the first argument is a polynomial ring {\tt R}, then {\tt n = numgens R-1}.
+	Example
+	    R = QQ[y_0,y_1];
+	    d = 2, m = 3 
+	    W = slEquivariantVectorBundle(R,d,m)
+	Text
+	    If the last argument is polynomial ring {\tt X} (and {\tt X} has the same number of variables of the coordinate ring of $\mathbb{P}(S^d{\bf C}^{n+1})$),
+	    then the vector bundle is defined over the projective space {\tt Proj(X)}.
+	Example
+	    n = 1, d = 3, m = 3 
+	    X = ZZ/7[z_0,z_1,z_2,z_3];
+	    W = slEquivariantVectorBundle(n,d,m,X)
+	    R = QQ[y_0,y_1];
+	    d = 3, m = 2 
+	    W = slEquivariantVectorBundle(R,d,m,X)
+///
+
+doc /// 
+    Key
+   	sl2EquivariantConstantRankMatrix
+	(sl2EquivariantConstantRankMatrix, ZZ, ZZ)
+	(sl2EquivariantConstantRankMatrix, PolynomialRing, ZZ)
+    Headline 
+    	computes a SL(2)-equivariant constant rank matrix
+    Usage
+    	M = sl2EquivariantConstantRankMatrix(d,m)
+	M = sl2EquivariantConstantRankMatrix(d,m,CoefficientRing=>C)
+    	M = sl2EquivariantConstantRankMatrix(R,m)
+    Inputs
+	R:PolynomialRing 
+	    with at least two variables
+	d:ZZ
+	    positive
+	m:ZZ
+	    at least 2
+	C:Ring 
+    Outputs  
+    	M:Matrix  
+    Description
+        Text 
+	    This function returns a constant rank matrix of linear forms. The matrix describes the morphism
+	    
+	    $\Phi: S^{md-2}V \otimes O_{\mathbb{P}^d} \to S^{(m-1)d}V \otimes O_{\mathbb{P}^d)}(1)$
+	    
+	    given by the projection
+	    
+	    $S^dV \otimes S^{(m-1)d}V \to S^{md-2}V$
+	    
+	    of the irreducible $SL(2)$-subrepresentation of highest weight $md-2$, where $\mathbb{P}^d = \mathbb{P}(S^dV)$ as $V=<v_0,v_1>$.
+    	    In the paper {\em A construction of equivariant bundles on the space of symmetric forms}, the entries of the matrix $\Phi$ 
+	    are explicitely described.
+	Example
+	    d = 4, m = 3 
+	    M = sl2EquivariantConstantRankMatrix(d,m)
+	Text
+	    By default, @TO sl2EquivariantConstantRankMatrix@ defines the matrix over a polynomial ring with rational coefficients. 
+	    The optional argument @TO CoefficientRing@ allows one to change the coefficient ring.
+	Example
+	    d = 4, m = 3 
+	    M = sl2EquivariantConstantRankMatrix(d,m,CoefficientRing=>ZZ/10007)
+	Text
+	    If the first argument is a polynomial ring {\tt R}, then {\tt d = numgens R-1}.
+	Example
+	    R = QQ[y_0..y_4];
+	    m = 3 
+	    M = sl2EquivariantConstantRankMatrix(R,m)
+///
+
+doc /// 
+    Key
+    	sl2EquivariantVectorBundle
+	(sl2EquivariantVectorBundle, ZZ, ZZ)
+	(sl2EquivariantVectorBundle, PolynomialRing, ZZ)
+    Headline 
+    	computes a SL(2)-equivariant vector bundle over some projective space
+    Usage
+    	W = sl2EquivariantVectorBundle(d,m)
+	W = sl2EquivariantVectorBundle(d,m,CoefficientRing=>C)
+    	W = sl2EquivariantVectorBundle(R,m)
+    Inputs
+	R:PolynomialRing 
+	    with at least two variables
+	d:ZZ
+	    positive
+	m:ZZ
+	    at least 2
+	C:Ring 
+    Outputs 
+    	W:CoherentSheaf
+	    vector bundle
+    Description
+        Text 
+    	    This function returns the kernel of the matrix describing the morphism
+	    
+	    $\Phi: S^{md-2}V \otimes O_{\mathbb{P}^d} \to S^{(m-1)d}V \otimes O_{\mathbb{P}^d)}(1)$
+	    
+	    given by the projection
+	    
+	    $S^dV \otimes S^{(m-1)d}V \to S^{md-2}V$
+	    
+	    of the irreducible $SL(2)$-subrepresentation of highest weight $md-2$, where $\mathbb{P}^d = \mathbb{P}(S^dV)$ as $V=<v_0,v_1>$.
+	    
+	    In the paper {\em A construction of equivariant bundles on the space of symmetric forms}, it is proved that the matrix $\Phi$ has constant co-rank 1, 
+	    so that the kernel $W = ker \Phi$ turns out to be a vector bundle, and the entries of the matrix $\Phi$ are explicitely describred.	
+	Example
+	    d = 3, m = 2 
+	    W = sl2EquivariantVectorBundle(d,m)
+	Text
+	    By default, @TO slEquivariantVectorBundle@ defines the vector bundle over a projective space whose coordinate ring has rational coefficients. 
+	    The optional argument @TO CoefficientRing@ allows one to change the coefficient ring.
+	Example
+	    d = 3, m = 2 
+	    W = sl2EquivariantVectorBundle(d,m,CoefficientRing=>ZZ/10007)
+	Text
+	    If the first argument is a polynomial ring {\tt R}, then {\tt d = numgens R-1}.
+	Example
+	    R = QQ[y_0..y_3];
+	    m = 2
+	    W = sl2EquivariantVectorBundle(R,m)
+///
+
+doc ///
+    Key
+        [slEquivariantConstantRankMatrix,CoefficientRing]
+    Headline
+        name for optional argument
+    Usage
+	M = slEquivariantConstantRankMatrix(n,m,d,CoefficientRing=>C)
+    Description
+      	Text
+       	    This is an option to tell @TO slEquivariantConstantRankMatrix@ to define the matrix
+	    over a polynomial ring with coefficients in the ring {\tt C}.
+///
+
+doc ///
+    Key
+        [slEquivariantVectorBundle,CoefficientRing]
+    Headline
+        name for optional argument
+    Usage
+	W = slEquivariantVectorBundle(n,m,d,CoefficientRing=>C)
+    Description
+      	Text
+       	    This is an option to tell @TO slEquivariantVectorBundle@ to define the vector bundle
+	    over a projective space whose coordinate ring has coefficients in the ring {\tt C}.
+///
+
+doc ///
+    Key
+        [sl2EquivariantConstantRankMatrix,CoefficientRing]
+    Headline
+        name for optional argument
+    Usage
+	M = sl2EquivariantConstantRankMatrix(m,d,CoefficientRing=>C)
+    Description
+      	Text
+       	    This is an option to tell @TO slEquivariantConstantRankMatrix@ to define the matrix
+	    over a polynomial ring with coefficients in the ring {\tt C}.
+///
+
+doc ///
+    Key
+        [sl2EquivariantVectorBundle,CoefficientRing]
+    Headline
+        name for optional argument
+    Usage
+	W = sl2EquivariantVectorBundle(m,d,CoefficientRing=>C)
+    Description
+      	Text
+       	    This is an option to tell @TO slEquivariantVectorBundle@ to define the vector bundle
+	    over a projective space whose coordinate ring has coefficients in the ring {\tt C}.
+///
+
+--****************************************************************************--
+-- TESTS FOR PACKAGE
+--****************************************************************************--
+TEST ///
+n = 1, a = 3, b = 6
+D = slIrreducibleRepresentationsTensorProduct(n,a,b);
+assert(#D == a+1)
+///
+
+TEST ///
+n = 1, a = 2, b = 4
+D = slIrreducibleRepresentationsTensorProduct(n,a,b);
+assert(#(D#0) == a+b+1)
+assert(#(D#1) == a+b-1)
+///
+
+TEST ///
+n = 2, d = 3, m = 2
+M = slEquivariantConstantRankMatrix(n,d,m);
+assert(rank M == numRows M - 1)
+///
+
+TEST ///
+n = 1, d = 3, m = 3
+W = slEquivariantVectorBundle(n,d,m);
+assert(rank W == d-1)
+///
+
+TEST ///
+d = 4, m = 3 
+M = sl2EquivariantConstantRankMatrix(d,m);
+assert(rank M == numRows M - 1)
+///
+
+TEST ///
+d = 4, m = 3
+W = sl2EquivariantVectorBundle(d,m);
+assert(rank W == d-1)
+///
+
+--restart
+--installPackage "SLnEquivariantMatrices"
+--loadPackage "SLnEquivariantMatrices"
+--viewHelp
+

--- a/M2/Macaulay2/packages/StronglyStableIdeals.m2
+++ b/M2/Macaulay2/packages/StronglyStableIdeals.m2
@@ -1,0 +1,1095 @@
+-- Copyright 2017-2018: Paolo Lella.
+-- You may redistribute this file under the terms of the GNU General Public
+-- License as published by the Free Software Foundation, either version 2
+-- of the License, or any later version.
+   
+newPackage("StronglyStableIdeals",
+           Version => "1.1",
+	   Date => "June 23, 2015",
+           Authors => {
+	               {Name => "Davide Alberelli"},
+	               {Name => "Paolo Lella", Email => "paolo.lella@polimi.it", HomePage => "http://www.paololella.it/"}
+    	              },
+    	   Headline => "A package to study strongly stable ideals related to Hilbert polynomials",
+	   DebuggingMode => false
+	  )
+
+-- For information see documentation key "StronglyStableIdeals" below.
+
+needsPackage("gfanInterface");
+
+export {
+      -- methods
+      "isHilbertPolynomial",
+      "gotzmannDecomposition",
+      "macaulayDecomposition",
+      "gotzmannNumber",
+      "lexIdeal",
+      "stronglyStableIdeals",
+      "isGenSegment",
+      "isHilbSegment",
+      "isRegSegment",
+      -- Options
+      "MaxRegularity",
+      "OrderVariables"
+      }
+     
+---------------------------------------------------------------------------------
+--          PROJECTIVE HILBERT POLYNOMIALS AND GOTZMANN DECOMPOSITION          --
+---------------------------------------------------------------------------------
+
+--------
+-- isHilbertPolynomial
+--------
+isHilbertPolynomial = method(TypicalValue => Boolean)
+
+isHilbertPolynomial ProjectiveHilbertPolynomial := hp -> (
+   currentHP := hp;
+   k := 0;
+   while degree currentHP > 0 do 
+   (
+      b := dim currentHP;
+      if b < 0 then return false;
+      currentHP = currentHP - projectiveHilbertPolynomial(b,-k);
+      k = k+1;
+   );
+   if degree currentHP != 0 then false else true
+) -- END isHilbertPolynomial ProjectiveHilbertPolynomial
+
+isHilbertPolynomial RingElement := p -> (
+   R := ring p;
+   if not isPolynomialRing R then return false;
+   if numgens R != 1 then return false;
+   if coefficientRing R =!= ZZ and coefficientRing R =!= QQ then return false;
+   
+   currentP := p;
+   k := 0;
+   while leadCoefficient currentP > 0 do 
+   (
+      b := first degree currentP;
+      currentP = currentP - polynomialBinom(b-k,b,R);
+      k = k+1;
+   );
+   if currentP != 0_R then false else true
+) -- END isHilbertPolynomial RingElement
+
+
+--------
+-- gotzmannDecomposition
+--------
+gotzmannDecomposition = method(TypicalValue => List)
+
+gotzmannDecomposition ProjectiveHilbertPolynomial := hp -> (
+   currentHP := hp;
+   decomposition := {};
+   k := 0;
+   while degree currentHP > 0 do 
+   (
+      b := dim currentHP;
+      if b < 0 then error "argument 1: expected a Hilbert polynomial";
+      decomposition = decomposition | {projectiveHilbertPolynomial(b,-k)};
+      currentHP = currentHP - projectiveHilbertPolynomial(b,-k);
+      k = k+1;
+   );
+   if degree currentHP != 0 then 
+      error "argument 1: expected a Hilbert polynomial"
+   else 
+      decomposition
+) -- END gotzmannDecomposition ProjectiveHilbertPolynomial
+
+gotzmannDecomposition RingElement := p -> (
+   R := ring p;
+   if not isPolynomialRing R then error "argument 1: expected a polynomial";
+   if numgens R != 1 then error "argument 1: expected a univariate polynomial";
+   if coefficientRing R =!= ZZ and coefficientRing R =!= QQ then error "argument 1: expected a numerical polynomial";
+   
+   currentP := p;
+   decomposition := {};
+   k := 0;
+   while leadCoefficient currentP > 0 do 
+   (
+      b := first degree currentP;
+      decomposition = decomposition | {projectiveHilbertPolynomial(b,-k)};
+      currentP = currentP - polynomialBinom(b-k,b,R);
+      k = k+1;
+   );
+   if currentP != 0_R then 
+      error "argument 1: expected a Hilbert polynomial"
+   else 
+      decomposition
+) -- END gotzmannDecomposition RingElement
+
+
+--------
+-- macaulayDecomposition
+--------
+macaulayDecomposition = method(TypicalValue => List)
+
+macaulayDecomposition ProjectiveHilbertPolynomial := hp -> (
+   lexExp := lexIdealExponents hp; 
+   d := dim hp; 
+   macaulayCoeff := {sum lexExp};
+   for i from 0 to d-1 do macaulayCoeff = macaulayCoeff | {macaulayCoeff#-1 - lexExp#i};
+   flatten for i from 0 to d list {projectiveHilbertPolynomial(i+1,-1),-projectiveHilbertPolynomial(i+1,-1-macaulayCoeff#i)}
+) -- END macaulayDecomposition ProjectiveHilbertPolynomial
+
+macaulayDecomposition RingElement := p -> (
+   lexExp := lexIdealExponents p; 
+   d := first degree p; 
+   macaulayCoeff := {sum lexExp};
+   for i from 0 to d-1 do macaulayCoeff = macaulayCoeff | {macaulayCoeff#-1 - lexExp#i};
+   flatten for i from 0 to d list {projectiveHilbertPolynomial(i+1,-1),-projectiveHilbertPolynomial(i+1,-1-macaulayCoeff#i)}
+) -- END macaulayDecomposition RingElement
+
+
+--------
+-- gotzmannNumber
+--------
+gotzmannNumber = method(TypicalValue => ZZ)
+
+gotzmannNumber ProjectiveHilbertPolynomial := hp -> #gotzmannDecomposition hp
+
+gotzmannNumber RingElement := p -> #gotzmannDecomposition p
+
+
+--------
+-- projectiveHilbertPolynomial
+--------
+projectiveHilbertPolynomial RingElement := p -> sum gotzmannDecomposition p
+
+
+
+-----------------------------------------------------------------
+--          STRONGLY STABLE IDEALS AND SEGMENT IDEALS          --
+-----------------------------------------------------------------
+
+--------
+-- lexIdeal
+--------
+lexIdeal = method(TypicalValue => Ideal,Options => {CoefficientRing=>QQ,OrderVariables=>Down})
+
+lexIdeal (ProjectiveHilbertPolynomial,PolynomialRing) := opts -> (hp,R) -> (
+   if hp == hilbertPolynomial R then return ideal(0_R);
+   lexExp := lexIdealExponents hp; 
+   d := dim hp; 
+   n := numgens R;
+   if n < d+2 then error ("argument 2: expected at least " | toString(d+2) | " variables");
+   lexExp = lexExp | for i from 0 to n-d-3 list 0;
+   gensLex := {};
+   for i from 0 to n-2 do
+   (
+      T := R_(n-2-i)^(lexExp#i);
+      if i > 0 then T = T*R_(n-2-i);
+
+      for j from i+1 to n-2 do T = T*R_(n-2-j)^(lexExp#j);	 
+      gensLex = gensLex | {T};
+   );
+   trim ideal gensLex
+) -- END lexIdeal (ProjectiveHilbertPolynomial,PolynomialRing)
+
+lexIdeal (RingElement,PolynomialRing) := opts -> (p,R) -> lexIdeal(projectiveHilbertPolynomial p,R)
+
+lexIdeal (ProjectiveHilbertPolynomial,ZZ) := opts -> (hp,n) -> (
+   if n < 2 then error "argument 2: expected at least 2 variables";
+   if not instance(opts.CoefficientRing,Ring) then error "option CoefficientRing: expected a ring";    
+   if opts.OrderVariables != Up and opts.OrderVariables != Down then error "option OrderVariables: expected Down or Up";
+   
+   R := (opts.CoefficientRing)(monoid [VariableBaseName=>getSymbol "x",Variables=>n]);
+   if opts.OrderVariables == Up then R = (opts.CoefficientRing)(monoid [sort gens R]);
+   lexIdeal(hp, R)
+) -- END lexIdeal (ProjectiveHilbertPolynomial,ZZ)
+
+lexIdeal (RingElement,ZZ) := opts -> (p,n) -> lexIdeal(projectiveHilbertPolynomial p,n,opts)
+
+lexIdeal (ZZ,PolynomialRing) := opts -> (d,R) -> lexIdeal(projectiveHilbertPolynomial d_(QQ[local t]),R)
+
+lexIdeal (ZZ,ZZ) := opts -> (d,n) -> lexIdeal(projectiveHilbertPolynomial d_(QQ[local t]),n,opts)
+
+
+--------
+-- stronglyStableIdeals
+--------
+stronglyStableIdeals = method(TypicalValue => List,Options => {MaxRegularity=>null,CoefficientRing=>QQ,OrderVariables=>Down})
+
+stronglyStableIdeals (ProjectiveHilbertPolynomial,PolynomialRing) := opts -> (hp,R) -> (
+   gN := gotzmannNumber hp;
+   d := dim hp;
+   n := numgens(R);
+   if n < 2 then error "argument 2: expected at least 2 variables";
+   if d >= n-1 then return {}; -- there are no schemes of dimension d in the n-dimensional projective space
+   r := gN;
+   if opts.MaxRegularity =!= null then
+   (
+       if not instance(opts.MaxRegularity,ZZ) or opts.MaxRegularity <= 0 then error "option MaxRegularity: expected a positive integer";
+       r = min(opts.MaxRegularity,r);        
+   );   
+   hpSeq := for i from 0 to d list (diff(hp,i)) r;
+   local growthVec;
+   local B;
+   if d == n-2 then
+   (
+      if hpSeq#d > r then return {};
+      B = new BorelSet from {NumVariables => 2, 
+		             Degree => r,
+			     Size => (hpSeq#d),
+			     MinimalElements => {R_0^(hpSeq#d)*R_1^(r-hpSeq#d)},
+	                     MinimalGenerators => {R_0^(hpSeq#d)},
+	                     GrowthVector => toList ((r-hpSeq#d+1 : 0) | (hpSeq#d : 1)),
+	                    };	    
+      if n == 2 then {ideal(B.MinimalGenerators)} else recursiveCall(B,hpSeq)
+   )
+   else
+   (
+      B = new BorelSet from {NumVariables => n-d-1, 
+  	                     Degree => r,
+			     Size => 0,
+			     MinimalElements => {R_(n-d-2)^r},
+	                     MinimalGenerators => {1_R},
+	                     GrowthVector => toList(r+1 : 0),
+	                    };				    
+      recursiveCall(B,hpSeq)
+   )
+) -- END stronglyStableIdeals (ProjectiveHilbertPolynomial,PolynomialRing) 
+ 
+stronglyStableIdeals (ProjectiveHilbertPolynomial,ZZ) := opts -> (hp,n) -> (
+   if n < 2 then error "argument 2: expected at least 2 variables";
+   if not instance(opts.CoefficientRing,Ring) then error "option CoefficientRing: expected a ring"; 
+   if opts.OrderVariables != Up and opts.OrderVariables != Down then error "option OrderVariables: expected Down or Up";
+   
+   R := (opts.CoefficientRing)(monoid [VariableBaseName=>getSymbol "x",Variables=>n]);
+   if opts.OrderVariables == Up then R = (opts.CoefficientRing)(monoid [sort gens R]);
+   stronglyStableIdeals(hp, R, MaxRegularity=>opts.MaxRegularity)  
+) -- END stronglyStableIdeals (ProjectiveHilbertPolynomial,ZZ)
+
+stronglyStableIdeals (RingElement,PolynomialRing) := opts -> (p,R) -> stronglyStableIdeals(projectiveHilbertPolynomial p, R, opts)
+
+stronglyStableIdeals (RingElement,ZZ) := opts -> (p,n) -> stronglyStableIdeals(projectiveHilbertPolynomial p, n, opts)
+
+stronglyStableIdeals (ZZ,PolynomialRing) := opts -> (d,R) -> stronglyStableIdeals (projectiveHilbertPolynomial d_(QQ[local t]), R, opts)
+
+stronglyStableIdeals (ZZ,ZZ) := opts -> (d,n) -> stronglyStableIdeals (projectiveHilbertPolynomial d_(QQ[local t]), n, opts)
+
+
+--------
+--  isGenSegment
+--------
+isGenSegment = method(TypicalValue => Sequence)
+
+isGenSegment MonomialIdeal := J -> (
+    if not isBorel J then error "argument 1: expected a strongly stable ideal";
+    R := ring J;
+    RmodJ := R/J;
+    leadMon := J_*;
+    tails := {};
+    completePolynomials := {};  
+    for m in leadMon do
+    (
+       outside := flatten entries basis(first degree m,RmodJ);
+       tails = tails | {for t in outside list lift(t,R)};
+       completePolynomials = completePolynomials | {m + sum(tails#-1)};
+    );
+    W := weightVector(leadMon,completePolynomials);
+    if W === null then return (false,null);
+    if isSegmentWeightVector(W,leadMon,tails) then (true,W) else (false,null) 
+) -- END isGenSegment MonomialIdeal
+
+isGenSegment Ideal := J -> (
+   if not isMonomialIdeal J then error "argument 1: expected a monomial ideal";
+   isGenSegment monomialIdeal J   
+) 
+
+
+--------
+-- isRegSegment
+--------
+isRegSegment = method(TypicalValue => Sequence)
+
+isRegSegment MonomialIdeal := J -> isGenSegment truncate(regularity J,J)
+
+isRegSegment Ideal := J -> (
+   if not isMonomialIdeal J then error "argument 1: expected a monomial ideal";
+   isRegSegment monomialIdeal J
+)
+
+
+--------
+-- isHilbSegment
+--------
+isHilbSegment = method(TypicalValue => Sequence)
+
+isHilbSegment MonomialIdeal := J -> isGenSegment truncate(gotzmannNumber hilbertPolynomial J,J)
+
+isHilbSegment Ideal := J -> (
+   if not isMonomialIdeal J then error "argument 1: expected a monomial ideal";
+   isHilbSegment monomialIdeal J
+)
+
+
+
+---------------------------------------------------------------
+--          AUXILIARY TYPES AND METHODS (unexported)          --
+---------------------------------------------------------------
+
+---------------------------------
+polynomialBinom = method (TypicalValue => RingElement)
+
+polynomialBinom (ZZ,ZZ,Ring) := (a,b,R) -> (
+   var := R_0;
+   product(for i from 0 to b-1 list (var+a-i)/(i+1))
+)
+---------------------------------
+
+---------------------------------
+lexIdealExponents = method(TypicalValue => List)
+
+lexIdealExponents ProjectiveHilbertPolynomial := hp -> (
+   gotzmannDec := gotzmannDecomposition hp;
+   d := dim hp;
+   lexExp := new MutableList from for i from 0 to d list 0;
+   for s in gotzmannDec do lexExp#(dim s) = lexExp#(dim s)+1;
+   toList lexExp 
+)
+
+lexIdealExponents RingElement := p -> (  
+   gotzmannDec := gotzmannDecomposition p;
+   d := first degree p;
+   lexExp := new MutableList from for i from 0 to d list 0;
+   for s in gotzmannDec do lexExp#(dim s) = lexExp#(dim s)+1;
+   toList lexExp 
+)
+---------------------------------
+
+---------------------------------
+BorelSet = new Type of HashTable 
+
+protect NumVariables
+protect MinimalElements
+protect Size
+protect GrowthVector
+---------------------------------
+
+
+---------------------------------
+recursiveCall = method (TypicalValue => List)
+recursiveCall (BorelSet,List) := (B,hpSeq) -> (
+   newB := addNextVariable(B);
+   S := ring(B.MinimalElements#0);
+   toRemove := hpSeq#(numgens S - newB.NumVariables) - newB.Size;
+   if toRemove >= 0 then removeMonomials(newB, toRemove, 1_S, hpSeq) else {}
+)
+---------------------------------
+
+
+---------------------------------
+removeMonomials = method (TypicalValue=>List)
+removeMonomials (BorelSet,ZZ,RingElement,List) := (B,toRemove,lastRemoved,hpSeq) -> (
+   S := ring(B.MinimalElements#0);
+   lastVar := B.NumVariables-1;
+   if toRemove == 0 then 
+   (
+      if B.NumVariables == numgens(S) then return {ideal(B.MinimalGenerators)} else return recursiveCall(B,hpSeq);
+   ) 
+   else 
+   (
+      output := {};
+      for m in B.MinimalElements do 
+      (
+         if m > lastRemoved and degree(S_lastVar,m) > 0 then 
+	 (
+            newB := removeMinimal(B,m);
+            output = output | removeMonomials(newB,toRemove-1,m,hpSeq);
+         );
+      );
+      return output;
+   );
+) 
+---------------------------------
+
+
+---------------------------------
+removeMinimal = method(TypicalValue => BorelSet)
+removeMinimal (BorelSet,RingElement) := (B,m) -> (
+   S := ring(B.MinimalElements#0);
+   newMinimalElements := delete(m, B.MinimalElements);
+   n := B.NumVariables;
+   newMinimalElements = newMinimalElements | toList(select(apply(select(1..n-1, i -> degree(S_i, m) > 0), j -> (up := (m//S_j)*S_(j-1); if not precBorel(up, newMinimalElements) then return up)), i -> i=!=null));
+   h := degree(S_(B.NumVariables-1), m);
+   newGrowthVector := new MutableList from B.GrowthVector;
+   newGrowthVector#h = newGrowthVector#h + 1;
+   minGen := m//(S_(B.NumVariables-1)^h);
+   newMinimalGenerators := delete(minGen,B.MinimalGenerators);
+   newMinimalGenerators = newMinimalGenerators | for i in max(0, minimum(minGen)) .. B.NumVariables-2 list minGen*S_i;
+
+   new BorelSet from {NumVariables => B.NumVariables, 
+	                    Degree => B.Degree,
+                              Size => B.Size-1,
+                   MinimalElements => rsort(newMinimalElements),
+                 MinimalGenerators => sort(newMinimalGenerators),
+                      GrowthVector => toList(newGrowthVector)}
+) 
+---------------------------------
+
+
+---------------------------------
+addNextVariable = method(TypicalValue => BorelSet)
+addNextVariable BorelSet := B -> (  
+   v := B.NumVariables;
+   S := ring(B.MinimalElements#0);
+   newMinimalElements := {};
+   for monomial in B.MinimalElements do 
+   (
+      lastDeg := degree(S_(v-1),monomial);
+      if lastDeg > 0 then 
+      (
+         newMinimalElements = append(newMinimalElements, monomial//(S_(v-1)^lastDeg)*(S_v^lastDeg));
+      ) 
+      else 
+      (
+         newMinimalElements = append(newMinimalElements, monomial);
+      );
+   );
+   newGrowthVector := {};
+   newSize := 0;
+   for i from 0 to B.Degree do 
+   (
+      newGrowthVector = append(newGrowthVector, sum (for j from i to B.Degree list B.GrowthVector#j));
+      newSize = newSize + (B.GrowthVector#i)*(i+1);
+   );
+
+   new BorelSet from {NumVariables => v+1,
+                            Degree => B.Degree,
+                              Size => newSize,
+                   MinimalElements => newMinimalElements,
+                 MinimalGenerators => B.MinimalGenerators,
+		      GrowthVector => newGrowthVector}
+) 
+---------------------------------
+
+
+---------------------------------
+minimum = method(TypicalValue => ZZ)
+minimum RingElement := m -> (
+   if first degree m == 0 then return 0;
+   R := ring m;
+   i := numgens R - 1;
+   while degree(R_i,m) == 0 do i = i-1;
+   i
+) 
+---------------------------------
+
+
+---------------------------------
+precBorel = method(TypicalValue => Boolean)
+precBorel (RingElement,RingElement) := (m,n) -> (
+   S := ring m;
+   v := numgens S;
+   s := 0;
+   for i from 0 to v-1 do (
+      s = s + degree(S_i,m) - degree(S_i,n);
+      if s < 0 then return false;
+   );
+   true
+) 
+---------------------------------
+
+
+---------------------------------
+precBorel (RingElement, List) := (m,L) -> (
+   l:=#L;
+   for i from 0 to l-1 do (
+      if precBorel(m, L#i) then return true;
+   );
+   false 
+) 
+---------------------------------
+
+
+---------------------------------
+isSegmentWeightVector = method(TypicalValue=>Boolean)
+isSegmentWeightVector (List, List, List) := (W,Ht,Tails) -> (
+    for i from 0 to #Ht-1 do 
+    (
+       for t in Tails#i do 
+       (
+	   if  dotProduct(W,flatten exponents(Ht#i)) <= dotProduct(W,flatten exponents(t)) then return false;
+       );	
+    );
+    true   
+) 
+---------------------------------
+
+
+---------------------------------
+dotProduct = method(TypicalValue=>RingElement)
+dotProduct (List, List) := (L,M) -> sum for i from 0 to #L-1 list L#i*M#i
+---------------------------------
+
+------------------------------------------
+-----          ASSERT TESTS          -----
+------------------------------------------
+
+-- isHilbertPolynomial
+TEST ///
+  QQ[t];
+  assert (isHilbertPolynomial(4*t));
+  assert (not isHilbertPolynomial(4*t-3));
+  assert (isHilbertPolynomial(projectiveHilbertPolynomial(3)));
+  assert (not isHilbertPolynomial(-projectiveHilbertPolynomial(2)));
+///
+
+-- gotzmannDecomposition
+TEST ///
+  QQ[t];
+  p = 3*t+1;
+  assert (gotzmannDecomposition p == {projectiveHilbertPolynomial(1,0),
+	                              projectiveHilbertPolynomial(1,-1),
+				      projectiveHilbertPolynomial(1,-2),
+				      projectiveHilbertPolynomial(0,-3)});
+  q = 2*projectiveHilbertPolynomial(1,0);
+  assert (gotzmannDecomposition q == {projectiveHilbertPolynomial(1,0),
+	                              projectiveHilbertPolynomial(1,-1),
+		         	      projectiveHilbertPolynomial(0,-2)}); 
+///
+
+-- macaulayDecomposition
+TEST ///
+  QQ[t];
+  p = 3*t+1;
+  assert (macaulayDecomposition p == {projectiveHilbertPolynomial(1,-1),
+	                              -projectiveHilbertPolynomial(1,-1-4),
+				      projectiveHilbertPolynomial(2,-1),
+				      -projectiveHilbertPolynomial(2,-1-3)});
+  q = 2*projectiveHilbertPolynomial(1,0);
+  assert (macaulayDecomposition q == {projectiveHilbertPolynomial(1,-1),
+	                              -projectiveHilbertPolynomial(1,-1-3),
+			              projectiveHilbertPolynomial(2,-1),
+		                      -projectiveHilbertPolynomial(2,-1-2)}); 
+///
+
+-- gotzmannNumber
+TEST ///
+  QQ[t];
+  p = 3*t+1;
+  assert (gotzmannNumber p == 4);
+  QQ[x,y,z];
+  I = ideal(x^2,x*y,y^4);
+  assert (gotzmannNumber(hilbertPolynomial I) == 5);
+///
+
+-- projectiveHilbertPolynomial
+TEST ///
+  QQ[t];
+  p = 2*t+2;
+  assert(projectiveHilbertPolynomial p == 2*projectiveHilbertPolynomial(1,0));
+///
+
+-- lexIdeal
+TEST ///
+   S = QQ[x_0..x_2];
+   L = lexIdeal(10,S);
+   assert (L == ideal(x_0,x_1^10));
+///
+
+-- stronglyStableIdeals
+TEST ///
+  QQ[t];
+  SSI = stronglyStableIdeals(4*t,4);
+  assert(#SSI == 4);
+///
+
+-- isGenSegment
+TEST ///
+  QQ[x,y,z];
+  I = ideal(x^2,x*y,y^4);
+  assert((isGenSegment I)#0);
+///
+
+-- isRegSegment
+TEST ///
+  QQ[x,y,z];
+  I = ideal(x^2,x*y,y^4);
+  assert((isRegSegment I)#0);
+///
+
+-- isHilbSegment
+TEST ///
+  QQ[x,y,z];
+  I = ideal(x^2,x*y,y^4);
+  assert((isHilbSegment I)#0);
+///
+
+-------------------------------------------
+-----          DOCUMENTATION          -----
+-------------------------------------------
+
+beginDocumentation()
+
+doc ///
+  Key
+    StronglyStableIdeals
+  Headline
+    Find projective varieties defined by strongly stable ideals with a given Hilbert polynomial
+  Description
+    Text
+      {\bf Overview:}
+      
+      Strongly stable ideals are a key tool in commutative algebra and algebraic geometry. These ideals have nice combinatorial properties 
+      that makes them well suited for both theoretical and computational applications. In the case of polynomial rings with coefficients in 
+      a field with characteristic zero, the notion of strongly stable ideals coincides with the notion of Borel-fixed ideals. Ideals of the 
+      latter type are fixed by the action of the Borel subgroup of triangular matrices of the linear group and they correspond to the possible 
+      generic initial ideals by a famous result by Galligo. In the context of Hilbert schemes, Galligo's theorem states that each component and 
+      each interesection of components contains at least a point corresponding to a scheme defined by a Borel-fixed ideal. 
+      Hence, these ideals represent a promising tool for studying Hilbert schemes and to obtain a complete knowledge of their structure.
+      The main feature of the this package is a method to compute the set of all the saturated strongly stable ideals in a polynomial ring 
+      with a given Hilbert polynomial. This method has been theoretically introduced in [CLMR11] and improved in [Lel12].
+      
+      {\bf References:}
+      
+      [CLMR11] F. Cioffi, P. Lella, M.G. Marinari, M. Roggero: Segments and Hilbert schemes of points, {\it Discrete Mathematics}, 311(20):2238–2252, 2011.
+      @BR{}@ Available at @HREF{"http://arxiv.org/abs/1003.2951"}@.
+      
+      [Lel12] P. Lella: An efficient implementation of the algorithm computing the Borel-fixed points of a Hilbert scheme, 
+      {\it ISSAC 2012 — Proceedings of the 37th International Symposium on Symbolic and Algebraic Computation}, 242–248, ACM, New York, 2012.
+      @BR{}@ Available at @HREF{"http://arxiv.org/abs/1205.0456"}@.
+      
+      {\bf Key user functions:}
+
+        {\it Hilbert polynomials:}
+
+          @TO isHilbertPolynomial@ -- Test whether a numerical polynomial is a Hilbert polynomial.
+
+          @TO gotzmannDecomposition@ -- Compute Gotzmann's decomposition of a Hilbert polynomial.
+
+          @TO gotzmannNumber@ -- Compute the Gotzmann number of a Hilbert polynomial.
+	  
+	  @TO macaulayDecomposition@ -- Compute Macaulay's decomposition of a Hilbert polynomial.
+
+        {\it Strongly stable ideals and segment ideals:}
+
+          @TO lexIdeal@ -- Compute the saturated lexicographic ideal with a given Hilbert polynomial.
+          
+          @TO stronglyStableIdeals@ -- Compute the saturated strongly stable ideals with a given Hilbert polynomial.
+	  
+	  @TO isGenSegment@ -- Test whether there exists a term ordering such that each minimal generator of a strongly stable ideal is greater than all mononials outside the ideal of the same degree.
+      
+	  @TO isRegSegment@ -- Test whether the truncation of a strongly stable ideal in degree equal to its regularity is a segment. 	                   
+
+	  @TO isHilbSegment@ -- Test whether the truncation of a strongly stable ideal in degree equal to the Gotzmann number of its Hilbert polynomial is a segment. 
+///   
+
+doc ///
+  Key
+    isHilbertPolynomial
+    (isHilbertPolynomial, ProjectiveHilbertPolynomial)
+    (isHilbertPolynomial, RingElement)
+  Headline
+    Determine whether a numerical polynomial can be a Hilbert polynomial
+  Usage
+    isHilbertPolynomial p
+  Inputs
+    p : ProjectiveHilbertPolynomial
+        or
+    p : RingElement
+        a numerical univariate polynomial.
+  Outputs
+    : Boolean
+  Description
+   Text
+      Returns true if the input polynomial is an admissible Hilbert polynomial, false otherwise.
+      
+   Example
+     QQ[t];
+     isHilbertPolynomial(3*t+4)
+     isHilbertPolynomial((2/3)*t-1)
+     isHilbertPolynomial(2*projectiveHilbertPolynomial(2))
+     isHilbertPolynomial(2*projectiveHilbertPolynomial(2,-1))
+///
+
+doc ///
+  Key
+    gotzmannDecomposition
+    (gotzmannDecomposition, ProjectiveHilbertPolynomial)
+    (gotzmannDecomposition, RingElement)
+  Headline
+    Compute Gotzmann's decomposition of Hilbert polynomial
+  Usage
+    gotzmannDecomposition hp
+  Inputs
+    hp : ProjectiveHilbertPolynomial
+         or
+    hp : RingElement
+         a Hilbert polynomial.
+  Outputs
+    : List
+  Description
+   Text
+      Returns the list of projective Hilbert polynomials of linear spaces summing up to the input polynomial.
+   
+   Example
+     QQ[t];
+     hp = projectiveHilbertPolynomial(3*t+4)
+     gD = gotzmannDecomposition hp
+     sum gD
+///
+
+doc ///
+  Key
+    macaulayDecomposition
+    (macaulayDecomposition, ProjectiveHilbertPolynomial)
+    (macaulayDecomposition, RingElement)
+  Headline
+    Compute Macaulay's decomposition of Hilbert polynomial
+  Usage
+    macaulayDecomposition hp
+  Inputs
+    hp : ProjectiveHilbertPolynomial
+         or
+    hp : RingElement
+         a Hilbert polynomial.
+  Outputs
+    : List
+  Description
+   Text
+      Returns the list of projective Hilbert polynomials of linear spaces summing up to the input polynomial.
+   
+   Example
+     QQ[t];
+     hp = projectiveHilbertPolynomial(3*t+4)
+     mD = macaulayDecomposition hp
+     sum mD
+///
+
+doc ///
+  Key
+    gotzmannNumber
+    (gotzmannNumber, ProjectiveHilbertPolynomial)
+    (gotzmannNumber, RingElement)
+  Headline
+    Compute the Gotzmann number of a Hilbert polynomial
+  Usage
+    gotzmannNumber hp
+  Inputs
+    hp : ProjectiveHilbertPolynomial
+         or
+    hp : RingElement
+         a Hilbert polynomial.
+  Outputs
+    : ZZ
+  Description
+   Text
+      Returns the Gotzmann number of the input polynomial, i.e., the length of its Gotzmann decomposition (see @TO gotzmannDecomposition@).
+   
+   Example
+     QQ[t];
+     gotzmannNumber(3*t+4)
+     gotzmannDecomposition(3*t+4)
+///
+
+doc ///
+  Key
+    (projectiveHilbertPolynomial, RingElement)
+  Headline
+    
+  Usage
+    projectiveHilbertPolynomial p
+  Inputs
+    p : RingElement
+        a Hilbert polynomial.
+  Outputs
+    : ProjectiveHilbertPolynomial
+  Description
+   Text
+      Convert a @TO RingElement@ representing a Hilbert polynomial to a @TO ProjectiveHilbertPolynomial@.
+   
+   Example
+     QQ[t];
+     projectiveHilbertPolynomial (3*t+4)
+///
+
+doc ///
+  Key
+    OrderVariables
+  Headline
+    Option to set the order of indexed variables
+  Description
+   Text
+    This option can be used to specify the order of the indexed variables of the polynomial ring containing the ideals,
+    when calling @TO lexIdeal@ or @TO stronglyStableIdeals@ giving as input only the number of variables of the polynomial ring. 
+    If @TO OrderVariables@ is set to @TO Up@ then @TT "x_i < x_j"@ iff @TT "i < j"@, otherwise 
+    if @TO OrderVariables@ is set to @TO Down@ then @TT "x_i < x_j"@ iff @TT "i > j"@.
+    
+    The default is @TO Down@.
+
+   Example
+     lexIdeal(3, 3, OrderVariables=>Down)
+     stronglyStableIdeals(3, 3, OrderVariables=>Up)
+///
+
+doc ///
+  Key
+    lexIdeal
+    (lexIdeal, ProjectiveHilbertPolynomial, PolynomialRing)
+    (lexIdeal, ProjectiveHilbertPolynomial, ZZ)
+    (lexIdeal, RingElement, PolynomialRing)
+    (lexIdeal, RingElement, ZZ)
+    (lexIdeal, ZZ, PolynomialRing)
+    (lexIdeal, ZZ, ZZ)
+  Headline
+    Compute the saturated lexicographic ideal in the given ambient space with given Hilbert polynomial
+  Usage
+    lexIdeal (hp ,S)
+    lexIdeal (hp, n)
+    lexIdeal (d, S)
+    lexIdeal (d, n)
+  Inputs
+    hp : ProjectiveHilbertPolynomial
+         or
+    hp : RingElement
+         a Hilbert polynomial; 
+    d : ZZ
+        a positive integer corresponding to a constant Hilbert polynomial;
+    S : PolynomialRing
+        with @TT "numgens S > 1"@;
+    n : ZZ
+         number of variables of the polynomial ring.
+  Outputs
+    : Ideal
+  Description
+   Text
+      Returns the saturated lexicographic ideal defining a subscheme of \mathbb{P}^{n} or @TT "Proj S"@ 
+      with Hilbert polynomial @TT "hp"@ or @TT "d"@.
+   
+   Example
+     QQ[t];
+     S = QQ[x,y,z,w];
+     lexIdeal(4*t, S)
+     lexIdeal(4*t, 5)
+     hp = hilbertPolynomial oo
+     lexIdeal(hp, S)
+     lexIdeal(hp, 3)
+     lexIdeal(5, S)
+     lexIdeal(5, 3)
+///
+
+doc ///
+  Key
+    [lexIdeal,CoefficientRing]
+  Headline
+    Option to set the ring of coefficients
+  Description
+   Text
+    This option can be used to specify the ring of coefficients of the polynomial ring containing the ideals,
+    when calling @TO lexIdeal@ giving as input only the number of variables of the polynomial ring. 
+    
+    The default is @TO QQ@.
+
+   Example
+     lexIdeal(10, 3, CoefficientRing=>ZZ/101)
+///
+
+doc ///
+  Key
+    [lexIdeal,OrderVariables]
+  Headline
+    Option to set the order of indexed variables
+  Description
+   Text
+    This option can be used to specify the order of the indexed variables of the polynomial ring containing the ideals,
+    when calling @TO lexIdeal@ giving as input only the number of variables of the polynomial ring. 
+    If @TO OrderVariables@ is set to @TO Up@ then @TT "x_i < x_j"@ iff @TT "i < j"@, otherwise 
+    if @TO OrderVariables@ is set to @TO Down@ then @TT "x_i < x_j"@ iff @TT "i > j"@.
+    
+    The default is @TO Down@.
+
+   Example
+     lexIdeal(3, 3, OrderVariables=>Down)
+     lexIdeal(3, 3, OrderVariables=>Up)
+///
+
+doc ///
+  Key
+    stronglyStableIdeals
+    (stronglyStableIdeals, ProjectiveHilbertPolynomial, PolynomialRing)
+    (stronglyStableIdeals, ProjectiveHilbertPolynomial, ZZ)
+    (stronglyStableIdeals, RingElement, PolynomialRing)
+    (stronglyStableIdeals, RingElement, ZZ)
+    (stronglyStableIdeals, ZZ, PolynomialRing)
+    (stronglyStableIdeals, ZZ, ZZ)
+  Headline
+    Compute the saturated strongly stable ideals in the given ambient space with given Hilbert polynomial
+  Usage
+    stronglyStableIdeals (hp ,S)
+    stronglyStableIdeals (hp, n)
+    stronglyStableIdeals (d, S)
+    stronglyStableIdeals (d, n)
+  Inputs
+    hp : ProjectiveHilbertPolynomial
+         or
+    hp : RingElement
+         a Hilbert polynomial; 
+    d : ZZ
+        a positive integer corresponding to a constant Hilbert polynomial;
+    S : PolynomialRing
+          with @TT "numgens S > 1"@;
+    n : ZZ
+         number of variables of the polynomial ring.
+  Outputs
+    : List
+  Description
+   Text
+      Returns the list of all the saturated strongly stable ideals defining subschemes of \mathbb{P}^{n} or @TT "Proj S"@ 
+      with Hilbert polynomial @TT "hp"@ or @TT "d"@.
+   
+   Example
+     QQ[t];
+     S = QQ[x,y,z,w];
+     stronglyStableIdeals(4*t, S)
+     stronglyStableIdeals(4*t, 4)
+     hp = hilbertPolynomial(oo#0)
+     stronglyStableIdeals(hp, S)
+     stronglyStableIdeals(hp, 4)
+     stronglyStableIdeals(5, S)
+     stronglyStableIdeals(5, 4)
+///
+
+doc ///
+  Key
+    MaxRegularity
+    [stronglyStableIdeals,MaxRegularity]
+  Headline
+    Option to set the maximum regularity
+  Description
+   Text
+    This option can be used to give an upper bound to the regularity of the strongly stable ideals.
+    
+    The default is null (i.e., no bound).
+    
+   Example
+     QQ[t];
+     stronglyStableIdeals(4*t, 4, MaxRegularity=>4)
+///
+
+doc ///
+  Key
+    [stronglyStableIdeals,CoefficientRing]
+  Headline
+    Option to set the ring of coefficients
+  Description
+   Text
+    This option can be used to specify the ring of coefficients of the polynomial ring containing the ideals,
+    when calling @TO stronglyStableIdeals@ giving as input only the number of variables of the polynomial ring. 
+    
+    The default is @TO QQ@.
+
+   Example
+     QQ[t];
+     stronglyStableIdeals(3, 3, CoefficientRing=>ZZ/101)
+     oo#0
+///
+
+doc ///
+  Key
+    [stronglyStableIdeals,OrderVariables]
+  Headline
+    Option to set the order of indexed variables
+  Description
+   Text
+    This option can be used to specify the order of the indexed variables of the polynomial ring containing the ideals,
+    when calling @TO stronglyStableIdeals@ giving as input only the number of variables of the polynomial ring. 
+    If @TO OrderVariables@ is set to @TO Up@ then @TT "x_i < x_j"@ iff @TT "i < j"@, otherwise 
+    if @TO OrderVariables@ is set to @TO Down@ then @TT "x_i < x_j"@ iff @TT "i > j"@.
+    
+    The default is @TO Down@.
+
+   Example
+     stronglyStableIdeals(3, 3, OrderVariables=>Down)
+     stronglyStableIdeals(3, 3, OrderVariables=>Up)
+///
+
+doc ///
+  Key
+    isGenSegment
+    (isGenSegment, MonomialIdeal)
+    (isGenSegment, Ideal)
+  Headline
+    gen-segment ideals
+  Usage
+    isGenSegment J
+  Inputs
+    J : MonomialIdeal
+        or
+    J : Ideal
+        a strongly stable ideal.
+  Outputs
+    : Sequence
+  Description
+   Text
+      The first element of the sequence is a boolean value. It tells if the ideal is a segment, i.e., if there exists a term ordering
+      such that every generator of the ideal is greater than every monomial outside the ideal of the same degree.     
+      If true, the second element of the sequence contains the list of weights giving the corresponding ordering on the monomials.
+   
+   Example
+     QQ[x,y,z];
+     isGenSegment(ideal(x^2,x*y,y^4))
+     isGenSegment(ideal(x^2,x*y^3,y^4))
+///
+
+doc ///
+  Key
+    isRegSegment
+    (isRegSegment, MonomialIdeal)
+    (isRegSegment, Ideal)
+  Headline
+    reg-segment ideals
+  Usage
+    isRegSegment J
+  Inputs
+    J : MonomialIdeal
+        or
+    J : Ideal
+        a strongly stable ideal.
+  Outputs
+    : Sequence
+  Description
+   Text
+      Calls the method @TO isGenSegment@ on the ideal @TT "truncate(regularity J, J)"@.
+   
+   Example
+     QQ[x,y,z];
+     J = ideal(x^2,x*y^3,y^4)
+     isRegSegment J
+     isGenSegment(truncate(regularity J,J))
+     isGenSegment J
+///
+
+doc ///
+  Key
+    isHilbSegment
+    (isHilbSegment, MonomialIdeal)
+    (isHilbSegment, Ideal)
+  Headline
+    hilb-segment ideals
+  Usage
+    isHilbSegment J
+  Inputs
+    J : MonomialIdeal
+        or
+    J : Ideal
+        a strongly stable ideal.
+  Outputs
+    : Sequence
+  Description
+   Text
+      Calls the method @TO isGenSegment@ on the ideal @TT "truncate(gotzmannNumber(hilbertPolynomial J), J)"@.
+   
+   Example
+     QQ[x,y,z];
+     J = ideal(x^2,x*y,y^4);
+     isHilbSegment J
+     isGenSegment(truncate(gotzmannNumber(hilbertPolynomial J), J))
+///
+
+end
+restart
+installPackage "StronglyStableIdeals"
+check "StronglyStableIdeals"


### PR DESCRIPTION
The package StronglyStableIdeals has been submitted to JSAG
in 2014, revised in 2015 according to referee's comments,
but no more volumes of JSAG have been published since then.
The main feature is a method to compute the complete list of
saturated strongly stable ideals given the number of
variables and the Hilbert polynomial.
The brief article prepared for JSAG and explaining the
contents of the package is available at
https://arxiv.org/abs/1406.6924.

The package SLnEquivariantMatrices is an ancillary file to
the paper "A construction of equivariant bundles on the space
of symmetric forms" recently appeared on arXiv
(see https://arxiv.org/abs/1804.06211).
It allows to compute spaces of matrices of constant rank
that are SL(n)-equivariant.