### PR TITLE
install libraries and programs from brew

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -159,11 +159,15 @@ jobs:
         if: matrix.build-system == 'autotools'
         run: |
           # Use the libraries and programs built by CMake
-          export      CPPFLAGS=-I./usr-host/include
-          export       LDFLAGS=-L./usr-host/lib
-          export PKG_CONFIG_PATH=./usr-host/lib/pkgconfig:$PKG_CONFIG_PATH
+          # Compare with M2/BUILD/mahrud/Makefile
+          # Set the path to the CMake build directory here
+          export CMAKE_BUILD_DIR=`pwd`
+          export      CPPFLAGS=-I$CMAKE_BUILD_DIR/usr-host/include
+          export       LDFLAGS=-L$CMAKE_BUILD_DIR/usr-host/lib
+          export PKG_CONFIG_PATH=$CMAKE_BUILD_DIR/usr-host/lib/pkgconfig:$PKG_CONFIG_PATH
           # TODO: perhaps store the distribution architecture to a file
-          export            PATH=./usr-dist/`basename usr-dist/x*`/libexec/Macaulay2/bin:$PATH
+          export  ARCH=`basename $CMAKE_BUILD_DIR/usr-dist/x*`
+          export            PATH=$CMAKE_BUILD_DIR/usr-dist/$ARCH/libexec/Macaulay2/bin:$PATH
 
           make -C ../.. get-libtool get-automake get-autoconf
           make -C ../.. all

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -219,6 +219,7 @@ jobs:
            path: |
              # Autotools
              M2/BUILD/build/config.log
+             M2/BUILD/build/include/*
              M2/BUILD/build/libraries/*/build/*/config.log
              # CMake
              M2/BUILD/build/CMakeFiles/CMakeCache.txt

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -119,7 +119,7 @@ jobs:
           fi
 
       - uses: actions/cache@v2
-        if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
+        if: matrix.build-system == 'cmake'
         id: restore-cache
         with:
           path: |
@@ -137,7 +137,7 @@ jobs:
 # ----------------------
 
       - name: Configure Macaulay2 using CMake
-        if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
+        if: matrix.build-system == 'cmake'
         run: |
           cmake -S../.. -B. -GNinja \
             -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_NATIVE=OFF \
@@ -145,12 +145,9 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr
 
       - name: Build libraries using Ninja
-        if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
+        if: matrix.build-system == 'cmake'
         run: |
           cmake --build . --target build-libraries build-programs
-          # TODO: perhaps store the distribution architecture in a file
-          export ARCH=`basename usr-dist/x*`
-          echo "`pwd`/usr-dist/$ARCH/libexec/Macaulay2/bin" >> $GITHUB_PATH
 
       - name: Build Macaulay2 using Ninja
         if: matrix.build-system == 'cmake'
@@ -169,14 +166,6 @@ jobs:
       - name: Configure Macaulay2 using Autotools
         if: matrix.build-system == 'autotools'
         run: |
-          # Use the libraries and programs built by CMake
-          # Compare with M2/BUILD/mahrud/Makefile
-          # Set the path to the CMake build directory here
-          export CMAKE_BUILD_DIR=`pwd`
-          export      CPPFLAGS=-I$CMAKE_BUILD_DIR/usr-host/include
-          export       LDFLAGS=-L$CMAKE_BUILD_DIR/usr-host/lib
-          export PKG_CONFIG_PATH=$CMAKE_BUILD_DIR/usr-host/lib/pkgconfig:$PKG_CONFIG_PATH
-
           make -C ../.. get-libtool get-automake get-autoconf
           make -C ../.. all
           ../../configure --enable-download

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -51,8 +51,8 @@ jobs:
           - build-system: cmake
             os: ubuntu-latest
             compiler: clang10
-            cxx: clang++
-            cc: clang
+            cxx: clang++-10
+            cc: clang-10
           # This build tests Clang rather than AppleClang (keep)
           - build-system: cmake
             os: macos-latest

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -112,7 +112,7 @@ jobs:
           fi
 
       - uses: actions/cache@v2
-        if: matrix.build-system == 'cmake' # TODO: remove when autotools is more efficient with space
+#        if: matrix.build-system == 'cmake' # TODO: remove when autotools is more efficient with space
         id: restore-cache
         with:
           path: |
@@ -130,14 +130,14 @@ jobs:
 # ----------------------
 
       - name: Configure Macaulay2 using CMake
-        if: matrix.build-system == 'cmake'
+#        if: matrix.build-system == 'cmake'
         run: |
           cmake -S../.. -B. -GNinja \
             -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` \
             -DBUILD_NATIVE=OFF -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK" # TODO: remove when the packages are updated
 
       - name: Build libraries using Ninja
-        if: matrix.build-system == 'cmake' # && steps.restore-cache.outputs.cache-hit != 'true'
+#        if: matrix.build-system == 'cmake' # && steps.restore-cache.outputs.cache-hit != 'true'
         run: |
           cmake --build . --target build-libraries build-programs
 
@@ -158,6 +158,13 @@ jobs:
       - name: Configure Macaulay2 using Autotools
         if: matrix.build-system == 'autotools'
         run: |
+          # Use the libraries and programs built by CMake
+          export      CPPFLAGS=-I./usr-host/include
+          export       LDFLAGS=-L./usr-host/lib
+          export PKG_CONFIG_PATH=./usr-host/lib/pkgconfig:$PKG_CONFIG_PATH
+          # TODO: perhaps store the distribution architecture to a file
+          export            PATH=./usr-dist/`basename usr-dist/x*`/libexec/Macaulay2/bin:$PATH
+
           make -C ../.. get-libtool get-automake get-autoconf
           make -C ../.. all
           ../../configure --enable-download

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -51,8 +51,8 @@ jobs:
           - build-system: cmake
             os: ubuntu-latest
             compiler: clang10
-            cxx: clang++-10
-            cc: clang-10
+            cxx: clang++
+            cc: clang
           # This build tests Clang rather than AppleClang (keep)
           - build-system: cmake
             os: macos-latest

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -54,11 +54,15 @@ jobs:
             cxx: clang++-10
             cc: clang-10
           # This build tests Clang rather than AppleClang (keep)
-          #- build-system: cmake
-          #  os: macos-latest
-          #  compiler: clang10
-          #  cxx: clang++
-          #  cc: clang
+          - build-system: cmake
+            os: macos-latest
+            compiler: clang10
+            cxx: clang++
+            cc: clang
+        exclude:
+          - build-system: cmake
+            os: macos-latest
+            compiler: default
 
     steps:
       - uses: actions/checkout@v2
@@ -133,8 +137,7 @@ jobs:
         if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
         run: |
           cmake -S../.. -B. -GNinja \
-            -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` \
-            -DBUILD_NATIVE=OFF # -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK" # TODO: remove when the packages are updated
+            -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` -DBUILD_NATIVE=OFF
 
       - name: Build libraries using Ninja
         if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -92,10 +92,9 @@ jobs:
           sudo apt-get install -y -q --no-install-recommends libatomic-ops-dev libboost-stacktrace-dev \
                   libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev liblapack-dev libxml2-dev \
                   libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libntl-dev gfan \
-                  libcdd-dev libgivaro-dev libboost-regex-dev fflas-ffpack w3c-markup-validator \
-                  cohomcalg libflint-dev libmps-dev topcom \
-                  libsingular-dev libfrobby-dev libgtest-dev libmemtailor-dev libmathic-dev \
-                  libmathicgb-dev 4ti2 normaliz coinor-csdp nauty lrslib singular-data
+                  libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
+                  libsingular-dev singular-data libmemtailor-dev libmathic-dev libmathicgb-dev libcdd-dev \
+                  cohomcalg topcom 4ti2 normaliz coinor-csdp nauty lrslib w3c-markup-validator
 
 # ----------------------
 #   Steps common to all build variants
@@ -137,12 +136,17 @@ jobs:
         if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
         run: |
           cmake -S../.. -B. -GNinja \
-            -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` -DBUILD_NATIVE=OFF
+            -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_NATIVE=OFF \
+            -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` \
+            -DCMAKE_INSTALL_PREFIX=/usr
 
       - name: Build libraries using Ninja
         if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
         run: |
           cmake --build . --target build-libraries build-programs
+          # TODO: perhaps store the distribution architecture in a file
+          export ARCH=`basename usr-dist/x*`
+          echo "`pwd`/usr-dist/$ARCH/libexec/Macaulay2/bin" >> $GITHUB_PATH
 
       - name: Build Macaulay2 using Ninja
         if: matrix.build-system == 'cmake'
@@ -168,9 +172,6 @@ jobs:
           export      CPPFLAGS=-I$CMAKE_BUILD_DIR/usr-host/include
           export       LDFLAGS=-L$CMAKE_BUILD_DIR/usr-host/lib
           export PKG_CONFIG_PATH=$CMAKE_BUILD_DIR/usr-host/lib/pkgconfig:$PKG_CONFIG_PATH
-          # TODO: perhaps store the distribution architecture to a file
-          export  ARCH=`basename $CMAKE_BUILD_DIR/usr-dist/x*`
-          export            PATH=$CMAKE_BUILD_DIR/usr-dist/$ARCH/libexec/Macaulay2/bin:$PATH
 
           make -C ../.. get-libtool get-automake get-autoconf
           make -C ../.. all

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -79,7 +79,8 @@ jobs:
           brew install autoconf automake bison ccache cmake gnu-tar libtool make ninja pkg-config yasm
           brew install bdw-gc boost eigen gdbm readline libatomic_ops libxml2 libomp tbb
           brew install gmp mpfr ntl flint@2.6.3 factory@4.1.3 cddlib@0.94k glpk
-          brew install frobby mpsolve memtailor mathic mathicgb givaro fflas-ffpack
+          # TODO: add frobby once it doesn't break autotools
+          brew install mpsolve memtailor mathic mathicgb givaro fflas-ffpack
           brew install 4ti2 cohomcalg csdp gfan lrs nauty normaliz topcom
 
 # ----------------------
@@ -107,7 +108,6 @@ jobs:
         run: |
           echo "CC=${{ matrix.cc }}" >> $GITHUB_ENV
           echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=`brew --prefix`/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           if [[ "${{ runner.os }}" == "Linux" ]]
           then echo "/usr/lib/ccache" >> $GITHUB_PATH
                # ccache doesn't seem to create the right symlink for clang-10 on ubuntu
@@ -138,9 +138,11 @@ jobs:
       - name: Configure Macaulay2 using CMake
         if: matrix.build-system == 'cmake'
         run: |
+          deps=`brew deps --1 --include-optional macaulay2 | tr '\n' ';'`
+          paths=$HOMEBREW_PREFIX/${deps//;/;$HOMEBREW_PREFIX/}
           cmake -S../.. -B. -GNinja \
             -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_NATIVE=OFF \
-            -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` \
+            -DCMAKE_PREFIX_PATH=$paths \
             -DCMAKE_INSTALL_PREFIX=/usr
 
       - name: Build libraries using Ninja

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -76,12 +76,11 @@ jobs:
         run: |
           brew config
           brew tap mahrud/tap
-          # autoconf, libtool are already in the virtual env
-          brew install automake ccache gnu-tar make ninja pkg-config yasm
-          brew install bdw-gc boost eigen glpk libatomic_ops libomp mpfr mpir ncurses ntl tbb
-          brew install flint@2.6.3 factory@4.1.3 cddlib@0.94k
+          brew install autoconf automake bison ccache cmake gnu-tar libtool make ninja pkg-config yasm
+          brew install bdw-gc boost eigen gdbm readline libatomic_ops libxml2 libomp tbb
+          brew install gmp mpfr ntl flint@2.6.3 factory@4.1.3 cddlib@0.94k glpk
           brew install frobby mpsolve memtailor mathic mathicgb givaro fflas-ffpack
-          brew install 4ti2 cohomcalg csdp gfan nauty topcom
+          brew install 4ti2 cohomcalg csdp gfan lrs nauty normaliz topcom
 
 # ----------------------
 #   Install missing tools and libraries for Linux

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -32,7 +32,7 @@ jobs:
     name: ${{ matrix.build-system }}-${{ matrix.os }}-${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false  # eventually make this true
+      fail-fast: true
       matrix:
         build-system:
           - cmake
@@ -75,9 +75,13 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew config
+          brew tap mahrud/tap
           # autoconf, libtool are already in the virtual env
           brew install automake ccache gnu-tar make ninja pkg-config yasm
-          brew install bdw-gc boost cddlib eigen flint glpk libatomic_ops libomp mpfr mpir ncurses ntl tbb
+          brew install bdw-gc boost eigen glpk libatomic_ops libomp mpfr mpir ncurses ntl tbb
+          brew install flint@2.6.3 factory@4.1.3 cddlib@0.94k
+          brew install frobby mpsolve memtailor mathic mathicgb givaro fflas-ffpack
+          brew install 4ti2 cohomcalg csdp gfan nauty topcom
 
 # ----------------------
 #   Install missing tools and libraries for Linux

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -112,7 +112,7 @@ jobs:
           fi
 
       - uses: actions/cache@v2
-#        if: matrix.build-system == 'cmake' # TODO: remove when autotools is more efficient with space
+        if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
         id: restore-cache
         with:
           path: |
@@ -130,14 +130,14 @@ jobs:
 # ----------------------
 
       - name: Configure Macaulay2 using CMake
-#        if: matrix.build-system == 'cmake'
+        if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
         run: |
           cmake -S../.. -B. -GNinja \
             -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` \
-            -DBUILD_NATIVE=OFF -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK" # TODO: remove when the packages are updated
+            -DBUILD_NATIVE=OFF # -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK" # TODO: remove when the packages are updated
 
       - name: Build libraries using Ninja
-#        if: matrix.build-system == 'cmake' # && steps.restore-cache.outputs.cache-hit != 'true'
+        if: matrix.build-system == 'cmake' || matrix.os == 'macos-latest'
         run: |
           cmake --build . --target build-libraries build-programs
 

--- a/M2/BUILD/docker/.gitignore
+++ b/M2/BUILD/docker/.gitignore
@@ -1,2 +1,3 @@
 storage
 !storage/.emacs
+nightly/*.zip

--- a/M2/BUILD/docker/Dockerfile
+++ b/M2/BUILD/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y macaulay2 && apt-get clean
 RUN apt-get install -y emacs bash-completion git mlocate && apt-get clean && updatedb
 
 # Add non-root user for running Macaulay2
-RUN useradd -G sudo -g root -u 1000 -m macaulay
+RUN useradd -G sudo -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 USER 1000:0
 
 # Setting environment variables

--- a/M2/BUILD/docker/Makefile
+++ b/M2/BUILD/docker/Makefile
@@ -1,10 +1,10 @@
 ## Parameters
 TAG = m2
-STORAGE = `pwd`/storage
-M2_REPO = `pwd`/../../..
 M2_HOME = /home/macaulay
+M2_REPO = $(shell git rev-parse --show-toplevel)
+STORAGE = $(M2_REPO)/M2/BUILD/docker/storage
 VOLUME = --volume $(STORAGE):$(M2_HOME) --volume $(M2_REPO):$(M2_HOME)/M2
-BUILD_DIR = M2/M2/BUILD/build-docker
+BUILD_DIR = M2/BUILD/build-docker
 
 ###############################################################################
 
@@ -12,7 +12,7 @@ always:; @cat README.md
 
 all: build run
 
-clean:;	rm -rf ${M2_REPO}/../$(BUILD_DIR) $(STORAGE)/.ccache
+clean:;	rm -rf ${M2_REPO}/$(BUILD_DIR) $(STORAGE)/.ccache
 
 ###############################################################################
 # Build targets
@@ -25,18 +25,19 @@ build-image:;	docker build --tag $(TAG) .
 # M2 targets
 
 run: run-emacs
+run-M2:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG)
+run-M2-safe:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --int --no-readline --no-randomize --no-threads
+run-emacs-tui:;	docker run $(VOLUME) -it --entrypoint emacs $(TAG)
+run-emacs:;	docker run $(VOLUME) --entrypoint emacs --net=host --env="DISPLAY" $(TAG)
 
-run-M2:;	docker run $(VOLUME) -it --entrypoint="" $(TAG) M2
-
-run-M2-safe:;	docker run $(VOLUME) -it --entrypoint="" $(TAG) M2 -q --int --no-readline --no-randomize --no-threads
-
-run-emacs-tui:;	docker run $(VOLUME) -it $(TAG)
-
-run-emacs:;	docker run $(VOLUME) --net=host --env="DISPLAY" $(TAG)
+check: check-1
+check-1:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 1 -e 'exit 0'
+check-2:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 2 -e 'exit 0'
+check-3:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 3 -e 'exit 0'
 
 ###############################################################################
 # Terminal targets
 
-root:;	docker run $(VOLUME) -it -w $(M2_HOME)/$(BUILD_DIR) --user root --entrypoint bash $(TAG)
+root:;	docker run $(VOLUME) -it -w $(M2_HOME)/M2/$(BUILD_DIR) --user root --entrypoint bash $(TAG)
 
-shell:;	docker run $(VOLUME) -it -w $(M2_HOME)/$(BUILD_DIR) --entrypoint bash $(TAG)
+shell:;	docker run $(VOLUME) -it -w $(M2_HOME)/M2/$(BUILD_DIR) --entrypoint bash $(TAG)

--- a/M2/BUILD/docker/README.md
+++ b/M2/BUILD/docker/README.md
@@ -7,6 +7,7 @@ The `Dockerfile` in this directory creates a container image based on Ubuntu 18.
 - `ubuntu`: Compiling Macaulay2 in a Container
 - `debian`: Packaging Macaulay2 for Debian (.deb)
 - `fedora`: Packaging Macaulay2 for Fedora (.rpm)
+- `actions`: Testing the Nightly Build of Macaulay2
 
 ## Getting Started
 0. Install Docker and start the daemon.

--- a/M2/BUILD/docker/debian/Dockerfile
+++ b/M2/BUILD/docker/debian/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get install -y libeigen3-dev  libglpk-dev libgmp3-dev libmpfr-dev \
 RUN apt-get install -y mlocate bash-completion
 
 # Add non-root user for building and running Macaulay2
-RUN useradd -G sudo -g root -u 1000 -m macaulay
+RUN useradd -G sudo -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 USER 1000:0
 
 ENV PKG_CONFIG_PATH /usr/lib/x86_64-linux-gnu/pkgconfig

--- a/M2/BUILD/docker/debian/Makefile
+++ b/M2/BUILD/docker/debian/Makefile
@@ -2,12 +2,8 @@ include ../ubuntu/Makefile
 
 ## Parameters
 TAG = m2-debian-build
-STORAGE = `pwd`/../storage
-M2_REPO = `pwd`/../../../..
-M2_HOME = /home/macaulay
-VOLUME = --volume $(STORAGE):$(M2_HOME) --volume $(M2_REPO):$(M2_HOME)/M2
-BUILD_DIR = M2/M2/BUILD/build-docker
-BUILD_OPT = -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DUSING_MPIR=OFF
+BUILD_DIR = M2/BUILD/build-docker
+BUILD_OPT = -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
 
 deb:;       docker run $(VOLUME) -it --entrypoint "" $(TAG) bash -c "cd $(BUILD_DIR); cpack -G DEB"
 

--- a/M2/BUILD/docker/fedora/Dockerfile
+++ b/M2/BUILD/docker/fedora/Dockerfile
@@ -24,7 +24,7 @@ RUN microdnf install eigen3-devel glpk-devel gmp-devel mpfr-devel ntl-devel libf
 RUN microdnf install mlocate bash-completion
 
 # Add non-root user for building and running Macaulay2
-RUN useradd -G wheel -g root -u 1000 -m macaulay
+RUN useradd -G wheel -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 USER 1000:0
 
 ENV PATH /home/macaulay/M2/M2/BUILD/build-docker:${PATH}

--- a/M2/BUILD/docker/fedora/Makefile
+++ b/M2/BUILD/docker/fedora/Makefile
@@ -2,12 +2,8 @@ include ../ubuntu/Makefile
 
 ## Parameters
 TAG = m2-fedora-build
-STORAGE = `pwd`/../storage
-M2_REPO = `pwd`/../../../..
-M2_HOME = /home/macaulay
-VOLUME = --volume $(STORAGE):$(M2_HOME) --volume $(M2_REPO):$(M2_HOME)/M2
-BUILD_DIR = M2/M2/BUILD/build-docker
-BUILD_OPT = -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DUSING_MPIR=OFF
+BUILD_DIR = M2/BUILD/build-docker
+BUILD_OPT = -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
 
 rpm:;       docker run $(VOLUME) -it --entrypoint "" $(TAG) bash -c "cd $(BUILD_DIR); cpack -G RPM"
 

--- a/M2/BUILD/docker/nightly/Dockerfile
+++ b/M2/BUILD/docker/nightly/Dockerfile
@@ -1,0 +1,33 @@
+# Time usage: <5min
+# Net usage:  ~100MB
+# Disk usage: <600MB docker image
+
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common apt-transport-https curl git sudo unzip gnupg && \
+    add-apt-repository -y ppa:macaulay2/macaulay2 && apt-get update && apt-get clean
+
+# this seems to be necessary because libstdc++6 is too old on Ubuntu 18.04
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get update && \
+    apt-get install -y -q --no-install-recommends libomp5-9 && apt-get clean
+
+# Install Macaulay2
+COPY Macaulay2-*.zip /
+RUN unzip Macaulay2-*.zip && apt-get install -y /Macaulay2-*.deb
+
+# Install optional packages
+RUN apt-get install -y -q --no-install-recommends mlocate bash-completion && apt-get clean && updatedb
+
+#RUN apt-get install -y -q --no-install-recommends emacs && apt-get clean
+
+# Add non-root user for building and running Macaulay2
+RUN useradd -G sudo -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+USER 1000:0
+
+# Setting environment variables
+ENV LD_LIBRARY_PATH /usr/local/lib/Macaulay2/lib
+ENV PATH /usr/local/libexec/Macaulay2/bin:${PATH}
+
+WORKDIR /home/macaulay
+ENTRYPOINT M2

--- a/M2/BUILD/docker/nightly/Makefile
+++ b/M2/BUILD/docker/nightly/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile
+
+## Parameters
+TAG = m2-github-nightly
+BUILD_DIR = ..
+
+###############################################################################
+# see ../Makefile

--- a/M2/BUILD/docker/nightly/README.md
+++ b/M2/BUILD/docker/nightly/README.md
@@ -1,0 +1,25 @@
+# Testing the Nightly Build of Macaulay2
+
+Every night, the latest version of Macaulay2 is built using a number of platforms and compilers using [Github Actions](https://github.com/Macaulay2/M2/actions). One of the builds, titled `cmake-ubuntu-latest-clang10`, uploads a packaged version of Macaulay2 for Ubuntu as a build artifact.
+
+The `Dockerfile` in this directory creates a container image based on Ubuntu 18.04.4 for testing the nightly package built by Github Actions.
+
+## Getting Started
+0. Install Docker and start the daemon.
+
+1. Find the latest [Build and Test Macaulay2](https://github.com/Macaulay2/M2/actions?query=workflow%3A%22Build+and+Test+Macaulay2%22) build
+
+2. Download the artifact titled `Macaulay2-[commit info]-ubuntu-x86_64` and place it in this directory
+
+3. Build the container using Docker:
+```
+make build
+```
+
+4. Check Macaulay2:
+```
+make check
+make check-1 # runs basic tests
+make check-2 # runs Core tests
+make check-3 # runs all package tests
+```

--- a/M2/BUILD/docker/storage/.emacs
+++ b/M2/BUILD/docker/storage/.emacs
@@ -1,6 +1,7 @@
 ;; .emacs
 
 ;; Macaulay2 start
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/Macaulay2")
 (load "M2-init")
 
 (custom-set-variables

--- a/M2/BUILD/docker/ubuntu/Dockerfile
+++ b/M2/BUILD/docker/ubuntu/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get install -y python && apt-get clean
 RUN apt-get install -y mlocate bash-completion
 
 # Add non-root user for building and running Macaulay2
-RUN useradd -G sudo -g root -u 1000 -m macaulay
+RUN useradd -G sudo -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 USER 1000:0
 
 ENV PKG_CONFIG_PATH /usr/lib/x86_64-linux-gnu/pkgconfig

--- a/M2/BUILD/docker/ubuntu/Makefile
+++ b/M2/BUILD/docker/ubuntu/Makefile
@@ -2,12 +2,8 @@ include ../Makefile
 
 ## Parameters
 TAG = m2-cmake-build
-STORAGE = `pwd`/../storage
-M2_REPO = `pwd`/../../../..
-M2_HOME = /home/macaulay
-VOLUME = --volume $(STORAGE):$(M2_HOME) --volume $(M2_REPO):$(M2_HOME)/M2
-BUILD_DIR = M2/M2/BUILD/build-docker
-BUILD_OPT = -DCMAKE_BUILD_TYPE=Release -DUSING_MPIR=OFF
+BUILD_DIR = M2/BUILD/build-docker
+BUILD_OPT = -DCMAKE_BUILD_TYPE=Release
 
 ## Script for building Macaulay2
 define M2_BUILD_SCRIPT

--- a/M2/BUILD/mahrud/Makefile
+++ b/M2/BUILD/mahrud/Makefile
@@ -5,7 +5,8 @@
 CMAKE_BUILD_DIR       = $(shell pwd)/../build
 
 # Set the exec_prefix here in order to also find the programs
-ARCH                  = x86_64-Linux-Fedora-32
+# TODO: perhaps store the distribution architecture in a file
+ARCH                  = $(shell basename $(CMAKE_BUILD_DIR)/usr-dist/x*)
 
 export CPPFLAGS       = -I$(CMAKE_BUILD_DIR)/usr-host/include
 export LDFLAGS        = -L$(CMAKE_BUILD_DIR)/usr-host/lib

--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -210,15 +210,7 @@ ifeq (@BUILD_givaro@,yes)
 submodules/fflas_ffpack/Makefile: install-in-givaro
 endif
 
-all-in-Macaulay2:install-licenses
-
-install-licenses:all-in-submodules
-	: installing library and submodule licenses in @pre_licensesdir@
-	if [ -d $(BUILTLIBPATH)/licenses/. ] ; \
-	then rm -rf @pre_licensesdir@ ; \
-	     @INSTALL@ -d @pre_licensesdir@ ; \
-	     @TAR@ cf - -C $(BUILTLIBPATH)/licenses/. . | @TAR@ xf - -C @pre_licensesdir@ ; \
-	fi
+all-in-Macaulay2:all-in-submodules
 
 ## 
 distclean:clean distclean-in-subdirs distclean-this-dir

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -146,8 +146,8 @@ For a complete list, along with descriptions, try `cmake -LAH .` or see `cmake/c
 - `BUILD_TESTING:BOOL=ON`: build the testing targets
   - `SKIP_TESTS:STRING="mpsolve;googletest"`: tests to skip
   - `SLOW_TESTS:STRING="eigen;ntl;flint"`: slow tests to skip
-- `BUILD_LIBRARIES:STRING="GTest"`: build libraries, even if found on the system
-- `BUILD_PROGRAMS:STRING="4ti2;Nauty;TOPCOM"`: build programs, even if found on the system
+- `BUILD_LIBRARIES:STRING=""`: build libraries, even if found on the system
+- `BUILD_PROGRAMS:STRING=""`: build programs, even if found on the system
 - `CMAKE_BUILD_TYPE:STRING=RelWithDebInfo`: valid CMake build types are `Debug` `Release` `RelWithDebInfo` `MinSizeRel`
 - `CMAKE_INSTALL_PREFIX:PATH=/usr`: installation prefix
 - `M2_HOST_PREFIX:PATH=${CMAKE_BINARY_DIR}/usr-host`: host build prefix
@@ -299,6 +299,19 @@ Below are a list of common issues and errors. If you run into a problem not list
 On macOS CMake automatically finds libraries installed on the Homebrew prefix. In order to use Linuxbrew (which has the same interface and packages), use the following command to tell CMake to look under the right prefix:
 ```
 cmake -DCMAKE_SYSTEM_PREFIX_PATH=`brew --prefix` .
+```
+</details>
+
+<details>
+<summary>Building from the source code tarfile</summary>
+
+When building from a source code tarfile (e.g. downloaded from GitHub, rather than a git clone), you may see an error like this:
+```
+  No download info given for 'build-bdwgc' and its source directory: ...
+```
+To resolve this, you should download and extract the source tarfiles for each git submodule in the `M2/submodules` directory. Also, you may need to manually turn off submodule updates:
+```
+cmake -DGIT_SUBMODULE=off .
 ```
 </details>
 

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -135,14 +135,19 @@ file(MAKE_DIRECTORY ${M2_INSTALL_LICENSESDIR})
 # See https://cmake.org/cmake/help/latest/module/ExternalProject.html
 
 # http://eigen.tuxfamily.org/
+if(CMAKE_BUILD_TYPE MATCHES "(Debug|Release|RelWithDebInfo)")
+  set(EIGEN_BUILD_TYPE ${CMAKE_BUILD_TYPE})
+else()
+  set(EIGEN_BUILD_TYPE Release)
+endif()
 ExternalProject_Add(build-eigen
-  URL               https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
-  URL_HASH          SHA256=d56fbad95abf993f8af608484729e3d87ef611dd85b3380a8bad1d5cbc373a57
+  URL               https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.bz2
+  URL_HASH          SHA256=0fa5cafe78f66d2b501b43016858070d52ba47bd9b1016b0165a7b8e04675677
   PREFIX            libraries/eigen
   BINARY_DIR        libraries/eigen/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${M2_HOST_PREFIX}
-                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                    -DCMAKE_BUILD_TYPE=${EIGEN_BUILD_TYPE}
                     -DBUILD_TESTING=${BUILD_TESTING}
                     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                     -DCMAKE_CXX_FLAGS=${CXXFLAGS}

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -11,10 +11,6 @@ set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
 set(LIBRARIES_LIST MPSOLVE MATHICGB MATHIC MEMTAILOR FROBBY FACTORY FLINT NTL MPFR MP BDWGC LAPACK)
 set(LIBRARY_LIST   READLINE HISTORY GDBM ATOMICOPS)
 
-if(WITH_TBB)
-  append(LIBRARIES_LIST TBB)
-endif()
-
 message(CHECK_START " Checking for existing libraries and programs")
 
 ###############################################################################
@@ -63,7 +59,12 @@ foreach(lang IN ITEMS C CXX)
     set(OpenMP_${lang}_LDLIBS "${OpenMP_${lang}_LDLIBS} -L${_libdir} -l${_lib}")
   endforeach()
 endforeach()
-find_package(TBB) # See FindTBB.cmake
+
+if(WITH_TBB)
+  # See FindTBB.cmake
+  find_package(TBB REQUIRED)
+  list(APPEND LIBRARIES_LIST TBB)
+endif()
 
 ###############################################################################
 ## Platform dependent requirements:

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -34,17 +34,12 @@ option(WITH_XML		"Link with the libxml2 library"		ON)
 option(WITH_PYTHON	"Link with the Python library"		OFF)
 option(WITH_MYSQL	"Link with the MySQL library"		OFF)
 
-set(BUILD_PROGRAMS "4ti2;Nauty;TOPCOM"
-  CACHE STRING "Build programs, even if found")
-set(BUILD_LIBRARIES "GTest"
-  CACHE STRING "Build libraries, even if found")
+set(BUILD_PROGRAMS  "" CACHE STRING "Build programs, even if found")
+set(BUILD_LIBRARIES "" CACHE STRING "Build libraries, even if found")
 set(PARALLEL_JOBS 4
   CACHE STRING "Number of parallel jobs for libraries and programs")
 set(SKIP_TESTS "mpsolve;googletest" CACHE STRING "Tests to skip")
 set(SLOW_TESTS "eigen;ntl;flint"    CACHE STRING "Slow tests to skip")
-
-# TODO: https://github.com/Macaulay2/M2/issues/1198
-list(APPEND BUILD_LIBRARIES "Frobby")
 
 # TODO: hopefully make these automatic
 if(USING_MPIR)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1321,7 +1321,7 @@ if test $BUILD_fflas_ffpack = no
 then AC_MSG_CHECKING([for fflas_ffpack library, version at least 2])
      if test "`type -t fflas-ffpack-config`" = "file" && test "`fflas-ffpack-config --decimal-version`" -gt 20000
      then AC_MSG_RESULT(found)
-          FFLAS_FFPACK_CXXFLAGS=$(for x in $(fflas-ffpack-config --cflags 2>&1) ; do case $x in (-I*) echo -n "$x " ;; esac done)
+          FFLAS_FFPACK_CXXFLAGS=$(for x in $(fflas-ffpack-config --cflags 2>&1) ; do case $x in (-I*) /bin/echo -n "$x " ;; esac done)
 	  AC_MSG_NOTICE([adding fflas_ffpack flags $FFLAS_FFPACK_CXXFLAGS])
           M2_CXXFLAGS="$M2_CXXFLAGS $FFLAS_FFPACK_CXXFLAGS"
 	  LIBS="$LIBS `fflas-ffpack-config --libs`"

--- a/M2/libraries/Makefile.in
+++ b/M2/libraries/Makefile.in
@@ -22,26 +22,24 @@ $(foreach d,@LIBLIST@ @PROGLIST@,		\
 		$(eval .PHONY: $t-all)))
 
 uninstall:; rm -rf */.installed* $(BUILTLIBPATH)
-all:install-programs
+all:install-programs install-licenses
 install-programs:
 	: installing programs in @pre_programsdir@
-	if [ -d $(BUILTLIBPATH)/bin/. ] ; \
-	then rm -rf @pre_programsdir@ ; \
-	     @INSTALL@ -d @pre_programsdir@ ; \
-	     @TAR@ cf - -C $(BUILTLIBPATH)/bin/. . | @TAR@ xf - -C @pre_programsdir@ ; \
-	fi
+	@INSTALL@ -d @pre_programsdir@ ; \
+	@TAR@ cf - -C $(BUILTLIBPATH)/bin/. . | @TAR@ xf - -C @pre_programsdir@ ;
+install-licenses:
+	: installing library and submodule licenses in @pre_licensesdir@
+	@INSTALL@ -d @pre_licensesdir@ ; \
+	@TAR@ cf - -C $(BUILTLIBPATH)/licenses/. . | @TAR@ xf - -C @pre_licensesdir@ ;
 install-dynamic-libraries:
 	: installing sharable library files in @pre_librariesdir@
-	if test -d $(BUILTLIBPATH)/lib ;				     \
-	then rm -rf @pre_librariesdir@ ;				     \
-		@INSTALL@ -d @pre_librariesdir@ ;			     \
-		cd $(BUILTLIBPATH)/lib &&				     \
-		for i in *.dll *.so.* *[0-9].dylib ;			     \
-		do if [ -e $$i ] ;					     \
-		   then @TAR@ cf - $$i | @TAR@ xfv - -C @pre_librariesdir@ ; \
-		   fi ;							     \
-		done ;							     \
-	fi
+	@INSTALL@ -d @pre_librariesdir@ ;			     \
+	cd $(BUILTLIBPATH)/lib &&				     \
+	for i in *.dll *.so.* *[0-9].dylib ;			     \
+	do if [ -e $$i ] ;					     \
+	   then @TAR@ cf - $$i | @TAR@ xfv - -C @pre_librariesdir@ ; \
+	   fi ;							     \
+	done ;
 ifeq (@SHARED@,yes)
 all: install-dynamic-libraries
 endif

--- a/M2/libraries/Makefile.in
+++ b/M2/libraries/Makefile.in
@@ -25,14 +25,17 @@ uninstall:; rm -rf */.installed* $(BUILTLIBPATH)
 all:install-programs install-licenses
 install-programs:
 	: installing programs in @pre_programsdir@
+	$(MKDIR_P) $(BUILTLIBPATH)/bin ; \
 	@INSTALL@ -d @pre_programsdir@ ; \
 	@TAR@ cf - -C $(BUILTLIBPATH)/bin/. . | @TAR@ xf - -C @pre_programsdir@ ;
 install-licenses:
 	: installing library and submodule licenses in @pre_licensesdir@
+	$(MKDIR_P) $(BUILTLIBPATH)/licenses ; \
 	@INSTALL@ -d @pre_licensesdir@ ; \
 	@TAR@ cf - -C $(BUILTLIBPATH)/licenses/. . | @TAR@ xf - -C @pre_licensesdir@ ;
 install-dynamic-libraries:
 	: installing sharable library files in @pre_librariesdir@
+	$(MKDIR_P) $(BUILTLIBPATH)/lib ; \
 	@INSTALL@ -d @pre_librariesdir@ ;			     \
 	cd $(BUILTLIBPATH)/lib &&				     \
 	for i in *.dll *.so.* *[0-9].dylib ;			     \


### PR DESCRIPTION
The changes allow autotools to outsource building the libraries and programs to CMake, which is much faster on macOS.
https://github.com/Macaulay2/M2/blob/73d0edb2d47aa20b413e39066fce3f635fc952ae/M2/BUILD/mahrud/Makefile#L1-L2

For now this is a test to see whether this works out of the box, and if so whether it provides significant savings.