### PR TITLE
"M2 --check" improvements

### DIFF
--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -525,7 +525,7 @@ action2 := hashTable {
 	  else if phase == 4 and arg == "2" then
 	       try check "Core" then exit 0 else exit 1
 	  else if phase == 4 and arg == "3" then (
-	       fails := for pkg in separate(" ", version#"packages")
+	       fails := for pkg in sort separate(" ", version#"packages")
 		   list try check pkg then continue else pkg;
 	       if #fails > 0 then printerr("package(s) with failing tests: ",
 		    demark(", ", fails));

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -522,13 +522,19 @@ action2 := hashTable {
 	       error ("--check ",arg,": expected 1, 2, or 3")
 	  else if phase == 1 and arg == "1" then
 	       runBasicTests()
-	  else if phase == 4 and arg == "2" then
-	       try check "Core" then exit 0 else exit 1
-	  else if phase == 4 and arg == "3" then (
+	  else if phase == 4 and arg == "2" then (
+	       argumentMode = defaultMode - SetCaptureErr -
+		    if noinitfile then 0 else ArgQ;
+	       if runString(///check "Core"///, Core, false)
+		    then exit 0 else exit 1
+	  ) else if phase == 4 and arg == "3" then (
 	       fails := for pkg in sort separate(" ", version#"packages")
 		    list (
 			 print HEADER1 pkg;
-			 try check pkg then continue else pkg
+			 argumentMode = defaultMode - SetCaptureErr -
+			      if noinitfile then 0 else ArgQ;
+			 if runString("check " | format pkg, Core, false)
+			      then continue else pkg
 		    ) do print "";
 	       if #fails > 0 then printerr("package(s) with failing tests: ",
 		    demark(", ", fails));

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -525,10 +525,11 @@ action2 := hashTable {
 	  else if phase == 4 and arg == "2" then
 	       try check "Core" then exit 0 else exit 1
 	  else if phase == 4 and arg == "3" then (
-	       fails := 0;
-	       scan(separate(" ", version#"packages"),
-		    pkg -> try check pkg else fails = fails + 1);
-	       exit fails
+	       fails := for pkg in separate(" ", version#"packages")
+		   list try check pkg then continue else pkg;
+	       if #fails > 0 then printerr("package(s) with failing tests: ",
+		    demark(", ", fails));
+	       exit(#fails)
 	  )
      }
 

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -527,20 +527,7 @@ action2 := hashTable {
 		    if noinitfile then 0 else ArgQ;
 	       if runString(///check("Core", Verbose => true)///, Core, false)
 		    then exit 0 else exit 1
-	  ) else if phase == 4 and arg == "3" then (
-	       argumentMode = defaultMode - SetCaptureErr -
-		    if noinitfile then 0 else ArgQ;
-	       fails := for pkg in sort separate(" ", version#"packages")
-		    list (
-			 print HEADER1 pkg;
-			 if runString(
-			      "check(" | format pkg | ", Verbose => true)",
-			       Core, false) then continue else pkg
-		    ) do print "";
-	       if #fails > 0 then printerr("package(s) with failing tests: ",
-		    demark(", ", fails));
-	       exit(#fails)
-	  )
+	  ) else if phase == 4 and arg == "3" then exit checkAllPackages()
      }
 
 scriptCommandLine = {}

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -528,11 +528,11 @@ action2 := hashTable {
 	       if runString(///check("Core", Verbose => true)///, Core, false)
 		    then exit 0 else exit 1
 	  ) else if phase == 4 and arg == "3" then (
+	       argumentMode = defaultMode - SetCaptureErr -
+		    if noinitfile then 0 else ArgQ;
 	       fails := for pkg in sort separate(" ", version#"packages")
 		    list (
 			 print HEADER1 pkg;
-			 argumentMode = defaultMode - SetCaptureErr -
-			      if noinitfile then 0 else ArgQ;
 			 if runString(
 			      "check(" | format pkg | ", Verbose => true)",
 			       Core, false) then continue else pkg

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -523,7 +523,7 @@ action2 := hashTable {
 	  else if phase == 1 and arg == "1" then
 	       runBasicTests()
 	  else if phase == 4 and arg == "2" then (
-	       argumentMode = defaultMode - SetCaptureErr -
+	       argumentMode = defaultMode - SetCaptureErr - SetUlimit -
 		    if noinitfile then 0 else ArgQ;
 	       if runString(///check("Core", Verbose => true)///, Core, false)
 		    then exit 0 else exit 1

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -526,7 +526,10 @@ action2 := hashTable {
 	       try check "Core" then exit 0 else exit 1
 	  else if phase == 4 and arg == "3" then (
 	       fails := for pkg in sort separate(" ", version#"packages")
-		   list try check pkg then continue else pkg;
+		    list (
+			 print HEADER1 pkg;
+			 try check pkg then continue else pkg
+		    ) do print "";
 	       if #fails > 0 then printerr("package(s) with failing tests: ",
 		    demark(", ", fails));
 	       exit(#fails)

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -525,7 +525,7 @@ action2 := hashTable {
 	  else if phase == 4 and arg == "2" then (
 	       argumentMode = defaultMode - SetCaptureErr -
 		    if noinitfile then 0 else ArgQ;
-	       if runString(///check "Core"///, Core, false)
+	       if runString(///check("Core", Verbose => true)///, Core, false)
 		    then exit 0 else exit 1
 	  ) else if phase == 4 and arg == "3" then (
 	       fails := for pkg in sort separate(" ", version#"packages")
@@ -533,8 +533,9 @@ action2 := hashTable {
 			 print HEADER1 pkg;
 			 argumentMode = defaultMode - SetCaptureErr -
 			      if noinitfile then 0 else ArgQ;
-			 if runString("check " | format pkg, Core, false)
-			      then continue else pkg
+			 if runString(
+			      "check(" | format pkg | ", Verbose => true)",
+			       Core, false) then continue else pkg
 		    ) do print "";
 	       if #fails > 0 then printerr("package(s) with failing tests: ",
 		    demark(", ", fails));

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -88,7 +88,8 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
 
 checkAllPackages = () -> (
     tmp := argumentMode;
-    argumentMode = defaultMode - SetCaptureErr - if noinitfile then 0 else ArgQ;
+    argumentMode = defaultMode - SetCaptureErr - SetUlimit -
+	if noinitfile then 0 else ArgQ;
     fails := for pkg in sort separate(" ", version#"packages") list (
 	print HEADER1 pkg;
 	if runString("check(" | format pkg | ", Verbose => true)",

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -62,7 +62,7 @@ check Package := opts -> pkg -> check(-1, pkg, opts)
 check(ZZ, String)  := opts -> (n, pkg) -> check(n, needsPackage (pkg, LoadDocumentation => true), opts)
 check(ZZ, Package) := opts -> (n, pkg) -> (
     if not pkg.Options.OptionalComponentsPresent then (
-	printerr("warning: optional components required for ", toString pkg, " tests are not present; skipping"); return);
+	printerr("warning: skipping tests; ", toString pkg, " requires optional components"); return);
     usermode := if opts.UserMode === null then not noinitfile else opts.UserMode;
     --
     use pkg;

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -85,3 +85,16 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
 		stderr << filename << ":" << lineno - 1 << ":1: error:" << endl;
 		printerr get("!tail " | outfile k)));
 	error("test(s) #", demark(", ", toString \ first \ errorList), " of package ", toString pkg, " failed.")))
+
+checkAllPackages = () -> (
+    tmp := argumentMode;
+    argumentMode = defaultMode - SetCaptureErr - if noinitfile then 0 else ArgQ;
+    fails := for pkg in sort separate(" ", version#"packages") list (
+	print HEADER1 pkg;
+	if runString("check(" | format pkg | ", Verbose => true)",
+	    Core, false) then continue else pkg) do print "";
+    argumentMode = tmp;
+    if #fails > 0 then printerr("package(s) with failing tests: ",
+	demark(", ", fails));
+    return #fails;
+)

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -41,7 +41,6 @@ captureTestResult := (desc, teststring, pkg, usermode) -> (
     runString(teststring, pkg, usermode))
 
 loadTestDir := pkg -> (
-    if pkg#?"test directory loaded" then return;
     testDir := pkg#"package prefix" |
         replace("PKG", pkg#"pkgname", currentLayout#"packagetests");
     if fileExists testDir then (
@@ -67,12 +66,10 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
     --
     use pkg;
     if pkg#?"documentation not loaded" then pkg = loadPackage(pkg#"pkgname", LoadDocumentation => true, Reload => true);
+    if not pkg#?"test directory loaded" then loadTestDir pkg;
     tests := if n == -1 then toList(0 .. pkg#"test number" - 1) else {n};
     if #tests == 0 then printerr("warning: ", toString pkg,  " has no tests");
     --
-
-    if pkg#"pkgname" == "Core" then loadTestDir(pkg);
-
     errorList := {};
     (hadError, numErrors) = (false, 0);
     scan(tests, k -> (

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -68,6 +68,7 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
     use pkg;
     if pkg#?"documentation not loaded" then pkg = loadPackage(pkg#"pkgname", LoadDocumentation => true, Reload => true);
     tests := if n == -1 then toList(0 .. pkg#"test number" - 1) else {n};
+    if #tests == 0 then printerr("warning: ", toString pkg,  " has no tests");
     --
 
     if pkg#"pkgname" == "Core" then loadTestDir(pkg);

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -80,8 +80,8 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
 		 (k, temporaryFilenameCounter - 2))));
     outfile := k -> temporaryDirectory() | toString k | ".tmp";
     if hadError then (
-	if opts.Verbose then apply(last \ errorList, k -> (
-		(filename, lineno, teststring) := pkg#"test inputs"#k;
+	if opts.Verbose then apply(errorList, (j, k) -> (
+		(filename, lineno, teststring) := pkg#"test inputs"#j;
 		stderr << filename << ":" << lineno - 1 << ":1: error:" << endl;
 		printerr get("!tail " | outfile k)));
 	error("test(s) #", demark(", ", toString \ first \ errorList), " of package ", toString pkg, " failed.")))

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -47,7 +47,7 @@ loadTestDir := pkg -> (
         tmp := currentPackage;
         currentPackage = pkg;
         TEST(sort apply(select(readDirectory testDir, file ->
-            match("\\.m2$", file)), test -> testDir | "/" | test),
+            match("\\.m2$", file)), test -> testDir | test),
             FileName => true);
         currentPackage = tmp;
         pkg#"test directory loaded" = true;


### PR DESCRIPTION
We add several improvements to the `M2 --check 2` and `M2 --check 3` command line options for checking `Core` and all packages, respectively.   An example of this PR in action:

```m2
profzoom@peg-amy:~/src/macaulay2/M2/M2/BUILD/doug$ usr-dist/x86_64-Linux-Ubuntu-20.10/bin/M2 --silent --check 3
AbstractToricVarieties
**********************
 -- warning: AbstractToricVarieties has no tests

AdjointIdeal
************
 -- warning: skipping tests; AdjointIdeal requires optional components

AlgebraicSplines
****************
 -- capturing check(0, "AlgebraicSplines")                                   -- 0.0284473 seconds elapsed
 -- capturing check(1, "AlgebraicSplines")                                   -- 0.0171626 seconds elapsed
 -- capturing check(2, "AlgebraicSplines")                                   -- 0.540551 seconds elapsed
 -- capturing check(3, "AlgebraicSplines")                                   -- 0.0364287 seconds elapsed
 -- capturing check(4, "AlgebraicSplines")                                   -- 0.00473615 seconds elapsed
 -- capturing check(5, "AlgebraicSplines")                                   -- 0.00457126 seconds elapsed
 -- capturing check(6, "AlgebraicSplines")                                   -- 0.0687845 seconds elapsed
 -- capturing check(7, "AlgebraicSplines")                                   -- 0.0210441 seconds elapsed
 -- capturing check(8, "AlgebraicSplines")                                   -- 0.127248 seconds elapsed
 -- capturing check(9, "AlgebraicSplines")                                   -- 0.76755 seconds elapsed

AnalyzeSheafOnP1
****************
 -- capturing check(0, "AnalyzeSheafOnP1")                                   -- 0.0136954 seconds elapsed
 -- capturing check(1, "AnalyzeSheafOnP1")                                   -- 0.00225502 seconds elapsed
 -- capturing check(2, "AnalyzeSheafOnP1")                                   -- 0.00876498 seconds elapsed
```

Also, I recently added a [patch](https://salsa.debian.org/science-team/macaulay2/-/blob/debian/development/debian/patches/skip-failing-package-tests.patch) to the latest draft of the Debian package that lets someone add a `-* no-check-flag *-` comment to a test it if `check` should skip it (due to known build failures or something).  Is there any interest in adding this functionality upstream?