### PR TITLE
Add a Github Actions hook for builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,0 +1,152 @@
+################################################################################
+#
+#  Github actions trigger (workflow script) for building Macaulay2
+#
+#    See https://help.github.com/en/actions for the documentation.
+#
+################################################################################
+
+name: Build and Test Macaulay2
+
+on:
+  # trigger a test quick build at both PR (on dev)
+  # and pushing to master (after merging or by Dan or Mike)
+  push:
+    branch:
+      - master
+      - feature/actions
+  pull_request:
+    branch:
+      - developement
+  schedule:
+    # cron time in UTC; set to 6a EDT
+    - cron: '0 10 * * *'
+
+env:
+#  CMAKE_VERSION: 3.17
+#  NINJA_VERSION: 1.9.0
+  BUILD_TYPE: Release  # add Buildfast
+  BUILD_DIR: M2/BUILD/cicd
+
+jobs:
+  build:
+    name: ${{matrix.os}}-${{matrix.build-type}}-${{matrix.compiler}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # eventually make this true
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        build-type: [cmake, autotools]
+        compiler: [gcc9, default]  # add clang
+#       language: [cxx17, cxx14]
+        include:
+          - compiler: gcc9
+            cxx: g++-9
+            cc: gcc-9
+          - os: macos-latest
+            make: gmake
+          - os: ubuntu-latest
+            make: make
+
+
+    steps:
+      - uses: actions/checkout@v1  # this set up the virtual environment, which has a whole lot
+                                   # as of this writing: gcc9, clang10, cmake3.17, homebrew...
+
+# ----------------------
+#   Install missing tools and libraries using homebrew (macOS and Linux)
+# ----------------------
+
+      - name: Install missing dev tools (homebrew)
+        id: get_dev_tools_brew
+        if: ${{ runner.os == 'macOS' }}
+        # autoconf, libtool are already in the virtual env
+        run: |
+          brew config
+          brew install ninja pkg-config autoconf automake gnu-tar libtool yasm make
+
+      - name: Install libraries (homebrew)
+        id: get_dev_libraries_brew
+        if: ${{ runner.os == 'macOS' }}
+        # mpfr, gdbm, libmpc, xz are already in the virtual env
+        run: brew install boost flint ntl mpir bdw-gc libatomic_ops glpk libomp eigen ncurses
+
+# ----------------------
+#   Install missing tools and libraries using apt-get (Debian-based Linux only)
+# ----------------------
+
+      - name: Install missing dev tools (apt-get)
+        id: get_dev_tools_aptget
+        if: ${{ runner.os == 'Linux' }}
+        # make is really gmake
+        run: sudo apt-get install -y ninja-build
+
+      - name: Install libraries (apt-get)
+        id: get_dev_libraries_aptget
+        if: ${{ runner.os == 'Linux' }}
+        # trim all this garbage
+        run: sudo apt-get install -y -q autoconf bison curl emacs fflas-ffpack flex g++ gcc gfortran install-info libatomic-ops-dev libboost-dev libc6-dev libcdd-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfr-dev libncurses-dev libncurses5-dev libntl-dev libreadline-dev libtool libxml2-dev libz-dev make openssh-server patch pinentry-curses pkg-config time unzip xbase-clients yasm zlib1g-dev polymake w3c-markup-validator git dpkg-dev gfan libeigen3-dev libtool-bin
+
+# ----------------------
+#   Steps common to all build variants
+# ----------------------
+
+      - name: Create build directory
+        id: step_build_dir
+        run: mkdir $BUILD_DIR
+
+# ----------------------
+#   Configure and build M2 using cmake
+# ----------------------
+
+      - name: Configure Macaulay2 (cmake)
+        id: step_configure_cmake
+        if: ${{ matrix.build-type == 'cmake' }}
+        working-directory: M2/BUILD/cicd  # use ${{ defaults.dir }} or something along those lines
+        env:
+          CXX: ${{matrix.cxx}}
+          CC: ${{matrix.cc}}
+        run: |
+          echo $CXX $CC
+          cmake -S../.. -B. -G"Ninja" -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build Macaulay2 (cmake)
+        id: step_build
+        if: ${{ matrix.build-type == 'cmake' }}
+        working-directory: M2/BUILD/cicd
+        run: |
+          cmake --build . --target build-libraries  -j4
+          cmake --build . --target build-programs   -j4
+          cmake --build . --target install-packages -j4
+          cmake --build . --target M2-emacs         -j4
+
+# ----------------------
+#   Configure and build M2 the old way
+# ----------------------
+
+      - name: Configure Macaulay2 (autotools)
+        id: step_configure_autotools
+        if: ${{ matrix.build-type == 'autotools' }}
+        env:
+          CXX: ${{matrix.cxx}}
+          CC: ${{matrix.cc}}
+        run: |
+          cd M2
+          ${{matrix.make}} get-tools
+          ${{matrix.make}} -f Makefile
+          cd BUILD/cicd
+          ../../configure --enable-download --enable-build-libraries="readline"
+
+      - name: Build Macaulay2 (autotools)
+        id: step_build_autotools
+        if: ${{ matrix.build-type == 'autotools' }}
+        working-directory: M2/BUILD/cicd
+        run: ${{matrix.make}}
+
+# ----------------------
+#   Run tests (Skip for now given the build failures)
+# ----------------------
+
+      - name: Run Tests
+        id: step_run_tests
+        run: echo "Placeholder. Don't do anything for now"


### PR DESCRIPTION
This is to add a [GitHub Actions](https://github.com/features/actions) build hook to the repository. I'll describe the details further down; the gist is as follows:

* Github Actions allows for an easy automation of software workflows — bilding, testing, deployment. Such a tool is an integral part of the so-called [CI/CD model](https://en.wikipedia.org/wiki/CI/CD).
* I find Github Actions quite superior to the ubiquitous [Travis-CI](https://travis-ci.org); Macaulay2 certainly doesn't need [Jenkins](https://www.jenkins.io); and [CircleCI](https://circleci.com) is probably in-between.
* The given workflow builds and tests M2 at every `master` push, `development` pull request, and everyday at 6am EDT. (Note that even if there's no activity in the codebase, the dependencies and environments could still change.)

Given how time-consuming building M2 is (around the 2-hour mark), distinct jobs can be used for the scheduled builds and pull requests, and it certainly doesn't make too much sense to have trigger builds at both `development` pull request and `master` push, although the two could technically be building different code.

Let me know what you think!

## Details
Starting from a fresh environment (macOS or Ubuntu), the workflow consists of the following steps:

1. Install the dev tools
2. Install the libraries
3. Configure (using cmake or autotools)
4. Build (including any remaining libraries and programs)
5. Test

The build matrix consists of:

* Two OSes: latest macOS (10.15) and Ubuntu 18.04. The newest Ubuntu 20.04 is available only in experimental mode.
* Two build systems: the new `cmake` one and the old `autotools` one. In the case of `cmake`, Ninja is used for the actual build. In the case of `autotools`, GNU's Make is used.
* Two compilers: `gcc9` and `default`. The latter just stands for whatever the default complier on the system is; e.g. `AppleClang` on macOS.

This results in just 8 variants, well below the limit of 20 parallel jobs (5 on macOS) for the free accounts.

In the future, a short-term update would be to add two language standards — `C++17/C11` along with the current `C++14/C11`. The switch to C++17 is desirable and should be quite painless. A long-term addition would be to add a specific version of `clang` too. Another optional branch would be to try building on Windows, although I am not a fan of it.

Finally, note that this is just *one* job, `build`, with 8 variants. It would make sense to trigger other kinds of checks when PR for a package is made, etc. The latter, for example, using the latest binary release, is quite simple to do, but not in the scope of the build job.

Note also that I am including a trigger on push to `feature/actions`, which I am happy to remove later. For the sake of reproducing the setup, my `feature/actions` is based off the upstream `master`, not the upstream `development` branch. My `pr/actions` is based off the upstream `development` and introduces a single new commit.

## Status

Perhaps more importantly, in the short-term, the hook should serve as a baseline for what works and what doesn't. In my limited experience, building M2 rarely just works.

In fact, looking at the [success rate](https://github.com/radoslavraynov/M2/actions/runs/130355320) of the builds off the current master, [this](https://giphy.com/gifs/this-is-fine-dumpster-fire-floating-1rNWZu4QQqCUaq434T/fullscreen) captures the state of affairs :) 

I could be wrong with setting up the environments, etc, but the problems I am seeing are consistent with problems I have experienced on my fresh Catalina. To that end, I'm opening #issue to address several issues and inconsistencies I've found.

Thanks!