### PR TITLE
Only use open for showing URLs in Darwin

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -43,7 +43,7 @@ runnable := fn -> (
 -- preferred web browser
 -- TODO: cache this value
 browser := () -> (
-    if runnable "open" then "open" -- Apple varieties
+    if version#"operating system" === "Darwin" and runnable "open" then "open" -- Apple varieties
     else if runnable "xdg-open" then "xdg-open" -- most Linux distributions
     else if runnable getenv "WWWBROWSER" then getenv "WWWBROWSER" -- compatibility
     else if runnable "firefox" then "firefox" -- backup


### PR DESCRIPTION
Otherwise in Ubuntu, we get:

    Couldn't get a file descriptor referring to the console

See https://groups.google.com/forum/#!topic/macaulay2/x9yrVDu2nM8