### PR TITLE
fix #765 and modify affected examples

### DIFF
--- a/M2/Macaulay2/m2/indeterminates.m2
+++ b/M2/Macaulay2/m2/indeterminates.m2
@@ -40,13 +40,35 @@ succS = new MutableHashTable;
 for i from 0 to 50 do succS#(varName i) = varName(i+1)
 succ = method()
 succ(ZZ,ZZ) := (x,y) -> x+1 === y
+succ(Sequence,Sequence) := (x,y) -> ( -- for multiple indices
+    #x === #y and all(#x-1,i-> x#i === y#i) and x#(#x-1)+1 === y#(#x-1)
+)
+succ(BinaryOperation,BinaryOperation) := (x,y) -> x#0 === symbol .. and y#0 === symbol .. and (
+    succ (x#2,y#1) or (
+	instance(x#1,Subscript) and instance(x#2,Subscript)
+	and instance(y#1,Subscript) and instance(y#2,Subscript) and (
+	    a := sequence x#1#1; b := sequence x#2#1; c := sequence y#1#1; d := sequence y#2#1;
+	    -- find what endpoints have in common, remove
+	    while #a>0 and #c>0 and last a === last c do ( a=drop(a,-1); c=drop(c,-1); );
+	    if #a === 0 then a=x#1#0 else a=new Subscript from {x#1#0,unsequence a};
+	    if #c === 0 then c=y#1#0 else c=new Subscript from {y#1#0,unsequence c};
+	    while #b>0 and #d>0 and last b === last d do ( b=drop(b,-1); d=drop(d,-1); );
+	    if #b === 0 then b=x#2#0 else b=new Subscript from {x#2#0,unsequence b};
+	    if #d === 0 then d=y#2#0 else d=new Subscript from {y#2#0,unsequence d};
+	    a===b and c===d and succ(a,c)
+	)))
 succ(Symbol,Symbol) := (x,y) -> (
      (s,t) := (toString x, toString y);
      isUserSymbol(s,x) and isUserSymbol(t,y) and succS#?s and succS#s === t)
-succ(IndexedVariable,IndexedVariable) := (x,y) -> x#0 === y#0 and succ(x#1,y#1)
+succ(Subscript,Subscript) := (x,y) -> x#0 === y#0 and succ(expressionValue x#1,expressionValue y#1)
 succ(Thing,Thing) := x -> false
 runLengthEncode = method(Dispatch => Thing)
 runLengthEncode VisibleList := x -> (
+    local xx;
+    while (xx=runLengthEncode0 x; #x =!= #xx) do x=xx;
+    xx
+    )
+runLengthEncode0 = x -> (
      if #x === 0 then return x;
      dupout := true;
      while first(dupout,dupout = false) do x = new class x from (
@@ -65,7 +87,7 @@ runLengthEncode VisibleList := x -> (
 		    continue)
 	       else first(
 		    if oi === symbol oi then (oi = i; m = 1 ; continue) else
-		    if m === 1 then hold oi else if dupin === true then hold m : hold oi else hold i0 .. hold oi,
+		    if m === 1 then hold oi else if dupin === true then hold m : expression oi else (if instance(i0,BinaryOperation) then i0#1 else expression i0) .. (if instance(oi,BinaryOperation) then oi#2 else expression oi),
 		    (dupin = null; oi = i; m = 1))));
      x)
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/test/formatting.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/test/formatting.m2
@@ -2,7 +2,7 @@
 R = ZZ [x..z, t_1 .. t_4, s_(1,1) .. s_(2,2), Degrees=>{1,2,3,4,1,2,3, 4: 1}, MonomialOrder=>Lex]
 assert (
      toExternalString R == 
-     "ZZ(monoid[x..z, t_1, t_2, t_3, t_4, s_(1,1), s_(1,2), s_(2,1), s_(2,2), Degrees => {1..4, 1..3, 4:1}, Heft => {1}, MonomialOrder => VerticalList{MonomialSize => 32, Lex => 11, Position => Up}, DegreeRank => 1])"
+     "ZZ(monoid[x..z, t_1..t_4, s_(1,1)..s_(2,2), Degrees => {1..4, 1..3, 4:1}, Heft => {1}, MonomialOrder => VerticalList{MonomialSize => 32, Lex => 11, Position => Up}, DegreeRank => 1])"
      )
 
 QQ[a][x]

--- a/M2/Macaulay2/packages/Polyhedra/tests/extended/stanleyReisner.m2
+++ b/M2/Macaulay2/packages/Polyhedra/tests/extended/stanleyReisner.m2
@@ -21,6 +21,6 @@ assert(minimalNonFaces addCone({C1,C2}, fan C0) == {{0,1,2}})
 TEST ///
 Phi = normalFan hypercube 2;
 SR = stanleyReisnerRing Phi;
-assert(toExternalString monoid SR == "monoid[x_0, x_1, x_2, x_3, Degrees => {4:1}, Heft => {1}, MonomialOrder => VerticalList{MonomialSize => 32, GRevLex => {4:1}, Position => Up}, DegreeRank => 1]")
+assert(toExternalString monoid SR == "monoid[x_0..x_3, Degrees => {4:1}, Heft => {1}, MonomialOrder => VerticalList{MonomialSize => 32, GRevLex => {4:1}, Position => Up}, DegreeRank => 1]")
 assert(toString toExternalString SR == "QQ[x_0, x_1, x_2, x_3]/(x_0*x_1,x_2*x_3)")
 ///


### PR DESCRIPTION
runLengthEncoding now encodes arbitrarily complicated patterns:
```
i6 : describe(QQ[a_(1,1)..c_(2,2)])

o6 = QQ[a   ..c   , Degrees => {12:1}, Heft => {1}, MonomialOrder => {MonomialSize => 32}, DegreeRank => 1]
         1,1   2,2                                                   {GRevLex => {12:1} }
                                                                     {Position => Up    }
```
but isn't fooled by say:
```
i7 : describe(QQ[a_1..a_2,b_1..b_3,c_1..c_2])

o7 = QQ[a ..a , b ..b , c ..c , Degrees => {7:1}, Heft => {1}, MonomialOrder => {MonomialSize => 32}, DegreeRank => 1]
         1   2   1   3   1   2                                                  {GRevLex => {7:1}  }
                                                                                {Position => Up    }
```

Two examples needed fixing; one of them is in the package Polyhedra, not sure what the etiquette is; feel free to revert the change to that example. The other one is effectively a test of the rLE upgrade.