### PR TITLE
fix #325 and #1457

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -913,8 +913,8 @@ net SparseMonomialVectorExpression := v -> (
 net Table := x -> netList (toList x, HorizontalSpace=>2, VerticalSpace => 1, BaseRow => 0, Boxes => false, Alignment => Center)
 
 compactMatrixForm=true; -- governs net MatrixExpression
-matrixDisplayOptions := hashTable { true => new OptionTable from { HorizontalSpace => 1, VerticalSpace => 0, BaseRow => 0, Boxes => false, Alignment => Left },
-                                   false => new OptionTable from { HorizontalSpace => 2, VerticalSpace => 1, BaseRow => 0, Boxes => false, Alignment => Center } }
+matrixDisplayOptions := hashTable { true => new OptionTable from { HorizontalSpace => 1, VerticalSpace => 0, BaseRow => 0, Alignment => Left },
+                                   false => new OptionTable from { HorizontalSpace => 2, VerticalSpace => 1, BaseRow => 0, Alignment => Center } }
 
 toCompactString := method(Dispatch => Thing)
 toCompactParen = x -> if precedence x < prec symbol * then "(" | toCompactString x | ")" else toCompactString x
@@ -936,27 +936,23 @@ net MatrixExpression := x -> (
     if all(x,r->all(r,i->class i===ZeroExpression)) then "0"
     else (
 	x=applyTable(toList x,if compactMatrixForm then toCompactString else net);
-	m := netList(x,matrixDisplayOptions#compactMatrixForm);
-	side := "|" ^ (height m, depth m);
-	horizontalJoin(side," ",m," ",side)
-	)
-     )
+	netList(x,Boxes=>{false,{0,#x#0}},matrixDisplayOptions#compactMatrixForm)
+     ))
 html MatrixExpression := x -> html TABLE toList x
 
 net MatrixDegreeExpression := x -> (
     if all(x#0,r->all(r,i->class i===ZeroExpression)) then "0"
-    else horizontalJoin(stack( x#1 / toString ), " ", net MatrixExpression x#0)
-    )
+    else (
+	x=apply(#x#0,i->apply(prepend(x#1#i,x#0#i),if compactMatrixForm then toCompactString else net));
+	netList(x,Boxes=>{false,{1,#x#0}},matrixDisplayOptions#compactMatrixForm)
+     ))
 
 net VectorExpression := x -> (
     if all(x,i->class i===ZeroExpression) then "0"
      else (
 	 x=apply(toList x,y->{(if compactMatrixForm then toCompactString else net)y});
-	 m := netList(x,HorizontalSpace=>if compactMatrixForm then 1 else 2, VerticalSpace => if compactMatrixForm then 0 else 1, BaseRow => 0, Boxes => false, Alignment => Center);
-	 side := "|" ^ (height m, depth m);
-	 horizontalJoin(side," ",m," ",side)
-	 )
-     )
+	netList(x,Boxes=>{false,{0,1}},HorizontalSpace=>1,VerticalSpace=>if compactMatrixForm then 0 else 1,BaseRow=>0,Alignment=>Center)
+     ))
 html VectorExpression := x -> html TABLE apply(toList x,y->{y})
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -79,7 +79,7 @@ unexportedSymbols = () -> hashTable apply(pairs Core#"private dictionary", (n,s)
 noinitfile' := noinitfile
 Function.GlobalReleaseHook = (X,x) -> (
      if dictionary X =!= User#"private dictionary" then warningMessage(X," redefined");
-     if hasAttribute(x,ReverseDictionary) then removeAttribute(x,ReverseDictionary);
+     if hasAttribute(x,ReverseDictionary) and getAttribute(x,ReverseDictionary) === X then removeAttribute(x,ReverseDictionary);
      )
 waterMark = serialNumber symbol waterMark      -- used by Serialization package
 endPackage "Core" -- after this point, private global symbols, such as noinitfile, are no longer visible, and public symbols have been exported

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
@@ -1053,7 +1053,7 @@ document { Key => {(netList, VisibleList),
      Usage => "netList v",
      Inputs => { 
 	  "v" => {"a list of lists of things to be converted to nets and displayed as a table in a net"},
-	  Boxes => Boolean => {"whether to draw boxes around the individual nets"},
+	  Boxes => {"whether to draw boxes around the individual nets. can be a Boolean or a pair of Booleans/lists of rows/columns to insert lines"},
 	  BaseRow => ZZ => {"the index of the base row, for the purpose of setting the baseline of the net produced.  The value
 	       is allowed to be as large as the length of ", TT "v", ", larger by 1 than one might expect."},
 	  HorizontalSpace => ZZ => {"the amount of space horizontally between entries or between entries and their enclosing boxes"},
@@ -1070,7 +1070,9 @@ document { Key => {(netList, VisibleList),
 	  netList(f,Boxes=>true,HorizontalSpace=>1,VerticalSpace=>1)
 	  netList(f,Boxes=>true,Alignment=>Center)
 	  netList(f,Boxes=>true,BaseRow=>1)
+	  netList(f,Boxes=>{{1},{1}})
 	  netList apply(5,i->apply(i+1,j->(i,j)))
+	  netList(apply(5,i->apply(i+1,j->(i,j))),Boxes=>{true,false})
      ///}
 
 document { Key => cache,

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
@@ -1051,9 +1051,11 @@ document { Key => {(netList, VisibleList),
 	  [netList, Alignment]},
      Headline => "a table of boxes",
      Usage => "netList v",
-     Inputs => { 
+     Inputs => {
 	  "v" => {"a list of lists of things to be converted to nets and displayed as a table in a net"},
-	  Boxes => {"whether to draw boxes around the individual nets. can be a Boolean or a pair of Booleans/lists of rows/columns to insert lines"},
+	  Boxes => {"whether to draw boxes around the individual nets.
+	      Can be a Boolean, or a pair controlling separately the horizontal and vertical lines of the boxes.
+	      Each element of the pair is either a Boolean (draw all or none) or a list of rows/columns where lines are to inserted."},
 	  BaseRow => ZZ => {"the index of the base row, for the purpose of setting the baseline of the net produced.  The value
 	       is allowed to be as large as the length of ", TT "v", ", larger by 1 than one might expect."},
 	  HorizontalSpace => ZZ => {"the amount of space horizontally between entries or between entries and their enclosing boxes"},


### PR DESCRIPTION
The option `Boxes` of `netList` can now take a two-element list corresponding to which rows/columns are separated by lines, see examples below. This allows for a neater encoding of `net MatrixExpression, MatrixDegreeExpression, VectorExpression` (possibly other `net` routines could benefit from it too) 
```
i1 : t=table(3,6,(i,j)->i*j)

o1 = {{0, 0, 0, 0, 0, 0}, {0, 1, 2, 3, 4, 5}, {0, 2, 4, 6, 8, 10}}

o1 : List

i2 : netList(t,Boxes=>true)

     +-+-+-+-+-+--+
o2 = |0|0|0|0|0|0 |
     +-+-+-+-+-+--+
     |0|1|2|3|4|5 |
     +-+-+-+-+-+--+
     |0|2|4|6|8|10|
     +-+-+-+-+-+--+

i3 : netList(t,Boxes=>{false,true})

o3 = |0|0|0|0|0|0 |
     |0|1|2|3|4|5 |
     |0|2|4|6|8|10|

i4 : netList(t,Boxes=>{{1},{1}},HorizontalSpace=>1)

o4 = 0 | 0 0 0 0 0 
     --+-----------
     0 | 1 2 3 4 5 
     0 | 2 4 6 8 10

i5 : netList(t,Boxes=>{{0,1,3},{0,1,6}},HorizontalSpace=>1)

     +---+------------+
o5 = | 0 | 0 0 0 0 0  |
     +---+------------+
     | 0 | 1 2 3 4 5  |
     | 0 | 2 4 6 8 10 |
     +---+------------+

i6 : netList(t,Boxes=>{true,{0,1,6}},VerticalSpace=>1,HorizontalSpace=>2)

     +-----+------------------+
     |     |                  |
o6 = |  0  |  0  0  0  0  0   |
     |     |                  |
     +-----+------------------+
     |     |                  |
     |  0  |  1  2  3  4  5   |
     |     |                  |
     +-----+------------------+
     |     |                  |
     |  0  |  2  4  6  8  10  |
     |     |                  |
     +-----+------------------+
```