### PR TITLE
Use example ideal from earlier version of IntegralClosure

### DIFF
--- a/M2/Macaulay2/packages/IntegralClosure.m2
+++ b/M2/Macaulay2/packages/IntegralClosure.m2
@@ -1343,40 +1343,40 @@ doc ///
      to instead compute Hom(J^-1, J^-1).  This is usually a more time consuming
      computation, but it does potentially get to the answer in a smaller number of steps.
    Example
-     S = QQ[x,y]
-     f = ideal (y^4-2*x^3*y^2-4*x^5*y+x^6-x^7)
+     S = QQ[x,y,z]
+     f = ideal (x^8-z^6-y^2*z^4-z^3)
      R = S/f
      time R' = integralClosure R
      netList (ideal R')_*
      icFractions R
    Example
-     S = QQ[x,y]
-     f = ideal (y^4-2*x^3*y^2-4*x^5*y+x^6-x^7)
+     S = QQ[x,y,z]
+     f = ideal (x^8-z^6-y^2*z^4-z^3)
      R = S/f
      time R' = integralClosure(R, Strategy => Radical)
      netList (ideal R')_*
      icFractions R
    Example
-     S = QQ[x,y]
-     f = ideal (y^4-2*x^3*y^2-4*x^5*y+x^6-x^7)
+     S = QQ[x,y,z]
+     f = ideal (x^8-z^6-y^2*z^4-z^3)
      R = S/f
      time R' = integralClosure(R, Strategy => AllCodimensions)
      netList (ideal R')_*
    Example
-     S = QQ[x,y]
-     f = ideal (y^4-2*x^3*y^2-4*x^5*y+x^6-x^7)
+     S = QQ[x,y,z]
+     f = ideal (x^8-z^6-y^2*z^4-z^3)
      R = S/f
      time R' = integralClosure(R, Strategy => SimplifyFractions)
      netList (ideal R')_*     
    Example
-     S = QQ[x,y]
-     f = ideal (y^4-2*x^3*y^2-4*x^5*y+x^6-x^7)
+     S = QQ[x,y,z]
+     f = ideal (x^8-z^6-y^2*z^4-z^3)
      R = S/f
      time R' = integralClosure (R, Strategy => RadicalCodim1)
      netList (ideal R')_*
    Example
-     S = QQ[x,y]
-     f = ideal (y^4-2*x^3*y^2-4*x^5*y+x^6-x^7)
+     S = QQ[x,y,z]
+     f = ideal (x^8-z^6-y^2*z^4-z^3)
      R = S/f
      time R' = integralClosure (R, Strategy => Vasconcelos)
      netList (ideal R')_*


### PR DESCRIPTION
The newer example, introduced in f1cea48, was causing memory errors on
i386 systems.  The examples run without problems after reverting to the
ideal that had been used previously.

Closes: #1423