### PR TITLE
CMake maintenance

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -967,7 +967,7 @@ _ADD_COMPONENT_DEPENDENCY(programs nauty "" NAUTY)
 # TODO: what to do when OpenMP is not found
 string(REPLACE " " "%20" normaliz_OpenMP_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${OpenMP_CXX_LDLIBS}")
 ExternalProject_Add(build-normaliz
-  URL               https://github.com/Normaliz/Normaliz/releases/download/v.3.8.9/normaliz-3.8.9.tar.gz
+  URL               https://github.com/Normaliz/Normaliz/releases/download/v3.8.9/normaliz-3.8.9.tar.gz
   URL_HASH          SHA256=a4c3eda39ffe42120adfd3bda9433b01d9965516e3f98e401b62752a54bee5dd
   PREFIX            libraries/normaliz
   SOURCE_DIR        libraries/normaliz/build


### PR DESCRIPTION
Fixes the link to download normaliz 3.8.9, which the Normaliz people changed _aftere_ the last PR was made (note that tests passed in https://github.com/Macaulay2/M2/pull/1506)!