### PR TITLE
Fix the build with -fno-common (default for GCC 10)

### DIFF
--- a/M2/Macaulay2/c/scc.h
+++ b/M2/Macaulay2/c/scc.h
@@ -18,7 +18,7 @@
 struct POS { char *filename; short lineno, column; } ;
 typedef struct NODE *node;
 typedef struct SCOPE *scope;
-scope global_scope;
+extern scope global_scope;
 typedef node (*chkfun) (node,scope);
 
 #define clear_memory(v) memset(v,0,sizeof(*v))

--- a/M2/Macaulay2/c/scc1.c
+++ b/M2/Macaulay2/c/scc1.c
@@ -2,6 +2,7 @@
 
 #include "scc.h"
 
+scope global_scope;
 FILE *dependfile;
 char *targetname;
 char *outfilename;


### PR DESCRIPTION
The upcoming GCC 10 release changes the long-standing default of -fcommon to -fno-common (see https://gcc.gnu.org/gcc-10/changes.html), thereby breaking the Macaulay2 build in Fedora Rawhide.  This patch fixes the lone instance of a multiply-defined variable.