### PR TITLE
Show correct minimum version of flint in autoconf check

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -937,7 +937,7 @@ dnl factory needs to know:
 AC_SUBST(BUILD_flint)
 if test $BUILD_flint = no
 then AC_LANG(C)
-     AC_MSG_CHECKING([for flint >= 2.7.0])
+     AC_MSG_CHECKING([for flint >= 2.6.3])
      AC_COMPILE_IFELSE(
         [AC_LANG_PROGRAM(
 	  [#include <flint/flint.h>


### PR DESCRIPTION
We're actually checking for a minimum version of 2.6.3, but the
message was stating a lower bound of 2.7.0.