### PR TITLE
Fix detection of Boost::Regex on armhf

### DIFF
--- a/M2/config/ax_boost_base.m4
+++ b/M2/config/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 47
+#serial 48
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -123,6 +123,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     dnl are almost assuredly the ones desired.
     AS_CASE([${host_cpu}],
       [i?86],[multiarch_libsubdir="lib/i386-${host_os}"],
+      [armv7l],[multiarch_libsubdir="lib/arm-${host_os}"],
       [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
     )
 


### PR DESCRIPTION
When running the configure script on a Raspberry Pi in a Debian
unstable chroot with Boost::Regex installed, we previously got the
following:

```
checking for boostlib >= 1.65 (106500)... yes
checking whether the Boost::Stacktrace library is available... yes, boost_stacktrace_backtrace
checking whether the Boost::Regex library is available... yes
configure: error: Could not find a version of the Boost::Regex library!
```

This is because AX_BOOST_BASE set BOOST_LDFLAGS as -L/usr/lib, and so
AX_BOOST_REGEX was looking in /usr/lib there for the shared library,
but they are in fact under /usr/lib/arm-linux-gnueabihf/.
AX_BOOST_BASE didn't detect this because it was looking for
/usr/lib/armv7-linux-gnueabihf/, which doesn't exist.

This bug has been fixed upstream in the autoconf archive
(https://github.com/autoconf-archive/autoconf-archive/pull/214),
and so we update our copy to the latest version, serial 48.