### PR TITLE
Don't check for gfan until the user actually needs it

### DIFF
--- a/M2/Macaulay2/packages/gfanInterface.m2
+++ b/M2/Macaulay2/packages/gfanInterface.m2
@@ -1062,7 +1062,7 @@ runGfanCommandCaptureBoth = (cmd, opts, data) -> (
 	errorMsg := "";
      	if(not returnvalue == 0) then
 	(
-	    errorMsg = "GFAN returned an error message.\n";
+	    errorMsg = "Gfan returned an error message.\n";
 	    errorMsg = errorMsg | "COMMAND:" | ex | "\n";
 	    errorMsg = errorMsg | "INPUT:\n";
 	    errorMsg = errorMsg | get(tmpFile);

--- a/M2/Macaulay2/packages/gfanInterface.m2
+++ b/M2/Macaulay2/packages/gfanInterface.m2
@@ -1045,6 +1045,11 @@ toPolymakeFormat(Fan) := (F) ->(
 --------------------------------------------------------
 
 runGfanCommand = (cmd, opts, data) -> (
+	(out, err, fileName) := runGfanCommandCaptureBoth(cmd, opts, data);
+	(out, fileName)
+)
+
+runGfanCommandCaptureBoth = (cmd, opts, data) -> (
 	if gfanPath === null then gfanPath = findGfanPath();
 	tmpFile := gfanMakeTemporaryFile data;
 	
@@ -1064,45 +1069,19 @@ runGfanCommand = (cmd, opts, data) -> (
 	    errorMsg = errorMsg | "ERROR:\n";
 	    errorMsg = errorMsg | get(tmpFile |".err");
 	     );
-		out := get(tmpFile | ".out");
-	gfanRemoveTemporaryFile tmpFile;
-	gfanRemoveTemporaryFile(tmpFile | ".out");
-	gfanRemoveTemporaryFile(tmpFile | ".err");
-	if length(errorMsg) > 0 then error errorMsg;
-	outputFileName := null;
-	
-	if gfanKeepFiles then outputFileName = tmpFile|".out";
-	
-	(out, "GfanFileName" => outputFileName)
-	
-)
-
-runGfanCommandCaptureBoth = (cmd, opts, data) -> (
-	tmpFile := gfanMakeTemporaryFile data;
-	args := concatenate apply(keys opts, key -> gfanArgumentToString(cmd, key, opts#key));
-	ex := gfanPath | cmd | args | " < " | tmpFile | " > " | tmpFile | ".out" | " 2> " | tmpFile | ".err";
-	if gfanVerbose then << ex << endl;
-	run ex;
 	out := get(tmpFile | ".out");
 	err := get(tmpFile | ".err");
 	gfanRemoveTemporaryFile tmpFile;
 	gfanRemoveTemporaryFile(tmpFile | ".out");
 	gfanRemoveTemporaryFile(tmpFile | ".err");
+	if length(errorMsg) > 0 then error errorMsg;
 	outputFileName := null;
 	if gfanKeepFiles then outputFileName = tmpFile|".out";
 	(out,err, "GfanFileName"=>outputFileName)
 )
 
 runGfanCommandCaptureError = (cmd, opts, data) -> (
-	tmpFile := gfanMakeTemporaryFile data;
-	args := concatenate apply(keys opts, key -> gfanArgumentToString(cmd, key, opts#key));
-	ex := gfanPath | cmd | args | " < " | tmpFile | " > " | tmpFile | ".out" | " 2> " | tmpFile | ".err";
-	if gfanVerbose then << ex << endl;
-	run ex;
-	err := get(tmpFile | ".err");
-	gfanRemoveTemporaryFile tmpFile;
-	gfanRemoveTemporaryFile(tmpFile | ".out");
-	gfanRemoveTemporaryFile(tmpFile | ".err");
+	(out, err, fileName) := runGfanCommandCaptureBoth(cmd, opts, data);
 	err
 )
 

--- a/M2/Macaulay2/packages/gfanInterface.m2
+++ b/M2/Macaulay2/packages/gfanInterface.m2
@@ -129,7 +129,7 @@ findGfanPath = () -> (
 
 fig2devPath = gfanInterface#Options#Configuration#"fig2devpath"
 gfanVerbose = gfanInterface#Options#Configuration#"verbose"
-gfanPath = findGfanPath()
+gfanPath = null
 
 gfanKeepFiles = gfanInterface#Options#Configuration#"keepfiles"
 gfanCachePolyhedralOutput = gfanInterface#Options#Configuration#"cachePolyhedralOutput"
@@ -1045,7 +1045,7 @@ toPolymakeFormat(Fan) := (F) ->(
 --------------------------------------------------------
 
 runGfanCommand = (cmd, opts, data) -> (
-	
+	if gfanPath === null then gfanPath = findGfanPath();
 	tmpFile := gfanMakeTemporaryFile data;
 	
 	args := concatenate apply(keys opts, key -> gfanArgumentToString(cmd, key, opts#key));


### PR DESCRIPTION
This prevents errors from occurring when just loading the
gfanInterface package but not calling any of its functions (e.g., when
running "help") when gfan is not installed.

Close: #1201