### PR TITLE
Link against Boost.Stacktrace in autotools build

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1240,6 +1240,28 @@ AC_CHECK_HEADER(boost/version.hpp,
 	AC_MSG_ERROR([boost library not installed, but required])
 	])
 
+AC_MSG_CHECKING([if we can link against Boost.Stacktrace library])
+SAVECPPFLAGS=$CPPFLAGS
+CPPFLAGS="$CPPFLAGS -DBOOST_STACKTRACE_LINK"
+SAVELIBS=$LIBS
+FOUND_stacktrace_library=no
+for stacktrace_library in backtrace addr2line
+do
+    LIBS="$SAVELIBS -lboost_stacktrace_${stacktrace_library}"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([#include <boost/stacktrace.hpp>
+         ], [boost::stacktrace::stacktrace();])],
+        [AC_MSG_RESULT([yes, ${stacktrace_library}])
+         FOUND_stacktrace_library=yes
+         break],)
+done
+if test $FOUND_stacktrace_library = no
+then
+    AC_MSG_RESULT([no, will use header-only library])
+    CPPFLAGS=$SAVECPPFLAGS
+    LIBS=$SAVELIBS
+fi
+
 AC_SUBST(ULIMIT_T,yes)
 AC_SUBST(ULIMIT_M,yes)
 AC_SUBST(ULIMIT_V,yes)


### PR DESCRIPTION
As discussed in #1429, this provides much more informative backtraces and
is already being done in the CMake build.  We first try linking against
libboost_stacktrace_backtrace, which is available in Ubuntu but not OS X,
and then libboost_stacktrace_addr2line, which is available in OS X. If
neither are found, then we go back to the original behavior of using
the header-only library.