### PR TITLE
Remove build paths from documentation (take 2)

### DIFF
--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -27,16 +27,14 @@ setupfun("reorganize",dbmreorganize);
 dbmopenin(e:Expr):Expr := (
      when e
      is a:stringCell do (
-	  if notify then stderr << "--opening database " <<
-	       relativizeFilename(a.v) << endl;
+	  if notify then stderr << "--opening database " << a.v << endl;
 	  dbmopenin(a.v))
      else buildErrorPacket("expected a string as filename"));
 setupfun("openDatabase",dbmopenin);
 dbmopenout(e:Expr):Expr := (
      when e
      is a:stringCell do (
-	  if notify then stderr << "--opening database for output " <<
-	       relativizeFilename(a.v) << endl;
+	  if notify then stderr << "--opening database for output " << a.v << endl;
 	  dbmopenout(a.v))
      else buildErrorPacket("expected a string as filename"));
 setupfun("openDatabaseOut",dbmopenout);
@@ -486,8 +484,7 @@ close(g:Expr):Expr := (
 	  g)
      is f:file do when close(f) is m:errmsg do buildErrorPacket(m.message) else g
      is x:Database do (
-	  if notify then stderr << "--closing database " <<
-	       relativizeFilename(x.filename) << endl;
+	  if notify then stderr << "--closing database " << x.filename << endl;
 	  dbmclose(x))
      else buildErrorPacket("expected a file or database"));
 setupfun("close",close).Protected = false;

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1500,7 +1500,7 @@ locate2(c:Code):Expr := (
      locate1();
      p := codePosition(c);
      Expr(Sequence(
-	       toExpr(relativizeFilename(locatedCode.filename)),
+	       toExpr(verifyMinimizeFilename(locatedCode.filename)),
 	       toExpr(locatedCode.minline),
 	       toExpr(locatedCode.mincol),
 	       toExpr(locatedCode.maxline),
@@ -1519,7 +1519,7 @@ locate(e:Expr):Expr := (
 	  then nullE
 	  else Expr(
 	       Sequence(
-		    toExpr(relativizeFilename(p.filename)),
+		    toExpr(verifyMinimizeFilename(p.filename)),
 		    toExpr(int(p.line)),toExpr(int(p.column)),
 		    toExpr(int(p.line)),toExpr(int(p.column)+length(s.symbol.word.name)),
 		    toExpr(int(p.line)),toExpr(int(p.column))

--- a/M2/Macaulay2/d/stdiop.d
+++ b/M2/Macaulay2/d/stdiop.d
@@ -112,7 +112,7 @@ export verifyMinimizeFilename(filename:string):string := (
 export tostring(w:Position) : string := (
      if w == dummyPosition 
      then "-*dummy position*-"
-     else errfmt(relativizeFilename(w.filename),int(w.line),int(w.column + 1),int(w.loadDepth)));
+     else errfmt(verifyMinimizeFilename(w.filename),int(w.line),int(w.column + 1),int(w.loadDepth)));
 export (o:file) << (w:Position) : file := o << tostring(w);
 export (o:BasicFile) << (w:Position) : BasicFile := o << tostring(w);
 threadLocal export SuppressErrors := false;

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -537,12 +537,19 @@ extractExamples := docBody -> (
 
 M2outputRE := "(\n+)i+[1-9][0-9]* : "
 M2outputREindex := 1
-separateM2output = method()
-separateM2output String := r -> (
+-- if called during installation (and thus generating html and info docs)
+-- then wrap examples to 77 characters.  otherwise, compute the width from
+-- printWidth, allowing space for the output prompt and box boundary
+separateM2output = method(Options => {"Install" => false})
+separateM2output String := o -> r -> (
      m := regex("^i1 : ",r);
      if m#?0 then r = substring(m#0#0,r);
      while r#?-1 and r#-1 == "\n" do r = substring(0,#r-1,r);
-     separateRegexp(M2outputRE,M2outputREindex,r))
+     wrapWidth := if o#"Install" then 77
+	  else printWidth - interpreterDepth - length toString lineNumber - 5;
+     apply(separateRegexp(M2outputRE,M2outputREindex,r), ex ->
+	  toString stack apply(lines ex, line -> wrap(wrapWidth, line)))
+     )
 
 makeExampleOutputFileName := (fkey,pkg) -> (			 -- may return 'null'
      if pkg#?"package prefix" and pkg#"package prefix" =!= null 

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -434,6 +434,33 @@ dispatcherMethod := m -> m#-1 === Sequence and (
      f := lookup m;
      any(dispatcherFunctions, g -> functionBody f === functionBody g))
 
+reproduciblePaths = outf -> (
+     outstr := get outf;
+     srcdir := regexQuote toAbsolutePath topSrcdir;
+     builddir := regexQuote prefixDirectory;
+     homedir := regexQuote homeDirectory;
+     if last homedir == "/" then homedir = substring(0, #homedir - 1, homedir);
+     if any({srcdir, builddir, homedir}, dir -> match(dir, outstr))
+     then (
+	 outstr = replace(srcdir | "Macaulay2/m2/startup.m2.in",
+	     "/path/to/source/Macaulay2/m2/startup.m2.in", outstr);
+	 outstr = replace(srcdir | "Macaulay2/m2",
+	     finalPrefix | Layout#1#"packages" | "Core", outstr);
+	 outstr = replace(srcdir | "Macaulay2/packages/",
+	     finalPrefix | Layout#1#"packages", outstr);
+	 outstr = replace(builddir | Layout#2#"bin",
+	     finalPrefix | Layout#1#"bin", outstr);
+	 outstr = replace(builddir | Layout#2#"data",
+	     finalPrefix | Layout#1#"data", outstr);
+	 outstr = replace(builddir | Layout#2#"lib",
+	     finalPrefix | Layout#1#"lib", outstr);
+	 outstr = replace(homedir, "/home/m2user", outstr);
+	 outstr = replace(builddir, finalPrefix, outstr);
+	 outf << outstr << close;
+	 );
+     outstr
+    )
+
 installPackage Package := opts -> pkg -> (
      tallyInstalledPackages();
      verbose := opts.Verbose or debugLevel > 0;
@@ -626,7 +653,10 @@ installPackage Package := opts -> pkg -> (
 			      )
 			 );
 		    -- read, separate, and store example output
-		    if fileExists outf then pkg#"example results"#fkey = drop(separateM2output get outf,-1)
+		    if fileExists outf then (
+			 outstr := reproduciblePaths outf;
+			 pkg#"example results"#fkey = drop(separateM2output outstr,-1)
+		    )
 		    else (
 			 if debugLevel > 1 then stderr << "--warning: missing file " << outf << endl;
 			 )

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -655,7 +655,8 @@ installPackage Package := opts -> pkg -> (
 		    -- read, separate, and store example output
 		    if fileExists outf then (
 			 outstr := reproduciblePaths outf;
-			 pkg#"example results"#fkey = drop(separateM2output outstr,-1)
+			 pkg#"example results"#fkey = drop(
+			      separateM2output(outstr, "Install" => true), -1)
 		    )
 		    else (
 			 if debugLevel > 1 then stderr << "--warning: missing file " << outf << endl;

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -436,6 +436,7 @@ dispatcherMethod := m -> m#-1 === Sequence and (
 
 reproduciblePaths = outf -> (
      outstr := get outf;
+     if topSrcdir === null then return outstr;
      srcdir := regexQuote toAbsolutePath topSrcdir;
      builddir := regexQuote prefixDirectory;
      homedir := regexQuote homeDirectory;

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -53,7 +53,7 @@ ArgNoTValues   := 1 << 10 -* add --no-tvalues *-
 ArgNotify      := 1 << 11 -* add --notify *-
 ArgSilent      := 1 << 12 -* add --silent *-
 ArgStop        := 1 << 13 -* add --stop *-
-ArgPrintWidth  := 1 << 14 -* add --print-width 77 *-
+ArgPrintWidth  := 1 << 14 -* add --print-width 0 *-
 -- suffixes
 SetInputFile   := 1 << 30 -* add <inf *-
 SetOutputFile  := 1 << 31 -* add >>tmpf *-
@@ -110,7 +110,7 @@ runFile = (inf, inputhash, outf, tmpf, desc, pkg, announcechange, usermode, exam
      cmd = cmd | readmode(ArgNotify,      "--notify");
      cmd = cmd | readmode(ArgSilent,      "--silent");
      cmd = cmd | readmode(ArgStop,        "--stop");
-     cmd = cmd | readmode(ArgPrintWidth,  "--print-width 77");
+     cmd = cmd | readmode(ArgPrintWidth,  "--print-width 0");
      cmd = cmd | concatenate apply(srcdirs, d -> (" --srcdir",format d));
      needsline := concatenate(" -e 'needsPackage(\"",pkgname,"\", Reload => true, FileName => \"",pkg#"source file","\")'");
      cmd = cmd | if pkgname != "Macaulay2Doc" then needsline else "";

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -32,7 +32,6 @@ toString := value' getGlobalSymbol if firstTime then "simpleToString" else "toSt
 match := X -> null =!= regex X
 
 local exe
-local topSrcdir
 local topBuilddir
 
 -- this next bit has to be *parsed* after the "debug" above, to prevent the symbols from being added to the User dictionary

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -51,7 +51,7 @@ if firstTime then (
      markLoaded = (fullfilename,origfilename,notify,filetime) -> ( 
 	  fullfilename = minimizeFilename fullfilename;
 	  filesLoaded#origfilename = (fullfilename,filetime); 
-	  loadedFiles##loadedFiles = relativizeFilename fullfilename;
+	  loadedFiles##loadedFiles = realpath toAbsolutePath fullfilename; 
 	  if notify then stderr << "--loaded " << fullfilename << endl;
 	  );
      normalPrompts = () -> (

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -296,6 +296,8 @@ if firstTime then (
 		    replaceStrings("^\\$\\{(pre_)?prefix\\}","common",	    -- as in configure.ac
 			 replaceStrings("^\\$\\{(pre_)?exec_prefix\\}",version#"machine", -- as in configure.ac
 			      x)))};
+	  finalPrefix = "@prefix@";
+	  if last finalPrefix != "/" then finalPrefix = finalPrefix | "/";
 	  );
      initlayout();
      )

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -274,7 +274,8 @@ document {
 	  prepended to the path, based on the value of the ", TO "applicationDirectory", "
 	  for your system."
 	  },
-     PRE concatenate between_"\n" apply(value Core#"private dictionary"#"userpath",s -> (5,s)),
+     PRE replace(regexQuote homeDirectory, "/home/m2user/",
+	   concatenate between_"\n" apply(value Core#"private dictionary"#"userpath",s -> (5,s))),
      EXAMPLE {
 	  "path",
 	  ///path = append(path, "~/resolutions/")///

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc2.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc2.m2
@@ -1090,8 +1090,9 @@ document {
      Outputs => {
 	  "the complete path to the current directory, together with an extra slash"
 	  },
-     EXAMPLE {PRE("i1 : currentDirectory()" | newline | newline |
-	  "o1 = /home/m2user/")},
+     EXAMPLE lines ///
+     currentDirectory()
+     ///,
      PARA {
 	  "If a component of the path to the current directory no longer exist, an error will be signalled."
 	  }

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
@@ -1425,8 +1425,9 @@ document { Key => toAbsolutePath,
      Outputs => {
 	  String => {"the absolute (real) path name of ", TT "filename"}
 	  },
-     EXAMPLE {PRE(///i1 : toAbsolutePath "a/b.m2"/// | newline | newline |
-	  ///o1 = /home/m2user/a/b.m2 ///)},
+     EXAMPLE lines ///
+         toAbsolutePath "a/b.m2"
+     ///,
      PARA {
 	  "Paths of the form ", TT "foo/x/../bar", ", are shortened to ", TT "foo/bar", " without
 	  checking the file system to see whether ", TT "x", " is a symbolic link.  For the other

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/endPackage-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/endPackage-doc.m2
@@ -15,6 +15,7 @@ document {
 	  abc = 3
 	  dictionaryPath
 	  endPackage "Foo"
+	  peek oo
 	  dictionaryPath
 	  abc
      ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/realpath-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/realpath-doc.m2
@@ -9,7 +9,8 @@ document {
      Inputs => { "fn" => String => "a filename, or path to a file" },
      Outputs => { String => { "a pathname to ", TT "fn", " passing through no symbolic links, and
 	       ending with a slash if ", TT "fn", " refers to a directory" }},
-     EXAMPLE (lines ///
+     EXAMPLE lines ///
+     	  realpath "."
      	  p = temporaryFileName()
 	  q = temporaryFileName()
 	  symlinkFile(p,q)
@@ -18,13 +19,11 @@ document {
 	  realpath q
 	  removeFile p
 	  removeFile q
-     /// | {PRE(///i9 : realpath "."/// | newline | newline |
-	  ///o9 = /home/m2user/ ///)}),
+     ///,
      PARA {
 	  "The empty string is interpreted as a reference to the current directory."
 	  },
-     EXAMPLE {PRE(///i10 : realpath ""/// | newline | newline |
-	  ///o10 = /home/m2user/ ///)},
+     EXAMPLE ///realpath ""///,
      SeeAlso => {readlink},
      Caveat => {
 	  "Every component of the path must exist in the file system and be accessible to the user.

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview3.m2
@@ -419,26 +419,17 @@ document {
 	  "The following example shows the list of places where we might find the source code of a package called ", TT "Foo", "
 	  after it has been installed by ", TO "installPackage", "."
 	  },
-     EXAMPLE {PRE(
-	  ///i1 : stack apply(prefixPath, p -> p | Layout#1#"packages" | "Foo.m2")///
-	  | newline | newline | ///o1 = /home/m2user/.Macaulay2/local/share/Macaulay2/Foo.m2///
-	  | newline | ///     /usr/share/Macaulay2/Foo.m2///)},
+     EXAMPLE ///stack apply(prefixPath, p -> p | Layout#1#"packages" | "Foo.m2")///,
      PARA {
      	  "This example shows the list of places where we might reasonably find the html file documenting a
 	  function named ", TT "bar", " in a package called ", TT "Foo", "."
 	  },
-     EXAMPLE {PRE(
-	  ///i2 : stack apply(prefixPath, p -> p | replace("PKG","Foo",Layout#1#"packagehtml") | "bar.html")///
-	  | newline | newline | ///o2 = /home/m2user/.Macaulay2/local/share/doc/Macaulay2/Foo/html/bar.html///
-	  | newline | ///     /usr/share/doc/Macaulay2/Foo/html/bar.html///)},
+     EXAMPLE ///stack apply(prefixPath, p -> p | replace("PKG","Foo",Layout#1#"packagehtml") | "bar.html")///,
      PARA {
      	  "This example shows the list of places where we might reasonably find the info file documenting a
 	  package called ", TT "Foo", "."
 	  },
-     EXAMPLE {PRE(
-	  ///i3 : stack apply(prefixPath, p -> p | Layout#1#"info" | "Foo.info")///
-	  | newline | newline | ///o3 = /home/m2user/.Macaulay2/local/share/info/Foo.info///
-	  | newline | ///     /usr/share/info/Foo.info///)},
+     EXAMPLE ///stack apply(prefixPath, p -> p | Layout#1#"info" | "Foo.info")///,
      SeeAlso => {"commandLine", "Invoking the program", applicationDirectory, "prefixDirectory", "path", searchPath, load, loadPackage, needsPackage}
      }
 

--- a/M2/Macaulay2/packages/ReflexivePolytopesDB.m2
+++ b/M2/Macaulay2/packages/ReflexivePolytopesDB.m2
@@ -134,7 +134,7 @@ availableOffline = () -> (
     hashTable for k in keys offlines list (
         val := offlines#k;
         (maxlimit, filename) := if instance(val, Sequence) then val else (infinity, val);
-        actualfile := relativizeFilename(offlineDirectory | filename);
+        actualfile := offlineDirectory | filename;
         fcncall := if instance(k, ZZ) then (
           "kreuzerSkarke("|k|
             (if maxlimit === infinity then ")" else ", Limit => "|maxlimit|")")

--- a/M2/Macaulay2/packages/RunExternalM2.m2
+++ b/M2/Macaulay2/packages/RunExternalM2.m2
@@ -760,7 +760,7 @@ runExternalM2 = {
 	);	
 	if (M2Loc===null) then (
 		-- TODO, do we need rootPath for Cygwin?
-		M2Loc=relativizeFilename(first(commandLine));
+		M2Loc=toAbsolutePath(first(commandLine));
 	);
 	if not(fileExists(M2Loc)) then (
 		error "runExternalM2: error finding location of M2 program; check M2Location option";

--- a/M2/Macaulay2/packages/gfanInterface.m2
+++ b/M2/Macaulay2/packages/gfanInterface.m2
@@ -2647,6 +2647,20 @@ doc ///
 			{\tt gfanInterface.m2} either before installing or in the installed copy.
 			You will find the path configuration near the top of the file.
 
+			If {\tt gfanInterface} is already installed and loaded, you can find the path
+			of the source file by the following command:
+
+		Example
+			gfanInterface#"source file"
+
+		Text
+			If you want to use {\tt gfan} executables outside of @EM "Macaulay2"@, they can be found with
+			{\tt currentLayout#"programs"}:
+
+		Example
+			prefixDirectory | currentLayout#"programs"
+
+		Text
 			If you would like to see the input and output files used to communicate with {\tt gfan}
 			you can set the {\tt "keepfiles"} configuration option to {\tt true}. If {\tt "verbose"}
 			is set to {\tt true}, {\tt gfanInterface} will output the names of the temporary files used.


### PR DESCRIPTION
My first attempt at making Macaulay2's builds more reproducible by removing instances of the build paths from the documentation (#1247) had several problems.  In particular:

* It relied on using relative instead of absolute paths.  But for this to work, we needed to be building the examples from the build directory instead of `/tmp`, or the build path would still appear in the relative path.  However, the commit that made this change (afda220) was causing problems (https://github.com/Macaulay2/M2/issues/1257#issuecomment-643654221) and was reverted in 1a1a009.
* Some examples required the use of absolute paths (e.g., `toAbsolutePath`), and so canned examples were used, which is not ideal.
* A fictional `HOME` environment variable was set for the benefit of examples like `homeDirectory`.  However, this was also causing problems and was reverted in 204983c.

Instead, we take a completely different approach.  Instead of changing the behavior of Macaulay2 so that the examples it produces are reproducible, we process the examples after they are generated with the help of the new `regexQuote` function introduced in #1278.

The only change to the example-generating process itself now is that we use a `printWidth` of 0 (i.e., no wrapping) instead of 77.  Wrapping then takes place after the examples are generated.  The original goal was to make it easier to replace build paths that have been split up between lines, but it also has a nice side effect in that *all* examples are wrapped, instead of just those that previously actually obeyed `printWidth`.  For example, consider the documentation for `HH^ZZ CoherentSheaf`.

In 1.15:

![wrap1 15](https://user-images.githubusercontent.com/1992248/85765335-03c0ff00-b6e4-11ea-9d28-be68d42b40f8.png)

After this PR:

![wrapnew](https://user-images.githubusercontent.com/1992248/85765389-0f142a80-b6e4-11ea-8b11-8032181a43da.png)

Closes: #1149

