### PR TITLE
CMake maintenance for Catalina

### DIFF
--- a/M2/BUILD/docker/ubuntu/Makefile
+++ b/M2/BUILD/docker/ubuntu/Makefile
@@ -12,6 +12,10 @@ BUILD_OPT = -DCMAKE_BUILD_TYPE=Release -DUSING_MPIR=OFF
 ## Script for building Macaulay2
 define M2_BUILD_SCRIPT
 set -xe
+
+git config --global user.email "macaulay@docker"
+git config --global user.name "Macaulay"
+
 ## Full build
 cmake -GNinja -S M2/M2 -B $(BUILD_DIR) $(BUILD_OPT)
 cmake --build $(BUILD_DIR) --target build-libraries # build-programs

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -281,6 +281,13 @@ For specific packages, the following targets are also available:
 Below are a list of common issues and errors. If you run into a problem not listed below, please open a [new issue](https://github.com/Macaulay2/M2/issues/new) on GitHub.
 
 <details>
+<summary>Detected library incompatibilities; rerun the build-libraries target</summary>
+This message indicates that the build scripts detected an inconsistency between the libraries found on the system, and that those libraries are marked to be compiled from source. Run `ninja build-libraries` (or `make build-libraries`) to build the libraries from source.
+
+If the problem persists, run `cmake --debug-trycompile` and open an issue with the contents of `CMakeFiles/CMakeError.log`.
+</details>
+
+<details>
 <summary>macOS 10.15 Catalina issues with AppleClang</summary>
 After ensuring that you have followed the usual steps from the [INSTALL](INSTALL) manual (e.g. running `xcode-select --install`, consider setting the `CMAKE_OSX_SYSROOT` variable to match the current SDK:
 ```

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -771,7 +771,7 @@ ExternalProject_Add(build-4ti2
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/4ti2
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different README ${M2_INSTALL_LICENSESDIR}/4ti2
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different ${4ti2_PROGRAMS} ${M2_INSTALL_PROGRAMSDIR}/
-          COMMAND   ${CMAKE_COMMAND} -E remove -f ${4ti2_PROGRAMS}
+          COMMAND   ${CMAKE_COMMAND} -E rm -f ${4ti2_PROGRAMS}
   TEST_COMMAND      ${MAKE} -j${PARALLEL_JOBS} check
   EXCLUDE_FROM_ALL  ON
   TEST_EXCLUDE_FROM_MAIN ON

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -756,6 +756,7 @@ ExternalProject_Add(build-4ti2
   CONFIGURE_COMMAND autoreconf -vif
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
+                      $<$<BOOL:${GLPK_FOUND}>:--with-glpk=${GLPK_INCLUDE_DIR}/..>
                       CPPFLAGS=${CPPFLAGS}
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}
@@ -837,7 +838,7 @@ ExternalProject_Add(build-gfan
   INSTALL_COMMAND   ${CMAKE_STRIP} gfan
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/gfan
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different LICENSE COPYING ${M2_INSTALL_LICENSESDIR}/gfan
-          COMMAND   ${MAKE} -j${PARALLEL_JOBS} PREFIX=${M2_INSTALL_PROGRAMSDIR}/../ install
+          COMMAND   ${MAKE} -j${PARALLEL_JOBS} PREFIX=${M2_INSTALL_PROGRAMSDIR}/.. install
   TEST_COMMAND      ${MAKE} -j${PARALLEL_JOBS} check
   EXCLUDE_FROM_ALL  ON
   TEST_EXCLUDE_FROM_MAIN ON

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -974,6 +974,7 @@ ExternalProject_Add(build-normaliz
                       STRIP=${CMAKE_STRIP}
                       RANLIB=${CMAKE_RANLIB}
                       OPENMP_CXXFLAGS=${normaliz_OpenMP_CXX_FLAGS}
+            COMMAND patch --fuzz=10 --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/normaliz/patch-libtool
   BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS}
   # TODO: do we need the libraries as well, or just the binary?
   INSTALL_COMMAND   ${CMAKE_STRIP} source/normaliz

--- a/M2/libraries/normaliz/patch-libtool
+++ b/M2/libraries/normaliz/patch-libtool
@@ -1,0 +1,18 @@
+diff -Nar -U 5 a/libtool b/libtool
+--- a/libtool	2020-06-11 13:23:35.000000000 -0400
++++ b/libtool	2020-06-11 13:23:35.000000000 -0400
+@@ -7582,14 +7582,10 @@
+       -mt|-mthreads|-kthread|-Kthread|-pthread|-pthreads|--thread-safe \
+       |-threads|-fopenmp|-openmp|-mp|-xopenmp|-omp|-qsmp=*)
+ 	func_append compiler_flags " $arg"
+ 	func_append compile_command " $arg"
+ 	func_append finalize_command " $arg"
+-	case "$new_inherited_linker_flags " in
+-	    *" $arg "*) ;;
+-	    * ) func_append new_inherited_linker_flags " $arg" ;;
+-	esac
+ 	continue
+ 	;;
+ 
+       -multi_module)
+ 	single_module=$wl-multi_module


### PR DESCRIPTION
The problem with building Normaliz with openmp on Catalina is that libtool is not smart and instead of adding `-Xclang -fopenmp` just adds `-fopenmp` to the end of the link command, which causes an error. I fixed part of this in `Normaliz/patch-3.8.5`, but unfortunately the libtool script that is generated in the build directory of Normaliz is also not smart, requiring a second patch *after configure*. Since the file is generated, the lines are not always a match, which makes this is a *fuzzy* patch.

It's definitely not an ideal solution, but I've tested it on Linux and Catalina and it seems to work fine on both. Suggestions for a better fix are welcome!