### PR TITLE
Update to latest versions of givaro and fflas_ffpack

### DIFF
--- a/M2/Macaulay2/e/aring-gf-givaro.cpp
+++ b/M2/Macaulay2/e/aring-gf-givaro.cpp
@@ -409,7 +409,7 @@ void ARingGFGivaro::getGenerator(ElementType &result_gen) const
 
 bool ARingGFGivaro::is_unit(const ElementType f) const
 {
-  return givaroField.isunit(f);
+  return givaroField.isUnit(f);
 }
 
 bool ARingGFGivaro::is_zero(const ElementType f) const

--- a/M2/Macaulay2/e/dmat.cpp
+++ b/M2/Macaulay2/e/dmat.cpp
@@ -101,9 +101,10 @@ void determinant(const DMatZZpFFPACK& mat, ZZpFFPACK::ElementType& result_det)
   else
     {
       DMatZZpFFPACK N(mat);
+      ZZpFFPACK::ElementType det;
       result_det = FFPACK::Det(mat.ring().field(),
+                               det,
                                mat.numRows(),
-                               mat.numColumns(),
                                N.array(),
                                mat.numColumns());
     }

--- a/M2/libraries/givaro/Makefile.in
+++ b/M2/libraries/givaro/Makefile.in
@@ -8,7 +8,7 @@ URL = http://macaulay2.com/Downloads/OtherSourceCode
 VLIMIT = 900000
 MLIMIT = 900000
 
-VERSION = 4.0.2
+VERSION = 4.1.1
 # disable the test because it fails to find <bits/stl_pair.h>
 # CHECKTARGET = .
 LICENSEFILES = COPYRIGHT Licence_CeCILL-B_V1-en.txt Licence_CeCILL-B_V1-fr.txt


### PR DESCRIPTION
As discussed in #1114, we currently build old versions of givaro and fflas_ffpack.  There have been some small API changes in the latest versions.  (In particular, `isunit` has become `isUnit` in givaro, and `Det` takes slightly different arguments in ffpack.)

In these commits, we install the latest versions and update our calls to these libraries.
