### PR TITLE
Several installPackage verbose logging updates

### DIFF
--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -181,7 +181,7 @@ getExampleOutput := (pkg, fkey) -> (
 -- used in installPackage.m2
 -- TODO: store in a database instead
 storeExampleOutput = (pkg, fkey, outf, verboseLog) -> (
-    verboseLog("storing example results from output file", minimizeFilename outf);
+    verboseLog("storing example results in ", minimizeFilename outf);
     if fileExists outf then (
 	outstr := reproduciblePaths get outf;
 	outf << outstr << close;

--- a/M2/Macaulay2/m2/files.m2
+++ b/M2/Macaulay2/m2/files.m2
@@ -20,13 +20,13 @@ makeDirectory String := name -> (			    -- make the whole path, too
 copyFile = method(Options => new OptionTable from { Verbose => false, UpdateOnly => false })
 copyFile(String,String) := opts -> (src,tar) -> (
      if src === tar then (
-     	  if opts.Verbose then stderr << "--skipping: " << src << " the same as " << tar << endl;
+     	  if opts.Verbose then printerr("skipping: " | src | " the same as " | tar);
 	  )
      else if opts.UpdateOnly and fileExists tar and fileTime src <= fileTime tar then (
-     	  if opts.Verbose then stderr << "--skipping: " << src << " not newer than " << tar << endl;
+     	  if opts.Verbose then printerr("skipping: " | src | " not newer than " | tar)
 	  )
      else (
-     	  if opts.Verbose then stderr << "--copying: " << src << " -> " << tar << endl;
+     	  if opts.Verbose then printerr("copying: " | src | " -> " | tar);
      	  tar << get src << close;
      	  fileTime(fileTime src,tar);
      	  fileMode(fileMode src,tar);

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -504,6 +504,15 @@ generateExampleResults := (pkg, rawDocumentationCache, exampleDir, exampleOutput
 	    if not isDirectory exampleDir then makeDirectory exampleDir;
 	    copyFile(outf, outf', Verbose => true)));
 
+    cmphash := (cachef, inputhash) -> (
+	cachehash := gethash cachef;
+	samehash := cachehash === inputhash;
+	if not samehash then verboseLog("warning: cached example file " |
+	    cachef | " does not have expected hash" | newline |
+	    "expected: " | toString inputhash |", actual: " |
+	    toString cachehash);
+	samehash);
+
     usermode := if opts.UserMode === null then not noinitfile else opts.UserMode;
     scan(pairs pkg#"example inputs", (fkey, inputs) -> (
 	    inpf  := inpfn  fkey; -- input file
@@ -515,11 +524,11 @@ generateExampleResults := (pkg, rawDocumentationCache, exampleDir, exampleOutput
 	    inputhash := hash inputs;
 	    -- use cached example results
 	    if  not opts.RunExamples
-	    or  not opts.RerunExamples and fileExists outf  and gethash outf  === inputhash then (
+	    or  not opts.RerunExamples and fileExists outf  and cmphash(outf, inputhash) then (
 		(possiblyCache(outf, outf', fkey))())
 	    -- use distributed example results
 	    else if pkgopts.UseCachedExampleOutput
-	    and not opts.RerunExamples and fileExists outf' and gethash outf' === inputhash then (
+	    and not opts.RerunExamples and fileExists outf' and cmphash(outf', inputhash) then (
 		if fileExists errf then removeFile errf; copyFile(outf', outf))
 	    -- run and capture example results
 	    else elapsedTime captureExampleOutput(

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -529,7 +529,10 @@ generateExampleResults := (pkg, rawDocumentationCache, exampleDir, exampleOutput
 	    -- use distributed example results
 	    else if pkgopts.UseCachedExampleOutput
 	    and not opts.RerunExamples and fileExists outf' and cmphash(outf', inputhash) then (
-		if fileExists errf then removeFile errf; copyFile(outf', outf))
+		if fileExists errf then removeFile errf;
+		copyFile(outf', outf);
+		verboseLog("using cached " | desc)
+		)
 	    -- run and capture example results
 	    else elapsedTime captureExampleOutput(
 		desc, demark_newline inputs, pkg,


### PR DESCRIPTION
A few updates for when `installPackage` is called with `Verbose => true`.

Consider the following small package:

```m2
newPackage("Foo",
    Headline => "foo",
    AuxiliaryFiles => true,
    UseCachedExampleOutput => true
    )

export {"foo", "bar"}

foo = () -> "foo"
bar = () -> "bar"

beginDocumentation()

doc ///
  Key
    foo
  Description
    Example
      foo ()
///

doc ///
  Key
    bar
  Description
    Example
      bar()
///
```

Both `foo` and `bar` have cached example files, but `foo`'s isn't quite what's expected (no space before the parentheses):
```m2
-- -*- M2-comint -*- hash: -1030763681

i1 : foo()

o1 = foo

i2 : 
///
```

#### Current behavior
```m2
i1 : installPackage("Foo", FileName => "~/tmp/Foo.m2", Verbose => true)
 -- installing package Foo in ../../../.Macaulay2/local/ with layout #1
 -- using package sources found in ../../../tmp/
 -- copying auxiliary source files from /home/profzoom/tmp/Foo
--skipping: /home/profzoom/tmp/Foo/examples/_bar.out not newer than /home/profzoom/.Macaulay2/local/share/Macaulay2/Foo/examples/_bar.out
--skipping: /home/profzoom/tmp/Foo/examples/_foo.out not newer than /home/profzoom/.Macaulay2/local/share/Macaulay2/Foo/examples/_foo.out
 -- storing raw documentation in ../../../.Macaulay2/local/lib/x86_64-linux-gnu/Macaulay2/Foo/cache/rawdocumentation-dcba-8.db
 -- closed the database
 -- running tests that are functions
 -- making example result files in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/
 -- making example results for "foo"                                         -- 0.577009 seconds elapsed
 -- storing example results from output file../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out
 -- storing example results from output file../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_bar.out

...
```

A few observations:
* The `skipping` comments don't line up with the others.
* We aren't told why the `foo` cached example isn't being used.
* We aren't told that the `bar` cached example *is* being used.
* `storing example results from output file` is confusing -- it seems to suggest that the file is the source of the example results and not the destination.  Plus there should be a space before the filename.

We address these issues in a series of commits.

#### Proposed behavior
```m2
i1 : installPackage("Foo", FileName => "~/tmp/Foo.m2", Verbose => true)
 -- installing package Foo in ../../../.Macaulay2/local/ with layout #1
 -- using package sources found in ../../../tmp/
 -- copying auxiliary source files from /home/profzoom/tmp/Foo
 -- skipping: /home/profzoom/tmp/Foo/examples/_bar.out not newer than /home/profzoom/.Macaulay2/local/share/Macaulay2/Foo/examples/_bar.out
 -- skipping: /home/profzoom/tmp/Foo/examples/_foo.out not newer than /home/profzoom/.Macaulay2/local/share/Macaulay2/Foo/examples/_foo.out
 -- storing raw documentation in ../../../.Macaulay2/local/lib/x86_64-linux-gnu/Macaulay2/Foo/cache/rawdocumentation-dcba-8.db
 -- closed the database
 -- running tests that are functions
 -- making example result files in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/
 -- warning: cached example file /home/profzoom/tmp/Foo/examples/_foo.out does not have expected hash
 -- expected: -249838157, actual: -1030763681
 -- making example results for "foo"                                         -- 0.574251 seconds elapsed
 -- storing example results in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out
 -- using cached example results for "bar"
 -- storing example results in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_bar.out
 
...
```

