### PR TITLE
Improvements to hooks

### DIFF
--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -162,6 +162,12 @@ methods Thing := F -> (
      -- sort -- too slow
      previousMethodsFound = new NumberedVerticalList from sortByName keys found)
 
+hooks = method()
+hooks   (MutableHashTable,Thing) := (obj,key) -> previousMethodsFound = new NumberedVerticalList from obj#key
+hooks   (HashTable,Thing) := (obj,key) -> previousMethodsFound = new NumberedVerticalList from (obj.cache)#key
+hooks   (Symbol) := (sym) -> previousMethodsFound = new NumberedVerticalList from (value sym)
+
+
 debuggerUsageMessage = ///--debugger activation depth control:
     errorDepth=3   	-- activate at positions in user code (default)
     errorDepth=2   	-- activate also at positions in packages

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -713,6 +713,7 @@ export {
 	"homology",
 	"homomorphism",
 	"homomorphism'",
+	"hooks",
 	"horizontalJoin",
 	"html",
 	"htmlWithTex",

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -193,7 +193,6 @@ export {
 	"HomePage",
 	"Homogeneous",
 	"Homogeneous2",
-	"HookOptions",
 	"HorizontalSpace",
 	"Ideal",
 	"IgnoreExampleErrors",

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -193,6 +193,7 @@ export {
 	"HomePage",
 	"Homogeneous",
 	"Homogeneous2",
+	"HookOptions",
 	"HorizontalSpace",
 	"Ideal",
 	"IgnoreExampleErrors",

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -510,24 +510,34 @@ dispatcherFunctions = join (dispatcherFunctions, {
 
 addHook = method()
 removeHook = method()
-runHooks = method(Options => {HookOptions => new OptionTable})
+runHooks = method(Options => true)
 
 addHook   (MutableHashTable,Thing,Function) := (obj,key,hook) -> obj#key = if obj#?key then prepend(hook,obj#key) else {hook}
 removeHook(MutableHashTable,Thing,Function) := (obj,key,hook) -> if obj#?key then obj#key = delete(obj#key,hook)
-runHooks  (MutableHashTable,Thing,Thing   ) := opts -> (obj,key,arg ) -> if obj#?key then scan(obj#key, hook -> (
-          result := (if instance(hook, MethodFunctionWithOptions) then hook(arg,opts.HookOptions) else hook arg);
-          if not instance(result, Nothing) then break result))
+runHooks  (MutableHashTable,Thing,Thing   ) := true >> opts -> (obj,key,arg ) -> (if obj#?key then scan(obj#key, hook -> (
+          result := (if options hook =!= null then (
+               hookOpts := select(keys options hook, k -> opts#?k) / (k -> k => opts#k);
+               hook(arg, new OptionTable from hookOpts)
+               ) else hook arg 
+          );
+          if not instance(result, Nothing) then break result)))
 
 addHook   (HashTable,Thing,Function) := (obj,key,hook) -> (c := obj.cache; c#key = if c#?key then prepend(hook,c#key) else {hook})
 removeHook(HashTable,Thing,Function) := (obj,key,hook) -> (c := obj.cache; if c#?key then c#key = delete(c#key,hook))
-runHooks  (HashTable,Thing,Thing   ) := opts -> (obj,key,arg ) -> (c := obj.cache; if c#?key then scan(c#key, hook -> (
-          result := (if instance(hook, MethodFunctionWithOptions) then hook(arg,opts.HookOptions) else hook arg);
+runHooks  (HashTable,Thing,Thing   ) := true >> opts -> (obj,key,arg ) -> (c := obj.cache; if c#?key then scan(c#key, hook -> (
+          result := (if options hook =!= null then ( 
+               hookOpts := select(keys options hook, k -> opts#?k) / (k -> k => opts#k);
+               hook(arg, new OptionTable from hookOpts)
+               ) else hook arg);
           if not instance(result, Nothing) then break result)))
 
 addHook   (Symbol,Function) := (sym,hook) -> sym <- if value sym =!= sym then prepend(hook,value sym) else {hook}
 removeHook(Symbol,Function) := (sym,hook) -> if value sym =!= sym then sym <- delete(value sym,hook)
-runHooks  (Symbol,Thing   ) := opts -> (sym,arg ) -> if value sym =!= sym then scan(value sym, hook -> (
-          result := (if instance(hook, MethodFunctionWithOptions) then hook(arg,opts.HookOptions) else hook arg);
+runHooks  (Symbol,Thing   ) := true >> opts -> (sym,arg ) -> if value sym =!= sym then scan(value sym, hook -> (
+          result := (if options hook =!= null then ( 
+               hookOpts := select(keys options hook, k -> opts#?k) / (k -> k => opts#k);
+               hook(arg, new OptionTable from hookOpts)
+               ) else hook arg);
           if not instance(result, Nothing) then break result))
 
 -- and keys

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -510,19 +510,25 @@ dispatcherFunctions = join (dispatcherFunctions, {
 
 addHook = method()
 removeHook = method()
-runHooks = method()
+runHooks = method(Options => {HookOptions => new OptionTable})
 
 addHook   (MutableHashTable,Thing,Function) := (obj,key,hook) -> obj#key = if obj#?key then prepend(hook,obj#key) else {hook}
 removeHook(MutableHashTable,Thing,Function) := (obj,key,hook) -> if obj#?key then obj#key = delete(obj#key,hook)
-runHooks  (MutableHashTable,Thing,Thing   ) := (obj,key,arg ) -> if obj#?key then scan(obj#key, hook -> hook arg)
+runHooks  (MutableHashTable,Thing,Thing   ) := opts -> (obj,key,arg ) -> if obj#?key then scan(obj#key, hook -> (
+          result := (if instance(hook, MethodFunctionWithOptions) then hook(arg,opts.HookOptions) else hook arg);
+          if not instance(result, Nothing) then break result))
 
 addHook   (HashTable,Thing,Function) := (obj,key,hook) -> (c := obj.cache; c#key = if c#?key then prepend(hook,c#key) else {hook})
 removeHook(HashTable,Thing,Function) := (obj,key,hook) -> (c := obj.cache; if c#?key then c#key = delete(c#key,hook))
-runHooks  (HashTable,Thing,Thing   ) := (obj,key,arg ) -> (c := obj.cache; if c#?key then scan(c#key, hook -> hook arg))
+runHooks  (HashTable,Thing,Thing   ) := opts -> (obj,key,arg ) -> (c := obj.cache; if c#?key then scan(c#key, hook -> (
+          result := (if instance(hook, MethodFunctionWithOptions) then hook(arg,opts.HookOptions) else hook arg);
+          if not instance(result, Nothing) then break result)))
 
 addHook   (Symbol,Function) := (sym,hook) -> sym <- if value sym =!= sym then prepend(hook,value sym) else {hook}
 removeHook(Symbol,Function) := (sym,hook) -> if value sym =!= sym then sym <- delete(value sym,hook)
-runHooks  (Symbol,Thing   ) := (sym,arg ) -> if value sym =!= sym then scan(value sym, hook -> hook arg)
+runHooks  (Symbol,Thing   ) := opts -> (sym,arg ) -> if value sym =!= sym then scan(value sym, hook -> (
+          result := (if instance(hook, MethodFunctionWithOptions) then hook(arg,opts.HookOptions) else hook arg);
+          if not instance(result, Nothing) then break result))
 
 -- and keys
 protect QuotientRingHook

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc13.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc13.m2
@@ -75,7 +75,7 @@ document {
 	       stored in ", TT "obj#key", " if ", TT "obj", " is mutable, or in ", TT "obj.cache#key", " if not" }
 	  },
      SourceCode => {(addHook,HashTable,Thing,Function), (addHook,MutableHashTable,Thing,Function)},
-     SeeAlso => { (runHooks,HashTable,Thing,Thing), (removeHook,HashTable,Thing,Function) }
+     SeeAlso => { "using hooks", (runHooks,HashTable,Thing,Thing), (removeHook,HashTable,Thing,Function) }
      }
 document {
      Key => { (addHook,Symbol,Function) },
@@ -86,7 +86,7 @@ document {
 	       stored as the value of ", TT "sym" }
 	  },
      SourceCode => {(addHook,HashTable,Thing,Function), (addHook,MutableHashTable,Thing,Function)},
-     SeeAlso => { (runHooks,Symbol,Thing), (removeHook,Symbol,Function) }
+     SeeAlso => { "using hooks", (runHooks,Symbol,Thing), (removeHook,Symbol,Function) }
      }
 undocumented {(removeHook,MutableHashTable,Thing,Function)}
 document {
@@ -101,7 +101,7 @@ document {
 	  { "the function ", TT "hook", " is removed from the list of hooks stored in ", TT "obj#key", " or ", TT "obj.cache#key" }
 	  },
      SourceCode => {(removeHook,HashTable,Thing,Function), (removeHook,MutableHashTable,Thing,Function)},
-     SeeAlso => { (runHooks,HashTable,Thing,Thing), (removeHook,HashTable,Thing,Function) }
+     SeeAlso => { "using hooks", (runHooks,HashTable,Thing,Thing), (removeHook,HashTable,Thing,Function) }
      }
 document {
      Key => { (removeHook,Symbol,Function)},
@@ -110,7 +110,7 @@ document {
      Consequences => {
 	  { "the function ", TT "hook", " is removed from the list of hooks stored in the value of ", TT "sym" }
 	  },
-     SeeAlso => { (runHooks,Symbol,Thing), (addHook,Symbol,Function) }
+     SeeAlso => { "using hooks", (runHooks,Symbol,Thing), (addHook,Symbol,Function) }
      }
 undocumented {(runHooks,MutableHashTable,Thing,Thing)}
 document {
@@ -122,28 +122,79 @@ document {
      Usage => "runHooks(obj,key,arg)",
      Inputs => { "obj", "key", "arg" },
      Outputs => {{
-	       "If one of the functions uses ", TO "break", " to return a value, that value will be returned.  Otherwise ", TO "null", " will be returned."
+	       "If one of the hook functions returns a non-", TO "null", " value, that value will be returned.  Otherwise ", TO "null", " will be returned."
 	       }},
-     Consequences => {
-	  { "each function ", TT "hook", " in list of hooks stored in ", TT "obj#key", " or ", TT "obj.cache#key", " is
-	       called with ", TT "arg", " as its argument or sequence of arguments." }
-	  },
-     SourceCode => { (runHooks,HashTable,Thing,Thing), (runHooks,MutableHashTable,Thing,Thing) },
-     SeeAlso => { addHook, removeHook }
+     PARA { "Each function ", TT "hook", " in the list of hooks stored in ", TT "obj#key", " or ", TT "obj.cache#key", " is
+            called with ", TT "arg", " as its argument or sequence of arguments. Any optional argument for ", TT "runHooks",
+            " that matches any key in ", TT "options hook", " will be passed on to ", TT "hook", ". Otherwise it will be ignored." 
+       },
+     SeeAlso => { "using hooks", addHook, removeHook }
      }
 document {
      Key => { (runHooks,Symbol,Thing) },
      Usage => "runHooks(sym,arg)",
      Inputs => { "sym", "arg" },
      Outputs => {{
-	       "If one of the functions uses ", TO "break", " to return a value, that value will be returned.  Otherwise ", TO "null", " will be returned."
-	       }},
-     Consequences => {
-	  { "each function ", TT "hook", " in list of hooks stored in value of ", TT "sym", " is
-	       called with ", TT "arg", " as its argument or sequence of arguments." }
-	  },
-     SeeAlso => { (addHook,Symbol,Function), (removeHook,Symbol,Function) }
+	       "If one of the hook functions returns a non-", TO "null", " value, that value will be returned.  Otherwise ", TO "null", " will be returned."
+            }},
+     PARA {
+	"Each function ", TT "hook", " in the list of hooks stored in the value of ", TT "sym", " is
+     called with ", TT "arg", " as its argument or sequence of arguments. Any optional argument for ", TT "runHooks",
+     " that matches any key in ", TT "options hook", " will be passed on to ", TT "hook", ". Otherwise it will be ignored." 
+	},
+     SeeAlso => { "using hooks", (addHook,Symbol,Function), (removeHook,Symbol,Function) }
      }
+
+
+document {
+     Key => {hooks,(hooks, MutableHashTable, Thing),(hooks, HashTable, Thing),(hooks, Symbol)},
+     Headline => "list hooks",
+     SYNOPSIS (
+       Usage => "methods(X, f)",
+       Inputs => {
+            "x" => { ofClass{MutableHashTable} }
+            },
+       Outputs => {{
+              ofClass VerticalList, " of those hooks associated with ", TT "X#f"
+              }},
+       EXAMPLE lines ///
+            instance(Ideal, MutableHashTable)
+            addHook(Ideal, symbol foo, I -> gens I);
+            addHook(Ideal, symbol foo, I -> if dim I == 0 then vars ring I);
+            Ideal#?(symbol foo)
+            hooks(Ideal, symbol foo)
+       ///
+       ),
+     SYNOPSIS (
+       Usage => "methods(X, f)",
+       Inputs => {
+            "x" => { ofClass{HashTable} }
+            },
+       Outputs => {{
+              ofClass VerticalList, " of those hooks associated with ", TT "X.cache#f"
+              }},
+       EXAMPLE lines ///
+            ht = new HashTable from {cache => new MutableHashTable};
+            addHook(ht, symbol foo, i -> i + 1);
+            hooks(ht, symbol foo)
+       ///
+       ),
+     SYNOPSIS (
+       Usage => "hooks(sym)",
+       Inputs => {
+            "sym" => Symbol
+            },
+       Outputs => {{
+              ofClass VerticalList, " of those hooks stored in the value of ", TT "sym"
+              }},
+       EXAMPLE lines ///
+            addHook(symbol bar, i-> i + 1)
+            hooks(symbol bar)
+       ///
+       ),
+     SeeAlso => { "using hooks" }
+     }
+
 undocumented {(generateAssertions, List)}
 document { Key => {generateAssertions,(generateAssertions, String)},
      Headline => "generate assert statements from experimental input",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2
@@ -51,6 +51,7 @@ document {
 	      TO "making functions with a variable number of arguments",
 	      TO "making functions with multiple return values",
 	      TO "making new functions with optional arguments",
+	      TO "using hooks",
 	  "classes and types",
 	      TO "what a class is",
 	      TO "installing methods",
@@ -551,6 +552,36 @@ document {
 	  "f(5,11,a=>10^20)",
 	  },
      }
+
+document { Key => "using hooks", 
+     PARA {"Hooks are a way to provide different implementations of functions and methods.
+     The user can attach multiple hooks to a function via ", TO "addHook", "."},
+     
+     PARA {"Hooks can be functions or methods, and they can accept optional arguments." },
+     EXAMPLE lines ///
+     f = {a=>3, c=>12} >> opts -> val -> if val == 1 then opts.a + opts.c
+     g = method(Options => {b => 5})
+     g ZZ := opts -> val -> if val == 2 then opts.b + 1
+     h = val -> if val == 3 then 24
+     addHook(ZZ, symbol foo, f)
+     addHook(ZZ, symbol foo, g)
+     addHook(ZZ, symbol foo, h)
+     ///,
+     PARA {"The command ", TO "hooks", " lists all hooks attached to a symbol."},
+     EXAMPLE {"hooks(ZZ, symbol foo)"},
+     PARA {"The method ", TO "runHooks", " runs all the hooks until one of them returns a non-null value.
+     Hooks are run in order starting from the most recently added hook. Because of this, 
+     hooks should be able to decide quickly if they should be used or not."},
+     PARA {"Any optional argument passed to ", TT "runHooks", " that matches a key in the ", TO "OptionTable", 
+     " of a hook will be passed on to it. Otherwise it will be ignored." },
+     EXAMPLE lines ///
+     foo = true >> opts -> args -> runHooks(ZZ, symbol foo, args, opts)
+     assert( foo 1 == 15 )
+     assert( foo(2, b => 9) == 10 )
+     assert( foo 3 == 24 )
+     ///,
+     SeeAlso => {addHook, removeHook, runHooks, hooks}
+}
 
 document {
      Key => "conditional execution",


### PR DESCRIPTION
Partially addresses #1153

- Added a method `hooks(...)` to list hooks. This returns a `NumberedVerticalList`, and code for each hook can be examined using `code ZZ`
- Hooks can now have optional arguments. The function `runHooks` passes any relevant optional arguments to each hook.
- Hooks no longer need to return their value via `break`, any non-null value will do.
- Improved documentation `runHooks`
- Added a documentation node "using hooks" under the node "The Macaulay2 language"

@pepperhdj