### PR TITLE
fix (check, Package)

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -509,9 +509,9 @@ runFile := (inf,inputhash,outf,tmpf,desc,pkg,announcechange,usermode,examplefile
      if # findFiles rundir == 1
      then removeDirectory rundir
      else stderr << rundir << ": error: files remain in temporary run directory after program exits abnormally" << endl;
-     r = if r<256 then r else r//256;
-     stderr << "M2: *** Error " << r << endl;
-     if r == 2 then error "interrupted";
+     if r % 256 == 0 then r = r >> 8; -- cancelling (ret) << 8 in bits/waitstatus.h
+     if r % 128 == 2 then error ("interrupted" | if r & 128 =!= 0 then " (core dumped)" else "")
+     else stderr << "M2: *** Error " << r << endl;
      hadExampleError = true;
      numExampleErrors = numExampleErrors + 1;
      return false;

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -509,7 +509,8 @@ runFile := (inf,inputhash,outf,tmpf,desc,pkg,announcechange,usermode,examplefile
      if # findFiles rundir == 1
      then removeDirectory rundir
      else stderr << rundir << ": error: files remain in temporary run directory after program exits abnormally" << endl;
-     stderr << "M2: *** Error " << (if r<256 then r else r//256) << endl;
+     r = if r<256 then r else r//256;
+     stderr << "M2: *** Error " << r << endl;
      if r == 2 then error "interrupted";
      hadExampleError = true;
      numExampleErrors = numExampleErrors + 1;


### PR DESCRIPTION
When Macaulay2 runs tests or creates documentation examples, if the process is interrupted with ctrl-c we want to stop running the rest of the tests or examples. This happened by checking whether the return code is 2. At least on my system, however, `(run, String)` multiplies the exit code by 256, which prevents Macaulay2 from detecting ctrl-c. This PR fixed this behavior.

**Question:** I couldn't find the source of `(run, String)` to verify whether multiplication by 256 happens in Macaulay2 or by some system call on my system. Where is it defined? I found it in `actors3.d` but can't find it in engine.