### PR TITLE
Remove (writeDotFile,String,Digraph) method from Chordal

### DIFF
--- a/M2/Macaulay2/packages/Chordal.m2
+++ b/M2/Macaulay2/packages/Chordal.m2
@@ -628,18 +628,6 @@ net(TriaSystem) := Net => T -> (
 size(ChordalNet) := N -> 
     for i in N.elimTree.nodes list #nodes(N,i)
 
--- this function should belong to the Graphs package
-writeDotFile (String, Digraph) := (filename, G) -> (
-    fil := openOut filename;
-    fil << "digraph G {" << endl;
-    V := vertexSet G;
-    scan(#V, i -> fil << "\t" | toString i | " [label=\""|toString V_i|"\"];" << endl);
-    A := adjacencyMatrix G;
-    E := flatten for i from 0 to #V - 1 list for j from i+1 to #V - 1 list if A_(i,j) == 1 then {i, j} else continue;
-    scan(E, e -> fil << "\t" | toString e_0 | " -> " | toString e_1 | ";" << endl);
-    fil << "}" << endl << close;
-)
-
 -- display an elimination tree
 displayGraph (String, String, ElimTree) := (dotfilename, jpgfilename, tree) -> (
     writeDotFile(dotfilename, tree);


### PR DESCRIPTION
As mentioned in the comment above the code for this method, it should belong to `Graphs`.  And, since https://github.com/Macaulay2/M2/commit/f6ac07134428e9770b462cdf71e1488ed9ecb54f, it does.