### PR TITLE
Use "show" for displaying images

### DIFF
--- a/M2/Macaulay2/packages/Chordal.m2
+++ b/M2/Macaulay2/packages/Chordal.m2
@@ -701,9 +701,8 @@ writeDotFile (String,Function,ChordalNet) := (filename, fun, N) -> (
 
 displayDotFile = (dotfilename,jpgfilename) -> (
     dotBinary := ((options Graphs).Configuration)#"DotBinary";
-    jpgViewer := ((options Graphs).Configuration)#"JpgViewer";
     runcmd(dotBinary  | " -Tjpg " | dotfilename | " -o " | jpgfilename);
-    runcmd(jpgViewer  | " " | jpgfilename|" &");
+    show URL("file://" | toAbsolutePath jpgfilename);
 )
 runcmd = cmd -> (
     stderr << "-- running: " << cmd << endl;

--- a/M2/Macaulay2/packages/Chordal/ChordalDoc.m2
+++ b/M2/Macaulay2/packages/Chordal/ChordalDoc.m2
@@ -1516,9 +1516,9 @@ doc /// --setDefaultConfiguration
         but its dependencies @TO Graphs@ and @TO MapleInterface@ do.
         For instance, the command 
 
-        {\tt setDefaultConfiguration("Graphs","JpgViewer","open") }
+        @TT "setDefaultConfiguration(\"Graphs\",\"DotBinary\",\"circo\")"@
 
-        sets the default jpg viewer used for visualizing graphs and chordal networks.
+        sets the Graphviz binary used for visualizing graphs and chordal networks.
       Code
       Pre
     Caveat
@@ -1580,12 +1580,7 @@ document { --configuration
     BR{},
 
     EM "Graphs: ",
-    "Visualizing chordal networks requires configuring the jpg viewer and the Graphviz executable. ",
-    "The default jpg viewer is \"display\", which should work on Ubuntu but may not work on OS X. ",
-    "This can be changed as follows:",
-    BR{},
-    TT "setDefaultConfiguration(\"Graphs\",\"JpgViewer\",\"open\")",
-    BR{},
+    "Visualizing chordal networks requires configuring the Graphviz executable. ",
     "The default Graphviz executable \"dot\" should work, but it if not it can be changed with:",
     BR{},
     TT "setDefaultConfiguration(\"Graphs\",\"DotBinary\",\"myexecutable\")",

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -395,7 +395,7 @@ displayGraph = method()
 displayGraph (String, String, Digraph) := (dotfilename, jpgfilename, G) -> (
      writeDotFile(dotfilename, G);
      runcmd(graphs'DotBinary  | " -Tjpg " | dotfilename | " -o " | jpgfilename);
-     runcmd(graphs'JpgViewer  | " " | jpgfilename|" &");
+     show URL("file://" | toAbsolutePath jpgfilename);
      )
 displayGraph (String, Digraph) := (dotfilename, G) -> (
      jpgfilename := temporaryFileName() | ".jpg";

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -40,7 +40,7 @@ newPackage select((
 	Keywords => {"Graph Theory"},
         Configuration => {
             "DotBinary" => "dot",
-            "JpgViewer" => "display"
+            "JpgViewer" => ""
             },
 	PackageImports => { "PrimaryDecomposition" },
         PackageExports => {
@@ -51,7 +51,10 @@ newPackage select((
 
 -- Load configurations
 graphs'DotBinary = if instance((options Graphs).Configuration#"DotBinary", String) then (options Graphs).Configuration#"DotBinary" else "dot";
-graphs'JpgViewer = if instance((options Graphs).Configuration#"JpgViewer", String) then (options Graphs).Configuration#"JpgViewer" else "display";
+
+importFrom_Core {"printerr"}
+if (options Graphs).Configuration#"JpgViewer" != "" then
+    printerr "warning: the \"JpgViewer\" configuration option is deprecated"
 
 -- Exports
 export {

--- a/M2/Macaulay2/packages/Markov.m2
+++ b/M2/Macaulay2/packages/Markov.m2
@@ -39,7 +39,7 @@ newPackage("Markov",
 export {"makeGraph", "displayGraph", "localMarkovStmts", "globalMarkovStmts", "pairMarkovStmts",
        "markovRing", "marginMap", "hideMap", "markovMatrices", "markovIdeal", "writeDotFile", "removeRedundants", 
        "gaussRing", "gaussMinors", "gaussIdeal", "gaussTrekIdeal", "Graph"}
-exportMutable {"dotBinary","jpgViewer"}
+exportMutable {"dotBinary"}
 
 -------------------------
 -- Graph visualization --
@@ -70,8 +70,6 @@ makeGraph List := (g) -> (
 
 -- dotBinary = "/sw/bin/dot"
 dotBinary = "dot"
--- jpgViewer = "/usr/bin/open"
-jpgViewer = "open"
 
 writeDotFile = method()
 writeDotFile(String,Graph) := (filename,G) -> (
@@ -105,7 +103,7 @@ displayGraph = method()
 displayGraph(String,String,Graph) := (dotfilename,jpgfilename,G) -> (
      writeDotFile(dotfilename,G);
      runcmd(dotBinary | " -Tjpg "|dotfilename | " -o "|jpgfilename);
-     runcmd(jpgViewer | " " | jpgfilename);
+     show URL("file://" | toAbsolutePath jpgfilename);
      )
 displayGraph(String,Graph) := (dotfilename,G) -> (
      jpgfilename := temporaryFileName() | ".jpg";

--- a/M2/Macaulay2/packages/Posets.m2
+++ b/M2/Macaulay2/packages/Posets.m2
@@ -138,7 +138,6 @@ export {
     "outputTexPoset",
     "texPoset",
         "Jitter",
-        "PDFViewer",
         "SuppressLabels",
     --
     -- Vertices & vertex properties
@@ -1112,17 +1111,16 @@ youngSubposet ZZ := Poset => n -> (
 -- TeX & GAP
 ------------------------------------------
 
-displayPoset = method(Options => { symbol PDFDirectory => "", symbol SuppressLabels => posets'SuppressLabels, symbol PDFViewer => posets'PDFViewer, symbol Jitter => false })
+displayPoset = method(Options => { symbol PDFDirectory => "", symbol SuppressLabels => posets'SuppressLabels, symbol Jitter => false })
 displayPoset Poset := opts -> P -> (
     if not instance(opts.PDFDirectory, String) then error "The option PDFDirectory must be a string.";
-    if not instance(opts.PDFViewer, String) then error "The option PDFViewer must be a string.";
     if not instance(opts.SuppressLabels, Boolean) then error "The option SuppressLabels must be a Boolean.";
     if not instance(opts.Jitter, Boolean) then error "The option Jitter must be a Boolean.";
     name := temporaryFileName();
     if opts.PDFDirectory != "" then name = opts.PDFDirectory | first lines get openIn concatenate("!basename ", name);
     outputTexPoset(P, concatenate(name, ".tex"), symbol SuppressLabels => opts.SuppressLabels, symbol Jitter => opts.Jitter);
     run concatenate("pdflatex -output-directory `dirname ", name, ".tex` ", name, " 1>/dev/null");
-    run concatenate(opts.PDFViewer, " ", name,".pdf &");
+    show URL("file://" | toAbsolutePath(name | ".pdf"));
     )
 
 gapConvertPoset = method()
@@ -4020,25 +4018,20 @@ doc ///
         displayPoset
         (displayPoset,Poset)
         [displayPoset,SuppressLabels]
-        [displayPoset,PDFViewer]
         [displayPoset,Jitter]
         [displayPoset,PDFDirectory]
         PDFDirectory
-        PDFViewer
     Headline
         generates a PDF representation of a poset and attempts to display it
     Usage
         displayPoset P
         displayPoset(P, SuppressLabels => Boolean)
-        displayPoset(P, PDFViewer => String)
         displayPoset(P, PDFDirectory => String)
         displayPoset(P, Jitter => Boolean)
     Inputs
         P:Poset
         SuppressLabels=>Boolean
             whether to display or suppress the labels of the poset
-        PDFViewer=>String
-            which gives the calling path of a PDF-viewer
         Jitter=>Boolean
             whether to randomly jitter the poset vertices
         PDFDirectory=>String
@@ -4046,18 +4039,14 @@ doc ///
     Description
         Text
             This method generates a PDF of the Hasse Diagram of the Poset view LaTeX code which
-            uses TikZ.  The method attempts to display the PDF via the
-            specified PDFViewer.  See @TO "texPoset"@ for more about the
-            representation.
+            uses TikZ.  The method attempts to display the PDF using @TO "show"@.
+            See @TO "texPoset"@ for more about the representation.
 
             Normally, the vertices of the Poset are placed at regular intervals along
             horizontal lines.  However, this can sometimes cause edges to appear in the
             Hasse diagram that are not truly there.  The Jitter option can be used to randomly
             shift the positions of the vertices horizontally, which can often cause the
             edges to be more clear.
-
-            Note that @TT "PDFViewer"@ option's default value can be set in
-            the "~/.Macaulay2/init-Posets.m2" file.
     SeeAlso
         outputTexPoset
         texPoset

--- a/M2/Macaulay2/packages/Posets.m2
+++ b/M2/Macaulay2/packages/Posets.m2
@@ -21,7 +21,7 @@ newPackage select((
         Headline => "partially ordered sets (posets)",
 	Keywords => {"Combinatorics"},
         Configuration => {
-            "DefaultPDFViewer" => "open", -- "open" for Macs and "evince" for Linux
+            "DefaultPDFViewer" => "",
             "DefaultPrecompute" => true,
             "DefaultSuppressLabels" => true
             },
@@ -48,9 +48,12 @@ newPackage select((
         ), x -> x =!= null)
 
 -- Load configurations
-posets'PDFViewer = if instance((options Posets).Configuration#"DefaultPDFViewer", String) then (options Posets).Configuration#"DefaultPDFViewer" else "open";
 posets'Precompute = if instance((options Posets).Configuration#"DefaultPrecompute", Boolean) then (options Posets).Configuration#"DefaultPrecompute" else true;
 posets'SuppressLabels = if instance((options Posets).Configuration#"DefaultSuppressLabels", Boolean) then (options Posets).Configuration#"DefaultSuppressLabels" else true;
+
+importFrom_Core {"printerr"}
+if (options Posets).Configuration#"DefaultPDFViewer" != "" then
+    printerr "warning: the \"DefaultPDFViewer\" configuration option is deprecated"
 
 export {
     --

--- a/M2/Macaulay2/packages/Posets.m2
+++ b/M2/Macaulay2/packages/Posets.m2
@@ -64,7 +64,6 @@ export {
     "transitiveClosure",
     --
     -- Set default configurations
-    "setPDFViewer",
     "setPrecompute",
         "Precompute",
     "setSuppressLabels",
@@ -286,13 +285,6 @@ transitiveClosure (List, List) := Matrix => (G, R) -> (
 ------------------------------------------
 -- Set default configurations
 ------------------------------------------
-
-setPDFViewer = method()
-setPDFViewer String := String => viewer -> (
-    alt := posets'PDFViewer;
-    posets'PDFViewer = viewer;
-    alt
-    )
 
 setPrecompute = method()
 setPrecompute Boolean := Boolean => pc -> (
@@ -2143,30 +2135,6 @@ doc ///
 ------------------------------------------
 -- Set default options
 ------------------------------------------
-
--- setPDFViewer
-doc ///
-    Key
-        setPDFViewer
-        (setPDFViewer,String)
-    Headline
-        sets the default PDFViewer option
-    Usage
-        alt = setPDFViewer viewer
-    Inputs
-        viewer:String
-            the new setting
-    Outputs
-        alt:String
-            the old setting
-    Description
-        Text
-            This method sets the default PDFViewer option.
-        Example
-            setPDFViewer "evince"
-    SeeAlso
-        PDFViewer
-///
 
 -- setPrecompute
 doc ///


### PR DESCRIPTION
A number of packages (`Graphs`, `Chordal`, `Markov`, and `Posets`) generate image files to visualize their objects.   Currently, the viewer used to display these files is selected by the user using a package configuration option (for `Graphs`, `Chordal`, and `Posets`) or a mutable exported variable (for `Markov`).

Similar functions in the `gfanInterface` package instead use `show`, which ends up calling `open` or `xdg-open` and therefore will run the user's preferred viewer already (see https://github.com/Macaulay2/M2/pull/1930#issuecomment-777045019).

We switch these packages over to do the same thing.