### PR TITLE
Update printing of functions inside listSymbols

### DIFF
--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -186,7 +186,7 @@ localSymbols Type := X -> select2(X,localSymbols ())
 
 robust := y -> silentRobustNet(55,4,3,y)
 abbreviate := x -> (
-     if instance(x, Function) and match("^--Function.*--$", toString x) then "..."
+     if instance(x, Function) and match("^-\\*Function.*\\*-$", toString x) then "..."
      else robust x)
 listSymbols = method()
 listSymbols Dictionary := d -> listSymbols values d


### PR DESCRIPTION
The `abbreviate` function was expecting strings beginning with `"--Function"`
and ending with `"--"`, but the current behavior (since 2017) is to begin
with `"-*Function"` and end with `"*-"`.