### PR TITLE
Use printf instead of echo for findProgram/runProgram test

### DIFF
--- a/M2/Macaulay2/tests/normal/programs.m2
+++ b/M2/Macaulay2/tests/normal/programs.m2
@@ -1,5 +1,5 @@
 fn = temporaryFileName()
-fn << "echo -n Hello $1!" << close
+fn << ///printf "Hello %s!" "$1"/// << close
 name = baseFilename fn
 dir = replace(name | "$", "", fn)
 programPaths#name = dir


### PR DESCRIPTION
It is more portable.  From [1]:

> It is not possible to use echo portably across all POSIX systems
> unless both -n (as the first argument) and escape sequences are
> omitted.
> ...
> New applications are encouraged to use printf instead of echo.

Closes: #1509

[1] https://pubs.opengroup.org/onlinepubs/007904975/utilities/echo.html