### PR TITLE
Improving support for external programs, part 3

### DIFF
--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -46,6 +46,7 @@ export {
 	"?",
 	"@",
 	"@@",
+	"AdditionalPaths",
 	"Adjacent",
 	"AffineVariety",
 	"AfterEval",

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -30,6 +30,8 @@ getProgramPath = (name, cmds, opts) -> (
 	pathsToTry = append(pathsToTry, programPaths#name);
     -- now try M2-installed path
     pathsToTry = append(pathsToTry, prefixDirectory | currentLayout#"programs");
+    -- any additional paths specified by the caller
+    pathsToTry = pathsToTry | opts.AdditionalPaths;
     -- finally, try PATH
     if getenv "PATH" != "" then
 	pathsToTry = join(pathsToTry, separate(":", getenv "PATH"));
@@ -50,7 +52,12 @@ getProgramPath = (name, cmds, opts) -> (
 )
 
 findProgram = method(TypicalValue => Program,
-    Options => {RaiseError => true, Verbose => false, Prefix => {}})
+    Options => {
+	RaiseError => true,
+	Verbose => false,
+	Prefix => {},
+	AdditionalPaths => {}
+    })
 findProgram(String, String) := opts -> (name, cmd) ->
     findProgram(name, {cmd}, opts)
 findProgram(String, List) := opts -> (name, cmds) -> (

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -44,10 +44,21 @@ export {
      "toricGraverDegrees"
      }
 
+-- for backward compatibility
+if not programPaths#?"4ti2" and FourTiTwo#Options#Configuration#"path" != ""
+    then programPaths#"4ti2" = FourTiTwo#Options#Configuration#"path"
 
-path'4ti2 = (options FourTiTwo).Configuration#"path"
--- NOTE: the absolute path should be put into the .init file for 4ti2 inside the .Macaulay2 directory.
-if path'4ti2 == "" then path'4ti2 = prefixDirectory | currentLayout#"programs"
+fourTiTwo = null
+
+run4ti2 = (exe, args) -> (
+    if fourTiTwo === null then
+	fourTiTwo = findProgram("4ti2", "markov -h",
+	    Prefix => {(".*", "4ti2-"), -- debian
+		       (".*", "4ti2_")}, -- suse
+	    AdditionalPaths =>
+		{"/usr/lib/4ti2/bin", "/usr/lib64/4ti2/bin"}); -- fedora
+     runProgram(fourTiTwo, exe, args)
+)
 
 getFilename = () -> (
      filename := temporaryFileName();
@@ -106,9 +117,7 @@ toricMarkov Matrix := Matrix => o -> (A) -> (
        	  F = openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     execstr := path'4ti2|"markov -q " |rootPath |filename;
-     ret := run(execstr);
-     if ret =!= 0 then error "error occurred while executing external program 4ti2: markov";
+     run4ti2("markov", rootPath | filename);
      getMatrix(filename|".mar")
      )
 toricMarkov(Matrix,Ring) := o -> (A,S) -> toBinomial(toricMarkov(A,o), S)
@@ -124,9 +133,7 @@ toricGroebner Matrix := o -> (A) -> (
 	  cost := concatenate apply(o.Weights, x -> (x|" "));
 	  (filename|".cost") << "1 " << #o.Weights << endl << cost << endl  << close;
 	  );
-     execstr := path'4ti2|"groebner -q "|rootPath|filename;
-     ret := run(execstr);
-     if ret =!= 0 then error "error occurred while executing external program 4ti2: groebner";
+     run4ti2("groebner", rootPath | filename);
      getMatrix(filename|".gro")
      )
 toricGroebner(Matrix,Ring) := o -> (A,S) -> toBinomial(toricGroebner(A,o), S)
@@ -138,9 +145,7 @@ toricCircuits Matrix := Matrix => (A ->(
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     execstr := path'4ti2|"circuits -q " | rootPath | filename;
-     ret := run(execstr);
-     if ret =!= 0 then error "error occurred while executing external program 4ti2: circuits";
+     run4ti2("circuits", rootPath | filename);
      getMatrix(filename|".cir")
      ))
 
@@ -151,9 +156,7 @@ toricGraver Matrix := Matrix => (A ->(
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     execstr := path'4ti2|"graver -q " | rootPath | filename;
-     ret := run(execstr);
-     if ret =!= 0 then error "error occurred while executing external program 4ti2: graver";
+     run4ti2("graver -q ", rootPath | filename);
      getMatrix(filename|".gra")
      ))
 toricGraver (Matrix,Ring) := Ideal => ((A,S)->toBinomial(toricGraver(A),S))
@@ -168,9 +171,7 @@ hilbertBasis Matrix := Matrix => o -> (A ->(
        	  F = openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     execstr := path'4ti2|"hilbert -q " |rootPath | filename;
-     ret := run(execstr);
-     if ret =!= 0 then error "error occurred while executing external program 4ti2: hilbert";
+     run4ti2("hilbert", rootPath | filename);
      getMatrix(filename|".hil")
      ))
 
@@ -182,9 +183,7 @@ rays Matrix := Matrix => (A ->(
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     execstr := path'4ti2|"rays -q " |rootPath | filename;
-     ret := run(execstr);
-     if ret =!= 0 then error "error occurred while executing external program 4ti2: rays";
+     run4ti2("rays", rootPath | filename);
      getMatrix(filename|".ray")
      ))
 
@@ -200,12 +199,9 @@ toricGraverDegrees Matrix := Matrix => (A ->(
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     execstr := path'4ti2|"graver -q " | rootPath | filename;
-     ret := run(execstr);
-     if ret =!= 0 then error "error occurred while executing external program 4ti2: graver"; -- getMatrix(filename|".gra")
-     execstr = path'4ti2|"output --degrees " | rootPath | filename|".gra";
-     ret = run(execstr);
-     if ret =!= 0 then error "error occurred while executing external program 4ti2: output";
+     run4ti2("graver", rootPath | filename);
+     ret := run4ti2("output", "--degrees " | rootPath | filename|".gra");
+     print ret#"output"
      ))
 
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -43,9 +43,15 @@ document {
 }
 
 document {
+    Key => AdditionalPaths,
+    Headline => "list of non-standard paths to search for a program"
+}
+
+document {
     Key => {findProgram,
 	(findProgram, String, String),
 	(findProgram, String, List),
+	[findProgram, AdditionalPaths],
 	[findProgram, Prefix],
 	[findProgram, RaiseError],
 	[findProgram, Verbose]},
@@ -70,7 +76,10 @@ document {
 	    "form ", TT "(regex, prefix)", " where ", TT "regex", " is a ",
 	    TO2("regular expressions", "regular expression"), " that should ",
 	    "match all binary executables that need the prefix and ",
-	    TT "prefix", " is the prefix itself."}
+	    TT "prefix", " is the prefix itself."},
+	AdditionalPaths => List => {
+	    "a list of strings containing any paths to check for the program ",
+	    "in addition to the default ones."}
     },
     Outputs => {Program => { "the program that was loaded.  ",
 	"If the program is not found and ", TT "RaiseError", " is set to ",
@@ -84,6 +93,7 @@ document {
 	{"The path specified by ",
 	    TT "prefixDirectory | currentLayout#\"programs\"",
 	    ", where the programs shipped with Macaulay2 are installed."},
+	{"Each path specified by the ", TT "AdditionalPaths", " option."},
 	{"Each path specified by the user's ", TT "PATH",
 	    " environment variable."}
     },

--- a/M2/Macaulay2/tests/normal/programs.m2
+++ b/M2/Macaulay2/tests/normal/programs.m2
@@ -32,3 +32,6 @@ fn << "touch baz" << close
 program = findProgram(name, name)
 runProgram(program, name, RunDirectory => dir | "/foo/bar")
 assert(fileExists(dir | "/foo/bar/baz"))
+
+program = findProgram("foo", name, AdditionalPaths => {dir})
+assert(program#"path" == dir)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -953,16 +953,27 @@ if test $BUILD_flint = yes
 then BUILTLIBS="-lflint $BUILTLIBS -lm"
 fi
 
-dnl we can't use the test below for the presence of 4ti2 until the package FourTiTwo knows
-dnl how to find programs such as "markov" under the name "4ti2-markov", and until our *.dmg and
-dnl *.deb making procedures know how to include them or set the dependencies appropriately
-BUILD_4ti2=yes
-dnl AC_MSG_CHECKING(whether the package 4ti2 is installed)
-dnl if test "`type -t 4ti2-circuits`" = file
-dnl then AC_MSG_RESULT(yes)
-dnl else AC_MSG_RESULT([no, will build])
-dnl      BUILD_4ti2=yes
-dnl fi
+dnl debian: 4ti2-
+dnl suse: 4ti2_
+dnl fedora: /usr/lib/4ti2/bin or /usr/lib64/4ti2/bin
+AC_MSG_CHECKING(whether the package 4ti2 is installed)
+SAVE=$PATH
+PATH="/usr/lib/4ti2/bin:/usr/lib64/4ti2/bin:$PATH"
+FOUND_4ti2=no
+for fourti2_prefix in "" "4ti2-" "4ti2_"
+do
+    if test "`type -t ${fourti2_prefix}circuits`" = file
+    then AC_MSG_RESULT([yes, using prefix "$fourti2_prefix"])
+         FILE_PREREQS="$FILE_PREREQS `type -p ${fourti2_prefix}circuits`"
+         FOUND_4ti2=yes
+         break
+    fi
+done
+if test $FOUND_4ti2 = no
+then AC_MSG_RESULT([no, will build])
+     BUILD_4ti2=yes
+fi
+PATH=$SAVE
 
 AC_MSG_CHECKING(whether the package cohomcalg is installed)
 if test "`type -t cohomcalg`" = file


### PR DESCRIPTION
Some distributions may install programs in a non-standard location, e.g., Fedora installs the various executables that come with 4ti2 in `/usr/lib/4ti2/bin` or `/usr/lib64/4ti2/bin`, depending on the architecture.

We add a `Path` option to `findProgram` which allows the user to specify additional paths to search to find a program in situations like this.

As a proof of concept, the `FourTiTwo` package has been ported to the new `findProgram`/`runProgram` interface.