### PR TITLE
Modify findProgram/runProgram examples to not need gfan/topcom installed

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -97,15 +97,15 @@ document {
     PARA {"Note that if a program consists of a single executable binary ",
 	"file, then ", TT "name", " should coincide with the name of this ",
 	"file."},
-    EXAMPLE lines ///
-	programPaths#"gfan" = "/path/to/gfan/"
-	gfan = findProgram("gfan", "gfan --help", Verbose => true)///,
+    EXAMPLE {///programPaths#"gfan" = "/path/to/gfan/"///,
+	///gfan = findProgram("gfan", "gfan --help", Verbose => true,
+	    RaiseError => false)///},
     PARA {"One program that is shipped with a variety of prefixes in ",
 	"different distributions and for which the ", TT "Prefix",
 	" option is useful is TOPCOM:"},
     EXAMPLE {///findProgram("topcom", "cube 3", Verbose => true, Prefix => {
     (".*", "topcom-"),
     ("^(cross|cube|cyclic|hypersimplex|lattice)$", "TOPCOM-"),
-    ("^cube$", "topcom_")})///},
+    ("^cube$", "topcom_")}, RaiseError => false)///},
     SeeAlso => {"Program", "programPaths", "runProgram"}
 }

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/runProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/runProgram-doc.m2
@@ -53,11 +53,10 @@ document {
     PARA {"This method runs an external program which has already been ",
 	"loaded using ", TO "findProgram", ".  The results of this run are ",
 	"available in a ", TO "ProgramRun", " object."},
-    EXAMPLE lines ///
-    	gfan = findProgram("gfan", "gfan --help")
-	runProgram(gfan, "_version")
-	oo#"output"
-	runProgram(gfan, "_foo", RaiseError => false)
-	oo#"error"///,
+    EXAMPLE {///ls = findProgram("ls", "ls .")///,
+	///runProgram(ls, "--version")///,
+	///oo#"output"///,
+	///runProgram(ls, "this-file-does-not-exist", RaiseError => false)///,
+	///oo#"error"///},
     SeeAlso => {"ProgramRun", "findProgram"}
 }


### PR DESCRIPTION
We set RaiseError to false for the findProgram examples.  For the
runProgram examples (which necessarily need a successful call to
findProgram), we switch from gfan to perl, which should be present on
most systems.