### PR TITLE
Cancel previous workflow runs when pushing new commits to a branch

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -61,6 +61,11 @@ jobs:
           #  cc: clang
 
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
 # ----------------------


### PR DESCRIPTION
This way, we don't have to cancel them manually.