### PR TITLE
Don't capture DiffAlg tests

### DIFF
--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -115,7 +115,7 @@ isCapturable = (inputs, pkg, isTest) -> (
     inputs = replace("-\\*.*?\\*-", "", inputs);
     -- TODO: remove this when the effects of capture on other packages is reviewed
     (isTest or match({"FirstPackage", "Macaulay2Doc"},            pkg#"pkgname"))
-    and not match({"EngineTests", "ThreadedGB", "RunExternalM2"}, pkg#"pkgname")
+    and not match({"EngineTests", "ThreadedGB", "RunExternalM2", "DiffAlg"}, pkg#"pkgname")
     -- FIXME: these are workarounds to prevent bugs, in order of priority for being fixed:
     and not match("(gbTrace|NAGtrace)",                       inputs) -- cerr/cout directly from engine isn't captured
     and not match("(notify|stopIfError|debuggingMode)",       inputs) -- stopIfError and debuggingMode may be fixable

--- a/M2/Macaulay2/packages/DiffAlg.m2
+++ b/M2/Macaulay2/packages/DiffAlg.m2
@@ -1316,7 +1316,6 @@ assert( (w^(diff (L_0)) + (L_0) ^ (diff w))#"f" == 0)
 ///
 
 TEST ///
--* no-capture-flag *-
 w = random newForm(3,2,2,"a")
 h = newForm(3,1,1,"b")
 L = genKer(w^(diff h) + h ^ (diff w), h)


### PR DESCRIPTION
As discussed in #1728, there appears to be a memory leak.  The test
failed on a recent build of the Debian package on powerpc.