### PR TITLE
Include "Synopsis" SimpleDoc keyword in syntax highlighting

### DIFF
--- a/M2/Macaulay2/editors/make-M2-symbols.m2
+++ b/M2/Macaulay2/editors/make-M2-symbols.m2
@@ -56,7 +56,7 @@ KEYWORDS  = first \ select(symbols, isKeyword)
 DATATYPES = first \ select(symbols, isType)
 FUNCTIONS = first \ select(symbols, isFunction)
 CONSTANTS = first \ select(symbols, isConst)
-CONSTANTS = CONSTANTS | {"Node", "Item", "Example", "CannedExample", "Pre", "Code", "Tree"} -- SimpleDoc words
+CONSTANTS = CONSTANTS | {"Node", "Item", "Example", "CannedExample", "Pre", "Code", "Tree", "Synopsis"} -- SimpleDoc words
 CONSTANTS = sort CONSTANTS
 STRINGS   = format "///\\\\(/?/?[^/]\\\\|\\\\(//\\\\)*////[^/]\\\\)*\\\\(//\\\\)*///"
 


### PR DESCRIPTION
It's currently missing.  See, for example, Github's own Markdown syntax highlighting:

```m2
       Synopsis
        Heading
         a different way to use this method
        Usage
         simpleDocFrom_n M
        Inputs
         :ZZ
         :Matrix
        Outputs
         :Matrix
        Consequences
         Item
          There may be specific consequences.

```