### PR TITLE
Use generic "/path/to/source/" path for cached files

### DIFF
--- a/M2/Macaulay2/d/Makefile.in
+++ b/M2/Macaulay2/d/Makefile.in
@@ -224,13 +224,16 @@ startup.c: startup-header.h ../m2/startup.m2 @srcdir@/../m2/basictests/*.m2 Make
 	@(\
 	 cat @srcdir@/startup-header.h; \
 	 echo 'cached_file startupFile = {' ; \
-	     echo @abs_top_srcdir@/Macaulay2/m2/startup.m2.in | sed $(BSTRING) ; \
+	     echo /path/to/source/Macaulay2/m2/startup.m2.in | sed $(BSTRING) ; \
 	     echo  ',' ; \
 	     cat ../m2/startup.m2 | sed $(SSTRING) ; \
 	 echo  '};' ; \
 	 echo 'cached_file testStrings[] = {' ; \
 	 for i in @abs_top_srcdir@/Macaulay2/m2/basictests/*.m2 ; \
-	 do echo '{' ; echo $$i | sed $(BSTRING) ; echo  ',' ; cat $$i | sed $(SSTRING) ; echo  '},' ; \
+	 do echo '{' ; \
+		echo "/path/to/source/Macaulay2/m2/basictests/`basename $$i`" | \
+		sed $(BSTRING) ; echo  ',' ; cat $$i | sed $(SSTRING) ; \
+		echo  '},' ; \
 	 done ; \
 	 echo '};' ; \
 	 cat @srcdir@/startup-trailer.h; \


### PR DESCRIPTION
These files are not installed with Macaulay2, and instead their contents
are cached as strings inside the Macaulay2 binary.  Currently, the
original source directory is displayed when running the basic tests
or locating the code of a function defined in startup.m2.in, which results
in non-reproducible builds and also may be confusing to users.

We instead replace the beginning of these paths with "/path/to/source/"
to indicate that these files are only present in the source code.