### PR TITLE
Find gftables during check-configure if they were not built

### DIFF
--- a/M2/Macaulay2/d/startup.m2.in
+++ b/M2/Macaulay2/d/startup.m2.in
@@ -286,7 +286,7 @@ if firstTime then (
 	       "programs" => "@programsdir@/",
 	       "program licenses" => "@licensesdir@/",
 	       "package" => "@packagesdir@/PKG/",
-	       "factory gftables" =>  "@gftablesdir@",
+	       "factory gftables" =>  "@GFTABLESDIR@",
 	       "packagedoc" => "@docdir@/PKG/",
 	       "packageimages" => "@docdir@/PKG/images/",
 	       "packagetests" => "@docdir@/PKG/tests/",

--- a/M2/check-configure/Makefile.in
+++ b/M2/check-configure/Makefile.in
@@ -14,7 +14,7 @@ check-config:
 	    PATH="$(BUILTLIBPATH)/bin:$(PATH)"					\
 	    @abs_top_srcdir@/configure						\
 	    PKG_CONFIG_PATH=$(BUILTLIBPATH)/lib/pkgconfig:$(PKG_CONFIG_PATH)	\
-	    GFTABLESDIR=@pre_packagesdir@/Core/factory/				\
+	    GFTABLESDIR=@gftablesdir@						\
 	    LDFLAGS="$(LDFLAGS)"						\
 	    --with-gtest-source-path="@GTEST_PATH@"				\
 	    CPPFLAGS="$(CPPFLAGS)"						\

--- a/M2/check-configure/Makefile.in
+++ b/M2/check-configure/Makefile.in
@@ -14,7 +14,7 @@ check-config:
 	    PATH="$(BUILTLIBPATH)/bin:$(PATH)"					\
 	    @abs_top_srcdir@/configure						\
 	    PKG_CONFIG_PATH=$(BUILTLIBPATH)/lib/pkgconfig:$(PKG_CONFIG_PATH)	\
-	    GFTABLESDIR=@gftablesdir@						\
+	    GFTABLESDIR=@GFTABLESDIR@						\
 	    LDFLAGS="$(LDFLAGS)"						\
 	    --with-gtest-source-path="@GTEST_PATH@"				\
 	    CPPFLAGS="$(CPPFLAGS)"						\

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1247,7 +1247,7 @@ AC_ARG_VAR([GFTABLESDIR],
 if test $BUILD_factory = yes
 then
     BUILD_gftables=yes
-    AC_SUBST([GFTABLESDIR], [${datadir}/Macaulay2/Core/factory/])
+    GFTABLESDIR="${datadir}/Macaulay2/Core/factory/"
 else
     BUILD_gftables=no
     if test x$GFTABLESDIR = x
@@ -1260,8 +1260,7 @@ else
 	fi
     fi
     adl_RECURSIVE_EVAL([$GFTABLESDIR], [GFTABLESDIR])
-    AC_CHECK_FILE([${GFTABLESDIR}gftables/961],
-	[AC_SUBST([GFTABLESDIR], [$GFTABLESDIR])],
+    AC_CHECK_FILE([${GFTABLESDIR}gftables/961],,
 	[AC_MSG_ERROR([could not find gftables but we are not building factory; try specifying the directory with GFTABLESDIR])])
 fi
 

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -778,7 +778,7 @@ PKGNAME_fflas_ffpack=fflas-ffpack
 LIBLIST=" $LIBLIST "
 AC_ARG_ENABLE(build-libraries, AS_HELP_STRING(--enable-build-libraries=...,[list of libraries, submodules, and programs to build from downloaded source code (e.g., gc gdbm mpir mpfr readline ntl gftables factory lapack mpsolve frobby glpk cddlib givaro fflas_ffpack linbox boost 4ti2 gfan normaliz csdp nauty cddplus lrslib)]),
     [for i in $enableval
-    do case "$LIBLIST $SUBLIST" in
+    do case "$LIBLIST $SUBLIST $PROGLIST" in
 	    *" $i "*) 
 	        eval BUILD_$i=yes 
 		BUILD_ALWAYS="$BUILD_ALWAYS $i"

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1247,7 +1247,7 @@ AC_ARG_VAR([GFTABLESDIR],
 if test $BUILD_factory = yes
 then
     BUILD_gftables=yes
-    AC_SUBST([gftablesdir], [${datadir}/Macaulay2/Core/factory/])
+    AC_SUBST([GFTABLESDIR], [${datadir}/Macaulay2/Core/factory/])
 else
     BUILD_gftables=no
     if test x$GFTABLESDIR = x
@@ -1261,7 +1261,7 @@ else
     fi
     adl_RECURSIVE_EVAL([$GFTABLESDIR], [GFTABLESDIR])
     AC_CHECK_FILE([${GFTABLESDIR}gftables/961],
-	[AC_SUBST([gftablesdir], [$GFTABLESDIR])],
+	[AC_SUBST([GFTABLESDIR], [$GFTABLESDIR])],
 	[AC_MSG_ERROR([could not find gftables but we are not building factory; try specifying the directory with GFTABLESDIR])])
 fi
 
@@ -1761,7 +1761,7 @@ sysconfdir=/nowhere
 sharedstatedir=/nowhere
 localstatedir=/nowhere
 for i in bindir datadir includedir infodir libdir libexecdir mandir sbindir \
-         psdir pdfdir dvidir htmldir localedir gftablesdir docdir datarootdir
+         psdir pdfdir dvidir htmldir localedir GFTABLESDIR docdir datarootdir
 do eval w=\$$i ; eval v="$w" ; eval v="$v" ; eval v="$v" ; eval v="$v" ; eval v="$v"
    case $v in
      "$exec_prefix"|"$exec_prefix"/*)
@@ -1774,7 +1774,7 @@ do eval w=\$$i ; eval v="$w" ; eval v="$v" ; eval v="$v" ; eval v="$v" ; eval v=
 	   eval  pre_${i}=`echo $v | sed s,"^$prefix","'\\${pre_prefix}'",`
 	   eval      ${i}=`echo $v | sed s,"^$prefix","'\\${prefix}'",`
 	   ;;
-     *) if test $i != gftablesdir #only needs normalized if we build factory
+     *) if test $i != GFTABLESDIR #only needs normalized if we build factory
 	then AC_MSG_ERROR([expected "\${$i}" => "$w" to start with "\${prefix}" or with "\${exec_prefix}"])
 	fi ;;
    esac


### PR DESCRIPTION
Previously, make check in M2/check-configure failed if we were using
gftables that were already present in the system, as it was assuming
that they were built and located in @pre_packagesdir@/Core/factory/.