### PR TITLE
Add "no-check-flag" comment for tests

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -29,18 +29,21 @@ TEST(String, String) := (title, teststring) -> (
 -- check
 -----------------------------------------------------------------------------
 
+checkmsg := (verb, desc) ->
+    stderr << commentize pad(pad(verb, 10) | desc, 72) << flush;
+
 captureTestResult := (desc, teststring, pkg, usermode) -> (
     stdio << flush; -- just in case previous timing information hasn't been flushed yet
     if match("no-check-flag", teststring) then (
-	stderr << commentize pad("skipping " | desc, 72) << flush;
+	checkmsg("skipping", desc);
 	return true);
     -- try capturing in the same process
     if isCapturable(teststring, pkg, true) then (
-	stderr << commentize pad("capturing " | desc, 72) << flush;
+	checkmsg("capturing", desc);
 	(err, output) := capture(teststring, PackageExports => pkg, UserMode => usermode);
 	if err then printerr "capture failed; retrying ..." else return true);
     -- fallback to using an external process
-    stderr << commentize pad("running " | desc, 72) << flush;
+    checkmsg("running", desc);
     runString(teststring, pkg, usermode))
 
 loadTestDir := pkg -> (

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -31,6 +31,9 @@ TEST(String, String) := (title, teststring) -> (
 
 captureTestResult := (desc, teststring, pkg, usermode) -> (
     stdio << flush; -- just in case previous timing information hasn't been flushed yet
+    if match("no-check-flag", teststring) then (
+	stderr << commentize pad("skipping " | desc, 72) << flush;
+	return true);
     -- try capturing in the same process
     if isCapturable(teststring, pkg, true) then (
 	stderr << commentize pad("capturing " | desc, 72) << flush;

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/check-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/check-doc.m2
@@ -34,6 +34,10 @@ Node
       Use @TO check@ to run all of the tests associated to a package.
 
       For an example, see @TO "SimpleDoc :: docExample"@ and @TO "an example of a package"@.
+
+      If a test should be skipped when running @TO "check"@, e.g., it is
+      known to fail under certain circumstances, then the comment
+      @TT "-* no-check-flag *-"@ may be added to @TT "s"@.
   Caveat
     When creating tests, try to ensure that they run relatively quickly.
   SeeAlso


### PR DESCRIPTION
I recently added this feature to the draft of the Debian package to simplify skipping all the package tests that have been failing on various architectures (see [this patch](https://salsa.debian.org/science-team/macaulay2/-/blob/debian/development/debian/patches/skip-failing-package-tests.patch)).  Would there be interest in having it upstream as well?  Note that this PR only enables the feature, and doesn't actually skip any tests.

Here's an example of what it looks like when a test is skipped:

```m2
 -- capturing check(10, "DeterminantalRepresentations")                      -- 1.46659 seconds elapsed
 -- capturing check(11, "DeterminantalRepresentations")                      -- 0.0888114 seconds elapsed
 -- skipping check(12, "DeterminantalRepresentations")                       -- 0.000079951 seconds elapsed
 -- capturing check(13, "DeterminantalRepresentations")                      -- 0.0776138 seconds elapsed
```