### PR TITLE
fix minor documentation/html issues

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -118,7 +118,7 @@ scan({net, info},
 	-- object or a sequence of such objects and BKs or SKs for later splicing.
 	parser' := value (toString parser | "'") <- method(Dispatch => Thing);
 	-- setup default rendering methods
-	parser' Hypertext := parser;
+	parser' Thing := parser;
 	-- { } indicates wrapping is already done or is not desired
 	parser' HypertextParagraph := x -> (SP, {parser x}, SP);
 	parser' HypertextContainer := x -> (BK, apply(toSequence x, parser'), BK);
@@ -140,7 +140,7 @@ scan({net, info},
 	    -- Drop the leading and trailing SPs or BKs
 	    l := position(x, e -> e =!= SP and e =!= BK);
 	    t := position(x, e -> e =!= SP and e =!= BK, Reverse => true);
-	    x = take(x, {l, t});
+	    if l =!= null and t =!= null then x = take(x, {l, t});
 	    -- ??
 	    x = splice sublists(x, i -> i === BK or i === SP,
 		SPBKs -> if member(SP,SPBKs) then (BK,"",BK) else BK);

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -182,6 +182,7 @@ html Boolean :=
 html Function :=
 html Type := html @@ toString
 -- except not these descendants
+html Monoid :=
 html RingFamily :=
 html Ring := lookup(html,Thing)
 

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -154,7 +154,7 @@ html TO2  := x -> (
     name := if match("^ +$", x#1) then #x#1 : "&nbsp;&nbsp;" else x#1;
     if isUndocumented tag then concatenate(html TT name, " (missing documentation<!-- tag: ", toString tag.Key, " -->)") else
     if isMissingDoc   tag then concatenate(html TT name, " (missing documentation<!-- tag: ", toString tag.Key, " -->)") else
-    concatenate(html ANCHOR{"title" => htmlLiteral headline tag, "href"  => toURL htmlFilename tag, htmlLiteral name}))
+    concatenate(html ANCHOR{"title" => htmlLiteral headline tag, "href"  => toURL htmlFilename tag, name}))
 
 ----------------------------------------------------------------------------
 -- html'ing non Hypertext

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -166,7 +166,8 @@ htmlLiteral1 = fixDollar @@ htmlLiteral
 
 -- text stuff: we use html instead of tex, much faster (and better spacing)
 html Net := n -> concatenate("<pre style=\"display:inline-table;vertical-align:",
-    toString(100*(height n-1)), "%\">\n", apply(unstack n, x-> htmlLiteral1 x | "<br/>"), "</pre>") -- the % is relative to line-height
+    toString(if height n+depth n>0 then 100*(height n-1) else 0), "%\">\n", -- the % is relative to line-height
+    apply(unstack n, x-> htmlLiteral1 x | "<br/>"), "</pre>")
 html String := x -> concatenate("<pre style=\"display:inline\">\n", htmlLiteral1 x,
     if #x>0 and last x === "\n" then " ", -- fix for html ignoring trailing \n
     "</pre>")

--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -11,7 +11,7 @@ toString Type := X -> (
 	  if hasAttribute(X,PrintNames) then return getAttribute(X,PrintNames);
 	  if hasAttribute(X,ReverseDictionary) then return toString getAttribute(X,ReverseDictionary);
 	  );
-     concatenate(toString class X, " of ", toString parent X, "{...", toString(#X), "...}"))
+     concatenate(toString class X, " of ", toString parent X))
 toString HashTable := s -> (
      concatenate (
 	  "new ", toString class s,
@@ -198,7 +198,7 @@ net Type := X -> (
 	  if hasAttribute(X,PrintNames) then return net getAttribute(X,PrintNames);
 	  if hasAttribute(X,ReverseDictionary) then return toString getAttribute(X,ReverseDictionary);
 	  );
-     horizontalJoin ( net class X, if #X > 0 then ("{...", toString(#X), "...}") else "{}" ))
+     horizontalJoin ( net class X, " of ", net parent X))
 
 -----------------------------------------------------------------------------
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc9.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc9.m2
@@ -289,7 +289,7 @@ document {
      Headline => "global Ext",
      Inputs => { "i", "M", "N(>=d)"},
      Outputs => {
-	  Module => {"The R-module ", TEX ///$\oplus_{j \geq d}{Ext^i_X(M,N(j))$///}
+	  Module => {"The R-module ", TEX ///$\oplus_{j \geq d} Ext^i_X(M,N(j))$///}
 	  },
      "If ", TT "M", " is a sheaf of rings, it is regarded as a sheaf of modules in the evident way.",
      PARA{},


### PR DESCRIPTION
- `TO` got double `htmlLiteral`ed, resulting in the documentation problems mentioned in #1529 -- fixed.
- A bug was introduced in the recent rewrite in format.m2:
```
i1 : needsPackage "Text"; net DIV {}
stdio:1:22:(3): error: expected a list of integers
```
fixed:
```
i1 : needsPackage "Text"; net DIV {}

o2 = 
```
- Now we allow `html` to process anything, this shouldn't cause an error:
```
i3 : net DIV { det }
stdio:2:1:(3): error: no method found for applying -*Function*- to:
     argument   :  determinant (of class MethodFunctionWithOptions)
```
fixed:
```
i3 : net DIV { det }

o3 = determinant
```