### PR TITLE
Remove build paths from documentation (take 4)

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -443,7 +443,7 @@ reproduciblePaths = outstr -> (
      if any({srcdir, builddir, homedir}, dir -> match(dir, outstr))
      then (
 	 -- .m2 files in source directory
-	 outstr = replace(srcdir | "Macaulay2/m2",
+	 outstr = replace(srcdir | "Macaulay2/\\b(m2|Core)\\b",
 	     finalPrefix | Layout#1#"packages" | "Core", outstr);
 	 outstr = replace(srcdir | "Macaulay2/packages/",
 	     finalPrefix | Layout#1#"packages", outstr);

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -455,6 +455,8 @@ reproduciblePaths = outstr -> (
 	     outstr = replace(prefixdir | Layout#2#key,
 		 finalPrefix | Layout#1#key, outstr));
 	 outstr = replace(prefixdir, finalPrefix, outstr);
+	 -- usr-build/bin is in PATH during build
+	 outstr = replace(builddir | "usr-build/", finalPrefix, outstr);
 	 -- home directory
 	 outstr = replace(homedir, "/home/m2user", outstr);
 	 );

--- a/M2/Macaulay2/packages/PushForward.m2
+++ b/M2/Macaulay2/packages/PushForward.m2
@@ -184,7 +184,10 @@ document{
   A = kk[a,d]
   use R
   F = map(R,A)
-  pushFwd F
+  (M,g,pf) = pushFwd F;
+  M
+  g
+  pf(a*b - c^2)
   ///,
   TEX "In a previous version of this package, the third output was a function which assigned to each element of the target of ", TT "f", " its representation as an element of a free module which surjected onto the pushed forward module."
   }


### PR DESCRIPTION
Two of the recent changes in the `development` branch (the `Core`/`m2` symlink and the documentation for the `findPackage` function, which has an example that prints some of the directories in `PATH`) have caused some more build paths to crop in the documentation.

This PR modifies `reproduciblePaths` to take care of these cases. 

Also, one example from `PushForward` has been modified to avoid wrapping.

*Before*:
```m2
i8 : pushFwd F

o8 = (cokernel {0} | 0  |, | 1 b b2 c c2 |,
               {1} | 0  |
               {2} | -d |
               {1} | 0  |
               {2} | a  |
     ------------------------------------------------------------------------
     -*Function[/build/macaulay2-1.16.0.1+git129.74c3aa6+ds/M2/Macaulay2/
     ------------------------------------------------------------------------
     packages/PushForward.m2:31:18-31:32]*-)
```

*After*:
```m2
i8 : netList toList pushFwd F

     +----------------------------------------------------------------------------------------------------------+
o8 = |cokernel {0} | 0  |                                                                                       |
     |         {1} | 0  |                                                                                       |
     |         {2} | -d |                                                                                       |
     |         {1} | 0  |                                                                                       |
     |         {2} | a  |                                                                                       |
     +----------------------------------------------------------------------------------------------------------+
     || 1 b b2 c c2 |                                                                                           |
     +----------------------------------------------------------------------------------------------------------+
     |-*Function[/usr/share/Macaulay2/PushForward.m2:31:18-31:32]*-|
     +----------------------------------------------------------------------------------------------------------+
```