### PR TITLE
Improving support for external programs, part 5

### DIFF
--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -254,6 +254,7 @@ export {
 	"MinimalGenerators",
 	"MinimalMatrix",
 	"Minimize",
+	"MinimumVersion",
 	"Minus",
 	"Module",
 	"ModuleMap",

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -10,14 +10,24 @@ addSlash = programPath -> (
     else return programPath
 )
 
-checkProgramPath = (name, cmds, opts) -> (
-    if all(cmds, cmd -> run(cmd | " >/dev/null 2>&1") == 0) then (
-	if opts.Verbose == true then print("    found");
-	return true;
-    ) else (
-	if opts.Verbose == true then print("    not found");
-	return false;
-    )
+checkProgramPath = (name, cmds, pathToTry, prefix, opts) -> (
+    found := all(cmds, cmd ->
+	run(pathToTry | addPrefix(cmd, prefix) | " >/dev/null 2>&1") == 0);
+    msg := "";
+    if found then (
+	if opts.MinimumVersion === null then msg = "    found"
+	else (
+	    thisVersion := get("!" | pathToTry |
+		addPrefix(opts.MinimumVersion_1, prefix));
+	    found = found and thisVersion >= opts.MinimumVersion_0;
+	    if found then msg = "    found version " | thisVersion | " >= " |
+		opts.MinimumVersion_0
+	    else msg = "   found, but version " | thisVersion | " < " |
+		opts.MinimumVersion_0;
+	)
+    ) else msg = "    not found";
+    if opts.Verbose == true then print(msg);
+    found
 )
 
 addPrefix = (cmd, prefix) ->
@@ -44,8 +54,8 @@ getProgramPath = (name, cmds, opts) -> (
 	    if opts.Verbose == true and #prefixes > 1 then
 		print("  trying prefix \"" | prefix_1 |
 		    "\" for executables matching \"" | prefix_0 | "\"...");
-	    if checkProgramPath(name, apply(cmds, cmd ->
-		pathToTry | addPrefix(cmd, prefix)), opts) then break prefix)
+	    if checkProgramPath(name, cmds, pathToTry, prefix, opts) then
+	        break prefix)
 	);
 	if prefix =!= null then break (pathToTry, prefix)
     ))
@@ -56,7 +66,8 @@ findProgram = method(TypicalValue => Program,
 	RaiseError => true,
 	Verbose => false,
 	Prefix => {},
-	AdditionalPaths => {}
+	AdditionalPaths => {},
+	MinimumVersion => null
     })
 findProgram(String, String) := opts -> (name, cmd) ->
     findProgram(name, {cmd}, opts)
@@ -66,7 +77,11 @@ findProgram(String, List) := opts -> (name, cmds) -> (
 	if opts.RaiseError then error("could not find " | name)
 	else return null;
     new Program from {"name" => name, "path" => programPathAndPrefix_0,
-	"prefix" => programPathAndPrefix_1}
+	"prefix" => programPathAndPrefix_1} |
+	if opts.MinimumVersion =!= null then
+	    {"version" => get("!" | programPathAndPrefix_0 |
+		addPrefix(opts.MinimumVersion_1, programPathAndPrefix_1))}
+	else {}
 )
 
 runProgram = method(TypicalValue => ProgramRun,

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -13,7 +13,10 @@ document {
 	{TT "\"prefix\"", ", a sequence of two strings identifying the ",
 	    "prefix prepended to the binary executables.  See ",
 	    TO "findProgram", ", specifically the description of the ",
-	    TT "Prefix", " option, for more."}},
+	    TT "Prefix", " option, for more."},
+	{TT "\"version\"", ", a string containing the version number ",
+	    "of the program.  Only present if ", TO "findProgram",
+	    " was called with the ", TT "MinimumVersion", " option."}},
     SeeAlso => {"programPaths", "findProgram"}
 }
 
@@ -47,11 +50,17 @@ document {
     Headline => "list of non-standard paths to search for a program"
 }
 
+document{
+    Key => MinimumVersion,
+    Headline => "the minimum required version of a program"
+}
+
 document {
     Key => {findProgram,
 	(findProgram, String, String),
 	(findProgram, String, List),
 	[findProgram, AdditionalPaths],
+	[findProgram, MinimumVersion],
 	[findProgram, Prefix],
 	[findProgram, RaiseError],
 	[findProgram, Verbose]},
@@ -79,7 +88,13 @@ document {
 	    TT "prefix", " is the prefix itself."},
 	AdditionalPaths => List => {
 	    "a list of strings containing any paths to check for the program ",
-	    "in addition to the default ones."}
+	    "in addition to the default ones."},
+	MinimumVersion => Sequence => {
+	    "containing two strings the form ",
+	    TT "(minVersion, versionCommand)", ", where  ", TT "minVersion",
+	    " is the minimum required version of the program and ",
+	    TT "versionCommand", " is a shell command to obtain the version ",
+	    "number of an installed program."}
     },
     Outputs => {Program => { "the program that was loaded.  ",
 	"If the program is not found and ", TT "RaiseError", " is set to ",
@@ -117,5 +132,15 @@ document {
     (".*", "topcom-"),
     ("^(cross|cube|cyclic|hypersimplex|lattice)$", "TOPCOM-"),
     ("^cube$", "topcom_")})///},
+    PARA {"Note that when using the ", TT "MinimumVersion", " option, the ",
+	"command used to obtain the current version number must remove ",
+	"everything except the version number itself, including any ",
+	"trailing newlines.  Piping with standard UNIX utilities such as ",
+	TT "sed", ", ", TT "head", ", ", TT "tail", ", ", TT "cut", ", and ",
+	TT "tr", " may be useful."},
+    EXAMPLE {///findProgram("gfan", "gfan --help", Verbose => true,
+  MinimumVersion => ("0.5",
+    "gfan _version | head -2 | tail -1 | sed 's/gfan//' | tr -d '\n'"))
+    ///},
     SeeAlso => {"Program", "programPaths", "runProgram"}
 }

--- a/M2/Macaulay2/packages/Normaliz.m2
+++ b/M2/Macaulay2/packages/Normaliz.m2
@@ -1301,7 +1301,7 @@ document {
 PARA{},"Depending on the options enabled (see ", TO setNmzOption, "), ", TT "Normaliz", " writes additional output files. To obtain the content of these files within Macaulay2, use ", TO readNmzData, " or ", TO allComputations,". The following files may be written, provided certain conditions are satisfied and the information that should go into them has been computed. We denote the files simply by their types.
 For the most types of inputs the ambient lattice is ", TEX "\\ZZ^n", " if the input of Normaliz is a matrix of n columns. In types polytope and rees_algebra the ambient lattice is ", TEX "\\ZZ^{n+1}", " since the input vectors are extended by 1 component. For congruences and inhomogeneous input it is ", TEX "\\ZZ^{n-1}", " and for inhomogenouse congruences ", TEX "\\ZZ^{n-2}", ".
 For input of type lattice_ideal the lattice is ", TEX "\\ZZ^{r}", " where n-r is the rank of the input matrix. The essential lattice is gp(M) where M is the monoid computed by Normaliz internally, i.e. after a linear transformation such that the cone is full-dimensional and the integral closure has to be computed.
-See the documentation of Normaliz at ", HREF "http://www.math.uos.de/normaliz/Normaliz2.12.2/Normaliz.pdf", " for more details.",
+See the documentation of Normaliz at ", HREF "https://github.com/Normaliz/Normaliz/blob/master/doc/Normaliz.pdf", " for more details.",
 UL{
    {TT "gen      ", "   The Hilbert basis"},
    {TT "ext      ", "   The extreme rays"},

--- a/M2/Macaulay2/tests/normal/programs.m2
+++ b/M2/Macaulay2/tests/normal/programs.m2
@@ -35,3 +35,10 @@ assert(fileExists(dir | "/foo/bar/baz"))
 
 program = findProgram("foo", name, AdditionalPaths => {dir})
 assert(program#"path" == dir)
+
+fn << "echo -n 1.0" << close
+program = findProgram(name, name, MinimumVersion => ("0.9", name))
+assert(program#"version" == "1.0")
+program = findProgram(name, name, MinimumVersion => ("1.1", name),
+    RaiseError => false)
+assert(program === null)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1024,17 +1024,17 @@ else AC_MSG_RESULT([no, will build])
      BUILD_csdp=yes
 fi
 
-dnl we can't use the test below for the presence of normaliz until the package Normaliz knows
-dnl how to find normaliz on the path, and until our *.dmg and
-dnl *.deb making procedures know how to include it or set the dependencies appropriately
-BUILD_normaliz=yes
-BUILD_ALWAYS="$BUILD_ALWAYS normaliz"
-dnl AC_MSG_CHECKING(whether the package normaliz is installed)
-dnl if test "`type -t normaliz`" = file
-dnl then AC_MSG_RESULT(yes)
-dnl else AC_MSG_RESULT([no, will build])
-dnl      BUILD_normaliz=yes
-dnl fi
+AC_MSG_CHECKING(whether the package normaliz is installed)
+if test "`type -t normaliz`" = file
+then normaliz_version=`normaliz --version | head -1 | cut -d " " -f 2`
+     AX_COMPARE_VERSION([$normaliz_version], [ge], [3.5.2],
+          [AC_MSG_RESULT([yes])
+           FILE_PREREQS="$FILE_PREREQS `type -p normaliz`"],
+          [AC_MSG_RESULT([yes, but < 3.5.2, will build])
+           BUILD_normaliz=yes])
+else AC_MSG_RESULT([no, will build])
+     BUILD_normaliz=yes
+fi
 
 dnl debian/fedora: nauty-
 AC_MSG_CHECKING(whether the package nauty (>= 2.7) is installed)


### PR DESCRIPTION
*I'm leaving this as a draft pull request pending #1400 and #1413, as they touch the same files and there will need to be some fixing up to do before this is merged.  But it's ready aside from that, so I figured I'd open it for review.*

This PR introduces the following:

* A new `versionCompare` method for comparing version strings.
* A `MinimumVersion` option to `findProgram`, which uses the above to determine whether the user has a new enough version of a program on their system.
* A `RunDirectory` option to `runProgram`, which gives the user the option of running their program in a directory other than the current working directory.
* Updates to the `Normaliz` package.  It uses the above options, as it requires at least version 2.11 of normaliz and needs to run in the same directory as its input and output files.