### PR TITLE
Don't use "capture" for Core or Cremona tests on 32-bit systems

### DIFF
--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -116,6 +116,7 @@ isCapturable = (inputs, pkg, isTest) -> (
     -- TODO: remove this when the effects of capture on other packages is reviewed
     (isTest or match({"FirstPackage", "Macaulay2Doc"},            pkg#"pkgname"))
     and not match({"EngineTests", "ThreadedGB", "RunExternalM2", "DiffAlg"}, pkg#"pkgname")
+    and not (match({"Core", "Cremona"}, pkg#"pkgname") and version#"pointer size" == 4)
     -- FIXME: these are workarounds to prevent bugs, in order of priority for being fixed:
     and not match("(gbTrace|NAGtrace)",                       inputs) -- cerr/cout directly from engine isn't captured
     and not match("(notify|stopIfError|debuggingMode)",       inputs) -- stopIfError and debuggingMode may be fixable


### PR DESCRIPTION
Otherwise, they run out of memory.  Band-aid for #1834.