### PR TITLE
Two infoHelp fixes

### DIFF
--- a/M2/Macaulay2/m2/files.m2
+++ b/M2/Macaulay2/m2/files.m2
@@ -395,6 +395,10 @@ dotemacsFix0 = ///
 ; want to use your f12 key for something else.  However, this action
 ; will be undone the next time you run setup() or setupEmacs().
 (global-set-key [ f12 ] 'M2)
+
+; Prevent Emacs from inserting a superfluous "See" or "see" in front
+; of the hyperlinks when reading documentation in Info mode.
+(setq Info-hide-note-references 'hide)
 ///
 
 emacsHeader := ";-*-emacs-lisp-*-\n"

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -453,7 +453,7 @@ setAttribute(viewHelp#0, ReverseDictionary, symbol viewHelp)
 
 infoHelp = method(Dispatch => Thing)
 infoHelp Thing := key -> (
-    if key === () then infoHelp "Macaulay2Doc";
+    if key === () then return infoHelp "Macaulay2Doc";
     tag := infoTagConvert makeDocumentTag(key, Package => null);
     if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format tag)
     -- used by M2-info-help in M2.el

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -457,7 +457,7 @@ infoHelp Thing := key -> (
     tag := infoTagConvert makeDocumentTag(key, Package => null);
     if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format tag)
     -- used by M2-info-help in M2.el
-    else print("-* infoHelp: " | tag | " *-");)
+    else print("-*" | " infoHelp: " | tag | " *-");)
 infoHelp ZZ := i -> seeAbout(infoHelp, i)
 infoHelp = new Command from infoHelp
 

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -460,6 +460,8 @@ infoHelp Thing := key -> (
     else print("-*" | " infoHelp: " | tag | " *-");)
 infoHelp ZZ := i -> seeAbout(infoHelp, i)
 infoHelp = new Command from infoHelp
+-- This ensures that "methods infoHelp" and "?infoHelp" work as expected
+setAttribute(infoHelp#0, ReverseDictionary, symbol infoHelp)
 
 -----------------------------------------------------------------------------
 -- View brief documentation within Macaulay2 using symbol?

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
@@ -162,6 +162,7 @@ doc ///
     If you read the info form of the documentation in Emacs, we recommend configuring
     the value of the Emacs variable @TT "Info-hide-note-references"@ to @TT "hide"@ in order to
     prevent Emacs from inserting a superfluous @TT "See"@ or @TT "see"@ in front of the hyperlinks.
+    This is done automatically for you by running @TO setup@ or @TO setupEmacs@.
   SeeAlso
     viewHelp
     help


### PR DESCRIPTION
This partially addresses #1805 (the other issue will need to be fixed in the M2-emacs repository) and fixes a small bug when `infoHelp` is run without arguments that somehow I missed the first time around.