### PR TITLE
WIP: Nix build environment 

### DIFF
--- a/M2/nix/default.nix
+++ b/M2/nix/default.nix
@@ -1,0 +1,57 @@
+######
+#
+# Author: Brandon Elam Barker
+# Authoremail: brandon.barker@gmail.com
+# Start time: 08 June, 2018
+#
+######
+with import <nixpkgs> { };
+stdenv.mkDerivation {
+  name = "Macaulay2-dev";
+  buildInputs = [
+    atlas
+    autoconf
+    automake
+    bison
+    boehmgc
+    boost
+    cddlib
+    curl
+    emacs
+    fflas-ffpack
+    flex
+    gfortran
+    gdbm
+    givaro
+    glpk
+    gmp
+    gnumake
+    gnupatch
+    libatomic_ops
+    liblapack
+    libmpc
+    libtool
+    libxml2
+    lzma    
+    mpfr
+    ncurses
+    # ncurses5
+    openssh
+    pari
+    pinentry_ncurses
+    pkgconfig
+    readline
+    time
+    unzip
+    xorg.xauth
+    xorg.xinit
+    xorg.xkill
+    xterm
+    yasm
+    zlib
+  ];
+  shellHook = ''
+    export FC=gfortran
+  '';
+
+}


### PR DESCRIPTION
This is an effort to make a reproducible build specification for M2 using the nix package manager. Once working, an M2 package could also be added to nixpkgs. It appears that all the M2 dependencies are already in nixpkgs.

Currently working on lapack configure success (possibly related [issue](https://github.com/NixOS/nixpkgs/issues/31874)):

```
checking whether the Accelerate framework for lapack is available... no
checking whether package blas is provided... no
checking whether package lapack is provided... yes
checking for library containing dgetrf_... no
configure: error: lapack function dgetrf_ not found with -L/nix/store/m8bgjcy0fhc1l02kpz2s7a
yj6gd5p017-liblapack-3.8.0/lib -llapack      
```