### PR TITLE
Fast exponentiation in prime characteristic

### DIFF
--- a/M2/Macaulay2/e/poly.cpp
+++ b/M2/Macaulay2/e/poly.cpp
@@ -846,6 +846,40 @@ ring_elem PolyRing::power(const ring_elem f0, mpz_t n) const
   return result;
 }
 
+ring_elem PolyRing::power_direct(const ring_elem f, int n) const
+{
+  ring_elem result = from_long(0);
+  Nterm *lead = f;
+  if(!lead) return result;
+  ring_elem tail = lead->next;
+
+  mpz_t binom_c;
+  mpz_init_set_si(binom_c, 1);
+  int *m = M_->make_one();
+  ring_elem c1, c2, c3;
+  ring_elem rest=from_long(1), temp;
+
+  for(int i=0; i<=n; ++i)
+  {
+    c1 = K_->from_int(binom_c);
+    c2 = K_->power(lead->coeff, n-i);
+    c3 = K_->mult(c1, c2);
+    M_->power(lead->monom, n-i, m);
+    temp = mult_by_term(rest, c3, m);
+    add_to(result, temp);
+
+    if(!tail) break;
+
+  // maintenance
+    mpz_mul_si(binom_c, binom_c, n-i);
+    mpz_fdiv_q_ui(binom_c, binom_c, (unsigned)(i+1));
+    temp = mult(rest, tail);
+    rest = temp;
+  }
+
+  return result;
+}
+
 ring_elem PolyRing::power(const ring_elem f0, int n) const
 {
   ring_elem ff;
@@ -853,58 +887,40 @@ ring_elem PolyRing::power(const ring_elem f0, int n) const
   if (n > 0)
     ff = f0;
   else if (n < 0)
-    {
-      ff = invert(f0);
-      n = -n;
-    }
+  {
+    ff = invert(f0);
+    n = -n;
+  }
   else
     return from_long(1);
 
-  ring_elem result, g, rest, h, tmp;
-  ring_elem coef1, coef2, coef3;
+  if(!characteristic())
+  {
+    return power_direct(ff, n);
+  }
+  else
+  {
+    long p=characteristic(), pk=1;
+    ring_elem result = from_long(1);
+    ring_elem gg = copy(ff), temp;
 
-  Nterm *lead = ff;
-  if (lead == NULL) return ZERO_RINGELEM;
-
-  rest = lead->next;
-  g = from_long(1);
-
-  // Start the result with the n th power of the lead term
-  Nterm *t = new_term();
-  t->coeff = K_->power(lead->coeff, n);
-  M_->power(lead->monom, n, t->monom);
-  t->next = NULL;
-  //  if (_base_ring != NULL) normal_form(t);  NOT NEEDED
-  result = t;
-
-  if (POLY(rest) == 0) return result;
-  int *m = M_->make_one();
-
-  mpz_t bin_c;
-
-  mpz_init_set_ui(bin_c, 1);
-
-  for (int i = 1; i <= n; i++)
+    while(n)
     {
-      tmp = mult(g, rest);
-      g = tmp;
+      for(Nterm *it=ff, *jt=gg; it!=NULL; it=it->next, jt=jt->next)
+      {
+        jt->coeff = K_->power(it->coeff, pk);
+        M_->power(it->monom, pk, jt->monom);
+      }
 
-      mpz_mul_ui(bin_c, bin_c, n - i + 1);
-      mpz_fdiv_q_ui(bin_c, bin_c, i);
+      temp = power_direct(gg, n%p);
+      result = mult(result, temp);
 
-      coef1 = K_->from_int(bin_c);
-
-      if (!K_->is_zero(coef1))
-        {
-          coef2 = K_->power(lead->coeff, n - i);
-          coef3 = K_->mult(coef1, coef2);
-          M_->power(lead->monom, n - i, m);
-
-          h = mult_by_term(g, coef3, m);
-          add_to(result, h);
-        }
+      pk *= p;
+      n /= p;
     }
-  return result;
+
+    return result;
+  }
 }
 
 ring_elem PolyRing::invert(const ring_elem f) const

--- a/M2/Macaulay2/e/poly.cpp
+++ b/M2/Macaulay2/e/poly.cpp
@@ -917,7 +917,7 @@ ring_elem PolyRing::power(const ring_elem f0, int n) const
   {
     long p=characteristic(), pk=1;
     ring_elem result = from_long(1);
-    ring_elem gg = copy(ff), temp;
+    ring_elem gg = copy(ff), temp; // no need to copy, just the correct number of terms
 
     while(n)
     {

--- a/M2/Macaulay2/e/poly.hpp
+++ b/M2/Macaulay2/e/poly.hpp
@@ -239,6 +239,7 @@ class PolyRing : public PolyRingFlat
                       const int *n,
                       int *resultmon,
                       int use_coeff) const;
+  ring_elem power_direct(const ring_elem f, int n) const;
 
   ring_elem get_logical_coeff(const Ring *coeffR, const Nterm *&f) const;
   // Given an Nterm f, return the coeff of its logical monomial, in the


### PR DESCRIPTION
This fixes #264.

I've moved the actual logic from PolyRing::power() into a new PolyRing::power_direct(), making the former a dispatcher based on the characteristic being 0 or not. In particular, the overhead in zero-characteristic is a single function call.

In the way of benchmarking, below is the average runtime of raising to power a given random polynomial `f` using engine and high-level code (for example, as in #657). The `(p,{n1,n2,...},k)` col spec describes a test case, in which `f` is the sum of random forms in `ZZ/p[x,y,z]` of degrees `n1,n2,...` and `k` is the exponent. ~~I am not sure why~~ the high-level code before is sometimes *slightly* faster than the engine code after the change.

```
               (5,{4, 3},10), (17,{5},4), (19,{10},21), (7,{5, 6},31), (11,{3},51)
[engine-before] .0698586,    .000479839, 2.37298,     26.8513,       .347187,
[hi-lvl-before] .000392648,  .00162537,   .00630307,    .379307,     .0127448
[engine-after ] .0000616816, .000492968,  .0092006,     .487706,     .0149149
[hi-lvl-after ] .000453994,  .00159426,   .0100856,     .500135,     .0171947
```
