### PR TITLE
Deal with unescaped spaces and parentheses in paths in findProgram

### DIFF
--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -18,7 +18,7 @@ fixPath = programPath -> (
 --   1 = could not find program
 --   2 = found program, but too version number too low
 --   3 = found program, but could not determine version number
--- versionNumber is a string containing the version number found, or null
+-- thisVersion is a string containing the version number found, or null
 --   if MinimumVersion option is not given or the version number can't be
 --   be determined.
 checkProgramPath = (name, cmds, pathToTry, prefix, opts) -> (

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -2,12 +2,14 @@ Program = new Type of HashTable
 ProgramRun = new Type of HashTable
 programPaths = new MutableHashTable
 
--- we expect a trailing slash in the path, but the paths given in the
--- PATH environment variable likely will not have one, so we add one
--- if needed
-addSlash = programPath -> (
-    if last programPath != "/" then return programPath | "/"
-    else return programPath
+fixPath = programPath -> (
+    -- escape any unescaped spaces or parentheses
+    programPath = replace(///(?<!\\)([ ()])///, ///\\\1///, programPath);
+    -- we expect a trailing slash in the path, but the paths given in the
+    -- PATH environment variable likely will not have one, so we add one
+    -- if needed
+    if last programPath != "/" then programPath | "/"
+    else programPath
 )
 
 -- returns (found, thisVersion)
@@ -67,7 +69,7 @@ getProgramPath = (name, cmds, opts) -> (
 	pathsToTry = join(pathsToTry,
 	    apply(separate(":", getenv "PATH"), dir ->
 		if dir == "" then "." else dir));
-    pathsToTry = apply(pathsToTry, addSlash);
+    pathsToTry = fixPath \ pathsToTry;
     prefixes := {(".*", "")} | opts.Prefix;
     errorCode := 1;
     versionFound := "0.0";

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -22,8 +22,9 @@ fixPath = programPath -> (
 --   if MinimumVersion option is not given or the version number can't be
 --   be determined.
 checkProgramPath = (name, cmds, pathToTry, prefix, opts) -> (
-    -- unescape spaces/parentheses for fileExists and fileMode
-    unescapedPathToTry := replace(///\\([ ()])///, ///\1///, pathToTry);
+    -- unescape spaces/parentheses and resolve HOME for fileExists and fileMode
+    unescapedPathToTry := replace(///^\$\{?HOME\}?///, getenv "HOME",
+	replace(///\\([ ()])///, ///\1///, pathToTry));
     found := if all(apply(cmds, cmd -> addPrefix(cmd, prefix)), cmd -> (
 	exe := unescapedPathToTry | first separate(" ", cmd);
 	if not fileExists exe then false else

--- a/M2/Macaulay2/tests/normal/programs.m2
+++ b/M2/Macaulay2/tests/normal/programs.m2
@@ -46,3 +46,12 @@ assert(program#"version" == "1.0")
 program = findProgram(name, name, MinimumVersion => ("1.1", name),
     RaiseError => false)
 assert(program === null)
+
+-- https://github.com/Macaulay2/M2/issues/1503
+newdir = dir | "foo (bar) baz"
+makeDirectory newdir
+copyFile(fn, newdir | "/" | name)
+programPaths#name = newdir
+findProgram(name, name)
+programPaths#name = dir | ///foo\ \(bar\)\ baz///
+findProgram(name, name)


### PR DESCRIPTION
This partially addresses #1503.

#### Before

```m2
i1 : findProgram("gfan", "gfan --help", AdditionalPaths => {"foo bar(baz)"},
         Verbose => true)
checking for gfan in /usr/lib/x86_64-linux-gnu/Macaulay2/bin/...
    not found
checking for gfan in foo bar(baz)/...
sh: 1: Syntax error: "(" unexpected
    not found
checking for gfan in /home/profzoom/.local/bin/...
    not found
checking for gfan in /usr/local/sbin/...
    not found
checking for gfan in /usr/local/bin/...
    not found
checking for gfan in /usr/sbin/...
    not found
checking for gfan in /usr/bin/...
    found

o1 = gfan

o1 : Program
```

#### After

```m2
i1 : findProgram("gfan", "gfan --help", AdditionalPaths => {"foo bar(baz)"},
         Verbose => true)
checking for gfan in /usr/lib/x86_64-linux-gnu/Macaulay2/bin/...
    not found
checking for gfan in foo\ bar\(baz\)/...
    not found
checking for gfan in /home/profzoom/.local/bin/...
    not found
checking for gfan in /usr/local/sbin/...
    not found
checking for gfan in /usr/local/bin/...
    not found
checking for gfan in /usr/sbin/...
    not found
checking for gfan in /usr/bin/...
    found

o1 = gfan

o1 : Program
```