### PR TITLE
Fixed toString(Digraph) in the Graphs package

### DIFF
--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -343,7 +343,7 @@ net Digraph := Net => G -> (
     ))
 
 toString Digraph := String => D -> (
-    horizontalJoin(
+    concatenate(
         toLower toString class D, 
         " (",
         toString vertexSet D,


### PR DESCRIPTION
`toString(Digraph)` now returns a String, not a Net. This closes #1109, and addresses an issue mentioned in the Google group.