### PR TITLE
Stack nested lists vertically

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -174,6 +174,18 @@ info PRE := x -> wrap(printWidth, "-", net concatenate noopts x)
 net  CODE :=
 info CODE := x -> stack lines concatenate noopts x
 
+LIop := op -> x -> (
+     -* we want to join each element of our li horizontally, unless
+        we encounter a nested list, in which case we want to stack
+        vertically.  so first identify these *-
+     toStack := sublists(sublists(toList noopts x,
+          i -> member(class i, {OL, UL})), j -> not instance(j, List));
+     stack apply(toStack, y -> wrapHorizontalJoin(op \ y))
+     )
+
+info LI := LIop info
+net  LI := LIop net
+
 ULop := op -> x -> (
      s := "  * ";
      printWidth = printWidth - #s;


### PR DESCRIPTION
Previously, each element of an LI object was joined horizontally.
This is usually what we want, unless we encounter a nested OL or UL
object.  In this case, we ended up with:

```m2
i1 : beginDocumentation()

i2 : LI{"a", "b", UL{"c", "d"}, "e", "f", OL{"g", "h"}}

o2 = ab  * cef  1. g
         * d    2. h

o2 : LI
```

We now separate these out and stack them vertically:

```m2
i1 : beginDocumentation()

i2 : LI{"a", "b", UL{"c", "d"}, "e", "f", OL{"g", "h"}}

o2 = ab
       * c
       * d
     ef
       1. g
       2. h

o2 : LI
```

Closes: #1598