### PR TITLE
Find system gftables if they exist.

### DIFF
--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -51,11 +51,14 @@ inversePermutation = v -> ( w := new MutableList from #v:null; scan(#v, i -> w#(
 -- We mimic the procedure for finding a finite field addition table used in the routine gf_get_table
 -- for building the file name in "gffilename", in the file BUILD_DIR/libraries/factory/build/factory/gfops.cc .
 -- Reminder: the contents of currentLayout are determined by the file ../d/startup.m2.in .
-gfdirs = {prefixDirectory | currentLayout#"factory gftables"}
+gfdirs = {prefixDirectory | currentLayout#"factory gftables",
+	  currentLayout#"factory gftables"}
 i := position(gfdirs, gfdir -> fileExists(gfdir | "gftables/961")) -- 961==31^2
 if i === null
 then error ("sample Factory finite field addition table file missing, needed for factorization: ",
-    prefixDirectory, currentLayout#"factory gftables")
+    prefixDirectory, currentLayout#"factory gftables",
+    " or ",
+    currentLayout#"factory gftables")
 setFactoryGFtableDirectory gfdirs_i
 
 irreducibleCharacteristicSeries = method()


### PR DESCRIPTION
d5bf979 introduced a regression in the feature added in 68a00e7.  In
particular, if we don't build factory, then we should use the gftables
already present on the user's system.

So we looked in two paths -- one prepended with `prefixDirectory`, for
M2-built factory, and one not prepended with `prefixDirectory`, for
system factory.

The second option was removed, an so we looked for gftables only in the
build directory.  But this would fail if we were using system factory.

This patch restores both options.