### PR TITLE
Check some packages with optional components

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -94,7 +94,8 @@ jobs:
                   libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libntl-dev gfan \
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
                   libsingular-dev singular-data libmemtailor-dev libmathic-dev libmathicgb-dev libcdd-dev \
-                  cohomcalg topcom 4ti2 normaliz coinor-csdp nauty lrslib w3c-markup-validator libtbb-dev libomp5-10 polymake
+                  cohomcalg topcom 4ti2 normaliz coinor-csdp nauty lrslib w3c-markup-validator libtbb-dev \
+                  libomp5-10 polymake phcpack
 
 # ----------------------
 #   Steps common to all build variants

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -94,7 +94,7 @@ jobs:
                   libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libntl-dev gfan \
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
                   libsingular-dev singular-data libmemtailor-dev libmathic-dev libmathicgb-dev libcdd-dev \
-                  cohomcalg topcom 4ti2 normaliz coinor-csdp nauty lrslib w3c-markup-validator libtbb-dev libomp5-10
+                  cohomcalg topcom 4ti2 normaliz coinor-csdp nauty lrslib w3c-markup-validator libtbb-dev libomp5-10 polymake
 
 # ----------------------
 #   Steps common to all build variants

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -42,9 +42,7 @@ $(foreach i,\
 	$(sort $(ALL_PACKAGES) $(DEVEL)),\
 	$(eval check::check-$i)\
 	$(eval check-$i:; \
-		if ! grep "CacheExampleOutput => true" @srcdir@/$i.m2 >/dev/null ;\
-		then @pre_bindir@/M2 -q --no-preload $(STOP) -e "needsPackage(\"$i\",LoadDocumentation=>true,DebuggingMode=>true); check($i,UserMode=>false,Verbose=>$(Verbose)); exit 0" ;\
-		fi ))
+		@pre_bindir@/M2 -q --no-preload $(STOP) -e "needsPackage(\"$i\",LoadDocumentation=>true,DebuggingMode=>true); check($i,UserMode=>false,Verbose=>$(Verbose)); exit 0" ))
 info-dir: @pre_infodir@/dir
 @pre_infodir@/dir:|@pre_infodir@
 	@INSTALL_DATA@ @abs_top_srcdir@/files/info-dir-template $@


### PR DESCRIPTION
This is a partial response to #1955.

- [x] Run checks (in autotools build) if optional components are present
- [x] Install polymake in Ubuntu builds
- [x] Install phcpack in Ubuntu builds

The last item is pending an upload of a PPA package for phcpack.  (My current draft is in very rough shape still and not ready for upload to Debian, but does provide a working copy of `/usr/bin/phc`.)

Opening for now as a draft to see how the polymake checks go.

