### PR TITLE
Print package headers to stderr during "M2 --check 3"

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -91,9 +91,9 @@ checkAllPackages = () -> (
     argumentMode = defaultMode - SetCaptureErr - SetUlimit -
 	if noinitfile then 0 else ArgQ;
     fails := for pkg in sort separate(" ", version#"packages") list (
-	print HEADER1 pkg;
+	stderr << HEADER1 pkg << endl;
 	if runString("check(" | format pkg | ", Verbose => true)",
-	    Core, false) then continue else pkg) do print "";
+	    Core, false) then continue else pkg) do stderr << endl;
     argumentMode = tmp;
     if #fails > 0 then printerr("package(s) with failing tests: ",
 	demark(", ", fails));


### PR DESCRIPTION
This is a short followup to #1750.  `check` prints all of its output to `stderr`, but we were printing the header for each package (and the newline before the next package) to `stdout`, which was causing issues with buffering, e.g.,:

```m2
PositivityToricBundles
**********************

PrimaryDecomposition
********************

PruneComplex
************

Pu -- capturing check(0, "Pullback")                                           -- 0.128674 seconds elapsed
 -- capturing check(1, "Pullback")                                           -- 0.182879 seconds elapsed
 -- capturing check(2, "Pullback")                                           -- 0.151492 seconds elapsed
```

Instead, we just print everything to `stderr` for consistency.