### PR TITLE
Don't try to install dynamic libraries if we don't build any

### DIFF
--- a/M2/libraries/Makefile.in
+++ b/M2/libraries/Makefile.in
@@ -41,7 +41,9 @@ install-dynamic-libraries:
 	      fi ;							\
 	   done
 ifeq (@SHARED@,yes)
+ifneq (@BUILDLIBLIST@,)
 all: install-dynamic-libraries
+endif
 endif
 
 $(foreach f,Makefile Makefile.library,					\


### PR DESCRIPTION
Otherwise, the build fails when we try to cd into $(BUILTLIBPATH)/lib,
which is never created.