### PR TITLE
Fix bug in installPackage when MakeDocumentation => false

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -771,7 +771,6 @@ installPackage Package := opts -> pkg -> (
 
 	  -- cache raw documentation in database, and check for changes
 	  rawDocUnchanged := new MutableHashTable;
-	  libDir := pkg#"package prefix" | replace("PKG",pkg#"pkgname",installLayout#"packagelib");
 	  rawdbname := databaseFilename(installLayout,pkg#"package prefix",pkg#"pkgname");
 	  rawdbnametmp := rawdbname | ".tmp";
 	  if verbose then stderr << "--storing raw documentation in " << rawdbname << endl;
@@ -1076,6 +1075,7 @@ installPackage Package := opts -> pkg -> (
      -- all done
      SRC = null;
      if not hadExampleError then (
+ 	  libDir := pkg#"package prefix" | replace("PKG",pkg#"pkgname",installLayout#"packagelib");
 	  iname := libDir|".installed";
 	  iname << close;
 	  if verbose then stderr << "--file created: " << iname << endl;


### PR DESCRIPTION
Currently, we get the following:

```
i1 : installPackage("FirstPackage", MakeDocumentation => false)
--installing package FirstPackage in /home/profzoom/.Macaulay2/local/ with layout 1
--using package sources found in /home/profzoom/tmp/
stdio:1:1:(3): error: no method for binary operator | applied to objects:
--            null (of class Nothing)
--      |     ".installed" (of class String)

```

The `null` is coming from the `libDir` variable, which is only defined
when `MakeDocumentation` is true.  We move the assignment of this variable
(which is only used once) to immediately before it is used.