### PR TITLE
Separation by zero-length regular expressions

### DIFF
--- a/M2/Macaulay2/tests/normal/regex.m2
+++ b/M2/Macaulay2/tests/normal/regex.m2
@@ -43,6 +43,13 @@ assert(demark_" " separate("[ \t]*\r?\n[ \t]*", " A\n\t  B  \r\n  \tC ", POSIX =
 assert(separate(".", "ABC.DEF") === {"ABC", "DEF"})
 assert(separate("-", "a-cd-xxx-yyy-") == {"a", "cd", "xxx", "yyy", ""})
 assert(separate(".?", "ABCD") === toList(5:""))
+-- zero-length separations
+assert(separate(    "a",  "ahoaaabba") == {"", "ho", "", "", "bb", ""})
+assert(separate( "(?=a)", "ahoaaabba") == {"aho", "a", "a", "abb", "a"}) -- positive lookahead
+assert(separate( "(?!a)", "ahoaaabba") == {"a", "h", "oaaa", "b", "ba"}) -- negative lookahead
+assert(separate("(?<=a)", "ahoaaabba") == {"a", "hoa", "a", "a", "bba"}) -- positive lookbehind
+-- FIXME: this one doesn't seem to work, are negative lookbehinds different in boost regex?
+--assert(separate("(?<!a)", "ahoaaabba") == {"ah", "o", "aaab", "b", "a"}) -- negative lookbehind
 
 -- tests for select
 assert(select("a+","aaa aaaa") === {"aaa","aaaa"})


### PR DESCRIPTION
Closes #1553.

For later: There seems to be an issue with negative lookbehinds, but it's a very specific edge case:
```m2
i1 : separate("(?<!a)", "aaabbb")

o1 = {a, a, a, b, b, b}

o1 : List

i2 : regex("(?<!a)", "aaabbb")

o2 = {(0, 0)}

o2 : List
```
Compared to Node:
```js
> "aaabbb".split(/(?<!a)/)
[ 'aaab', 'b', 'b' ]
> "aaabbb".search(/(?<!a)/)
0
```
Not sure how the search finds the first match at 0, but doesn't split until 4.