### PR TITLE
Append to LDFLAGS instead of overwriting it when building scc1

### DIFF
--- a/M2/Macaulay2/c/Makefile.in
+++ b/M2/Macaulay2/c/Makefile.in
@@ -9,7 +9,6 @@ include ../../include/config.Makefile
 # In this directory, we compile "scc1", the D to C translator, which we want to run
 # on the "build" machine, in the sense of autoconf.  So we do not want the cross-compiling compiler:
 CC = @CC_FOR_BUILD@
-LDFLAGS = $(LDFLAGS_FOR_BUILD)
 
 top_srcdir = @top_srcdir@
 VPATH = @srcdir@

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -253,11 +253,9 @@ if test "$GCC" = yes
 then CFLAGS="$CFLAGS -g3"
      CXXFLAGS="$CXXFLAGS -g3"
      LDFLAGS="$LDFLAGS -g3"
-     LDFLAGS_FOR_BUILD="$LDFLAGS_FOR_BUILD -g3"
 else CFLAGS="$CFLAGS -g"
      CXXFLAGS="$CXXFLAGS -g"
      LDFLAGS="$LDFLAGS -g"
-     LDFLAGS_FOR_BUILD="$LDFLAGS_FOR_BUILD -g"
 fi
 
 AC_SUBST(DEBUG,no)     AC_ARG_ENABLE(debug, AS_HELP_STRING(--enable-debug,enable debugging (and disable stripping)), DEBUG=$enableval)
@@ -1780,7 +1778,6 @@ AC_MSG_NOTICE([using LIBS_GDBM         = $LIBS_GDBM])
 AC_MSG_NOTICE([using LIBS_GLPK         = $LIBS_GLPK])
 AC_MSG_NOTICE([using LIBS_GMP          = $LIBS_GMP])
 AC_MSG_NOTICE([using CC_FOR_BUILD      = $CC_FOR_BUILD])
-AC_MSG_NOTICE([using LDFLAGS_FOR_BUILD = $LDFLAGS_FOR_BUILD])
 AC_MSG_NOTICE([with  ISSUE             = $ISSUE])
 AC_MSG_NOTICE([with  NODENAME          = $NODENAME])
 AC_MSG_NOTICE([with  OS REL            = $OS $REL])

--- a/M2/include/config.Makefile.in
+++ b/M2/include/config.Makefile.in
@@ -36,7 +36,6 @@ CPPFLAGS += @CPPFLAGS@
 CXXFLAGS = @CXXFLAGS@
 FCFLAGS = @FCFLAGS@
 LDFLAGS = @LDFLAGS@
-LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
 OPENMP_CXXFLAGS = @OPENMP_CXXFLAGS@
 
 # here we set the variables that "configure" uses
@@ -85,10 +84,6 @@ LDFLAGS :=						\
 	-L$(BUILTLIBPATH)/lib				\
 	$(foreach S, $(BUILTSUBS), -L@abs_top_builddir@/submodules/$S/.libs) \
 	$(LDFLAGS)
-LDFLAGS_FOR_BUILD :=					\
-	-L$(BUILTLIBPATH)/lib				\
-	$(foreach S, $(BUILTSUBS), -L@abs_top_builddir@/submodules/$S/.libs) \
-	$(LDFLAGS_FOR_BUILD)
 
 LIBDEPS_FOR_BUILD := $(foreach S, $(BUILTSUBS), @abs_top_builddir@/submodules/$S/.libs/lib$S.a)
 LDLIBS_FOR_BUILD := $(foreach S, $(BUILTSUBS), -l$S)
@@ -126,7 +121,6 @@ ifeq "@DEBUG@" "yes"
 CFLAGS += -debug
 CXXFLAGS += -debug
 LDFLAGS += -debug
-LDFLAGS_FOR_BUILD += -debug
 endif
 else
 M2_BOTH += -Wno-parentheses


### PR DESCRIPTION
This way, LDFLAGS from the environment are preserved, e.g., the hardening
flags from dpkg-buildflags used when building the Debian package.