### PR TITLE
fix bug in Bertini.m2

### DIFF
--- a/M2/Macaulay2/packages/Bertini.m2
+++ b/M2/Macaulay2/packages/Bertini.m2
@@ -2147,7 +2147,7 @@ importMainDataFile(String) := o->(aString)->(
       theLine0:=separate(" ",allInfo_0);      
       aNewPoint.SolutionNumber=value (theLine0_1);
       if o.Verbose then print theLine0;
-      aNewPoint.PathNumber=value replace(")","",(theLine0_4));
+      aNewPoint.PathNumber=value replace(")|#","",(theLine0_4));
       --Estimated condition number
       theLine1:=separate(":",allInfo_1);
       aNewPoint.ConditionNumber=valueBM2(theLine1_1);


### PR DESCRIPTION
main_data usually includes the line "path number 1".
But sometimes it writes "path number 1#".
The character "#" must be ignored.