### PR TITLE
Remove build paths from documentation

### DIFF
--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -27,14 +27,16 @@ setupfun("reorganize",dbmreorganize);
 dbmopenin(e:Expr):Expr := (
      when e
      is a:stringCell do (
-	  if notify then stderr << "--opening database " << a.v << endl;
+	  if notify then stderr << "--opening database " <<
+	       relativizeFilename(a.v) << endl;
 	  dbmopenin(a.v))
      else buildErrorPacket("expected a string as filename"));
 setupfun("openDatabase",dbmopenin);
 dbmopenout(e:Expr):Expr := (
      when e
      is a:stringCell do (
-	  if notify then stderr << "--opening database for output " << a.v << endl;
+	  if notify then stderr << "--opening database for output " <<
+	       relativizeFilename(a.v) << endl;
 	  dbmopenout(a.v))
      else buildErrorPacket("expected a string as filename"));
 setupfun("openDatabaseOut",dbmopenout);
@@ -484,7 +486,8 @@ close(g:Expr):Expr := (
 	  g)
      is f:file do when close(f) is m:errmsg do buildErrorPacket(m.message) else g
      is x:Database do (
-	  if notify then stderr << "--closing database " << x.filename << endl;
+	  if notify then stderr << "--closing database " <<
+	       relativizeFilename(x.filename) << endl;
 	  dbmclose(x))
      else buildErrorPacket("expected a file or database"));
 setupfun("close",close).Protected = false;

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1500,7 +1500,7 @@ locate2(c:Code):Expr := (
      locate1();
      p := codePosition(c);
      Expr(Sequence(
-	       toExpr(verifyMinimizeFilename(locatedCode.filename)),
+	       toExpr(relativizeFilename(locatedCode.filename)),
 	       toExpr(locatedCode.minline),
 	       toExpr(locatedCode.mincol),
 	       toExpr(locatedCode.maxline),
@@ -1519,7 +1519,7 @@ locate(e:Expr):Expr := (
 	  then nullE
 	  else Expr(
 	       Sequence(
-		    toExpr(verifyMinimizeFilename(p.filename)),
+		    toExpr(relativizeFilename(p.filename)),
 		    toExpr(int(p.line)),toExpr(int(p.column)),
 		    toExpr(int(p.line)),toExpr(int(p.column)+length(s.symbol.word.name)),
 		    toExpr(int(p.line)),toExpr(int(p.column))

--- a/M2/Macaulay2/d/stdiop.d
+++ b/M2/Macaulay2/d/stdiop.d
@@ -112,7 +112,7 @@ export verifyMinimizeFilename(filename:string):string := (
 export tostring(w:Position) : string := (
      if w == dummyPosition 
      then "-*dummy position*-"
-     else errfmt(verifyMinimizeFilename(w.filename),int(w.line),int(w.column + 1),int(w.loadDepth)));
+     else errfmt(relativizeFilename(w.filename),int(w.line),int(w.column + 1),int(w.loadDepth)));
 export (o:file) << (w:Position) : file := o << tostring(w);
 export (o:BasicFile) << (w:Position) : BasicFile := o << tostring(w);
 threadLocal export SuppressErrors := false;

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -501,7 +501,8 @@ runFile := (inf,inputhash,outf,tmpf,desc,pkg,announcechange,usermode,examplefile
      if fileExists outf then removeFile outf;
      pkgname := toString pkg;
      tmpf << "-- -*- M2-comint -*- hash: " << inputhash << endl << close; -- must match regular expression below
-     rundir := temporaryFileName() | "-rundir/";
+     rundir := toString temporaryFilenameCounter | "-rundir/";
+     temporaryFilenameCounter = temporaryFilenameCounter + 1;
      makeDirectory rundir;
      -* The bits in the binary representation of argmode determine arguments to add.
         If the 64th bit is set, argumentMode modifies the defaultMode rather than overriding them. *-

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -51,7 +51,7 @@ if firstTime then (
      markLoaded = (fullfilename,origfilename,notify,filetime) -> ( 
 	  fullfilename = minimizeFilename fullfilename;
 	  filesLoaded#origfilename = (fullfilename,filetime); 
-	  loadedFiles##loadedFiles = realpath toAbsolutePath fullfilename; 
+	  loadedFiles##loadedFiles = relativizeFilename fullfilename;
 	  if notify then stderr << "--loaded " << fullfilename << endl;
 	  );
      normalPrompts = () -> (

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc2.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc2.m2
@@ -1090,9 +1090,8 @@ document {
      Outputs => {
 	  "the complete path to the current directory, together with an extra slash"
 	  },
-     EXAMPLE lines ///
-     currentDirectory()
-     ///,
+     EXAMPLE {PRE("i1 : currentDirectory()" | newline | newline |
+	  "o1 = /home/m2user/")},
      PARA {
 	  "If a component of the path to the current directory no longer exist, an error will be signalled."
 	  }

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
@@ -1425,9 +1425,8 @@ document { Key => toAbsolutePath,
      Outputs => {
 	  String => {"the absolute (real) path name of ", TT "filename"}
 	  },
-     EXAMPLE lines ///
-         toAbsolutePath "a/b.m2"
-     ///,
+     EXAMPLE {PRE(///i1 : toAbsolutePath "a/b.m2"/// | newline | newline |
+	  ///o1 = /home/m2user/a/b.m2 ///)},
      PARA {
 	  "Paths of the form ", TT "foo/x/../bar", ", are shortened to ", TT "foo/bar", " without
 	  checking the file system to see whether ", TT "x", " is a symbolic link.  For the other

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/endPackage-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/endPackage-doc.m2
@@ -15,7 +15,6 @@ document {
 	  abc = 3
 	  dictionaryPath
 	  endPackage "Foo"
-	  peek oo
 	  dictionaryPath
 	  abc
      ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/realpath-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/realpath-doc.m2
@@ -9,8 +9,7 @@ document {
      Inputs => { "fn" => String => "a filename, or path to a file" },
      Outputs => { String => { "a pathname to ", TT "fn", " passing through no symbolic links, and
 	       ending with a slash if ", TT "fn", " refers to a directory" }},
-     EXAMPLE lines ///
-     	  realpath "."
+     EXAMPLE (lines ///
      	  p = temporaryFileName()
 	  q = temporaryFileName()
 	  symlinkFile(p,q)
@@ -19,11 +18,13 @@ document {
 	  realpath q
 	  removeFile p
 	  removeFile q
-     ///,
+     /// | {PRE(///i9 : realpath "."/// | newline | newline |
+	  ///o9 = /home/m2user/ ///)}),
      PARA {
 	  "The empty string is interpreted as a reference to the current directory."
 	  },
-     EXAMPLE ///realpath ""///,
+     EXAMPLE {PRE(///i10 : realpath ""/// | newline | newline |
+	  ///o10 = /home/m2user/ ///)},
      SeeAlso => {readlink},
      Caveat => {
 	  "Every component of the path must exist in the file system and be accessible to the user.

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview3.m2
@@ -419,17 +419,26 @@ document {
 	  "The following example shows the list of places where we might find the source code of a package called ", TT "Foo", "
 	  after it has been installed by ", TO "installPackage", "."
 	  },
-     EXAMPLE ///stack apply(prefixPath, p -> p | Layout#1#"packages" | "Foo.m2")///,
+     EXAMPLE {PRE(
+	  ///i1 : stack apply(prefixPath, p -> p | Layout#1#"packages" | "Foo.m2")///
+	  | newline | newline | ///o1 = /home/m2user/.Macaulay2/local/share/Macaulay2/Foo.m2///
+	  | newline | ///     /usr/share/Macaulay2/Foo.m2///)},
      PARA {
      	  "This example shows the list of places where we might reasonably find the html file documenting a
 	  function named ", TT "bar", " in a package called ", TT "Foo", "."
 	  },
-     EXAMPLE ///stack apply(prefixPath, p -> p | replace("PKG","Foo",Layout#1#"packagehtml") | "bar.html")///,
+     EXAMPLE {PRE(
+	  ///i2 : stack apply(prefixPath, p -> p | replace("PKG","Foo",Layout#1#"packagehtml") | "bar.html")///
+	  | newline | newline | ///o2 = /home/m2user/.Macaulay2/local/share/doc/Macaulay2/Foo/html/bar.html///
+	  | newline | ///     /usr/share/doc/Macaulay2/Foo/html/bar.html///)},
      PARA {
      	  "This example shows the list of places where we might reasonably find the info file documenting a
 	  package called ", TT "Foo", "."
 	  },
-     EXAMPLE ///stack apply(prefixPath, p -> p | Layout#1#"info" | "Foo.info")///,
+     EXAMPLE {PRE(
+	  ///i3 : stack apply(prefixPath, p -> p | Layout#1#"info" | "Foo.info")///
+	  | newline | newline | ///o3 = /home/m2user/.Macaulay2/local/share/info/Foo.info///
+	  | newline | ///     /usr/share/info/Foo.info///)},
      SeeAlso => {"commandLine", "Invoking the program", applicationDirectory, "prefixDirectory", "path", searchPath, load, loadPackage, needsPackage}
      }
 

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -68,7 +68,7 @@ unmark-$1: ; rm -rf  @pre_libm2dir@/$1/.installed
 	$$(WHY)
 	$(MKDIR_P) $1-temporary
 	@echo "make: Entering directory \`$(shell pwd)/$1-temporary'"
-	cd $1-temporary && @pre_bindir@/M2 $(M2DIRS) \
+	cd $1-temporary && HOME=/home/m2user @pre_bindir@/M2 $(M2DIRS) \
 	    -q $(STOP) \
 	    -e errorDepth=$(errorDepth) \
 	    -e debugLevel=$(debugLevel) \

--- a/M2/Macaulay2/packages/ReflexivePolytopesDB.m2
+++ b/M2/Macaulay2/packages/ReflexivePolytopesDB.m2
@@ -134,7 +134,7 @@ availableOffline = () -> (
     hashTable for k in keys offlines list (
         val := offlines#k;
         (maxlimit, filename) := if instance(val, Sequence) then val else (infinity, val);
-        actualfile := offlineDirectory | filename;
+        actualfile := relativizeFilename(offlineDirectory | filename);
         fcncall := if instance(k, ZZ) then (
           "kreuzerSkarke("|k|
             (if maxlimit === infinity then ")" else ", Limit => "|maxlimit|")")

--- a/M2/Macaulay2/packages/RunExternalM2.m2
+++ b/M2/Macaulay2/packages/RunExternalM2.m2
@@ -760,7 +760,7 @@ runExternalM2 = {
 	);	
 	if (M2Loc===null) then (
 		-- TODO, do we need rootPath for Cygwin?
-		M2Loc=toAbsolutePath(first(commandLine));
+		M2Loc=relativizeFilename(first(commandLine));
 	);
 	if not(fileExists(M2Loc)) then (
 		error "runExternalM2: error finding location of M2 program; check M2Location option";

--- a/M2/Macaulay2/packages/gfanInterface.m2
+++ b/M2/Macaulay2/packages/gfanInterface.m2
@@ -2643,20 +2643,6 @@ doc ///
 			{\tt gfanInterface.m2} either before installing or in the installed copy.
 			You will find the path configuration near the top of the file.
 
-			If {\tt gfanInterface} is already installed and loaded, you can find the path
-			of the source file by the following command:
-
-		Example
-			gfanInterface#"source file"
-
-		Text
-			If you want to use {\tt gfan} executables outside of @EM "Macaulay2"@, they can be found with
-			{\tt currentLayout#"programs"}:
-
-		Example
-			prefixDirectory | currentLayout#"programs"
-
-		Text
 			If you would like to see the input and output files used to communicate with {\tt gfan}
 			you can set the {\tt "keepfiles"} configuration option to {\tt true}. If {\tt "verbose"}
 			is set to {\tt true}, {\tt gfanInterface} will output the names of the temporary files used.


### PR DESCRIPTION
Quite a few times in the documentation, the build path appears.  For example, in [the debugger](https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.15/share/doc/Macaulay2/Macaulay2Doc/html/_the_spdebugger.html):

```
i2 : listUserSymbols

o2 = symbol   class              value
     ------   -----              -----
     g      : FunctionClosure -- g    
     ------------------------------------------------------------------------
     location of symbol
     ------------------                                                      
     /home/dan/src/M2/M2.git/M2/Macaulay2/packages/Macaulay2Doc/demo1.m2:11:1
     ------------------------------------------------------------------------
          
     -11:2
```

This results in builds that aren't [reproducible](https://reproducible-builds.org/), as we will get different documentation when Macaulay2 is built from a different directory or on a different machine. They were also raising many [`file-references-package-build-path`](https://lintian.debian.org/tags/file-references-package-build-path.html) Lintian warnings in the Debian package.

The attached commits remove these build paths.  A summary of the changes:

* Whenever possible, use relative paths instead of absolute paths.
* Set a dummy `HOME` environment variable when building the documentation.  The value is `/home/m2user`, inspired by the [web interface](http://habanero.math.cornell.edu:3690/).
* When relative paths don't make sense (e.g., `toAbsolutePath`), use canned examples.
* Using relative paths for the package installation directory caused build failures, so we just removed the examples that printed this information as they weren't essential.

Closes: #1149