### PR TITLE
Update PPA used for downloading extra packages during workflows

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install requirements for Linux
         if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository -y ppa:profzoom/macaulay2
+          sudo add-apt-repository -y ppa:macaulay2/macaulay2
           sudo apt-get update
           sudo apt-get install -y -q --no-install-recommends clang-10 gfortran libtool-bin ninja-build yasm ccache
           sudo apt-get install -y -q --no-install-recommends libatomic-ops-dev libboost-stacktrace-dev \


### PR DESCRIPTION
Switching from the one under my personal account, which hosts unstable
builds of the development branch, to one under a new Macaulay2
Launchpad team, which I plan to use to host stable builds of recent
releases.  It already hosts packages of the various build dependencies
missing from Ubuntu 18.04.