### PR TITLE
Fix broken links in PencilsofQuadrics package

### DIFF
--- a/M2/Macaulay2/packages/PencilsOfQuadrics.m2
+++ b/M2/Macaulay2/packages/PencilsOfQuadrics.m2
@@ -20,10 +20,10 @@ peek loadedFiles
                        HomePage => ""},
              	         {Name => "David Eisenbud", 
                        Email => "de@msri.org", 
-                       HomePage => "www.msri.org/~de"},
+                       HomePage => "https://www.msri.org/~de"},
 		       {Name => "Yeongrak Kim",
 			   Email => "kim@math.uni-sb.de",
-			   HomePage => "sites.google.com/view/yeongrak"}
+			   HomePage => "https://sites.google.com/view/yeongrak"}
 		   },
 	               PackageExports => {"CompleteIntersectionResolutions"},
              Headline => "Clifford Algebra of a pencil of quadratic forms",


### PR DESCRIPTION
The HomePage fields were missing the https protocol, causing
html-check-links to fail:

```
cd /build/macaulay2-1.15.1.0+git714.dd7b420+ds/M2/usr-dist/common/share/doc/Macaulay2 && find . -name \*.html -o -name \*.xhtml | xargs ls -rt | LD_LIBRARY_PATH="/build/macaulay2-1.15.1.0+git714.dd7b420+ds/M2/usr-host/lib:$LD_LIBRARY_PATH" xargs "/build/macaulay2-1.15.1.0+git714.dd7b420+ds/M2/Macaulay2/html-check-links"/html-check-links --no-absolute-links
./PencilsOfQuadrics/html/index.html:95:9: error: broken link: ../../../../../../www.msri.org/~de
./PencilsOfQuadrics/html/index.html:97:9: error: broken link: ../../../../../../sites.google.com/view/yeongrak
make[3]: *** [Makefile:62: run-html-check-links] Error 123
rm lex.c
make[3]: Leaving directory '/build/macaulay2-1.15.1.0+git714.dd7b420+ds/M2/Macaulay2/html-check-links'
make[2]: *** [Makefile:14: all-in-html-check-links] Error 2
make[2]: Leaving directory '/build/macaulay2-1.15.1.0+git714.dd7b420+ds/M2/Macaulay2'
make[1]: *** [GNUmakefile:217: all-in-Macaulay2] Error 2
make[1]: Leaving directory '/build/macaulay2-1.15.1.0+git714.dd7b420+ds/M2'
dh_auto_build: error: cd M2 && make -j12 returned exit code 2
make: *** [debian/rules:12: binary] Error 25
```