### PR TITLE
Properly split CannedExamples

### DIFF
--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -177,28 +177,6 @@ TOH        = new IntermediateMarkUpType of Hypertext
 toExternalString LATER := x -> toExternalString x#0()
 
 -----------------------------------------------------------------------------
--- EXAMPLE
------------------------------------------------------------------------------
--- TODO: Move this
-
-makeExampleItem = method()
-makeExampleItem PRE    := identity -- this will allow precomputed example text
-makeExampleItem String := s -> ExampleItem s
-makeExampleItem Thing  := s -> error ("EXAMPLE expected a string or a PRE item, but encountered ", toString s)
-
-trimfront := x -> apply(x, line -> if not instance(line, String) then line else (
-	  s := lines line;
-	  r := if not s#?0 then line else concatenate between(newline, prepend(replace("^[[:space:]]+", "", s#0), drop(s, 1)));
-	  if #r =!= 0 then r))
-
-EXAMPLE = method(Dispatch => Thing)
-EXAMPLE String      := x -> EXAMPLE {x}
-EXAMPLE VisibleList := x -> (
-    x = nonnull trimfront toSequence x;
-    if #x == 0 then error "empty list of examples encountered";
-    TABLE splice {"class" => "examples", apply(x, item -> TR TD makeExampleItem item)})
-
------------------------------------------------------------------------------
 -- MarkUpType constructors
 -----------------------------------------------------------------------------
 

--- a/M2/Macaulay2/packages/SimpleDoc.m2
+++ b/M2/Macaulay2/packages/SimpleDoc.m2
@@ -1,6 +1,5 @@
 -- -*- coding: utf-8 -*-
 -- TODO: add linter
--- TODO: small bug: if indentation of examples increases, the further indented lines are ignored
 newPackage(
     "SimpleDoc",
     Version => "1.2",

--- a/M2/Macaulay2/packages/SimpleDoc/example.m2
+++ b/M2/Macaulay2/packages/SimpleDoc/example.m2
@@ -46,7 +46,7 @@ docExample = "doc ///
 
       o1 = 8
 
-      i1000 = 2+2
+      i1000 : 2+2
 
       o1000 = 4
    Text


### PR DESCRIPTION
Close #1258 with the following solution:
```m2
i1 : beginDocumentation()

i2 : EXAMPLE PRE "i1 : 4 * 4\n\no1 = 16\ni2 : 12 + 16;\ni3 : 11\n\no3 = 11"

     +-------------+
o2 = |i1 : 4 * 4   |
     |             |
     |o1 = 16      |
     +-------------+
     |i2 : 12 + 16;|
     +-------------+
     |i3 : 11      |
     |             |
     |o3 = 11      |
     +-------------+

o2 : TABLE

i3 : document {Key => "foo", EXAMPLE lines "4 * 4\n12 + 16;\n11"};

i4 : help "foo"

o4 = foo
     ***

     +-------------+
     |i1 : 4 * 4   |
     |             |
     |o1 = 16      |
     +-------------+
     |i2 : 12 + 16;|
     +-------------+
     |i3 : 11      |
     |             |
     |o3 = 11      |
     +-------------+

o4 : DIV

i5 : o4#1#0 === o2

o5 = true
```