### PR TITLE
fix printing in threads, part 1

### DIFF
--- a/M2/Macaulay2/d/Makefile.in
+++ b/M2/Macaulay2/d/Makefile.in
@@ -238,7 +238,7 @@ redo-startup:clean-startup.c startup.c cat-startup.c
 
 all: $(M2_LIBDEPS)
 tags: @srcdir@/TAGS
-@srcdir@/TAGS: $(M2_SRCFILES); cd @srcdir@ && @ETAGS@ $(M2_SRCFILES)
+@srcdir@/TAGS: $(M2_SRCFILES); cd @srcdir@ && @ETAGS@ @srcdir@/../system/*.{hpp,h,cpp} $(M2_SRCFILES)
 clean-bin:; rm -f *.o *-tmp.c *-tmp.cc *.sig.tmp *-exports.h.tmp
 clean::; rm -f typecode.db *-exports.h *-exports.h.tmp *-tmp.c *-tmp.cc *.log a.out *.o *.sym *.out *.a *.oo *.sig *.sig.tmp *.sg *.dep *.dp *.dep.tmp core gmon.out mapfile restart.tmp TAGS
 distclean: clean; rm -f Makefile ../m2/startup.m2 @srcdir@/TAGS

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -252,6 +252,9 @@ readeval4(file:TokenFile,printout:bool,dictionary:Dictionary,returnLastvalue:boo
 					else buildErrorPacket("error occurred in parsing")))))))));
 
 interpreterDepthS := setupvar("interpreterDepth",zeroE);
+setInterpreterDepth(n:int):void := (
+     interpreterDepth = n;
+     setGlobalVariable(interpreterDepthS,toExpr(interpreterDepth)));
 incrementInterpreterDepth():void := (
      interpreterDepth = interpreterDepth + 1;
      setGlobalVariable(interpreterDepthS,toExpr(interpreterDepth)));
@@ -540,9 +543,11 @@ internalCapture(e:Expr):Expr := (
 	  foss.outbuffer = new string len 100 do provide ' ';
 	  stringFile := stringTokenFile("currentString", s.v+newline);
 	  stringFile.posFile.file.echo = true;
+     	  oldInterpreterDepth := interpreterDepth;
+	  setInterpreterDepth(1);
 	  oldLineNumber := lineNumber;
-	  previousLineNumber = -1;
 	  setLineNumber(0);
+	  previousLineNumber = -1;
 	  setprompt(stringFile,topLevelPrompt);
 	  r := readeval3(stringFile,true,newStaticLocalDictionaryClosure(),false,false,true);
 	  out := substrAlwaysCopy(foss.outbuffer,0,foss.outindex);
@@ -550,6 +555,7 @@ internalCapture(e:Expr):Expr := (
 	  foss.outbuffer = oldbuf;
 	  foss.outbol = oldbol;
 	  foss.outindex = oldindex;
+	  setInterpreterDepth(oldInterpreterDepth);
 	  setLineNumber(oldLineNumber);
 	  setDebuggingMode(oldDebuggingMode);
 	  previousLineNumber = -1;


### PR DESCRIPTION
some assertion statements have been put into stdio.d

Currently working on getting this code to work:
```m2
n = 0 ; schedule( () -> while true do (n=n+1; << "hi there hi there hi there hi there hi there hi there  " << n << endl << flush ));
```

The problem seems to be that the FOSS obtained by the master thread and the scheduled thread is the same, so somehow the "outindex" field in it is altered by the master thread when it prints the next prompt.  That happens after the scheduled thread has printed its message about 500 times, and thread context switching most often occurs while the scheduled thread is in the "write" system call.

The next step would be to check whether the two FOSS structures really are the same, perhaps by writing a little code so the address can be printed from top level.

@mahrud 