### PR TITLE
fixes #1061: teaching setup() about zsh

### DIFF
--- a/M2/Macaulay2/m2/files.m2
+++ b/M2/Macaulay2/m2/files.m2
@@ -498,6 +498,7 @@ installMethod(setup, () -> (
      mungeFile("~/"|".bashrc",startToken,endToken,M2profileRead) or
      mungeFile("~/"|".login",startToken,endToken,M2loginRead) or
      fileExists("~/"|".tcshrc" ) and mungeFile("~/"|".tcshrc",startToken,endToken,M2loginRead) or
+     fileExists("~/"|".zshrc" ) and mungeFile("~/"|".zshrc",startToken,endToken,M2loginRead) or
      mungeFile("~/"|".cshrc",startToken,endToken,M2loginRead) or
      mungeEmacs(); ))
 


### PR DESCRIPTION
macOS 10.15 Catalina switched the default shell to zsh, which for some reason does not know about M2 by default. This became an issue for at least one person at a coding sprint.

I'm not confident that this patch works on the prescribed situation though, as `.zshrc` or `.zprofile` files were not present, only `.zsh_history`. It could be that this machine was an exception, so someone else who has upgraded their Apple laptop to this version should ideally try it first.

It might also be worth using the `SHELL` environment variable instead.

fixes #1061