### PR TITLE
Add quotes around reference to "break" keyword in docs for scan function

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/scan-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/scan-doc.m2
@@ -30,7 +30,7 @@ doc///
    scan(4, print)
    v = {a,b,c}; scan(#v, i -> print(i,v#i))
   Text
-   The keyword @TO break@ can be used to terminate the scan prematurely, 
+   The keyword @TO "break"@ can be used to terminate the scan prematurely,
    and optionally to specify a return value for the expression. Here we
    use it to locate the first even number in a list.
   Example


### PR DESCRIPTION
Without the quotes, "break" is completely missing from the documentation,
likely due to the following:

    i22 : TO break
    stdio:23:4:(3): error: unhandled break command

See https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.15/share/doc/Macaulay2/Macaulay2Doc/html/_scan.html

By adding quotes, it works as intended.  This is already done in the
documentation for "lists and sequences".
See https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.15/share/doc/Macaulay2/Macaulay2Doc/html/_lists_spand_spsequences.html