### PR TITLE
"infoHelp" updates

### DIFF
--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -455,15 +455,17 @@ setAttribute(viewHelp#0, ReverseDictionary, symbol viewHelp)
 
 infoHelp = method(Dispatch => Thing)
 infoHelp Thing := key -> (
-    if key === () then return infoHelp "Macaulay2Doc";
-    rawdoc := fetchAnyRawDocumentation makeDocumentTag(key, Package => null);
-    if (tag := getOption(rawdoc, symbol DocumentTag)) =!= null
+    if key === () then infoHelp "Macaulay2Doc"
+    else infoHelp makeDocumentTag key)
+infoHelp DocumentTag := tag -> (
+    rawdoc := fetchAnyRawDocumentation tag;
+    if (tag' := getOption(rawdoc, symbol DocumentTag)) =!= null
     then (
-	tag = infoTagConvert tag;
-	if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format tag)
+	infoTag := infoTagConvert tag';
+	if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format infoTag)
 	-- used by M2-info-help in M2.el
-	else print("-*" | " infoHelp: " | tag | " *-");
-    ) else error("no documentation for ", format key))
+	else print("-*" | " infoHelp: " | infoTag | " *-");
+    ) else error("no documentation for ", format tag))
 infoHelp ZZ := i -> seeAbout(infoHelp, i)
 infoHelp = new Command from infoHelp
 -- This ensures that "methods infoHelp" and "?infoHelp" work as expected

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -453,19 +453,26 @@ viewHelp = new Command from viewHelp
 -- This ensures that "methods viewHelp" and "?viewHelp" work as expected
 setAttribute(viewHelp#0, ReverseDictionary, symbol viewHelp)
 
+makeInfo := tag -> (
+    infoFile := temporaryDirectory() | toFilename format tag | ".info";
+    if not fileExists infoFile then infoFile << "\037" << endl <<
+	"Node: Top, Up: (Macaulay2Doc)Top" << endl << endl <<
+	info help tag << endl << close;
+    infoFile
+)
+
 infoHelp = method(Dispatch => Thing)
 infoHelp Thing := key -> (
     if key === () then infoHelp "Macaulay2Doc"
     else infoHelp makeDocumentTag key)
 infoHelp DocumentTag := tag -> (
     rawdoc := fetchAnyRawDocumentation tag;
-    if (tag' := getOption(rawdoc, symbol DocumentTag)) =!= null
-    then (
-	infoTag := infoTagConvert tag';
-	if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format infoTag)
-	-- used by M2-info-help in M2.el
-	else print("-*" | " infoHelp: " | infoTag | " *-");
-    ) else error("no documentation for ", format tag))
+    tag' := getOption(rawdoc, symbol DocumentTag);
+    infoTag := if tag' =!= null then infoTagConvert tag' else makeInfo tag;
+    if getenv "INSIDE_EMACS" == "" then chkrun ("info " | format infoTag)
+    -- used by M2-info-help in M2.el
+    else print("-*" | " infoHelp: " | infoTag | " *-")
+)
 infoHelp ZZ := i -> seeAbout(infoHelp, i)
 infoHelp = new Command from infoHelp
 -- This ensures that "methods infoHelp" and "?infoHelp" work as expected

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
@@ -113,6 +113,7 @@ doc ///
   Key
     infoHelp
     (infoHelp, Thing)
+    (infoHelp, DocumentTag)
   Headline
     view documentation in Info format
   Usage


### PR DESCRIPTION
We more closely mimic the behavior of `viewHelp`.  In particular:

* Add a new `(infoHelp, DocumentTag)` method that ends up doing most of the work.
* Generate info pages on the fly for unknown documentation.

### Before
```
i1 : infoHelp foo
stdio:1:1:(3): error: no method found for applying format to:
     argument   :  foo (of class Symbol)
```
(We actually raised an error while creating our error message, since `infoHelp`'s error message was trying to call `format` on a `Thing`!)

### After
```m2
i1 : infoHelp foo
```
brings up:

```info
Up: (Macaulay2Doc)Top

foo
***

For the programmer
==================

The object foo (missing documentation) is a *note symbol: (Macaulay2Doc)Symbol,\
.












-----Info: (foo)Top, 10 lines --All---------------------------------------------
Welcome to Info version 6.7.  Type H for help, h for tutorial.

```