### PR TITLE
Don't use capture during check "Core"

### DIFF
--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -115,7 +115,7 @@ isCapturable = (inputs, pkg, isTest) -> (
     inputs = replace("-\\*.*?\\*-", "", inputs);
     -- TODO: remove this when the effects of capture on other packages is reviewed
     (isTest or match({"FirstPackage", "Macaulay2Doc"},            pkg#"pkgname"))
-    and not match({"EngineTests", "ThreadedGB", "RunExternalM2", "DiffAlg"}, pkg#"pkgname")
+    and not match({"EngineTests", "ThreadedGB", "RunExternalM2", "DiffAlg", "Core"}, pkg#"pkgname")
     -- FIXME: these are workarounds to prevent bugs, in order of priority for being fixed:
     and not match("(gbTrace|NAGtrace)",                       inputs) -- cerr/cout directly from engine isn't captured
     and not match("(notify|stopIfError|debuggingMode)",       inputs) -- stopIfError and debuggingMode may be fixable


### PR DESCRIPTION
Otherwise, we run out of memory on i386.

Closes: #1834