### PR TITLE
Print useful message and raise an error when call to gfan fails

### DIFF
--- a/M2/Macaulay2/packages/gfanInterface.m2
+++ b/M2/Macaulay2/packages/gfanInterface.m2
@@ -1016,20 +1016,21 @@ runGfanCommand = (cmd, opts, data) -> (
 
 	if gfanVerbose then << ex << endl;
 	returnvalue := run ex;
+	errorMsg := "";
      	if(not returnvalue == 0) then
 	(
---	     << "GFAN returned an error message.\n";
---	     << "COMMAND:" << ex << endl;
---	     << "INPUT:\n";
---	     << get(tmpFile);
---	     << "ERROR:\n";
---	     << get(tmpFile |".err");
-
+	    errorMsg = "GFAN returned an error message.\n";
+	    errorMsg = errorMsg | "COMMAND:" | ex | "\n";
+	    errorMsg = errorMsg | "INPUT:\n";
+	    errorMsg = errorMsg | get(tmpFile);
+	    errorMsg = errorMsg | "ERROR:\n";
+	    errorMsg = errorMsg | get(tmpFile |".err");
 	     );
 		out := get(tmpFile | ".out");
 	gfanRemoveTemporaryFile tmpFile;
 	gfanRemoveTemporaryFile(tmpFile | ".out");
 	gfanRemoveTemporaryFile(tmpFile | ".err");
+	if length(errorMsg) > 0 then error errorMsg;
 	outputFileName := null;
 	
 	if gfanKeepFiles then outputFileName = tmpFile|".out";

--- a/M2/Macaulay2/packages/gfanInterface.m2
+++ b/M2/Macaulay2/packages/gfanInterface.m2
@@ -88,11 +88,52 @@ export {
 	"multiplicitiesReorder"
 }
 
-gfanPath = gfanInterface#Options#Configuration#"path"
-if gfanPath == "" then gfanPath = prefixDirectory | currentLayout#"programs"
+tryGfanPath = gfanPath -> run(gfanPath | "gfan --help 2> /dev/null")
+
+-- we expect a trailing slash in the path, but the paths given in the
+-- PATH environment variable likely will not have one, so we add one
+-- if needed
+addSlash = gfanPath -> (
+	if last gfanPath != "/" then return gfanPath | "/"
+	else return gfanPath
+)
+
+checkGfanPath = gfanPath -> (
+	if gfanVerbose == true then
+		print("checking for gfan in " | gfanPath | "...");
+	if tryGfanPath(gfanPath) == 0 then (
+		if gfanVerbose == true then print("  found");
+		return true
+	) else (
+		if gfanVerbose == true then print("  not found");
+		return false
+	)
+)
+
+findGfanPath = () -> (
+	-- try user-configured path first
+	gfanPath := gfanInterface#Options#Configuration#"path";
+	if gfanPath != "" then (
+		gfanPath = addSlash(gfanPath);
+		if checkGfanPath(gfanPath) then return gfanPath;
+	);
+	-- now try M2-installed gfan
+	gfanPath = addSlash(prefixDirectory | currentLayout#"programs");
+	if checkGfanPath(gfanPath) then return gfanPath;
+	-- finally, try PATH
+	if getenv "PATH" == "" then error "could not find gfan";
+	paths := apply(separate(":", getenv "PATH"), addSlash);
+	gfanPath = scan(paths, gfanPath ->
+		if checkGfanPath(gfanPath) then break gfanPath
+	);
+	if class(gfanPath) === String then return gfanPath
+	else error "could not find gfan"
+)
 
 fig2devPath = gfanInterface#Options#Configuration#"fig2devpath"
 gfanVerbose = gfanInterface#Options#Configuration#"verbose"
+gfanPath = findGfanPath()
+
 gfanKeepFiles = gfanInterface#Options#Configuration#"keepfiles"
 gfanCachePolyhedralOutput = gfanInterface#Options#Configuration#"cachePolyhedralOutput"
 --minmax switch disabled


### PR DESCRIPTION
The printing of a message existed in the code but was commented out.
In addition, we raise an error.  If our call to gfan doesn't work,
then the user should be informed right away rather than encountering
a less useful error a bit later when Macaulay2 isn't able to deal
with the output that doesn't exist.

Closes: #1066