### PR TITLE
Compile the e directory with GNU C++17 extensions

### DIFF
--- a/M2/Macaulay2/d/Makefile.in
+++ b/M2/Macaulay2/d/Makefile.in
@@ -181,7 +181,7 @@ CFLAGS   += -Wunused-function
 CXXFLAGS += -Wunused-function
 
 CFLAGS   += -Wfatal-errors
-CXXFLAGS += -Wfatal-errors -std=c++17
+CXXFLAGS += -Wfatal-errors
 
 version.o : CXXFLAGS += -Wno-unused-local-typedefs
 

--- a/M2/Macaulay2/e/Makefile.in
+++ b/M2/Macaulay2/e/Makefile.in
@@ -9,7 +9,7 @@ PRE.cc   = $(COMPILE.cc) -E
 include @srcdir@/Makefile.files
 include Makefile.common
 CPPFLAGS := -I@srcdir@ $(CPPFLAGS) -I../d -I@srcdir@/../c -Wno-fatal-errors
-CXXFLAGS += -Wno-unknown-pragmas -std=c++17
+CXXFLAGS += -Wno-unknown-pragmas -std=gnu++17
 
 DOXYGEN_CONF_DIR :=$(SRCDIR)/doxygen-settings
 


### PR DESCRIPTION
The lack of GNU extensions was causing build failures on 64-bit Ubuntu 18.04 systems (#1902) and some powerpc systems (#1901) during the autotools build.  (Note that I don't believe this was an issue with the CMake build -- [compiler extensions are enabled by default](https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html)).

~I also removed setting the C and C++ standards from the configure script, as suggested by Dan's comment (https://github.com/Macaulay2/M2/issues/1901#issuecomment-775211692)~, and also removed setting the C++ standard in the `d` directory Makefile, since we really only need C++17 in the `e` directory.

~(I'm not 100% sure yet that this will fix #1901 -- waiting on tonight's PPA build to confirm.)~ It worked!