### PR TITLE
Switch order of givaro and flint includes

### DIFF
--- a/M2/Macaulay2/e/interface/aring.cpp
+++ b/M2/Macaulay2/e/interface/aring.cpp
@@ -4,9 +4,9 @@
 #include <utility>
 #include <vector>
 
+#include "aring-gf-givaro.hpp"
 #include "aring-gf-flint-big.hpp"
 #include "aring-gf-flint.hpp"
-#include "aring-gf-givaro.hpp"
 #include "aring-glue.hpp"
 #include "aring-m2-gf.hpp"
 #include "aring-qq.hpp"


### PR DESCRIPTION
M2::ARingZZpFlint::subtract_multiple uses flint's NMOD_ADDMUL macro,
which in turn uses the umul_ppmm and add_ssaaaa macros.  However,
these macros are defined in both flint and givaro, and the conflict
caused a build failure was on some architectures (e.g., arm64,
ppc64el, and s390x).  Switching the order of the includes fixes this,
as givaro undef's them when it is done with them (see
https://github.com/linbox-team/givaro/pull/99).

Closes: #1674