### PR TITLE
Run "apt-get update" before installing Ubuntu packages in workflow

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Install requirements for Linux
         if: runner.os == 'Linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y -q --no-install-recommends clang-10 gfortran libtool-bin ninja-build yasm ccache
           sudo apt-get install -y -q --no-install-recommends libatomic-ops-dev libboost-stacktrace-dev \
                   libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev liblapack-dev libxml2-dev \


### PR DESCRIPTION
This will fix the 404 errors that we occasionally get when packages
have been recently updated in Ubuntu, but Github hasn't updated the
package index files yet.