### PR TITLE
Improving support for external programs, part 6

### DIFF
--- a/M2/Macaulay2/packages/CohomCalg/dP1.in
+++ b/M2/Macaulay2/packages/CohomCalg/dP1.in
@@ -1,0 +1,27 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%    Example input file for cohomCalg
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% This file contains the geometry data of the del-Pezzo-1 surface, which
+% corresponds to the single blowup of the CP^2 projective space
+%
+
+% The vertices and GLSM charges:
+    vertex u1 = (  1,  1 ) | PIC: H  | GLSM:  ( 1,  0 );
+    vertex u2 = ( -1,  0 )           | GLSM:  ( 1,  0 );
+    vertex u3 = (  0, -1 )           | GLSM:  ( 1,  1 );
+    vertex u4 = (  0,  1 ) | PIC: X  | GLSM:  ( 0,  1 );  
+
+% The Stanley-Reisner ideal:
+    srideal [u1*u2,  u3*u4];
+
+% Computation time for this example is quasi-instantaneous,
+% so turn off intermediate files:
+    monomialfile off;
+
+% And finally the requested line bundle cohomologies:
+    ambientcohom O(-1, -2);
+    ambientcohom O(-2,  0);
+    ambientcohom O(-3, -2);

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -973,9 +973,8 @@ then if test "$OS" = Darwin -a "$DMG" = yes
      	  # Also, the package CohomCalg looks only in the directory where Macaulay2's binaries are
 	  AC_MSG_RESULT([yes, will build anyway])
           BUILD_cohomcalg=yes
-     else AC_MSG_RESULT([yes, will build anyway])
-     	  # the package CohomCalg looks only in the directory where Macaulay2's binaries are
-          BUILD_cohomcalg=yes
+     else AC_MSG_RESULT([yes])
+          FILE_PREREQS="$FILE_PREREQS `type -p cohomcalg`"
      fi
 else AC_MSG_RESULT([no, will build])
      BUILD_cohomcalg=yes


### PR DESCRIPTION
This PR ports the `CohomCalg` package to the new `findProgram`/`runProgram` interface.

For `findProgram` to work, we need a command that will return 0.  Somewhat frustratingly, the natural choice doesn't:

```console
profzoom@peg-amy:~$ cohomcalg --help

    cohomCalg v0.32
    (compiled for Linux/Unix x86-64 / 64 bit)
    author: Benjamin Jurke (mail@benjaminjurke.com)
    Based on the algorithm detailed in arXiv:1003.5217


Syntax:  cohomcalg [--option1] [--option2] ... InputFileName [> OutputFileName]

Command line options:
  --in="..."      Treats the text between parentheses like additional
                  input data, i.e. like appended content of the input file.
  --nomonomfile   Prohibits usage and generation of monomial file.
  --checkserre    Computes the Serre dual cohomology for comparison.
  --noreduction   Deactivates the Serre self-duality reduction for ambiguous
                  monomials (may increase computation time dramatically!)
  --hideinput     Does not print the input data read from the input file.
  --showtime      Shows timing stats even for application runs < 1 second.
  --showbits      Prints the internally used bitmasks for debug output.
  --mathematica   Gives formattet output for the Mathematica script version.
  --integrated    Produces minimalistic output for application integration.
  --verboseN      Provides debug output at level N=1..6, e.g. --verbose3.
  --maxX=N        Defines limits for X=verts,srgens,cohoms to N.

The order of options is irrelevant, but later commands always overwrite
prior options, e.g. from '--verbose4 --verbose1' only the later one will
have any effect.

The program automatically tries to add the file extension '.in' to the
InputFileName. See the package manual for further information.

profzoom@peg-amy:~$ echo $?
1
```

So instead, we include a small example file from the upstream source (the [del Pezzo surface](https://github.com/BenjaminJurke/cohomCalg/blob/master/bin/dP1.in)) and use it as an input file for the call to `cohomcalg` used by `findPackage`.

We also remove the now deprecated mutable exported string `cohomCalgExecutable`, since its purpose is now covered by setting `programPaths#"cohomcalg"`.

Note that this PR shouldn't have any conflicts with any of the others in this series.