### PR TITLE
findProgram Improvements

### DIFF
--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -10,30 +10,44 @@ addSlash = programPath -> (
     else return programPath
 )
 
+-- returns (found, thisVersion)
+-- found is an integer:
+--   0 = successfully found program
+--   1 = could not find program
+--   2 = found program, but too version number too low
+--   3 = found program, but could not determine version number
+-- versionNumber is a string containing the version number found, or null
+--   if MinimumVersion option is not given or the version number can't be
+--   be determined.
 checkProgramPath = (name, cmds, pathToTry, prefix, opts) -> (
-    found := all(cmds, cmd ->
-	run(pathToTry | addPrefix(cmd, prefix) | " >/dev/null 2>&1") == 0);
+    found := if all(cmds, cmd -> run(pathToTry | addPrefix(cmd, prefix) |
+	" >/dev/null 2>&1") == 0) then 0 else 1;
     msg := "";
-    if found then (
+    thisVersion := null;
+    if found == 0 then (
 	if opts.MinimumVersion === null then msg = "    found"
 	else (
-	    thisVersion := replace("(^\\s+)|(\\s+$)", "", get("!" | pathToTry |
+	    thisVersion = replace("(^\\s+)|(\\s+$)", "", get("!" | pathToTry |
 		addPrefix(opts.MinimumVersion_1, prefix)));
 	    if not match(///^\d[\-+\.:\~\da-zA-Z]*$///, thisVersion) then (
 		msg = "    found version \"" | thisVersion |
 		    "\", but this does not appear to be a valid version number";
-		found = false
+		found = 3;
+		thisVersion = null;
 	    ) else (
-		found = found and thisVersion >= opts.MinimumVersion_0;
-		if found then msg = "    found version " | thisVersion |
-		    " >= " | opts.MinimumVersion_0
-		else msg = "   found, but version " | thisVersion | " < " |
-		    opts.MinimumVersion_0;
+		if thisVersion >= opts.MinimumVersion_0 then
+		    msg = "    found version " | thisVersion |
+			" >= " | opts.MinimumVersion_0
+		else (
+		    msg = "    found, but version " | thisVersion | " < " |
+			opts.MinimumVersion_0;
+		    found = 2;
+		)
 	    )
 	)
     ) else msg = "    not found";
     if opts.Verbose == true then print(msg);
-    found
+    (found, thisVersion)
 )
 
 addPrefix = (cmd, prefix) ->
@@ -53,18 +67,29 @@ getProgramPath = (name, cmds, opts) -> (
 	pathsToTry = join(pathsToTry, separate(":", getenv "PATH"));
     pathsToTry = apply(pathsToTry, addSlash);
     prefixes := {(".*", "")} | opts.Prefix;
-    scan(pathsToTry, pathToTry -> (
+    errorCode := 1;
+    versionFound := "0.0";
+    result := scan(pathsToTry, pathToTry -> (
 	if opts.Verbose == true then
 	    print("checking for " | name | " in " | pathToTry | "...");
 	prefix := scan(prefixes, prefix -> (
 	    if opts.Verbose == true and #prefixes > 1 then
 		print("  trying prefix \"" | prefix_1 |
 		    "\" for executables matching \"" | prefix_0 | "\"...");
-	    if checkProgramPath(name, cmds, pathToTry, prefix, opts) then
-	        break prefix)
-	);
-	if prefix =!= null then break (pathToTry, prefix)
-    ))
+	    result := checkProgramPath(name, cmds, pathToTry, prefix, opts);
+	    if result_0 == 0 then (
+		errorCode = 0;
+		versionFound = result_1;
+		break prefix
+	    ) else if result_0 == 2 and result_1 > versionFound then (
+		errorCode = 2;
+		versionFound = result_1;
+	    ) else if result_0 == 3 then errorCode = 3;
+	));
+	if errorCode == 0 then
+	    break (errorCode, pathToTry, prefix, versionFound)
+    ));
+    if result =!= null then result else (errorCode, null, null, versionFound)
 )
 
 findProgram = method(TypicalValue => Program,
@@ -78,17 +103,22 @@ findProgram = method(TypicalValue => Program,
 findProgram(String, String) := opts -> (name, cmd) ->
     findProgram(name, {cmd}, opts)
 findProgram(String, List) := opts -> (name, cmds) -> (
-    programPathAndPrefix := getProgramPath(name, cmds, opts);
-    if programPathAndPrefix === null then
-	if opts.RaiseError then error("could not find " | name)
-	else return null;
-    new Program from {"name" => name, "path" => programPathAndPrefix_0,
-	"prefix" => programPathAndPrefix_1} |
-	if opts.MinimumVersion =!= null then
-	    {"version" => replace("(^\\s+)|(\\s+$)", "",
-		    get("!" | programPathAndPrefix_0 |
-			addPrefix(opts.MinimumVersion_1,
-			    programPathAndPrefix_1)))}
+    programInfo := getProgramPath(name, cmds, opts);
+    if programInfo_0 != 0 then
+	if opts.RaiseError then (
+	    msg := "";
+	    if programInfo_0 == 1 then
+		msg = "could not find " | name
+	    else if programInfo_0 == 2 then
+		msg = "found " | name | ", but version (" | programInfo_3 |
+		    ") is too low"
+	    else if programInfo_0 == 3 then
+		msg = "found " | name | ", but could not determine version";
+	    error(msg)
+	) else return null;
+    new Program from {"name" => name, "path" => programInfo_1,
+	"prefix" => programInfo_2} |
+	if opts.MinimumVersion =!= null then {"version" => programInfo_3}
 	else {}
 )
 

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -19,11 +19,17 @@ checkProgramPath = (name, cmds, pathToTry, prefix, opts) -> (
 	else (
 	    thisVersion := replace("(^\\s+)|(\\s+$)", "", get("!" | pathToTry |
 		addPrefix(opts.MinimumVersion_1, prefix)));
-	    found = found and thisVersion >= opts.MinimumVersion_0;
-	    if found then msg = "    found version " | thisVersion | " >= " |
-		opts.MinimumVersion_0
-	    else msg = "   found, but version " | thisVersion | " < " |
-		opts.MinimumVersion_0;
+	    if not match(///^\d[\-+\.:\~\da-zA-Z]*$///, thisVersion) then (
+		msg = "    found version \"" | thisVersion |
+		    "\", but this does not appear to be a valid version number";
+		found = false
+	    ) else (
+		found = found and thisVersion >= opts.MinimumVersion_0;
+		if found then msg = "    found version " | thisVersion |
+		    " >= " | opts.MinimumVersion_0
+		else msg = "   found, but version " | thisVersion | " < " |
+		    opts.MinimumVersion_0;
+	    )
 	)
     ) else msg = "    not found";
     if opts.Verbose == true then print(msg);

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -17,8 +17,8 @@ checkProgramPath = (name, cmds, pathToTry, prefix, opts) -> (
     if found then (
 	if opts.MinimumVersion === null then msg = "    found"
 	else (
-	    thisVersion := get("!" | pathToTry |
-		addPrefix(opts.MinimumVersion_1, prefix));
+	    thisVersion := replace("(^\\s+)|(\\s+$)", "", get("!" | pathToTry |
+		addPrefix(opts.MinimumVersion_1, prefix)));
 	    found = found and thisVersion >= opts.MinimumVersion_0;
 	    if found then msg = "    found version " | thisVersion | " >= " |
 		opts.MinimumVersion_0
@@ -79,8 +79,10 @@ findProgram(String, List) := opts -> (name, cmds) -> (
     new Program from {"name" => name, "path" => programPathAndPrefix_0,
 	"prefix" => programPathAndPrefix_1} |
 	if opts.MinimumVersion =!= null then
-	    {"version" => get("!" | programPathAndPrefix_0 |
-		addPrefix(opts.MinimumVersion_1, programPathAndPrefix_1))}
+	    {"version" => replace("(^\\s+)|(\\s+$)", "",
+		    get("!" | programPathAndPrefix_0 |
+			addPrefix(opts.MinimumVersion_1,
+			    programPathAndPrefix_1)))}
 	else {}
 )
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -134,13 +134,13 @@ document {
     ("^cube$", "topcom_")})///},
     PARA {"Note that when using the ", TT "MinimumVersion", " option, the ",
 	"command used to obtain the current version number must remove ",
-	"everything except the version number itself, including any ",
-	"trailing newlines.  Piping with standard UNIX utilities such as ",
+	"everything except the version number itself and any leading or ",
+	"trailing whitespace.  Piping with standard UNIX utilities such as ",
 	TT "sed", ", ", TT "head", ", ", TT "tail", ", ", TT "cut", ", and ",
 	TT "tr", " may be useful."},
     EXAMPLE {///findProgram("gfan", "gfan --help", Verbose => true,
   MinimumVersion => ("0.5",
-    "gfan _version | head -2 | tail -1 | sed 's/gfan//' | tr -d '\n'"))
+    "gfan _version | head -2 | tail -1 | sed 's/gfan//'"))
     ///},
     SeeAlso => {"Program", "programPaths", "runProgram"}
 }

--- a/M2/Macaulay2/tests/normal/programs.m2
+++ b/M2/Macaulay2/tests/normal/programs.m2
@@ -37,13 +37,7 @@ program = findProgram("foo", name, AdditionalPaths => {dir})
 assert(program#"path" == dir)
 
 
--- note: Sometimes the built-in sh command "echo" does not know about "-n".
-	-- testing: /Users/dan/src/M2/M2.git/M2/Macaulay2/tests/normal/programs.m2
-	-- ../../../../../../../Macaulay2/tests/normal/programs.m2:40:11:(3):[4]: error: could not find 0
-	-- programs.errors:0: error output left here for the errors above:
-	-- gmake[4]: *** [../Makefile.test:67: programs.out] Error 1
---       Another work-around might be to use /bin/echo.
-fn << "echo 1.0 | tr -d '\n'" << endl << close
+fn << "echo 1.0" << endl << close
 
 
 program = findProgram(name, name, MinimumVersion => ("0.9", name))


### PR DESCRIPTION
Based on Dan's comments on 30a21e5, we have improved how the `MinimumVersion` option to `findProgram` deals with whitespace, version numbers that aren't really version numbers, and error messages.

```m2
i1 :  -- no longer need tr to strip trailing newline
     findProgram("gfan", "gfan --help",
         MinimumVersion => ("0.5",
     "gfan _version | head -2 | tail -1 | sed 's/gfan//'"))

o1 = gfan

o1 : Program

i2 : findProgram("gfan", "gfan --help",
         MinimumVersion => ("1.0",
     "gfan _version | head -2 | tail -1 | sed 's/gfan//'"))
stdio:5:1:(3): error: found gfan, but version (0.6.2) is too low

i3 : findProgram("gfan", "gfan --help",
         MinimumVersion => ("0.5", "gfan _version | head -2 | tail -1"))
stdio:8:1:(3): error: found gfan, but could not determine version
```

Closes: #1650

