### PR TITLE
Angle bar list

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1380,6 +1380,7 @@ locate(e:Code):void := (
      is nullCode do nothing
      is v:adjacentCode do (lookat(v.position); locate(v.lhs); locate(v.rhs);)
      is v:arrayCode do foreach c in v.z do locate(c)
+     is v:angleBarListCode do foreach c in v.t do locate(c)
      is v:Error do lookat(v.position)
      is v:semiCode do foreach c in v.w do locate(c)
      is v:binaryCode do (lookat(v.position); locate(v.lhs); locate(v.rhs);)

--- a/M2/Macaulay2/d/basic.d
+++ b/M2/Macaulay2/d/basic.d
@@ -143,6 +143,12 @@ export Array(e:Expr,f:Expr):Expr := Array(Sequence(e,f));
 export Array(e:Expr,f:Expr,g:Expr):Expr := Array(Sequence(e,f,g));
 export Array(e:Expr,f:Expr,g:Expr,h:Expr):Expr := Array(Sequence(e,f,g,h));
 
+export AngleBarList(a:Sequence):Expr := (
+     r := List(angleBarListClass,a,0,false);
+     r.hash = hash(r);
+     Expr(r));
+export emptyAngleBarList := AngleBarList(Sequence());
+
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d basic.o "
 -- End:

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -287,6 +287,7 @@ bumpPrecedence();
 bumpPrecedence();
      precBracket := prec;
      export leftbracket := parens("[","]",precBracket, precRightParen, precRightParen);
+     export leftAngleBar := parens("<|","|>",precBracket, precRightParen, precRightParen);
 bumpPrecedence();
      export BackslashBackslashS := makeKeyword(binaryright("\\\\"));
      export StarS := makeKeyword(unarybinaryleft("*"));	    -- also binary

--- a/M2/Macaulay2/d/classes.dd
+++ b/M2/Macaulay2/d/classes.dd
@@ -73,6 +73,7 @@ setupconst("Database",Expr(dbClass));
 setupconst("Sequence",Expr(sequenceClass));
 setupconst("VisibleList",Expr(visibleListClass));
 setupconst("Array",Expr(arrayClass));
+setupconst("AngleBarList",Expr(angleBarListClass));
 setupconst("Ring",Expr(ringClass));
 setupconst("Nothing",Expr(nothingClass));
 setupconst("Task",Expr(taskClass));

--- a/M2/Macaulay2/d/common.d
+++ b/M2/Macaulay2/d/common.d
@@ -7,6 +7,7 @@ export codePosition(c:Code):Position := (
      when c
      is f:adjacentCode do f.position
      is f:arrayCode do f.position
+     is f:angleBarListCode do f.position
      is f:binaryCode do f.position
      is f:catchCode do f.position
      is f:Error do f.position
@@ -52,6 +53,7 @@ export tostring(c:Code):string := (
      is x:Error do concatenate(array(string)( "(error \"", x.message, "\")"))
      is x:semiCode do concatenate(array(string)( "(semi ", between(" ",new array(string) len length(x.w) do foreach s in x.w do provide tostring(s)), ")"))
      is x:arrayCode do concatenate(array(string)( "(array ", between(" ",new array(string) len length(x.z) do foreach s in x.z do provide tostring(s)), ")"))
+     is x:angleBarListCode do concatenate(array(string)( "(angleBarList ", between(" ",new array(string) len length(x.t) do foreach s in x.t do provide tostring(s)), ")"))
      is x:binaryCode do concatenate(array(string)("(2-OP ",getBinopName(x.f)," ",tostring(x.lhs)," ",tostring(x.rhs),")"))
      is x:adjacentCode do concatenate(array(string)("(adjacent ",tostring(x.lhs)," ",tostring(x.rhs),")"))
      is x:forCode do concatenate(array(string)(

--- a/M2/Macaulay2/d/convertr.d
+++ b/M2/Macaulay2/d/convertr.d
@@ -186,6 +186,7 @@ export convert(e:ParseTree):Code := (
 	  if p.left.word == leftparen then Code(sequenceCode(CodeSequence(),treePosition(e)))
 	  else if p.left.word == leftbrace then Code(listCode(CodeSequence(),treePosition(e)))
 	  else if p.left.word == leftbracket then Code(arrayCode(CodeSequence(),treePosition(e)))
+	  else if p.left.word == leftAngleBar then Code(angleBarListCode(CodeSequence(),treePosition(e)))
 	  else dummyCode			  -- should not happen
 	  )
      is p:Parentheses do (
@@ -195,6 +196,9 @@ export convert(e:ParseTree):Code := (
 	  else 
 	  if p.left.word == leftbracket 
 	  then Code(arrayCode(makeCodeSequence(p.contents,CommaW),treePosition(e)))
+	  else 
+	  if p.left.word == leftAngleBar
+	  then Code(angleBarListCode(makeCodeSequence(p.contents,CommaW),treePosition(e)))
 	  else 
 	  dummyCode			  -- should not happen
 	  )

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1420,6 +1420,11 @@ export evalraw(c:Code):Expr := (
 	       if length(v.z) == 0 then return emptyArray;
 	       r := evalSequence(v.z);
 	       if evalSequenceHadError then evalSequenceErrorMessage else Array(r)
+	       )
+	  is v:angleBarListCode do (
+	       if length(v.t) == 0 then return emptyAngleBarList;
+	       r := evalSequence(v.t);
+	       if evalSequenceHadError then evalSequenceErrorMessage else AngleBarList(r)
 	       ));
      when e is Error do handleError(c,e) else e);
 

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -280,6 +280,7 @@ export visibleListClass := newtypeof(basicListClass);
 export listClass := newtypeof(visibleListClass);
 export sequenceClass := newtypeof(visibleListClass);
 export arrayClass := newtypeof(visibleListClass);
+export angleBarListClass := newtypeof(visibleListClass);
 export errorMessageClass := newtypeof(basicListClass);
 export missingMethodClass := newtypeof(errorMessageClass);
 

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -280,7 +280,6 @@ export visibleListClass := newtypeof(basicListClass);
 export listClass := newtypeof(visibleListClass);
 export sequenceClass := newtypeof(visibleListClass);
 export arrayClass := newtypeof(visibleListClass);
-export angleBarListClass := newtypeof(visibleListClass);
 export errorMessageClass := newtypeof(basicListClass);
 export missingMethodClass := newtypeof(errorMessageClass);
 
@@ -327,6 +326,7 @@ export rawSLProgramClass := newtypeof(rawObjectClass);    -- RawSLProgram
 export rawPointArrayClass := newtypeof(rawObjectClass);    -- RawPointArray
 -- NAG end
 export rawMutableComplexClass := newtypeof(rawObjectClass);	    -- RawMutableComplex
+export angleBarListClass := newtypeof(visibleListClass);
 -- all new types, dictionaries, and classes go just above this line, if possible, so hash codes don't change gratuitously!
 
 

--- a/M2/Macaulay2/d/parse.d
+++ b/M2/Macaulay2/d/parse.d
@@ -225,13 +225,14 @@ export newFromCode   := {+newClause:Code,fromClause:Code,position:Position};
 export newOfCode     := {+newClause:Code,ofClause:Code,position:Position};
 export newCode       := {+newClause:Code,position:Position};
 
-export CodeSequence := tarray(Code);
-export sequenceCode := {+x:CodeSequence, position:Position};
-export listCode     := {+y:CodeSequence, position:Position};
-export arrayCode    := {+z:CodeSequence, position:Position};
-export semiCode     := {+w:CodeSequence, position:Position};
-export multaryCode := {+f:multop, args:CodeSequence, position:Position};
-export forCode := {+inClause:Code, fromClause:Code, toClause:Code, whenClause:Code, listClause:Code, doClause:Code, frameID:int, framesize:int, position:Position} ;
+export CodeSequence     := tarray(Code);
+export sequenceCode     := {+x:CodeSequence, position:Position};
+export listCode         := {+y:CodeSequence, position:Position};
+export arrayCode        := {+z:CodeSequence, position:Position};
+export angleBarListCode := {+t:CodeSequence, position:Position};
+export semiCode         := {+w:CodeSequence, position:Position};
+export multaryCode      := {+f:multop, args:CodeSequence, position:Position};
+export forCode          := {+inClause:Code, fromClause:Code, toClause:Code, whenClause:Code, listClause:Code, doClause:Code, frameID:int, framesize:int, position:Position} ;
 
 export newLocalFrameCode := {+
      frameID:int,
@@ -258,7 +259,7 @@ export Code := (
      or globalSymbolClosureCode or threadSymbolClosureCode or localSymbolClosureCode
      or parallelAssignmentCode 
      or unaryCode or binaryCode or ternaryCode or multaryCode or forCode
-     or sequenceCode or listCode or arrayCode or semiCode
+     or sequenceCode or listCode or arrayCode or angleBarListCode or semiCode
      or newCode or newFromCode or newOfCode or newOfFromCode
      or whileDoCode or whileListCode or whileListDoCode
      or ifCode or tryCode or adjacentCode or functionCode or catchCode

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -55,6 +55,7 @@ export {
 	"AfterPrint",
 	"Algorithm",
 	"Alignment",
+	"AngleBarList",
 	"Array",
 	"Ascending",
 	"AssociativeExpression",

--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -28,6 +28,7 @@ toString BasicList := s -> concatenate(
      "{", between(", ",apply(toList s,toStringn)), "}"
      )
 toString Array := s -> concatenate ( "[", between(", ",toStringn \ toList s), "]" )
+toString AngleBarList := s -> concatenate ( "<|", between(", ",toStringn \ toList s), "|>" )
 toString Sequence := s -> (
      if # s === 1 then concatenate("1 : (",toString s#0,")")
      else concatenate("(",between(",",toStringn \ s),")")
@@ -167,6 +168,10 @@ net Array := x -> horizontalJoin deepSplice (
      "[",
      toSequence between(comma,apply(x,netn)),
      "]")
+net AngleBarList := x -> horizontalJoin deepSplice (
+     "<|",
+     toSequence between(comma,apply(x,netn)),
+     "|>")
 net BasicList := x -> horizontalJoin deepSplice (
       net class x, 
       "{",

--- a/M2/Macaulay2/tests/normal/lists.m2
+++ b/M2/Macaulay2/tests/normal/lists.m2
@@ -10,3 +10,9 @@ assert( product(3,g) == 24 )
 assert( sum(a,b,h) == 18 )
 assert( product(a,b,h) == 192 )
 
+i = <| x,y,z |>
+assert (#i == 3)
+assert (toString i == "<|x, y, z|>")
+assert (net i == "<|x, y, z|>"^0)
+assert (toList i === {x,y,z})
+assert (class i === AngleBarList)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1139,8 +1139,8 @@ AC_LANG(C++)
 AC_CHECK_HEADER(frobby.h,LIBS="-lfrobby $LIBS",BUILD_frobby=yes)
 if test $BUILD_frobby = yes
 then BUILTLIBS="-lfrobby $BUILTLIBS"
-    dnl change this to [1] when frobby is built from a submodule
-    AC_DEFINE([HAVE_FROBBY_VERSION], [0], [whether frobby has frobby_version])
+    dnl uncomment this to [1] when frobby is built from a submodule (?)
+    dnl AC_DEFINE([HAVE_FROBBY_VERSION], [0], [whether frobby has frobby_version])
 else
     AC_MSG_CHECKING([whether frobby has frobby_version])
     AC_COMPILE_IFELSE(


### PR DESCRIPTION
add a new type of visible list of a type called AngleBarList
    
Example:

        i11 : <| x,y,z |>
    
        o11 = <|x, y, z|>

Intended use: associative algebras, by Stillman and Moore
