### PR TITLE
Upgrade to FLINT 2.7.0 and Factory 4.2.0

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -75,7 +75,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew config
-          brew tap mahrud/tap
+          brew tap macaulay2/tap
           brew install autoconf automake bison ccache cmake gnu-tar libtool make ninja pkg-config yasm
           brew install bdw-gc boost eigen gdbm readline libatomic_ops libxml2 libomp tbb
           brew install gmp mpfr ntl flint@2.6.3 factory@4.1.3 mpsolve glpk
@@ -124,11 +124,10 @@ jobs:
             ~/.ccache
             ~/work/M2/M2/M2/BUILD/build/usr-host
           key: build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-${{ hashFiles('**/cmake/*-libraries.cmake', '.github/workflows/test_build.yml') }}
-          # TODO: uncomment these after a successful build
-          # restore-keys: |
-            #build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-
-            #build-cache-${{ runner.os }}-${{ matrix.compiler }}-
-            #build-cache-${{ runner.os }}-
+          restore-keys: |
+            build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-
+            build-cache-${{ runner.os }}-${{ matrix.compiler }}-
+            build-cache-${{ runner.os }}-
 
 
 # ----------------------
@@ -138,8 +137,8 @@ jobs:
       - name: Configure Macaulay2 using CMake
         if: matrix.build-system == 'cmake'
         run: |
-          deps=`brew deps --1 --include-optional mahrud/tap/macaulay2 | tr '\n' ';'`
-          paths=$HOMEBREW_PREFIX/${deps//;/;$HOMEBREW_PREFIX/}
+          deps=`brew deps --1 --include-optional macaulay2/tap/M2 | tr '\n' ';'`
+          paths=$HOMEBREW_PREFIX/opt/${deps//;/;$HOMEBREW_PREFIX/opt/}
           cmake -S../.. -B. -GNinja \
             -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_NATIVE=OFF \
             -DCMAKE_PREFIX_PATH=$paths \

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -123,11 +123,12 @@ jobs:
           path: |
             ~/.ccache
             ~/work/M2/M2/M2/BUILD/build/usr-host
-          key: build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-${{ hashFiles('**/cmake/*-libraries.cmake') }}
-          restore-keys: |
-            build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-
-            build-cache-${{ runner.os }}-${{ matrix.compiler }}-
-            build-cache-${{ runner.os }}-
+          key: build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-${{ hashFiles('**/cmake/*-libraries.cmake', '.github/workflows/test_build.yml') }}
+          # TODO: uncomment these after a successful build
+          # restore-keys: |
+            #build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-
+            #build-cache-${{ runner.os }}-${{ matrix.compiler }}-
+            #build-cache-${{ runner.os }}-
 
 
 # ----------------------

--- a/M2/BUILD/docker/brew/Dockerfile
+++ b/M2/BUILD/docker/brew/Dockerfile
@@ -1,6 +1,6 @@
-# Time usage: 
-# Net usage:  
-# Disk usage: 
+# Time usage: <15min
+# Net usage:  ~700MB
+# Disk usage: ~1GB
 
 FROM linuxbrew/brew
 
@@ -10,17 +10,17 @@ RUN apt-get update && apt-get install -y -q --no-install-recommends vim mlocate 
 USER 1000:0
 
 # Add the tap containing the formulae for Macaulay2 and its dependencies
-RUN brew update && brew config && brew tap mahrud/tap
+RUN brew update && brew config && brew tap Macaulay2/tap
 
 RUN brew install bash-completion && echo '\n\
     [[ -r "`brew --prefix`/etc/profile.d/bash_completion.sh" ]] && \n\
 	. "`brew --prefix`/etc/profile.d/bash_completion.sh"' >> /home/linuxbrew/.bashrc
 
 # Install dependencies of Macaulay2
-#RUN brew install --only-dependencies mahrud/tap/macaulay2
+#RUN brew install --only-dependencies Macaulay2/tap/macaulay2
 
 # Install Macaulay2
-#RUN brew install --verbose --build-bottle mahrud/tap/macaulay2
+#RUN brew install --verbose --build-bottle Macaulay2/tap/macaulay2
 
 RUN sudo updatedb
 

--- a/M2/BUILD/docker/brew/Makefile
+++ b/M2/BUILD/docker/brew/Makefile
@@ -24,7 +24,7 @@ build-image:; docker build --tag $(TAG) .
 ###############################################################################
 # Terminal targets
 
-shell: shell-Linux
+shell: shell-linux
 
 # Run this on Linux
 shell-linux:; docker run $(VOLUME-A) $(VOLUME-C) -it --entrypoint bash $(TAG)

--- a/M2/BUILD/docker/brew/README.md
+++ b/M2/BUILD/docker/brew/README.md
@@ -1,6 +1,6 @@
 # Bottling Macaulay2 for [Homebrew](https://brew.sh/)
 
-Homebrew is a package manager for macOS and Linux. The `Dockerfile` in this directory creates a container image based on Ubuntu 20.04 for building and testing the Homebrew formula for Macaulay2 available at [`mahrud/tap`](https://github.com/mahrud/homebrew-tap).
+Homebrew is a package manager for macOS and Linux. The `Dockerfile` in this directory creates a container image based on Ubuntu 20.04 for building and testing the Homebrew formula for Macaulay2 available at [`Macaulay2/tap`](https://github.com/Macaulay2/homebrew-tap).
 
 ## Getting Started
 0. Install Docker and start the daemon (optionally, also install [Homebrew](https://brew.sh/)).
@@ -18,5 +18,5 @@ make shell-macos # if you are using Homebrew
 
 3. Bottle Macaulay2:
 ```
-brew install --keep-tmp --verbose --build-bottle mahrud/tap/macaulay2
+brew install --keep-tmp --verbose --build-bottle Macaulay2/tap/M2
 ```

--- a/M2/BUILD/mahrud/markdown-changelog.m2
+++ b/M2/BUILD/mahrud/markdown-changelog.m2
@@ -8,6 +8,6 @@ changelog = markdown help("changes, " | ver);
 changelog = replace("/home/.*?/common/share", illinois, changelog);
 changelog = replace("common/share", illinois, changelog);
 changelog = replace("https://faculty.math.illinois.edu", "http://www2.macaulay2.com", changelog);
-("changelog-" | ver | ".md") << changelog
+("changelog-" | ver | ".md") << changelog << close
 
 

--- a/M2/CMakeLists.txt
+++ b/M2/CMakeLists.txt
@@ -1,25 +1,21 @@
-################################## WARNING!! ##################################
-## This is not yet the official build system of Macaulay2. See INSTALL.
-## Why use CMake at all? See https://lwn.net/Articles/188693/ and
-## https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/Really-Cool-CMake-Features
+###############################################################################
+## CMake is a cross-platform system for generating build environments using
+## native tools such as Make and Ninja or IDEs such as Xcode and Visual Studio.
 ##
+## See INSTALL-CMake.md for a comprehensive guide to building M2 using CMake.
 ## Take a look at cmake/configure.cmake for a list of options
 ## and read cmake/check-libraries.cmake for a list of requirements.
 ##
-## Full instructions: INSTALL-CMake.md
 ## Short instructions:
-##  1. cd M2/BUILD/build-cmake
-##  2. cmake -GNinja ../..
-##  3. ninja build-libraries build-programs
-##  4. ninja M2-engine M2-binary M2-core M2-emacs
-##  5. ninja install-packages check-packages
-##  6. ninja install
-##
-## IDEs such as Xcode or vscode can also configure and build using CMake.
+##  1. cmake -GNinja -S . -B BUILD/cmake
+##  2. cmake --build BUILD/cmake --target build-libraries build-programs
+##  2. cmake --build BUILD/cmake --target M2-engine M2-binary M2-core M2-emacs
+##  2. cmake --build BUILD/cmake --target install-packages check-packages
+##  6. cmake --install BUILD/cmake
 ###############################################################################
 
-## Requires CMake version 3.15 and is tested with 3.17
-cmake_minimum_required(VERSION 3.15...3.17)
+## Requires CMake version 3.15 and is tested with 3.19
+cmake_minimum_required(VERSION 3.15...3.19)
 cmake_policy(VERSION 3.14)
 
 ## Use the C++14 standard
@@ -27,11 +23,8 @@ set(CMAKE_CXX_STANDARD 14)
 ## Use the C11 (C0X) standard
 set(CMAKE_C_STANDARD 11)
 
-## Source of truth for project version
-file(STRINGS VERSION VERSION)
-
 ###############################################################################
-## Set the defaultg build configuration
+## Set the default build configuration
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()
@@ -48,7 +41,7 @@ endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 ## Enable ccache or distcc acceleration with Makefile and Ninja
-# TODO: libraries and programs aren't using ccache this way.
+# Note: libraries and programs aren't using ccache this way.
 find_program(CCACHE ccache)
 if(CCACHE)
   # run ccache -s to get the CCache statistics
@@ -57,8 +50,10 @@ if(CCACHE)
 endif()
 
 ###############################################################################
+## Source of truth for project version
+file(STRINGS VERSION VERSION)
+
 ## Set the project name, version, and languages
-## This is the source of truth for the version number
 project(Macaulay2
   VERSION	${VERSION}
   DESCRIPTION	"A software system for algebraic geometry research"
@@ -75,7 +70,6 @@ include(configure) ## CMake script for configuring various variables
 include(check-libraries) ## CMake script for checking which libraries exist and which need to be built
 include(build-libraries) ## CMake script for downloading, building, and installing external libraries
 include(startup) ## CMake script for messy substitutions in Macaulay2/bin/startup.c
-# Note: we separate the two so that check-libraries.cmake can be called by Macaulay2/bin/CMakeLists.txt
 
 ###############################################################################
 ## Configure M2/config.h

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -367,7 +367,6 @@ ExternalProject_Add(build-flint
                     -DCMAKE_CXX_FLAGS=${CXXFLAGS}
                     -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                     -DIPO_SUPPORTED=OFF # TODO: because of clang; see https://github.com/wbhart/flint2/issues/644
-                    -DHAVE_TLS=OFF
                     -DWITH_NTL=ON
                     -DWITH_MPIR=${USING_MPIR}
                     # TODO: force SIMD flags off for distribution
@@ -394,13 +393,12 @@ _ADD_COMPONENT_DEPENDENCY(libraries flint "mp;mpfr;ntl" FLINT_FOUND)
 # https://service.mathematik.uni-kl.de/ftp/pub/Math/Singular/Factory/
 # TODO: what is ftmpl_inst.o?
 ExternalProject_Add(build-factory
-  URL               ${M2_SOURCE_URL}/factory-4.1.3.tar.gz
-  URL_HASH          SHA256=d004dd7e3aafc9881b2bf42b7bc935afac1326f73ad29d7eef0ad33eb72ee158
+  URL               https://service.mathematik.uni-kl.de/ftp/pub/Math/Factory/factory-4.2.0.tar.gz
+  URL_HASH          SHA256=b66c4c78847e24b71386a42ea2fb368b721f5cb03966c8c78801f1677c45e6c0
   PREFIX            libraries/factory
   SOURCE_DIR        libraries/factory/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
-  PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/factory/patch-4.1.3
   CONFIGURE_COMMAND autoreconf -vif &&
                     ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -434,7 +434,7 @@ if(GFTABLESDIR AND NOT EXISTS ${M2_DIST_PREFIX}/${M2_INSTALL_DATADIR}/Core/facto
   message(STATUS "Copying gftables from ${GFTABLESDIR}/gftables")
   file(COPY ${GFTABLESDIR}/gftables DESTINATION ${M2_DIST_PREFIX}/${M2_INSTALL_DATADIR}/Core/factory)
 endif()
-_ADD_COMPONENT_DEPENDENCY(libraries factory "mp;mpfr;ntl;flint" FACTORY_FOUND)
+_ADD_COMPONENT_DEPENDENCY(libraries factory "mp;ntl;flint" FACTORY_FOUND)
 
 
 # https://github.com/Macaulay2/frobby (previously https://www.broune.com/frobby)

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -36,11 +36,10 @@ find_program(ETAGS NAMES etags)
 find_package(Threads	REQUIRED QUIET)
 find_package(LAPACK	REQUIRED QUIET)
 find_package(Boost	REQUIRED QUIET COMPONENTS regex ${Boost_stacktrace})
+# TODO: replace gdbm, see https://github.com/Macaulay2/M2/issues/594
 find_package(GDBM	REQUIRED QUIET) # See FindGDBM.cmake
-# TODO: replace gdbm with capnproto.org or msgpack.org
-# Alternatively protobuf: https://developers.google.com/protocol-buffers/docs/proto#maps
+# TODO: replace libatomic_ops, see https://github.com/Macaulay2/M2/issues/1113
 find_package(AtomicOps	REQUIRED QUIET) # See FindAtomicOps.cmake
-# TODO: remove libatomic_ops
 
 ###############################################################################
 ## Optional	Debian package	RPM package 	Homebrew package
@@ -71,9 +70,9 @@ endif()
 #   readline, history, termcap, ...
 #    (provided by libreadline-dev on Ubuntu and readline )
 
+# TODO: replace these two with libedit, see https://github.com/Macaulay2/M2/issues/825
 find_package(Readline	REQUIRED QUIET) # See FindReadline.cmake
 find_package(History	REQUIRED QUIET) # See FindHistory.cmake
-# TODO: replace Readline with https://github.com/AmokHuginnsson/replxx
 
 ###############################################################################
 ## Multi-precision arithmetic requirements:
@@ -255,12 +254,6 @@ foreach(_program IN LISTS PROGRAM_OPTIONS)
       unset(${_name} CACHE) # Unlike libraries, programs are set in cache
     else()
       # exists on the system
-      # TODO: Make a symbolic link to the existing executable in the programs directory
-      # if(${program} AND NOT ${program} MATCHES ${M2_INSTALL_PROGRAMSDIR})
-      #   get_filename_component(program_name ${${program}} NAME)
-      #   file(CREATE_LINK ${${program}} ${M2_INSTALL_PROGRAMSDIR}/${program_name} SYMBOLIC)
-      # endif()
-      # TODO: alternatively, fix M2 to look for programs on PATH
     endif()
   else()
     # was not found

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -79,7 +79,7 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
     OUTPUT_VARIABLE   COMMIT_COUNT)
   set(GIT_DESCRIPTION version-${PROJECT_VERSION}-${COMMIT_COUNT}-${GIT_COMMIT})
 else()
-  set(GIT_DESCRIPTION version-${PROJECT_VERSION}-unknown)
+  set(GIT_DESCRIPTION version-${PROJECT_VERSION})
 endif()
 
 message("## Configure Macaulay2

--- a/M2/libraries/factory/Makefile.in
+++ b/M2/libraries/factory/Makefile.in
@@ -4,6 +4,7 @@
 # old URL = ftp://www.mathematik.uni-kl.de/pub/Math/Singular/Factory
 # URL = ftp://jim.mathematik.uni-kl.de/pub/Math/Factory
 # https://github.com/Singular/Sources
+# https://service.mathematik.uni-kl.de/ftp/pub/Math/Factory/factory-4.2.0.tar.gz
 
 # We seem to be the only users of the factory library, which is part of
 # Singular.  Its source code accompanies binary installations of Singular,
@@ -12,8 +13,8 @@
 # it at one of the ftp sites above.  Version 4.1.3 is available.
 
 URL = http://macaulay2.com/Downloads/OtherSourceCode
-VERSION = 4.1.3
-PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+VERSION = 4.2.0
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PRECONFIGURE = autoreconf -vif
 
 BUILDTARGET = all ftmpl_inst.o

--- a/M2/libraries/flint/Makefile.in
+++ b/M2/libraries/flint/Makefile.in
@@ -1,8 +1,9 @@
+LIBNAME = flint2
 HOMEPAGE = http://flintlib.org
 # git://github.com/wbhart/flint2.git
 URL = http://macaulay2.com/Downloads/OtherSourceCode
-VERSION = 2.6.0
-# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+VERSION = 2.7.0
+PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PARALLEL = yes
 
 # Many other tests keep failing, so disable them all:
@@ -16,7 +17,7 @@ endif
 CFLAGS += -std=c90 -pedantic-errors
 # the flint configure script does not accept CPPFLAGS
 # CONFIGURECMD =  LIB_DIRS=$(LIBRARIESDIR)/lib ./configure  --with-gc --with-blas --disable-tls
-CONFIGURECMD =  LIB_DIRS=$(LIBRARIESDIR)/lib ./configure --with-blas --disable-tls \
+CONFIGURECMD =  LIB_DIRS=$(LIBRARIESDIR)/lib ./configure --without-blas --disable-tls \
 			--prefix='$(PREFIX)' --disable-shared CC='$(CC)' \
 			CFLAGS='$(CFLAGS) $(CPPFLAGS)'
 

--- a/M2/libraries/flint/patch-2.7.0
+++ b/M2/libraries/flint/patch-2.7.0
@@ -1,0 +1,21 @@
+diff -ur --unidirectional-new-file /Users/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/gallium-release-1.17/libraries/flint/tmp/flint2-2.7.0/fmpz_mod_mpoly/test/t-foo.c flint2-2.7.0/fmpz_mod_mpoly/test/t-foo.c
+--- /Users/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/gallium-release-1.17/libraries/flint/tmp/flint2-2.7.0/fmpz_mod_mpoly/test/t-foo.c	1969-12-31 18:00:00.000000000 -0600
++++ flint2-2.7.0/fmpz_mod_mpoly/test/t-foo.c	2021-01-12 16:12:07.000000000 -0600
+@@ -0,0 +1,3 @@
++int main () {
++     return 0;
++     }
+diff -ur --unidirectional-new-file /Users/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/gallium-release-1.17/libraries/flint/tmp/flint2-2.7.0/fq_zech_mpoly/test/t-foo.c flint2-2.7.0/fq_zech_mpoly/test/t-foo.c
+--- /Users/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/gallium-release-1.17/libraries/flint/tmp/flint2-2.7.0/fq_zech_mpoly/test/t-foo.c	1969-12-31 18:00:00.000000000 -0600
++++ flint2-2.7.0/fq_zech_mpoly/test/t-foo.c	2021-01-12 16:12:07.000000000 -0600
+@@ -0,0 +1,3 @@
++int main () {
++     return 0;
++     }
+diff -ur --unidirectional-new-file /Users/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/gallium-release-1.17/libraries/flint/tmp/flint2-2.7.0/fq_zech_mpoly_factor/test/t-foo.c flint2-2.7.0/fq_zech_mpoly_factor/test/t-foo.c
+--- /Users/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/gallium-release-1.17/libraries/flint/tmp/flint2-2.7.0/fq_zech_mpoly_factor/test/t-foo.c	1969-12-31 18:00:00.000000000 -0600
++++ flint2-2.7.0/fq_zech_mpoly_factor/test/t-foo.c	2021-01-12 16:12:07.000000000 -0600
+@@ -0,0 +1,3 @@
++int main () {
++     return 0;
++     }


### PR DESCRIPTION
- [x] Fixes #1808 for CMake
- [x] update factory build for autotools.

@DanGrayson: this only updates the CMake build. The builds won't fail, because flint is installed from either brew or apt currently, but could you fix the autotools build and add a commit to this PR?