### PR TITLE
Implement --check 2 and --check 3 command line options.

### DIFF
--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -518,11 +518,17 @@ action2 := hashTable {
 	  if not match("/$",arg) then arg = arg | "/";
 	  prefixDirectory = arg;
 	  ),
-     "--check" => arg -> if phase == 1 then (
-	  if arg == "1" then runBasicTests()
-	  else if arg == "2" then error ("--check ",arg," not implemented yet")
-	  else if arg == "3" then error ("--check ",arg," not implemented yet")
-	  else error ("--check ",arg,": expected 1, 2, or 3")
+     "--check" => arg -> if arg != "1" and arg != "2" and arg != "3" then
+	       error ("--check ",arg,": expected 1, 2, or 3")
+	  else if phase == 1 and arg == "1" then
+	       runBasicTests()
+	  else if phase == 4 and arg == "2" then
+	       try check "Macaulay2Doc" then exit 0 else exit 1
+	  else if phase == 4 and arg == "3" then (
+	       fails := 0;
+	       scan(separate(" ", version#"packages"),
+		    pkg -> try check pkg else fails = fails + 1);
+	       exit fails
 	  )
      }
 


### PR DESCRIPTION
According to `M2 --help`, these options are supposed to:

```
    --check n          run tests to level n
                           n=1: basic tests
                           n=2: test Core
                           n=3: test all packages
```

However, only `--check 1` is currently implemented.  We implement the
others by running "check" for "Macaulay2Doc" only for `--check 2` and
for *all* packages for `--check 3`.  Afterwards, Macaulay2 exits, and
the exit code is equal to the number of failing packages.

This will make running continous integration tests on installed copies of
Macaulay2 simpler.