### PR TITLE
Use z instead of l in printf format strings for size_t variables

### DIFF
--- a/M2/Macaulay2/e/mem.cpp
+++ b/M2/Macaulay2/e/mem.cpp
@@ -71,7 +71,7 @@ void stash::text_out(buffer &o) const
 {
   char s[200];
   sprintf(s,
-          "%16s %9dk %9dk %10zd %10lu %10lu %10lu %10lu%s",
+          "%16s %9dk %9dk %10zd %10zu %10zu %10zu %10zu%s",
           name,
           static_cast<int>((element_size * highwater + 1023) / 1024),
           static_cast<int>((element_size * n_inuse + 1023) / 1024),


### PR DESCRIPTION
On 32-bit systems, they may be unsigned ints instead of unsigned longs.
This gives us compiler warnings:

```
../../../../Macaulay2/e/mem.cpp: In member function 'void stash::text_out(buffer&) const':
../../../../Macaulay2/e/mem.cpp:74:37: warning: format '%lu' expects argument of type 'long unsigned int', but argument 7 has type 'unsigned int' [-Wformat=]
   74 |           "%16s %9dk %9dk %10zd %10lu %10lu %10lu %10lu%s",
      |                                 ~~~~^
      |                                     |
      |                                     long unsigned int
      |                                 %10u
......
   79 |           n_allocs,
      |           ~~~~~~~~
      |           |
      |           unsigned int
../../../../Macaulay2/e/mem.cpp:74:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 8 has type 'unsigned int' [-Wformat=]
   74 |           "%16s %9dk %9dk %10zd %10lu %10lu %10lu %10lu%s",
      |                                       ~~~~^
      |                                           |
      |                                           long unsigned int
      |                                       %10u
......
   80 |           n_inuse,
      |           ~~~~~~~
      |           |
      |           unsigned int
../../../../Macaulay2/e/mem.cpp:74:49: warning: format '%lu' expects argument of type 'long unsigned int', but argument 9 has type 'unsigned int' [-Wformat=]
   74 |           "%16s %9dk %9dk %10zd %10lu %10lu %10lu %10lu%s",
      |                                             ~~~~^
      |                                                 |
      |                                                 long unsigned int
      |                                             %10u
......
   81 |           highwater,
      |           ~~~~~~~~~
      |           |
      |           unsigned int
../../../../Macaulay2/e/mem.cpp:74:55: warning: format '%lu' expects argument of type 'long unsigned int', but argument 10 has type 'unsigned int' [-Wformat=]
   74 |           "%16s %9dk %9dk %10zd %10lu %10lu %10lu %10lu%s",
      |                                                   ~~~~^
      |                                                       |
      |                                                       long unsigned int
      |                                                   %10u
......
   82 |           n_frees,
      |           ~~~~~~~
      |           |
      |           unsigned int
```