### PR TITLE
Two fixes for finding gftables in the autotools build

### DIFF
--- a/M2/check-configure/Makefile.in
+++ b/M2/check-configure/Makefile.in
@@ -14,7 +14,7 @@ check-config:
 	    PATH="$(BUILTLIBPATH)/bin:$(PATH)"					\
 	    @abs_top_srcdir@/configure						\
 	    PKG_CONFIG_PATH=$(BUILTLIBPATH)/lib/pkgconfig:$(PKG_CONFIG_PATH)	\
-	    GFTABLESDIR=@GFTABLESDIR@						\
+	    GFTABLESDIR=@PRE_GFTABLESDIR@					\
 	    LDFLAGS="@BUILTLIBS@ $(LDFLAGS)"					\
 	    --with-gtest-source-path="@GTEST_PATH@"				\
 	    CPPFLAGS="$(CPPFLAGS)"						\

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1278,9 +1278,9 @@ else
     then
 	if test $FACTORY_NAME = factory
 	then
-	    GFTABLESDIR="${datadir}/factory/"
+	    GFTABLESDIR="`$PKG_CONFIG --variable=prefix $FACTORY_NAME`/share/factory/"
 	else
-	    GFTABLESDIR="${datadir}/singular/factory/"
+	    GFTABLESDIR="`$PKG_CONFIG --variable=prefix $FACTORY_NAME`/share/singular/factory/"
 	fi
     fi
     adl_RECURSIVE_EVAL([$GFTABLESDIR], [GFTABLESDIR])

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1814,6 +1814,13 @@ done
 prefix=$save_prefix
 exec_prefix=$save_exec_prefix
 
+if test $BUILD_gftables = no
+then PRE_GFTABLESDIR="$GFTABLESDIR"
+else
+PRE_GFTABLESDIR="$pre_datadir/Macaulay2/Core/factory/"
+fi
+AC_SUBST(PRE_GFTABLESDIR)
+
 AC_SUBST(pre_bindir) dnl In Macaulay2/bin/M2.in we assume that $pre_bindir/.. is $pre_exec_prefix, which follows from pre_bindir=${pre_exec_prefix}/bin.
 AC_SUBST(pre_datadir)
 AC_SUBST(pre_includedir)


### PR DESCRIPTION
The first fixes a bug that I introduced in 400a7bc and is responsible for the failing "Run Tests" target in the autotools workflows.

The second uses `pkg-config` to find the location of gftables instead of assuming they're under the same prefix we're planning on installing Macaulay2 under.