### PR TITLE
Revert an accidentally changed submodule hash

### DIFF
--- a/M2/BUILD/mahrud/Makefile
+++ b/M2/BUILD/mahrud/Makefile
@@ -1,0 +1,21 @@
+# This Makefile uses a pre-existing CMake build so that
+# the autotools build doesn't have to build any libraries
+
+# Set the path to the CMake build directory here
+CMAKE_BUILD_DIR       = $(shell pwd)/../build
+
+# Set the exec_prefix here in order to also find the programs
+ARCH                  = x86_64-Linux-Fedora-32
+
+export CPPFLAGS       = -I$(CMAKE_BUILD_DIR)/usr-host/include
+export LDFLAGS        = -L$(CMAKE_BUILD_DIR)/usr-host/lib
+export PATH            := $(CMAKE_BUILD_DIR)/usr-dist/$(ARCH)/libexec/Macaulay2/bin:$(PATH)
+export PKG_CONFIG_PATH := $(CMAKE_BUILD_DIR)/usr-host/lib/pkgconfig:$(PKG_CONFIG_PATH)
+
+all:
+	make -j4 -C ../.. && \
+	mkdir -p build && cd build && \
+	../../../configure --prefix=/usr --enable-download && \
+	make -j4 -C Macaulay2
+
+#TODO: can we skip building factory? use FTABLESDIR=/usr/share/factory/ 

--- a/M2/BUILD/mahrud/markdown-changelog.m2
+++ b/M2/BUILD/mahrud/markdown-changelog.m2
@@ -1,0 +1,13 @@
+restart
+importFrom_Core {"markdown"}
+
+ver = "1.17"
+illinois = "https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-" | ver | "/share"
+
+changelog = markdown help("changes, " | ver);
+changelog = replace("/home/.*?/common/share", illinois, changelog);
+changelog = replace("common/share", illinois, changelog);
+changelog = replace("https://faculty.math.illinois.edu", "http://www2.macaulay2.com", changelog);
+("changelog-" | ver | ".md") << changelog
+
+

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -421,6 +421,28 @@ cmake -U*BDWGC* .
 
 
 <details>
+<summary><code>error: Runtime CPU support is only available with GCC 4.6 or later.</code></summary>
+
+When compiling using Clang, the following error might occur if NTL was built with GCC instead:
+<pre>
+[ 25%] Building CXX object Macaulay2/e/CMakeFiles/M2-engine.dir/ntl-internal.cpp.o
+In file included from M2/Macaulay2/e/ntl-debugio.cpp:4:
+In file included from M2/Macaulay2/e/./ntl-interface.hpp:16:
+In file included from /usr/include/NTL/ZZ.h:18:
+In file included from /usr/include/NTL/lip.h:5:
+/usr/include/NTL/ctools.h:510:2: fatal error: Runtime CPU support is only available with GCC 4.6 or later.
+#error Runtime CPU support is only available with GCC 4.6 or later.
+ ^
+</pre>
+Solution:
+<pre>
+cmake --build . --target build-ntl-install
+cmake -U*NTL_* .
+</pre>
+</details>
+
+
+<details>
 <summary>How to compile with Intel(R) Math Kernel Library</summary>
 
 [MKL](https://software.intel.com/en-us/mkl) is a linear algebra routines library specifically optimized for Intel(R) processors. To enable linking with MKL, adjust the path and architecture appropriately and run the following before calling `cmake`:


### PR DESCRIPTION
I accidentally changed the flint submodule hash in e453cba2cbdb809feebfcf0e3eaf4bd6d3f410bf while fixing something in the new version of flint.

Also:
- adds a new FAQ entry to CMake install guide
- adds two useful scripts to `BUILD/mahrud`:
  - one for generating changelogs in markdown format (see #1691) 
  - a Makefile that takes advantage of an existing CMake build to speed up an autotools build