### PR TITLE
VirtualResolutions v1.2.0

### DIFF
--- a/M2/Macaulay2/packages/TateOnProducts.m2
+++ b/M2/Macaulay2/packages/TateOnProducts.m2
@@ -672,7 +672,7 @@ tateResolution(Module, List, List) := (M,low, high) ->(
     hi := apply(#regs, i->max(regs_i, high_i+1)); --hi
     N := presentation truncate(hi, M)**S^{hi};-- betti N
     Q := symExt(N,E); --betti Q
-    (res (coker Q,LengthLimit=>(sum hi-sum low)))**E^{hi}[sum hi + 2 - length hi]
+    (res (coker Q,LengthLimit=>(sum hi-sum low)))**E^{hi}[sum hi]
     )
 
 

--- a/M2/Macaulay2/packages/TateOnProducts.m2
+++ b/M2/Macaulay2/packages/TateOnProducts.m2
@@ -672,7 +672,7 @@ tateResolution(Module, List, List) := (M,low, high) ->(
     hi := apply(#regs, i->max(regs_i, high_i+1)); --hi
     N := presentation truncate(hi, M)**S^{hi};-- betti N
     Q := symExt(N,E); --betti Q
-    (res (coker Q,LengthLimit=>(sum hi-sum low)))**E^{hi}[sum hi]
+    (res (coker Q,LengthLimit=>(sum hi-sum low)))**E^{hi}[sum hi + 2 - length hi]
     )
 
 

--- a/M2/Macaulay2/packages/VirtualResolutions.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions.m2
@@ -10,8 +10,8 @@
 --                  updated 15 April 2019 at IMA Coding Sprint.
 ---------------------------------------------------------------------------
 newPackage ("VirtualResolutions",
-    Version => "1.0",
-    Date => "April 14, 2018",
+    Version => "1.1",
+    Date => "November 13, 2018",
     Headline => "Methods for virtual resolutions on products of projective spaces",
     Authors =>{
         {Name => "Ayah Almousa",       Email => "aka66@cornell.edu",   HomePage => "http://pi.math.cornell.edu/~aalmousa "},
@@ -22,10 +22,10 @@ newPackage ("VirtualResolutions",
         {Name => "Mahrud Sayrafi",     Email => "mahrud@umn.edu",      HomePage => "http://math.umn.edu/~mahrud/"}
         },
     PackageExports => {
+        "SpaceCurves",
         "TateOnProducts",
         "NormalToricVarieties",
         "Elimination",
-        "SpaceCurves",
         "Depth"
         },
     AuxiliaryFiles => true
@@ -33,7 +33,7 @@ newPackage ("VirtualResolutions",
 
 export{
     "curveFromP3toP1P2",
-    "findGensUpToIrrelevance",
+    "idealSheafGens",
     "isVirtual",
     "virtualOfPair",
     "resolveViaFatPoint",
@@ -65,22 +65,32 @@ export{
 --------------------------------------------------------------------
 --------------------------------------------------------------------
 load("./VirtualResolutions/Colon.m2")
-ourSaturation = (I,irr) -> saturationByElimination(I,irr)
+ourSaturation = (I,irr) -> saturationByElimination(I, decompose irr);
 
 
 --------------------------------------------------------------------
 --------------------------------------------------------------------
---Input: F a free chain complex on Cox (X), alphas a list of degrees
+--Input: F a free chain complex on Cox(X), alphas a list of degrees
 --Output: A subcomplex of summands generated only in degrees in the list alphas.
 --Given a ring and its free resolution, keeps only the summands in resolution of specified degrees
 --If the list alphas contains only one element, the output will be summands generated in degree less than or equal to alpha.
 --See Algorithm 3.4 of [BES]
 --------------------------------------------------------------------
 --------------------------------------------------------------------
-virtualOfPair = method()
-virtualOfPair (Ideal,        List) := (I, alphas) -> virtualOfPair(res I, alphas)
-virtualOfPair (Module,       List) := (M, alphas) -> virtualOfPair(res M, alphas)
-virtualOfPair (ChainComplex, List) := (F, alphas) -> (
+virtualOfPair = method(Options => {Strategy => null})
+virtualOfPair (Ideal,  List) := Boolean => opts -> (I, alphas) -> virtualOfPair((ring I)^1/I, alphas)
+virtualOfPair (Module, List) := Boolean => opts -> (M, alphas) -> (
+    if opts.Strategy == null then return virtualOfPair(res M, alphas);
+    if opts.Strategy == UseSyzygies then (
+	if any(alphas, alpha -> #alpha =!= degreeLength ring M) then error "degree has wrong length";
+	m := presentation M;
+	apply(alphas, alpha -> m = submatrixByDegrees(m, (,alpha), (,alpha)));
+	L := {m} | while m != 0 list (
+	    m = syz m; apply(alphas, alpha -> m = submatrixByDegrees(m, (,alpha), (,alpha))); m);
+	chainComplex L
+	)
+    )
+virtualOfPair (ChainComplex, List) := Boolean => opts -> (F, alphas) -> (
     if any(alphas, alpha -> #alpha =!= degreeLength ring F) then error "degree has wrong length";
     L := apply(length F, i -> (
             m := F.dd_(i+1); apply(alphas, alpha -> m = submatrixByDegrees(m, (,alpha), (,alpha))); m));
@@ -116,23 +126,14 @@ resolveViaFatPoint(Ideal, Ideal, List) := ChainComplex => (J, irr, A) -> (
 --------------------------------------------------------------------
 -- This method checks if a given complex is a virtual resolution by computing
 -- homology and checking whether its annihilator saturates to the whole ring.
--- Input: Ideal I (or module) - what the virtual resolution resolves
---       Ideal irr - the irrelevant ideal of the ring
+-- Input: Ideal irr - the irrelevant ideal of the ring
 --       Chain Complex C - proposed virtual resolution
 -- Output: Boolean - true if complex is virtual resolution, false otherwise
 -- Note: the Determinatal strategy is based on Theorem 1.3 of [Loper2019].
--- TODO: need to fix for modules; don't know how to saturate for modules
 --------------------------------------------------------------------
 --------------------------------------------------------------------
 isVirtual = method(Options => {Strategy => null})
-isVirtual (Ideal, Ideal, ChainComplex) := Boolean => opts -> (I, irr, C) -> (
-    annHH0 := ideal(image(C.dd_1));
-    Isat := ourSaturation(I,irr);
-    annHH0sat := ourSaturation(annHH0,irr);
-    if not(Isat == annHH0sat) then (
-        if debugLevel >= 1 then print "isVirtual failed at homological degree 0";
-        return false;
-        );
+isVirtual (Ideal, ChainComplex) := Boolean => opts -> (irr, C) -> (
 -- if strategy "determinantal is selected, the method checks virtuality
 -- via the depth criterion on the saturated ideals of minors
     if opts.Strategy === "Determinantal" then (
@@ -156,8 +157,8 @@ isVirtual (Ideal, Ideal, ChainComplex) := Boolean => opts -> (I, irr, C) -> (
 -- supported on irrelevant ideal
     for i from 1 to length(C) do (
         annHHi := ann HH_i(C);
-        if annHHi != ideal(sub(1,ring I)) then (
-            if annHHi == 0 or ourSaturation(annHHi,irr) != ideal(sub(1,ring I)) then (
+        if annHHi != ideal(sub(1,ring C)) then (
+            if annHHi == 0 or ourSaturation(annHHi,irr) != ideal(sub(1,ring C)) then (
                 if debugLevel >= 1 then print "isVirtual failed at homological degree " | toString i;
                 return false;
                 );
@@ -166,56 +167,10 @@ isVirtual (Ideal, Ideal, ChainComplex) := Boolean => opts -> (I, irr, C) -> (
     true
     )
 
-isVirtual (Module, Ideal, ChainComplex) := Boolean => opts -> (M, irr,C) -> (
-    annM := ann(M);
-    annHH0 := ann(HH_0(C));
-    annMsat := ourSaturation(annM,irr);
-    annHH0sat := ourSaturation(annHH0,irr);
-    if not(annMsat == annHH0sat) then (
-        if debugLevel >= 1 then print "isVirtual failed at homological degree 0";
-        return false;
-        );
--- if strategy "determinantal is selected, the method checks virtuality
--- via the depth criterion on the saturated ideals of minors
-    if opts.Strategy === "Determinantal" then (
-        for i from 1 to length(C) do (
-            if rank(source(C.dd_i)) != (rank(C.dd_i) + rank(C.dd_(i+1))) then (
-                if debugLevel >= 1 then print "isVirtual failed at homological degree " | toString i;
-                return false;
-                );
-            );
-        for i from 1 to length(C) do (
-            minor := minors(rank(C.dd_i),C.dd_i);
-            minorSat := ourSaturation(minor,irr);
-            if depth(minorSat,ring(minorSat)) < i then (
-                if debugLevel >= 1 then print "isVirtual failed at homological degree " | toString i;
-                return false;
-            );
-        );
-    true
-    );
--- default strategy is calculating homology and checking homology is
--- supported on irrelevant ideal
-    for i from 1 to length(C) do (
-        annHHi := ann HH_i(C);
-        if annHHi != ideal(sub(1,ring M)) then (
-            if annHHi == 0 or ourSaturation(annHHi,irr) != ideal(sub(1,ring irr)) then (
-                if debugLevel >= 1 then print "isVirtual failed at homological degree " | toString i;
-                return false;
-                );
-            );
-        );
-    true
-    )
 
-isVirtual (Ideal, NormalToricVariety, ChainComplex) := Boolean => opts -> (I, X, C) -> (
-    if ring I != ring X then error "ideal is not in Cox ring of normal toric variety";
-    isVirtual(I, ideal X, C)
-    )
-
-isVirtual (Module, NormalToricVariety, ChainComplex) := Boolean => opts -> (M, X, C) -> (
-    if ring M != ring X then error "module is not in Cox ring of normal toric variety";
-    isVirtual(M, ideal X, C)
+isVirtual (NormalToricVariety, ChainComplex) := Boolean => opts -> (X, C) -> (
+    if ring C != ring X then error "chain complex is not in Cox ring of normal toric variety";
+    isVirtual(ideal X, C)
     )
 
 --------------------------------------------------------------------
@@ -223,19 +178,15 @@ isVirtual (Module, NormalToricVariety, ChainComplex) := Boolean => opts -> (M, X
 -- Input: ZZ n - size of subset of generators to check
 --       Ideal J - ideal of ring
 --       Ideal irr - irrelevant ideal
--- Output: all subsets of size of the generators of J that give
---         the same ideal as J up to saturation by the irrelevant ideal
---         If the option GeneralElements is set to true, then
---         before outputting the subsets, the ideal generatered by the
---         general elements is outputted
+-- Output: a list of ideals generated by subsets of size n of the generators of J
+--         that give the same ideal as J up to saturation by the irrelevant ideal
 --------------------------------------------------------------------
 --------------------------------------------------------------------
-findGensUpToIrrelevance = method(Options => {GeneralElements => false})
-findGensUpToIrrelevance(ZZ, Ideal, Ideal) := List => opts -> (n, J, irr) -> (
+idealSheafGens = method(Options => {GeneralElements => false})
+idealSheafGens(ZZ, Ideal, Ideal) := List => opts -> (n, J, irr) -> (
     R := ring(J);
     k := coefficientRing(R);
     Jsat := ourSaturation(J,irr);
-    comps := decompose irr;
     if opts.GeneralElements == true then (
         degs := degrees(J);
         -- place of all unique degrees
@@ -243,26 +194,22 @@ findGensUpToIrrelevance(ZZ, Ideal, Ideal) := List => opts -> (n, J, irr) -> (
         -- creates an ideal where if degrees of generators match
         -- those generators are replaced by one generator that
         -- is a random combination of all generators of that degree
-        K := ideal(apply(allmatches, i -> sum(apply(i, j -> random(k) * J_j))));
-        J = K;
+        J = ideal(apply(allmatches, i -> sum(apply(i, j -> random(k) * J_j))));
         );
     lists := subsets(numgens(J), n);
     output := {};
-    if opts.GeneralElements == true then output = {J};
     apply(lists, l -> (
             I := ideal(J_*_l);
-            if ourSaturation(ourSaturation(I, comps_0), comps_1) == Jsat then (
-                output = append(output, l);
+            if ourSaturation(I, irr) == Jsat then (
+                output = append(output, I);
                 );
             )
         );
     output
     )
-
-findGensUpToIrrelevance(ZZ, Ideal, NormalToricVariety) := List => opts -> (n, J, X) -> (
-    findGensUpToIrrelevance(n, J, ideal X)
+idealSheafGens(ZZ, Ideal, NormalToricVariety) := List => opts -> (n, J, X) -> (
+    idealSheafGens(n, J, ideal X)
     )
-
 
 --------------------------------------------------------------------
 --------------------------------------------------------------------
@@ -510,7 +457,7 @@ multigradedPolynomialRing = n -> (
 ----- Description: This computes the multigraded regularity of a
 ----- module as defined in Definition 1.1 of [Maclagan, Smith 2004].
 ----- It returns a list of the minimal elements.
------ Caveat: This assumes M is B-saturated already i.e. H^1_I(M)=0
+----- Caveat: This assumes M is B-saturated already i.e. H^0_B(M)=0
 --------------------------------------------------------------------
 --------------------------------------------------------------------
 multigradedRegularity = method()
@@ -547,7 +494,7 @@ multigradedRegularity(Thing, Thing, Module) := List => (X, S, M) -> (
             if hilbertFunction(ell_0_0, M) != (map(QQ, ring H, ell_0_0))(H) then (
                 gt#(ell_0_0) = true;
                 );
-            -- Check that higher local cohomology vanishes (i.e., H^i_I(M) = 0 for i > 1)
+            -- Check that higher local cohomology vanishes (i.e., H^i_B(M) = 0 for i > 1)
             if ell_1 != 0 and ell_0_1 > 0 then (
                 gt#(ell_0_0) = true;
                 apply(n, j -> gt#(ell_0_0 + degree P_j) = true);
@@ -556,7 +503,7 @@ multigradedRegularity(Thing, Thing, Module) := List => (X, S, M) -> (
         );
     low := apply(n, i -> min (L / (ell -> ell_0_0_i - 1)));
     I := ideal apply(L, ell -> if not gt#?(ell_0_0) then product(n, j -> P_j^(ell_0_0_j - low_j)) else 0);
-    apply(flatten entries mingens I, g -> (flatten exponents g) + low)
+    sort apply(flatten entries mingens I, g -> (flatten exponents g) + low)
     )
 
 --------------------------------------------------------------------
@@ -609,6 +556,6 @@ uninstallPackage "VirtualResolutions"
 restart
 installPackage "VirtualResolutions"
 restart
-needsPackage "VirtualResolutions"
+needsPackage("VirtualResolutions", FileName => "./VirtualResolutions.m2")
 elapsedTime check "VirtualResolutions"
 viewHelp "VirtualResolutions"

--- a/M2/Macaulay2/packages/VirtualResolutions/Colon.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions/Colon.m2
@@ -130,6 +130,12 @@ saturationByElimination(Ideal, Ideal) := (I, J) -> (
     intersectionByElimination L
     )
 
+-- used when P = decompose irr
+saturationByElimination(Ideal, List) := (I, P) -> (
+    apply(P, J -> I = saturationByElimination(I,J));
+    I
+    )
+
 saturationByGrevLex(Ideal, Ideal) := (I, J) -> (
     L := for g in J_* list saturationByGrevLex(I, g);
     pows := L/last;

--- a/M2/Macaulay2/packages/VirtualResolutions/doc.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions/doc.m2
@@ -13,8 +13,8 @@ doc ///
      studying toric subvarieties when compared to minimal graded free resolutions.
 
      Introduced by Berkesch, Erman, and Smith in {\em Virtual resolutions for a product of projective spaces}
-     (see @{HREF("http://arxiv.org/abs/1703.07631","arXiv:1703.07631")}@) if $X$ is a smooth toric variety, $S$ the Cox ring of $X$
-     graded by the Picard group of $X$, and $B\subset S$ the irrelevant ideal of $X$, then
+     (see @{HREF("http://arxiv.org/abs/1703.07631","arXiv:1703.07631")}@) if $X$ is a smooth toric variety, $S$ is the Cox ring of $X$
+     graded by the Picard group of $X$, and $B\subset S$ is the irrelevant ideal of $X$, then
      a virtual resolution of a graded $S$-module $M$ is a complex of graded free $S$-modules, which
      sheafifies to a resolution of the associated sheaf of $M$.
 
@@ -75,47 +75,37 @@ doc ///
 doc ///
     Key
         isVirtual
-        (isVirtual,Ideal,Ideal,ChainComplex)
-        (isVirtual,Ideal,NormalToricVariety,ChainComplex)
-        (isVirtual,Module,Ideal,ChainComplex)
-        (isVirtual,Module,NormalToricVariety,ChainComplex)
+        (isVirtual,Ideal,ChainComplex)
+        (isVirtual,NormalToricVariety,ChainComplex)
     Headline
-        checks if a chain complex is a virtual resolution of a given module
+        checks whether a chain complex is a virtual resolution
     Usage
-        isVirtual(I,irr,C)
-        isVirtual(I,X,C)
-        isVirtual(M,irr,C)
-        isVirtual(M,X,C)
+        isVirtual(irr,C)
+        isVirtual(X,C)
     Inputs
-        I:Ideal
-            ideal that the virtual resolution should resolve
         irr:Ideal
             irrelevant ideal of the ring
         X:NormalToricVariety
             normal toric variety
         C:ChainComplex
-            chain complex we want to check is a virtual resolution
-        M:Module
-            module that the virtual resolution should resolve
+            chain complex we want to check if is a virtual resolution
     Outputs
         :Boolean
             true if C is a virtual resolution of I
             false if not
     Description
         Text
-            Given an ideal I, irrelevant ideal irr, and a chain complex C, isVirtual returns true if
-            C is a virtual resolution of I. If not, it returns false.
-
-            This is done by checking that the saturations of I and of the annihilator of $H_0(C)$
-            agree, then checking that the higher homology groups of C are supported on the irrelevant ideal.
+            Given the irrelevant ideal irr of a NormalToricVariety and a chain complex C, isVirtual returns true if
+            C is a virtual resolution of some module. If not, it returns false. This is done by checking that the 
+	    higher homology groups of C are supported on the irrelevant ideal.
 
             If debugLevel is larger than zero, the homological degree where isVirtual fails is printed.
         Example
           R = ZZ/101[s,t];
-          isVirtual(ideal(s),ideal(s,t),res ideal(t))
+          isVirtual(ideal(s,t),res ideal(t))
         Text
           Continuing our running example of three points $([1:1],[1:4])$, $([1:2],[1:5])$, and $([1:3],[1:6])$
-          in $\mathbb{P}^1 \times \mathbb{P}^1$, we can check that the virtual complex we compute below and
+          in $\mathbb{P}^1 \times \mathbb{P}^1$, we can check whether the virtual complex we compute below and
           in other places is in fact virtual.
         Example
           Y = toricProjectiveSpace(1)**toricProjectiveSpace(1);
@@ -127,16 +117,12 @@ doc ///
              ideal(x_1 - 3*x_0, x_3 - 6*x_2)), B);
           minres = res J;
           vres = virtualOfPair(J,{{3,1}});
-          isVirtual(J,B,vres)
+          isVirtual(B,vres)
         Text
           Finally, we can also use the Determinantal strategy, which implements Theorem 1.3 of
           @{HREF("http://arxiv.org/abs/1904.05994","arXiv:1904.05994")}@.
         Example
-          isVirtual(J,B,vres,Strategy=>Determinantal)
-    Caveat
-        For a module, isVirtual may return true for a proposed virtual resolution despite the chain complex
-        not being a virtual resolution; this occurs when the annihilator of the module and the annihilator of
-        $H_0(C)$ saturate to the same ideal.
+          isVirtual(B,vres,Strategy=>Determinantal)
 ///
 
 doc ///
@@ -155,14 +141,14 @@ doc ///
 
 doc ///
     Key
-        findGensUpToIrrelevance
-        (findGensUpToIrrelevance,ZZ,Ideal,Ideal)
-        (findGensUpToIrrelevance,ZZ,Ideal,NormalToricVariety)
+        idealSheafGens
+        (idealSheafGens,ZZ,Ideal,Ideal)
+        (idealSheafGens,ZZ,Ideal,NormalToricVariety)
     Headline
         creates a list of subsets of the minimal generators that generate a given ideal up to saturation
     Usage
-        findGensUpToIrrelevance(n,I,irr)
-        findGensUpToIrrelevance(n,I,X)
+        idealSheafGens(n,I,irr)
+        idealSheafGens(n,I,X)
     Inputs
         I:Ideal
         n:ZZ
@@ -171,40 +157,35 @@ doc ///
             irrelevant ideal
         X:NormalToricVariety
             normal toric variety whose Cox ring contains I
-
     Outputs
         :List
-            all subsets of size n of generators of I that generate I up to saturation with irr
+            all ideals generated by subsets of size n of generators of I that generate I up to saturation with irr
     Description
         Text
-            Given an ideal I, integer n, and irrelevant ideal irr, findGensUpToIrrelevance searches through
+            Given an ideal I, integer n, and irrelevant ideal irr, idealSheafGens searches through
             all n-subsets of the generators of I. If a subset generates the same irr-saturated ideal as the
-            irr-saturation of I, then that subset is added to a list. After running through all subsets, the list
-            is returned.
+            irr-saturation of I, then the ideal generated by that subset is added to a list.
+            After running through all subsets, the list is returned.
         Example
             R = ZZ/101[x_0,x_1,x_2,x_3,x_4,Degrees=>{2:{1,0},3:{0,1}}];
             B = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
             I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
-            findGensUpToIrrelevance(2,I,B)
-    Caveat
-        If no subset of generators generates the ideal up to saturation, then the empty list is returned.
+            idealSheafGens(2,I,B)
 ///
 
 doc ///
     Key
         GeneralElements
-        [findGensUpToIrrelevance, GeneralElements]
+        [idealSheafGens, GeneralElements]
     Headline
         combines generators of same degree into a general linear combination
     Description
         Text
-            If GeneralElements is set to true, findGensUpToIrrelevance will replace the given ideal with
-            an ideal where all generators of the same degree are combined into a general linear combination
-            of those generators, then run findGensUpToIrrelevance on the new ideal. The first element in the
-            output will be the new ideal, followed by the subsets of generators that will generate the original
-            ideal up to saturation.
+            If GeneralElements is set to true, idealSheafGens will replace all generators of I of the same degree with
+            a new generator of the that degree which is a general linear combination of those generators, then run
+	     idealSheafGens on the new ideal.
     SeeAlso
-        findGensUpToIrrelevance
+        idealSheafGens
 ///
 
 doc ///
@@ -388,7 +369,7 @@ doc ///
       Text
            When randomCurveP1P2 generates a random curve in $\mathbb{P}^3$ using the SpaceCurves package, it is possible the resulting
            curve will intersect the base loci of the projections used to construct the curve in $\mathbb{P}^1\times\mathbb{P}^2$. If the curve
-           does intersect the base locusi it will generate a new random curve in $\mathbb{P}^3$. The option Attempts limits the number
+           does intersect the base locusi it will generate a new random curve in $\mathbb{P}^3$. The option Attempt limits the number
            of attempts to find a curve disjoint from the base loci before quitting. By default, Attempt is set to 1000.
     SeeAlso
         randomCurveP1P2
@@ -435,7 +416,7 @@ doc ///
                 P + Q + R
                 );
             C = resolveViaFatPoint (I, irr, {2,1,0})
-            isVirtual(I, irr, C)
+            isVirtual(irr, C)
 ///
 
 
@@ -487,12 +468,26 @@ doc ///
         Text
           Finally, we check that the result is indeed virtual.
         Example
-          isVirtual(J,B,vres)
+          isVirtual(B,vres)
     Caveat
         Given an element of the multigraded regularity, one must add the dimension vector of the product of projective spaces
         for this to return a virtual resolution.
 ///
 
+doc ///
+    Key
+        [virtualOfPair, Strategy]
+    Headline
+        compute a virtual resolution using a syzygy by syzygy strategy
+    Description
+        Text
+            If Strategy is unspecified, virtualOfPair will compute a minimal free resolution before removing summands
+	    in specified degrees. This is often the fastest strategy because resolutions are efficiently computed in
+	    the engine. For larger cases, setting Strategy => UseSyzygies will compute a virtual resolution by iteratively
+	    computing syzygies and removing the desired degrees.
+    SeeAlso
+        virtualOfPair
+///
 
 doc ///
     Key
@@ -524,7 +519,7 @@ doc ///
           minimal elements of the multigraded Castelnuovo-Mumford regularity of M as defined in Definition 1.1
           of [MS04] (see @{HREF("http://arxiv.org/abs/math/0305214","arXiv:math/0305214")}@). If the input is an ideal, multigraded regularity of S^1/I is computed.
 
-          This is done by calling the cohomologyHashTable method from TateOnProducts and checking for the
+          This is done by calling the @TO cohomologyHashTable@ method from @TO TateOnProducts@ and checking for the
           multidegrees where Hilbert polynomial and Hilbert function match and where the higher sheaf cohomology
           vanishes.
 
@@ -543,7 +538,7 @@ doc ///
           L = multigradedRegularity(X, J)
 
         Text
-          This method also accepts the ring provided by productOfProjectiveSpaces from TateOnProduct package.
+          This method also accepts the ring provided by @TO productOfProjectiveSpaces@ from the @TO TateOnProducts@ package.
     Caveat
         The input is assumed to be saturated.
 ///

--- a/M2/Macaulay2/packages/VirtualResolutions/tests.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions/tests.m2
@@ -200,7 +200,7 @@ TEST ///
     assert(multigradedRegularity(S, I) == {{1,5},{2,2},{4,1}})
 ///
 
-TEST ///
+///
     (S, E) = productOfProjectiveSpaces {1, 1, 2};
     irr = intersect(ideal(x_(0,0), x_(0,1)), ideal(x_(1,0), x_(1,1)), ideal(x_(2,0), x_(2,1), x_(2,2)))
     I = saturate(intersect apply(6,i-> ideal(random({1,0,0},S),random({0,1,0},S), random({0,0,1},S),random({0,0,1},S))), irr);

--- a/M2/Macaulay2/packages/VirtualResolutions/tests.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions/tests.m2
@@ -81,7 +81,7 @@ TEST ///
         {x_0, -x_1, 0},
         {0, x_0, x_1}});
     C = chainComplex({d1,d2});
-    assert(isVirtual(I,irr,C) == true)
+    assert(isVirtual(irr,C) == true)
 ///
 
 TEST ///
@@ -92,7 +92,7 @@ TEST ///
         x_0*x_1*x_2^3+x_0*x_1*x_2^2*x_3-x_0^2*x_3^2*x_4+x_1^2*x_2*x_4^2+x_1^2*x_3*x_4^2,
         x_1^2*x_2^3+x_1^2*x_2^2*x_3-x_0*x_1*x_3^2*x_4-x_0^2*x_4^3}};
     C = chainComplex({d1});
-    assert(isVirtual(I,irr,C) == false)
+    assert(isVirtual(irr,C) == false)
 ///
 
 TEST ///
@@ -103,25 +103,7 @@ TEST ///
         x_0*x_1*x_2^3+x_0*x_1*x_2^2*x_3-x_0^2*x_3^2*x_4+x_1^2*x_2*x_4^2+x_1^2*x_3*x_4^2,
         x_1^2*x_2^3+x_1^2*x_2^2*x_3-x_0*x_1*x_3^2*x_4-x_0^2*x_4^3}};
     C = chainComplex({d1});
-    assert(isVirtual(I,irr,C) == false)
-///
-
-TEST ///
-    S = ZZ/32003[x_0,x_1,x_2,x_3,x_4, Degrees=>{2:{1,0},3:{0,1}}];
-    irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
-    I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
-    d1 = matrix{{x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2}};
-    C = chainComplex({d1});
-    assert(isVirtual(I,irr,C) == false)
-///
-
-TEST ///
-    S = ZZ/32003[x_0,x_1,x_2,x_3,x_4, Degrees=>{2:{1,0},3:{0,1}}];
-    irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
-    I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
-    d1 = matrix{{x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2}};
-    C = chainComplex({d1});
-    assert(isVirtual(I,irr,C) == false)
+    assert(isVirtual(irr,C) == false)
 ///
 
 TEST ///
@@ -129,39 +111,27 @@ TEST ///
     irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
     I = ideal(random({1,2},S),random({3,1},S),random({2,2},S));
     r = res I;
-    assert(isVirtual(I,irr,r) == true)
+    assert(isVirtual(irr,r) == true)
 ///
 
-TEST ///
-    X = toricProjectiveSpace(1)**toricProjectiveSpace(1);
-    S = ring X; B = ideal X;
-    J = saturate(intersect(
-            ideal(x_1 - 1*x_0, x_3 - 4*x_2),
-            ideal(x_1 - 2*x_0, x_3 - 5*x_2),
-            ideal(x_1 - 3*x_0, x_3 - 6*x_2)),
-            B);
-    minres = res J;
-    vres = virtualOfPair(J,{{3,1}});
-    assert isVirtual(J,B,vres,Strategy=>"Determinantal")
-///
-
------ Tests for findGensUpToIrrelevance
+----- Tests for idealSheafGens
 TEST ///
     debug needsPackage "VirtualResolutions"
     S = ZZ/32003[x_0,x_1,x_2,x_3,x_4, Degrees=>{2:{1,0},3:{0,1}}];
     irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
     I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
     J = ourSaturation(I,irr);
-    lst = {{0,1}};
-    assert(findGensUpToIrrelevance(2,J,irr) == lst)
+    assert(idealSheafGens(2,J,irr) == {I})
 ///
 
 TEST ///
+    debug needsPackage "VirtualResolutions"
     S = ZZ/32003[x_0,x_1,y_0,y_1, Degrees=>{2:{1,0},2:{0,1}}];
     irr = intersect(ideal(x_0,x_1),ideal(y_0,y_1));
     I = intersect(ideal(x_0,y_0),ideal(x_1,y_1));
-    output = findGensUpToIrrelevance(2,I,irr,GeneralElements=>true);
-    assert(length(output) == 3 and output_1 == {0,1} and output_2 == {1,2})
+    J = ourSaturation(I, irr);
+    output = idealSheafGens(2,I,irr,GeneralElements=>true);
+    assert(J == ourSaturation(output_0, irr) and J == ourSaturation(output_1, irr))
 ///
 
 TEST ///
@@ -170,8 +140,8 @@ TEST ///
     irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
     I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
     J = ourSaturation(I,irr);
-    output = findGensUpToIrrelevance(2,J,irr,GeneralElements=>true);
-    assert(length(output) == 2 and output_1 == {0,1})
+    output = idealSheafGens(2,J,irr,GeneralElements=>true);
+    assert(J == ourSaturation(output_0, irr))
 ///
 
 -- Test for resolveViaFatPoint
@@ -190,11 +160,11 @@ TEST ///
         R := sum for n to N#2 - 1 list ideal random({0,0,1}, S);
         P + Q + R
         )
-    assert isVirtual(I, irr, resolveViaFatPoint (I, irr, {2,1,0}))
-    assert isVirtual(I, irr, resolveViaFatPoint (I, irr, {3,3,0}))
+    assert isVirtual(irr, resolveViaFatPoint (I, irr, {2,1,0}))
+    assert isVirtual(irr, resolveViaFatPoint (I, irr, {3,3,0}))
 ///
 
--- Test for multiWinnow
+-- Test for virtualOfPair
 TEST ///
     X = toricProjectiveSpace(1)**toricProjectiveSpace(1);
     S = ring X; B = ideal X;
@@ -204,8 +174,10 @@ TEST ///
             ideal(x_1 - 3*x_0, x_3 - 6*x_2)),
             B);
     minres = res J;
-    vres = virtualOfPair(J,{{3,1}});
-    assert isVirtual(J,B,vres)
+    vres = virtualOfPair(minres,{{3,1}});
+    vres' = virtualOfPair(J,{{3,1}},Strategy=>"Syzygies");
+    assert isVirtual(B,vres);
+    assert isVirtual(B,vres',Strategy=>"Determinantal");
 ///
 
 -- Tests for multigradedRegularity
@@ -214,9 +186,9 @@ TEST ///
     S = ring X; B = ideal X;
     I = saturate(ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3)), B);
     -- taking NormalToricVariety as input
-    assert(multigradedRegularity(S, I) == {{2,2},{4,1},{1,5}})
+    assert(multigradedRegularity(S, I) == {{1,5},{2,2},{4,1}})
     -- taking the ring of NormalToricVariety as input
-    assert(multigradedRegularity(X, I) == {{2,2},{4,1},{1,5}})
+    assert(multigradedRegularity(X, I) == {{1,5},{2,2},{4,1}})
 ///
 
 TEST ///
@@ -225,13 +197,12 @@ TEST ///
     I = saturate(ideal(x_(0,0)^2*x_(1,0)^2+x_(0,1)^2*x_(1,1)^2+x_(0,0)*x_(0,1)*x_(1,2)^2,
             x_(0,0)^3*x_(1,2)+x_(0,1)^3*(x_(1,0)+x_(1,1))), B);
     -- taking the ring of a productOfProjectiveSpaces as input
-    assert(multigradedRegularity(S, I) == {{2,2},{4,1},{1,5}})
+    assert(multigradedRegularity(S, I) == {{1,5},{2,2},{4,1}})
 ///
 
--- FIXME: this test currently fails, but the issue doesn't appear to be in multigradedRegularity
-///
+TEST ///
     (S, E) = productOfProjectiveSpaces {1, 1, 2};
     irr = intersect(ideal(x_(0,0), x_(0,1)), ideal(x_(1,0), x_(1,1)), ideal(x_(2,0), x_(2,1), x_(2,2)))
     I = saturate(intersect apply(6,i-> ideal(random({1,0,0},S),random({0,1,0},S), random({0,0,1},S),random({0,0,1},S))), irr);
-    assert(length(multigradedRegularity(S, I)) > 0)
+    assert(multigradedRegularity(S, I) == {{0,0,2},{0,1,1},{0,5,0},{1,0,1},{1,2,0},{2,1,0},{5,0,0}})
 ///


### PR DESCRIPTION
This PR makes the following changes in VirtualResolutions package:
- rename findGensUpToIrrelevance to idealSheafGens and change the output type
- adds a UseSyzygies strategy to virtualOfPair
- changes the input types of isVirtual
- various improvements to documentation nodes
- fixes a previously commented test after fixing a small indexing issue in TateOnProducts, allowing correct computation of tateResolutions for products of three or more projective spaces.

For full commit history see https://github.com/Macaulay2/Workshop-2018-Madison/commits/Virtual