### PR TITLE
CMake maintenance

### DIFF
--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -19,6 +19,7 @@ header "
    #include <mathic.h>
    #include <gdbm.h>
    #include <mathicgb.h>
+   #include <mps/mps.h>
    #define stringize0(a) #a
    #define stringize(a) stringize0(a)
    namespace constants { extern const char* const version; } /* we have to copy this from frobby until they make it more accessible */
@@ -162,7 +163,7 @@ setupconst("version", Expr(toHashTable(Sequence(
 	       \"not present\"
 	  #endif
 	  "),
-   "mpsolve version" => "3.1.8", -- TODO: DETERMINE VERSION #??
+   "mpsolve version" => Ccode(constcharstar, "stringize(MPS_MAJOR_VERSION) \".\" stringize(MPS_MINOR_VERSION) \".\" stringize(MPS_PATCH_VERSION)" ),
    "python version" => Ccode(constcharstar,"
 	#ifdef WITH_PYTHON
 		 PY_VERSION				      

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -165,7 +165,7 @@ setupconst("version", Expr(toHashTable(Sequence(
 	  "),
    "mpsolve version" => Ccode(constcharstar, "
 	#ifdef MPS_MAJOR_VERSION
-               stringize(MPS_MAJOR_VERSION) \".\" stringize(MPS_MINOR_VERSION) \".\" stringize(MPS_PATCH_VERSION)
+	       stringize(MPS_MAJOR_VERSION) \".\" stringize(MPS_MINOR_VERSION) \".\" stringize(MPS_PATCH_VERSION)
 	#else
 	       \"MPS_MAJOR_VERSION undefined\"
 	#endif

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -163,7 +163,13 @@ setupconst("version", Expr(toHashTable(Sequence(
 	       \"not present\"
 	  #endif
 	  "),
-   "mpsolve version" => Ccode(constcharstar, "stringize(MPS_MAJOR_VERSION) \".\" stringize(MPS_MINOR_VERSION) \".\" stringize(MPS_PATCH_VERSION)" ),
+   "mpsolve version" => Ccode(constcharstar, "
+	#ifdef MPS_MAJOR_VERSION
+               stringize(MPS_MAJOR_VERSION) \".\" stringize(MPS_MINOR_VERSION) \".\" stringize(MPS_PATCH_VERSION)
+	#else
+	       \"MPS_MAJOR_VERSION undefined\"
+	#endif
+	"),
    "python version" => Ccode(constcharstar,"
 	#ifdef WITH_PYTHON
 		 PY_VERSION				      

--- a/M2/Macaulay2/tests/CMakeLists.txt
+++ b/M2/Macaulay2/tests/CMakeLists.txt
@@ -108,18 +108,19 @@ add_custom_target(M2-tests-ComputationsBook)
 set(CHAPTERS completeIntersections constructions d-modules exterior-algebra geometry
   monomialIdeals preface programming schemes solving toricHilbertScheme varieties)
 
-set(M2_ARGS -q --stop)
+set(M2_ARGS -q --stop --print-width 0)
 
 foreach(_chapter IN LISTS CHAPTERS)
 
   ## configure the test string
+  set(_testfile test.m2)
   set(_group ComputationsBook/${_chapter})
 
   set(book_patterns    ${CMAKE_CURRENT_SOURCE_DIR}/${_group}/../patterns)
   set(chapter_patterns ${CMAKE_CURRENT_SOURCE_DIR}/${_group}/patterns)
 
   string(CONFIGURE "${M2_TEST_TEMPLATE}" M2_TEST_STRING)
-  set(M2_PATH "join({\"./${_group}\",\"${CMAKE_CURRENT_SOURCE_DIR}/${_group}\"},path)")
+  set(M2_PATH "join({\"${CMAKE_CURRENT_BINARY_DIR}/${_group}\",\"${CMAKE_CURRENT_SOURCE_DIR}/${_group}\"},path)")
 
   if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${_group})
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_group})
@@ -152,7 +153,9 @@ foreach(_chapter IN LISTS CHAPTERS)
 
   ###############################################################################
   add_test(NAME ${_group}
-    COMMAND diff -B -b -u ${_group}/test.out.expected.trim ${_group}/test.out.trim
+    COMMAND diff -B -b -u
+      ${CMAKE_CURRENT_BINARY_DIR}/${_group}/test.out.expected.trim
+      ${CMAKE_CURRENT_BINARY_DIR}/${_group}/test.out.trim
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_group}
     )
 

--- a/M2/cmake/FindMPSolve.cmake
+++ b/M2/cmake/FindMPSolve.cmake
@@ -1,18 +1,94 @@
-# Try to find the MPSOLVE libraries
+# Try to find the MPSolve libraries
 # See https://numpi.dm.unipi.it/software/mpsolve
 #
-# This file sets up MPSOLVE for CMake. Once done this will define
-#  MPSOLVE_FOUND             - system has MPSOLVE lib
-#  MPSOLVE_INCLUDE_DIR       - the MPSOLVE include directory
-#  MPSOLVE_LIBRARIES         - the MPSOLVE library
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(MPSolve 3.2.1)
+# to require version 3.2.0 to newer of MPSOLVE.
+#
+# Once done this will define
+#
+#  MPSOLVE_FOUND	- system has the MPSOLVE library with correct version
+#  MPSOLVE_INCLUDE_DIR	- the MPSOLVE include directory
+#  MPSOLVE_LIBRARIES	- the MPSOLVE library
+#  MPSOLVE_VERSION	- MPSOLVE version
+
+# Copyright (c) 2020, Mahrud Sayrafi, <mahrud@umn.edu>
 #
 # Redistribution and use is allowed according to the terms of the BSD license.
 
-find_path(MPSOLVE_INCLUDE_DIR NAMES mps/mps.h)
-find_library(MPSOLVE_LIBRARIES NAMES mps)
+# Set MPSolve_FIND_VERSION to 3.0.0 if no minimum version is specified
+if(NOT MPSolve_FIND_VERSION)
+  if(NOT MPSolve_FIND_VERSION_MAJOR)
+    set(MPSolve_FIND_VERSION_MAJOR 3)
+  endif()
+  if(NOT MPSolve_FIND_VERSION_MINOR)
+    set(MPSolve_FIND_VERSION_MINOR 0)
+  endif()
+  if(NOT MPSolve_FIND_VERSION_PATCH)
+    set(MPSolve_FIND_VERSION_PATCH 0)
+  endif()
 
-# handle the QUIETLY and REQUIRED arguments and set XXX_FOUND to TRUE if all listed variables are TRUE
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(MPSolve DEFAULT_MSG MPSOLVE_LIBRARIES MPSOLVE_INCLUDE_DIR)
+  set(MPSolve_FIND_VERSION "${MPSolve_FIND_VERSION_MAJOR}.${MPSolve_FIND_VERSION_MINOR}.${MPSolve_FIND_VERSION_PATCH}")
+endif()
 
-mark_as_advanced(MPSOLVE_INCLUDE_DIR MPSOLVE_LIBRARIES)
+macro(_mpsolve_check_version)
+  # Query MPSolve_VERSION
+  file(READ "${MPSOLVE_INCLUDE_DIR}/mps/version.h" _mpsolve_version_header)
+
+  string(REGEX MATCH "define[ \t]+MPS_MAJOR_VERSION[ \t]+([0-9]+)"
+    _mpsolve_major_version_match "${_mpsolve_version_header}")
+  set(MPSOLVE_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+MPS_MINOR_VERSION[ \t]+([0-9]+)"
+    _mpsolve_minor_version_match "${_mpsolve_version_header}")
+  set(MPSOLVE_MINOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+MPS_PATCH_VERSION[ \t]+([0-9]+)"
+    _mpsolve_patch_version_match "${_mpsolve_version_header}")
+  set(MPSOLVE_PATCH_VERSION "${CMAKE_MATCH_1}")
+
+  set(MPSOLVE_VERSION
+    ${MPSOLVE_MAJOR_VERSION}.${MPSOLVE_MINOR_VERSION}.${MPSOLVE_PATCH_VERSION})
+
+  # Check whether found version exceeds minimum required
+  if(${MPSOLVE_VERSION} VERSION_LESS ${MPSolve_FIND_VERSION})
+    set(MPSOLVE_VERSION_OK FALSE)
+    message(STATUS "MPSolve version ${MPSOLVE_VERSION} found in ${MPSOLVE_INCLUDE_DIR}, "
+                   "but at least version ${MPSolve_FIND_VERSION} is required")
+  else()
+    set(MPSOLVE_VERSION_OK TRUE)
+  endif()
+endmacro(_mpsolve_check_version)
+
+if(NOT MPSOLVE_FOUND)
+  set(MPSOLVE_INCLUDE_DIR NOTFOUND)
+  set(MPSOLVE_LIBRARIES NOTFOUND)
+
+  # search first if an MPSolveConfig.cmake is available in the system,
+  # if successful this would set MPSOLVE_INCLUDE_DIR and the rest of
+  # the script will work as usual
+  find_package(MPSolve ${MPSolve_FIND_VERSION} NO_MODULE QUIET)
+
+  if(NOT MPSOLVE_INCLUDE_DIR)
+    find_path(MPSOLVE_INCLUDE_DIR NAMES mps/mps.h
+      HINTS ENV MPSDIR
+      PATHS ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/include
+      PATH_SUFFIXES mps
+      )
+  endif()
+
+  if(MPSOLVE_INCLUDE_DIR)
+    _mpsolve_check_version()
+  endif()
+
+  if(NOT MPSOLVE_LIBRARIES)
+    find_library(MPSOLVE_LIBRARIES NAMES mps
+      HINTS ENV MPSDIR
+      PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
+      )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(MPSolve DEFAULT_MSG MPSOLVE_INCLUDE_DIR MPSOLVE_LIBRARIES MPSOLVE_VERSION_OK)
+
+  mark_as_advanced(MPSOLVE_INCLUDE_DIR MPSOLVE_LIBRARIES)
+
+endif()

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -1034,8 +1034,10 @@ ExternalProject_Add(build-topcom
   )
 _ADD_COMPONENT_DEPENDENCY(programs topcom cddlib TOPCOM)
 
+###############################################################################
+## Experimental build scripts for other software programs.
+## These programs are not built by default, but the build targets are provided.
 
-# TODO: this is still experimental
 # https://polymake.org
 # Polymake needs gmp, mpfr, cdd, lrs, libnormaliz, nauty and jReality
 #set(polymake_CPPFLAGS "${CPPFLAGS}")
@@ -1069,6 +1071,38 @@ ExternalProject_Add(build-polymake
   STEP_TARGETS      install test
   )
 #_ADD_COMPONENT_DEPENDENCY(programs polymake "cddlib;lrs;normaliz;nauty" POLYMAKE)
+
+
+# https://www3.nd.edu/~sommese/bertini/
+ExternalProject_Add(build-bertini
+  URL               https://bertini.nd.edu/BertiniSource_v1.6.tar.gz
+  URL_HASH          SHA256=b742d4a55623092eb0c46f8ee644aa487e5decf4ad05eb9297306b599795a424
+  PREFIX            libraries/bertini
+  SOURCE_DIR        libraries/bertini/build
+  DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
+  BUILD_IN_SOURCE   ON
+  CONFIGURE_COMMAND autoreconf -vif
+            COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
+                      #-C --cache-file=${CONFIGURE_CACHE}
+                      --disable-shared
+                      CPPFLAGS=${CPPFLAGS}
+                      CFLAGS=${CFLAGS}
+                      CXXFLAGS=${CXXFLAGS}
+                      LDFLAGS=${LDFLAGS}
+                      CC=${CMAKE_C_COMPILER}
+                      CXX=${CMAKE_CXX_COhMPILER}
+  BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS}
+  INSTALL_COMMAND   ${MAKE} -j${PARALLEL_JOBS} install
+          COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/bertini
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING ${M2_INSTALL_LICENSESDIR}/bertini
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different bertini-serial ${M2_INSTALL_PROGRAMSDIR}/
+  TEST_COMMAND      ${MAKE} -j${PARALLEL_JOBS} check
+  EXCLUDE_FROM_ALL  ON
+  TEST_EXCLUDE_FROM_MAIN ON
+  STEP_TARGETS      install test
+  )
+#_ADD_COMPONENT_DEPENDENCY(libraries bertini "mp;mpfr" BERTINI)
+
 
 ###############################################################################
 ## Post-build actions

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -1074,9 +1074,13 @@ ExternalProject_Add(build-polymake
                       CXX=${CMAKE_CXX_COMPILER}
   BUILD_COMMAND     ${NINJA} -C build/Opt
   INSTALL_COMMAND   ${NINJA} -C build/Opt install
-#          COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/polymake
-#          COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING ${M2_INSTALL_LICENSESDIR}/polymake
-#          COMMAND   ${CMAKE_COMMAND} -E copy_if_different polymake ${M2_INSTALL_PROGRAMSDIR}/
+          COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/polymake
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING ${M2_INSTALL_LICENSESDIR}/polymake
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different ${M2_HOST_PREFIX}/bin/polymake ${M2_INSTALL_PROGRAMSDIR}/
+          COMMAND   ${CMAKE_COMMAND} -E copy_directory
+	    ${M2_HOST_PREFIX}/lib/polymake   ${M2_DIST_PREFIX}/${M2_INSTALL_LIBDIR}/Macaulay2/lib
+          COMMAND   ${CMAKE_COMMAND} -E copy_directory
+	    ${M2_HOST_PREFIX}/share/polymake ${M2_DIST_PREFIX}/${M2_INSTALL_DATAROOTDIR}
   TEST_COMMAND      ${MAKE} test
   EXCLUDE_FROM_ALL  ON
   TEST_EXCLUDE_FROM_MAIN ON

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -435,8 +435,9 @@ set(frobby_CXXFLAGS "${CPPFLAGS} ${CXXFLAGS} -Wno-deprecated-declarations")
 ExternalProject_Add(build-frobby
 #  GIT_REPOSITORY    ${CMAKE_SOURCE_DIR}/submodules/frobby/.git
 #  GIT_TAG           HEAD # WIP: 51c3e075
-  URL               https://github.com/Macaulay2/frobby/archive/d12b7b786a0e50765c1a2878601125ac2f55b68c.tar.gz
-  URL_HASH          SHA256=ccd686a4f76ad21ce55c6534ad17fce1f59ff9382485a1c8fd5fe4e1a80fc8b8
+  URL               https://github.com/Macaulay2/frobby/archive/v0.9.1.tar.gz
+  URL_HASH          SHA256=4bd699ff009973bc2d209ec9abdee33ef09e11de83914046fcc4ce68e7cc25b5
+  DOWNLOAD_NAME     frobby-v0.9.1.tar.gz
   PREFIX            libraries/frobby
   SOURCE_DIR        libraries/frobby/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -1073,7 +1073,34 @@ ExternalProject_Add(build-polymake
 #_ADD_COMPONENT_DEPENDENCY(programs polymake "cddlib;lrs;normaliz;nauty" POLYMAKE)
 
 
+# http://homepages.math.uic.edu/~jan/download.html
+ExternalProject_Add(build-phcpack
+  URL               https://github.com/janverschelde/PHCpack/archive/v2.4.77.tar.gz
+  URL_HASH          SHA256=cc4f4274253dc4a6794d5f7e01f10622b6d3f58bea1f8da83467e6f7e1d90e88
+  DOWNLOAD_NAME     PHCpack-v2.4.77.tar.gz
+  PREFIX            libraries/phcpack
+  SOURCE_DIR        libraries/phcpack/build
+  DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
+  BUILD_IN_SOURCE   ON
+  CONFIGURE_COMMAND true
+  BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS} -C src/Objects phc
+                      CC=${CMAKE_C_COMPILER}
+                      gpp=${CMAKE_CXX_COMPILER}
+  INSTALL_COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/phcpack
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different LICENSE ${M2_INSTALL_LICENSESDIR}/phcpack
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different src/bin/phc ${M2_INSTALL_PROGRAMSDIR}/
+  TEST_COMMAND      ${MAKE} -j${PARALLEL_JOBS} -C src/Objects testall
+  EXCLUDE_FROM_ALL  ON
+  TEST_EXCLUDE_FROM_MAIN ON
+  STEP_TARGETS      install test
+  USES_TERMINAL_BUILD ON
+  USES_TERMINAL_TEST ON
+  )
+#_ADD_COMPONENT_DEPENDENCY(libraries phcpack "???" PHC)
+
+
 # https://www3.nd.edu/~sommese/bertini/
+# NOTE: Bertini's license is restrictive, so we don't build and distribute it by default.
 ExternalProject_Add(build-bertini
   URL               https://bertini.nd.edu/BertiniSource_v1.6.tar.gz
   URL_HASH          SHA256=b742d4a55623092eb0c46f8ee644aa487e5decf4ad05eb9297306b599795a424

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -851,6 +851,7 @@ _ADD_COMPONENT_DEPENDENCY(programs gfan "mp;cddlib;factory" GFAN)
 
 
 # http://www-cgrl.cs.mcgill.ca/~avis/C/lrs.html
+# TODO: the shared library target doesn't work on Apple
 ExternalProject_Add(build-lrslib
   URL               http://cgm.cs.mcgill.ca/~avis/C/lrslib/archive/lrslib-071.tar.gz
   URL_HASH          SHA256=d3ea5636bfde3011d43c835773fabe131d9251197b6cc666a52d8caa3e1c7816
@@ -858,16 +859,18 @@ ExternalProject_Add(build-lrslib
   SOURCE_DIR        libraries/lrslib/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
+  PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/lrslib/patch-071
   CONFIGURE_COMMAND true
-  BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS} prefix=${M2_HOST_PREFIX} all-shared
+  BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS} prefix=${M2_HOST_PREFIX} lrs # all-shared
                       INCLUDEDIR=${MP_ROOT}/include
                       LIBDIR=${MP_ROOT}/lib
                       CPPFLAGS=${CPPFLAGS}
+                      CFLAGS=${CFLAGS}
                       LDFLAGS=${LDFLAGS}
                       CC=${CMAKE_C_COMPILER}
                       RANLIB=${CMAKE_RANLIB}
-  INSTALL_COMMAND   ${CMAKE_STRIP} lrs liblrs.so.1.0.0
-          COMMAND   ${MAKE} -j${PARALLEL_JOBS} prefix=${M2_HOST_PREFIX} install
+  INSTALL_COMMAND   ${CMAKE_STRIP} lrs # lrs-shared liblrs.so.1.0.0
+#          COMMAND   ${MAKE} -j${PARALLEL_JOBS} prefix=${M2_HOST_PREFIX} install
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/lrslib
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING ${M2_INSTALL_LICENSESDIR}/lrslib
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different lrs ${M2_INSTALL_PROGRAMSDIR}/
@@ -1078,16 +1081,16 @@ ExternalProject_Add(build-polymake
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING ${M2_INSTALL_LICENSESDIR}/polymake
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different ${M2_HOST_PREFIX}/bin/polymake ${M2_INSTALL_PROGRAMSDIR}/
           COMMAND   ${CMAKE_COMMAND} -E copy_directory
-	    ${M2_HOST_PREFIX}/lib/polymake   ${M2_DIST_PREFIX}/${M2_INSTALL_LIBDIR}/Macaulay2/lib
+            ${M2_HOST_PREFIX}/lib/polymake   ${M2_DIST_PREFIX}/${M2_INSTALL_LIBDIR}/Macaulay2/lib
           COMMAND   ${CMAKE_COMMAND} -E copy_directory
-	    ${M2_HOST_PREFIX}/share/polymake ${M2_DIST_PREFIX}/${M2_INSTALL_DATAROOTDIR}
+            ${M2_HOST_PREFIX}/share/polymake ${M2_DIST_PREFIX}/${M2_INSTALL_DATAROOTDIR}
   TEST_COMMAND      ${MAKE} test
   EXCLUDE_FROM_ALL  ON
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   USES_TERMINAL_BUILD ON
   )
-#_ADD_COMPONENT_DEPENDENCY(programs polymake "mp;mpfr;cddlib;flint;normaliz;lrs;nauty" POLYMAKE)
+#_ADD_COMPONENT_DEPENDENCY(programs polymake "mp;mpfr;cddlib;flint;normaliz;lrslib;nauty" POLYMAKE)
 
 
 # http://homepages.math.uic.edu/~jan/download.html

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -505,15 +505,18 @@ _ADD_COMPONENT_DEPENDENCY(libraries cddlib mp CDDLIB_FOUND)
 # https://numpi.dm.unipi.it/software/mpsolve
 # Known issue: tests don't work with static library
 ExternalProject_Add(build-mpsolve
-  URL               https://numpi.dm.unipi.it/_media/software/mpsolve/mpsolve-3.1.8.tar.gz
-  URL_HASH          SHA256=34740339d14cf8ca6d3f7da7ca12237b6da642623d14a6d6d5b5fc684c9c0fe5
+  URL               https://github.com/robol/MPSolve/archive/3.2.1.tar.gz
+  URL_HASH          SHA256=7edb7899d69a3e09848b893b12f360b8a83429a18eee4a7f193fcfc8692dca71
+  DOWNLOAD_NAME     MPSolve-3.2.1.tar.gz
   PREFIX            libraries/mpsolve
   SOURCE_DIR        libraries/mpsolve/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
-  CONFIGURE_COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
+  CONFIGURE_COMMAND autoreconf -vif
+            COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
                       ${shared_setting}
+		      --disable-debug # TODO: replace with --enable-debug-build conditionally
                       --disable-examples
                       --disable-ui
                       --disable-documentation
@@ -528,7 +531,7 @@ ExternalProject_Add(build-mpsolve
   INSTALL_COMMAND   ${MAKE} -j${PARALLEL_JOBS} -C src/libmps install
           COMMAND   ${MAKE} -j${PARALLEL_JOBS} -C include install
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/mpsolve
-          COMMAND   ${CMAKE_COMMAND} -E copy_if_different README ${M2_INSTALL_LICENSESDIR}/mpsolve
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING ${M2_INSTALL_LICENSESDIR}/mpsolve
   TEST_COMMAND      ${MAKE} -j${PARALLEL_JOBS} check
   EXCLUDE_FROM_ALL  ON
   TEST_EXCLUDE_FROM_MAIN ON

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -969,7 +969,7 @@ ExternalProject_Add(build-normaliz
   CONFIGURE_COMMAND autoreconf -vif
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
-                      --enable-shared
+                      --disable-shared # TODO: for polymake --enable-shared
                       --without-flint # ${FLINT_INCLUDE_DIR}/..
                       CPPFLAGS=${CPPFLAGS}
                       CFLAGS=${CFLAGS}
@@ -984,7 +984,7 @@ ExternalProject_Add(build-normaliz
                       OPENMP_CXXFLAGS=${normaliz_OpenMP_CXX_FLAGS}
             COMMAND patch --fuzz=10 --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/normaliz/patch-libtool
   BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS}
-  INSTALL_COMMAND   ${MAKE} -j${PARALLEL_JOBS} install-strip
+  INSTALL_COMMAND   ${CMAKE_STRIP} source/normaliz # TODO: for polymake ${MAKE} -j${PARALLEL_JOBS} install-strip
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/normaliz
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING ${M2_INSTALL_LICENSESDIR}/normaliz
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different source/normaliz ${M2_INSTALL_PROGRAMSDIR}/
@@ -1059,9 +1059,9 @@ ExternalProject_Add(build-polymake
                       --with-gmp=${MP_ROOT}
                       --with-cdd=${CDDLIB_INCLUDE_DIR}/..
                       --with-flint=${FLINT_INCLUDE_DIR}/..
-                      --with-libnormaliz=${M2_HOST_PREFIX}
-                      --with-lrs=${M2_HOST_PREFIX}
-                      --with-lrs-include=${CMAKE_BINARY_DIR}/libraries/lrslib/build
+#                      --with-libnormaliz=${M2_HOST_PREFIX}
+#                      --with-lrs=${M2_HOST_PREFIX}
+#                      --with-lrs-include=${CMAKE_BINARY_DIR}/libraries/lrslib/build
                       --with-nauty-src=${CMAKE_BINARY_DIR}/libraries/nauty/build
                       --without-bliss
                       --without-java

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -189,7 +189,8 @@ find_program(CSDP	NAMES	csdp)
 find_program(NORMALIZ	NAMES	normaliz)
 find_program(NAUTY	NAMES	dreadnaut)
 find_program(TOPCOM	NAMES	checkregularity)
-# NOTE: we don't build the following, but some packages use them
+# NOTE: we don't build the following by default, but some packages use them, so
+# we provide targets build-polymake, build-bertini, build-phcpack for building them.
 find_program(POLYMAKE	NAMES	polymake)
 find_program(BERTINI	NAMES	bertini)
 find_program(PHC	NAMES	phc)

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -125,7 +125,7 @@ find_package(Factory	4.1.0)
 # TODO: add minimum version checks
 find_package(Frobby	0.9.0)
 find_package(CDDLIB)  # 094h?
-find_package(MPSolve	3.1.8)
+find_package(MPSolve	3.2.0)
 find_package(GTest	1.10)
 find_package(Memtailor	1.0.0)
 find_package(Mathic	1.0.0)

--- a/M2/libraries/lrslib/patch-071
+++ b/M2/libraries/lrslib/patch-071
@@ -1,0 +1,14 @@
+--- a/makefile	2020-06-19 06:57:40.128413417 -0500
++++ b/makefile	2020-06-19 07:01:27.258023656 -0500
+@@ -52,10 +52,7 @@
+ 
+ lrs: ${LRSOBJ}
+ 	$(CC) ${CFLAGS} -DMA -DB128 -L${LIBDIR} -o lrs ${LRSOBJ} -lgmp
+-	$(CC)  -O3   -DGMP -I${INCLUDEDIR} -o lrsgmp lrs.c lrslib.c lrsgmp.c lrsdriver.c -L${LIBDIR}  -lgmp
+-	$(CC) -O3 hvref.c -o hvref
+-	ln -s -f lrs redund
+-	ln -s -f lrsgmp redundgmp
++	$(CC) ${CFLAGS} -DGMP -I${INCLUDEDIR} -o lrsgmp lrs.c lrslib.c lrsgmp.c lrsdriver.c -L${LIBDIR}  -lgmp
+ 
+ lrs64: ${LRSOBJ64}
+ 	$(CC) ${CFLAGS} -DMA -L${LIBDIR} -o lrs ${LRSOBJ64} -lgmp


### PR DESCRIPTION
- [x] update frobby to v0.9.1
- [x] update mpsolve to v3.2.1
- [x] teach cmake how to check the mpsolve version
- [x] add the mpsolve version to version.dd (see #1175)
- [x] upload the mpsolve archive to Macaulay2 website and update `libraries/mpsolve/Makefile`

@DanGrayson could you do the last item? Also, mpsolve has a COPYING file that probably should be used as the license file rather than the README.