### PR TITLE
Changed code for eagonNorthcott complex 

### DIFF
--- a/M2/Macaulay2/m2/chaincomplexes.m2
+++ b/M2/Macaulay2/m2/chaincomplexes.m2
@@ -1084,26 +1084,32 @@ eagonNorthcott = method(TypicalValue => ChainComplex)
 eagonNorthcott Matrix := f -> (
      -- code is by GREG SMITH, but is experimental, and 
      -- should be replaced by engine code
+     -- Modified by ELIANA DUARTE to fix the grading for matrices 
+     -- with entries of arbitrary degrees.
+     if not isHomogeneous f then error "Matrix not homogeneous.";
      R := ring f;
      m := rank source f;
      n := rank target f;
      B := hashTable apply(toList(1..m-n+2), 
      	  i -> {i, flatten table(subsets(m,n+i-1), compositions(n,i-1), 
 	       	    (p,q) -> {p,q})});
-     d1 := map(R^1, R^{#B#1:-n}, matrix {apply(B#1, r -> determinant f_(r#0))});
-     d := {d1} | apply(toList(2..m-n+2), i -> (
-	       map(R^{#B#(i-1):-n-i+2}, R^{#B#i:-n-i+1}, 
-	       matrix_R table(B#(i-1), B#i, 
-		    (p,q) -> if not isSubset(p#0,q#0) then 0_R
-		    else (
-			 vec := q#1 - p#1;
-			 if any(vec, e -> e < 0 or e > 1) then 0_R 
-			 else (
-			      s := first select(toList(0..#q#0-1), 
-				   l -> not member(q#0#l, p#0));
-      	       		      t := first select(toList(0..n-1), l -> vec#l == 1);
-	       		      (-1)^(s+1)*f_(t,q#0#s)))))));
-     chainComplex d);
+     d1 := map(R^1,, {apply(B#1, r -> determinant f_(r#0))});
+     nextDegrees := toSequence(-flatten degrees source d1);
+     d := {d1};
+     j:=2; while j<m-n+3 do(
+	             d=d|{map(source d_(j-2),, table(B#(j-1), B#j, 
+                          (p,q) -> if not isSubset(p#0,q#0) then 0_R
+                          else (
+                               vec := q#1 - p#1;
+                               if any(vec, e -> e < 0 or e > 1) then 0_R 
+                               else (
+                                    s := first select(toList(0..#q#0-1), 
+                                         l -> not member(q#0#l, p#0));
+                                    t := first select(toList(0..n-1), l -> vec#l == 1);
+                                    (-1)^(s+1)*f_(t,q#0#s)))))};
+		    j=j+1) ;
+     assert isHomogeneous(chainComplex d);
+      chainComplex d);
 
 ------ koszul
 

--- a/M2/Macaulay2/m2/chaincomplexes.m2
+++ b/M2/Macaulay2/m2/chaincomplexes.m2
@@ -1108,7 +1108,6 @@ eagonNorthcott Matrix := f -> (
                                     t := first select(toList(0..n-1), l -> vec#l == 1);
                                     (-1)^(s+1)*f_(t,q#0#s)))))};
 		    j=j+1) ;
-     assert isHomogeneous(chainComplex d);
       chainComplex d);
 
 ------ koszul

--- a/M2/Macaulay2/packages/Macaulay2Doc/test/chaincomplexes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/test/chaincomplexes.m2
@@ -4,3 +4,36 @@ C = R^b
 assert(b == betti C)
 assert( C.dd == 0 ) 
 
+
+R=ZZ/31991[x,y,z];
+M=random(R^{2:0},R^{3:-1});
+cpx=eagonNorthcott M;
+assert(isHomogeneous cpx)
+
+
+R=ZZ/31991[x,y,z];
+M=random(R^{2:0},R^{2:-1});
+cpx=eagonNorthcott M;
+assert(isHomogeneous cpx)
+assert(det M ==det cpx.dd_1)
+
+
+
+R=ZZ/31991[x,y,x,w];
+M=random(R^{2:0},R^{4:-2});
+eagonNorthcott M;
+
+
+R=ZZ/31991[s,t,u,v,Degrees=>{{1,0},{1,0},{0,1},{0,1}}]
+M=random(R^{{0,0},{0,0}},R^({{-1,-1},{-1,-1},{-1,-1},{-1,-1}}))
+cpx=eagonNorthcott M
+assert(isHomogeneous cpx)
+
+
+
+R=ZZ/31991[s,t,u,v,Degrees=>{{1,0,0,0},{0,1,0,0},{0,0,1,0},{0,0,0,1}}]
+M=matrix{{random(R^{{0,0,0,0},{0,0,0,0}},R^{4:{-1,-1,-1,-1}})}}
+cpx=eagonNorthcott M
+assert(isHomogeneous cpx)
+
+


### PR DESCRIPTION
Updated the code of the eagonNorthcott complex. tIt now displays the correct degrees of the matrices in the case that the input matrix is homogeneous but whose entries are not necessarily linear forms.