### PR TITLE
simplify (show, URL)

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -1181,6 +1181,7 @@ makePackageIndex List := path -> ( -- TO DO : rewrite this function to use the r
      )
 
 runnable := fn -> (
+     if fn == "" then false;
      if isAbsolutePath fn then fileExists fn
      else 0 < # select(1, apply(separate(":", getenv "PATH"), p -> p|"/"|fn), fileExists)
      )
@@ -1190,8 +1191,9 @@ show URL := x -> (
      url := x#0;
      if runnable "open" then browser := "open" -- Apple varieties
      else if runnable "xdg-open" then browser = "xdg-open" -- most Linux distributions
+     else if runnable getenv "WWWBROWSER" then browser = getenv "WWWBROWSER" -- compatibility
      else if runnable "firefox" then browser = "firefox" -- backup
-     else error "neither open nor xdg-open are found";
+     else error "neither open nor xdg-open are found and WWWBROWSER is not set";
      cmd := { browser, url };
      if fork() == 0 then (
 	  setGroupID(0,0);

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -1193,7 +1193,7 @@ show URL := x -> (
      else if runnable "xdg-open" then browser = "xdg-open" -- most Linux distributions
      else if runnable getenv "WWWBROWSER" then browser = getenv "WWWBROWSER" -- compatibility
      else if runnable "firefox" then browser = "firefox" -- backup
-     else error "neither open nor xdg-open are found and WWWBROWSER is not set";
+     else error "neither open nor xdg-open is found and WWWBROWSER is not set";
      cmd := { browser, url };
      if fork() == 0 then (
 	  setGroupID(0,0);

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -1181,38 +1181,18 @@ makePackageIndex List := path -> ( -- TO DO : rewrite this function to use the r
      )
 
 runnable := fn -> (
-     if isAbsolutePath fn then (
-	  fileExists fn
-	  )
-     else (
-     	  0 < # select(1,apply(separate(":", getenv "PATH"),p -> p|"/"|fn),fileExists)
-	  )
+     if isAbsolutePath fn then fileExists fn
+     else 0 < # select(1, apply(separate(":", getenv "PATH"), p -> p|"/"|fn), fileExists)
      )
-chk := ret -> if ret != 0 then (
-     if version#"operating system" === "MicrosoftWindows" and ret == 256 then return;     
-     error "external command failed"
-     )
-browserMethods := hashTable {
-     "firefox" => url -> {"firefox", url},
-     "open" => url -> {"open", url},
-     "cygstart" => url -> {"cygstart", url},
-     "netscape" => url -> {"netscape", "-remote",  "openURL(" | url | ")" },
-     "windows firefox" => url -> { "/cygdrive/c/Program Files/Mozilla Firefox/firefox", "-remote", "openURL(" | url | ")" }
-     }
 URL = new SelfInitializingType of BasicList
 new URL from String := (URL,str) -> new URL from {str}
 show URL := x -> (
      url := x#0;
-     browser := getenv "WWWBROWSER";
-     if version#"operating system" === "Darwin" and runnable "open" then browser = "open" -- should ignore WWWBROWSER, according to Mike
-     else
-     if version#"issue" === "Cygwin" then browser = "cygstart";
-     if browser === "" then (
-	  if runnable "firefox" then browser = "firefox"
-	  else if runnable "netscape" then browser = "netscape"
-	  else error "no browser found, and none specified in $WWWBROWSER"
-	  );
-     cmd := if browserMethods#?browser then browserMethods#browser url else { browser, url };
+     if runnable "open" then browser := "open" -- Apple varieties
+     else if runnable "xdg-open" then browser = "xdg-open" -- most Linux distributions
+     else if runnable "firefox" then browser = "firefox" -- backup
+     else error "neither open nor xdg-open are found";
+     cmd := { browser, url };
      if fork() == 0 then (
 	  setGroupID(0,0);
      	  try exec cmd;

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc1.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc1.m2
@@ -96,8 +96,9 @@ document {
      Consequences => {
 	  {"The given documentation page is displayed in your default web browser, as determined
 	    by either ", TT "open", " on macOS or ", TT "xdg-open", " on Linux distributions.
-	    As backup for when neither ", TT "open", " nor ", TT "xdg-open", " are available, ",
-	    TT "firefox", " used.
+	    As backup for when neither ", TT "open", " nor ", TT "xdg-open", " are available,
+	    the environmental variable ", TT "WWWBROWSER", " or ", TT "firefox", " are used.
+
 	    If no argument is given to ", TT "viewHelp", " then the top page of your local html
 	    documentation is displayed."}},
      "Some example uses:",

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc1.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc1.m2
@@ -96,8 +96,8 @@ document {
      Consequences => {
 	  {"The given documentation page is displayed in your default web browser, as determined
 	    by either ", TT "open", " on macOS or ", TT "xdg-open", " on Linux distributions.
-	    As backup for when neither ", TT "open", " nor ", TT "xdg-open", " are available,
-	    the environmental variable ", TT "WWWBROWSER", " or ", TT "firefox", " are used.
+	    As backup for when neither ", TT "open", " nor ", TT "xdg-open", " is available,
+	    the environmental variable ", TT "WWWBROWSER", " or ", TT "firefox", " is used.
 
 	    If no argument is given to ", TT "viewHelp", " then the top page of your local html
 	    documentation is displayed."}},

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc1.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc1.m2
@@ -94,9 +94,12 @@ document {
 	  "s" => "a descriptor for a documentation node (see below for examples)"
 	  },
      Consequences => {
-	  {"The given documentation page is displayed in your default web browser.  If
-	  the browser is not running, it is started.  If no argument is given to ", TT "viewHelp", 
-	  "then the top page of your local html documentation is displayed."}},
+	  {"The given documentation page is displayed in your default web browser, as determined
+	    by either ", TT "open", " on macOS or ", TT "xdg-open", " on Linux distributions.
+	    As backup for when neither ", TT "open", " nor ", TT "xdg-open", " are available, ",
+	    TT "firefox", " used.
+	    If no argument is given to ", TT "viewHelp", " then the top page of your local html
+	    documentation is displayed."}},
      "Some example uses:",
      UL {
 	  (TT "viewHelp", " -- top of local copy of the documentation, including installed packages"),	  


### PR DESCRIPTION
This PR simplifies part of `html.m2` that deals with opening a browser. With this change, instead of specifying how to open a few browsers, we look for the `open` on macOS and `[xdg-open](https://www.freedesktop.org/wiki/Software/xdg-utils/)` on Linux. I'm fairly sure all Linux distributions that we support come with `xdg-utils` scripts, but I haven't tested them all, so as a backup we still check if firefox exists.