### PR TITLE
Release 1.17 bug fix in `integralClosure Ideal`

### DIFF
--- a/M2/Macaulay2/packages/MinimalPrimes/splitIdeals.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes/splitIdeals.m2
@@ -536,7 +536,7 @@ splitFunction#IndependentSet = (I,opts) -> (
         return splitLexGB I;
     );
     -- otherwise compute over the fraction field.
-    if hf =!= null then gb(JS, Hilbert=>hf) else gb JS;
+    if hf =!= null and degreesRing ring JS === ring hf then gb(JS, Hilbert=>hf) else gb JS;
     --gens gb IS;
     (JSF, coeffs) := minimalizeOverFrac(JS, SF);
     if coeffs == {} then (


### PR DESCRIPTION
This pull request fixes a major bug in `integralClosure Ideal`, posted by Youngsu on 21 Dec 2020.  It also fixes a couple of other smaller issues, including a bug in `MinimalPrimes`, that presents itself if the original ideal is multigraded, found in the process of fixing the bug.