### PR TITLE
Use "fetchAnyRawDocumentation" in "infoHelp"

### DIFF
--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -456,10 +456,14 @@ setAttribute(viewHelp#0, ReverseDictionary, symbol viewHelp)
 infoHelp = method(Dispatch => Thing)
 infoHelp Thing := key -> (
     if key === () then return infoHelp "Macaulay2Doc";
-    tag := infoTagConvert makeDocumentTag(key, Package => null);
-    if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format tag)
-    -- used by M2-info-help in M2.el
-    else print("-*" | " infoHelp: " | tag | " *-");)
+    rawdoc := fetchAnyRawDocumentation makeDocumentTag(key, Package => null);
+    if (tag := getOption(rawdoc, symbol DocumentTag)) =!= null
+    then (
+	tag = infoTagConvert tag;
+	if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format tag)
+	-- used by M2-info-help in M2.el
+	else print("-*" | " infoHelp: " | tag | " *-");
+    ) else error("no documentation for ", format key))
 infoHelp ZZ := i -> seeAbout(infoHelp, i)
 infoHelp = new Command from infoHelp
 -- This ensures that "methods infoHelp" and "?infoHelp" work as expected


### PR DESCRIPTION
We weren't always finding the correct package, e.g., when spaces were
in the key.

We also raise an error when no documentation exists in Macaulay2,
rather than calling info first and having it raise an error.

Closes: #1868