### PR TITLE
CMake maintenance

### DIFF
--- a/.github/workflows/package-review.yml
+++ b/.github/workflows/package-review.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run examples and tests
-        uses: mahrud/M2/.github/actions/package-review@master
+        uses: Macaulay2/M2/.github/actions/package-review@master
         id: run_tests
         with:
           package: ${{ github.event.inputs.package }}

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -91,13 +91,11 @@ jobs:
       - name: Install requirements for Linux
         if: runner.os == 'Linux'
         run: |
-          # TODO: add libgivaro-dev and fflas-ffpack once they are updated
           sudo apt-get install -y -q --no-install-recommends clang-10 gfortran libtool-bin ninja-build yasm ccache
           sudo apt-get install -y -q --no-install-recommends libatomic-ops-dev libboost-stacktrace-dev \
                   libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev liblapack-dev libxml2-dev \
                   libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libntl-dev gfan \
-                  libcdd-dev w3c-markup-validator
-                  # libz-dev zlib1g-dev liblzma-dev fflas-ffpack libgivaro-dev
+                  libcdd-dev libgivaro-dev fflas-ffpack w3c-markup-validator
           # TODO: help autotools detect flint from brew
           brew install flint
 
@@ -131,11 +129,11 @@ jobs:
           path: |
             ~/.ccache
             ~/M2/BUILD/build/usr-host
-          key: usr-host-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-${{ hashFiles('**/cmake/*-libraries.cmake') }}
+          key: build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-${{ hashFiles('**/cmake/*-libraries.cmake') }}
           restore-keys: |
-            usr-host-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-
-            usr-host-${{ runner.os }}-${{ matrix.compiler }}-
-            usr-host-${{ runner.os }}-
+            build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-
+            build-cache-${{ runner.os }}-${{ matrix.compiler }}-
+            build-cache-${{ runner.os }}-
 
 
 # ----------------------
@@ -146,7 +144,8 @@ jobs:
         if: matrix.build-system == 'cmake'
         run: |
           cmake -S../.. -B. -GNinja -DUSING_MPIR=OFF \
-            -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix`
+            -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` \
+            -DBUILD_NATIVE=OFF -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK" # TODO: remove when the packages are updated
 
       - name: Build libraries using Ninja
         if: matrix.build-system == 'cmake' # && steps.restore-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -25,143 +25,189 @@ on:
     # cron time in UTC; set to 6a EDT
     - cron: '0 10 * * *'
 
-env:
-#  CMAKE_VERSION: 3.17
-#  NINJA_VERSION: 1.9.0
-  BUILD_TYPE: Release  # add Buildfast
-  BUILD_DIR: M2/BUILD/cicd
+defaults:
+  run:
+    working-directory: M2/BUILD/build
 
 jobs:
   build:
     if: github.repository == 'Macaulay2/M2' || contains(github.ref, 'global')
-    name: ${{matrix.os}}-${{matrix.build-type}}-${{matrix.compiler}}
+    name: ${{ matrix.os }}-${{ matrix.build-system }}-${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false  # eventually make this true
       matrix:
-        os: [macos-latest, ubuntu-latest]
-        build-type: [cmake, autotools]
-        compiler: [gcc9, default]  # add clang
-#       language: [cxx17, cxx14]
+        os:
+          - macos-latest
+          - ubuntu-latest
+        build-system:
+          - cmake
+          - autotools
+        compiler:
+#          - clang10
+          - gcc9
+          - default
+#          - xcode11
+        # fine-tuning some configurations and excluding a few
         include:
           - compiler: gcc9
             cxx: g++-9
             cc: gcc-9
           - os: macos-latest
-            make: gmake
+            build-system: cmake
+            compiler: clang10
+            cxx: clang++
+            cc: clang
           - os: ubuntu-latest
-            make: make
+            build-system: cmake
+            compiler: clang10
+            cxx: clang++-10
+            cc: clang-10
         exclude:
           - os: macos-latest
             compiler: gcc9
+#          - os: ubuntu-latest
+#            compiler: xcode11
 
     steps:
-      - uses: actions/checkout@v1  # this set up the virtual environment, which has a whole lot
-                                   # as of this writing: gcc9, clang10, cmake3.17, homebrew...
+      - uses: actions/checkout@v2
 
 # ----------------------
-#   Install missing tools and libraries using homebrew (macOS and Linux)
+#   Install missing tools and libraries for macOS
 # ----------------------
 
-      - name: Install missing dev tools (homebrew)
-        id: get_dev_tools_brew
-        if: ${{ runner.os == 'macOS' }}
-        # autoconf, libtool are already in the virtual env
+      - name: Install requirements for macOS
+        if: runner.os == 'macOS'
         run: |
           brew config
-          brew install ninja pkg-config autoconf automake gnu-tar libtool yasm make
-
-      - name: Install libraries (homebrew)
-        id: get_dev_libraries_brew
-        if: ${{ runner.os == 'macOS' }}
-        # mpfr, gdbm, libmpc, xz are already in the virtual env
-        run: brew install boost flint ntl mpir bdw-gc libatomic_ops glpk libomp eigen ncurses cddlib
+          # autoconf, libtool are already in the virtual env
+          brew install automake ccache gnu-tar make ninja pkg-config yasm
+          brew install bdw-gc boost cddlib eigen flint glpk libatomic_ops libomp mpfr mpir ncurses ntl tbb
 
 # ----------------------
-#   Install missing tools and libraries using apt-get (Debian-based Linux only)
+#   Install missing tools and libraries for Linux
 # ----------------------
 
-      - name: Install missing dev tools (apt-get)
-        id: get_dev_tools_aptget
-        if: ${{ runner.os == 'Linux' }}
+      - name: Install requirements for Linux
+        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ninja-build
-
-      - name: Install libraries (apt-get)
-        id: get_dev_libraries_aptget
-        if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get install -y -q --ignore-missing autoconf bison curl emacs fflas-ffpack flex g++ gcc gfortran install-info libatomic-ops-dev libboost-dev libboost-stacktrace-dev libc6-dev libcdd-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfr-dev libncurses-dev libncurses5-dev libntl-dev libreadline-dev libtool libxml2-dev libz-dev make openssh-server patch pinentry-curses pkg-config time unzip xbase-clients yasm zlib1g-dev polymake w3c-markup-validator git dpkg-dev gfan libeigen3-dev libtool-bin
+          # TODO: add libgivaro-dev and fflas-ffpack once they are updated
+          sudo apt-get install -y -q --no-install-recommends clang-10 gfortran libtool-bin ninja-build yasm ccache
+          sudo apt-get install -y -q --no-install-recommends libatomic-ops-dev libboost-stacktrace-dev \
+                  libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev liblapack-dev libxml2-dev \
+                  libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libntl-dev gfan \
+                  libcdd-dev w3c-markup-validator
+                  # libz-dev zlib1g-dev liblzma-dev fflas-ffpack libgivaro-dev
+          # TODO: help autotools detect flint from brew
+          brew install flint
 
 # ----------------------
 #   Steps common to all build variants
 # ----------------------
 
-      - name: Create build directory
-        id: step_build_dir
-        run: mkdir $BUILD_DIR
-
-# ----------------------
-#   Configure and build M2 using cmake
-# ----------------------
-
-      - name: Configure Macaulay2 (cmake)
-        id: step_configure_cmake
-        if: ${{ matrix.build-type == 'cmake' }}
-        working-directory: M2/BUILD/cicd  # use ${{ defaults.dir }} or something along those lines
-        env:
-          CXX: ${{matrix.cxx}}
-          CC: ${{matrix.cc}}
-        run: cmake -S../.. -B. -G"Ninja" -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build Macaulay2 (cmake)
-        id: step_build
-        if: ${{ matrix.build-type == 'cmake' }}
-        working-directory: M2/BUILD/cicd
+      - name: Prepare build environment
         run: |
-          cmake --build . --target build-libraries  -j4
-          cmake --build . --target build-programs   -j4
-          cmake --build . --target M2-core          -j4
-          cmake --build . --target install-packages -j4
+          echo "::set-env name=CC::${{ matrix.cc }}"
+          echo "::set-env name=CXX::${{ matrix.cxx }}"
+          echo "::set-env name=LD_LIBRARY_PATH::`brew --prefix`/lib:$LD_LIBRARY_PATH"
 
-# ----------------------
-#   Configure and build M2 the old way
-# ----------------------
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            PATH=/usr/lib/ccache:$PATH
+            # Necessary for clang-10 on Linux
+            # echo "::set-env name=LIBRARY_PATH::`llvm-config-10 --libdir`"
+          else
+            # PATH=`brew --prefix llvm`/bin:$PATH
+            PATH=`brew --prefix ccache`/libexec:$PATH
+            PATH=`brew --prefix make`/libexec/gnubin:$PATH
+            # Necessary for clang on macOS
+            # echo "::set-env name=LIBRARY_PATH::`llvm-config --libdir`"
+          fi
+          echo "::set-env name=PATH::$PATH"
 
-      - name: Configure Macaulay2 (autotools)
-        id: step_configure_autotools
-        if: ${{ matrix.build-type == 'autotools' }}
-        env:
-          CXX: ${{matrix.cxx}}
-          CC: ${{matrix.cc}}
-        run: |
-          cd M2
-          ${{matrix.make}} get-tools
-          ${{matrix.make}} -f Makefile
-          cd BUILD/cicd
-          ../../configure --prefix=/usr --enable-download --enable-build-libraries="readline"
-
-      - name: Save artifacts (autotools)
-        if: always() && matrix.build-type == 'autotools'
-        uses: actions/upload-artifact@v1
+      - uses: actions/cache@v2
+        if: matrix.build-system == 'cmake' # TODO: remove when autotools is more efficient with space
+        id: restore-cache
         with:
-           name: config-log-${{matrix.os}}-${{matrix.compiler}}
-           path: M2/BUILD/cicd/config.log
+          path: |
+            ~/.ccache
+            ~/M2/BUILD/build/usr-host
+          key: usr-host-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-${{ hashFiles('**/cmake/*-libraries.cmake') }}
+          restore-keys: |
+            usr-host-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-
+            usr-host-${{ runner.os }}-${{ matrix.compiler }}-
+            usr-host-${{ runner.os }}-
 
-      - name: Build Macaulay2 (autotools)
-        id: step_build_autotools
-        if: ${{ matrix.build-type == 'autotools' }}
-        working-directory: M2/BUILD/cicd
-        run: ${{matrix.make}}
+
+# ----------------------
+#   Configure and build M2 using CMake
+# ----------------------
+
+      - name: Configure Macaulay2 using CMake
+        if: matrix.build-system == 'cmake'
+        run: |
+          cmake -S../.. -B. -GNinja -DUSING_MPIR=OFF \
+            -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix`
+
+      - name: Build libraries using Ninja
+        if: matrix.build-system == 'cmake' # && steps.restore-cache.outputs.cache-hit != 'true'
+        run: |
+          cmake --build . --target build-libraries build-programs
+
+      - name: Build Macaulay2 using Ninja
+        if: matrix.build-system == 'cmake'
+        run: |
+          cmake --build . --target M2-core install-packages
+
+# ----------------------
+#   Configure and build M2 using Autotools
+# ----------------------
+
+      - name: Configure Macaulay2 using Autotools
+        if: matrix.build-system == 'autotools'
+        run: |
+          make -C ../.. get-libtool get-automake get-autoconf
+          make -C ../.. all
+          ../../configure --enable-download
+
+      - name: Build Macaulay2 using Make
+        if: matrix.build-system == 'autotools'
+        run: |
+          make
 
 # ----------------------
 #   Run tests
 # ----------------------
 
-      - name: Run Tests (autotools, ubuntu)
-        if: matrix.build-type == 'autotools' && matrix.os == 'ubuntu-latest'
-        working-directory: M2/BUILD/cicd
+      - name: Run Tests using CTest
+        if: matrix.build-system == 'cmake' && matrix.os == 'ubuntu-latest'
         run: |
-          ${{matrix.make}} check
-          ${{matrix.make}} -C Macaulay2/html-check-links check
-          ${{matrix.make}} validate-html
+          # cmake --build . --target M2-unit-tests
+          # ctest -R "unit-tests"
+          ctest -R "normal/" -E "command|program|schenck|threads|doc-links" -j4
+
+      - name: Run Tests using Autotools
+        if: matrix.build-system == 'autotools' && matrix.os == 'ubuntu-latest'
+        run: |
+          make check
+          make -C Macaulay2/html-check-links check
+          make validate-html
+
+# ----------------------
+#   Upload build logs
+# ----------------------
+
+      - name: Upload build logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+           name: ${{ matrix.os }}-${{ matrix.build-system }}-${{ matrix.compiler }}-logs
+           path: |
+             # Autotools
+             M2/BUILD/build/config.log
+             M2/BUILD/build/libraries/*/build/*/config.log
+             # CMake
+             M2/BUILD/build/CMakeFiles/CMakeCache.txt
+             M2/BUILD/build/CMakeFiles/CMake(Error|Output).log
+             M2/BUILD/build/libraries/*/build/config.log
+             # Example errors
+             M2/BUILD/build/usr-dist/common/share/doc/Macaulay2/*/example-output/*.errors

--- a/M2/BUILD/docker/Makefile
+++ b/M2/BUILD/docker/Makefile
@@ -37,6 +37,6 @@ run-emacs:;	docker run $(VOLUME) --net=host --env="DISPLAY" $(TAG)
 ###############################################################################
 # Terminal targets
 
-root:;	docker run $(VOLUME) -it --user root --entrypoint bash $(TAG)
+root:;	docker run $(VOLUME) -it -w $(M2_HOME)/$(BUILD_DIR) --user root --entrypoint bash $(TAG)
 
-shell:;	docker run $(VOLUME) -it --entrypoint bash $(TAG)
+shell:;	docker run $(VOLUME) -it -w $(M2_HOME)/$(BUILD_DIR) --entrypoint bash $(TAG)

--- a/M2/BUILD/mahrud/package-review.sh
+++ b/M2/BUILD/mahrud/package-review.sh
@@ -1,8 +1,8 @@
-owner=mahrud
+user=mahrud
 token=`cat ~/.github_token` # https://github.com/settings/tokens
 
 # List workflows:
-#curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$owner/M2/actions/workflows
+#curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/Macaulay2/M2/actions/workflows
 
 if [[ -z "$1" ]];
 then package="FirstPackage"
@@ -20,7 +20,7 @@ echo package: $package
 echo     ref: $ref
 
 curl \
-  -u $owner:$token -X POST \
+  -u $user:$token -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   -d "{\"inputs\":{\"package\":\"$package\"}, \"ref\":\"$ref\"}" \
-  https://api.github.com/repos/$owner/M2/actions/workflows/1877698/dispatches
+  https://api.github.com/repos/Macaulay2/M2/actions/workflows/1904671/dispatches

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -282,12 +282,23 @@ Below are a list of common issues and errors. If you run into a problem not list
 
 
 <details>
+<summary>Installing dependencies using Linuxbrew</summary>
+
+On macOS CMake automatically finds libraries installed on the Homebrew prefix. In order to use Linuxbrew (which has the same interface and packages), use the following command to tell CMake to look under the right prefix:
+```
+cmake -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` .
+```
+</details>
+
+<details>
 <summary>CMake is not using the local version of MPIR, Flint, etc.</summary>
+
 Currently, when CMake is set to use the MPIR library, it compiles MPIR and a number of other libraries from source, including MPFR, NTL, Flint, Factory, Frobby, and Givaro. This is done to avoid linking conflicts caused by the libraries linking instead with the GMP library. Therefore, in order to link with system libraries the `-DUSING_MPIR=OFF` option is required. See this [comment](https://github.com/Macaulay2/M2/issues/1275#issuecomment-644217756) for more details on the reasoning behind this.
 </details>
 
 <details>
 <summary><code>No download info given for 'build-flint' and its source directory</code></summary>
+
 When building from a downloaded archive (i.e., not a git repository), it is necessary to also download and extract archives of the required submodules in the `M2/submodules` directory.
 
 If a given library is not required on a particular system, CMake might still complain that the submodule directory is empty. One way to prevent this is to create a dummy file in the submodule directory for the libraries that are not required; for instance:
@@ -298,43 +309,63 @@ touch M2/submodules/flint2/empty
 
 <details>
 <summary>Detected library incompatibilities; rerun the build-libraries target</summary>
+
 This message indicates that the build scripts detected an inconsistency between the libraries found on the system, and that those libraries are marked to be compiled from source. Run `ninja build-libraries` (or `make build-libraries`) to build the libraries from source.
 
 If the problem persists, run `cmake --debug-trycompile` and open an issue with the contents of `CMakeFiles/CMakeError.log`.
 </details>
 
 <details>
-<summary>macOS 10.15 Catalina issues with AppleClang</summary>
-After ensuring that you have followed the usual steps from the [INSTALL](INSTALL) manual (e.g. running `xcode-select --install`, consider setting the `CMAKE_OSX_SYSROOT` variable to match the current SDK:
+<summary>macOS 10.15 Catalina issues with Clang and AppleClang</summary>
+
+<b>Clang</b>: The Clang compiler installed via Homebrew or built from source typically includes OpenMP, but by default the system root is set to the Xcode SDK directory which does not contain the `libomp.dylib` library. The following command tells Clang how to find the correct library path:
+```
+LIBRARY_PATH=`llvm-config --libdir` cmake -S../.. -B. -GNinja -DCMAKE_BUILD_TYPE=Release
+```
+The `llvm-config` executable is typically located at `/usr/local/opt/llvm/bin/llvm-config`.
+
+<b>AppleClang</b>: After ensuring that you have followed the usual steps from the [INSTALL](INSTALL) manual (e.g. running `xcode-select --install`, consider setting the `CMAKE_OSX_SYSROOT` variable to match the current SDK:
 ```
 cmake -DCMAKE_OSX_SYSROOT=`xcrun --show-sdk-path` .
 ```
-This would, for instance, tell CMake to look in `/Applications/Xcode.app/Contents/Developer/SDKs/MacOSX.sdk/usr/include` for headers. If problems persist, open an issue.
+This would, for instance, tell CMake to look in `/Applications/Xcode.app/Contents/Developer/SDKs/MacOSX.sdk/usr/include` for headers.
+
+Moreover, when building with MPIR, adding the following option allows CMake to find OpenMP from its own prefix rather than the common prefix at `/usr/local`, which may help avoid linking conflicts:
+```
+cmake -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix libomp` .
+```
+
+If problems persist for either compiler, open an issue.
 </details>
 
 <details>
 <summary><code>M2/include/M2/config.h:75:0: warning: "HAVE_ALARM" redefined</code></summary>
+
 This error indicates that a previous in-source build has files left in the source tree. Run `make clean distclean` from the source directory or start from a clean clone of Macaulay2.
 </details>
 
 <details>
 <summary><code>engine.h:84:3: error: ‘gmp_arrayZZ’ does not name a type; did you mean ‘gmp_newZZ’?</code></summary>
+
 Same as above.
 </details>
 
 <details>
 <summary><code>gmp-util.h:96:31: error: ‘gmp_CCmutable’ was not declared in this scope</code></summary>
+
 Same as above.
 </details>
 
 <details>
 <summary><code>mpirxx.h:3482:13: error: ‘mpir_ui’ has not been declared</code></summary>
+
 This error indicates that a system version of `gmp.h` was found before `mpir.h`. If this occurs, open an issue.
 </details>
 
 
 <details>
 <summary><code>undefined reference to `GC_malloc`</code></summary>
+
 This error occurs if the GC library path is not set correctly.
 <pre>
 [  4%] Linking C executable scc1
@@ -351,6 +382,7 @@ cmake -U*BDWGC* .
 
 <details>
 <summary>How to compile with Intel(R) Math Kernel Library</summary>
+
 [MKL](https://software.intel.com/en-us/mkl) is a linear algebra routines library specifically optimized for Intel(R) processors. To enable linking with MKL, adjust the path and architecture appropriately and run the following before calling `cmake`:
 <pre>
 source /opt/intel/bin/compilervars.sh intel64
@@ -363,5 +395,6 @@ See [FindLAPACK](https://cmake.org/cmake/help/latest/module/FindLAPACK.html) for
 
 <details>
 <summary>How to compile with AMD(R) Optimizing CPU Libraries</summary>
+
 TODO: [AOCL](https://developer.amd.com/amd-aocl/) includes AMD BLIS and AMD libFLAME
 </details>

--- a/M2/Macaulay2/editors/CMakeLists.txt
+++ b/M2/Macaulay2/editors/CMakeLists.txt
@@ -37,11 +37,16 @@ set(M2_INSTALL_EMACSDIR
 file(COPY emacs/ DESTINATION ${M2_INSTALL_EMACSDIR}
   FILES_MATCHING PATTERN "M2*" PATTERN "*.in" EXCLUDE)
 
-add_custom_target(M2-emacs ALL
+set(EMACS_FILES M2-emacs-help.txt M2-emacs.m2 M2-symbols.el.gz)
+list(TRANSFORM EMACS_FILES PREPEND ${M2_INSTALL_EMACSDIR}/)
+add_custom_target(M2-emacs ALL DEPENDS ${EMACS_FILES})
+add_custom_command(OUTPUT ${EMACS_FILES}
   COMMENT "Generating Emacs package"
   COMMAND ${M2} ${M2_ARGS} ${CMAKE_CURRENT_SOURCE_DIR}/emacs/make-M2-emacs-help.m2
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/emacs/M2-symbols.el ${M2_INSTALL_EMACSDIR}
   COMMAND gzip -nf9 M2-symbols.el
+  # This command updates the generated content in the M2-emacs submodule
   COMMAND ${CMAKE_COMMAND} -E copy M2-emacs-help.txt M2-emacs.m2 M2-symbols.el.gz ${CMAKE_CURRENT_SOURCE_DIR}/emacs
+  MAIN_DEPENDENCY emacs/make-M2-emacs-help.m2
   WORKING_DIRECTORY ${M2_INSTALL_EMACSDIR}
   DEPENDS M2-editors)

--- a/M2/cmake/FindCDDLIB.cmake
+++ b/M2/cmake/FindCDDLIB.cmake
@@ -3,6 +3,7 @@
 #
 # This file sets up cddlib for CMake. Once done this will define
 #  CDDLIB_FOUND             - system has the CDDLIB library
+#  CDDLIB_ROOT              - the CDDLIB install prefix
 #  CDDLIB_INCLUDE_DIR       - the CDDLIB include directory
 #  CDDLIB_LIBRARIES         - Libraries needed to use CDDLIB
 #
@@ -17,15 +18,17 @@ find_path(CDDLIB_INCLUDE_DIR NAMES cdd.h
   PATH_SUFFIXES cdd cddlib
   )
 
-find_path(CDDLIB_LIBRARY_DIR NAMES cdd cddgmp
-  PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
-  )
-
 find_library(CDDLIB_LIBRARIES NAMES cdd cddgmp
   PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
   )
 
-include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(CDDLIB DEFAULT_MSG CDDLIB_INCLUDE_DIR CDDLIB_LIBRARY_DIR CDDLIB_LIBRARIES)
+if(CDDLIB_LIBRARIES)
+  get_filename_component(CDDLIB_LIBRARY_DIR "${CDDLIB_LIBRARIES}" DIRECTORY)
+endif()
 
-mark_as_advanced(CDDLIB_INCLUDE_DIR CDDLIB_LIBRARY_DIR CDDLIB_LIBRARIES)
+string(REGEX REPLACE "/include(/${CMAKE_LIBRARY_ARCHITECTURE}$)?" "" CDDLIB_ROOT "${CDDLIB_INCLUDE_DIR}")
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(CDDLIB DEFAULT_MSG CDDLIB_ROOT CDDLIB_INCLUDE_DIR CDDLIB_LIBRARY_DIR CDDLIB_LIBRARIES)
+
+mark_as_advanced(CDDLIB_ROOT CDDLIB_INCLUDE_DIR CDDLIB_LIBRARY_DIR CDDLIB_LIBRARIES)

--- a/M2/cmake/FindFlint.cmake
+++ b/M2/cmake/FindFlint.cmake
@@ -8,6 +8,7 @@
 # Once done this will define
 #
 #  FLINT_FOUND		- system has the FLINT library with correct version
+#  FLINT_ROOT		- the FLINT install prefix
 #  FLINT_INCLUDE_DIR	- the FLINT include directory
 #  FLINT_LIBRARIES	- the FLINT library
 #  FLINT_VERSION	- FLINT version
@@ -59,6 +60,7 @@ macro(_flint_check_version)
 endmacro(_flint_check_version)
 
 if(NOT FLINT_FOUND)
+  set(FLINT_ROOT NOTFOUND)
   set(FLINT_INCLUDE_DIR NOTFOUND)
   set(FLINT_LIBRARIES NOTFOUND)
 
@@ -86,9 +88,11 @@ if(NOT FLINT_FOUND)
       )
   endif()
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(Flint DEFAULT_MSG FLINT_INCLUDE_DIR FLINT_LIBRARIES FLINT_VERSION_OK)
+  string(REGEX REPLACE "/include(/${CMAKE_LIBRARY_ARCHITECTURE}$)?" "" FLINT_ROOT "${FLINT_INCLUDE_DIR}")
 
-  mark_as_advanced(FLINT_INCLUDE_DIR FLINT_LIBRARIES)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Flint DEFAULT_MSG FLINT_ROOT FLINT_INCLUDE_DIR FLINT_LIBRARIES FLINT_VERSION_OK)
+
+  mark_as_advanced(FLINT_ROOT FLINT_INCLUDE_DIR FLINT_LIBRARIES)
 
 endif()

--- a/M2/cmake/FindGLPK.cmake
+++ b/M2/cmake/FindGLPK.cmake
@@ -3,6 +3,7 @@
 #
 # This file sets up GLPK for CMake. Once done this will define
 #  GLPK_FOUND             - system has GLPK lib
+#  GLPK_ROOT              - the GLPK install prefix
 #  GLPK_INCLUDE_DIR       - the GLPK include directory
 #  GLPK_LIBRARIES         - Libraries needed to use GLPK
 #
@@ -16,7 +17,9 @@ find_library(GLPK_LIBRARIES NAMES glpk libglpk
   PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
   )
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GLPK DEFAULT_MSG GLPK_INCLUDE_DIR GLPK_LIBRARIES)
+string(REGEX REPLACE "/include(/${CMAKE_LIBRARY_ARCHITECTURE}$)?" "" GLPK_ROOT "${GLPK_INCLUDE_DIR}")
 
-mark_as_advanced(GLPK_INCLUDE_DIR GLPK_LIBRARIES)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLPK DEFAULT_MSG GLPK_ROOT GLPK_INCLUDE_DIR GLPK_LIBRARIES)
+
+mark_as_advanced(GLPK_ROOT GLPK_INCLUDE_DIR GLPK_LIBRARIES)

--- a/M2/cmake/FindGMP.cmake
+++ b/M2/cmake/FindGMP.cmake
@@ -8,7 +8,9 @@
 # Once done this will define
 #
 #  GMP_FOUND             - system has GMP lib
+#  GMP_ROOT              - the GMP install prefix
 #  GMP_INCLUDE_DIRS      - the GMP include directory
+#  GMP_LIBRARY_DIRS      - the GMP library directory
 #  GMP_LIBRARIES         - Libraries needed to use GMP
 #  GMP_VERSION           - GMP version
 
@@ -70,7 +72,9 @@ macro(_gmp_check_version)
 endmacro(_gmp_check_version)
 
 if(NOT GMP_VERSION_OK)
+  set(GMP_ROOT NOTFOUND)
   set(GMP_INCLUDE_DIRS NOTFOUND)
+  set(GMP_LIBRARY_DIRS NOTFOUND)
   set(GMP_LIBRARIES NOTFOUND)
   set(GMPXX_LIBRARIES NOTFOUND)
 
@@ -99,9 +103,15 @@ if(NOT GMP_VERSION_OK)
     set(GMP_LIBRARIES ${GMPXX_LIBRARIES} ${GMP_LIBRARIES})
   endif()
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(GMP DEFAULT_MSG GMP_INCLUDE_DIRS GMP_LIBRARIES GMP_VERSION_OK)
+  if(GMPXX_LIBRARIES)
+    get_filename_component(GMP_LIBRARY_DIRS "${GMPXX_LIBRARIES}" DIRECTORY)
+  endif()
 
-  mark_as_advanced(GMP_INCLUDE_DIRS GMP_LIBRARIES)
+  string(REGEX REPLACE "/include(/${CMAKE_LIBRARY_ARCHITECTURE}$)?" "" GMP_ROOT "${GMP_INCLUDE_DIRS}")
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(GMP DEFAULT_MSG GMP_ROOT GMP_INCLUDE_DIRS GMP_LIBRARIES GMP_LIBRARY_DIRS GMP_VERSION_OK)
+
+  mark_as_advanced(GMP_ROOT GMP_INCLUDE_DIRS GMP_LIBRARIES GMP_LIBRARY_DIRS)
 
 endif()

--- a/M2/cmake/FindMPIR.cmake
+++ b/M2/cmake/FindMPIR.cmake
@@ -8,7 +8,9 @@
 # Once done this will define
 #
 #  MPIR_FOUND             - system has MPIR lib
+#  MPIR_ROOT              - the MPIR install prefix
 #  MPIR_INCLUDE_DIRS      - the MPIR include directory
+#  MPIR_LIBRARY_DIRS      - the MPIR library directory
 #  MPIR_LIBRARIES         - Libraries needed to use MPIR
 #  MPIR_VERSION           - MPIR version
 
@@ -58,7 +60,9 @@ macro(_mpir_check_version)
 endmacro(_mpir_check_version)
 
 if(NOT MPIR_VERSION_OK)
+  set(MPIR_ROOT NOTFOUND)
   set(MPIR_INCLUDE_DIRS NOTFOUND)
+  set(MPIR_LIBRARY_DIRS NOTFOUND)
   set(MPIR_LIBRARIES NOTFOUND)
   set(MPIRXX_LIBRARIES NOTFOUND)
 
@@ -87,9 +91,15 @@ if(NOT MPIR_VERSION_OK)
     set(MPIR_LIBRARIES ${MPIRXX_LIBRARIES} ${MPIR_LIBRARIES})
   endif()
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(MPIR DEFAULT_MSG MPIR_INCLUDE_DIRS MPIR_LIBRARIES MPIR_VERSION_OK)
+  if(MPIRXX_LIBRARIES)
+    get_filename_component(MPIR_LIBRARY_DIRS "${MPIRXX_LIBRARIES}" DIRECTORY)
+  endif()
 
-  mark_as_advanced(MPIR_INCLUDE_DIRS MPIR_LIBRARIES)
+  string(REGEX REPLACE "/include(/${CMAKE_LIBRARY_ARCHITECTURE}$)?" "" MPIR_ROOT "${MPIR_INCLUDE_DIRS}")
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(MPIR DEFAULT_MSG MPIR_ROOT MPIR_INCLUDE_DIRS MPIR_LIBRARIES MPIR_LIBRARY_DIRS MPIR_VERSION_OK)
+
+  mark_as_advanced(MPIR_ROOT MPIR_INCLUDE_DIRS MPIR_LIBRARIES MPIR_LIBRARY_DIRS)
 
 endif()

--- a/M2/cmake/FindNTL.cmake
+++ b/M2/cmake/FindNTL.cmake
@@ -8,6 +8,7 @@
 # Once done this will define
 #
 #  NTL_FOUND		- system has the NTL library with correct version
+#  NTL_ROOT		- the NTL install prefix
 #  NTL_INCLUDE_DIR	- the NTL include directory
 #  NTL_LIBRARIES	- the NTL library
 #  NTL_VERSION		- NTL version
@@ -59,6 +60,7 @@ macro(_NTL_check_version)
 endmacro(_NTL_check_version)
 
 if(NOT NTL_FOUND)
+  set(NTL_ROOT NOTFOUND)
   set(NTL_INCLUDE_DIR NOTFOUND)
   set(NTL_LIBRARIES NOTFOUND)
 
@@ -86,9 +88,11 @@ if(NOT NTL_FOUND)
       )
   endif()
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(NTL DEFAULT_MSG NTL_INCLUDE_DIR NTL_LIBRARIES NTL_VERSION_OK)
+  string(REGEX REPLACE "/include(/${CMAKE_LIBRARY_ARCHITECTURE}$)?" "" NTL_ROOT "${NTL_INCLUDE_DIR}")
 
-  mark_as_advanced(NTL_INCLUDE_DIR NTL_LIBRARIES)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(NTL DEFAULT_MSG NTL_ROOT NTL_INCLUDE_DIR NTL_LIBRARIES NTL_VERSION_OK)
+
+  mark_as_advanced(NTL_ROOT NTL_INCLUDE_DIR NTL_LIBRARIES)
 
 endif()

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -162,7 +162,6 @@ _ADD_COMPONENT_DEPENDENCY(libraries eigen "" EIGEN3_FOUND)
 # https://github.com/ivmai/bdwgc/
 # TODO: add environment variables GC_LARGE_ALLOC_WARN_INTERVAL and GC_ABORT_ON_LEAK
 # Note: Starting with 8.0, libatomic_ops is not necessary for C11 or C++14.
-# FIXME: fix a commit to use instead of master
 ExternalProject_Add(build-bdwgc
   PREFIX            libraries/bdwgc
   SOURCE_DIR        ${CMAKE_SOURCE_DIR}/submodules/bdwgc
@@ -243,6 +242,12 @@ if(NOT MP_FOUND)
     _ADD_COMPONENT_DEPENDENCY(libraries mpir "" MPIR_FOUND)
   endif()
 endif()
+if(NOT MP_ROOT)
+  set(MP_ROOT ${M2_HOST_PREFIX})
+  set(MP_LIBRARY_DIRS ${MP_ROOT}/lib)
+  set(MP_INCLUDE_DIRS ${MP_ROOT}/include)
+endif()
+set(MP_INCLUDE_DIR ${${MP_LIBRARY}_INCLUDE_DIRS})
 
 
 # https://www.mpfr.org/
@@ -280,7 +285,7 @@ ExternalProject_Add(build-mpfr
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
-set(MPFR_INCLUDE_DIR ${MPFR_INCLUDE_DIRS}) # TODO: make this unnecessary in e/CMakeLists.txt
+set(MPFR_INCLUDE_DIR ${MPFR_INCLUDE_DIRS}) # TODO: make this unnecessary in d/CMakeLists.txt
 _ADD_COMPONENT_DEPENDENCY(libraries mpfr mp MPFR_FOUND)
 
 
@@ -334,6 +339,9 @@ ExternalProject_Add_Step(build-ntl wizard
   EXCLUDE_FROM_MAIN ON
   USES_TERMINAL ON
   )
+if(NOT NTL_ROOT)
+  set(NTL_ROOT ${M2_HOST_PREFIX})
+endif()
 if(AUTOTUNE)
   add_dependencies(build-ntl-install build-ntl-wizard)
 endif()
@@ -372,14 +380,15 @@ ExternalProject_Add(build-flint
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
+if(NOT FLINT_ROOT)
+  set(FLINT_ROOT ${M2_HOST_PREFIX})
+endif()
 _ADD_COMPONENT_DEPENDENCY(libraries flint "mp;mpfr;ntl" FLINT_FOUND)
 
 
 # https://github.com/Singular/Sources/tree/spielwiese/factory
 # https://service.mathematik.uni-kl.de/ftp/pub/Math/Singular/Factory/
 # TODO: what is ftmpl_inst.o?
-set(factory_NTL_HOME_PATH "${M2_HOST_PREFIX} ${NTL_INCLUDE_DIR}/..")
-set(factory_FLINT_HOME_PATH "${M2_HOST_PREFIX} ${FLINT_INCLUDE_DIR}/..")
 ExternalProject_Add(build-factory
   URL               ${M2_SOURCE_URL}/factory-4.1.3.tar.gz
   URL_HASH          SHA256=d004dd7e3aafc9881b2bf42b7bc935afac1326f73ad29d7eef0ad33eb72ee158
@@ -397,8 +406,9 @@ ExternalProject_Add(build-factory
                       ${assertions_setting}
                       --enable-streamio
                       --without-Singular
-                      --with-ntl=${factory_NTL_HOME_PATH}
-                      --with-flint=${factory_FLINT_HOME_PATH}
+                      --with-gmp=${MP_ROOT}
+                      --with-ntl=${NTL_ROOT}
+                      --with-flint=${FLINT_ROOT}
                       CPPFLAGS=${CPPFLAGS}
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}
@@ -428,7 +438,6 @@ _ADD_COMPONENT_DEPENDENCY(libraries factory "mp;mpfr;ntl;flint" FACTORY_FOUND)
 # https://www.broune.com/frobby/
 # https://github.com/Macaulay2/frobby
 # TODO: to use Frobby as a submodule, it needs to support out-of-tree builds
-set(frobby_CXXFLAGS "${CPPFLAGS} ${CXXFLAGS} -Wno-deprecated-declarations")
 ExternalProject_Add(build-frobby
 #  GIT_REPOSITORY    ${CMAKE_SOURCE_DIR}/submodules/frobby/.git
 #  GIT_TAG           HEAD # WIP: 51c3e075
@@ -441,12 +450,11 @@ ExternalProject_Add(build-frobby
   BUILD_IN_SOURCE   ON
   CONFIGURE_COMMAND true
   BUILD_COMMAND     ${MAKE} library -j${PARALLEL_JOBS} prefix=${M2_HOST_PREFIX}
-                      GMP_INC_DIR=${MP_ROOT}/include
+                      GMP_INC_DIR=${MP_INCLUDE_DIRS}
                       CPPFLAGS=${CPPFLAGS}
                       CFLAGS=${CFLAGS}
-                      CXXFLAGS=${frobby_CXXFLAGS}
+                      CXXFLAGS=${CXXFLAGS}
                       LDFLAGS=${LDFLAGS}
-                      CC=${CMAKE_C_COMPILER}
                       CXX=${CMAKE_CXX_COMPILER}
                       AR=${CMAKE_AR}
                       OBJDUMP=${CMAKE_OBJDUMP}
@@ -496,19 +504,24 @@ ExternalProject_Add(build-cddlib
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
+if(NOT CDDLIB_ROOT)
+  set(CDDLIB_ROOT ${M2_HOST_PREFIX})
+  set(CDDLIB_LIBRARY_DIR ${CDDLIB_ROOT}/lib)
+  set(CDDLIB_INCLUDE_DIR ${CDDLIB_ROOT}/include)
+endif()
 _ADD_COMPONENT_DEPENDENCY(libraries cddlib mp CDDLIB_FOUND)
 
 
 # https://numpi.dm.unipi.it/software/mpsolve
 # Known issue: tests don't work with static library
 ExternalProject_Add(build-mpsolve
-  URL               https://github.com/robol/MPSolve/archive/3.2.1.tar.gz
-  URL_HASH          SHA256=7edb7899d69a3e09848b893b12f360b8a83429a18eee4a7f193fcfc8692dca71
-  DOWNLOAD_NAME     MPSolve-3.2.1.tar.gz
+  URL               ${M2_SOURCE_URL}/mpsolve-3.2.1.tar.gz
+  URL_HASH          SHA256=3d11428ae9ab2e020f24cabfbcd9e4d9b22ec572cf70af0d44fe8dae1d51e78e
   PREFIX            libraries/mpsolve
   SOURCE_DIR        libraries/mpsolve/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
+  PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/mpsolve/patch-3.2.1
   CONFIGURE_COMMAND autoreconf -vif
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
@@ -517,6 +530,8 @@ ExternalProject_Add(build-mpsolve
                       --disable-examples
                       --disable-ui
                       --disable-documentation
+                      GMP_CFLAGS=-I${MP_INCLUDE_DIRS}
+                      GMP_LDFLAGS=-L${MP_LIBRARY_DIRS}
                       CPPFLAGS=${CPPFLAGS}
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}
@@ -550,6 +565,7 @@ ExternalProject_Add(build-givaro
                       #-C --cache-file=${CONFIGURE_CACHE}
                       ${shared_setting}
                       $<$<NOT:$<BOOL:${BUILD_NATIVE}>>:--without-archnative>
+                      --with-gmp=${MP_ROOT}
                       CPPFLAGS=${CPPFLAGS}
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}
@@ -650,6 +666,9 @@ ExternalProject_Add(build-glpk
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
+if(NOT GLPK_ROOT)
+  set(GLPK_ROOT ${M2_HOST_PREFIX})
+endif()
 _ADD_COMPONENT_DEPENDENCY(libraries glpk mp GLPK_FOUND)
 
 
@@ -710,7 +729,6 @@ _ADD_COMPONENT_DEPENDENCY(libraries mathic memtailor MATHIC_FOUND)
 
 
 # https://github.com/Macaulay2/mathicgb
-# TODO: use TBB when it is present
 # TODO: g++ warning: tbb.h contains deprecated functionality.
 # https://www.threadingbuildingblocks.org/docs/help/reference/appendices/deprecated_features.html
 ExternalProject_Add(build-mathicgb
@@ -756,11 +774,11 @@ ExternalProject_Add(build-4ti2
   CONFIGURE_COMMAND autoreconf -vif
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
-                      $<$<BOOL:${GLPK_FOUND}>:--with-glpk=${GLPK_INCLUDE_DIR}/..>
-                      CPPFLAGS=${CPPFLAGS}
+                      --with-glpk=${GLPK_ROOT}
+                      "CPPFLAGS=${CPPFLAGS} -I${MP_INCLUDE_DIRS}"
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}
-                      LDFLAGS=${LDFLAGS}
+                      "LDFLAGS=${LDFLAGS}  -L${MP_LIBRARY_DIRS}"
                       CC=${CMAKE_C_COMPILER}
                       CXX=${CMAKE_CXX_COMPILER}
                       AR=${CMAKE_AR}
@@ -797,8 +815,7 @@ ExternalProject_Add(build-cohomcalg
                       CXXFLAGS=${CXXFLAGS}
                       LDFLAGS=${LDFLAGS}
                       CC=${CMAKE_C_COMPILER}
-                      CXX=${CMAKE_CXX_COMPILER}
-                      LD=${CMAKE_CXX_COMPILER} # correct?
+                      LD=${CMAKE_CXX_COMPILER} # set to g++ in Makefile
   INSTALL_COMMAND   ${CMAKE_STRIP} bin/cohomcalg
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/cohomcalg
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different LICENSE ${M2_INSTALL_LICENSESDIR}/cohomcalg
@@ -813,14 +830,6 @@ _ADD_COMPONENT_DEPENDENCY(programs cohomcalg "" COHOMCALG)
 
 # https://users-math.au.dk/~jensen/software/gfan/gfan.html
 # gfan needs cddlib and is used by the packages gfanInterface and StatePolytopes
-set(gfan_OPTFLAGS "${CPPFLAGS} -DGMPRATIONAL") # overriding the flags defined in Makefile
-set(gfan_CLINKER  "${CMAKE_C_COMPILER}   ${LDFLAGS}")
-set(gfan_CCLINKER "${CMAKE_CXX_COMPILER} ${LDFLAGS}")
-if(CDDLIB_FOUND)
-  set(gfan_OPTFLAGS "${gfan_OPTFLAGS} -I${CDDLIB_INCLUDE_DIR}")
-  set(gfan_CLINKER  "${gfan_CLINKER}  -L${CDDLIB_LIBRARY_DIR}")
-  set(gfan_CCLINKER "${gfan_CCLINKER} -L${CDDLIB_LIBRARY_DIR}")
-endif()
 ExternalProject_Add(build-gfan
   URL               ${M2_SOURCE_URL}/gfan0.6.2.tar.gz
   URL_HASH          SHA256=a674d5e5dc43634397de0d55dd5da3c32bd358d05f72b73a50e62c1a1686f10a
@@ -832,11 +841,13 @@ ExternalProject_Add(build-gfan
   CONFIGURE_COMMAND true
   BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS}
                       cddnoprefix=yes
+                      "GMP_LINKOPTIONS=-L${MP_LIBRARY_DIRS} -lgmp"
+                      "GMP_INCLUDEOPTIONS=-I${MP_INCLUDE_DIRS}"
                       CC=${CMAKE_C_COMPILER}
                       CXX=${CMAKE_CXX_COMPILER}
-                      OPTFLAGS=${gfan_OPTFLAGS}
-                      CLINKER=${gfan_CLINKER}
-                      CCLINKER=${gfan_CCLINKER}
+                      "OPTFLAGS=${CPPFLAGS} -DGMPRATIONAL -I${CDDLIB_INCLUDE_DIR}"
+                      "CLINKER=${CMAKE_C_COMPILER} ${LDFLAGS} -L${CDDLIB_LIBRARY_DIR}"
+                      "CCLINKER=${CMAKE_CXX_COMPILER} ${LDFLAGS} -L${CDDLIB_LIBRARY_DIR}"
   INSTALL_COMMAND   ${CMAKE_STRIP} gfan
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/gfan
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different LICENSE COPYING ${M2_INSTALL_LICENSESDIR}/gfan
@@ -861,8 +872,8 @@ ExternalProject_Add(build-lrslib
   PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/lrslib/patch-071
   CONFIGURE_COMMAND true
   BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS} prefix=${M2_HOST_PREFIX} lrs # all-shared
-                      INCLUDEDIR=${MP_ROOT}/include
-                      LIBDIR=${MP_ROOT}/lib
+                      INCLUDEDIR=${MP_INCLUDE_DIRS}
+                      LIBDIR=${MP_LIBRARY_DIRS}
                       CPPFLAGS=${CPPFLAGS}
                       CFLAGS=${CFLAGS}
                       LDFLAGS=${LDFLAGS}
@@ -884,11 +895,10 @@ _ADD_COMPONENT_DEPENDENCY(programs lrslib mp LRSLIB)
 # https://github.com/coin-or/Csdp
 # TODO: what to do when OpenMP is not found
 # TODO: set CFLAGS instead of CC, this is tricky due to csdp's Makefile
-set(csdp_CC      "${CMAKE_C_COMPILER} ${OpenMP_C_FLAGS} ${CFLAGS}")
-set(csdp_LIBS    "-L../lib -lsdp ${LA_LIBRARIES} -lm")
 ExternalProject_Add(build-csdp
-  URL               http://www.coin-or.org/download/source/Csdp/Csdp-6.2.0.tgz
-  URL_HASH          SHA256=7f202a15f33483ee205dcfbd0573fdbd74911604bb739a04f8baa35f8a055c5b
+  URL               https://github.com/coin-or/Csdp/archive/releases/6.2.0.tar.gz
+  URL_HASH          SHA256=3d341974af1f8ed70e1a37cc896e7ae4a513375875e5b46db8e8f38b7680b32f
+  DOWNLOAD_NAME     csdp-6.2.0.tar.gz
   PREFIX            libraries/csdp
   SOURCE_DIR        libraries/csdp/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
@@ -896,9 +906,9 @@ ExternalProject_Add(build-csdp
   PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/csdp/patch-6.2.0
   CONFIGURE_COMMAND true
   BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS} prefix=${M2_HOST_PREFIX}
-                      CC=${csdp_CC}
+                      "CC=${CMAKE_C_COMPILER} ${OpenMP_C_FLAGS} ${CFLAGS}"
                       LDLIBS=${OpenMP_C_LDLIBS}
-                      LIBS=${csdp_LIBS}
+                      "LIBS=-L../lib -lsdp ${LA_LIBRARIES} -lm"
   INSTALL_COMMAND   ${CMAKE_STRIP} solver/csdp
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/csdp
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different LICENSE README ${M2_INSTALL_LICENSESDIR}/csdp
@@ -969,11 +979,11 @@ ExternalProject_Add(build-normaliz
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
                       --disable-shared # TODO: for polymake --enable-shared
-                      --without-flint # ${FLINT_INCLUDE_DIR}/..
-                      CPPFLAGS=${CPPFLAGS}
+                      --without-flint # ${FLINT_ROOT}
+                      "CPPFLAGS=${CPPFLAGS} -I${MP_INCLUDE_DIRS}"
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}
-                      LDFLAGS=${LDFLAGS}
+                      "LDFLAGS=${LDFLAGS}  -L${MP_LIBRARY_DIRS}"
                       CC=${CMAKE_C_COMPILER}
                       CXX=${CMAKE_CXX_COMPILER}
                       AR=${CMAKE_AR}
@@ -996,23 +1006,18 @@ _ADD_COMPONENT_DEPENDENCY(programs normaliz "mp;nauty" NORMALIZ)
 
 
 # http://www.rambau.wm.uni-bayreuth.de/TOPCOM/
-# topcom needs cddlib
 set(topcom_PROGRAMS
-  src-reg/checkregularity src/points2finetriang src/points2chiro src/chiro2circuits src/chiro2cocircuits
-  src/points2allfinetriangs src/points2alltriangs src/points2ntriangs src/points2nfinetriangs
-  src/points2finetriangs src/points2flips src/points2nallfinetriangs src/points2nalltriangs src/points2nflips
-  src/points2triangs src/points2volume src/B_A src/B_A_center src/B_D
-  src/chiro2allfinetriangs src/chiro2alltriangs src/chiro2dual src/chiro2finetriang src/chiro2finetriangs
-  src/chiro2mintriang src/chiro2nallfinetriangs src/chiro2nalltriangs src/chiro2nfinetriangs
-  src/chiro2ntriangs src/chiro2placingtriang src/chiro2triangs src/cocircuits2facets src/cross
-  src/cube src/cyclic src/hypersimplex src/lattice src/points2facets src/points2placingtriang
-  src/santos_22_triang src/santos_dim4_triang src/santos_triang)
-set(topcom_CPPFLAGS "${CPPFLAGS}")
-set(topcom_LDFLAGS  "${LDFLAGS}")
-if(CDDLIB_FOUND)
-  set(topcom_CPPFLAGS "${topcom_CPPFLAGS} -I${CDDLIB_INCLUDE_DIR}")
-  set(topcom_LDFLAGS  "${topcom_LDFLAGS}  -L${CDDLIB_LIBRARY_DIR}")
-endif()
+  B_A B_A_center B_D checkregularity cocircuits2facets cross cube cyclic hypersimplex lattice
+  chiro2allfinetriangs   chiro2dual              chiro2nallfinetriangs  chiro2placingtriang
+  chiro2alltriangs       chiro2finetriang        chiro2nalltriangs      chiro2triangs
+  chiro2circuits         chiro2finetriangs       chiro2nfinetriangs
+  chiro2cocircuits       chiro2mintriang         chiro2ntriangs
+  points2allfinetriangs  points2finetriang       points2nalltriangs     points2placingtriang
+  points2alltriangs      points2finetriangs      points2nfinetriangs    points2triangs
+  points2chiro           points2flips            points2nflips          points2volume
+  points2facets          points2nallfinetriangs  points2ntriangs
+  santos_22_triang       santos_dim4_triang      santos_triang)
+list(TRANSFORM topcom_PROGRAMS PREPEND ${M2_HOST_PREFIX}/bin/ OUTPUT_VARIABLE topcom_PROGRAMS)
 ExternalProject_Add(build-topcom
   URL               ${M2_SOURCE_URL}/TOPCOM-0.17.8.tar.gz
   URL_HASH          SHA256=3f83b98f51ee859ec321bacabf7b172c25884f14848ab6c628326b987bd8aaab
@@ -1024,18 +1029,18 @@ ExternalProject_Add(build-topcom
   CONFIGURE_COMMAND autoreconf -vif
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
-                      CPPFLAGS=${topcom_CPPFLAGS}
+                      "CPPFLAGS=${CPPFLAGS} -I${MP_INCLUDE_DIRS} -I${CDDLIB_INCLUDE_DIR}"
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}
-                      LDFLAGS=${topcom_LDFLAGS}
+                      "LDFLAGS=${LDFLAGS} -L${MP_LIBRARY_DIRS} -L${CDDLIB_LIBRARY_DIR}"
                       CC=${CMAKE_C_COMPILER}
                       CXX=${CMAKE_CXX_COMPILER}
   BUILD_COMMAND     ${MAKE} -j1 # topcom doesn't like parallel builds
-  # TODO: put topcom programs in a folder?
-  INSTALL_COMMAND   ${CMAKE_STRIP} ${topcom_PROGRAMS}
+  INSTALL_COMMAND   ${MAKE} -j1 install-strip
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/topcom
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING README ${M2_INSTALL_LICENSESDIR}/topcom
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different ${topcom_PROGRAMS} ${M2_INSTALL_PROGRAMSDIR}/
+          COMMAND   ${CMAKE_COMMAND} -E remove -f ${topcom_PROGRAMS}
   TEST_COMMAND      ${MAKE} -j${PARALLEL_JOBS} check
   EXCLUDE_FROM_ALL  ON
   TEST_EXCLUDE_FROM_MAIN ON
@@ -1050,7 +1055,6 @@ _ADD_COMPONENT_DEPENDENCY(programs topcom cddlib TOPCOM)
 # https://polymake.org/doku.php/install/install
 # Note: polymake requires ~16G storage and permlib and perl-Term-ReadLine-Gnu on Fedora.
 # TODO: the install target doesn't install polymake in usr-dist, only in usr-host
-set(polymake_CXXFLAGS "${CPPFLAGS} -std=gnu++14 -w -Wno-mismatched-tags -Wno-deprecated-register")
 ExternalProject_Add(build-polymake
 #  URL               https://polymake.org/lib/exe/fetch.php/download/polymake-4.1.tar.bz2 # Bundled version
 #  URL_HASH          9ee571c08552672e990d0478f8c1ce13467b769c99049b8afd2fc39fe6ab35d6
@@ -1063,8 +1067,8 @@ ExternalProject_Add(build-polymake
   CONFIGURE_COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
                       --with-gmp=${MP_ROOT}
-                      --with-cdd=${CDDLIB_INCLUDE_DIR}/..
-                      --with-flint=${FLINT_INCLUDE_DIR}/..
+                      --with-cdd=${CDDLIB_ROOT}
+                      --with-flint=${FLINT_ROOT}
 #                      --with-libnormaliz=${M2_HOST_PREFIX}
 #                      --with-lrs=${M2_HOST_PREFIX}
 #                      --with-lrs-include=${CMAKE_BINARY_DIR}/libraries/lrslib/build
@@ -1077,7 +1081,7 @@ ExternalProject_Add(build-polymake
 #                      --without-soplex
 #                      --without-sympol
                       CFLAGS=${CFLAGS}
-                      CXXFLAGS=${polymake_CXXFLAGS}
+                      "CXXFLAGS=${CPPFLAGS} -std=gnu++14 -w -Wno-mismatched-tags -Wno-deprecated-register"
                       LDFLAGS=${LDFLAGS}
                       CC=${CMAKE_C_COMPILER}
                       CXX=${CMAKE_CXX_COMPILER}

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -236,6 +236,11 @@ if(VERBOSE)
   message("## Build flags (excluding standard ${CMAKE_BUILD_TYPE} flags)
      Compiler flags    = ${COMPILE_OPTIONS}
      Linker flags      = ${LINK_OPTIONS}\n")
+  message("## CMake path variables
+     CMAKE_SYSTEM_PREFIX_PATH
+       ${CMAKE_SYSTEM_PREFIX_PATH}
+     CMAKE_C_IMPLICIT_LINK_DIRECTORIES
+       ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}\n")
 endif()
 
 ###############################################################################

--- a/M2/libraries/mpsolve/patch-3.2.1
+++ b/M2/libraries/mpsolve/patch-3.2.1
@@ -47,3 +47,23 @@ diff -ur /Users/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/einsteinium-gcc9-devel
 -	$(GTK_LIBS)
 -
 -nodist_EXTRA_mpsolve_SOURCES = dummy.cxx
+
+--- mpsolve-3.2.1/configure.ac-orig	2020-07-09 02:28:06.018935996 -0500
++++ mpsolve-3.2.1/configure.ac	2020-07-09 02:28:20.903885679 -0500
+@@ -311,13 +311,13 @@
+     # Add GMP_CFLAGS and GMP_LIBS to CFLAGS and LDFLAGS in case they are set.
+     # This is an easy way for the user to override system libgmp or to provide
+     # its location if it's not installed system-wide. 
+-    AS_IF([test -z $GMP_CFLAGS], [], [
++    AS_IF([test -z "$GMP_CFLAGS"], [], [
+       CFLAGS="$GMP_CFLAGS $CFLAGS"
+     ])
+-    AS_IF([test -z $GMP_LDFLAGS], [], [
++    AS_IF([test -z "$GMP_LDFLAGS"], [], [
+       LDFLAGS="$GMP_LDFLAGS $LDFLAGS"
+     ])
+-    AS_IF([test -z $GMP_LIBS], [], [
++    AS_IF([test -z "$GMP_LIBS"], [], [
+       LDFLAGS="$GMP_LIBS $LDFLAGS"
+     ])
+ 


### PR DESCRIPTION
Includes:
- many important improvements to how CMake finds libraries
- add Clang10 test for ubuntu and macOS, but only for CMake
- add github action tests for CMake
- improve github action artifact uploads for both cmake and autotools to include example errors, if any occurred