### PR TITLE
Improve Makefile.in for cohomcalg

### DIFF
--- a/M2/libraries/cohomcalg/Makefile.in
+++ b/M2/libraries/cohomcalg/Makefile.in
@@ -2,7 +2,7 @@ HOMEPAGE = http://wwwth.mpp.mpg.de/members/bjurke/cohomcalg/
 HOMEPAGE = http://wwwth.mppmu.mpg.de/members/blumenha/cohomcalg/
 URL = http://www.math.uiuc.edu/Macaulay2/Downloads/OtherSourceCode
 VERSION = 031b
-BUILDOPTIONS := CC=@CC@ CXX=@CXX@ LD=@CXX@ CFLAGS=$(CFLAGS)
+BUILDOPTIONS := CC="@CC@" CXX="@CXX@" LD="@CXX@" CFLAGS="$(CFLAGS)"
 TARFILE = cohomCalg-$(VERSION).zip
 UNTARCMD = unzip $(TARFILE_DIR)/$(TARFILE)
 LICENSEFILES = "GPLv3 License.txt"


### PR DESCRIPTION
Previously the generated Makefile would not work if any of these
variables contained space, such as in CC="gcc -march=native"