### PR TITLE
concatenate/commentize/pad updates

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -615,10 +615,8 @@ stringcatfun(e:Expr):Expr := (
      is y:SymbolClosure do toExpr(y.symbol.word.name)
      is n:ZZcell do (
 	  if isInt(n) then (
-	       m := toInt(n);
-	       if m >= 0
-	       then toExpr(new string len m do provide ' ')
-	       else buildErrorPacket("encountered negative integer")
+	       m := max(toInt(n), 0);
+	       toExpr(new string len m do provide ' ')
 	       )
 	  else buildErrorPacket("encountered a large integer")
 	  )

--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -262,7 +262,9 @@ commentize = method(Dispatch => Thing)
 commentize Nothing   := s -> ""
 commentize BasicList := s -> commentize horizontalJoin s
 commentize String    := s -> concatenate(" -- ", between("\n -- ", separate s))
-commentize Net       := S -> stack(commentize \ unstack S)
+commentize Net       := S -> (
+    baseline := height S - if height S == -depth S then 0 else 1;
+    (stack(commentize \ unstack S))^baseline)
 
 printerr = msg -> (stderr << commentize msg << endl;) -- always return null
 warning  = msg -> if debugLevel > 0 then (

--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -66,7 +66,9 @@ toString Manipulator := f -> (
 toExternalString String := format
 
 toString Net := x -> demark("\n",unstack x)
-toExternalString Net := x -> concatenate(format toString x, "^", toString(height x - 1))
+toExternalString Net := x -> if height x + depth x == 0 then
+     concatenate("(horizontalJoin())", "^", toString height x) else
+     concatenate(format toString x, "^", toString(height x - 1))
 
 toExternalString MutableHashTable := s -> (
      if hasAttribute(s,ReverseDictionary) then return toString getAttribute(s,ReverseDictionary);

--- a/M2/Macaulay2/m2/printing.m2
+++ b/M2/Macaulay2/m2/printing.m2
@@ -4,6 +4,8 @@ pad = method()
 
 pad(String,ZZ) := String => (s,n) -> concatenate(s,n-# s)
 pad(ZZ,String) := String => (n,s) -> concatenate(n-# s,s)
+pad(Net, ZZ) := (S, n) -> S | (concatenate(n - width S))^(-depth S)
+pad(ZZ, Net) := (n, S) -> (concatenate(n - width S))^(height S - 1) | S
 
 columnate = (wid,items) -> (
      lens := apply(items,i -> #i);

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc12.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc12.m2
@@ -550,16 +550,32 @@ document {
      	  }
      }
 
-document {
-     Key => {pad,(pad, String, ZZ),(pad, ZZ, String)},
-     Headline => "pad a string with spaces",
-     TT "pad(s,n)", " -- pads the string ", TT "s", " to length ", TT "n", " with
-     spaces on the right.",
-     BR{},
- 
-     TT "pad(n,s)", " -- pads the string ", TT "s", " to length ", TT "n", " with
-     spaces on the left."
-     }
+doc ///
+  Key
+    pad
+    (pad, String, ZZ)
+    (pad, ZZ, String)
+    (pad, Net, ZZ)
+    (pad, ZZ, Net)
+  Headline
+    pad a string or net with spaces
+  Usage
+    pad(s,n)
+    pad(n,s)
+  Inputs
+    s:Net
+    n:ZZ
+  Description
+    Text
+      @TT "pad(s,n)"@ pads the string or net @TT "s"@ to length @TT
+      "n"@ with spaces on the right.
+
+      @TT "pad(n,s)"@ pads the string or net @TT "s"@ to length @TT
+      "n"@ with spaces on the left.
+    Example
+      pad(6, "foo")
+      pad("foo", 6) | "bar"
+///
 
 document {
      Key => columnate,

--- a/M2/Macaulay2/tests/normal/nets.m2
+++ b/M2/Macaulay2/tests/normal/nets.m2
@@ -18,6 +18,9 @@ assert ( toString net x === x )
 x = "\nasdf\nqwer"
 assert ( toString net x === x )
 
+-- https://github.com/Macaulay2/M2/issues/1763
+assert(value toExternalString horizontalJoin() == horizontalJoin())
+
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test nets.out"

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -24,3 +24,12 @@ assert(pad(3,"ABC")=="ABC");
 -- ignore the numbers if it's too short
 assert(pad("ABC",2)=="ABC");
 assert(pad(2,"ABC")=="ABC");
+-- nets
+assert(pad(4,"ABC"^1)==" ABC"^1)
+assert(pad("ABC"^1,4)=="ABC "^1)
+assert(pad(4,"ABC\nDEF"^1)==" ABC\n DEF"^1)
+assert(pad("ABC\nDEF"^1,4)=="ABC\nDEF "^1)
+assert(pad(3,"ABC"^1)=="ABC"^1)
+assert(pad("ABC"^1,3)=="ABC"^1)
+assert(pad(2,"ABC"^1)=="ABC"^1)
+assert(pad("ABC"^1,2)=="ABC"^1)

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -33,3 +33,13 @@ assert(pad(3,"ABC"^1)=="ABC"^1)
 assert(pad("ABC"^1,3)=="ABC"^1)
 assert(pad(2,"ABC"^1)=="ABC"^1)
 assert(pad("ABC"^1,2)=="ABC"^1)
+
+-- commentize
+debug Core
+assert(commentize null=="")
+assert(commentize()==horizontalJoin())
+assert(commentize("ABC")==" -- ABC")
+assert(commentize("ABC","DEF")==" -- ABCDEF")
+assert(commentize("ABC\nDEF")==" -- ABC\n -- DEF")
+assert(commentize("ABC"^1)==" -- ABC"^1)
+assert(commentize("ABC\nDEF"^1)==" -- ABC\n -- DEF"^1)

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -3,8 +3,7 @@
 assert(concatenate("ABC")=="ABC");
 assert(concatenate(2)=="  ");
 assert(concatenate(0)=="");
--- concatenate(-1) should give an error
-try concatenate(-1) then assert(false) else true;
+assert(concatenate(-1)=="");
 -- multiple args
 assert(concatenate("ABC","DEF")=="ABCDEF");
 assert(concatenate("ABC",2)=="ABC  ");


### PR DESCRIPTION
After initially agreeing to dropping the filenames and line numbers of tests during `check` recently, I've found myself missing them when, for example, we get a segfault during `capture` and never get to `check`'s message at the end with information about the failing tests.  It's possible to do some sleuthing to figure out the location of the tests, but it would be nice if we had that information in the log, at least when check's `Verbose` option is set to `true`.

This PR accomplishes this.  For example:
```m2
i1 : check(0, "Core")
 -- capturing check(0, "Core")                                               -- 0.0316604 seconds elapsed

i2 : check(0, "Core", Verbose => true)
 -* capturing check(0, "Core") in file:                                     
    /usr/share/doc/Macaulay2/Core/tests/0-homog.m2:0:1:                      *- -- 0.0315109 seconds elapsed
```

Although the actual change to `check` itself was just a couple of lines, I ended up needing to do a fair amount of work changing `pad` and `commentize` to play nicely with multiline strings and nets so we wouldn't end up with a `--` in front of the filename and preventing us from jumping to it quickly in Emacs.

In particular:

## `pad`
Now works with multiline strings and nets in (what I would consider) the expected way:

*before*
```m2
i1 : pad(4, "foo\nbar")

o1 = foo
     bar
```
Nothing happened since the string was longer than 4 characters, regardless of the fact that each line only has 3.

*after*
```m2
i1 : pad(4, "foo\nbar")

o1 =  foo
      bar
```
## `commentize`
Now uses `-* ... *-` comments for multiline strngs and nets, and also preserves the baseline of nets:

*before*
```m2
i4 : commentize "foo\nbar"

o4 =  -- foo
      -- bar

i5 : commentize "foo"^1

o5 =  -- foo
```

*after*
```m2
i4 : commentize "foo\nbar"

o4 =  -* foo
         bar *-

i5 : commentize "foo"^1

      -- foo
o5 = 
```

## `concatenate`
Now accepts negative integers (returning the empty string), which is consistent with its current behavior when given a list containing a negative integer.  I needed this for an early draft of the `pad` updates that I ended up changing, but it seemed like a good idea, so I kept it in.

*before*
```m2
i6 : concatenate {-1}

o6 = 

i7 : concatenate(-1)
stdio:7:1:(3): error: encountered negative integer
```

*after*
```m2
i1 : concatenate(-1)

o1 = 
```
