### PR TITLE
"assert" improvements

### DIFF
--- a/M2/Macaulay2/m2/basictests/W02-threads.m2
+++ b/M2/Macaulay2/m2/basictests/W02-threads.m2
@@ -1,3 +1,5 @@
+assert = x -> if not x then error "assertion failed"
+
 assert( getGlobalSymbol "stopIfError" === symbol stopIfError )
 threadVariable foo
 assert( getGlobalSymbol "foo" === symbol foo )

--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -64,6 +64,12 @@ expressionValue Symbol := value
 
 value Expression := expressionValue
 
+assert Expression := v -> (
+    val := value v;
+    if not instance(val, Boolean) then error "assert: expected true or false";
+    if not val then error toString("assertion failed:" || net v | " is false")
+)
+
 --Holder2 = new WrapperType of Expression			    -- Holder{ printable form, value form }
 --Holder2.synonym = "holder"
 --Holder = new WrapperType of Holder2			    -- Holder{ printable form, value form }, with printable form === value form

--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -470,7 +470,13 @@ binaryOperatorFunctions := new HashTable from {
      symbol != => ((x,y) -> x != y),
      symbol and => ((x,y) -> x and y),
      symbol or => ((x,y) -> x or y),
-     symbol ^** => ((x,y) -> x^**y)
+     symbol ^** => ((x,y) -> x^**y),
+     symbol === => ((x,y) -> x === y),
+     symbol =!= => ((x,y) -> x =!= y),
+     symbol < => ((x,y) -> x < y),
+     symbol <= => ((x,y) -> x <= y),
+     symbol > => ((x,y) -> x > y),
+     symbol >= => ((x,y) -> x >= y)
      }
 
 expressionBinaryOperators =

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -1,9 +1,9 @@
 --		Copyright 1993-2002 by Daniel R. Grayson
 
 -- temporary definitions to get error messages to work before methods are working, so we can debug methods
-assert( class between === Symbol )
+assert'( class between === Symbol )
 between = (m,v) -> mingle(v,#v-1:m)			    -- provisional
-assert( class toString === Symbol )
+assert'( class toString === Symbol )
 toString = x -> (					    -- provisional
      if hasAttribute(x,ReverseDictionary) then simpleToString getAttribute(x,ReverseDictionary)
      else if class x === Net then concatenate between("\n",unstack x)
@@ -686,6 +686,10 @@ exp RingElement := RingElement => r -> (
 	       if rn == 0 then break e;
 	       e = e + rn;
 	       )))
+
+-- assert
+assert = method()
+assert Thing := x -> assert' x
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -16,12 +16,12 @@ firstTime := class PackageDictionary === Symbol
 
 if firstTime then (
      -- we do this bit *before* "debug Core", so that Core (the symbol, not the package), which may not be there yet, ends up in the right dictionary
-     assert = x -> (
+     assert' = x -> (
 	  if class x =!= Boolean then error "assert: expected true or false";
 	  if not x then error "assertion failed");
      PackageDictionary = new Dictionary;
      dictionaryPath = append(dictionaryPath,PackageDictionary);
-     assert( not isGlobalSymbol "Core" );
+     assert'( not isGlobalSymbol "Core" );
      PackageDictionary#("Package$Core") = getGlobalSymbol(PackageDictionary,"Core");
      ) 
 -- we can't make this an else-clause, because then "Core" will be in the wrong dictionary

--- a/M2/Macaulay2/packages/Macaulay2Doc/debugging.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/debugging.m2
@@ -307,16 +307,36 @@ document {
      SeeAlso => {"lookup"}
      }
 
-document {
-     Key => assert,
-     Headline => "assert something is true",
-	   Usage => "assert x",
-     TT "assert x", " prints an error message if x isn't true.",
-     EXAMPLE lines ///
-     assert( (2+2) === 4 )
-     ///,
-     SeeAlso => {"generateAssertions"}
-     }
+doc ///
+  Key
+    assert
+    (assert, Thing)
+    (assert, Expression)
+  Headline
+    assert something is true
+  Usage
+    assert x
+  Inputs
+    x:Thing
+  Description
+    Text
+      @TT "assert x"@ prints an error message if @TT "x"@ isn't true.
+    CannedExample
+      i1 : assert( (2+2) === 4)
+
+      i2 : assert(rank matrix {{1, 2}, {2, 4}} == 2)
+      stdio:2:1:(3): error: assertion failed
+    Text
+      If @TT "x"@ is an @TO Expression@ that evaluates to false, then
+      a partially evaluated form is printed with the error message to
+      assist in debugging.
+    CannedExample
+      i3 : assert Equation(rank matrix {{1, 2}, {2, 4}}, 2)
+      stdio:3:1:(3): error: assertion failed:
+      1 == 2 is false
+  SeeAlso
+    generateAssertions
+///
 
 document {
      Key => notImplemented,

--- a/M2/Macaulay2/tests/normal/assert-expression.m2
+++ b/M2/Macaulay2/tests/normal/assert-expression.m2
@@ -1,0 +1,10 @@
+assert Equation(2 + 2, 4)
+assert not Equation(2 + 2, 5)
+assert BinaryOperation {symbol <, 1, 3}
+assert BinaryOperation {symbol <=, 1, 3}
+assert BinaryOperation {symbol >, 3, 1}
+assert BinaryOperation {symbol >=, 3, 1}
+assert BinaryOperation {symbol ===, 2, 2}
+assert BinaryOperation {symbol =!=, 2, 2.0}
+assert(hold true and true)
+assert(hold true or false)

--- a/M2/Macaulay2/tests/normal/timing-quotient.m2
+++ b/M2/Macaulay2/tests/normal/timing-quotient.m2
@@ -213,11 +213,11 @@ tim = timing(jacW : comp1); -- recomputes the same GB 150 times in 1.8.  We want
 -- version 1.7: 0.15 seconds
 -- version 1.8: 17.5 seconds
 -- after fix: .166 seconds
-assert(numgens tim#1 == 33)
-assert(tim#0 < .5 * standardSecond)
+assert Equation(numgens tim#1, 33)
+assert BinaryOperation {symbol <, tim#0, .5 * standardSecond}
 
 P=QQ[x,y,z,MonomialOrder=>Lex];
 d=z^4+z^2*x*y^9+z*x^9*y+x^5*y^5;
 phi=map(P,P,matrix{{x^13*y^4,x^3*y,x^20*y^6*z}});
 tim = timing factor(phi(d));
-assert(tim#0 < .05 * standardSecond)
+assert BinaryOperation {symbol <, tim#0, .05 * standardSecond}


### PR DESCRIPTION
We convert `assert` into a method and add `(assert, BinaryOperation)` with various wrappers for more informative error messages.  For example:

```m2
i1 : assertEqual(2 + 2, 5)
stdio:1:1:(3): error: assertion failed:
4==5 is false

i2 : assertGreaterThan(rank matrix{{1, 2}, {2, 4}}, 2)
stdio:2:1:(3): error: assertion failed:
1>2 is false
```

Still to do:

- [x] Documentation
- [x] Unit tests
- [x] Convert some existing tests as a proof of concept

Closes: #1736