### PR TITLE
Ignore more auto-made files

### DIFF
--- a/M2/.gitignore
+++ b/M2/.gitignore
@@ -47,6 +47,9 @@
 /Macaulay2/c/.gdbinit
 /Macaulay2/m2/.gdbinit
 /libraries/atomic_ops/Makefile
+/libraries/cohomcalg/Makefile
+/libraries/csdp/Makefile
+/libraries/topcom/Makefile
 /libraries/M2/Makefile
 /libraries/gc/Makefile
 /libraries/gdbm/Makefile
@@ -101,12 +104,14 @@
 /Macaulay2/e/Makefile.common
 /Macaulay2/e/f4/Makefile
 /Macaulay2/e/unit-tests/Makefile
+/Macaulay2/d/distributed-packages.h
 /Macaulay2/emacs/M2-init.el
 /Macaulay2/emacs/Makefile
 /Macaulay2/html-check-links/Makefile
 /Macaulay2/packages/Style/Makefile
 /Macaulay2/m2/Makefile
 /Macaulay2/m2/version.m2
+/Macaulay2/m2/.gdbinit*
 /Macaulay2/man/Makefile
 /Macaulay2/man/M2.1
 /Macaulay2/packages/ComputationsBook/Makefile

--- a/M2/.gitignore
+++ b/M2/.gitignore
@@ -44,8 +44,8 @@
 /libraries/missing/src/Makefile
 /libraries/Makefile.library
 /Macaulay2/bin/M2
-/Macaulay2/c/.gdbinit
-/Macaulay2/m2/.gdbinit
+/Macaulay2/c/.gdbinit*
+/Macaulay2/m2/.gdbinit*
 /libraries/atomic_ops/Makefile
 /libraries/cohomcalg/Makefile
 /libraries/csdp/Makefile
@@ -111,7 +111,6 @@
 /Macaulay2/packages/Style/Makefile
 /Macaulay2/m2/Makefile
 /Macaulay2/m2/version.m2
-/Macaulay2/m2/.gdbinit*
 /Macaulay2/man/Makefile
 /Macaulay2/man/M2.1
 /Macaulay2/packages/ComputationsBook/Makefile

--- a/M2/.gitignore
+++ b/M2/.gitignore
@@ -44,8 +44,8 @@
 /libraries/missing/src/Makefile
 /libraries/Makefile.library
 /Macaulay2/bin/M2
-/Macaulay2/c/.gdbinit*
-/Macaulay2/m2/.gdbinit*
+/Macaulay2/c/.gdbinit
+/Macaulay2/m2/.gdbinit
 /libraries/atomic_ops/Makefile
 /libraries/cohomcalg/Makefile
 /libraries/csdp/Makefile


### PR DESCRIPTION
This is extremely low-impact. There are no gitignore entries for the Makefiles for *cohomcalg*, *csdp* and *topcom*. Also, on some systems one has `.gdbinit.USERNAME` instead of just `.gdbinit`.

Shouldn't the items (at least within each group) be alphabetically sorted?