### PR TITLE
Valgrind

### DIFF
--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -402,7 +402,11 @@ export (x:ZZ) ^^ (y:ZZ) : ZZ := (
 base := 10;
 toCstring(x:ZZ) ::= getstr(charstarOrNull(null()), base, x);
 
-export tostring(x:ZZ):string := tostring(toCstring(x));
+export tostring(x:ZZ):string := (
+     cstr := toCstring(x);
+     ret := tostring(cstr);
+     Ccode(void,"mp_free_str(", cstr, ")");
+     ret);
 
 export (x:int) + (y:ZZ) : ZZ := toInteger(x) + y;
 

--- a/M2/Macaulay2/d/gmp1.d
+++ b/M2/Macaulay2/d/gmp1.d
@@ -48,9 +48,13 @@ floor(x:double) ::= Ccode(double, "floor(", x, ")" );
 log2ten := log(10.) / log(2.);
 base := 10;
 
-getstr(returnexponent:long, base:int, sigdigs:int, x:RR) ::= tostring(
-     Ccode(charstarOrNull, "(M2_charstarOrNull) mpfr_get_str((char *)0,&", returnexponent, ",",
-	  base, ",(size_t)", sigdigs, ",", x, ",GMP_RNDN)"));
+getstr(returnexponent:long, base:int, sigdigs:int, x:RR):string := (
+     strptr := Ccode(charstarOrNull, "(M2_charstarOrNull) mpfr_get_str((char *)0,&", returnexponent, ",",
+	  base, ",(size_t)", sigdigs, ",", x, ",GMP_RNDN)");
+     ret := tostring(strptr);
+     Ccode(void, "mpfr_free_str(", strptr, ")");
+     ret);
+
 export format(
      s:int,			  -- number of significant digits (0 means all)
      ac:int,	    -- accuracy, how far to right of point to go (-1 means all)

--- a/M2/Macaulay2/d/gmp1.d
+++ b/M2/Macaulay2/d/gmp1.d
@@ -48,7 +48,7 @@ floor(x:double) ::= Ccode(double, "floor(", x, ")" );
 log2ten := log(10.) / log(2.);
 base := 10;
 
-getstr(returnexponent:long, base:int, sigdigs:int, x:RR):string := (
+getstr(returnexponent:long, base:int, sigdigs:int, x:RR) ::= (
      strptr := Ccode(charstarOrNull, "(M2_charstarOrNull) mpfr_get_str((char *)0,&", returnexponent, ",",
 	  base, ",(size_t)", sigdigs, ",", x, ",GMP_RNDN)");
      ret := tostring(strptr);

--- a/M2/Macaulay2/d/gmp_aux.c
+++ b/M2/Macaulay2/d/gmp_aux.c
@@ -21,6 +21,12 @@ int mpfr_hash(mpfr_srcptr x) {
   return 777 + h * 3737 + x->_mpfr_exp + 11 * x->_mpfr_sign;
 }
 
+void mp_free_str(char *str){
+    void (*free_function) (void *ptr, size_t size);
+    mp_get_memory_functions(NULL,NULL,&free_function);
+    free_function(str,strlen(str)+1);
+}
+
 /*
  Local Variables:
  compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d "

--- a/M2/Macaulay2/d/gmp_aux.c
+++ b/M2/Macaulay2/d/gmp_aux.c
@@ -1,6 +1,7 @@
 /* some routines to augment the gmp library */
 #include <M2/config.h>
 #include "M2/math-include.h"
+#include <string.h>
 
 int mpz_hash(mpz_srcptr x) {
   int h = 0;

--- a/M2/Macaulay2/d/gmp_aux.h
+++ b/M2/Macaulay2/d/gmp_aux.h
@@ -2,3 +2,4 @@
 
 extern int mpz_hash(mpz_srcptr x);
 extern int mpfr_hash(mpfr_srcptr x);
+extern void mp_free_str(char* str);

--- a/M2/Macaulay2/system/m2file.cpp
+++ b/M2/Macaulay2/system/m2file.cpp
@@ -8,7 +8,11 @@ extern stdio0_fileOutputSyncState stdio0_newDefaultFileOutputSyncState();
 };
 
 M2File::M2File(stdio0_fileOutputSyncState fileUnsyncState):
-  currentThreadMode(0),unsyncState(fileUnsyncState),recurseCount(0),exclusiveRecurseCount(0)
+    currentThreadMode(0),
+    unsyncState(fileUnsyncState),
+    exclusiveChangeCondition(PTHREAD_COND_INITIALIZER),
+    recurseCount(0),
+    exclusiveRecurseCount(0)
 {
   clearThread(exclusiveOwner);
 }

--- a/M2/files/M2-suppressions.supp
+++ b/M2/files/M2-suppressions.supp
@@ -5,63 +5,22 @@
 #Currently, almost all of these relate to the fact that the mark & sweep process
 #can end up reading uninitialized memory, which valgrind complains about.
 {
-   GC_mark_thread
+   libgc
    Memcheck:Value8
    ...
-   fun:GC_mark_thread
+   obj:*/libgc.so*
 }
 {
-   GC_mark_thread
+   libgc
    Memcheck:Cond
    ...
-   fun:GC_mark_thread
+   obj:*/libgc.so*
 }
 {
-   GC_mark_thread
+   libgc
    Memcheck:Addr8
    ...
-   fun:GC_mark_thread
-}
-{
-   GC_malloc
-   Memcheck:Cond
-   ...
-   fun:GC_malloc*
-}
-{
-   GC_malloc
-   Memcheck:Addr8
-   ...
-   fun:GC_malloc*
-}
-{
-   GC_malloc
-   Memcheck:Value8
-   ...
-   fun:GC_malloc*
-}
-{
-   GC_generic_malloc
-   Memcheck:Cond
-   ...
-   fun:GC_generic_malloc*
-}
-{
-   GC_generic_malloc
-   Memcheck:Addr8
-   ...
-   fun:GC_generic_malloc*
-}
-{
-   GC_generic_malloc
-   Memcheck:Value8
-   ...
-   fun:GC_generic_malloc*
-}
-{
-   GC_add_to_black_list_stack
-   Memcheck:Value8
-   fun:GC_add_to_black_list_stack
+   obj:*/libgc.so*
 }
 
 #This rule is to deal with phantom leaks related to thread local storage

--- a/M2/files/M2-suppressions.supp
+++ b/M2/files/M2-suppressions.supp
@@ -1,0 +1,76 @@
+#This is a suppressions file for Macaulay2 running under valgrind.
+#You might need to install debugging symbols for libgc for this to work effectively
+
+
+#Currently, almost all of these relate to the fact that the mark & sweep process
+#can end up reading uninitialized memory, which valgrind complains about.
+{
+   GC_mark_thread
+   Memcheck:Value8
+   ...
+   fun:GC_mark_thread
+}
+{
+   GC_mark_thread
+   Memcheck:Cond
+   ...
+   fun:GC_mark_thread
+}
+{
+   GC_mark_thread
+   Memcheck:Addr8
+   ...
+   fun:GC_mark_thread
+}
+{
+   GC_malloc
+   Memcheck:Cond
+   ...
+   fun:GC_malloc*
+}
+{
+   GC_malloc
+   Memcheck:Addr8
+   ...
+   fun:GC_malloc*
+}
+{
+   GC_malloc
+   Memcheck:Value8
+   ...
+   fun:GC_malloc*
+}
+{
+   GC_generic_malloc
+   Memcheck:Cond
+   ...
+   fun:GC_generic_malloc*
+}
+{
+   GC_generic_malloc
+   Memcheck:Addr8
+   ...
+   fun:GC_generic_malloc*
+}
+{
+   GC_generic_malloc
+   Memcheck:Value8
+   ...
+   fun:GC_generic_malloc*
+}
+{
+   GC_add_to_black_list_stack
+   Memcheck:Value8
+   fun:GC_add_to_black_list_stack
+}
+
+#This rule is to deal with phantom leaks related to thread local storage
+#These are probably all safe (they are only "possible" leaks)
+{
+   pthread_create
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   ...
+   fun:pthread_create*
+}


### PR DESCRIPTION
This pull request fixes two memory bugs, the first of which was required to get M2 to run under valgrind, and the second was found immediately after running under valgrind.

1. The `M2File` constructor previously didn't initialize `exclusiveChangeCondition`. While this tended to be fine in practice, valgrind is stricter about uninitialized values.
2. `mpz_get_str` and `mpfr_get_str` both use gmp/mpir's default allocator, which does not allocate in the GC heap, and so their return values must be manually freed.

I believe the second problem also affects the pull request #1465, since it also uses mpfr_get_str.

The main reason this pull request is a draft is that I didn't add a valgrind suppressions file to silence most of the valgrind warnings coming from libgc. I have one mostly written, but I'm not certain where in the tree it should go. If there is a place to put it, I can add that to this pull request.