### PR TITLE
Add "Verbose" option to "check"

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -39,7 +39,7 @@ onecheck = (n, pkg, usermode) -> (
      runString(teststring, pkg, usermode);
      )
 
-check = method(Options => {UserMode => null})
+check = method(Options => {UserMode => null, Verbose => false})
 check String  := opts -> pkg -> check(-1, pkg, opts)
 check Package := opts -> pkg -> check(-1, pkg, opts)
 
@@ -58,4 +58,12 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
                 errorList = append(errorList, k)));
     if hadError then error("test", if numErrors > 1 then "s" else "",
         " #", demark(", ", toString \ errorList),
-        " of package ", toString pkg, " failed");)
+        " of package ", toString pkg, " failed",
+        if opts.Verbose then (
+            numTests := if n == -1 then pkg#"test number" else 1;
+            ":" | newline |
+            concatenate(apply(errorList, k ->
+                newline | get("!tail " | temporaryDirectory() |
+                toString(temporaryFilenameCounter + 2 * (k - numTests)) |
+                ".tmp")))
+        ) else "");)

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -40,15 +40,8 @@ onecheck = (n, pkg, usermode) -> (
      )
 
 check = method(Options => {UserMode => null})
-check String  := opts -> pkg -> check(needsPackage (pkg, LoadDocumentation => true), opts)
-check Package := opts -> pkg -> (
-    if not pkg.Options.OptionalComponentsPresent then (
-        stderr << "--warning: optional components required for " <<
-            toString pkg << " tests are not present; skipping" << endl;
-        return);
-    pkg = prep pkg;
-    scan(keys pkg#"test inputs", n -> onecheck(n, pkg, if opts.UserMode === null then not noinitfile else opts.UserMode));
-    if hadError then error(toString numErrors, " error(s) occurred running tests for package ", toString pkg);)
+check String  := opts -> pkg -> check(-1, pkg, opts)
+check Package := opts -> pkg -> check(-1, pkg, opts)
 
 check(ZZ, String)  := opts -> (n, pkg) -> check(n, needsPackage (pkg, LoadDocumentation => true), opts)
 check(ZZ, Package) := opts -> (n, pkg) -> (
@@ -57,5 +50,12 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
             toString pkg << " tests are not present; skipping" << endl;
         return);
     pkg = prep pkg;
-    onecheck(n, pkg, if opts.UserMode === null then not noinitfile else opts.UserMode);
-    if hadError then error("test #", toString n, " of package ", toString pkg, " failed");)
+    errorList := {};
+    scan(if n == -1 then keys pkg#"test inputs" else {n}, k -> (
+            previousNumErrors := numErrors;
+            onecheck(k, pkg, if opts.UserMode === null then not noinitfile else opts.UserMode);
+            if numErrors > previousNumErrors then
+                errorList = append(errorList, k)));
+    if hadError then error("test", if numErrors > 1 then "s" else "",
+        " #", demark(", ", toString \ errorList),
+        " of package ", toString pkg, " failed");)

--- a/M2/Macaulay2/packages/CMakeLists.txt
+++ b/M2/Macaulay2/packages/CMakeLists.txt
@@ -70,7 +70,7 @@ set(M2_INSTALL_TEMPLATE [[installPackage("@package@",
 set(M2_NEED_TEMPLATE    [[needsPackage("@package@", LoadDocumentation=>true, DebuggingMode=>true)]])
 set(M2_TEST_TEMPLATE    [[debug Core \; argumentMode = @ArgumentMode@ \; check(@_i@, "@package@")]])
 set(M2_INFO_TEMPLATE    [["info-"|"@package@" << @package@#"test number" << close]]) # ignore the color
-set(M2_CHECK_TEMPLATE   [[check("@package@", UserMode=>false)]])
+set(M2_CHECK_TEMPLATE   [[check("@package@", UserMode=>false, Verbose=>$<IF:$<BOOL:${VERBOSE}>,true,false>)]])
 
 #################################################################################
 ## Declare all targets: {install,check,all,uninstall}-{packages,PACKAGE}

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/check-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/check-doc.m2
@@ -58,6 +58,8 @@ Node
       and allowing packages it loads to read their configuration files from the user's
       @TO2 {"applicationDirectory", "application directory"}@. If false, the @TT "-q"@ argument is added.
       If @TO "null"@, then add @TT "-q"@ if it appears as an option in @TO "commandLine"@.
+    Verbose=>Boolean
+      if true, then print the output of all failing tests
   Consequences
     Item
       the tests in the package @TT "pkg"@ are run (in separate Macaulay2 processes, with the random number

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/check-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/check-doc.m2
@@ -50,7 +50,7 @@ Node
     pkg:Package
       or String, the package to test
     i:ZZ
-      the index of the test to run
+      the index of the test to run or -1 to run all tests
     UserMode=>Boolean
       if true, do not use the @TT "-q"@ in arguments to the Macaulay2 executable when running tests,
       thereby allowing it to load the user's @TO "initialization file"@, allowing it to load packages

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -41,7 +41,7 @@ $(foreach i,\
 	$(eval check::check-$i)\
 	$(eval check-$i:; \
 		if ! grep "CacheExampleOutput => true" @srcdir@/$i.m2 >/dev/null ;\
-		then @pre_bindir@/M2 -q --no-preload $(STOP) -e "needsPackage(\"$i\",LoadDocumentation=>true,DebuggingMode=>true); check($i,UserMode=>false); exit 0" ;\
+		then @pre_bindir@/M2 -q --no-preload $(STOP) -e "needsPackage(\"$i\",LoadDocumentation=>true,DebuggingMode=>true); check($i,UserMode=>false,Verbose=>$(Verbose)); exit 0" ;\
 		fi ))
 info-dir: @pre_infodir@/dir
 @pre_infodir@/dir:|@pre_infodir@


### PR DESCRIPTION
This pull request is similar to #1407, but for running `check` on a package rather than building its examples.  It's especially useful when building on a system where the user doesn't have access to any build artifacts to aid in diagnosing failing tests.

In particular, we add a `Verbose` option to `check` that displays the output of a failing test when `true`.  I've already applied this patch to my PPA builds, and here's an example of the output (from https://launchpadlibrarian.net/504684149/buildlog_ubuntu-bionic-i386.macaulay2_1.16.0.2+git202010291401-0ppa202010311520~ubuntu18.04.1_BUILDING.txt.gz):

```m2
-* running test 12 of package DeterminantalRepresentations in file:
   DeterminantalRepresentations.m2:1527:1:
   rerun with: check_12 "DeterminantalRepresentations" *-
 -- making test results
-* running test 13 of package DeterminantalRepresentations in file:
   DeterminantalRepresentations.m2:1539:1:
   rerun with: check_13 "DeterminantalRepresentations" *-
 -- making test results
../m2/debugging.m2:20:6:(1):[9]: error: test #2 of package DeterminantalRepresentations failed:

     1.81712x1+1.81712x2+.757134x3 |  | .312572x3                    
     ------------------------------------------------------------------------
     .438081x3                     .312572x3                     |}
     1.81712x1+3.63424x2+1.21141x3 .0920576x3                    |
     .0920576x3                    1.81712x1+1.81712x2+.757134x3 |

o7 : List

i8 : assert(all(reps, L -> clean(1e-10, fRR - det L) == 0))
stdio:10:1:(3): error: assertion failed

../m2/testing.m2:59:22:(1):[8]: --back trace--
../m2/methods.m2:119:80:(1):[7]: --back trace--
../m2/option.m2:16:8:(1):[6]: --back trace--
../m2/testing.m2:44:33:(1):[5]: --back trace--
../m2/methods.m2:119:80:(1):[4]: --back trace--
../m2/option.m2:16:8:(1):[3]: --back trace--
currentString:1:91:(3):[2]: --back trace--
Macaulay2/Core/startup.m2.in:563:33:(0):[1]: --back trace--
Macaulay2/Core/startup.m2.in:674:6:(0): --back trace--
Makefile:39: recipe for target 'check-DeterminantalRepresentations' failed
make[4]: *** [check-DeterminantalRepresentations] Error 1
make[4]: Leaving directory '/<<BUILDDIR>>/macaulay2-1.16.0.2+git202010291401/M2/Macaulay2/packages'
Makefile:14: recipe for target 'check-in-packages' failed
make[3]: *** [check-in-packages] Error 2
```

Note that we've also refactored `check` so that all of the code is in one place, instead of having to make sure that `check Package` and `check(ZZ, Package)` stay in sync with one another.

*Note*:  I haven't actually tested the CMake commit.