### PR TITLE
Remove build paths from documentation (take 3)

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -671,7 +671,7 @@ fixupTable := new HashTable from {
 				   if f === null then error("SourceCode: ", toString m, ": not a method");
 				   c := code f;
 				   if c === null then error("SourceCode: ", toString m, ": code for method not found");
-				   c)))}}
+				   reproduciblePaths toString c)))}}
 	  else v),
      Subnodes => v -> (
 	  v = nonnull enlist v;

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -439,9 +439,8 @@ reproduciblePaths = outf -> (
      if topSrcdir === null then return outstr;
      srcdir := regexQuote toAbsolutePath topSrcdir;
      prefixdir := regexQuote prefixDirectory;
-     builddir := substring(0, #prefixdir - 9, prefixdir); -- 9 = #"usr-dist/"
-     homedir := regexQuote homeDirectory;
-     homedir = substring(0, #homedir - 1, homedir); -- remove trailing "/"
+     builddir := replace("usr-dist/?$", "", prefixdir);
+     homedir := replace("/$", "", regexQuote homeDirectory);
      if any({srcdir, builddir, homedir}, dir -> match(dir, outstr))
      then (
 	 -- .m2 files in source directory

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -434,8 +434,7 @@ dispatcherMethod := m -> m#-1 === Sequence and (
      f := lookup m;
      any(dispatcherFunctions, g -> functionBody f === functionBody g))
 
-reproduciblePaths = outf -> (
-     outstr := get outf;
+reproduciblePaths = outstr -> (
      if topSrcdir === null then return outstr;
      srcdir := regexQuote toAbsolutePath topSrcdir;
      prefixdir := regexQuote prefixDirectory;
@@ -458,7 +457,6 @@ reproduciblePaths = outf -> (
 	 outstr = replace(prefixdir, finalPrefix, outstr);
 	 -- home directory
 	 outstr = replace(homedir, "/home/m2user", outstr);
-	 outf << outstr << close;
 	 );
      outstr
     )
@@ -656,7 +654,8 @@ installPackage Package := opts -> pkg -> (
 			 );
 		    -- read, separate, and store example output
 		    if fileExists outf then (
-			 outstr := reproduciblePaths outf;
+			 outstr := reproduciblePaths get outf;
+			 outf << outstr << close;
 			 pkg#"example results"#fkey = drop(separateM2output outstr,-1)
 		    )
 		    else (

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -277,8 +277,8 @@ document {
      PRE replace(regexQuote homeDirectory, "/home/m2user/",
 	   concatenate between_"\n" apply(value Core#"private dictionary"#"userpath",s -> (5,s))),
      EXAMPLE {
-	  "path",
-	  ///path = append(path, "~/resolutions/")///
+	  "stack path",
+	  ///path = append(path, "~/resolutions/"); stack path///
 	  }
      }
 

--- a/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
@@ -30,8 +30,8 @@ ideal NormalToricVariety := Ideal => (
 	    )
 	)
     );
-monomialIdeal NormalToricVariety := MonomialIdeal => X -> monomialIdeal ideal X
-
+monomialIdeal NormalToricVariety := MonomialIdeal => X ->
+    monomialIdeal ideal X
 
 ------------------------------------------------------------------------------
 -- sheaves

--- a/M2/Macaulay2/packages/RandomMonomialIdeals.m2
+++ b/M2/Macaulay2/packages/RandomMonomialIdeals.m2
@@ -1803,7 +1803,6 @@ doc ///
       The key Generate points to the function that is used to generate random elements according to the given model. 
     Example
       myModel = ER(2,2,0.5)
-      peek myModel
   SeeAlso
     Model
 ///


### PR DESCRIPTION
One of the commits from #1337 (3a686bc) has been reverted due to #1372.  Its goal was to wrap examples after they were generated so that `reproduciblePaths` could swap out any build paths without worrying about whether they had been split between two lines due to wrapping.

It turns out that even when wrapping the examples during generation as was done before #1337, only two examples were missed.  (At least on my system -- there may be some variation from system to system depending on the length of the build path.)

The goal of this pull request is to tweak these examples so this is not an issue.

### Example 1
In `RandomMonomialIdeals`, when describing the `Generate` key of a `Model` object, we `peek`'ed at the model, but this provided no extra information, as the exact same information was present when printing a `Model` without `peek`.  Furthermore, since `peek` results in a net, it was getting wrapped, splitting up a build path.  (Thanks again, Dan, for providing an explanation in #1380!)

So we just remove the `peek` line.

*Before*:
```m2
i1 : myModel = ER(2,2,0.5)

o1 = Model{Generate => -*Function[/usr/share/Macaulay2/RandomMonomialIdeals.m2:129:23-129:47]*-}
           Name => Erdos-Renyi
           Parameters => (2, 2, .5)

o1 : Model

i2 : peek myModel

o2 = Model{Generate => -*Function[/build/macaulay2-1.16+git41.3c2eac5+ds/M2/
           Name => Erdos-Renyi
           Parameters => (2, 2, .5)
     ------------------------------------------------------------------------
     Macaulay2/packages/RandomMonomialIdeals.m2:129:23-129:47]*-}
```

*After*:
```m2
i1 : myModel = ER(2,2,0.5)

o1 = Model{Generate => -*Function[/usr/share/Macaulay2/RandomMonomialIdeals.m2:129:23-129:47]*-}
           Name => Erdos-Renyi
           Parameters => (2, 2, .5)

o1 : Model
```

### Example 2
In `NormalToricVarieties`, the code of the `(monomialIdeal, NormalToricVariety)` method is displayed.  Since it's a one-liner, we get a net with 3 rows (the ` -- code for ...` comment, the path, and the code itself).  Any net of 3 or fewer rows will be wrapped.

So we add a newline in the middle of the code so we end up with a net with 4 rows, which won't be wrapped.

*Before*:
```m2
i20 : code (monomialIdeal, NormalToricVariety)

o20 = -- code for method: monomialIdeal(NormalToricVariety
      /build/macaulay2-1.16+git41.3c2eac5+ds/M2/Macaulay2/
      monomialIdeal NormalToricVariety := MonomialIdeal =>
      -----------------------------------------------------------------------
      )
      packages/NormalToricVarieties/Sheaves.m2:33:56-33:79: --source code:
       X -> monomialIdeal ideal X
```

*After*:
```m2
i20 : code (monomialIdeal, NormalToricVariety)

o20 = -- code for method: monomialIdeal(NormalToricVariety)
      /usr/share/Macaulay2/NormalToricVarieties/Sheaves.m2:33:56-34:25: --source code:
      monomialIdeal NormalToricVariety := MonomialIdeal => X ->
          monomialIdeal ideal X
```