### PR TITLE
Find location of failing test output correctly when running a single test

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -62,7 +62,7 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
         if opts.Verbose then (
             numTests := if n == -1 then pkg#"test number" else 1;
             ":" | newline |
-            concatenate(apply(errorList, k ->
+            concatenate(apply(if n == -1 then errorList else {0}, k ->
                 newline | get("!tail " | temporaryDirectory() |
                 toString(temporaryFilenameCounter + 2 * (k - numTests)) |
                 ".tmp")))

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/check-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/check-doc.m2
@@ -46,6 +46,7 @@ Node
     (check, ZZ, Package)
     (check, ZZ, String)
     [check, UserMode]
+    [check, Verbose]
   Headline
     perform tests of a package
   Usage


### PR DESCRIPTION
`temporaryFilenameCounter` is incremented twice every time we run a
test, so we use this fact to compute the location of the temporary
file containing the output of failing tests when the `Verbose` option
to `check` is `true`.

However, this was done incorrectly when a single test was checked.  In
particular, the number of the test was being used to compute the
location of the temporary file, but this number is meaningless in this
case.  Instead, we always want to subtract 2 from the current value of
`temporaryFilenameCounter`.

Closes: #1686