### PR TITLE
fix RingZZ::lower_content()

### DIFF
--- a/M2/Macaulay2/e/ZZ.cpp
+++ b/M2/Macaulay2/e/ZZ.cpp
@@ -220,6 +220,8 @@ void RingZZ::lower_content(ring_elem &c, ring_elem g) const
   mpz_srcptr a = c.get_mpz();
   mpz_srcptr b = g.get_mpz();
   mpz_gcd(result, a, b);
+  if(mpz_sgn(a) == -1)
+    mpz_neg(result, result);
   c = ring_elem(result);
 }
 


### PR DESCRIPTION
Makes ringZZ::lower_content() parallel the M2::QQ variant. In particular, this fixes #740.