### PR TITLE
Improving support for external programs, part 7

### DIFF
--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -342,6 +342,7 @@ export {
 	"RingFamily",
 	"RingMap",
 	"RowExpression",
+	"RunDirectory",
 	"RunExamples",
 	"SPACE",
 	"SVD",

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -63,14 +63,23 @@ findProgram(String, List) := opts -> (name, cmds) -> (
 )
 
 runProgram = method(TypicalValue => ProgramRun,
-    Options => {RaiseError => true, KeepFiles => false, Verbose => false})
+    Options => {
+	RaiseError => true,
+	KeepFiles => false,
+	Verbose => false,
+	RunDirectory => null
+	})
 runProgram(Program, String) := opts -> (program, args) ->
     runProgram(program, program#"name", args, opts)
 runProgram(Program, String, String) := opts -> (program, name, args) -> (
     tmpFile := temporaryFileName();
     outFile := tmpFile | ".out";
     errFile := tmpFile | ".err";
-    cmd := program#"path" | addPrefix(name, program#"prefix") | " " | args;
+    cmd := if opts.RunDirectory =!= null then (
+	if not isDirectory opts.RunDirectory then
+	    makeDirectory opts.RunDirectory;
+	"cd " | opts.RunDirectory | " && " ) else "";
+    cmd = cmd | program#"path" | addPrefix(name, program#"prefix") | " " | args;
     returnValue := run (cmd | " > " | outFile | " 2> " | errFile);
     message := "running: " | cmd | "\n";
     output := get outFile;

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/runProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/runProgram-doc.m2
@@ -28,11 +28,17 @@ document {
 }
 
 document {
+    Key => {RunDirectory},
+    Headline => "the directory from which to run a program"
+}
+
+document {
     Key => {runProgram,
 	(runProgram, Program, String),
 	(runProgram, Program, String, String),
 	[runProgram, KeepFiles],
 	[runProgram, RaiseError],
+	[runProgram, RunDirectory],
 	[runProgram, Verbose]},
     Headline => "run an external program",
     Usage => "runProgram(program, args)\nrunProgram(program, exe, args)",
@@ -47,6 +53,11 @@ document {
 	    "containing the program's output."},
 	RaiseError => Boolean => {"whether to raise an error if the program ",
 	    "returns a nonzero value."},
+	RunDirectory => String => {"the directory from which to run the ",
+	    "program.  If it does not exist, then it will be created.  ",
+	    "If ", TO "null", ", then the program will be run ",
+	    "from the current working directory (see ",
+	    TO "currentDirectory", ")."},
 	Verbose => Boolean => {"whether to print the command line input and ",
 	    "the program's output."}
 	},

--- a/M2/Macaulay2/tests/normal/programs.m2
+++ b/M2/Macaulay2/tests/normal/programs.m2
@@ -27,3 +27,8 @@ copyFile(fn, dir | "/foo-bar")
 prefix = ("bar", "foo-")
 program = findProgram(name, {name, "bar"}, Prefix => {prefix})
 assert(program#"prefix" == prefix)
+
+fn << "touch baz" << close
+program = findProgram(name, name)
+runProgram(program, name, RunDirectory => dir | "/foo/bar")
+assert(fileExists(dir | "/foo/bar/baz"))

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1012,9 +1012,8 @@ fi
 
 AC_MSG_CHECKING(whether the package csdp is installed)
 if test "`type -t csdp`" = file
-then AC_MSG_RESULT([yes, will build anyway])
-     dnl because the package SemidefiniteProgramming doesn't look for it on the PATH
-     BUILD_csdp=yes
+then AC_MSG_RESULT([yes])
+     FILE_PREREQS="$FILE_PREREQS `type -p csdp`"
 else AC_MSG_RESULT([no, will build])
      BUILD_csdp=yes
 fi


### PR DESCRIPTION
This is the last pull request in this series.  If it and the others in the series are merged, then we can close #407 and #1165, as every one of Macaulay2's build dependencies on programs could be satisfied by using existing installations.

The focus is on the `SemidefiniteProgramming` package, which uses csdp (and mosek and sdpa, but only csdp is a build dependency).

Since csdp needs to be run in the same directory as the `params.csdp` file containing various parameters, we need the `RunDirectory` option to `runProgram`.  However, this was introduced in #1417, which hasn't been merged yet, so I went ahead and also added the corresponding commit to this branch, too.  If one of the PR's is merged, then I'll remove this commit from the other so they don't conflict.
