### PR TITLE
Alternate fix for differences between normaliz output file formats

### DIFF
--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -255,6 +255,7 @@ export {
 	"MinimalGenerators",
 	"MinimalMatrix",
 	"Minimize",
+	"MinimumVersion",
 	"Minus",
 	"Module",
 	"ModuleMap",

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -10,14 +10,24 @@ addSlash = programPath -> (
     else return programPath
 )
 
-checkProgramPath = (name, cmds, opts) -> (
-    if all(cmds, cmd -> run(cmd | " >/dev/null 2>&1") == 0) then (
-	if opts.Verbose == true then print("    found");
-	return true;
-    ) else (
-	if opts.Verbose == true then print("    not found");
-	return false;
-    )
+checkProgramPath = (name, cmds, pathToTry, prefix, opts) -> (
+    found := all(cmds, cmd ->
+	run(pathToTry | addPrefix(cmd, prefix) | " >/dev/null 2>&1") == 0);
+    msg := "";
+    if found then (
+	if opts.MinimumVersion === null then msg = "    found"
+	else (
+	    thisVersion := get("!" | pathToTry |
+		addPrefix(opts.MinimumVersion_1, prefix));
+	    found = found and thisVersion >= opts.MinimumVersion_0;
+	    if found then msg = "    found version " | thisVersion | " >= " |
+		opts.MinimumVersion_0
+	    else msg = "   found, but version " | thisVersion | " < " |
+		opts.MinimumVersion_0;
+	)
+    ) else msg = "    not found";
+    if opts.Verbose == true then print(msg);
+    found
 )
 
 addPrefix = (cmd, prefix) ->
@@ -44,8 +54,8 @@ getProgramPath = (name, cmds, opts) -> (
 	    if opts.Verbose == true and #prefixes > 1 then
 		print("  trying prefix \"" | prefix_1 |
 		    "\" for executables matching \"" | prefix_0 | "\"...");
-	    if checkProgramPath(name, apply(cmds, cmd ->
-		pathToTry | addPrefix(cmd, prefix)), opts) then break prefix)
+	    if checkProgramPath(name, cmds, pathToTry, prefix, opts) then
+	        break prefix)
 	);
 	if prefix =!= null then break (pathToTry, prefix)
     ))
@@ -56,7 +66,8 @@ findProgram = method(TypicalValue => Program,
 	RaiseError => true,
 	Verbose => false,
 	Prefix => {},
-	AdditionalPaths => {}
+	AdditionalPaths => {},
+	MinimumVersion => null
     })
 findProgram(String, String) := opts -> (name, cmd) ->
     findProgram(name, {cmd}, opts)
@@ -66,7 +77,11 @@ findProgram(String, List) := opts -> (name, cmds) -> (
 	if opts.RaiseError then error("could not find " | name)
 	else return null;
     new Program from {"name" => name, "path" => programPathAndPrefix_0,
-	"prefix" => programPathAndPrefix_1}
+	"prefix" => programPathAndPrefix_1} |
+	if opts.MinimumVersion =!= null then
+	    {"version" => get("!" | programPathAndPrefix_0 |
+		addPrefix(opts.MinimumVersion_1, programPathAndPrefix_1))}
+	else {}
 )
 
 runProgram = method(TypicalValue => ProgramRun,

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -13,7 +13,10 @@ document {
 	{TT "\"prefix\"", ", a sequence of two strings identifying the ",
 	    "prefix prepended to the binary executables.  See ",
 	    TO "findProgram", ", specifically the description of the ",
-	    TT "Prefix", " option, for more."}},
+	    TT "Prefix", " option, for more."},
+	{TT "\"version\"", ", a string containing the version number ",
+	    "of the program.  Only present if ", TO "findProgram",
+	    " was called with the ", TT "MinimumVersion", " option."}},
     SeeAlso => {"programPaths", "findProgram"}
 }
 
@@ -47,11 +50,17 @@ document {
     Headline => "list of non-standard paths to search for a program"
 }
 
+document{
+    Key => MinimumVersion,
+    Headline => "the minimum required version of a program"
+}
+
 document {
     Key => {findProgram,
 	(findProgram, String, String),
 	(findProgram, String, List),
 	[findProgram, AdditionalPaths],
+	[findProgram, MinimumVersion],
 	[findProgram, Prefix],
 	[findProgram, RaiseError],
 	[findProgram, Verbose]},
@@ -79,7 +88,13 @@ document {
 	    TT "prefix", " is the prefix itself."},
 	AdditionalPaths => List => {
 	    "a list of strings containing any paths to check for the program ",
-	    "in addition to the default ones."}
+	    "in addition to the default ones."},
+	MinimumVersion => Sequence => {
+	    "containing two strings the form ",
+	    TT "(minVersion, versionCommand)", ", where  ", TT "minVersion",
+	    " is the minimum required version of the program and ",
+	    TT "versionCommand", " is a shell command to obtain the version ",
+	    "number of an installed program."}
     },
     Outputs => {Program => { "the program that was loaded.  ",
 	"If the program is not found and ", TT "RaiseError", " is set to ",
@@ -117,5 +132,15 @@ document {
     (".*", "topcom-"),
     ("^(cross|cube|cyclic|hypersimplex|lattice)$", "TOPCOM-"),
     ("^cube$", "topcom_")})///},
+    PARA {"Note that when using the ", TT "MinimumVersion", " option, the ",
+	"command used to obtain the current version number must remove ",
+	"everything except the version number itself, including any ",
+	"trailing newlines.  Piping with standard UNIX utilities such as ",
+	TT "sed", ", ", TT "head", ", ", TT "tail", ", ", TT "cut", ", and ",
+	TT "tr", " may be useful."},
+    EXAMPLE {///findProgram("gfan", "gfan --help", Verbose => true,
+  MinimumVersion => ("0.5",
+    "gfan _version | head -2 | tail -1 | sed 's/gfan//' | tr -d '\n'"))
+    ///},
     SeeAlso => {"Program", "programPaths", "runProgram"}
 }

--- a/M2/Macaulay2/packages/Normaliz.m2
+++ b/M2/Macaulay2/packages/Normaliz.m2
@@ -368,29 +368,20 @@ readMultipleNmzData String:=nmzSuffix->
     s:=lines(inf);
 
     L:={};
-    t:="";
-    b:=0;
-
-    while(b<#s)
-    do(
-      nmzGen:={};
-      numRows:=value s#b;
-      numCols:=value s#(b+1);
-      if(numRows==0)
-        then L=append(L,matrix(for j from 0 to numCols-1 list {}))
-      else(
-        for i from b+2 to b+1+numRows
-        do(
-          t = select("[0-9-]+",s#i);
-          gen:=apply(t,value);
-          nmzGen=append(nmzGen,gen);
-        );
-        -- function matrix expects nonempty list
-        if(nmzGen!={})
-        then  L=append(L,matrix(nmzGen));
-        --else  L=append(L,{{}});  -- better {{},{},...,{}};
-      );
-      b=b+numRows+3;
+    i := 0;
+    j := 0;
+    while i < #s do (
+        while j < #s and match("[0-9-]+", s#j) do j = j + 1;
+        nmzGen := if i == j then {{}}
+            else apply(take(s, {i, j - 1}), t -> value \ select("[0-9-]+", t));
+        -- versions between 3.4.0 and 3.5.1 did not print row/column data
+        -- we remove it if present
+        if #nmzGen > 2 and
+            nmzGen#0#0 == #nmzGen - 2 and -- number of rows
+            nmzGen#1#0 == #nmzGen#2 -- number of columns
+        then nmzGen = drop(nmzGen, 2);
+        L = append(L, matrix nmzGen);
+        i = j = j + 1;
     );
     return L;
 );

--- a/M2/Macaulay2/packages/Normaliz.m2
+++ b/M2/Macaulay2/packages/Normaliz.m2
@@ -104,7 +104,6 @@ nmzNumberThreads=1;
 --nmzUserCalled=true;  -- whether the user calls a method
 nmzFile="";        -- Internal name of the data files
 nmzVersion="";     -- normaliz
-nmzExecVersion=""; -- needs to be at least nmzMinExecVersion
 nmzMinExecVersion="2.11"; -- minimal normaliz version
 nmzGen=true;      -- indicates whether ".gen" is generated
 
@@ -167,8 +166,7 @@ getNmzExec=()->
     (
         nmzExec="normaliz";
     );
---    return nmzExec;
-    return prefixDirectory | currentLayout#"programs" | nmzExec;
+    return nmzExec;
 );
 
 
@@ -503,20 +501,6 @@ showNmzOptions=()->
   << collectNmzOptions();
 )
 
-checkNmzExecVersion=()->
-(
-  if (nmzExecVersion=="") then (
-    cmd := "! " | getNmzExec() | " --version 2>&1 </dev/null || true";
-    result := get cmd;
-    if not match("Normaliz ([0-9.]*)",result) then error("normaliz executable not found: " | getNmzExec());
-    nmzExecVersion = replace("(.|\n)*Normaliz ([0-9.]+)(.|\n)*", "\\2", result);
-    if not match("\\`[0-9.]+\\'$",nmzExecVersion) then error ("failed to recognize version number of program normaliz");
-  );
-  if (nmzExecVersion < nmzMinExecVersion) then
-    error("normaliz: Normaliz executable ("|getNmzExec()|") too old (" | nmzExecVersion | "), at least version " | nmzMinExecVersion | " needed!");
-)
-
-
 normaliz=method(Options=>true)
 opts={allComputations=>false, grading=>{}}
 normaliz(Matrix,String):=opts>>o->(sgr,nmzMode)->
@@ -540,6 +524,8 @@ normaliz(List):=opts>>o->(s)->
 
 
 -- sequence should contain pairs (sgr,nmzMode)
+normalizProgram = null
+
 runNormaliz=method(Options=>true)
 opts={allComputations=>false, grading=>{}}
 runNormaliz(Matrix,String):=opts>>o->(sgr,nmzMode)->
@@ -551,8 +537,10 @@ runNormaliz(Matrix,String):=opts>>o->(sgr,nmzMode)->
 runNormaliz(List):=opts>>o->(s)->
 (
     setNmzFile();
-
-    checkNmzExecVersion();
+    if normalizProgram === null then normalizProgram =
+	findProgram("normaliz", "normaliz --help",
+	    Verbose => debugLevel > 0, MinimumVersion => (nmzMinExecVersion,
+		"normaliz --version | head -1 | cut -d' ' -f 2 | tr -d '\n'"));
 
     if (#o.grading > 0) then (
         s = append(s, (matrix{o.grading}, "grading"));
@@ -560,14 +548,10 @@ runNormaliz(List):=opts>>o->(s)->
     doWriteNmzData(s);
     options:=collectNmzOptions();
 
-    cmd:="";
     dir:=select(".*/",nmzFile);
-    if(dir!={}) then cmd="cd "|dir#0|"; ";
-
-    cmd = (cmd|getNmzExec()|options|baseFilename(nmzFile));
-    if debugLevel > 0 then << "--running command: " << cmd << endl;
-    if 0 != run cmd then error ("command failed : ", cmd);
-    if debugLevel > 0 then << "--command succeeded" << endl;
+    runDir := if dir != {} then dir#0 else null;
+    runProgram(normalizProgram, getNmzExec(), options | baseFilename(nmzFile),
+	RunDirectory => runDir, Verbose => debugLevel > 0);
 
     if(not nmzGen)  -- return nothing if .gen is not
     then(            -- generated

--- a/M2/Macaulay2/packages/Normaliz.m2
+++ b/M2/Macaulay2/packages/Normaliz.m2
@@ -1301,7 +1301,7 @@ document {
 PARA{},"Depending on the options enabled (see ", TO setNmzOption, "), ", TT "Normaliz", " writes additional output files. To obtain the content of these files within Macaulay2, use ", TO readNmzData, " or ", TO allComputations,". The following files may be written, provided certain conditions are satisfied and the information that should go into them has been computed. We denote the files simply by their types.
 For the most types of inputs the ambient lattice is ", TEX "\\ZZ^n", " if the input of Normaliz is a matrix of n columns. In types polytope and rees_algebra the ambient lattice is ", TEX "\\ZZ^{n+1}", " since the input vectors are extended by 1 component. For congruences and inhomogeneous input it is ", TEX "\\ZZ^{n-1}", " and for inhomogenouse congruences ", TEX "\\ZZ^{n-2}", ".
 For input of type lattice_ideal the lattice is ", TEX "\\ZZ^{r}", " where n-r is the rank of the input matrix. The essential lattice is gp(M) where M is the monoid computed by Normaliz internally, i.e. after a linear transformation such that the cone is full-dimensional and the integral closure has to be computed.
-See the documentation of Normaliz at ", HREF "http://www.math.uos.de/normaliz/Normaliz2.12.2/Normaliz.pdf", " for more details.",
+See the documentation of Normaliz at ", HREF "https://github.com/Normaliz/Normaliz/blob/master/doc/Normaliz.pdf", " for more details.",
 UL{
    {TT "gen      ", "   The Hilbert basis"},
    {TT "ext      ", "   The extreme rays"},

--- a/M2/Macaulay2/packages/Normaliz.m2
+++ b/M2/Macaulay2/packages/Normaliz.m2
@@ -321,33 +321,9 @@ readNmzData(String):=(nmzSuffix)->
     if member(nmzSuffix, {"inv", "in", "out", "cst"}) then
         error("readNmzData: To read .inv use getNumInvs(), to read .cst use readMultipleNmzData, to read .out or .in there is no function provided");
 
-    if(nmzSuffix=="sup") then ( -- for backward compatibility, should only appear if nmzUserCalled
-          L:=readMultipleNmzData "cst";
-          return L#0;
-    );
-
-    checkNmzFile("readNmzData");
-
-    if not fileExists(nmzFile|"."|nmzSuffix) then
-        error("readNmzData: No file "|nmzFile|"."|nmzSuffix|" found. Perhaps you need to activate another option.");
-
-
-    if debugLevel > 0 then << "--reading " << nmzFile << "." << nmzSuffix << endl;
-    inf:=get(nmzFile|"."|nmzSuffix);
-    s:=lines(inf);
-    nmzGen:={};
-    numRows:=value s#0;
-    numCols:=value s#1;
-    t:="";
-    for i from 2 to numRows+1
-    do(
-       t = select("[0-9-]+",s#i);
-       gen:=apply(t,value);
-       nmzGen=append(nmzGen,gen);
-    );
-    if(nmzGen!={})
-    then  return(matrix(nmzGen))
-    else return;   -- should not appear unless the user calls it
+    L := readMultipleNmzData if nmzSuffix=="sup" then "cst" -- for backward compatibility, should only appear if nmzUserCalled
+        else nmzSuffix;
+    return L#0;
 );
 
 -- reads several matrices from one output file and returns them as list

--- a/M2/Macaulay2/tests/normal/programs.m2
+++ b/M2/Macaulay2/tests/normal/programs.m2
@@ -35,3 +35,10 @@ assert(fileExists(dir | "/foo/bar/baz"))
 
 program = findProgram("foo", name, AdditionalPaths => {dir})
 assert(program#"path" == dir)
+
+fn << "echo -n 1.0" << close
+program = findProgram(name, name, MinimumVersion => ("0.9", name))
+assert(program#"version" == "1.0")
+program = findProgram(name, name, MinimumVersion => ("1.1", name),
+    RaiseError => false)
+assert(program === null)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1034,17 +1034,17 @@ else AC_MSG_RESULT([no, will build])
      BUILD_csdp=yes
 fi
 
-dnl we can't use the test below for the presence of normaliz until the package Normaliz knows
-dnl how to find normaliz on the path, and until our *.dmg and
-dnl *.deb making procedures know how to include it or set the dependencies appropriately
-BUILD_normaliz=yes
-BUILD_ALWAYS="$BUILD_ALWAYS normaliz"
-dnl AC_MSG_CHECKING(whether the package normaliz is installed)
-dnl if test "`type -t normaliz`" = file
-dnl then AC_MSG_RESULT(yes)
-dnl else AC_MSG_RESULT([no, will build])
-dnl      BUILD_normaliz=yes
-dnl fi
+AC_MSG_CHECKING(whether the package normaliz is installed)
+if test "`type -t normaliz`" = file
+then normaliz_version=`normaliz --version | head -1 | cut -d " " -f 2`
+     AX_COMPARE_VERSION([$normaliz_version], [ge], [2.11],
+          [AC_MSG_RESULT([yes])
+           FILE_PREREQS="$FILE_PREREQS `type -p normaliz`"],
+          [AC_MSG_RESULT([yes, but < 2.11, will build])
+           BUILD_normaliz=yes])
+else AC_MSG_RESULT([no, will build])
+     BUILD_normaliz=yes
+fi
 
 dnl debian/fedora: nauty-
 AC_MSG_CHECKING(whether the package nauty (>= 2.7) is installed)


### PR DESCRIPTION
As reported in #1439, depending on the version, normaliz may or may not include the number of rows and columns in a matrix in its output.  Currently, the `Normaliz` package expects these numbers to be present.  If using an older normaliz (e.g., from Ubuntu 18.04, which is an LTS release), then the package fails.

One proposal, used in #1417, is to just require a new enough version of normaliz to guarantee the expected format.  In this pull request, which contains many of the same commits as #1417 (in particular, adding a `MinimumVersion` option to `findProgram` and porting the `Normaliz`package to use `findProgram` and `runProgram`), we also modify the matrix-parsing algorithm so that it will work with either output format and we don't need to worry about the version of normaliz (aside from requiring at least version 2.11, which was already the case).

If this solution is preferable, then I'll close #1417.  Otherwise, I'll close this.

