### PR TITLE
Use more forgiving epsilon when running DeterminantalRepresentations tests

### DIFF
--- a/M2/Macaulay2/packages/DeterminantalRepresentations.m2
+++ b/M2/Macaulay2/packages/DeterminantalRepresentations.m2
@@ -1350,9 +1350,9 @@ assert(all(reps, L -> clean(1e-10, fRR - det L) == 0))
 SCC=CC[x1,x2,x3]
 fCC=sub(f, SCC)
 reps = detRep fCC
-assert(all(reps, L -> clean(1e-10, fCC - det L) == 0))
+assert(all(reps, L -> clean(1e-9, fCC - det L) == 0))
 reps = detRep(fCC, HyperbolicPt => matrix{{3_RR},{2},{-7}}) -- representations are not monic
-assert(all(reps, L -> clean(1e-8, fCC - det L) == 0))
+assert(all(reps, L -> clean(1e-6, fCC - det L) == 0))
 ///
 
 TEST /// -- Cubic case: homogeneous, 3 variables


### PR DESCRIPTION
Otherwise, clean may not round to 0 when running on an i386 system.

Closes: #1561