### PR TITLE
Use toString when writing topcom input file

### DIFF
--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -86,7 +86,7 @@ callTopcom(String, List) := (command, inputs) -> (
     -- now create the output file
     F := openOut(infile);
     for f in inputs do (
-        F << f << endl;
+        F << toString f << endl;
     );
     F << close;
 


### PR DESCRIPTION
Otherwise, any fractions that appear in the matrix are printed as Macaulay2
nets, e.g.,
```
1
-
2
```
instead of `1/2`.  This results in strange errors like the one reported at
https://groups.google.com/g/macaulay2/c/6B4CqSlerOI

```m2
i2 : volume convexHull matrix {{0, 1, 1, 1, 1, 1, 1}, {0, 0, 0, -1, -1/2, 0, 0}, {0, 0, 1, 1, 1/2, 1/2, 1/2}, {0, -1, -1, -1, -1/2, -1/2,-1/2}, {0, 0, 0, 0, 0, -1/2, 0}, {0, 0, 0, 0, 0, 0, -1/2}};
stdio:2:1:(3): error: "error running topcom:Evaluating Comman$
```