### PR TITLE
Remove getWWW test from core-tests.m2

### DIFF
--- a/M2/Macaulay2/tests/normal/core-tests.m2
+++ b/M2/Macaulay2/tests/normal/core-tests.m2
@@ -1311,15 +1311,6 @@ Exceeded limit of 5
 ")
 
 
-
-
--- example for use with splitWWW
-str = getWWW "http://quark.itp.tuwien.ac.at/cgi-bin/cy/cydata.cgi?h11=10&L=5";
-(head,body) = splitWWW str;
-head
-body
-
-
 --
 A = ZZ[a..d]
 B = A[r,s,t]


### PR DESCRIPTION
This test will fail if we don't have network access during build.
(For example, this is the case when building Debian packages.)

Also, it's not even really a test.  It looks like it was just the code
used to generated the canned example for the "splitWWW" documentation.