### PR TITLE
Add Emacs support to infoHelp

### DIFF
--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -466,8 +466,9 @@ viewHelp = new Command from viewHelp
 setAttribute(viewHelp#0, ReverseDictionary, symbol viewHelp)
 
 infoHelp = key -> (
-    tag := makeDocumentTag(key, Package => null);
-    chkrun ("info " | format infoTagConvert tag);)
+    tag := infoTagConvert makeDocumentTag(key, Package => null);
+    if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format tag)
+    else print("-* infoHelp: " | tag | " *-");)
 
 -----------------------------------------------------------------------------
 -- View brief documentation within Macaulay2 using symbol?


### PR DESCRIPTION
If we detect that Macaulay2 is running inside Emacs, then print a
message instead of running info.  M2-mode will then use this message
to open the corresponding documentation node in Info mode.

Closes: #1772