### PR TITLE
Use toExternalString for entries in (describe, Matrix)

### DIFF
--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -233,7 +233,7 @@ texMath Matrix := m -> texMath expression m
 describe Matrix := m -> (
     args:=(describe target m,describe source m);
     if m.?RingMap then args=append(args,describe m.RingMap);
-    args=append(args,expression if m == 0 then 0 else entries m);
+    args=append(args,expression if m == 0 then 0 else toExternalString \ entries m);
     if not all(degree m,zero) then args=append(args,expression(Degree=>degree m));
     Describe (expression map) args
     )

--- a/M2/Macaulay2/tests/ComputationsBook/programming/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/programming/test.out.expected
@@ -329,7 +329,7 @@ o65 = matrix {{x, y, z}}
 
 i66 : toExternalString vars R
 
-o66 = map(R^1,R^{{-1}, {-1}, {-1}},{{x, y, z}})
+o66 = map(R^1,R^{{-1}, {-1}, {-1}},{{x,y,z}})
 
 i67 : R = QQ[x,y,z]/(x^3-y)
 


### PR DESCRIPTION
Previously, there may not have been enough information about the
entries, which caused problems with generateAssertions.

Closes: #1642