### PR TITLE
Run M2 with -q during 'make check'

### DIFF
--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -52,7 +52,7 @@ relink:
 foo : ; : @libdir@ $(BUILTLIBPATH)
 
 check: $(EXEFILE)
-	LD_LIBRARY_PATH="$(BUILTLIBPATH)/lib:$$LD_LIBRARY_PATH" $< --check 1 --stop -E "exit 0"
+	LD_LIBRARY_PATH="$(BUILTLIBPATH)/lib:$$LD_LIBRARY_PATH" $< --check 1 -q --stop -E "exit 0"
 
 ifeq (@OS@,Darwin)
 # We specify the search path for finding shareable libraries, in case there are any,


### PR DESCRIPTION
Otherwise, we try to create ~/.Macaulay2 but we may not have permission
to create this directory.  For example, during a test build of the
Debian package:

    ../m2/files.m2:18:30:(1):[16]: error: can't make directory
    "/nonexistent": Permission denied