### PR TITLE
Fixes the expression of local rings and update documentation of (length, Module)

### DIFF
--- a/M2/Macaulay2/m2/localring.m2
+++ b/M2/Macaulay2/m2/localring.m2
@@ -23,25 +23,24 @@
 
 LocalRing = new Type of EngineRing
 LocalRing.synonym = "Local ring"
+LocalRing#{Standard,AfterPrint} = RP -> (
+     << endl << concatenate(interpreterDepth:"o") << lineNumber << " : "; -- standard template
+     << "LocalRing, maximal " << RP.MaximalIdeal << endl;
+     )
 
 localRing = method(TypicalValue => LocalRing)
       localRing LocalRing := identity
-     expression LocalRing := RP -> (expression localRing) (expression ring RP.MaximalIdeal, expression max RP)
-       describe LocalRing := RP -> net expression RP
-       toString LocalRing := RP -> (if hasAttribute(RP, ReverseDictionary)
-                                    then toString getAttribute(RP, ReverseDictionary)
-                                    else "localRing(" | toString ring RP.MaximalIdeal | ", " | toString RP.MaximalIdeal | ")")
-            net LocalRing := RP -> (if hasAttribute(RP, ReverseDictionary)
-                                    then toString getAttribute(RP, ReverseDictionary)
-                                    else net new FunctionApplication from { localRing, (ring RP.MaximalIdeal, RP.MaximalIdeal)})
+       describe LocalRing := RP -> Describe (expression localRing) (expression ring RP.MaximalIdeal, expression max RP)
+     expression LocalRing := RP -> if hasAttribute(RP, ReverseDictionary) then expression getAttribute(RP, ReverseDictionary) else describe RP
+toExternalString LocalRing:= RP -> toString describe RP
 coefficientRing LocalRing := RP -> coefficientRing ring RP.MaximalIdeal
   isWellDefined LocalRing := RP -> isPrime RP.MaximalIdeal
   isCommutative LocalRing := RP -> isCommutative ring RP.MaximalIdeal -- FIXME make sure this is correct
    degreeLength LocalRing := RP -> degreeLength ring RP.MaximalIdeal
    presentation LocalRing := RP -> map(RP^1, RP^0, 0)
-     generators LocalRing := opts ->
-                             RP -> (if opts.CoefficientRing =!= RP
-                                    then generators(ring RP.MaximalIdeal, opts) / (r -> promote(r, RP)) else {})
+     generators LocalRing := opts -> RP -> (if opts.CoefficientRing === ring RP.MaximalIdeal
+                                            then generators(ring RP.MaximalIdeal) / (r -> promote(r, RP))
+				            else generators(ring RP.MaximalIdeal, opts) / (r -> promote(r, RP)))
       precision LocalRing := RP -> precision ring RP.MaximalIdeal
         degrees LocalRing := RP -> degrees ring RP.MaximalIdeal
         numgens LocalRing := RP -> numgens ring RP.MaximalIdeal

--- a/M2/Macaulay2/packages/LocalRings/doc.m2
+++ b/M2/Macaulay2/packages/LocalRings/doc.m2
@@ -164,8 +164,7 @@ Description
     RP = localRing(R, ideal gens R);
     I = ideal"x5+y3+z3,x3+y5+z3,x3+y3+z5"
     M = RP^1/I
-    elapsedTime length M -- 0.55 seconds
-    elapsedTime hilbertSamuelFunction(M, 0, 6) -- 0.55 seconds
+    elapsedTime hilbertSamuelFunction(M, 0, 6)
     oo//sum
 
   Text
@@ -183,23 +182,39 @@ SeeAlso
   (length, Module)
 ///
 
-///
+doc ///
 Key
-   length
   (length, Module)
 Headline
-  Computes the length of modules over local rings
+  Computes the length of a module
 Usage
+  l = length M
 Inputs
+  M: Module
 Outputs
+  l: ZZ
+    the length of M
 Description
   Text
+    If M is a graded module over a singly graded polynomal ring or a quotient of a
+    polynomial ring over a field k then length is the same as the degree.
+
+    If M is over a local ring then length is computed by summing the output of
+    the Hilbert-Samuel function until it vanishes.
   Example
+    R = QQ[x,y,z];
+    RP = localRing(R, ideal gens R);
+    I = ideal"x5+y3+z3,x3+y5+z3,x3+y3+z5"
+    M = RP^1/I
+    elapsedTime length M
 Consequences
   Item
-    If the algorithm terminates, the length of the module is stored in M.cache.length.
+    If the function terminates, the length of the module is stored in M.cache.length.
 Caveat
+  The input is not verified to have finite length, therefore the function is not guaranteed to terminate.
 SeeAlso
+  (degree, Module)
+  hilbertSamuelFunction
 ///
 
 end--

--- a/M2/Macaulay2/packages/LocalRings/doc.m2
+++ b/M2/Macaulay2/packages/LocalRings/doc.m2
@@ -182,40 +182,7 @@ SeeAlso
   (length, Module)
 ///
 
-doc ///
-Key
-  (length, Module)
-Headline
-  Computes the length of a module
-Usage
-  l = length M
-Inputs
-  M: Module
-Outputs
-  l: ZZ
-    the length of M
-Description
-  Text
-    If M is a graded module over a singly graded polynomal ring or a quotient of a
-    polynomial ring over a field k then length is the same as the degree.
-
-    If M is over a local ring then length is computed by summing the output of
-    the Hilbert-Samuel function until it vanishes.
-  Example
-    R = QQ[x,y,z];
-    RP = localRing(R, ideal gens R);
-    I = ideal"x5+y3+z3,x3+y5+z3,x3+y3+z5"
-    M = RP^1/I
-    elapsedTime length M
-Consequences
-  Item
-    If the function terminates, the length of the module is stored in M.cache.length.
-Caveat
-  The input is not verified to have finite length, therefore the function is not guaranteed to terminate.
-SeeAlso
-  (degree, Module)
-  hilbertSamuelFunction
-///
+-- See (length, Module) in packages/Macaulay2Doc/functions/degree-doc.m2.
 
 end--
 

--- a/M2/Macaulay2/packages/LocalRings/legacy.m2
+++ b/M2/Macaulay2/packages/LocalRings/legacy.m2
@@ -125,15 +125,15 @@ localResolution Module := options -> (M) -> (
 	  );
      C)
 
-end--
-
 beginDocumentation()
 
+-*
 document { Key => LocalRings,
      Headline => "Polynomial rings localized at a maximal ideal",
      EM "LocalRings", " is a package for finding minimal generators, syzygies and resolutions
      for polynomial rings localized at a maximal ideal.",
      }
+*-
 
 document {
      Key => {setMaxIdeal, (setMaxIdeal,Ideal)},

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/degree-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/degree-doc.m2
@@ -163,20 +163,7 @@ document {
      SeeAlso => {hilbertPolynomial, isHomogeneous}
      }
 
-document { 
-     Key => (length,Module),
-     Usage => "length M",
-     Inputs => {
-	  "M"
-	  },
-     Outputs => {
-	  ZZ => {"the length of ", TT "M"}
-	  },
-     "We assume that ", TT "M", " is a graded module over a singly graded 
-     polynomal ring or a quotient of a polynomial ring, 
-     over a field ", TT "k", ".  In this case, the length is the same as the degree, 
-     see ", TO (degree,Module), "."
-     }
+-- (length,Module) was moved to packages/LocalRings/doc.m2
 
 document { 
      Key => (degree,Ring),

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/degree-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/degree-doc.m2
@@ -163,7 +163,34 @@ document {
      SeeAlso => {hilbertPolynomial, isHomogeneous}
      }
 
--- (length,Module) was moved to packages/LocalRings/doc.m2
+doc ///
+Key
+  (length, Module)
+Headline
+  Computes the length of a module
+Usage
+  l = length M
+Inputs
+  M: Module
+Outputs
+  l: ZZ
+    the length of M
+Description
+  Text
+    If M is a graded module over a singly graded polynomal ring or a quotient of a
+    polynomial ring over a field k then length is the same as the degree.
+
+    If M is over a local ring then length is computed by summing the output of
+    the Hilbert-Samuel function until it vanishes. Note that in this case the @TO LocalRings@
+    package must be loaded first.
+Consequences
+  Item
+    In the local case, the length of the module is stored in M.cache.length.
+Caveat
+  In the local case, the input is assumed to have finite length.
+SeeAlso
+  (degree, Module)
+///
 
 document { 
      Key => (degree,Ring),


### PR DESCRIPTION
This PR has two small changes that I was waiting to submit with an update to the local rings package, but that hasn't finished yet, so just wanted to submit these two for now:
- adds documentation for (length,Module) of local rings (I did this by moving the documentation node from degree-doc.m2 to LocalRings/doc.m2, but if you think it's better I can move the same thing to degree-doc.m2)
- fixes the expression of local rings. This has been an issue since v1.13, where named local rings were not presented correctly. (for instance compare [v1.12](https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.12/share/doc/Macaulay2/LocalRings/html/index.html) and [v1.13](https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.13/share/doc/Macaulay2/LocalRings/html/index.html))