### PR TITLE
Remove empty example-output directories.

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -822,6 +822,10 @@ installPackage Package := opts -> pkg -> (
  	  if not opts.IgnoreExampleErrors 
 	  then if hadExampleError then error(toString numExampleErrors, " error(s) occurred running examples for package ", pkg#"pkgname");
 
+	  -- if no examples were generated, then remove the directory
+	  if length readDirectory exampleOutputDir == 2 then
+	  	  removeDirectory exampleOutputDir;
+
 	  -- process documentation
 	  rawkey := "raw documentation database";
 	  if verbose then stderr << "--processing documentation nodes..." << endl;


### PR DESCRIPTION
They were resulting in a "package-contains-empty-directory" Lintian
warning in the Debian package:

> This package installs an empty directory. This might be intentional
> but it's normally a mistake. If it is intentional, add a Lintian
> override.
>
> If a package ships with or installs empty directories, you can remove
> them in debian/rules by calling:
>
> $ find path/to/base/dir -type d -empty -delete