### PR TITLE
Valgrind in CTest

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -133,11 +133,11 @@ jobs:
         if: matrix.build-system == 'cmake'
         run: |
           cmake -S../.. -B. -GNinja \
-            --debug-trycompile \
             -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK" \
-            -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_NATIVE=OFF \
+            -DCMAKE_BUILD_TYPE=Release -DBUILD_NATIVE=OFF \
             -DCMAKE_PREFIX_PATH=`brew --prefix` \
-            -DCMAKE_INSTALL_PREFIX=/usr
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            --debug-trycompile
 
       - name: Build libraries using Ninja
         if: matrix.build-system == 'cmake'

--- a/M2/BUILD/docker/ubuntu/Dockerfile
+++ b/M2/BUILD/docker/ubuntu/Dockerfile
@@ -23,16 +23,18 @@ RUN apt-get install -y libopenblas-dev libxml2-dev libreadline-dev libgdbm-dev \
 # This is a dependency that we should get rid of
 RUN apt-get install -y libatomic-ops-dev && apt-get clean
 
-# Libraries we can build (factory not available on ubuntu)
-RUN apt-get install -y libeigen3-dev libglpk-dev libgmp3-dev libmpfr-dev \
-      libntl-dev libfrobby-dev libgc-dev && apt-get clean
-
-# FIXME: The base container doesn't have Python, which is needed by MPSolve
-RUN apt-get install -y python && apt-get clean
+# Libraries we can build
+RUN apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:macaulay2/macaulay2 && apt-get update && \
+    apt-get install -y -q --no-install-recommends libeigen3-dev libgc-dev \
+	libglpk-dev libgmp3-dev libmpfr-dev libmps-dev libgtest-dev \
+	libntl-dev libflint-dev libsingular-dev singular-data libfrobby-dev \
+	libmemtailor-dev libmathic-dev libmathicgb-dev && apt-get clean
 
 # Programs we can build
-# TODO: cohomcalg available soon.
-# RUN apt-get install -y --no-install-recommends libcdd-dev 4ti2 gfan polymake normaliz coinor-csdp nauty lrslib && apt-get clean
+RUN apt-get install -y --no-install-recommends libcdd-dev lrslib \
+	4ti2 cohomcalg coinor-csdp gfan nauty normaliz polymake topcom && \
+    apt-get clean
 
 # Optional packages
 RUN apt-get install -y mlocate bash-completion

--- a/M2/BUILD/docker/ubuntu/Makefile
+++ b/M2/BUILD/docker/ubuntu/Makefile
@@ -3,7 +3,7 @@ include ../Makefile
 ## Parameters
 TAG = m2-cmake-build
 BUILD_DIR = M2/BUILD/build-docker
-BUILD_OPT = -DCMAKE_BUILD_TYPE=Release
+BUILD_OPT = -DCMAKE_BUILD_TYPE=Release --debug-trycompile -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK"
 
 ## Script for building Macaulay2
 define M2_BUILD_SCRIPT

--- a/M2/CMakeLists.txt
+++ b/M2/CMakeLists.txt
@@ -63,8 +63,8 @@ project(Macaulay2
 ###############################################################################
 ## Set path for CMake modules
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
-include(CTest) ## CMake module for generating a 'test' target for all unit-tests
 include(prechecks) ## CMake macros for preprocessor checks and linting
+include(CTest)     ## CMake module for generating a 'test' target for all unit-tests
 include(profiling) ## CMake macros for profiling Macaulay2 code
 include(configure) ## CMake script for configuring various variables
 include(check-libraries) ## CMake script for checking which libraries exist and which need to be built

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -22,15 +22,10 @@ There are various tools needed to compile Macaulay2 dependencies.
 - On Fedora/CentOS, install `autoconf automake bison libtool pkg-config yasm`.
 - On Mac OS X, using Homebrew, install `autoconf automake bison libtool pkg-config yasm`.
 
-There are 7 libraries that must be found on the system.
-- On Debian/Ubuntu, install `libopenblas-dev libgmp3-dev libxml2-dev libreadline-dev libgdbm-dev libboost-regex-dev libboost-stacktrace-dev libatomic-ops-dev`.
-- On Fedora/CentOS, install `openblas-devel gmp-devel libxml2-devel readline-devel gdbm-devel boost-devel libatomic_ops-devel`.
-- On Mac OS X, using Homebrew, install `gmp libxml2 readline gdbm boost libatomic_ops`.
-
-Finally, there are 2 optional libraries that help with building other requirements.
-- On Debian/Ubuntu, install `libomp-dev libtbb-dev`.
-- On Fedora/CentOS, install `libomp-devel tbb-devel`.
-- On Mac OS X, using Homebrew, install `libomp tbb`.
+There are 10 libraries that must be found on the system.
+- On Debian/Ubuntu, install `libopenblas-dev libgmp3-dev libxml2-dev libreadline-dev libgdbm-dev libboost-regex-dev libboost-stacktrace-dev libatomic-ops-dev libomp-dev libtbb-dev`.
+- On Fedora/CentOS, install `openblas-devel gmp-devel libxml2-devel readline-devel gdbm-devel boost-devel libatomic_ops-devel libomp-devel tbb-devel`.
+- On Mac OS X, using Homebrew, install `gmp libxml2 readline gdbm boost libatomic_ops libomp tbb`.
 
 **TIP**: x86_64 binary packages for all dependencies on Mac OS X 10.15+ and Linux distributions are available through the [Macaulay2 tap](https://github.com/Macaulay2/homebrew-tap/) for Homebrew. To download the dependencies this way run:
 ```
@@ -154,7 +149,6 @@ For a complete list, along with descriptions, try `cmake -LAH .` or see `cmake/c
 - `WITH_OMP:BOOL=OFF`: link with the OpenMP library
 - `WITH_PYTHON:BOOL=OFF`: link with the Python library
 - `WITH_SQL:BOOL=OFF`: link with the MySQL library
-- `WITH_TBB:BOOL=OFF`: link with the TBB library
 - `WITH_XML:BOOL=ON`: link with the libxml2 library
 - `BUILD_DOCS:BOOL=OFF`: build internal documentation
 - `BUILD_NATIVE:BOOL=ON`: use native SIMD instructions

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -105,6 +105,8 @@ There are unit-tests available within the `Macaulay2/e/unit-tests` and `Macaulay
 - `ctest --rerun-failed -V`: rerun the tests that failed in the last batch and echo the results.
 - `ctest -R check-LocalRings -j4`: run all tests in the LocalRings package, in 4 parallel jobs.
 - `ctest -R check-LocalRings-2 -V`: run the 3rd test in the LocalRings package and echo the result.
+- `ctest -T memcheck -R ARingQQFlint`: run matching tests through Valgrind
+
 
 Note: if the last option does not work, try running `ninja info-packages` and `cmake .` to populate the tests.
 

--- a/M2/Macaulay2/tests/CMakeLists.txt
+++ b/M2/Macaulay2/tests/CMakeLists.txt
@@ -5,6 +5,8 @@
 ## - build and test:  ctest --build-and-test
 ## - rerun matching tests:
 ##     ctest -R schorder --rerun-failed -V
+##
+## See https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest
 
 # TODO: some targets have different resource limits
 set(SUBDIRS normal slow gigantic goals quarantine engine threads)
@@ -175,47 +177,3 @@ foreach(CORE_TEST ${CORE_TESTS})
 endforeach()
 
 # TODO: add_subdirectory(rationality)
-
-###############################################################################
-##### STILL PROCESSING
-
-#status: status-files
-#status-files: $(TESTFILES)
-#	@ egrep -n '^--status:' $(TESTFILES) /dev/null || true
-
-#%.out : %.m2
-#	@ echo testing: $<
-#	@ $(LIMIT) \
-#		echo "--*- compilation -*-" >$*.errors; \
-#		if (echo 'input "$<"'; echo 'collectGarbage()'; echo exit 0) | \
-#		   GC_MAXIMUM_HEAP_SIZE=400M time @pre_exec_prefix@/bin/M2 $(ARGS) >>$*.errors 2>&1 ; \
-#		then mv $*.errors $@ ; \
-#		else a=$$?; \
-#		     <$*.errors $(FILTER) ; \
-#		     echo "$*.errors:0: error output left here for the errors above:" >&2 ; \
-#		     egrep -n '^--status:' $< /dev/null || true ; \
-#		     exit $$a ; \
-#		fi
-
-#%.out : %.m2-input
-#	@ echo testing: $<
-#	@ egrep -n '^--status:' $< /dev/null || true
-#	@ $(LIMIT) \
-#		echo "--*- compilation -*-" >$*.errors; \
-#		if GC_MAXIMUM_HEAP_SIZE=400M time @pre_exec_prefix@/bin/M2 $(ARGS) <$< >>$*.errors 2>&1 ; \
-#		then mv $*.errors $@ ; \
-#		else a=$$?; \
-#		     echo "$*.errors:0: error output left here; some errors follow" >&2 ; \
-#		     <$*.errors $(FILTER) ; \
-#		     exit $$a ; \
-#		fi
-
-#review:
-#	@ echo error: `ls *.errors | wc -l` errors occurred
-#	@ echo summary of errors:
-#	@ for i in *.errors ; \
-#	  do echo `basename $$i .errors`.m2: ; \
-#	     <$$i $(FILTER) ; \
-#	  done
-
-#clean:; rm -f *.okay *.out core *.errors

--- a/M2/Macaulay2/tests/CMakeLists.txt
+++ b/M2/Macaulay2/tests/CMakeLists.txt
@@ -29,13 +29,6 @@ endif()
 ## make the stack limit always the same as it would be under MacOS
 #SLIMIT ?= 8192
 
-# TODO: get this to work
-# See https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest
-if(MEMDEBUG)
-  find_program(MEMORYCHECK_COMMAND valgrind)
-  set( MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full --show-reachable=yes --track-origins=yes" )
-endif()
-
 ###############################################################################
 ## M2 arguments and commands that will be passed to M2 -e ${STR}
 set(GC_MAXIMUM_HEAP_SIZE 400M CACHE STRING "maximum collected heap size")

--- a/M2/Macaulay2/tests/normal/memleak5.m2
+++ b/M2/Macaulay2/tests/normal/memleak5.m2
@@ -1,0 +1,12 @@
+-- try with:
+--  ctest -T memcheck -R memleak5
+
+R = ZZ[x,y,z];
+I = ideal(9*x^6*y^2*z^2-8*x^2*y^3*z^5,3*x^8*z^2-x^5*y^2*z^3,x^5*y^5-3*x^2*y^6*z^2);
+mingens gb I;
+I = null;
+R = null;
+collectGarbage();
+collectGarbage();
+collectGarbage();
+collectGarbage();

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -728,8 +728,8 @@ ExternalProject_Add(build-mathicgb
                     -DBUILD_TESTING=OFF # FIXME: ${BUILD_TESTING}
                     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                     -DCMAKE_CXX_FLAGS=${CXXFLAGS}
-                    -Dwith_tbb=${WITH_TBB}
                     -Denable_mgb=ON
+                    -Dwith_tbb=ON
   EXCLUDE_FROM_ALL  ON
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -8,7 +8,7 @@
 
 # These are the libraries linked with Macaulay2 in Macaulay2/{e,bin}/CMakeLists.txt
 set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
-set(LIBRARIES_LIST MPSOLVE MATHICGB MATHIC MEMTAILOR FROBBY FACTORY FLINT NTL MPFR MP BDWGC LAPACK)
+set(LIBRARIES_LIST MPSOLVE MATHICGB MATHIC MEMTAILOR FROBBY FACTORY FLINT NTL MPFR MP BDWGC LAPACK TBB)
 set(LIBRARY_LIST   READLINE HISTORY GDBM ATOMICOPS)
 
 message(CHECK_START " Checking for existing libraries and programs")
@@ -28,7 +28,9 @@ endif()
 ## Requirement	Debian package	RPM package	Homebrew package
 #   Threads	libc6-dev	glibc-headers	N/A
 #   LAPACK	libopenblas-dev	openblas-devel	N/A (Accelerate)
-#   Boost       libboost-dev    boost-devel     boost
+#   Boost	libboost-dev    boost-devel     boost (Regex and Stacktrace)
+#   TBB 	libtbb-dev	tbb-devel	tbb
+#   OpenMP	libomp-dev	libomp-devel	libomp (Optional)
 #   GDBM	libgdbm-dev	gdbm-devel	gdbm
 #   libatomic_ops libatomic_ops-dev libatomic_ops-devel libatomic_ops
 
@@ -39,15 +41,11 @@ endif()
 find_package(Threads	REQUIRED QUIET)
 find_package(LAPACK	REQUIRED QUIET)
 find_package(Boost	REQUIRED QUIET COMPONENTS regex ${Boost_stacktrace})
+find_package(TBB	REQUIRED QUIET) # See FindTBB.cmake
 # TODO: replace gdbm, see https://github.com/Macaulay2/M2/issues/594
 find_package(GDBM	REQUIRED QUIET) # See FindGDBM.cmake
 # TODO: replace libatomic_ops, see https://github.com/Macaulay2/M2/issues/1113
 find_package(AtomicOps	REQUIRED QUIET) # See FindAtomicOps.cmake
-
-###############################################################################
-## Optional	Debian package	RPM package 	Homebrew package
-#   OpenMP	libomp-dev	libomp-devel	libomp
-#   TBB		libtbb-dev	tbb-devel	tbb
 
 if(WITH_OMP)
   find_package(OpenMP REQUIRED)
@@ -65,12 +63,6 @@ foreach(lang IN ITEMS C CXX)
     set(OpenMP_${lang}_LDLIBS "${OpenMP_${lang}_LDLIBS} -L${_libdir} -l${_lib}")
   endforeach()
 endforeach()
-
-if(WITH_TBB)
-  # See FindTBB.cmake
-  find_package(TBB REQUIRED)
-  list(APPEND LIBRARIES_LIST TBB)
-endif()
 
 ###############################################################################
 ## Platform dependent requirements:

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -108,6 +108,7 @@ message("## Configure Macaulay2
      BUILD_TESTING     = ${BUILD_TESTING}
      BUILD_DOCS        = ${BUILD_DOCS}\n
      COVERAGE          = ${COVERAGE}
+     MEMDEBUG          = ${MEMDEBUG}
      PROFILING         = ${PROFILING}\n
      DEVELOPMENT       = ${DEVELOPMENT}
      EXPERIMENT        = ${EXPERIMENT}")

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -26,7 +26,6 @@ option(BUILD_NATIVE	"Use native SIMD instructions"		ON)
 option(BUILD_SHARED_LIBS "Build shared libraries"		OFF)
 option(BUILD_DOCS	"Build internal documentation"		OFF)
 option(AUTOTUNE		"Autotune library parameters"		OFF)
-option(WITH_TBB		"Link with the TBB library"		ON)
 option(WITH_OMP		"Link with the OpenMP library"		ON)
 # TODO: parse.d expr.d tokens.d actors4.d actors5.d still need xml
 option(WITH_XML		"Link with the libxml2 library"		ON)

--- a/M2/cmake/prechecks.cmake
+++ b/M2/cmake/prechecks.cmake
@@ -54,13 +54,11 @@ MACRO (_ADD_CLANG_FORMAT _target _c_sources _cxx_sources)
   endif()
 ENDMACRO (_ADD_CLANG_FORMAT)
 
-
-# See https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest
+# use ctest -T memcheck -R unit-tests, for instance, to run tests with Valgrind
 if(VALGRIND)
-  message("## Setting up reformat target for running clang-format on ${_target}")
+  message("## Setting up Valgrind memory checking through CTest (ctest -T memcheck)")
   set(VALGRIND_COMMAND         "${VALGRIND}")
   set(VALGRIND_COMMAND_OPTIONS "--trace-children=yes --trace-children-skip=/bin/sh --leak-check=full --error-exitcode=1 --show-reachable=yes --track-origins=yes")
-
   set(MEMORYCHECK_COMMAND           "${VALGRIND_COMMAND}")
   set(MEMORYCHECK_COMMAND_OPTIONS   "${VALGRIND_COMMAND_OPTIONS}")
   set(MEMORYCHECK_SUPPRESSIONS_FILE "${CMAKE_SOURCE_DIR}/files/M2-suppressions.supp")

--- a/M2/cmake/prechecks.cmake
+++ b/M2/cmake/prechecks.cmake
@@ -3,6 +3,7 @@ find_program(CLANG_FORMAT	NAMES clang-format)
 find_program(CPPCHECK		NAMES cppcheck)
 find_program(CPPLINT		NAMES cpplint) # pip install cpplint
 find_program(IWYU		NAMES iwyu) # https://github.com/include-what-you-use/include-what-you-use
+find_program(VALGRIND		NAMES valgrind)
 
 # List of available checks: clang-tidy -checks=* --list-checks
 # TIP: Starting with "-*" means exclude all
@@ -52,3 +53,15 @@ MACRO (_ADD_CLANG_FORMAT _target _c_sources _cxx_sources)
       )
   endif()
 ENDMACRO (_ADD_CLANG_FORMAT)
+
+
+# See https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest
+if(VALGRIND)
+  message("## Setting up reformat target for running clang-format on ${_target}")
+  set(VALGRIND_COMMAND         "${VALGRIND}")
+  set(VALGRIND_COMMAND_OPTIONS "--trace-children=yes --trace-children-skip=/bin/sh --leak-check=full --error-exitcode=1 --show-reachable=yes --track-origins=yes")
+
+  set(MEMORYCHECK_COMMAND           "${VALGRIND_COMMAND}")
+  set(MEMORYCHECK_COMMAND_OPTIONS   "${VALGRIND_COMMAND_OPTIONS}")
+  set(MEMORYCHECK_SUPPRESSIONS_FILE "${CMAKE_SOURCE_DIR}/files/M2-suppressions.supp")
+endif()


### PR DESCRIPTION
- [x] make tbb a requirement in CMake and remove `WITH_TBB` option.
- [x] update a Dockerfile
- [x] sets up CTest to run Valgrind. You can run any tests through valgrind by adding `-T memcheck`, for instance for engine tests:
```
ctest -T memcheck -R unit-tests:ARingQQFlint
...
Total Test time (real) =  23.51 sec

The following tests FAILED:
	 32 - unit-tests:ARingQQFlint.arithmetic (Failed)
-- Processing memory checking output:
1/3 MemCheck: #30: unit-tests:ARingQQFlint.create .......   Defects: 5
2/3 MemCheck: #31: unit-tests:ARingQQFlint.display ......   Defects: 5
3/3 MemCheck: #32: unit-tests:ARingQQFlint.arithmetic ...   Defects: 18
MemCheck log files can be found here: (<#> corresponds to test number)
/home/mahrud/Projects/M2/engine/M2/BUILD/build/Testing/Temporary/MemoryChecker.<#>.log
Memory checking results:
Potential Memory Leak - 28
```
Or m2 tests: (memleak5.m2 is the code from https://github.com/Macaulay2/M2/issues/1938)
```
ctest -T memcheck -R memleak5
...
Total Test time (real) = 236.61 sec

The following tests FAILED:
	658 - normal/memleak5.m2 (Failed)
-- Processing memory checking output:
1/1 MemCheck: #658: normal/memleak5.m2 ...............   Defects: 347
MemCheck log files can be found here: (<#> corresponds to test number)
/home/mahrud/Projects/M2/engine/M2/BUILD/build/Testing/Temporary/MemoryChecker.<#>.log
Memory checking results:
Potential Memory Leak - 347
```
Or even package tests:
```
ctest -T memcheck -R NormalToricVarieties-0 -V
```
That should help @mikestillman run the tests more easily, and once we clear out the bugs sufficiently we should be able to run this for the engine tests on github as well.

_Originally posted by @mahrud in https://github.com/Macaulay2/M2/issues/1934#issuecomment-779825651_