### PR TITLE
Minor edits related to singularLocus

### DIFF
--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -491,11 +491,11 @@ Ideal#{Standard,AfterPrint} = Ideal#{Standard,AfterNoPrint} = (I) -> (
 Ideal ^ ZZ := Ideal => (I,n) -> ideal symmetricPower(n,generators I)
 Ideal * Ideal := Ideal => ((I,J) -> ideal flatten (generators I ** generators J)) @@ samering
 Ideal * Module := Module => ((I,M) -> subquotient (generators I ** generators M, relations M)) @@ samering
-dim Ideal := I -> dim cokernel generators I
+dim Ideal := (cacheValue symbol dim) (I -> dim cokernel generators I)
 Ideal + Ideal := Ideal => ((I,J) -> ideal (generators I | generators J)) @@ tosamering
 Ideal + RingElement := Ideal + Number := ((I,r) -> I + ideal r) @@ tosamering
 RingElement + Ideal := Number + Ideal := ((r,I) -> ideal r + I) @@ tosamering
-degree Ideal := I -> degree cokernel generators I
+degree Ideal := (cacheValue symbol degree) (I -> degree cokernel generators I)
 Ideal _ ZZ := RingElement => (I,n) -> (generators I)_(0,n)
 Matrix % Ideal := Matrix => ((f,I) -> 
      if numRows f === 1

--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -491,11 +491,11 @@ Ideal#{Standard,AfterPrint} = Ideal#{Standard,AfterNoPrint} = (I) -> (
 Ideal ^ ZZ := Ideal => (I,n) -> ideal symmetricPower(n,generators I)
 Ideal * Ideal := Ideal => ((I,J) -> ideal flatten (generators I ** generators J)) @@ samering
 Ideal * Module := Module => ((I,M) -> subquotient (generators I ** generators M, relations M)) @@ samering
-dim Ideal := (cacheValue symbol dim) (I -> dim cokernel generators I)
+dim Ideal := I -> dim cokernel generators I
 Ideal + Ideal := Ideal => ((I,J) -> ideal (generators I | generators J)) @@ tosamering
 Ideal + RingElement := Ideal + Number := ((I,r) -> I + ideal r) @@ tosamering
 RingElement + Ideal := Number + Ideal := ((r,I) -> ideal r + I) @@ tosamering
-degree Ideal := (cacheValue symbol degree) (I -> degree cokernel generators I)
+degree Ideal := I -> degree cokernel generators I
 Ideal _ ZZ := RingElement => (I,n) -> (generators I)_(0,n)
 Matrix % Ideal := Matrix => ((f,I) -> 
      if numRows f === 1

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -353,10 +353,10 @@ Module == ZZ := (M,n) -> (
 	  )
      )
 
-dim Module := (cacheValue symbol dim) (M -> (
+dim Module := M -> (
      c := codim M;
      if c === infinity then -1 else dim ring M - c
-     ))
+     )
 
 degree Ring := (cacheValue symbol degree) (R -> degree R^1)
 degree Module := (

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -353,12 +353,12 @@ Module == ZZ := (M,n) -> (
 	  )
      )
 
-dim Module := M -> (
+dim Module := (cacheValue symbol dim) (M -> (
      c := codim M;
      if c === infinity then -1 else dim ring M - c
-     )
+     ))
 
-degree Ring := R -> degree R^1
+degree Ring := (cacheValue symbol degree) (R -> degree R^1)
 degree Module := (
      () -> (
      	  -- constants:
@@ -366,7 +366,7 @@ degree Module := (
 	  local T;
 	  local h;
 	  local ev;
-	  M -> (
+	  (cacheValue symbol degree) (M -> (
 	       if ZZ1 === null then (
 		    ZZ1 = degreesRing 1;
 		    T = ZZ1_0;
@@ -382,7 +382,7 @@ degree Module := (
 	       if hn == 0 then return 0;
 	       while hn % h == 0 do hn = hn // h;
 	       if ev === null then ev = map(ZZ,ZZ1,{1}); -- ring maps are defined only later
-	       ev hn)))()
+	       ev hn))))()
 
 multidegree Module := M -> (
      A := degreesRing M;

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -265,7 +265,7 @@ presentation(PolynomialRing, PolynomialRing) := (R,S) -> (
 	  );
      v)
 
-dim QuotientRing := (R) -> (
+dim QuotientRing := (cacheValue symbol dim) ((R) -> (
      if isField R then 0
      else if R.?SkewCommutative then notImplemented()
      else (
@@ -273,7 +273,7 @@ dim QuotientRing := (R) -> (
 	  cd := codim I;
 	  if cd === infinity then -1 else dim ring I - codim I
 	  )
-     )
+     ))
 
 monoid QuotientRing := o -> (cacheValue monoid) (S -> monoid ambient S)
 degreesMonoid QuotientRing := (cacheValue degreesMonoid) (S -> degreesMonoid ambient S)
@@ -296,12 +296,12 @@ char QuotientRing := (stashValue symbol char) ((S) -> (
      if g == 0 then return char ring g;
      m := g_(0,0);
      if liftable(m,ZZ) then lift(m,ZZ) else 0))
-singularLocus(Ring) := QuotientRing => (R) -> (
+singularLocus(Ring) := QuotientRing => (cacheValue symbol singularLocus) ((R) -> (
      f := presentation R;
      A := ring f;
-     A / (ideal f + minors(codim(R,Generic=>true), jacobian presentation R)))
+     A / (ideal f + minors(codim(R,Generic=>true), jacobian f, Strategy=>Cofactor))))
 
-singularLocus(Ideal) := QuotientRing => (I) -> singularLocus(ring I / I)
+singularLocus(Ideal) := QuotientRing => (cacheValue symbol singularLocus) ((I) -> singularLocus(ring I / I))
 
 toField = method()
 toField Ring := R -> (

--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -25,8 +25,6 @@ degmap0 := n -> ( d := toList ( n : 0 ); e -> d )
 map(RingFamily,Thing,Thing) := RingMap => opts -> (R,S,m) -> map(default R,S,m,opts)
 map(Thing,RingFamily,Thing) := RingMap => opts -> (R,S,m) -> map(R,default S,m,opts)
 
-workable = f -> try (f(); true) else false
-
 map(Ring,Ring,Matrix) := RingMap => opts -> (R,S,m) -> (
      if not isFreeModule target m or not isFreeModule source m
      then error "expected a homomorphism between free modules";
@@ -49,7 +47,6 @@ map(Ring,Ring,Matrix) := RingMap => opts -> (R,S,m) -> (
 		    " into a degree of length ", toString degreeLength R);
 	       opts.DegreeMap
 	       )
-	  else if workable (() -> promote({},S,R)) then (d -> first promote({d},S,R))
 	  else if degreeLength R === degreeLength S then identity
 	  else if degreeLength S === 0 or degreeLength R === 0 then degmap0 degreeLength R
 	  else (

--- a/M2/Macaulay2/m2/varieties.m2
+++ b/M2/Macaulay2/m2/varieties.m2
@@ -300,7 +300,7 @@ singularLocus(ProjectiveVariety) := X -> (
      f := presentation R;
      A := ring f;
      checkRing A;
-     Proj(A / saturate (minors(codim(R,Generic=>true), jacobian f) + ideal f)))
+     Proj(A / saturate (minors(codim(R,Generic=>true), jacobian f, Strategy=>Cofactor) + ideal f)))
 
 singularLocus(AffineVariety) := X -> Spec singularLocus ring X
 


### PR DESCRIPTION
Related to #1899 
- Changed the `minors` strategy to `Cofactor` in `singularLocus`;
- Removed one useless test in ringmap.m2 (`promote` cannot be used this way so it will always fail) that can slow down computation;
- Added `cacheValue` to several properties.