### PR TITLE
Minor html, texMath, webapp, VectorGraphics updates

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -570,7 +570,6 @@ keywordTexMath := new HashTable from { -- both unary and binary keywords
     symbol ** => "\\otimes ",
     symbol ++ => "\\oplus ",
     symbol != => "\\ne ",
-    symbol = => "=",
     symbol -> => "\\rightarrow ",
     symbol <- => "\\leftarrow ",
     symbol ===> => "{\\large\\Longrightarrow}",
@@ -582,20 +581,18 @@ keywordTexMath := new HashTable from { -- both unary and binary keywords
     symbol _ => "\\_ ",
     symbol | => "|",
     symbol || => "||",
-    symbol * => "*",
-    symbol + => "+",
-    symbol - => "-",
-    symbol / => "/",
-    symbol // => "//",
     symbol { => "\\{ ",
     symbol } => "\\} ",
     symbol \ => "\\backslash ",
     symbol \\ => "\\backslash\\backslash ",
-    symbol : => ":",
-    symbol ; => ";"
+    symbol SPACE => "\\texttt{SPACE}",
+    symbol # => "\\#",
+    symbol #? => "\\#?",
+    symbol % => "\\%",
+    symbol & => "\\&",
+    symbol ^ => "\\wedge",
+    symbol ^^ => "\\wedge\\wedge"
     }
-
-texMath Keyword := x -> if keywordTexMath#?x then keywordTexMath#x else texMath toString x
 
 BinaryOperation = new HeaderType of Expression -- {op,left,right}
 BinaryOperation.synonym = "binary operation expression"
@@ -1174,24 +1171,30 @@ texMath Table := m -> (
 	"\\end{array}}")
 )
 
-texMath MatrixExpression := m -> (
-    if all(m,r->all(r,i->class i===ZeroExpression)) then "0"
-    else if m#?0 then if #m#0>10 then "{\\left(" | texMath(new Table from toList m) | "\\right)}" -- the extra {} is to discourage line breaks
-     else concatenate(
-      	      "\\begin{pmatrix}" | newline,
-     	      between(///\\/// | newline, apply(toList m, row -> concatenate between("&",apply(row,texMath)))),
-	      "\\end{pmatrix}" -- notice the absence of final \\ -- so lame. no newline either in case last line is empty
-	      )
-	  )
-texMath MatrixDegreeExpression := x -> texMath MatrixExpression x#0 -- degrees not displayed atm
+texMath MatrixExpression := m -> if all(m,r->all(r,i->class i===ZeroExpression)) then "0" else concatenate(
+    "\\begin{pmatrix}" | newline,
+    between(///\\/// | newline, apply(toList m, row -> concatenate between("&",apply(row,
+		    if compactMatrixForm then texMath else x -> "\\displaystyle "|texMath x)))),
+    "\\end{pmatrix}"
+    )
+texMath MatrixDegreeExpression := m -> if all(m#0,r->all(r,i->class i===ZeroExpression)) then "0" else concatenate(
+    mat := applyTable(m#0,if compactMatrixForm then texMath else x -> "\\displaystyle "|texMath x);
+    deg := apply(m#1,texMath);
+    "\\begin{matrix}",
+    between(///\\///,apply(#mat, i -> deg#i | "\\vphantom{" | concatenate mat#i | "}")),
+    "\\end{matrix}",
+    "\\begin{pmatrix}" | newline,
+    between(///\\/// | newline, apply(#mat, i -> "\\vphantom{"| deg#i | "}" | concatenate between("&",mat#i))),
+    "\\end{pmatrix}"
+    )
 
 texMath VectorExpression := v -> (
-     concatenate(
-	 "\\begin{pmatrix}" | newline,
-	 between(///\\///,apply(toList v,texMath)),
-	 "\\end{pmatrix}"
-	 )
-     )
+    concatenate(
+	"\\begin{pmatrix}" | newline,
+	between(///\\///,apply(toList v,if compactMatrixForm then texMath else x -> "\\displaystyle "|texMath x)),
+	"\\end{pmatrix}"
+	)
+    )
 
 ctr := 0
 showTex = method()
@@ -1227,19 +1230,19 @@ texMath Thing := x -> texMath net x -- if we're desperate (in particular, for ra
 
 bbLetters := set characters "kABCDEFGHIJKLMNOPQRSTUVWXYZ"
 suffixes := {"bar","tilde","hat","vec","dot","ddot","check","acute","grave","breve"};
-suffixesRegExp := "("|demark("|",suffixes)|")\\'";
+suffixesRegExp := "\\w("|demark("|",suffixes)|")$";
 texVariable := x -> (
     if x === "" then return "";
     xx := separate("\\$",x); if #xx > 1 then return concatenate between("{\\char36}",texVariable\xx); -- avoid the use of "$" in tex output
     if #x === 2 and x#0 === x#1 and bbLetters#?(x#0) then return "{\\mathbb "|x#0|"}";
     if last x === "'" then return texVariable substring(x,0,#x-1) | "'";
     r := regex(suffixesRegExp,x); if r =!= null then (
-	r = first r;
+	r = r#1;
 	return "\\"|substring(r,x)|"{"|texVariable substring(x,0,r#0)|"}"
 	);
     if #x === 1 or regex("[^[:alnum:]]",x) =!= null then x else "\\textit{"|x|"}"
     )
-texMath Symbol := x -> texVariable toString x;
+texMath Symbol :=  x -> if keywordTexMath#?x then keywordTexMath#x else texVariable toString x
 
 -----------------------------------------------------------------------------
 

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -126,14 +126,11 @@ html HTML := x -> demark(newline, {
     	popIndentLevel(pushIndentLevel 1, apply(x, html)),
 	///</html>///})
 
-treatImgSrc := x -> apply(x, y -> if class y === Option and y#0 === "src" then "src" => htmlLiteral toURL y#1 else y)
+treatImgSrc := x -> apply(x, y -> if class y === Option and y#0 === "src" then "src" => toURL y#1 else y)
 html IMG := (lookup(html, IMG)) @@ treatImgSrc
 
-fixDollar := x -> replace("\\$","&dollar;",x)
-splitLines := x -> apply(x, y -> if class y === String then demark(newline, lines y) else y) -- effectively, \r\n -> \n and removes last [\r]\n
-html PRE := fixDollar @@ (lookup(html, PRE)) @@ splitLines
-html TT := fixDollar @@ (lookup(html, TT))
-html CODE := fixDollar @@ (lookup(html, CODE))
+fixNewlines := x -> apply(x, y -> if class y === String then replace("\r\n","\n",y) else y)
+html PRE := (lookup(html, PRE)) @@ fixNewlines
 
 html CDATA   := x -> concatenate("<![CDATA[",x,"]]>")
 html COMMENT := x -> concatenate("<!--",x,"-->")
@@ -162,22 +159,25 @@ html TO2  := x -> (
 
 html Thing := htmlLiteral @@ tex -- by default, we use tex (as opposed to actual html)
 
-htmlLiteral1 = fixDollar @@ htmlLiteral
-
 -- text stuff: we use html instead of tex, much faster (and better spacing)
-html Net := n -> concatenate("<pre style=\"display:inline-table;vertical-align:",
+html Net := n -> concatenate("<pre style=\"display:inline-table;text-align:left;vertical-align:",
     toString(if height n+depth n>0 then 100*(height n-1) else 0), "%\">\n", -- the % is relative to line-height
-    apply(unstack n, x-> htmlLiteral1 x | "<br/>"), "</pre>")
-html String := x -> concatenate("<pre style=\"display:inline\">\n", htmlLiteral1 x,
-    if #x>0 and last x === "\n" then " ", -- fix for html ignoring trailing \n
+    apply(unstack n, x-> htmlLiteral x | "<br/>"), "</pre>")
+html String := x -> concatenate("<pre style=\"display:inline\">\n", htmlLiteral x,
+    if #x>0 and last x === "\n" then " " else "", -- fix for html ignoring trailing \n
     "</pre>")
-html Descent := x -> concatenate("<pre style=\"display:inline-table\">\n", sort apply(pairs x,
+html Descent := x -> concatenate("<span style=\"display:inline-table;text-align:left\">\n", apply(sortByName pairs x,
      (k,v) -> (
 	  if #v === 0
 	  then html k
 	  else html k | " : " | html v
-	  ) | "<br/>"), "</pre>")
+	  ) | "<br/>"), "</span>")
+html Time := x -> html x#1 | html DIV ("-- ", toString x#0, " seconds")
 -- a few types are just strings
+html File :=
+html IndeterminateNumber :=
+html GroebnerBasis :=
+html Package :=
 html Boolean :=
 html Function :=
 html Type := html @@ toString

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/texMath-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/texMath-doc.m2
@@ -56,7 +56,6 @@ undocumented {
 	(texMath, IndeterminateNumber),
 	(texMath, IndexedVariable),
 	(texMath, IndexedVariableTable),
-	(texMath, Keyword),
 	(texMath, MapExpression),
 	(texMath, Matrix),
 	(texMath, MatrixDegreeExpression),

--- a/M2/Macaulay2/packages/VectorGraphics.m2
+++ b/M2/Macaulay2/packages/VectorGraphics.m2
@@ -1,7 +1,7 @@
 -- -*- coding: utf-8 -*-
 newPackage(
         "VectorGraphics",
-        Version => "0.91",
+        Version => "0.92",
         Date => "May 18, 2018",
         Authors => {{Name => "Paul Zinn-Justin",
                   Email => "pzinn@unimelb.edu.au",
@@ -98,7 +98,8 @@ GraphicsType List := (T,opts) -> (
 
 perspective = g -> (
     persp := if g.?Perspective then g.Perspective else 1000.; -- some arbitrary number
-    if instance(persp,Matrix) then persp else matrix {{1,0,0,0},{0,-1,0,0},{0,0,-1,0},{0,0,-1/persp,1}} -- useful to have output {x,-y,-z,1-z/p}
+    if instance(persp,Matrix) then persp else matrix {{1,0,0,0},{0,1,0,0},{0,0,-1,persp},{0,0,0,persp}} -- output is {x,y,p-z,p}
+    -- note in particular that distance : p = p-z : p = z' : w'
 )
 
 viewPort = g -> (
@@ -121,23 +122,27 @@ distance = g -> (
 distance1 := method()
 distance1 GraphicsObject := x -> 0_RR
 
+scale := x -> x_3/x_2
+project2d := x -> (scale x)*x^{0,1}
+project2d' := x -> (scale x)*vector {x_0,-x_1} -- annoying sign
+
 updateGraphicsCache := g -> (
     g.cache.ViewPort = viewPort1 g; -- update the range
     g.cache.Distance = distance1 g; -- update the distance
     if g.?OneSided and g.OneSided then determineSide g;
     -- bit of a hack: 2d objects Circle, Ellipse get scaled in a 3d context
     if instance(g,Circle) then (
-	scale := 1/(g.cache.CurrentMatrix*g.Center)_3;
-	g.cache.ScaledRadius=max(0,g.Radius*scale);
+	sc := scale(g.cache.CurrentMatrix*g.Center);
+	g.cache.ScaledRadius=max(0,g.Radius*sc);
 	) else if instance(g,Ellipse) then (
-	scale = 1/(g.cache.CurrentMatrix*g.Center)_3;
-	g.cache.ScaledRadiusX=max(0,g.RadiusX*scale);
-	g.cache.ScaledRadiusY=max(0,g.RadiusY*scale);
+	sc = scale(g.cache.CurrentMatrix*g.Center);
+	g.cache.ScaledRadiusX=max(0,g.RadiusX*sc);
+	g.cache.ScaledRadiusY=max(0,g.RadiusY*sc);
 	) else if instance(g,GraphicsText) then ( -- same for GraphicsText
 	-- choose font size
 	f := if g.?FontSize then g.FontSize else 14.;
-	scale = 1/(g.cache.CurrentMatrix*g.Point)_3;
-	f = max(0,f*scale);
+	sc = scale(g.cache.CurrentMatrix*g.Point);
+	f = max(0,f*sc);
 	g.cache#"font-size"= toString f|"px";
 	if instance(g,GraphicsHtml) then ( -- hack
 	    g.cache#"overflow"="visible"; -- makes width/height irrelevant
@@ -145,8 +150,6 @@ updateGraphicsCache := g -> (
 	    );
 	);
     )
-
-project2d := x -> vector {x_0/x_3,x_1/x_3}
 
 new GraphicsType of GraphicsObject from VisibleList := (T,T2,x) -> (
     g:=new MutableHashTable;
@@ -163,14 +166,14 @@ Circle = new GraphicsType of GraphicsObject from ( "circle",
     )
 viewPort1 Circle := g -> (
     p := g.cache.CurrentMatrix * g.Center;
-    r:=g.Radius/p_3;
+    r:=g.Radius*(scale p);
     p=project2d p;
     r = vector {r,r};
     { p - r, p + r }
     )
 distance1 Circle := g -> (
     y := g.cache.CurrentMatrix * g.Center;
-    y_2
+    y_2/y_3
     )
 
 Ellipse = new GraphicsType of GraphicsObject from ( "ellipse",
@@ -179,14 +182,15 @@ Ellipse = new GraphicsType of GraphicsObject from ( "ellipse",
     )
 viewPort1 Ellipse := g -> (
     p := g.cache.CurrentMatrix * g.Center;
-    rx:=g.RadiusX/p_3; ry:=g.RadiusY/p_3;
+    sc := scale p;
+    rx:=g.RadiusX*sc; ry:=g.RadiusY*sc;
     p=project2d p;
     r := vector {rx,ry};
     { p - r, p + r }
     )
 distance1 Ellipse := g -> (
     y := g.cache.CurrentMatrix * g.Center;
-    y_2
+    y_2/y_3
     )
 
 GraphicsText = new GraphicsType of GraphicsObject from ( "text",
@@ -196,12 +200,12 @@ GraphicsText = new GraphicsType of GraphicsObject from ( "text",
 viewPort1 GraphicsText := g -> (
     f := if g.?FontSize then g.FontSize else 14.;
     p := g.cache.CurrentMatrix * g.Point;
-    f=f/p_3;
+    f=f*scale p;
     p=project2d p;
     r := vector { f*0.6*length g.TextContent, 0.8*f }; -- width/height. very approximate TODO properly
     pp := p + vector {
 	if g#?"text-anchor" then (if g#"text-anchor" == "middle" then -0.5*r_0 else if g#"text-anchor" == "end" then -r_0 else 0) else 0,
-	if g#?"dominant-baseline" then (if g#"dominant-baseline" == "middle" then 0.5*r_1 else if g#"dominant-baseline" == "hanging" then 0 else -r_1) else -r_1
+	if g#?"dominant-baseline" then (if g#"dominant-baseline" == "middle" then 0.5*r_1 else if g#"dominant-baseline" == "hanging" then -r_1 else 0) else 0
 	};
     {pp,pp+r}
     )
@@ -219,7 +223,7 @@ viewPort1 Line := g -> (
 distance1 Line := g -> (
     p1 := g.cache.CurrentMatrix * g.Point1;
     p2 := g.cache.CurrentMatrix * g.Point1;
-    0.5*(p1_2+p2_2)
+    0.5*(p1_2/p1_3+p2_2/p2_3)
     )
 
 GraphicsPoly = new Type of GraphicsObject;
@@ -298,27 +302,27 @@ svgLookup := hashTable { -- should be more systematic
     symbol TransformMatrix => (x,m) -> "data-matrix" => jsString x,
     symbol AnimMatrix => (x,m) -> "data-dmatrix" => jsString x,
     symbol Center => (x,m) -> (
-	x = project2d (m*x);
+	x = project2d' (m*x);
 	"cx" => toString x_0,
 	"cy" => toString x_1
 	),
     symbol ScaledRadius => (x,m) ->  "r" => toString x,
     symbol ScaledRadiusX => (x,m) ->  "rx" => toString x,
     symbol ScaledRadiusY => (x,m) ->  "ry" => toString x,
-    symbol PathList => (x,m) -> "d" => demark(" ", flatten apply(x, y -> if instance(y,Vector) then apply(entries project2d(m*y),toString) else y)),
-    symbol Points => (x,m) -> "points" => demark(" ", flatten apply(x, y -> apply(entries project2d(m*y),toString))),
+    symbol PathList => (x,m) -> "d" => demark(" ", flatten apply(x, y -> if instance(y,Vector) then apply(entries project2d'(m*y),toString) else y)),
+    symbol Points => (x,m) -> "points" => demark(" ", flatten apply(x, y -> apply(entries project2d'(m*y),toString))),
     symbol Point => (x,m) -> (
-	x = project2d (m*x);
+	x = project2d' (m*x);
 	"x" => toString x_0,
 	"y" => toString x_1
 	),
     symbol Point1 => (x,m) -> (
-	x = project2d (m*x);
+	x = project2d' (m*x);
 	"x1" => toString x_0,
 	"y1" => toString x_1
 	),
     symbol Point2 => (x,m) -> (
-	x = project2d (m*x);
+	x = project2d' (m*x);
 	"x2" => toString x_0,
 	"y2" => toString x_1
 	),
@@ -380,7 +384,7 @@ expression GraphicsObject := hold
 
 distance1 GraphicsPoly := g -> (
     if instance(g,Path) then s := select(g.PathList, x -> instance(x,Vector)) else s = g.Points;
-    sum(s,x->(g.cache.CurrentMatrix*x)_2) / #s
+    sum(s,x->(xx:=g.cache.CurrentMatrix*x;xx_2/xx_3)) / #s
     )
 distance1 GraphicsList := g -> (
     if #(g.Contents) == 0 then 0_RR else sum(g.Contents, distance) / #(g.Contents)
@@ -388,7 +392,7 @@ distance1 GraphicsList := g -> (
 GraphicsObject ? GraphicsObject := (x,y) -> (distance y) ? (distance x)
 distance1 GraphicsText := g -> (
     y := g.cache.CurrentMatrix*g.Point;
-    y_2
+    y_2/y_3
     )
 
 graphicsIdCount := 0;
@@ -476,9 +480,10 @@ new SVG from GraphicsObject := (S,g) -> (
 --	"id" => tag,
 	"style" => concatenate("width:",toString g.cache.SizeX,"em;",
 	    "height:",toString g.cache.SizeY,"em;",
+	    "stroke-linejoin:round;",
 	    if not g#?"stroke-width" then "stroke-width:1%", -- define a default stroke-width
 	),
-	"viewBox" => concatenate between(" ",toString \ {r#0_0,r#0_1,r#1_0-r#0_0,r#1_1-r#0_1}),
+	"viewBox" => concatenate between(" ",toString \ {r#0_0,-r#1_1,r#1_0-r#0_0,r#1_1-r#0_1}),
 	"data-pmatrix" => jsString p
 	};
     if is3d g then ss = append(ss, "onmousedown" => "gfxMouseDown.call(this,event)");
@@ -538,13 +543,15 @@ determineSide GraphicsPoly := g -> (
     -- find first 3 coords
     if instance(g,Path) then coords := select(g.PathList, x -> instance(x,Vector)) else coords = g.Points;
     if #coords<3 then ( remove(g.cache,Filter); return; );
-    coords=apply(take(coords,3),x->(g.cache.CurrentMatrix*x)^{0,1,2});
-    g.cache#"visibility" = if det(matrix coords#0 | matrix coords#1 | matrix coords#2) > 0 then "hidden" else "visible";
+    coords=apply(take(coords,3),x->g.cache.CurrentMatrix*x);
+    coords = apply(coords, x -> (1/x_3)*x^{0,1});
+    coords = {coords#1-coords#0,coords#2-coords#0};
+    g.cache#"visibility" = if coords#0_0*coords#1_1-coords#0_1*coords#1_0 < 0 then "hidden" else "visible";
     )
 
 -- lighting
 Light = new GraphicsType of Circle from ( "circle",
-    { symbol Center => vector {0,0,0,1.}, symbol Radius => 0, symbol Specular => 64, symbol Blur => 0.3, symbol Static => true, "fill" => "#FFFFFF", "stroke" => "none" },
+    { symbol Center => vector {0,0,0,1.}, symbol Radius => 10, symbol Specular => 64, symbol Blur => 0.3, symbol Static => true, "opacity" => "0", "fill" => "#FFFFFF", "stroke" => "none" },
     { "r", "cx", "cy" } -- atm these are not inherited
     )
 -- in case it's drawn, it's a circle
@@ -569,9 +576,6 @@ toString HypertextInternalLink := net HypertextInternalLink := x -> (
     tag := (select(x, y -> instance(y,Option) and y#0==="id"))#0#1;
     "url(#"|tag|")"
 )
-
-noid := x -> select(x,e -> class e =!= Option or e#0 =!= "id")
---htmlWithTex HypertextInternalLink := html @@ noid -- bit of a hack: to prevent id from being printed directly in WebApp mode TODO: fix
 
 svgFilter := new MarkUpType of HypertextInternalLink
 addAttribute(svgFilter,svgAttr | {"x","y","width","height"})
@@ -609,22 +613,20 @@ filter = (g,l) -> if (g.?Blur and g.Blur != 0) or (#l > 0 and instance(g,Graphic
     	-- find first 3 coords
 	if instance(g,Path) then coords := select(g.PathList, x -> instance(x,Vector)) else coords = g.Points;
     	if #coords>=3 then (
-	    coords=apply(take(coords,3),x->(g.cache.CurrentMatrix*x)^{0,1,2});
-    	    d:=-det(matrix coords#0 | matrix coords#1 | matrix coords#2);
-    	    u:=coords#1-coords#0; v:=coords#2-coords#0; w:=vector{u_1*v_2-v_1*u_2,u_2*v_0-v_2*u_0,u_0*v_1-v_0*u_1}; w2:=w_0*w_0+w_1*w_1+w_2*w_2;
+	    coords=apply(take(coords,3),x->(xx:=g.cache.CurrentMatrix*x;(1/xx_3)*xx^{0,1,2}));
+	    u:=coords#1-coords#0; v:=coords#2-coords#0; w:=vector{u_1*v_2-v_1*u_2,u_2*v_0-v_2*u_0,u_0*v_1-v_0*u_1}; w2:=w_0*w_0+w_1*w_1+w_2*w_2;
+	    if w_2>0 then w=-w;
 	    scan(l, gg -> (
 	    	    -- compute reflected coords
-		    light := gg.cache.CurrentMatrix*gg.Center;
-	    	    p := light_2/light_3;
-	    	    light=light^{0,1,2};
-	    	    lightrel := light-coords#0;
+		    light0 := gg.cache.CurrentMatrix*gg.Center;
+		    light := (1/light0_3)*light0^{0,1,2};
+		    lightrel := light-coords#0;
 	    	    sp := w_0*lightrel_0+w_1*lightrel_1+w_2*lightrel_2;
 	    	    c := 2*sp/w2;
-	    	    lightmir := light - c*w;
-		    if d<0 then sp=-sp;
+		    light = light - c*w;
 		    opts = opts | {
-			feSpecularLighting { "result" => "spec"|toString i, "specularExponent" => toString gg.Specular, "lighting-color" => if sp<0 then "black" else toString g#"fill",
-			    fePointLight { "data-origin" => gg.cache.GraphicsId, "x" => toString(lightmir_0*p/lightmir_2), "y" => toString(lightmir_1*p/lightmir_2), "z" => toString(sp/sqrt(w2)) } },
+			feSpecularLighting { "result" => "spec"|toString i, "specularExponent" => toString gg.Specular, "lighting-color" => if sp<0 then "black" else toString gg#"fill",
+			    fePointLight { "data-origin" => gg.cache.GraphicsId, "x" => toString(light_0*light0_3/light_2), "y" => toString(-light_1*light0_3/light_2), "z" => toString(4*gg.Radius/light_2) } },
 			feComposite { "in" => "spec"|toString i, "in2" => "SourceGraphic", "operator" => "in", "result" => "clipspec"|toString i },
 			feComposite { "in" => (if i==0 then "SourceGraphic" else "result"|toString(i-1)),  "in2" => "clipspec"|toString i, "result" => "result"|toString i,
 			    "operator" => "arithmetic", "k1" => "0", "k2" => "1", "k3" => "1", "k4" => "0" }
@@ -669,14 +671,16 @@ radialGradient = true >> o -> stop -> (
 
 GraphicsArrow = new OptionTable from gParse { symbol Points => { vector {0,0}, vector {0,4}, vector {3,2} }, "fill" => "black", "stroke" => "none", Is3d => false }
 svgMarker := new MarkUpType of HypertextInternalLink
-addAttribute(svgMarker,svgAttr|{ "orient" => "auto", "markerSizeX" => "3", "markerSizeY" => "4", "refX" => "0", "refY" => "2"})
+addAttribute(svgMarker,svgAttr|{ "orient" => "auto", "markerWidth" => "3", "markerHeight" => "4", "refX" => "0", "refY" => "2"})
 svgMarker.qname="marker"
+
+m := matrix {{1,0,0,0},{0,-1,0,0},{0,0,1,0},{0,0,0,1}}*perspective 1;
 
 arrow = true >> o -> x -> (
     tag := graphicsId();
     svgMarker {
 	"id" => tag,
-	svg(new Polygon from (GraphicsArrow ++ gParse o),map(RR^4,RR^4,1),map(RR^4,RR^4,1))  -- eww
+	svg(new Polygon from (GraphicsArrow ++ gParse o),m,m)  -- eww
 	}
     )
 
@@ -809,15 +813,15 @@ multidoc ///
    Text
     A source of light for a 3d SVG picture.
     This corresponds to the SVG "specular" lighting, use the property Specular. The location is given by Center.
-    By default a Light is invisible (it has Radius 0) and is unaffected by matrix transformations outside it (Static true).
+    By default a Light is invisible (it has opacity 0) and is unaffected by matrix transformations outside it (Static true).
    Example
-    Light{Radius=>10,"fill"=>"yellow"}
+    Light{Radius=>10,"opacity"=>"1","fill"=>"yellow"}
     v={(74.5571, 52.0137, -41.6631),(27.2634, -29.9211, 91.4409),(-81.3041, 57.8325, 6.71156),(-20.5165, -79.9251, -56.4894)};
     f={{v#2,v#1,v#0},{v#0,v#1,v#3},{v#0,v#3,v#2},{v#1,v#2,v#3}};
     c={"red","green","blue","yellow"};
     tetra=gList(apply(4,i->Polygon{f#i,"fill"=>c#i,"stroke"=>"none"}),
-	Light{(100,0,0),Radius=>10},ViewPort=>{(-100,-100),(100,100)},
-	SizeY=>30,TransformMatrix=>rotation(-1.5,(0,1,0)))
+	Light{(110,0,0),Radius=>10,"opacity"=>"1"},ViewPort=>{(-110,-100),(110,100)},
+	SizeY=>30,TransformMatrix=>rotation(-1.5,(4,1,0)))
   Caveat
    Do not use the same Light object multiple times in a given @ TO {GraphicsList} @.
  Node
@@ -924,7 +928,8 @@ multidoc ///
    Distance to the viewer
   Description
    Text
-    Returns the distance (perpendicularly to the screen) to the viewer of a @ TO {VectorGraphics} @ 3d object.
+    Returns the distance (perpendicularly to the screen) to the viewer of a @ TO {VectorGraphics} @ 3d object,
+    normalized so the screen is at distance $1$.
  Node
   Key
    rotation
@@ -990,10 +995,11 @@ multidoc ///
   Description
    Text
     A 4x4 matrix that is applied to 3d coordinates for perspective.
-    After this tranformation, the coordinates must be (x,-y,-z,z/p) in the reference frame
-    where the viewer is at (0,0,0) and the screen at z=-p.
-    One can instead provide a real number p, which is equivalent to placing the screen
-    centered at z=0 and the viewer at (0,0,p).
+    After this tranformation, the coordinates must be up to normalization $(x,y,z,p)$
+    where $(x,y,z>0)$ are coordinates in the reference frame where the observer is at the origin looking in the $z$ direction,
+    and $p$ is the distance from the observer to the screen.
+    One can instead provide a real number $p$, which is equivalent to placing the screen
+    centered at $z=0$ and the viewer at $(0,0,p)$.
     Only has an effect if in the outermost @ TO {VectorGraphics} @ object.
  Node
   Key
@@ -1226,7 +1232,7 @@ icosa=apply(faces,f->Polygon{apply(f,j->vertices#j),"fill"=>"gray","stroke"=>"no
 i=gList(icosa,TransformMatrix=>matrix{{0.7,0,0,0},{0,0.7,0,0},{0,0,0.7,0},{0,0,0,1}})
 
 rnd = () -> random(-1.,1.); cols={"red","green","blue","yellow","magenta","cyan"};
-gList(i, apply(cols, c -> Light{100*vector{1.5+rnd(),rnd(),rnd()},Radius=>10,"fill"=>c,Specular=>10,AnimMatrix=>rotation(0.02,(rnd(),rnd(),rnd()))}),ViewPort=>{(-200,-200),(200,200)},SizeY=>30)
+gList(i, apply(cols, c -> Light{100*vector{1.5+rnd(),rnd(),rnd()},Radius=>10,"opacity"=>1,"fill"=>c,Specular=>20,AnimMatrix=>rotation(0.02,(rnd(),rnd(),rnd()))}),ViewPort=>{(-200,-200),(200,200)},SizeY=>30)
 
 subdivide = (v,f) -> (
     u := v#0;
@@ -1285,7 +1291,7 @@ far=-10000;
 screen=1000;
 stars=apply(n,i->(
 z=speed*(random(far,screen)//speed);
-Circle{(random(-200,200),random(-200,200),z),10,"fill"=>"yellow","stroke"=>"none",Blur=>0.3,
+Circle{(random(-200,200),random(-200,200),z),10,"fill"=>"yellow","stroke"=>"none",Blur=>0.3, -- TODO: make blurriness dynamically depend on size
 AnimMatrix=>{((screen-z)//speed)=>translation (0,0,speed),translation (0,0,far-screen),((-far+z)//speed)=>translation (0,0,speed)}}
 ));
 gList(stars,ViewPort=>{(-100,-100),(100,100)})

--- a/M2/Macaulay2/packages/VectorGraphics/VectorGraphics.js
+++ b/M2/Macaulay2/packages/VectorGraphics/VectorGraphics.js
@@ -468,10 +468,47 @@ class Matrix extends Float32Array {
 
     inverse() // size 4 only!
     {
-	var A2323 = this[10] * this[15] - this[11] * this[14], A1323 = this[9] * this[15] - this[11] * this[13], A1223 = this[9] * this[14] - this[10] * this[13], A0323 = this[8] * this[15] - this[11] * this[12], A0223 = this[8] * this[14] - this[10] * this[12], A0123 = this[8] * this[13] - this[9] * this[12], A2313 = this[6] * this[15] - this[7] * this[14], A1313 = this[5] * this[15] - this[7] * this[13], A1213 = this[5] * this[14] - this[6] * this[13], A2312 = this[6] * this[11] - this[7] * this[10], A1312 = this[5] * this[11] - this[7] * this[9], A1212 = this[5] * this[10] - this[6] * this[9], A0313 = this[4] * this[15] - this[7] * this[12], A0213 = this[4] * this[14] - this[6] * this[12], A0312 = this[4] * this[11] - this[7] * this[8], A0212 = this[4] * this[10] - this[6] * this[8], A0113 = this[4] * this[13] - this[5] * this[12], A0112 = this[4] * this[9] - this[5] * this[8];
-	var det = this[0] * ( this[5] * A2323 - this[6] * A1323 + this[7] * A1223 ) - this[1] * ( this[4] * A2323 - this[6] * A0323 + this[7] * A0223 ) + this[2] * ( this[4] * A1323 - this[5] * A0323 + this[7] * A0123 ) - this[3] * ( this[4] * A1223 - this[5] * A0223 + this[6] * A0123 );
+	var A2323 = this[10] * this[15] - this[11] * this[14],
+	    A1323 = this[9] * this[15] - this[11] * this[13],
+	    A1223 = this[9] * this[14] - this[10] * this[13],
+	    A0323 = this[8] * this[15] - this[11] * this[12],
+	    A0223 = this[8] * this[14] - this[10] * this[12],
+	    A0123 = this[8] * this[13] - this[9] * this[12],
+	    A2313 = this[6] * this[15] - this[7] * this[14],
+	    A1313 = this[5] * this[15] - this[7] * this[13],
+	    A1213 = this[5] * this[14] - this[6] * this[13],
+	    A2312 = this[6] * this[11] - this[7] * this[10],
+	    A1312 = this[5] * this[11] - this[7] * this[9],
+	    A1212 = this[5] * this[10] - this[6] * this[9],
+	    A0313 = this[4] * this[15] - this[7] * this[12],
+	    A0213 = this[4] * this[14] - this[6] * this[12],
+	    A0312 = this[4] * this[11] - this[7] * this[8],
+	    A0212 = this[4] * this[10] - this[6] * this[8],
+	    A0113 = this[4] * this[13] - this[5] * this[12],
+	    A0112 = this[4] * this[9] - this[5] * this[8];
+	var det =
+	    this[0] * ( this[5] * A2323 - this[6] * A1323 + this[7] * A1223 )
+	    - this[1] * ( this[4] * A2323 - this[6] * A0323 + this[7] * A0223 )
+	    + this[2] * ( this[4] * A1323 - this[5] * A0323 + this[7] * A0123 )
+	    - this[3] * ( this[4] * A1223 - this[5] * A0223 + this[6] * A0123 );
 	det = 1 / det;
-	return new Matrix( [ det *   ( this[5] * A2323 - this[6] * A1323 + this[7] * A1223 ), det * - ( this[1] * A2323 - this[2] * A1323 + this[3] * A1223 ), det *   ( this[1] * A2313 - this[2] * A1313 + this[3] * A1213 ), det * - ( this[1] * A2312 - this[2] * A1312 + this[3] * A1212 ), det * - ( this[4] * A2323 - this[6] * A0323 + this[7] * A0223 ), det *   ( this[0] * A2323 - this[2] * A0323 + this[3] * A0223 ), det * - ( this[0] * A2313 - this[2] * A0313 + this[3] * A0213 ), det *   ( this[0] * A2312 - this[2] * A0312 + this[3] * A0212 ), det *   ( this[4] * A1323 - this[5] * A0323 + this[7] * A0123 ), det * - ( this[0] * A1323 - this[1] * A0323 + this[3] * A0123 ), det *   ( this[0] * A1313 - this[1] * A0313 + this[3] * A0113 ), det * - ( this[0] * A1312 - this[1] * A0312 + this[3] * A0112 ), det * - ( this[4] * A1223 - this[5] * A0223 + this[6] * A0123 ), det *   ( this[0] * A1223 - this[1] * A0223 + this[2] * A0123 ), det * - ( this[0] * A1213 - this[1] * A0213 + this[2] * A0113 ), det *   ( this[0] * A1212 - this[1] * A0212 + this[2] * A0112 ) ] );
+	return new Matrix(
+	    [ det *   ( this[5] * A2323 - this[6] * A1323 + this[7] * A1223 ),
+	      det * - ( this[1] * A2323 - this[2] * A1323 + this[3] * A1223 ),
+	      det *   ( this[1] * A2313 - this[2] * A1313 + this[3] * A1213 ),
+	      det * - ( this[1] * A2312 - this[2] * A1312 + this[3] * A1212 ),
+	      det * - ( this[4] * A2323 - this[6] * A0323 + this[7] * A0223 ),
+	      det *   ( this[0] * A2323 - this[2] * A0323 + this[3] * A0223 ),
+	      det * - ( this[0] * A2313 - this[2] * A0313 + this[3] * A0213 ),
+	      det *   ( this[0] * A2312 - this[2] * A0312 + this[3] * A0212 ),
+	      det *   ( this[4] * A1323 - this[5] * A0323 + this[7] * A0123 ),
+	      det * - ( this[0] * A1323 - this[1] * A0323 + this[3] * A0123 ),
+	      det *   ( this[0] * A1313 - this[1] * A0313 + this[3] * A0113 ),
+	      det * - ( this[0] * A1312 - this[1] * A0312 + this[3] * A0112 ),
+	      det * - ( this[4] * A1223 - this[5] * A0223 + this[6] * A0123 ),
+	      det *   ( this[0] * A1223 - this[1] * A0223 + this[2] * A0123 ),
+	      det * - ( this[0] * A1213 - this[1] * A0213 + this[2] * A0113 ),
+	      det *   ( this[0] * A1212 - this[1] * A0212 + this[2] * A0112 ) ] );
     }
 
     transpose()

--- a/M2/Macaulay2/packages/VectorGraphics/VectorGraphics.js
+++ b/M2/Macaulay2/packages/VectorGraphics/VectorGraphics.js
@@ -149,14 +149,13 @@ function gfxRecompute(el) {
 	for (var j=0; j<el.gfxdata.coords.length; j++) {
 	    if (el.gfxdata.coords[j] instanceof Float32Array) {
 		var u=el.gfxdata.cmatrix.vectmultiply(el.gfxdata.coords[j]);
-		if (u[3]<=0) flag=true; else {
-		    var v=[u[0]/u[3],u[1]/u[3]];
+		if (u[2]/u[3]<=0) flag=true; else {
+		    var v=[u[0]*u[3]/u[2],-u[1]*u[3]/u[2]];
 		    coords.push(u);
 		    s+=v[0]+" "+v[1]+" ";
-		    distance+=u[2]; // not homogenous?
+		    distance+=u[2]/u[3];
 		}
 	    }
-	    else s+=el.gfxdata.coords[j]+" ";
 	}
 	if (flag) el.style.display="none"; else {
 	    el.style.display="";
@@ -165,24 +164,25 @@ function gfxRecompute(el) {
 	    // recompute distance as average of distances of vertices
 	    el.gfxdata.distance=distance/coords.length;
 	    if (coords.length>2) {
-		var det = coords[0][2]*coords[1][1]*coords[2][0]
-		    -coords[0][1]*coords[1][2]*coords[2][0]
-		    -coords[0][2]*coords[1][0]*coords[2][1]
-		    +coords[0][0]*coords[1][2]*coords[2][1]
-		    +coords[0][1]*coords[1][0]*coords[2][2]
-		    -coords[0][0]*coords[1][1]*coords[2][2]; // TODO optimize
-		// visibility
-		if (el.gfxdata.onesided) {
-		    if (det<0) { el.style.visibility="hidden"; return; } else el.style.visibility="visible";
+		var u=[],v=[];
+		for (var i=0; i<3; i++) {
+		    u.push(coords[1][i]/coords[1][3]-coords[0][i]/coords[0][3]);
+		    v.push(coords[2][i]/coords[2][3]-coords[0][i]/coords[0][3]);
 		}
+		var w=[u[1]*v[2]-v[1]*u[2],u[2]*v[0]-v[2]*u[0],u[0]*v[1]-v[0]*u[1]];
+		// visibility
+		if (w[2]<0) {
+		    if (el.gfxdata.onesided)
+			el.style.visibility="hidden"; return;
+		}
+		else
+		    w=[-w[0],-w[1],-w[2]];
+		el.style.visibility="visible";
 		// lighting
 		var lightname = el.getAttribute("filter");
 		if (lightname) {
 		    lightname=lightname.substring(5,lightname.length-1); // eww. what is correct way??
 		    var lightel=document.getElementById(lightname);
-		    var u=[coords[1][0]-coords[0][0],coords[1][1]-coords[0][1],coords[1][2]-coords[0][2]];
-		    var v=[coords[2][0]-coords[0][0],coords[2][1]-coords[0][1],coords[2][2]-coords[0][2]];
-		    var w=[u[1]*v[2]-v[1]*u[2],u[2]*v[0]-v[2]*u[0],u[0]*v[1]-v[0]*u[1]];
 		    var w2=w[0]*w[0]+w[1]*w[1]+w[2]*w[2];
 		    for (var j=0; j<lightel.children.length; j++)
 			if (lightel.children[j].tagName == "feSpecularLighting") {
@@ -191,17 +191,18 @@ function gfxRecompute(el) {
 			    //var origin=document.getElementById(lightel2.gfxdata.origin);
 			    var origin=lightel2.gfxdata.origin; // eval acts as getElementById
 			    if (!origin.gfxdata.pcenter) gfxRecompute(origin); // hopefully won't create infinite loops
-			    var light = new Float32Array(origin.gfxdata.pcenter); // phew
-			    var sp = w[0]*(light[0]-coords[0][0])+w[1]*(light[1]-coords[0][1])+w[2]*(light[2]-coords[0][2]);
+			    var light0 = new Float32Array(origin.gfxdata.pcenter); // phew
+			    var light=[];
+			    for (var i=0; i<3; i++)
+				light.push(light0[i]/light0[3]);
+			    var sp = w[0]*(light[0]-coords[0][0]/coords[0][3])+w[1]*(light[1]-coords[0][1]/coords[0][3])+w[2]*(light[2]-coords[0][2]/coords[0][3]);
 			    var c = 2*sp/w2;
-			    var p = light[2]/light[3]; // eww
 			    for (var i=0; i<3; i++) light[i]-=c*w[i];
-			    if (det<0) sp=-sp;
 			    if (sp<0) lightel.children[j].setAttribute("lighting-color","#000000"); else {
 				lightel.children[j].setAttribute("lighting-color",origin.style.fill);
-				lightel2.setAttribute("x",light[0]*p/light[2]);
-				lightel2.setAttribute("y",light[1]*p/light[2]);
-				lightel2.setAttribute("z",sp/Math.sqrt(w2));
+				lightel2.setAttribute("x",light[0]*light0[3]/light[2]);
+				lightel2.setAttribute("y",-light[1]*light0[3]/light[2]);
+				lightel2.setAttribute("z",4*origin.gfxdata.r/light[2]);
 			    }
 			}
 		}
@@ -211,11 +212,13 @@ function gfxRecompute(el) {
     else if (el.tagName=="line") {
 	var u1=el.gfxdata.cmatrix.vectmultiply(el.gfxdata.point1);
 	var u2=el.gfxdata.cmatrix.vectmultiply(el.gfxdata.point2);
-	if ((u1[3]<=0)||(u2[3]<=0)) el.style.display="none"; else {
+	var sc1 = u1[3]/u1[2];
+	var sc2 = u2[3]/u2[2];
+	if ((sc1<=0)||(sc2<=0)) el.style.display="none"; else {
 	    el.style.display="";
-	    var v1=[u1[0]/u1[3],u1[1]/u1[3]];
-	    var v2=[u2[0]/u2[3],u2[1]/u2[3]];
-	    el.gfxdata.distance=0.5*(u1[2]+u2[2]);
+	    var v1=[u1[0]*sc1,-u1[1]*sc1];
+	    var v2=[u2[0]*sc2,-u2[1]*sc2];
+	    el.gfxdata.distance=0.5*(u1[2]/u1[3]+u2[2]/u2[3]);
 	    el.setAttribute("x1",v1[0]);
 	    el.setAttribute("y1",v1[1]);
 	    el.setAttribute("x2",v2[0]);
@@ -225,31 +228,33 @@ function gfxRecompute(el) {
     else if ((el.tagName=="text")||(el.tagName=="foreignObject")) {
 	if (!el.gfxdata.fontsize) el.gfxdata.fontsize=14;
 	var u=el.gfxdata.cmatrix.vectmultiply(el.gfxdata.point);
-	if (u[3]<=0) el.style.display="none"; else {
+	var sc = u[3]/u[2];
+	if (sc<=0) el.style.display="none"; else {
 	    el.style.display="";
-	    var v=[u[0]/u[3],u[1]/u[3]];
-	    el.gfxdata.distance=u[2];
+	    var v=[u[0]*sc,-u[1]*sc];
+	    el.gfxdata.distance=u[2]/u[3];
 	    el.setAttribute("x",v[0]);
 	    el.setAttribute("y",v[1]);
 	    // rescale font size
-	    el.style.fontSize = el.gfxdata.fontsize/u[3]+"px"; // chrome doesn't mind absence of units but firefox does
+	    el.style.fontSize = el.gfxdata.fontsize*sc+"px"; // chrome doesn't mind absence of units but firefox does
 	}
     }
     else if ((el.tagName=="circle")||(el.tagName=="ellipse")) {
 	var u=el.gfxdata.cmatrix.vectmultiply(el.gfxdata.center);
 	el.gfxdata.pcenter = u; // in case someone needs it ... (light)
-	if (u[3]<=0) el.style.display="none"; else {
+	var sc=u[3]/u[2];
+	if (sc<=0) el.style.display="none"; else {
 	    el.style.display="";
-	    var v=[u[0]/u[3],u[1]/u[3]];
-	    el.gfxdata.distance=u[2];
+	    var v=[u[0]*sc,-u[1]*sc];
+	    el.gfxdata.distance=u[2]/u[3];
 	    el.setAttribute("cx",v[0]);
 	    el.setAttribute("cy",v[1]);
 	    // also, rescale radius
 	    if (el.tagName=="circle")
-		el.setAttribute("r", el.gfxdata.r/u[3]);
+		el.setAttribute("r", el.gfxdata.r*sc);
 	    else {
-		el.setAttribute("rx", el.gfxdata.rx/u[3]);
-		el.setAttribute("ry", el.gfxdata.ry/u[3]);
+		el.setAttribute("rx", el.gfxdata.rx*sc);
+		el.setAttribute("ry", el.gfxdata.ry*sc);
 	    }
 	}
     }
@@ -283,12 +288,14 @@ function gfxReorder(el) {
 
 function checkData(el) {
     var mat = el.gfxdata.cmatrix.inverse();
+    var sc = el.gfxdata.cmatrix.e(3,3); // not quite right but close enough TODO better
+    var z = sc;
     if ((el.tagName=="polyline")||(el.tagName=="polygon")) {
 	if (!el.gfxdata.coords) {
 	    var pts = el.points;
 	    el.gfxdata.coords = [];
 	    for (var i=0; i<pts.length; i++)
-		el.gfxdata.coords.push(mat.vectmultiply(vector([pts[i].x,pts[i].y,0,1])));
+		el.gfxdata.coords.push(mat.vectmultiply(vector([pts[i].x,-pts[i].y,z,sc])));
 	}
     }
     else if (el.tagName=="path") {
@@ -298,38 +305,38 @@ function checkData(el) {
 	    for (var i=0; i<path.length; i++)
 		if ( path[i] >= "A" && path[i] <= "Z" ) el.gfxdata.coords.push(path[i]);
 	    else {
-		el.gfxdata.coords.push(mat.vectmultiply(vector([+path[i],+path[i+1],0,1])));
+		el.gfxdata.coords.push(mat.vectmultiply(vector([+path[i],-path[i+1],z,sc])));
 		i++;
 	    }
 	}
     }
     else if (el.tagName=="line") {
 	if (!el.gfxdata.point1 || !el.gfxdata.point2) {
-	    el.gfxdata.point1=mat.vectmultiply(vector([el.x1.baseVal.value,el.y1.baseVal.value,0,1]));
-	    el.gfxdata.point2=mat.vectmultiply(vector([el.x2.baseVal.value,el.y2.baseVal.value,0,1]));
+	    el.gfxdata.point1=mat.vectmultiply(vector([el.x1.baseVal.value,-el.y1.baseVal.value,z,sc]));
+	    el.gfxdata.point2=mat.vectmultiply(vector([el.x2.baseVal.value,-el.y2.baseVal.value,z,sc]));
 	}
     }
     else if (el.tagName=="text") {
 	if (!el.gfxdata.point) {
-	    el.gfxdata.point=mat.vectmultiply(vector([el.x.baseVal[0].value,el.y.baseVal[0].value,0,1])); // weird
+	    el.gfxdata.point=mat.vectmultiply(vector([el.x.baseVal[0].value,-el.y.baseVal[0].value,z,sc])); // weird
 	    el.gfxdata.fontsize=el.style.fontSize.substring(0,el.style.fontSize.length-2);
 	}
     }
     else if (el.tagName=="foreignObject") {
 	if (!el.gfxdata.point) {
-	    el.gfxdata.point=mat.vectmultiply(vector([el.x.baseVal.value,el.y.baseVal.value,0,1]));
+	    el.gfxdata.point=mat.vectmultiply(vector([el.x.baseVal.value,-el.y.baseVal.value,z,sc]));
 	    el.gfxdata.fontsize=el.style.fontSize.substring(0,el.style.fontSize.length-2);
 	}
     }
     else if (el.tagName=="circle") {
 	if (!el.gfxdata.center) {
-	    el.gfxdata.center=mat.vectmultiply(vector([el.cx.baseVal.value,el.cy.baseVal.value,0,1]));
+	    el.gfxdata.center=mat.vectmultiply(vector([el.cx.baseVal.value,-el.cy.baseVal.value,z,sc]));
 	    el.gfxdata.r=el.r.baseVal.value;
 	}
     }
     else if (el.tagName=="ellipse") {
 	if (!el.gfxdata.center) {
-	    el.gfxdata.center=mat.vectmultiply(vector([el.cx.baseVal.value,el.cy.baseVal.value,0,1]));
+	    el.gfxdata.center=mat.vectmultiply(vector([el.cx.baseVal.value,-el.cy.baseVal.value,z,sc]));
 	    el.gfxdata.rx=el.rx.baseVal.value;
 	    el.gfxdata.ry=el.ry.baseVal.value;
 	}
@@ -461,47 +468,10 @@ class Matrix extends Float32Array {
 
     inverse() // size 4 only!
     {
-	var A2323 = this[10] * this[15] - this[11] * this[14],
-	    A1323 = this[9] * this[15] - this[11] * this[13],
-	    A1223 = this[9] * this[14] - this[10] * this[13],
-	    A0323 = this[8] * this[15] - this[11] * this[12],
-	    A0223 = this[8] * this[14] - this[10] * this[12],
-	    A0123 = this[8] * this[13] - this[9] * this[12],
-	    A2313 = this[6] * this[15] - this[7] * this[14],
-	    A1313 = this[5] * this[15] - this[7] * this[13],
-	    A1213 = this[5] * this[14] - this[6] * this[13],
-	    A2312 = this[6] * this[11] - this[7] * this[10],
-	    A1312 = this[5] * this[11] - this[7] * this[9],
-	    A1212 = this[5] * this[10] - this[6] * this[9],
-	    A0313 = this[4] * this[15] - this[7] * this[12],
-	    A0213 = this[4] * this[14] - this[6] * this[12],
-	    A0312 = this[4] * this[11] - this[7] * this[8],
-	    A0212 = this[4] * this[10] - this[6] * this[8],
-	    A0113 = this[4] * this[13] - this[5] * this[12],
-	    A0112 = this[4] * this[9] - this[5] * this[8];
-	var det =
-	    this[0] * ( this[5] * A2323 - this[6] * A1323 + this[7] * A1223 )
-	    - this[1] * ( this[4] * A2323 - this[6] * A0323 + this[7] * A0223 )
-	    + this[2] * ( this[4] * A1323 - this[5] * A0323 + this[7] * A0123 )
-	    - this[3] * ( this[4] * A1223 - this[5] * A0223 + this[6] * A0123 );
+	var A2323 = this[10] * this[15] - this[11] * this[14], A1323 = this[9] * this[15] - this[11] * this[13], A1223 = this[9] * this[14] - this[10] * this[13], A0323 = this[8] * this[15] - this[11] * this[12], A0223 = this[8] * this[14] - this[10] * this[12], A0123 = this[8] * this[13] - this[9] * this[12], A2313 = this[6] * this[15] - this[7] * this[14], A1313 = this[5] * this[15] - this[7] * this[13], A1213 = this[5] * this[14] - this[6] * this[13], A2312 = this[6] * this[11] - this[7] * this[10], A1312 = this[5] * this[11] - this[7] * this[9], A1212 = this[5] * this[10] - this[6] * this[9], A0313 = this[4] * this[15] - this[7] * this[12], A0213 = this[4] * this[14] - this[6] * this[12], A0312 = this[4] * this[11] - this[7] * this[8], A0212 = this[4] * this[10] - this[6] * this[8], A0113 = this[4] * this[13] - this[5] * this[12], A0112 = this[4] * this[9] - this[5] * this[8];
+	var det = this[0] * ( this[5] * A2323 - this[6] * A1323 + this[7] * A1223 ) - this[1] * ( this[4] * A2323 - this[6] * A0323 + this[7] * A0223 ) + this[2] * ( this[4] * A1323 - this[5] * A0323 + this[7] * A0123 ) - this[3] * ( this[4] * A1223 - this[5] * A0223 + this[6] * A0123 );
 	det = 1 / det;
-	return new Matrix(
-	    [ det *   ( this[5] * A2323 - this[6] * A1323 + this[7] * A1223 ),
-	      det * - ( this[1] * A2323 - this[2] * A1323 + this[3] * A1223 ),
-	      det *   ( this[1] * A2313 - this[2] * A1313 + this[3] * A1213 ),
-	      det * - ( this[1] * A2312 - this[2] * A1312 + this[3] * A1212 ),
-	      det * - ( this[4] * A2323 - this[6] * A0323 + this[7] * A0223 ),
-	      det *   ( this[0] * A2323 - this[2] * A0323 + this[3] * A0223 ),
-	      det * - ( this[0] * A2313 - this[2] * A0313 + this[3] * A0213 ),
-	      det *   ( this[0] * A2312 - this[2] * A0312 + this[3] * A0212 ),
-	      det *   ( this[4] * A1323 - this[5] * A0323 + this[7] * A0123 ),
-	      det * - ( this[0] * A1323 - this[1] * A0323 + this[3] * A0123 ),
-	      det *   ( this[0] * A1313 - this[1] * A0313 + this[3] * A0113 ),
-	      det * - ( this[0] * A1312 - this[1] * A0312 + this[3] * A0112 ),
-	      det * - ( this[4] * A1223 - this[5] * A0223 + this[6] * A0123 ),
-	      det *   ( this[0] * A1223 - this[1] * A0223 + this[2] * A0123 ),
-	      det * - ( this[0] * A1213 - this[1] * A0213 + this[2] * A0113 ),
-	      det *   ( this[0] * A1212 - this[1] * A0212 + this[2] * A0112 ) ] );
+	return new Matrix( [ det *   ( this[5] * A2323 - this[6] * A1323 + this[7] * A1223 ), det * - ( this[1] * A2323 - this[2] * A1323 + this[3] * A1223 ), det *   ( this[1] * A2313 - this[2] * A1313 + this[3] * A1213 ), det * - ( this[1] * A2312 - this[2] * A1312 + this[3] * A1212 ), det * - ( this[4] * A2323 - this[6] * A0323 + this[7] * A0223 ), det *   ( this[0] * A2323 - this[2] * A0323 + this[3] * A0223 ), det * - ( this[0] * A2313 - this[2] * A0313 + this[3] * A0213 ), det *   ( this[0] * A2312 - this[2] * A0312 + this[3] * A0212 ), det *   ( this[4] * A1323 - this[5] * A0323 + this[7] * A0123 ), det * - ( this[0] * A1323 - this[1] * A0323 + this[3] * A0123 ), det *   ( this[0] * A1313 - this[1] * A0313 + this[3] * A0113 ), det * - ( this[0] * A1312 - this[1] * A0312 + this[3] * A0112 ), det * - ( this[4] * A1223 - this[5] * A0223 + this[6] * A0123 ), det *   ( this[0] * A1223 - this[1] * A0223 + this[2] * A0123 ), det * - ( this[0] * A1213 - this[1] * A0213 + this[2] * A0113 ), det *   ( this[0] * A1212 - this[1] * A0212 + this[2] * A0112 ) ] );
     }
 
     transpose()


### PR DESCRIPTION
- `html` code cleanup: various workarounds I'd introduced are now useless, I've removed them. also added `html Time`, and a few more types where `html` -> `toString`.
- `texMath`: `texMath MatrixDegreeExpression` finally coded after years of procrastinating. `compactMatrixForm` now also affects `texMath` (if false, entries are typeset with `\displaystyle`). `texMath Symbol`, `Keyword` minor improvement.
- `WebApp`: code cleanup thanks to https://github.com/mahrud/M2/commit/702fac88f7861d3de55aca0ddb92e66ea1f0c65e
- package `VectorGraphics` updated.