### PR TITLE
Add gftables path to FILE_PREREQS if found

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1414,6 +1414,7 @@ else
     adl_RECURSIVE_EVAL([$GFTABLESDIR], [GFTABLESDIR])
     AC_CHECK_FILE([${GFTABLESDIR}gftables/961],,
 	[AC_MSG_ERROR([could not find gftables but we are not building factory; try specifying the directory with GFTABLESDIR])])
+    FILE_PREREQS="$FILE_PREREQS ${GFTABLESDIR}gftables/961"
 fi
 
 if test $BUILD_factory = no


### PR DESCRIPTION
The 1.16.99 Ubuntu package was apparently built with the singular-data
package installed, as it points to the singular copy of these tables
instead of shipping its own.  Indeed:

```m2
Macaulay2, version 1.16.99
with packages: ConwayPolynomials, Elimination, IntegralClosure, InverseSystems,
               LLLBases, MinimalPrimes, PrimaryDecomposition, ReesAlgebra,
               Saturation, TangentCone

i1 : currentLayout#"factory gftables"

o1 = /usr/share/singular/factory/
```

However, the singular-data package is not listed as a dependency,
potentially resulting errors when running Macaulay2 after installing
the package if singular-data is not already present.  For example, see
https://groups.google.com/g/macaulay2/c/1Rb7fYsJMME/m/OVhjRvMZAwAJ.

We add the gftables path to FILE_PREREQS so that singular-data will be
included as a dependency to future builds of the package.