### PR TITLE
Replace build paths that appear in docs for option default values

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -435,7 +435,7 @@ processSignature := (tag, fn) -> item -> (
 	opttag := getPrimaryTag makeDocumentTag([fn, optsymb], Package => package tag);
 	name := if tag === opttag then TT toString optsymb else TO2 { opttag, toString optsymb };
 	type  = if type =!= null and type =!= Nothing then ofClass type else TT "..."; -- type Nothing is treated as above
-	defval := SPAN{"default value ", replace("^-\\*Function.*?\\*-", "-*Function*-", toString opts#optsymb)};
+	defval := SPAN{"default value ", reproduciblePaths replace("^-\\*Function.*?\\*-", "-*Function*-", toString opts#optsymb)};
 	text = if text =!= null and #text > 0 then text else if tag =!= opttag then headline opttag;
 	text = if text =!= null and #text > 0 then (", ", text);
 	-- e.g: Key => an integer, default value 42, the meaning of the universe


### PR DESCRIPTION
Otherwise, we will have things like:

    InstallPrefix => a string, default value
      /build/macaulay2-1.16.0.2+git815.1b4bbe4+ds/debian/.debhelper/
      generated/_source/home/.Macaulay2/local/, ...

This results in non-reproducible builds.