### PR TITLE
Check that we're using googletest >= 1.10.0 during build.

### DIFF
--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -83,7 +83,7 @@ various modern operating systems:
 
   Ubuntu and Debian:
     Install packages as root with:
-      apt-get install -y -q sudo autoconf bison curl emacs fflas-ffpack flex g++ gcc gfortran install-info libatomic-ops-dev libboost-dev libc6-dev libcdd-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfr-dev libncurses-dev libncurses5-dev libntl-dev libpari-dev libreadline-dev libtool libxml2-dev libz-dev make openssh-server patch pinentry-curses pkg-config time unzip xbase-clients yasm zlib1g-dev polymake w3c-markup-validator git dpkg-dev gfan
+      apt-get install -y -q sudo autoconf bison cmake curl emacs fflas-ffpack flex g++ gcc gfortran install-info libatomic-ops-dev libboost-dev libc6-dev libcdd-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfr-dev libncurses-dev libncurses5-dev libntl-dev libpari-dev libreadline-dev libtool libxml2-dev libz-dev make openssh-server patch pinentry-curses pkg-config time unzip xbase-clients yasm zlib1g-dev polymake w3c-markup-validator git dpkg-dev gfan
         # note: libz-dev seems to have been replaced by zlib1g-dev
         # note: libncurses-dev seems to have been replaced by libncurses5-dev
         # note: libreadline-gplv2-dev is an older GPL v2 version of libreadline
@@ -103,7 +103,7 @@ various modern operating systems:
 
   Raspbian:
     Install packages with:
-      sudo apt-get install -y -q autoconf bison curl emacs flex g++ gcc gfortran libc6-dev libcdd-dev libgc-dev libgdbm-dev libglpk-dev libgmp3-dev liblapack-dev libmpfr-dev libncurses-dev libntl-dev libpari-dev libreadline-dev libxml2-dev libz-dev make openssh-server subversion xbase-clients time libtool libmpc-dev yasm
+      sudo apt-get install -y -q autoconf bison cmake curl emacs flex g++ gcc gfortran libc6-dev libcdd-dev libgc-dev libgdbm-dev libglpk-dev libgmp3-dev liblapack-dev libmpfr-dev libncurses-dev libntl-dev libpari-dev libreadline-dev libxml2-dev libz-dev make openssh-server subversion xbase-clients time libtool libmpc-dev yasm
     On a 32-bit system, add
         --with-mpir-config-options="ABI=32 --build=i686-pc-linux-gnu"
       to the "configure" command line below.  (The --build option is necessary
@@ -114,11 +114,11 @@ various modern operating systems:
 
   Fedora:
     Install packages with:
-      sudo dnf -y install autoconf bison boost-devel cddlib-devel debuginfo-install emacs emacs factory-devel flex flint-devel frobby gc-devel gcc-c++ gdbm-devel git givaro-devel glpk-devel gmp-devel gtest-devel kernel-devel kernel-devel lapack-devel libatomic_ops-devel libfac-devel libgfortran-static libgfortran-static libmpc-devel libtool libxml2-devel mpfr-devel mpir-devel ncurses-devel ntl-devel pari-devel patch polymake readline-devel rpm-build rpm-sign rpmdevtools strace time which yasm
+      sudo dnf -y install autoconf bison boost-devel cddlib-devel cmake debuginfo-install emacs emacs factory-devel flex flint-devel frobby gc-devel gcc-c++ gdbm-devel git givaro-devel glpk-devel gmp-devel gtest-devel kernel-devel kernel-devel lapack-devel libatomic_ops-devel libfac-devel libgfortran-static libgfortran-static libmpc-devel libtool libxml2-devel mpfr-devel mpir-devel ncurses-devel ntl-devel pari-devel patch polymake readline-devel rpm-build rpm-sign rpmdevtools strace time which yasm
 
   Scientific linux (Red Hat, CentOS, ...):
     Install packages with: (SL 7.x)
-      sudo yum install -y autoconf bison boost-devel emacs flex gc-devel gcc-c++ gcc-gfortran gdbm-devel glpk-devel gmp-devel lapack-devel libatomic_ops-devel  libtool libxml2-devel mpfr-devel ncurses-devel readline-devel rpm-build rpm-sign git-all zlib-devel xz-devel libmpc-devel time blas blas-devel texinfo redhat-lsb wget
+      sudo yum install -y autoconf bison boost-devel cmake emacs flex gc-devel gcc-c++ gcc-gfortran gdbm-devel glpk-devel gmp-devel lapack-devel libatomic_ops-devel  libtool libxml2-devel mpfr-devel ncurses-devel readline-devel rpm-build rpm-sign git-all zlib-devel xz-devel libmpc-devel time blas blas-devel texinfo redhat-lsb wget
     Install other software:
       Download yasm from http://yasm.tortall.net/Download.html and install it in /usr/local, the usual
         way (untar, configure, make, make install).
@@ -137,7 +137,7 @@ various modern operating systems:
 
   Suse Linux Leap 42.1:
 
-    sudo zypper -n install man man-pages emacs-x11 gcc git screen autoconf bison createrepo emacs flex gc-devel gcc gcc-c++ gcc-fortran gdbm-devel gmp-devel lapack-devel libxml2-devel make mpfr-devel ncurses-devel patch readline-devel subversion zlib-devel libtool libatomic_ops-devel libmpir-devel mpfr-devel pari-devel ntl-devel flint-devel glpk-devel cddlib-devel givaro-devel boost-devel rpm-build mpc-devel yasm
+    sudo zypper -n install man man-pages emacs-x11 gcc git screen autoconf bison cmake createrepo emacs flex gc-devel gcc gcc-c++ gcc-fortran gdbm-devel gmp-devel lapack-devel libxml2-devel make mpfr-devel ncurses-devel patch readline-devel subversion zlib-devel libtool libatomic_ops-devel libmpir-devel mpfr-devel pari-devel ntl-devel flint-devel glpk-devel cddlib-devel givaro-devel boost-devel rpm-build mpc-devel yasm
 
     Add
 
@@ -151,7 +151,7 @@ various modern operating systems:
 
       sudo pacman --sync --needed archlinux-keyring
       sudo pacman-key --populate archlinux
-      sudo pacman --sync --needed autoconf automake bison boost cddlib emacs flex flint gc gcc gcc-fortran gdbm gfan git givaro glpk gmp gtest lapack make mpfr nauty ntl pkg-config readline texinfo time unzip yasm gtest wget patch
+      sudo pacman --sync --needed autoconf automake bison boost cddlib cmake emacs flex flint gc gcc gcc-fortran gdbm gfan git givaro glpk gmp gtest lapack make mpfr nauty ntl pkg-config readline texinfo time unzip yasm gtest wget patch
 
     To upgrade the system:
 

--- a/M2/config/gtest.m4
+++ b/M2/config/gtest.m4
@@ -57,6 +57,16 @@ AC_DEFUN([CHECK_GTEST],
 
   AC_CHECK_FILES([$GTEST_SOURCE/src/gtest-all.cc]
                  [$GTEST_SOURCE/src/gtest_main.cc],
+                 # mathicgb's unit tests fail to build with googletest
+                 # 1.8.1, so we require googletest >= 1.10.0. As the
+                 # gtest-config script may or may not be available to
+                 # check the version number (e.g., it's not included in
+                 # the Debian googletest package), we instead compile a
+                 # short program using TYPED_TEST_SUITE, one of the
+                 # functions which was introduced in 1.10.0 in the
+                 # switch from the *_TEST_CASE to the *_TEST_SUITE naming
+                 # convention.  If this test fails, then an older
+                 # googletest is installed and we will build it instead.
                  [AC_COMPILE_IFELSE(
 		   [AC_LANG_PROGRAM(
 		     [[#include <gtest/gtest.h>]],

--- a/M2/config/gtest.m4
+++ b/M2/config/gtest.m4
@@ -55,14 +55,20 @@ AC_DEFUN([CHECK_GTEST],
 
   AC_CHECK_HEADER([gtest/gtest.h])
 
+  AC_CHECK_FILES([$GTEST_SOURCE/src/gtest-all.cc]
+                 [$GTEST_SOURCE/src/gtest_main.cc],
+                 [AC_COMPILE_IFELSE(
+		   [AC_LANG_PROGRAM(
+		     [[#include <gtest/gtest.h>]],
+		     [[TYPED_TEST_SUITE(int, int);]])],
+		   [have_gtest_source=yes],
+		   [AC_MSG_WARN([googletest source found, but it has version < 1.10.0, which is needed for mathicgb])
+		    have_gtest_source=no])],
+                 [have_gtest_source=no])
+
   CPPFLAGS="$tmp_CPPFLAGS"
 
   AC_LANG_POP
-
-  AC_CHECK_FILES([$GTEST_SOURCE/src/gtest-all.cc]
-                 [$GTEST_SOURCE/src/gtest_main.cc],
-                 [have_gtest_source=yes],
-                 [have_gtest_source=no])
 
   AS_IF([test "x$ac_cv_header_gtest_gtest_h" = xyes -a \
               "x$have_gtest_source" = xyes],

--- a/M2/libraries/gtest/Makefile.in
+++ b/M2/libraries/gtest/Makefile.in
@@ -1,7 +1,8 @@
 # from https://github.com/google/googletest/archive/release-1.8.0.tar.gz, renamed to gtest-1.8.0.tar.gz
-VERSION = 1.8.0
+VERSION = 1.10.0
 TARDIR = googletest-release-$(VERSION)/googletest
-PRECONFIGURE = autoreconf -vif
+CONFIGURECMD = :
+BUILDCMD = cmake
 
 LICENSEFILES = LICENSE
 URL = http://macaulay2.com/Downloads/OtherSourceCode


### PR DESCRIPTION
mathicgb's unittests fail using 1.8.1 (Macaulay2/mathicgb#12
and Macaulay2/mathicgb#13).  We adapt the check proposed in
Macaulay2/mathicgb#15 to Macaulay2.

closes: #1058