### PR TITLE
Dockerfiles for M2

### DIFF
--- a/M2/BUILD/docker/.gitignore
+++ b/M2/BUILD/docker/.gitignore
@@ -1,0 +1,1 @@
+storage

--- a/M2/BUILD/docker/Dockerfile
+++ b/M2/BUILD/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && \
+    apt-get install -y curl gnupg apt-transport-https emacs && \
+    curl https://faculty.math.illinois.edu/Macaulay2/PublicKeys/Macaulay2-key -s --output - | apt-key add - && \
+    echo 'deb http://www.math.uiuc.edu/Macaulay2/Repositories/Ubuntu bionic main' > \
+    	 /etc/apt/sources.list.d/macaulay2.list && apt-get clean
+
+RUN apt-get update && \
+    apt-get install -y macaulay2 && \
+    apt-get clean
+
+RUN yes | M2 --silent --print-width 77 --stop --int --no-readline -q --no-randomize -e "setupEmacs(); exit(0);"
+COPY emacs-docker.el /root/.emacs
+
+WORKDIR /home
+ENTRYPOINT emacs
+
+# Create the image:
+# docker build --tag m2 .
+
+# Start a graphical instance:
+# docker run --volume `pwd`/storage:/home --volume `pwd`/../../../:/home/M2 --net=host --env="DISPLAY" m2
+
+# Start a non-graphical instance:
+# docker run --volume `pwd`/storage:/home --volume `pwd`/../../../:/home/M2 --interactive --tty m2

--- a/M2/BUILD/docker/Makefile
+++ b/M2/BUILD/docker/Makefile
@@ -1,0 +1,21 @@
+TAG = m2
+STORAGE = `pwd`/storage
+M2REPO = `pwd`/../../../
+
+always:
+	@cat README.md
+
+build: build-minimal
+
+run: run-graphical
+
+all: build run
+
+build-minimal:
+	docker build --tag $(TAG) .
+
+run-graphical:
+	docker run --volume $(STORAGE):/home --volume $(M2REPO):/home/M2 --net=host --env="DISPLAY" $(TAG)
+
+run-terminal:
+	docker run --volume $(STORAGE):/home --volume $(M2REPO):/home/M2 --interactive --tty $(TAG)

--- a/M2/BUILD/docker/README.md
+++ b/M2/BUILD/docker/README.md
@@ -1,0 +1,28 @@
+# Running Macaulay2 in Docker
+
+Docker is a software for building, shipping, or running applications on different
+platforms. A Dockerfile contains instructions for building an image with Macaulay2.
+
+## Getting Started
+0. Install Docker and start the daemon.
+
+1. Build a Macaulay2-in-a-container:
+```
+make build
+```
+
+2. Run Macaulay2-in-a-container:
+```
+make run
+```
+
+## Accessing files and packages
+
+A local folder named `storage` is shared as the `/home` directory inside the container.
+Furthermore, the current Macaulay2 git repository is available at `/home/M2`.
+
+## Other Use Cases
+ - build an RPM package for an arbitrary version of Fedora Linux from any platform.
+ - run the latest version of Macaulay2 on any OS that runs Docker (including Mac, Windows, etc.).
+ - develop Macaulay2 by running it on different libraries or kernels simultaneously.
+ - run any number of threads of the latest version of Macaulay2 in the cloud efficiently.

--- a/M2/BUILD/docker/emacs-docker.el
+++ b/M2/BUILD/docker/emacs-docker.el
@@ -1,0 +1,41 @@
+;; .emacs
+
+;; Macaulay2 start
+(load "~/.emacs-Macaulay2" t)
+
+(custom-set-variables
+ '(column-number-mode t)
+ '(inhibit-startup-screen t)
+ '(initial-scratch-message "\
+-- Welcome to Macaulay2!\n\
+-- This buffer is for scratchwork, and for Macaulay2 evaluations with \\[M2-send-to-program].\n\
+-- You can save this buffer into a file with \\[save-buffer], or open a file with \\[find-file].\n\
+-- Use \\[other-window] to cycle through visible buffers or \\[switch-to-buffer] to twitch to other buffers.\n\
+-- To exit, close Emacs with \\[save-buffers-kill-terminal].
+
+-* Here are some sample kcommands:\n\
+  R = ZZ/101[a,b,c,d]\n\
+  I = ideal(a^2-b*c, a^3-b^3, a^4-b*d^3, a^5-c^2*d^3)\n\
+  J = ideal groebnerBasis I;\n\
+  netList J_*\n\
+\n\
+  -- Some examples of rings\n\
+  A = ZZ/32003[a..g]\n\
+  B = QQ[x_1..x_6]\n\
+  C = ZZ/101[vars(0..12)]\n\
+*-\n\n"))
+
+(setq M2-demo-buffer "*scratch*")
+(setq initial-major-mode 'M2-mode)
+;; Macaulay2 end
+
+;; start on eshell, M2, and scratch
+(add-hook 'emacs-startup-hook
+	  (lambda ()
+	    (eshell)
+	    (call-interactively 'M2)
+	    (goto-line 8 "*scratch*")))
+
+;; set decent font size
+(custom-set-faces
+ '(default ((t (:family "DejaVu Sans Mono" :foundry "PfEd" :slant normal :weight normal :height 143 :width normal)))))


### PR DESCRIPTION
This PR will track work on Dockerfiles for Macaulay2 images, continuing from the Google groups [thread](https://groups.google.com/d/msg/macaulay2/tYMtN1hpIXk/caF9eM-hEQAJ).

The first commit adds a minimal Dockerfile which includes M2 v1.15 along with a graphical Emacs user interface. Run `make build` to build the image (<5 minutes) and `make run` to start and instance (<1 second).

We can add several other Dockerfiles here:
- compile from source and run tests for CI
- start a local Habanero instance (see [Dockerfile](https://github.com/Macaulay2/InteractiveShell/blob/master/Dockerfile) from InteractiveShell)
- start a local Jupyter instance with M2 (see @radoslavraynov's [Dockerfile](https://github.com/radoslavraynov/Macaulay2-Jupyter-Kernel/blob/master/docker/Dockerfile))

I'm not sure if `M2/BUILD/docker` is the most easy to find place for these so any suggestions are welcome.

