### PR TITLE
Feature: package review workflow

### DIFF
--- a/.github/actions/package-review/action.yml
+++ b/.github/actions/package-review/action.yml
@@ -1,0 +1,29 @@
+# Relevant documentation:
+# https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
+
+name: Package Review Action
+description: 'Run all examples and tests in a package'
+
+inputs:
+  package:
+    description: 'Package name'
+    required: true
+    default: 'FirstPackage'
+outputs:
+  numExampleErrors:
+    description: 'Number of errors occured running examples'
+  numTestErrors:
+    description: 'Number of errors occured running tests'
+runs:
+  using: 'docker'
+  image: 'docker://mahrud/macaulay2:v1.16.0.1'
+  entrypoint: 'M2'
+  args: ["-q", "--stop", "--silent", "--srcdir", "/github/workspace/M2",
+         "-e", "debug Core;
+           pkg = installPackage(\"${{ inputs.package }}\",
+               IgnoreExampleErrors => true, InstallPrefix => \"/github/workspace/\");
+           stderr << \"::set-output name=numExampleErrors::\" << numErrors << endl;
+           check pkg;
+           stderr << \"::set-output name=numTestErrors::\" << numErrors << endl;
+           exit 0"]

--- a/.github/workflows/package-review.yml
+++ b/.github/workflows/package-review.yml
@@ -1,0 +1,39 @@
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events
+# https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#manually-running-a-workflow
+
+name: Package Review Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to install and check'
+        required: true
+        default: 'FirstPackage'
+
+jobs:
+  package-review:
+    runs-on: ubuntu-latest
+    name: ${{ github.event.inputs.package }}@${{ github.event.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run examples and tests
+        uses: mahrud/M2/.github/actions/package-review@master
+        id: run_tests
+        with:
+          package: ${{ github.event.inputs.package }}
+
+      - name: Upload errors
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+           name: ${{ github.event.inputs.package }}-errors
+           path: |
+             ${{ github.workspace }}/share/doc/Macaulay2/${{ github.event.inputs.package }}/example-output/*.errors
+#            /tmp/M2-*/*.tmp # TODO: since tests run in a container, I don't know how to access them
+
+      - name: Summary
+        run: |
+          echo "${{ steps.run_tests.outputs.numExampleErrors }} error(s) occured running examples"
+          echo "${{ steps.run_tests.outputs.numTestErrors }} error(s) occured running tests"

--- a/M2/BUILD/mahrud/package-review.sh
+++ b/M2/BUILD/mahrud/package-review.sh
@@ -1,0 +1,26 @@
+owner=mahrud
+token=`cat ~/.github_token` # https://github.com/settings/tokens
+
+# List workflows:
+#curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$owner/M2/actions/workflows
+
+if [[ -z "$1" ]];
+then package="FirstPackage"
+else package=$1
+fi
+
+shift
+
+if [[ -z "$1" ]];
+then ref="refs/master"
+else ref=$1
+fi
+
+echo package: $package
+echo     ref: $ref
+
+curl \
+  -u $owner:$token -X POST \
+  -H "Accept: application/vnd.github.v3+json" \
+  -d "{\"inputs\":{\"package\":\"$package\"}, \"ref\":\"$ref\"}" \
+  https://api.github.com/repos/$owner/M2/actions/workflows/1877698/dispatches

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -111,7 +111,7 @@ runFile = (inf, inputhash, outf, tmpf, desc, pkg, announcechange, usermode, exam
      cmd = cmd | readmode(ArgSilent,      "--silent");
      cmd = cmd | readmode(ArgStop,        "--stop");
      cmd = cmd | readmode(ArgPrintWidth,  "--print-width 77");
-     cmd = cmd | concatenate apply(srcdirs, d -> (" --srcdir",format d));
+     cmd = cmd | concatenate apply(srcdirs, d -> (" --srcdir ", format d));
      needsline := concatenate(" -e 'needsPackage(\"",pkgname,"\", Reload => true, FileName => \"",pkg#"source file","\")'");
      cmd = cmd | if pkgname != "Macaulay2Doc" then needsline else "";
      cmd = cmd | readmode(SetInputFile,   "<" | format inf);


### PR DESCRIPTION
The added action and workflow allow running the tests and examples from any package from either web interface, like this:
![image](https://user-images.githubusercontent.com/3147718/87405250-cafaa400-c584-11ea-9350-d6359b482fa3.png)
or a `POST` request like this:
```
curl \
  -u $owner:$token -X POST \
  -H "Accept: application/vnd.github.v3+json" \
  -d "{\"inputs\":{\"package\":\"$package\"}, \"ref\":\"$ref\"}" \
  https://api.github.com/repos/$owner/M2/actions/workflows/1877698/dispatches
```