### PR TITLE
Added install-info package to Ubuntu section on INSTALL

### DIFF
--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -237,14 +237,14 @@ various modern operating systems:
   the directory where you want to install the files; if it's a directory not
   owned by you, prefix the "make install" command below with "sudo".
 
-       wget ftp://ftp.gnu.org/gnu/gcc/gcc-7.1/gcc-7.1.tar.bz2
-       tar xjf gcc-7.1.tar.bz2
-       cd gcc-7.1
+       wget ftp://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2
+       tar xjf gcc-7.1.0.tar.bz2
+       cd gcc-7.1.0
        ./contrib/download_prerequisites
        cd ..
-       mkdir gcc-7.1-build
-       cd gcc-7.1-build
-       ../gcc-7.1/configure --prefix=$HOME/local --program-suffix=-7.1 --enable-languages=c,c++,fortran --disable-multilib
+       mkdir gcc-7.1.0-build
+       cd gcc-7.1.0-build
+       ../gcc-7.1.0/configure --prefix=$HOME/local --program-suffix=-7.1.0 --enable-languages=c,c++,fortran --disable-multilib
        make
        make install
 
@@ -256,16 +256,16 @@ various modern operating systems:
      command line above, allowing the resulting binaries to depend on the
      version of libstdc++ already installed on your system.
 
-     The resulting compiler executables will be named gcc-7.1 and g++-7.1.
+     The resulting compiler executables will be named gcc-7.1.0 and g++-7.1.0.
      Now put the following lines in your file $HOME/.profile :
 
         export PATH=$HOME/local/bin:$PATH
         export MANPATH=$HOME/local/share/man:$MANPATH
         export INFOPATH=$HOME/local/share/info:$INFOPATH
         export LD_LIBRARY_PATH=$HOME/local/lib:$HOME/local/lib64:$LD_LIBRARY_PATH
-        export CC=gcc-7.1
-        export CXX=g++-7.1
-        export FC=gfortran-7.1
+        export CC=gcc-7.1.0
+        export CXX=g++-7.1.0
+        export FC=gfortran-7.1.0
 
      and then log out and log in again (or source the file into your
      environment and continue in the same process or in daughter processes).

--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -83,7 +83,7 @@ various modern operating systems:
 
   Ubuntu and Debian:
     Install packages with:
-      sudo apt-get install -y -q autoconf bison curl emacs fflas-ffpack flex g++ gcc gfortran libatomic-ops-dev libboost-dev libc6-dev libcdd-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfr-dev libncurses-dev libncurses5-dev libntl-dev libpari-dev libreadline-dev libtool libxml2-dev libz-dev make openssh-server patch pinentry-curses pkg-config time unzip xbase-clients yasm zlib1g-dev
+      sudo apt-get install -y -q autoconf bison curl emacs fflas-ffpack flex g++ gcc gfortran install-info libatomic-ops-dev libboost-dev libc6-dev libcdd-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfr-dev libncurses-dev libncurses5-dev libntl-dev libpari-dev libreadline-dev libtool libxml2-dev libz-dev make openssh-server patch pinentry-curses pkg-config time unzip xbase-clients yasm zlib1g-dev
         # note: libz-dev seems to have been replaced by zlib1g-dev
         # note: libncurses-dev seems to have been replaced by libncurses5-dev
         # note: libreadline-gplv2-dev is an older GPL v2 version of libreadline


### PR DESCRIPTION
Apparently install-info isn't installed on Ubuntu 16.04 by default