### PR TITLE
Install FirstPackage before Macaulay2Doc.

### DIFF
--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -1,6 +1,6 @@
 Style
-Macaulay2Doc
 FirstPackage
+Macaulay2Doc
 Parsing
 Classic
 Browse

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -91,9 +91,11 @@ $(foreach i, $(PACKAGES), $(eval all: unmark-$i))
 endif
 $(foreach i, $(PACKAGES), $(eval all: all-$i) $(eval install: install-$i))
 
-# make packages Style and Macaulay2Doc get installed before the others:
+# make packages Style, FirstPackage, and Macaulay2Doc get installed
+# before the others:
 $(foreach i, $(patsubst Style,,$(ALL_PACKAGES)), $(eval @pre_libm2dir@/$i/.installed: | @pre_libm2dir@/Style/.installed))
-$(foreach i, $(patsubst Macaulay2Doc,,$(patsubst Style,,$(ALL_PACKAGES))), $(eval @pre_libm2dir@/$i/.installed: | @pre_libm2dir@/Macaulay2Doc/.installed))
+$(foreach i, $(patsubst FirstPackage,,$(patsubst Style,,$(ALL_PACKAGES))), $(eval @pre_libm2dir@/$i/.installed: | @pre_libm2dir@/FirstPackage/.installed))
+$(foreach i, $(patsubst Macaulay2Doc,,$(patsubst FirstPackage,,$(patsubst Style,,$(ALL_PACKAGES)))), $(eval @pre_libm2dir@/$i/.installed: | @pre_libm2dir@/Macaulay2Doc/.installed))
 
 # the Info-validate function doesn't work well enough to be useful:
 # check::check-info


### PR DESCRIPTION
Since we load FirstPackage as an example in the documentation but the
database hasn't been built yet, we currently get a warning message in the
example for "loadPackage":

     |i2 : loadPackage "FirstPackage"                                                                                                                                                               |
     |--database not present: /home/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/ubuntu1910-release-1.15/usr-dist/x86_64-Linux-Ubuntu-19.10/lib/Macaulay2/FirstPackage/cache/rawdocumentation-dcba-8.db|

After switching the installation order, the example's behavior is the
normal one when loading a package with notify set to true:

     |i2 : loadPackage "FirstPackage"                                                                                                                                                    |
     |--opening database /build/macaulay2-1.15.1.0+git390.695bfc7+ds/M2/usr-dist/x86_64-Linux-Debian-unknown/lib/x86_64-linux-gnu/Macaulay2/FirstPackage/cache/rawdocumentation-dcba-8.db|