### PR TITLE
Fix path to editors Makefile

### DIFF
--- a/M2/Macaulay2/m2/Makefile.in
+++ b/M2/Macaulay2/m2/Makefile.in
@@ -71,7 +71,7 @@ clean::; rm -f TAGS @srcdir@/TAGS @srcdir@/TAGS.doc
 		loadsequence \
 		Makefile.in \
 		Makefile.tests \
-		../editors/emacs/Makefile.in \
+		../editors/Makefile.in \
 		../tests/Makefile.in \
 		../tests/Makefile.test.in \
 		../tests/slow/Makefile.in \


### PR DESCRIPTION
It was dropped down a directory from emacs => editors in 7818687 before
the M2-emacs submodule was split off.

It was deleted from the M2-emacs submodule in Macaulay2/M2-emacs@04b6a0d,
so using the old path will give build errors:

    make[3]: *** No rule to make target '../editors/emacs/Makefile.in',
    needed by 'TAGS'.  Stop.