### PR TITLE
CMake maintenance

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Configure Macaulay2 using CMake
         if: matrix.build-system == 'cmake'
         run: |
-          cmake -S../.. -B. -GNinja -DUSING_MPIR=OFF \
+          cmake -S../.. -B. -GNinja \
             -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` \
             -DBUILD_NATIVE=OFF -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK" # TODO: remove when the packages are updated
 

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -183,7 +183,7 @@ jobs:
         run: |
           # cmake --build . --target M2-unit-tests
           # ctest -R "unit-tests"
-          ctest -R "normal/" -E "command|program|schenck|threads|doc-links" -j4
+          ctest -R "normal/" -E "command|program|schenck|threads|doc-links" -j4 --output-on-failure
 
       - name: Run Tests using Autotools
         if: matrix.build-system == 'autotools' && matrix.os == 'ubuntu-latest'

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -320,7 +320,8 @@ If the problem persists, run `cmake --debug-trycompile` and open an issue with t
 
 <b>Clang</b>: The Clang compiler installed via Homebrew or built from source typically includes OpenMP, but by default the system root is set to the Xcode SDK directory which does not contain the `libomp.dylib` library. The following command tells Clang how to find the correct library path:
 ```
-LIBRARY_PATH=`llvm-config --libdir` cmake -S../.. -B. -GNinja -DCMAKE_BUILD_TYPE=Release
+export LIBRARY_PATH=`llvm-config --libdir`
+cmake -S../.. -B. -GNinja -DCMAKE_BUILD_TYPE=Release
 ```
 The `llvm-config` executable is typically located at `/usr/local/opt/llvm/bin/llvm-config`.
 

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -187,6 +187,7 @@ find_program(COHOMCALG	NAMES	cohomcalg)
 find_program(GFAN	NAMES	gfan)
 # TODO: library or program?
 find_program(LRSLIB	NAMES	lrs)
+# TODO: check for alternatives as well: sdpa or mosek
 find_program(CSDP	NAMES	csdp)
 find_program(NORMALIZ	NAMES	normaliz)
 find_program(NAUTY	NAMES	dreadnaut)

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -14,7 +14,7 @@
 # use CMAKE_BUILD_TYPE=RelMinSize            for minimized release
 # use BUILD_TESTING=ON                       to build the testing tree
 
-option(USING_MPIR	"Use MPIR instead of GMP"		ON)
+option(USING_MPIR	"Use MPIR instead of GMP"		OFF)
 option(DEVELOPMENT	"Set the DEVELOPMENT macro in config.h"	OFF)
 option(EXPERIMENT	"Set the EXPERIMENT macro in config.h"	OFF)
 option(LINTING		"Enable linting source files"		OFF)


### PR DESCRIPTION
- upgrade flint to 2.6.2
  - Also merge this: https://github.com/Macaulay2/flint2/pull/4
- use gmp by default to close #1243