### PR TITLE
Output version number with autoconf

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -25,8 +25,7 @@ dnl Note:
 dnl   Debian distributions may append a "downstream" debian release number N to the version number: X.Y.Z-N
 dnl   See distributions/deb/Makefile.in, where we allow for that, as a way to fix badly prepared binary distributions.
 
-AC_INIT(Macaulay2, NO_VERSION_NUMBER, Macaulay2@math.uiuc.edu, Macaulay2, http://macaulay2.com/)
-PACKAGE_VERSION=`cat $srcdir/VERSION`
+AC_INIT(Macaulay2, [m4_esyscmd_s([cat VERSION])], Macaulay2@math.uiuc.edu, Macaulay2, http://macaulay2.com/)
 
 dnl The convention for version numbers of Macaulay2 is this:
 dnl   1.3     : a major release, such as occurs every 6-12 months, stable, made into binary distributions


### PR DESCRIPTION
In c0e33c4, the version number was moved to a separate VERSION file and
assigned to a shell variable by autoconf.  However, autoconf will only
substitute output variables during AC_OUTPUT, not all shell variables.
Indeed, from config.log:

```
| #define PACKAGE_VERSION "NO_VERSION_NUMBER"
```

And when running Macaulay2:

```
Macaulay2, version NO_VERSION_NUMBER
```

Instead, we use a solution from https://stackoverflow.com/questions/8559456.
Note that we no longer need to use $srcdir to find VERSION.  It will work
from any build directory.