### PR TITLE
Call external M2 with -q in RunExternalM2 if parent M2 was

### DIFF
--- a/M2/Macaulay2/packages/RunExternalM2.m2
+++ b/M2/Macaulay2/packages/RunExternalM2.m2
@@ -85,7 +85,6 @@ export {
 	"runExternalM2ReturnAnswer",
 	-- Various Options:
 	"M2Location",
-	"KeepFiles",
 	"KeepStatistics",
 	"KeepStatisticsCommand",
 	"PreRunScript"
@@ -479,7 +478,6 @@ safelyRemoveFile := (s,f) -> (
 mydoc=concatenate(mydoc,///
 Node
 	Key
-		KeepFiles
 		[runExternalM2,KeepFiles]
 	Headline
 		indicate whether or not temporary files should be saved

--- a/M2/Macaulay2/packages/RunExternalM2.m2
+++ b/M2/Macaulay2/packages/RunExternalM2.m2
@@ -334,10 +334,12 @@ Node
 -*
   These are the options to automatically provide when calling the M2 executable.
   We would use --script (=--stop --no-debug --silent -q ), but we do NOT want
-  -q so that our child processes can find installed packages, namely, this package.
+  -q so that our child processes can find installed packages, namely, this package,
+  unless the parent M2 was also called with -q.
 *-
 M2Options:=" --stop --no-debug --silent ";
-
+debug Core
+if noinitfile then M2Options = M2Options | " -q ";
 
 mydoc=concatenate(mydoc,///
 Node


### PR DESCRIPTION
This prevents errors if we don't have permission to write to the home
directory.

Closes: #1330