### PR TITLE
try to fix ThreadedGB package

### DIFF
--- a/M2/Macaulay2/packages/ThreadedGB.m2
+++ b/M2/Macaulay2/packages/ThreadedGB.m2
@@ -21,6 +21,23 @@ newPackage("ThreadedGB",
     Keywords => {"Groebner Basis Algorithms"},
     Headline => "Compute a Groebner basis using the classical Buchberger with multiple threads"
   )
+
+-- The factory library code is not thread-safe, and 'gcd' calls.  Here we insert some simple routines to avoid it.
+-- This code assumes we are over a field, so we don't have to take gcd's of the coefficients, and that f and g are monomials, which is the case in the code.
+manualGCD = (f,g) -> (
+     R := ring f;
+     a := first exponents f;
+     b := first exponents g;
+     c := apply(a,b,min);
+     R_c)
+manualLCM = (f,g) -> (
+     R := ring f;
+     a := first exponents f;
+     b := first exponents g;
+     c := apply(a,b,max);
+     R_c)
+
+
 export {
     "tgb",
     "minimalize",
@@ -85,7 +102,6 @@ tgb (List,ZZ) := HashTable => o -> (basisList, nThreads) -> (
         if not isReady(tasksValues_i) then allReady = false;
     	);
       if allReady then allowableThreads=1;
-      if allReady then allowableThreads=1 else sleep 1;
     );
     -- final clean up:
     if # keys trivial > 0 then (
@@ -204,7 +220,7 @@ initializeBasis(List) := MutableHashTable => (basisList)->(
 ---------------------------------------------------------------------------------------------
 spoly = method()
 spoly(RingElement, RingElement) := RingElement => (f, g) -> (
-    gamma := lcm(leadMonomial f, leadMonomial g);
+    gamma := manualLCM(leadMonomial f, leadMonomial g);
     (gamma // leadTerm f) * f - (gamma // leadTerm g) * g
     )
 ---------------------------------------------------------------------------------------------
@@ -219,8 +235,9 @@ spoly(RingElement, RingElement) := RingElement => (f, g) -> (
 -- computed so far are saved).
 -- Polynomials whose initial terms are relatively prime are not considered.
 ---------------------------------------------------------------------------------------------
+
 taskFn = {Verbose=>false} >> o-> (f1,f2,currentPairKey) -> () -> (
-    if gcd(leadTerm f1, leadTerm f2)==1 then r := 0 else r = remainderFn(spoly(f1,f2),values endGB);
+    if manualGCD(leadTerm f1, leadTerm f2)==1 then r := 0 else r = remainderFn(spoly(f1,f2),values endGB);
     if r!=0 and r!=1 and r!=-1 then (
       scan(keys endGB,i-> (
         currentPairKeyChild := concatenate("(",currentPairKey,"-",toString(i),")");
@@ -334,7 +351,7 @@ doc ///
     Example
       QQ[a..d]
       I=ideal( -c^3+a^2+b*d, a*b*c-1,a*b*c)
-      -- T = tgb(I,2,Verbose=>true)
+      T = tgb(I,2,Verbose=>true)
     Text
       In particular, the lineages of null values tell us what S-polynomials didn't reduce to zero until $1$ was found as
       a remainder.
@@ -395,7 +412,7 @@ doc ///
       QQ[a..d];
       f0 = a*b-c^2;
       f1 = b*c-d^2;
-      -- tgb({f0,f1},2,Verbose=>true)
+      tgb({f0,f1},2,Verbose=>true)
     Text
       In the above example, the S-polynomial S(f0,f1) didn't reduce to zero hence the remainder was added to the
       output with key "(0-1)". The additional two S-polynomials reduced and the process ended.
@@ -504,7 +521,7 @@ doc ///
       Lineages are reported as well.
     Example
       S = QQ[x,y,z,w];
-      -- tgb({x*y-z^2,y*z-w^2},2,Verbose=>true);
+      tgb({x*y-z^2,y*z-w^2},2,Verbose=>true);
 ///
 doc ///
   Key


### PR DESCRIPTION
Here we undo all previous changes, and instead insert simple
routines for computing lcm and gcd of monomials, so we can avoid
calling the "factory" library, which is not thread-safe.

resolves #1463 