### PR TITLE
Set "Up" node to "(dir) for "Top" nodes of package info files

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -354,7 +354,8 @@ installInfo := (pkg, installPrefix, installLayout, verboseLog) -> (
 	    if PREV#?tag then infofile << ", Prev: " << infoTagConvert' format PREV#tag;
 	    -- nodes without an Up: link tend to make the emacs info reader unable to construct the table of contents,
 	    -- and the display isn't as nice after that error occurs
-	    infofile << ", Up: " << if UP#?tag then infoTagConvert' format UP#tag else "Top";
+	    infofile << ", Up: " << if UP#?tag then infoTagConvert' format UP#tag else
+		if fkey == infotitle then "(dir)" else "Top";
 	    infofile << endl << endl << info fetchProcessedDocumentation(pkg, fkey) << endl));
     infofile << "\037" << endl << "Tag Table:" << endl;
     scan(values byteOffsets, b -> infofile << b << endl);


### PR DESCRIPTION
Previously, they served as their own "Up" node, but the convention
among other info files on the system (e.g., the Emacs documentation)
is to point to the directory node.