### PR TITLE
Improving support for external programs, part 4

### DIFF
--- a/M2/Macaulay2/packages/Nauty.m2
+++ b/M2/Macaulay2/packages/Nauty.m2
@@ -36,10 +36,9 @@ newPackage select((
 -- Configuration
 -------------------
 
--- Check the ~/.Macaulay2/init-Nauty.m2 file for the absolute path.
--- If it's not there, then use the M2-Programs directory.
-nauty'path = (options Nauty).Configuration#"path";
-if nauty'path == "" then nauty'path = prefixDirectory | currentLayout#"programs";
+-- for backward compatibility
+if not programPaths#?"nauty" and Nauty#Options#Configuration#"path" != ""
+    then programPaths#"nauty" = Nauty#Options#Configuration#"path"
 
 -------------------
 -- Exports
@@ -458,6 +457,8 @@ stringToGraph (String, PolynomialRing) := Graph => (str, R) -> graph stringToEdg
 -- Local-Only Code
 -------------------
 
+nauty = null
+
 -- Sends a command and retrieves the results into a list of lines.
 -- If ReadError is set to true and the command is successfully executed,
 -- then the data from stderr is returned (filterGraphs and removeIsomorphs
@@ -465,34 +466,20 @@ stringToGraph (String, PolynomialRing) := Graph => (str, R) -> graph stringToEdg
 protect ReadError;
 callNauty = method(Options => {ReadError => false})
 callNauty (String, List) := List => opts -> (cmdStr, dataList) -> (
+    if nauty === null then
+	nauty = findProgram("nauty", "complg --help",
+	    Prefix => {(".*", "nauty-")}); -- debian/fedora
     infn := temporaryFileName();
     erfn := temporaryFileName();
     -- output the data to a file
     o := openOut infn;
     scan(graphToString \ dataList, d -> o << d << endl);
     close o;
-    -- try to harvest the lines
-    r := lines try get openIn ("!" | nauty'path | cmdStr | " <" | infn | " 2>" | erfn)
-    else (
-        -- nauty errored, harvest the error
-        e := last separate(":", first lines get openIn erfn);
-        removeFile infn;
-        removeFile erfn;
-        -- special cases 
-        if e == " not found" then error("callNauty: nauty could not be found on the path [" | nauty'path | "].");
-        if e == "#q -V] [--keys] [-constraints -v] [ifile [ofile]]" then e = "invalid filter";
-	    error("callNauty: nauty terminated with the error [", e, "].");
-    );
+    exe := first separate(" ", cmdStr);
+    args := replace(exe | " ", "", cmdStr);
+    r := runProgram(nauty, exe, args | " < " | infn);
     removeFile infn;
-    -- If the method wants it, then read the stderr data instead.
-    if opts.ReadError then (
-        r = lines try get openIn erfn else (
-            removeFile erfn;
-            error("callNauty: nauty ran successfully, but no data was written to stderr as expected.  Report this to the package maintainer.");
-        );
-    );
-    removeFile erfn;
-    r
+    if opts.ReadError then lines r#"error" else lines r#"output"
 )
 
 -- Processes an option which should be a Boolean.

--- a/M2/Macaulay2/tests/normal/schenck-book-3.m2
+++ b/M2/Macaulay2/tests/normal/schenck-book-3.m2
@@ -1,7 +1,13 @@
 needsPackage "gfanInterface"
 R=QQ[x,y]
 assert( (I=ideal(x^7-1, y-x^5)) === ideal map((R)^1,(R)^{{-7},{-5}},{{x^7-1, -x^5+y}}) );
-assert( (gfan(I)) === {new MarkedPolynomialList from {{y^7,x},{y^7-1,-y^3+x}},new MarkedPolynomialList from {{x^3,x^2*y,y^3},{x^3-y^2,x^2*y-1,y^3-x}},new MarkedPolynomialList from {{x^5,x^2*y,y^2},{x^5-y,x^2*y-1,-x^3+y^2}},new MarkedPolynomialList from {{x^7,y},{x^7-1,-x^5+y}}} );
+L1 = gfan I
+L2 = {new MarkedPolynomialList from {{y^7,x},{y^7-1,-y^3+x}},
+    new MarkedPolynomialList from {{x^3,x^2*y,y^3},{x^3-y^2,x^2*y-1,y^3-x}},
+    new MarkedPolynomialList from {{x^5,x^2*y,y^2},{x^5-y,x^2*y-1,-x^3+y^2}},
+    new MarkedPolynomialList from {{x^7,y},{x^7-1,-x^5+y}}}
+assert(#L1 == #L2)
+assert(all(4, i -> set transpose L1_i === set transpose L2_i))
 end
 
 print generateAssertions ///

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -953,16 +953,27 @@ if test $BUILD_flint = yes
 then BUILTLIBS="-lflint $BUILTLIBS -lm"
 fi
 
-dnl we can't use the test below for the presence of 4ti2 until the package FourTiTwo knows
-dnl how to find programs such as "markov" under the name "4ti2-markov", and until our *.dmg and
-dnl *.deb making procedures know how to include them or set the dependencies appropriately
-BUILD_4ti2=yes
-dnl AC_MSG_CHECKING(whether the package 4ti2 is installed)
-dnl if test "`type -t 4ti2-circuits`" = file
-dnl then AC_MSG_RESULT(yes)
-dnl else AC_MSG_RESULT([no, will build])
-dnl      BUILD_4ti2=yes
-dnl fi
+dnl debian: 4ti2-
+dnl suse: 4ti2_
+dnl fedora: /usr/lib/4ti2/bin or /usr/lib64/4ti2/bin
+AC_MSG_CHECKING(whether the package 4ti2 is installed)
+SAVE=$PATH
+PATH="/usr/lib/4ti2/bin:/usr/lib64/4ti2/bin:$PATH"
+FOUND_4ti2=no
+for fourti2_prefix in "" "4ti2-" "4ti2_"
+do
+    if test "`type -t ${fourti2_prefix}circuits`" = file
+    then AC_MSG_RESULT([yes, using prefix "$fourti2_prefix"])
+         FILE_PREREQS="$FILE_PREREQS `type -p ${fourti2_prefix}circuits`"
+         FOUND_4ti2=yes
+         break
+    fi
+done
+if test $FOUND_4ti2 = no
+then AC_MSG_RESULT([no, will build])
+     BUILD_4ti2=yes
+fi
+PATH=$SAVE
 
 AC_MSG_CHECKING(whether the package cohomcalg is installed)
 if test "`type -t cohomcalg`" = file

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1031,12 +1031,20 @@ dnl else AC_MSG_RESULT([no, will build])
 dnl      BUILD_normaliz=yes
 dnl fi
 
+dnl debian/fedora: nauty-
 AC_MSG_CHECKING(whether the package nauty is installed)
-if test "`type -t nauty-complg`" = file
-then AC_MSG_RESULT([yes, will build anyway])
-     dnl because the package Nauty doesn't look for it on the PATH
-     BUILD_nauty=yes
-else AC_MSG_RESULT([no, will build])
+FOUND_nauty=no
+for nauty_prefix in "" "nauty-"
+do
+    if test "`type -t ${nauty_prefix}complg`" = file
+    then AC_MSG_RESULT([yes, using prefix "$nauty_prefix"])
+         FILE_PREREQS="$FILE_PREREQS `type -p ${nauty_prefix}complg`"
+         FOUND_nauty=yes
+         break
+    fi
+done
+if test $FOUND_nauty = no
+then AC_MSG_RESULT([no, will build])
      BUILD_nauty=yes
 fi
 

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1048,12 +1048,24 @@ then AC_MSG_RESULT([no, will build])
      BUILD_nauty=yes
 fi
 
+dnl debian: topcom-
+dnl fedora: TOPCOM- (only for cube)
+dnl gentoo: topcom_ (only for cube, 4 others)
+dnl we save ourselves some trouble and check one of the programs that
+dnl only debian gives a prefix
 AC_MSG_CHECKING(whether the package topcom is installed)
-if test "`type -t points2finetriangs`" = file
-then AC_MSG_RESULT([yes, will build anyway])
-     BUILD_topcom=yes
-     dnl currently the package Topcom uses only the internal Macaulay2 path to run its programs
-else AC_MSG_RESULT([no, will build])
+FOUND_topcom=no
+for topcom_prefix in "" "topcom-"
+do
+    if test "`type -t ${topcom_prefix}points2finetriangs`" = file
+    then AC_MSG_RESULT([yes, using prefix "$topcom_prefix"])
+         FILE_PREREQS="$FILE_PREREQS `type -p ${topcom_prefix}points2finetriangs`"
+         FOUND_topcom=yes
+         break
+    fi
+done
+if test $FOUND_topcom = no
+then AC_MSG_RESULT([no, will build])
      BUILD_topcom=yes
 fi
 

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -994,16 +994,12 @@ fi
 
 AC_MSG_CHECKING(whether the package gfan is installed)
 if test "`type -t gfan`" = file
-then AC_MSG_RESULT([yes, will build anyway])
-     dnl currently the gfanInterface package doesn't know how to find gfan if we don't build it.
-     dnl see https://github.com/Macaulay2/M2/pull/1123
-     dnl Also our *.dmg and *.deb making procedures need to know how to include it or set the dependencies appropriately
+then AC_MSG_RESULT([yes])
+     FILE_PREREQS="$FILE_PREREQS `type -p gfan`"
+else AC_MSG_RESULT([no, will build])
      BUILD_gfan=yes
      dnl we'll also build cddlib until gfan can find its files in /usr/include instead of in /usr/include/cdd
      BUILD_cddlib=yes
-     BUILD_ALWAYS="$BUILD_ALWAYS gfan cddlib"
-else AC_MSG_RESULT([no, will build])
-     BUILD_gfan=yes
 fi
 
 AC_MSG_CHECKING(whether the package lrs is installed)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1039,20 +1039,28 @@ dnl      BUILD_normaliz=yes
 dnl fi
 
 dnl debian/fedora: nauty-
-AC_MSG_CHECKING(whether the package nauty is installed)
+AC_MSG_CHECKING(whether the package nauty (>= 2.7) is installed)
 FOUND_nauty=no
 for nauty_prefix in "" "nauty-"
 do
     if test "`type -t ${nauty_prefix}complg`" = file
-    then AC_MSG_RESULT([yes, using prefix "$nauty_prefix"])
-         FILE_PREREQS="$FILE_PREREQS `type -p ${nauty_prefix}complg`"
-         FOUND_nauty=yes
-         break
+    then nauty_version=`${nauty_prefix}complg --version | cut -d " " -f 3`
+         if test `echo "$nauty_version >= 2.7000" | bc -l` = 1
+         then AC_MSG_RESULT([yes, using prefix "$nauty_prefix"])
+             FILE_PREREQS="$FILE_PREREQS `type -p ${nauty_prefix}complg`"
+             FOUND_nauty=yes
+             break
+         else FOUND_nauty=old
+         fi
     fi
 done
-if test $FOUND_nauty = no
-then AC_MSG_RESULT([no, will build])
-     BUILD_nauty=yes
+if test $FOUND_nauty != yes
+then
+    if test $FOUND_nauty = old
+    then AC_MSG_RESULT([yes, but < 2.7, will build])
+    else AC_MSG_RESULT([no, will build])
+    fi
+    BUILD_nauty=yes
 fi
 
 dnl debian: topcom-


### PR DESCRIPTION
This PR has two main parts:

* Use `findProgram`/`runProgram` in the two nauty packages, `Nauty` and `NautyGraphs`.
* Now that the appropriate packages can find gfan, topcom, and pending #1400 and this PR, 4ti2 and nauty, out of the box, we modify the `configure` script to allow the autotools build to use pre-installed versions of these programs.  For example:

```
checking whether the package 4ti2 is installed... yes, using prefix "4ti2-"
checking whether the package cohomcalg is installed... yes, will build anyway
checking whether the package gfan is installed... yes
checking whether the package lrs is installed... yes
checking whether the package csdp is installed... yes, will build anyway
checking whether the package nauty is installed... yes, using prefix "nauty-"
checking whether the package topcom is installed... yes, using prefix "topcom-"

...

configure: using BUILDLIBLIST  =  flint mpsolve gtest
configure: using BUILDSUBLIST  = 
configure: using BUILDPROGLIST =  normaliz csdp cohomcalg
configure: using BUILDLIST     =  flint mpsolve gtest normaliz csdp cohomcalg
configure: using BUILD_ALWAYS  =  normaliz
configure: using FILE_PREREQS  =  /usr/bin/4ti2-circuits /usr/bin/gfan /usr/bin/lrs /usr/bin/nauty-complg /usr/bin/topcom-points2finetriangs
```