### PR TITLE
Get the source code for functions defined in startup.m2.in.

### DIFF
--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -8,7 +8,7 @@ getSourceLines Sequence := x -> (
      (filename,start,startcol,stop,stopcol,pos,poscol) -> if filename =!= "stdio" then (
 	  wp := set characters " \t\r);";
 	  file := (
-	       if filename === "layout.m2" then startupString
+	       if match("startup.m2.in$", filename) then startupString
 	       else if filename === "currentString" then currentString
 	       else (
 		    if not fileExists filename then error ("couldn't find file ", filename);

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc13.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc13.m2
@@ -232,7 +232,7 @@ document { Key => {applicationDirectory, "application directory"},
 	  },
      PARA { "The function ", TO "applicationDirectorySuffix", " determines the value of ", TT "applicationDirectory", ", and can be modified by the user." },
      EXAMPLE "applicationDirectory()",
-     SeeAlso => applicationDirectorySuffix}
+     SeeAlso => "applicationDirectorySuffix"}
 
 document {
      Key => installedPackages,

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc13.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc13.m2
@@ -225,6 +225,7 @@ document { Key => {applicationDirectory, "application directory"},
      Headline => "the path to the user's application directory",
      Usage => "applicationDirectory()",
      Outputs => { String => "the path to the user's application directory" },
+     SourceCode => applicationDirectory,
      PARA { "The function ", TO "installPackage", ", by default, installs packages under the application directory.  At program startup,
 	  unless the ", TT "-q", " option is provided on the command line, an entry will be added to the ", TO "path", " so
 	  packages can be loaded from there by ", TO "loadPackage", " and ", TO "needsPackage", ".  Moreover, the ", TO "initialization file", ", if found there, will be run."


### PR DESCRIPTION
This file only exists in the Macaulay2 source code and is not installed.
However, its contents are available as a string, and we can still
access it.  The code to do this exists in code.m2, but was still
set up for when these functions were defined in layout.m2, which hasn't
existed since fb2a04e.

We also restore the SoureCode option to applicationDirectory's
documentation.  It was removed in 728c632 because of this bug.