### PR TITLE
Fix "Verbose" option to "check" after recent capture changes

### DIFF
--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -367,6 +367,8 @@ NewOfFromFun = newoffromfun;
 
 export stdioS  := setupconst("stdio", Expr(stdIO));
 export stderrS := setupconst("stderr",Expr(stdError));
+export setStdIO   (f:file):void := ( stdIO    = f; setGlobalVariable(stdioS,  Expr(stdIO)));
+export setStdError(f:file):void := ( stdError = f; setGlobalVariable(stderrS, Expr(stdError)));
 
 openfilesfun(e:Expr):Expr := (
      n := 0;

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -532,6 +532,7 @@ capture(e:Expr):Expr := (
 	  flush(stdError);
 	  oldStdError := stdError; -- doesn't quite work, see stderrS in actors2.dd
 	  stdError = stdIO;
+	  setGlobalVariable(stderrS, Expr(stdIO));
 	  oldDebuggingMode := debuggingMode;
 	  setDebuggingMode(false);
           foss := getFileFOSS(stdIO);

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -252,13 +252,11 @@ readeval4(file:TokenFile,printout:bool,dictionary:Dictionary,returnLastvalue:boo
 					else buildErrorPacket("error occurred in parsing")))))))));
 
 interpreterDepthS := setupvar("interpreterDepth",zeroE);
-incrementInterpreterDepth():void := (
-     interpreterDepth = interpreterDepth + 1;
-     setGlobalVariable(interpreterDepthS,toExpr(interpreterDepth)));
-decrementInterpreterDepth():void := (
-     interpreterDepth = interpreterDepth - 1;
-     setGlobalVariable(interpreterDepthS,toExpr(interpreterDepth)));
-
+setInterpreterDepth(n:int):void := (
+     interpreterDepth = n;
+     setGlobalVariable(interpreterDepthS, toExpr(interpreterDepth)));
+incrementInterpreterDepth():void := setInterpreterDepth(interpreterDepth + 1);
+decrementInterpreterDepth():void := setInterpreterDepth(interpreterDepth - 1);
 
 readeval3(file:TokenFile,printout:bool,dc:DictionaryClosure,returnLastvalue:bool,stopIfBreakReturnContinue:bool,returnIfError:bool):Expr := (
      saveLocalFrame := localFrame;
@@ -530,11 +528,18 @@ capture(e:Expr):Expr := (
      is s:stringCell do (
      	  flush(stdIO);
 	  flush(stdError);
-	  oldStdError := stdError; -- doesn't quite work, see stderrS in actors2.dd
-	  stdError = stdIO;
-	  setGlobalVariable(stderrS, Expr(stdIO));
+	  oldStdError := stdError;
+	  setStdError(stdIO);
+	  oldStopIfError := stopIfError;
+	  setstopIfError(true);
 	  oldDebuggingMode := debuggingMode;
 	  setDebuggingMode(false);
+	  oldInterpreterDepth := interpreterDepth;
+	  setInterpreterDepth(1);
+	  oldLineNumber := lineNumber;
+	  setLineNumber(0);
+	  previousLineNumber = -1;
+	  --
           foss := getFileFOSS(stdIO);
 	  foss.capturing = true;
 	  releaseFileFOSS(stdIO);
@@ -544,20 +549,23 @@ capture(e:Expr):Expr := (
 	  foss.outbuffer = new string len 100 do provide ' ';
 	  stringFile := stringTokenFile("currentString", s.v+newline);
 	  stringFile.posFile.file.echo = true;
-	  oldLineNumber := lineNumber;
-	  previousLineNumber = -1;
-	  setLineNumber(0);
 	  setprompt(stringFile,topLevelPrompt);
+	  --
 	  r := readeval3(stringFile,true,newStaticLocalDictionaryClosure(),false,false,true);
+	  --
 	  out := substrAlwaysCopy(foss.outbuffer,0,foss.outindex);
      	  foss.capturing = false;
 	  foss.outbuffer = oldbuf;
 	  foss.outbol = oldbol;
 	  foss.outindex = oldindex;
-	  setLineNumber(oldLineNumber);
+	  --
+	  setStdError(oldStdError);
+	  setstopIfError(oldStopIfError);
 	  setDebuggingMode(oldDebuggingMode);
-	  stdError = oldStdError;
+	  setInterpreterDepth(oldInterpreterDepth);
+	  setLineNumber(oldLineNumber);
 	  previousLineNumber = -1;
+	  --
 	  Expr(Sequence( when r is err:Error do True else False, toExpr(out) )))
      else WrongArg(1,"a string"));
 setupfun("capture", capture).Protected = false; -- will be overloaded in m2/examples.m2

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -526,7 +526,7 @@ setupfun("value'",value);
 capture(e:Expr):Expr := (
      when e
      is s:stringCell do (
-     	  flush(stdIO);
+	  flush(stdIO);
 	  flush(stdError);
 	  oldStdError := stdError;
 	  setStdError(stdIO);
@@ -540,9 +540,8 @@ capture(e:Expr):Expr := (
 	  setLineNumber(0);
 	  previousLineNumber = -1;
 	  --
-          foss := getFileFOSS(stdIO);
+	  foss := getFileFOSS(stdIO);
 	  foss.capturing = true;
-	  releaseFileFOSS(stdIO);
 	  oldbuf := foss.outbuffer;
 	  oldbol := foss.outbol;
 	  oldindex := foss.outindex;
@@ -554,10 +553,11 @@ capture(e:Expr):Expr := (
 	  r := readeval3(stringFile,true,newStaticLocalDictionaryClosure(),false,false,true);
 	  --
 	  out := substrAlwaysCopy(foss.outbuffer,0,foss.outindex);
-     	  foss.capturing = false;
+	  foss.capturing = false;
 	  foss.outbuffer = oldbuf;
 	  foss.outbol = oldbol;
 	  foss.outindex = oldindex;
+	  releaseFileFOSS(stdIO);
 	  --
 	  setStdError(oldStdError);
 	  setstopIfError(oldStopIfError);

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -445,6 +445,7 @@ flushnets(o:file):int := (
 export flush(o:file):int := (
      foss := getFileFOSS(o);
      if foss.hadNet then if ERROR == flushnets(o) then (releaseFileFOSS(o); return ERROR);
+     foss.outbol = foss.outindex;
      releaseFileFOSS(o);
      simpleflush(o));
 

--- a/M2/Macaulay2/d/stdiop.d
+++ b/M2/Macaulay2/d/stdiop.d
@@ -127,12 +127,12 @@ cleanscreen():void := (
 printMessage(position:Position,message:string):void := (
      if !SuppressErrors then (
      	  cleanscreen();
-     	  stderr << position;
-	  if recursionDepth > 0 then stderr << "[" << recursionDepth << "]:";
+	  stdError << position;
+	  if recursionDepth > 0 then stdError << "[" << recursionDepth << "]:";
      	  -- gettid() is not there in Solaris
 	  -- tid := gettid();
-	  -- if tid != -1 && tid != getpid() then stderr << "<" << gettid() << ">:";
-	  stderr << " " << message << endl;
+	  -- if tid != -1 && tid != getpid() then stdError << "<" << gettid() << ">:";
+	  stdError << " " << message << endl;
 	  );
      );
 export printErrorMessage(position:Position,message:string):void := (

--- a/M2/Macaulay2/editors/make-M2-symbols.m2
+++ b/M2/Macaulay2/editors/make-M2-symbols.m2
@@ -22,7 +22,7 @@ isAlphaNumeric := s -> match("^[[:alnum:]]+$", s)
 isType     := is Type
 isKeyword  := is Keyword
 isFunction := is Function
-isConst    := (name, symb) -> (isAlpha name
+isConst    := (name, symb) -> (isAlphaNumeric name
     and not (isFunction or isType or isKeyword) (name, symb)
     and (symb === symbol null or value symb =!= null))
 

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -101,14 +101,14 @@ protect symbol capture
 isCapturable = (inputs, pkg, isTest) -> (
     -- argumentMode is mainly used by ctest to select M2 subprocess arguments,
     -- or whether capture should be avoided; see packages/CMakeLists.txt
-    if argumentMode & NoCapture =!= 0 then return false;
+    -- alternatively, no-capture-flag can be used with an example or test
+    if argumentMode & NoCapture =!= 0 or match("no-capture-flag", inputs) then return false;
     -- strip commented segments first
     inputs = replace("--.*$", "",       inputs);
     inputs = replace("-\\*.*?\\*-", "", inputs);
-    -- this flag is sometimes unavoidable, but hopefully rarely
-    not match("no-capture-flag",        inputs)
     -- TODO: remove this when the effects of capture on other packages is reviewed
-    and (isTest or match({"FirstPackage", "Macaulay2Doc"}, pkg#"pkgname"))
+    (isTest or match({"FirstPackage", "Macaulay2Doc"},            pkg#"pkgname"))
+    and not match({"EngineTests", "ThreadedGB", "RunExternalM2"}, pkg#"pkgname")
     -- FIXME: these are workarounds to prevent bugs, in order of priority for being fixed:
     and not match("(gbTrace|stderr|stdio|(P|p)rint|<<)",      inputs) -- stderr and prints are not handled correctly
     and not match("(notify|stopIfError|debuggingMode)",       inputs) -- stopIfError and debuggingMode may be fixable
@@ -119,7 +119,6 @@ isCapturable = (inputs, pkg, isTest) -> (
     and not match("(addHook|export|newPackage)",              inputs) -- these commands have permanent effects
     and not match("(installMethod|installAssignmentMethod)",  inputs) -- same as above
     and not match("(Global.{6,7}Hook|StartFunction|Echo)",    inputs) -- same as above
-    and not match({"EngineTests", "ThreadedGB", "RunExternalM2"}, pkg#"pkgname") -- TODO: eventually remove
     )
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -96,6 +96,9 @@ protect symbol capture
 -- returns false if the inputs or the package are not known to behave well with capture
 -- this is also used in testing.m2, where isTest is set to true.
 isCapturable = (inputs, pkg, isTest) -> (
+    -- argumentMode is mainly used by ctest to select M2 subprocess arguments,
+    -- or whether capture should be avoided; see packages/CMakeLists.txt
+    if argumentMode & NoCapture =!= 0 then return false;
     -- strip commented segments first
     inputs = replace("--.*$", "",       inputs);
     inputs = replace("-\\*.*?\\*-", "", inputs);

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -119,7 +119,7 @@ isCapturable = (inputs, pkg, isTest) -> (
     and not match("(addHook|export|newPackage)",              inputs) -- these commands have permanent effects
     and not match("(installMethod|installAssignmentMethod)",  inputs) -- same as above
     and not match("(Global.{6,7}Hook|StartFunction|Echo)",    inputs) -- same as above
-    and not match({"ThreadedGB", "RunExternalM2"},     pkg#"pkgname") -- TODO: eventually remove
+    and not match({"EngineTests", "ThreadedGB", "RunExternalM2"}, pkg#"pkgname") -- TODO: eventually remove
     )
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -63,11 +63,12 @@ capture String := opts -> s -> if opts.UserMode then capture' s else (
     scan(flatten apply(loadedPackages, pkg -> pkg#"exported mutable symbols"), symb -> oldMutableVars#symb = value symb);
     -* see run.m2 for details of defaultMode, argumentMode, etc. *-
     -- TODO: somehow use SetUlimit, GCMAXHEAP, GCSTATS, GCVERBOSE,
-    --       ArgInt, ArgNoReadline, ArgNoSetup, and ArgNoThreads
+    --       ArgInt, ArgQ, ArgNoReadline, ArgNoSetup, and ArgNoThreads
     argmode := if 0 < argumentMode & InvertArgs then xor(defaultMode, argumentMode) else argumentMode;
     hasmode := m -> argmode & m == m;
     pushvar(symbol randomSeed, if hasmode ArgNoRandomize then 0 else randomSeed);
-    if hasmode ArgStop        then (stopIfError, debuggingMode) = (true, false);
+    -- FIXME: https://github.com/Macaulay2/M2/issues/1536#issuecomment-721826413
+    -- if hasmode ArgStop        then (stopIfError, debuggingMode) = (true, false);
     if hasmode ArgNoDebug     then debuggingMode = false;
     if hasmode ArgNoBacktrace then backtrace = false;
     if hasmode ArgNotify      then notify = true;
@@ -88,6 +89,7 @@ capture String := opts -> s -> if opts.UserMode then capture' s else (
     currentPackage = User;
 
     ret := capture' s;
+    collectGarbage();
 
     User#"private dictionary" = oldPrivateDictionary;
     -- TODO: this should eventually be unnecessary

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -85,7 +85,8 @@ capture String := opts -> s -> if opts.UserMode then capture' s else (
     if not hasmode ArgNoPreload then
     scan(Core#"pre-installed packages", needsPackage);
     needsPackage toString if opts#Package === null then currentPackage else opts#Package;
-    dictionaryPath = prepend(oldPrivateDictionary,      dictionaryPath); -- this is necessary mainly due to T from degreesMonoid
+    -- TODO: is this still necessary? If so, add a test in tests/normal/capture.m2
+    -- dictionaryPath = prepend(oldPrivateDictionary,      dictionaryPath); -- this is necessary mainly due to T from degreesMonoid
     dictionaryPath = prepend(User#"private dictionary", dictionaryPath); -- this is necessary mainly due to indeterminates.m2
     currentPackage = User;
 

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -67,12 +67,11 @@ capture String := opts -> s -> if opts.UserMode then capture' s else (
     argmode := if 0 < argumentMode & InvertArgs then xor(defaultMode, argumentMode) else argumentMode;
     hasmode := m -> argmode & m == m;
     pushvar(symbol randomSeed, if hasmode ArgNoRandomize then 0 else randomSeed);
-    -- FIXME: https://github.com/Macaulay2/M2/issues/1536#issuecomment-721826413
-    -- if hasmode ArgStop        then (stopIfError, debuggingMode) = (true, false);
-    if hasmode ArgNoDebug     then debuggingMode = false;
+    -- TODO: these two are overriden in interp.dd at the moment
+    --if hasmode ArgStop        then (stopIfError, debuggingMode) = (true, false);
+    --if hasmode ArgNoDebug     then debuggingMode = false;
     if hasmode ArgNoBacktrace then backtrace = false;
     if hasmode ArgNotify      then notify = true;
-    interpreterDepth = 1;
 
     oldPrivateDictionary := User#"private dictionary";
     User#"private dictionary" = new Dictionary;
@@ -183,9 +182,9 @@ storeExampleOutput = (pkg, fkey, outf, verboseLog) -> (
     else verboseLog("warning: missing file ", outf));
 
 -- used in installPackage.m2
-captureExampleOutput = (pkg, fkey, inputs, cacheFunc, inf, outf, errf, inputhash, changeFunc, usermode, verboseLog) -> (
+-- TODO: reduce the inputs to this function
+captureExampleOutput = (desc, inputs, pkg, cacheFunc, inf, outf, errf, data, inputhash, changeFunc, usermode) -> (
     stdio << flush; -- just in case previous timing information hasn't been flushed yet
-    desc := "example results for " | format fkey;
     -- try capturing in the same process
     if isCapturable(inputs, pkg, false) then (
 	desc = concatenate(desc, 62 - #desc);
@@ -194,10 +193,9 @@ captureExampleOutput = (pkg, fkey, inputs, cacheFunc, inf, outf, errf, inputhash
 	if not err then return outf << M2outputHash << inputhash << endl << output << close);
     -- fallback to using an external process
     stderr << commentize pad("making " | desc, 72) << flush;
-    data := if pkg#"example data files"#?fkey then pkg#"example data files"#fkey else {};
     inf << replace("-\\* no-capture-flag \\*-", "", inputs) << endl << close;
-    if runFile(inf, inputhash, outf, errf, pkg, changeFunc fkey, usermode, data)
-    then ( removeFile inf; cacheFunc fkey ))
+    if runFile(inf, inputhash, outf, errf, pkg, changeFunc, usermode, data)
+    then ( removeFile inf; cacheFunc() ))
 
 -----------------------------------------------------------------------------
 -- process examples

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -496,34 +496,37 @@ generateExampleResults := (pkg, rawDocumentationCache, exampleDir, exampleOutput
 	if m =!= null then value substring(m#1, f));
     changeFunc := fkey -> () -> remove(rawDocumentationCache, fkey);
 
-    possiblyCache := (outf, outf') -> fkey -> (
+    possiblyCache := (outf, outf', fkey) -> () -> (
 	if opts.CacheExampleOutput =!= false and pkgopts.CacheExampleOutput === true
 	and ( not fileExists outf' or fileExists outf' and fileTime outf > fileTime outf' ) then (
 	    verboseLog("caching example results for ", fkey, " in ", outf');
 	    if not isDirectory exampleDir then makeDirectory exampleDir;
 	    copyFile(outf, outf', Verbose => true)));
 
+    usermode := if opts.UserMode === null then not noinitfile else opts.UserMode;
     scan(pairs pkg#"example inputs", (fkey, inputs) -> (
 	    inpf  := inpfn  fkey; -- input file
 	    outf' := outfn' fkey; -- cached file
 	    outf  := outfn  fkey; -- output file
 	    errf  := errfn  fkey; -- error file
+	    desc  := "example results for " | format fkey;
+	    data  := if pkg#"example data files"#?fkey then pkg#"example data files"#fkey else {};
 	    inputhash := hash inputs;
 	    -- use cached example results
 	    if  not opts.RunExamples
 	    or  not opts.RerunExamples and fileExists outf  and gethash outf  === inputhash then (
-		(possiblyCache(outf, outf'))(fkey))
+		(possiblyCache(outf, outf', fkey))())
 	    -- use distributed example results
 	    else if pkgopts.UseCachedExampleOutput
 	    and not opts.RerunExamples and fileExists outf' and gethash outf' === inputhash then (
 		if fileExists errf then removeFile errf; copyFile(outf', outf))
 	    -- run and capture example results
 	    else elapsedTime captureExampleOutput(
-		pkg, fkey, demark_newline inputs,
-		possiblyCache(outf, outf'),
-		inpf, outf, errf,
-		inputhash, changeFunc,
-		if opts.UserMode === null then not noinitfile else opts.UserMode, verboseLog);
+		desc, demark_newline inputs, pkg,
+		possiblyCache(outf, outf', fkey),
+		inpf, outf, errf, data,
+		inputhash, changeFunc fkey,
+		usermode);
 	    storeExampleOutput(pkg, fkey, outf, verboseLog)));
 
     -- check for obsolete example output files and remove them

--- a/M2/Macaulay2/m2/orderedmonoidrings.m2
+++ b/M2/Macaulay2/m2/orderedmonoidrings.m2
@@ -41,7 +41,7 @@ expression PolynomialRing := R -> (
      if hasAttribute(R,ReverseDictionary) then return expression getAttribute(R,ReverseDictionary);
      k := last R.baseRings;
      T := if (options R).Local === true then List else Array;
-     (expression k) (new T from R.generatorExpressions)
+     (expression k) (new T from toSequence runLengthEncode R.generatorExpressions)
      )
 
 describe PolynomialRing := R -> (

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -54,6 +54,7 @@ ArgNotify      = 1 << 11 -* add --notify *-
 ArgSilent      = 1 << 12 -* add --silent *-
 ArgStop        = 1 << 13 -* add --stop *-
 ArgPrintWidth  = 1 << 14 -* add --print-width 77 *-
+ArgPrintWidthN = 77
 -- suffixes
 SetInputFile   = 1 << 30 -* add <inf *-
 SetOutputFile  = 1 << 31 -* add >>tmpf *-
@@ -113,7 +114,7 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
      cmd = cmd | readmode(ArgNotify,      "--notify");
      cmd = cmd | readmode(ArgSilent,      "--silent");
      cmd = cmd | readmode(ArgStop,        "--stop");
-     cmd = cmd | readmode(ArgPrintWidth,  "--print-width 77");
+     cmd = cmd | readmode(ArgPrintWidth,  "--print-width " | ArgPrintWidthN);
      cmd = cmd | concatenate apply(srcdirs, d -> (" --srcdir ", format d));
      -- TODO: fix capture, add preloaded packages to Macaulay2Doc, then delete the following two lines
      needsline := concatenate(" -e 'needsPackage(",format pkgname,",Reload=>true,FileName=>",format pkg#"source file",")'");

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -64,7 +64,7 @@ NoCapture      = 1 << 63 -* don't use capture *-
 InvertArgs     = 1 << 64 -* negate the effect of argumentMode *-
 
 -* by default, the following commandline fixtures are used *-
-defaultMode := (SetUlimit + GCMAXHEAP + ArgQ + ArgInt -- + ArgNoPreload
+defaultMode  = (SetUlimit + GCMAXHEAP + ArgQ + ArgInt -- + ArgNoPreload
     + ArgNoRandomize + ArgNoReadline + ArgSilent + ArgStop
     + ArgPrintWidth + SetInputFile + SetOutputFile + SetCaptureErr)
 -* making this global, so it can be edited after entering debug Core *-
@@ -116,7 +116,7 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
      cmd = cmd | readmode(ArgPrintWidth,  "--print-width 77");
      cmd = cmd | concatenate apply(srcdirs, d -> (" --srcdir ", format d));
      -- TODO: fix capture, add preloaded packages to Macaulay2Doc, then delete the following two lines
-     needsline := concatenate(" -e 'needsPackage(\"",pkgname,"\", Reload => true, FileName => \"",pkg#"source file","\")'");
+     needsline := concatenate(" -e 'needsPackage(",format pkgname,",Reload=>true,FileName=>",format pkg#"source file",")'");
      cmd = cmd | if pkgname != "Macaulay2Doc" then needsline else "";
      cmd = cmd | readmode(SetInputFile,   "<" | format inf);
      cmd = cmd | readmode(SetOutputFile,  ">>" | format toAbsolutePath tmpf);

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -34,30 +34,34 @@ runString = (teststring, pkg, usermode) -> (
     ret)
 
 -- prefixes
-SetUlimit      := 1 << 20 -* sets ulimits *-
-GCMAXHEAP      := 1 << 21 -* sets GC_MAXIMUM_HEAP_SIZE=400M *-
-GCSTATS        := 1 << 22 -* sets GC_PRINT_STATS=1 *-
-GCVERBOSE      := 1 << 23 -* sets GC_PRINT_VERBOSE_STATS=1 *-
+SetUlimit      = 1 << 20 -* sets ulimits *-
+GCMAXHEAP      = 1 << 21 -* sets GC_MAXIMUM_HEAP_SIZE=400M *-
+GCSTATS        = 1 << 22 -* sets GC_PRINT_STATS=1 *-
+GCVERBOSE      = 1 << 23 -* sets GC_PRINT_VERBOSE_STATS=1 *-
 -- arguments
-ArgQ           := 1 <<  0 -* add -q *-
-ArgInt         := 1 <<  1 -* add --int *-
-ArgNoBacktrace := 1 <<  2 -* add --no-backtrace *-
-ArgNoDebug     := 1 <<  3 -* add --no-debug *-
-ArgNoPreload   := 1 <<  4 -* add --no-preload *-
-ArgNoRandomize := 1 <<  5 -* add --no-randomize *-
-ArgNoReadline  := 1 <<  6 -* add --no-readline *-
-ArgNoSetup     := 1 <<  7 -* add --no-setup *-
-ArgNoThreads   := 1 <<  8 -* add --no-threads *-
-ArgNoTTY       := 1 <<  9 -* add --no-tty *-
-ArgNoTValues   := 1 << 10 -* add --no-tvalues *-
-ArgNotify      := 1 << 11 -* add --notify *-
-ArgSilent      := 1 << 12 -* add --silent *-
-ArgStop        := 1 << 13 -* add --stop *-
-ArgPrintWidth  := 1 << 14 -* add --print-width 77 *-
+ArgQ           = 1 <<  0 -* add -q *-
+ArgInt         = 1 <<  1 -* add --int *-
+ArgNoBacktrace = 1 <<  2 -* add --no-backtrace *-
+ArgNoDebug     = 1 <<  3 -* add --no-debug *-
+ArgNoPreload   = 1 <<  4 -* add --no-preload *-
+ArgNoRandomize = 1 <<  5 -* add --no-randomize *-
+ArgNoReadline  = 1 <<  6 -* add --no-readline *-
+ArgNoSetup     = 1 <<  7 -* add --no-setup *-
+ArgNoThreads   = 1 <<  8 -* add --no-threads *-
+ArgNoTTY       = 1 <<  9 -* add --no-tty *-
+ArgNoTValues   = 1 << 10 -* add --no-tvalues *-
+ArgNotify      = 1 << 11 -* add --notify *-
+ArgSilent      = 1 << 12 -* add --silent *-
+ArgStop        = 1 << 13 -* add --stop *-
+ArgPrintWidth  = 1 << 14 -* add --print-width 77 *-
 -- suffixes
-SetInputFile   := 1 << 30 -* add <inf *-
-SetOutputFile  := 1 << 31 -* add >>tmpf *-
-SetCaptureErr  := 1 << 32 -* add 2>&1 *-
+SetInputFile   = 1 << 30 -* add <inf *-
+SetOutputFile  = 1 << 31 -* add >>tmpf *-
+SetCaptureErr  = 1 << 32 -* add 2>&1 *-
+-- used by CMake to signal whether check should use capture
+NoCapture      = 1 << 63 -* don't use capture *-
+-- used by CMake to modify defaultMode rather than overriding it
+InvertArgs     = 1 << 64 -* negate the effect of argumentMode *-
 
 -* by default, the following commandline fixtures are used *-
 defaultMode := (SetUlimit + GCMAXHEAP + ArgQ + ArgInt -- + ArgNoPreload
@@ -83,8 +87,8 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
      rundir := temporaryFileName() | "-rundir/";
      makeDirectory rundir;
      -* The bits in the binary representation of argmode determine arguments to add.
-        If the 64th bit is set, argumentMode modifies the defaultMode rather than overriding them. *-
-     argmode := if 0 < argumentMode & (1<<64) then xor(defaultMode, argumentMode) else argumentMode;
+        If InvertArgs is set, argumentMode modifies the defaultMode rather than overriding them. *-
+     argmode := if 0 < argumentMode & InvertArgs then xor(defaultMode, argumentMode) else argumentMode;
      -* returns (" "|arg) if all bits in m are set in argmode *-
      readmode := (m, arg) -> if argmode & m == m then " " | arg else "";
      cmd := readmode(SetUlimit, ulimit);

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -25,19 +25,6 @@ TEST(String, String) := (title, teststring) -> (
 -- check
 -----------------------------------------------------------------------------
 
--- returns false if the inputs or the package are not known to behave well with capture
--- also see the one in examples.m2
-isCapturableTest := (inputs, pkg) -> (
-    not match("no-capture-flag", inputs) -- this flag is really necessary, but only sometimes
-    -- FIXME: these are workarounds to prevent bugs, in order of priority for being fixed:
-    and not match("(end|exit|restart)",                       inputs) -- these commands interrupt the interpreter
-    and not match("(gbTrace|read|run|stderr|stdio|print|<<)", inputs) -- stderr and prints are not handled correctly
-    and not match("([Cc]ommand|schedule|thread|Task)",        inputs) -- remove when threads work more predictably
-    and not match("(installMethod|load|export|newPackage)",   inputs) -- exports may land in the package User
-    and not match("(GlobalAssignHook|GlobalReleaseHook)",     inputs) -- same as above
-    and not match({"ThreadedGB", "RunExternalM2"},     pkg#"pkgname") -- TODO: eventually remove
-    )
-
 checkMessage := (verb, n, pkgname, filename, lineno) -> (
     stderr
     << commentize(verb, " check(", toString n, ", ", format pkgname, ") from source:") << endl
@@ -47,7 +34,7 @@ captureTestResult := (n, pkg, usermode) -> (
     stdio << flush; -- just in case previous timing information hasn't been flushed yet
     (filename, lineno, teststring) := pkg#"test inputs"#n;
     -- try capturing in the same process
-    if isCapturableTest(teststring, pkg) then (
+    if isCapturable(teststring, pkg, true) then (
 	checkMessage("capturing", n, pkg#"pkgname", filename, lineno);
 	(err, output) := capture(teststring, UserMode => false, Package => pkg);
 	if err then printerr "capture failed; trying again in an external process ..." else return true);

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -25,21 +25,15 @@ TEST(String, String) := (title, teststring) -> (
 -- check
 -----------------------------------------------------------------------------
 
-checkMessage := (verb, n, pkgname, filename, lineno) -> (
-    stderr
-    << commentize(verb, " check(", toString n, ", ", format pkgname, ") from source:") << endl
-    << pad("   " | filename | ":" | lineno - 1 | ":1:", 76)                            << flush)
-
-captureTestResult := (n, pkg, usermode) -> (
+captureTestResult := (desc, teststring, pkg, usermode) -> (
     stdio << flush; -- just in case previous timing information hasn't been flushed yet
-    (filename, lineno, teststring) := pkg#"test inputs"#n;
     -- try capturing in the same process
     if isCapturable(teststring, pkg, true) then (
-	checkMessage("capturing", n, pkg#"pkgname", filename, lineno);
-	(err, output) := capture(teststring, UserMode => usermode, Package => pkg);
-	if err then printerr "capture failed; trying again in an external process ..." else return true);
+	stderr << commentize pad("capturing " | desc, 72) << flush;
+	(err, output) := capture(teststring, Package => pkg, UserMode => usermode);
+	if err then printerr "capture failed; retrying in a subprocess ..." else return true);
     -- fallback to using an external process
-    checkMessage("running", n, pkg#"pkgname", filename, lineno);
+    stderr << commentize pad("running " | desc, 72) << flush;
     runString(teststring, pkg, usermode))
 
 check = method(Options => {UserMode => null, Verbose => false})
@@ -49,26 +43,24 @@ check Package := opts -> pkg -> check(-1, pkg, opts)
 check(ZZ, String)  := opts -> (n, pkg) -> check(n, needsPackage (pkg, LoadDocumentation => true), opts)
 check(ZZ, Package) := opts -> (n, pkg) -> (
     if not pkg.Options.OptionalComponentsPresent then (
-        stderr << "--warning: optional components required for " <<
-            toString pkg << " tests are not present; skipping" << endl;
-        return);
+	printerr("warning: optional components required for ", toString pkg, " tests are not present; skipping"); return);
+    usermode := if opts.UserMode === null then not noinitfile else opts.UserMode;
     --
     use pkg;
     if pkg#?"documentation not loaded" then pkg = loadPackage(pkg#"pkgname", LoadDocumentation => true, Reload => true);
+    tests := if n == -1 then toList(0 .. pkg#"test number" - 1) else {n};
     --
     errorList := {};
     (hadError, numErrors) = (false, 0);
-    scan(if n == -1 then keys pkg#"test inputs" else {n}, k -> (
-            ret := elapsedTime captureTestResult(k, pkg, if opts.UserMode === null then not noinitfile else opts.UserMode);
-            if ret then errorList = append(errorList, k)));
-    if hadError then error("test", if numErrors > 1 then "s" else "",
-        " #", demark(", ", toString \ errorList),
-        " of package ", toString pkg, " failed",
-        if opts.Verbose then (
-            numTests := if n == -1 then pkg#"test number" else 1;
-            ":" | newline |
-            concatenate(apply(if n == -1 then errorList else {0}, k ->
-                newline | get("!tail " | temporaryDirectory() |
-                toString(temporaryFilenameCounter + 2 * (k - numTests)) |
-                ".tmp")))
-        ) else "");)
+    scan(tests, k -> (
+	    (filename, lineno, teststring) := pkg#"test inputs"#k;
+	    desc := "check(" | toString k | ", " | format pkg#"pkgname" | ")";
+	    ret := elapsedTime captureTestResult(desc, teststring, pkg, usermode);
+	    if not ret then errorList = append(errorList, k)));
+    outfile := k -> temporaryDirectory() | toString(temporaryFilenameCounter + 2 * (k - #tests - min tests)) | ".tmp";
+    if hadError then (
+	if opts.Verbose then apply(errorList, k -> (
+		(filename, lineno, teststring) := pkg#"test inputs"#k;
+		stderr << filename << ":" << lineno - 1 << ":1: error:" << endl;
+		printerr get("!tail " | outfile k)));
+	error("test(s) #", demark(", ", toString \ errorList), " of package ", toString pkg, " failed.")))

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -36,7 +36,7 @@ captureTestResult := (n, pkg, usermode) -> (
     -- try capturing in the same process
     if isCapturable(teststring, pkg, true) then (
 	checkMessage("capturing", n, pkg#"pkgname", filename, lineno);
-	(err, output) := capture(teststring, UserMode => false, Package => pkg);
+	(err, output) := capture(teststring, UserMode => usermode, Package => pkg);
 	if err then printerr "capture failed; trying again in an external process ..." else return true);
     -- fallback to using an external process
     checkMessage("running", n, pkg#"pkgname", filename, lineno);

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -56,11 +56,12 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
 	    (filename, lineno, teststring) := pkg#"test inputs"#k;
 	    desc := "check(" | toString k | ", " | format pkg#"pkgname" | ")";
 	    ret := elapsedTime captureTestResult(desc, teststring, pkg, usermode);
-	    if not ret then errorList = append(errorList, k)));
-    outfile := k -> temporaryDirectory() | toString(temporaryFilenameCounter + 2 * (k - #tests - min tests)) | ".tmp";
+	    if not ret then errorList = append(errorList,
+		 (k, temporaryFilenameCounter - 2))));
+    outfile := k -> temporaryDirectory() | toString k | ".tmp";
     if hadError then (
-	if opts.Verbose then apply(errorList, k -> (
+	if opts.Verbose then apply(last \ errorList, k -> (
 		(filename, lineno, teststring) := pkg#"test inputs"#k;
 		stderr << filename << ":" << lineno - 1 << ":1: error:" << endl;
 		printerr get("!tail " | outfile k)));
-	error("test(s) #", demark(", ", toString \ errorList), " of package ", toString pkg, " failed.")))
+	error("test(s) #", demark(", ", toString \ first \ errorList), " of package ", toString pkg, " failed.")))

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -31,7 +31,7 @@ captureTestResult := (desc, teststring, pkg, usermode) -> (
     if isCapturable(teststring, pkg, true) then (
 	stderr << commentize pad("capturing " | desc, 72) << flush;
 	(err, output) := capture(teststring, Package => pkg, UserMode => usermode);
-	if err then printerr "capture failed; retrying in a subprocess ..." else return true);
+	if err then printerr "capture failed; retrying ..." else return true);
     -- fallback to using an external process
     stderr << commentize pad("running " | desc, 72) << flush;
     runString(teststring, pkg, usermode))

--- a/M2/Macaulay2/packages/CMakeLists.txt
+++ b/M2/Macaulay2/packages/CMakeLists.txt
@@ -39,8 +39,8 @@ set(CheckDocumentation       "true" CACHE STRING "check documentation for comple
 set(IgnoreExampleErrors     "false" CACHE STRING "ignore errors in example code")
 set(RemakeAllDocumentation  "false" CACHE STRING "remake all documentation")
 set(RerunExamples           "false" CACHE STRING "rerun example outpuat files")
-## Arguments to the M2 subprocess that runs individual tests and exampels; see runFile in m2/html.m2
-set(ArgumentMode "(1<<31)|(1<<32)|(1<<64)" # |(1<<8) for --no-threads
+## Arguments to the M2 subprocess that runs individual tests and exampels; see runFile in m2/run.m2
+set(ArgumentMode "InvertArgs|SetOutputFile|SetCaptureErr|NoCapture" # |ArgNoThreads for --no-threads
   CACHE INTERNAL "bitmask for ctest check arguments")
 
 # Allow arguments above to be set via environment variables

--- a/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
@@ -910,7 +910,7 @@ document { Key => FunctionBody,
      Headline => "the class of function bodies",
      SeeAlso => functionBody }
 
-document { Key => OutputDictionary,
+document { Key => symbol OutputDictionary,
      Headline => "the dictionary for output values",
      "The symbols ", TT "o1", ", ", TT "o2", ", ", TT "o3", ", etc., are used to store the output values arising from interaction with the user,
      one line at a time.  The dictionary ", TT "OutputDictionary", " is the dictionary in which those symbols reside.",

--- a/M2/Macaulay2/packages/MinimalPrimes.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes.m2
@@ -423,10 +423,11 @@ setAmbientField(Ring, Ring) := (KR, RU) -> (
     )
 
 -- TODO: what does factors f do? is this always correct, or only for the purposes of MinimalPrimes
-mySat = (I, f) -> saturate(I, f, Strategy => Factorization)
+--mySat = (I, f) -> saturate(I, f, Strategy => Factorization)
+mySat = (I, f) -> saturate(I, last \ factors f)
 -- TODO: if this is always correct, move it to Saturation
 -- Note: if it is the default strategy, it can lead to infinite loops
-addHook((saturate, Ideal, RingElement), (opts, I, f) -> saturate(I, last \ factors f, opts), Strategy => Factorization)
+--addHook((saturate, Ideal, RingElement), (opts, I, f) -> saturate(I, last \ factors f, opts), Strategy => Factorization)
 
 -- needs documentation
 factors = method()

--- a/M2/Macaulay2/packages/Polyhedra/documentation/intro.m2
+++ b/M2/Macaulay2/packages/Polyhedra/documentation/intro.m2
@@ -15,7 +15,7 @@ document {
 	
 	PARA{}, TT "Polyhedra", " uses the ",
    UL {
-      {TO FourierMotzkin, " package by ", HREF("http://www.mast.queensu.ca/~ggsmith", "Gregory G. Smith")},
+      { TO "FourierMotzkin", " package by ", HREF("http://www.mast.queensu.ca/~ggsmith", "Gregory G. Smith")},
       { TO "FourTiTwo", " package by ", HREF("http://pi.math.cornell.edu/~mike/", "Michael Stillman"),", ", HREF("http://people.math.gatech.edu/~jyu67/", "Josephine Yu"), ", and ",
       HREF("http://math.iit.edu/~spetrov1/", "Sonja Petrovic")},
       { TO "Topcom", " package by ",  HREF("http://pi.math.cornell.edu/~mike/", "Michael Stillman"), "."}

--- a/M2/Macaulay2/tests/normal/capture.m2
+++ b/M2/Macaulay2/tests/normal/capture.m2
@@ -8,16 +8,25 @@ i1 :  << id_(ZZ^0) << id_(ZZ^3) << id_(ZZ^2) << id_(ZZ^1);
  | 0 1 0 || 0 1 |
  | 0 0 1 |
 i2 : \n")
+(err, out) = capture("K = ZZ/101\nA = matrix\"1,2,3,4;1,3,6,10;19,7,11,13\" ** oo", UserMode => false);
+-*
+-- FIXME:
+assert(not err and match(regexQuote "
+i1 : K = ZZ/101\n\no1 = K\n\no1 : QuotientRing\n
+i2 : A = matrix\"1,2,3,4;1,3,6,10;19,7,11,13\" ** oo\n
+o2 = | 1  2 3  4  |
+     | 1  3 6  10 |
+     | 19 7 11 13 |\n
+             3       4
+o2 : Matrix K  <--- K\n" | ".*", out))
+*-
 
 -- printing errors
 (err, out) = capture "1/0"
 assert(err and match("\\A\ni1 : 1/0\ncurrentString:1:2:\\(3\\):\\[.\\]: error: division by zero\n\\Z", out))
 
--- FIXME:
+-- make sure runaway existing private symbols are not changed
+-- TODO: how can we prevent new methods or hooks from escaping capture?
 assert(instance(K, Symbol))
 capture("K = ZZ/3", UserMode => false);
---assert(instance(K, Symbol))
-
--- FIXME
-last capture("K = ZZ/101\nA = matrix\"1,2,3,4;1,3,6,10;19,7,11,13\" ** oo", UserMode => false)
-
+assert(instance(K, Symbol))

--- a/M2/Macaulay2/tests/normal/capture.m2
+++ b/M2/Macaulay2/tests/normal/capture.m2
@@ -11,7 +11,7 @@ i2 : \n")
 
 -- printing errors
 (err, out) = capture "1/0"
-assert(err and out == "\ni1 : 1/0\ncurrentString:1:2:(3):[3]: error: division by zero\n")
+assert(err and match("\\A\ni1 : 1/0\ncurrentString:1:2:\\(3\\):\\[.\\]: error: division by zero\n\\Z", out))
 
 -- FIXME:
 assert(instance(K, Symbol))

--- a/M2/Macaulay2/tests/normal/capture.m2
+++ b/M2/Macaulay2/tests/normal/capture.m2
@@ -1,0 +1,23 @@
+-- See https://github.com/Macaulay2/M2/issues/1689
+
+-- printing nets
+(err, out) = capture " << id_(ZZ^0) << id_(ZZ^3) << id_(ZZ^2) << id_(ZZ^1);"
+assert(not err and out == "
+i1 :  << id_(ZZ^0) << id_(ZZ^3) << id_(ZZ^2) << id_(ZZ^1);
+0| 1 0 0 || 1 0 || 1 |
+ | 0 1 0 || 0 1 |
+ | 0 0 1 |
+i2 : \n")
+
+-- printing errors
+(err, out) = capture "1/0"
+assert(err and out == "\ni1 : 1/0\ncurrentString:1:2:(3):[3]: error: division by zero\n")
+
+-- FIXME:
+assert(instance(K, Symbol))
+capture("K = ZZ/3", UserMode => false);
+--assert(instance(K, Symbol))
+
+-- FIXME
+last capture("K = ZZ/101\nA = matrix\"1,2,3,4;1,3,6,10;19,7,11,13\" ** oo", UserMode => false)
+


### PR DESCRIPTION
Previously, we computed the filename of the temporary file containing
the output of failing tests based on the number of the test itself in
relation to the total number of tests being run.  However, now that
"capture" is used for testing, this will no longer work, as temporary
files are not always created, and the temporary filename counter will
not be incremented in a predictable manner.

Instead, we store the location of the temporary file immediately after
the test is run.  In particular, the local variable "errorList" now
contains tuples of the form "(test number, temporary file number)".