### PR TITLE
Don't update git submodules if we aren't building any

### DIFF
--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -12,6 +12,9 @@ all install:										\
 ifeq "@DEVELOPMENT@" "yes"
 optional-git-submodule-update:
 	: skipping automatic updating of submodules, because --enable-development was specified
+else ifeq "@BUILDSUBLIST@" ""
+optional-git-submodule-update:
+	: skipping automatic updating of submodules, because no submodules are being built
 else
 optional-git-submodule-update:
 	git submodule update


### PR DESCRIPTION
This new feature was causing failures in building the Debian package
as git is not a build dependency, and the Debian packages for
fflas-ffpack, memtailor, mathic, and mathicgb are used instead of
building them from the submodules.