### PR TITLE
Minimize filename for package test inputs

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -33,8 +33,9 @@ prep := pkg -> (
 
 onecheck = (n, pkg, usermode) -> (
      (filename, lineno, teststring) := pkg#"test inputs"#n;
-     stderr << "-- running test " << n << " of package " << pkg << " on line " << lineno << " in file " << filename << endl;
-     stderr << "--    rerun with: check_" << n << " \"" << pkg << "\"" << endl;
+     stderr << "-* running test " << n << " of package " << pkg << " in file:" << endl;
+     stderr << "   " << filename << ":" << lineno << ":1:" << endl;
+     stderr << "   rerun with: check_" << n << " \"" << pkg << "\" *-" << endl;
      runString(teststring, pkg, usermode);
      )
 

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -13,7 +13,8 @@ TEST = method()
 TEST List   := testlist   -> TEST \ testlist
 TEST String := teststring -> (
     n := currentPackage#"test number";
-    currentPackage#"test inputs"#n = (currentFileName, currentLineNumber(),
+    currentPackage#"test inputs"#n = (
+        minimizeFilename currentFileName, currentLineNumber(),
         concatenate(sourceFileStamp(), newline, teststring));
     currentPackage#"test number" = n + 1;)
 -- TODO: support test titles


### PR DESCRIPTION
This improves the readability of the output from the "check" function.
An (extreme) example of the current behavior:

```m2
i1 : get "foo.m2"

o1 = newPackage "Foo"

     input "~/tmp/bar.m2"
     input "~/tmp/./././././bar.m2"

i2 : get "bar.m2"

o2 = TEST "assert(1 + 1 == 2)"

i3 : loadPackage("Foo", FileName => "~/tmp/foo.m2")

ii4 : TEST "assert(1 + 1 == 2)"

ii5 :

ii6 : TEST "assert(1 + 1 == 2)"

ii7 :

o7 = Foo

o7 : Package

i8 : check "Foo"
-- running test 0 of package Foo on line 2 in file /home/dtorrance/tmp/bar.m2
--    rerun with: check_0 "Foo"
 -- making test results
-- running test 1 of package Foo on line 2 in file /home/dtorrance/tmp/./././././bar.m2
--    rerun with: check_1 "Foo"
 -- making test results
```

And after this commit:

```m2
i8 : check "Foo"
-- running test 0 of package Foo on line 2 in file bar.m2
--    rerun with: check_0 "Foo"
 -- making test results
-- running test 1 of package Foo on line 2 in file bar.m2
--    rerun with: check_1 "Foo"
 -- making test results
```