### PR TITLE
Only include line about program licenses if the directory exists

### DIFF
--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -616,7 +616,7 @@ homeDirectory = getenv "HOME" | "/"
 
 initcurrentlayout()
 
-if firstTime then
+if firstTime and fileExists(prefixDirectory | currentLayout#"program licenses") then
 copyright = copyright | newline | "For licenses see " | prefixDirectory | currentLayout#"program licenses"
 
 path = (x -> select(x, i -> i =!= null)) deepSplice {


### PR DESCRIPTION
If we don't build any programs or libraries, then this directory is
never created.