### PR TITLE
Bump upper bound a bit more for timing-quotient test

### DIFF
--- a/M2/Macaulay2/tests/normal/timing-quotient.m2
+++ b/M2/Macaulay2/tests/normal/timing-quotient.m2
@@ -214,6 +214,13 @@ tim = timing(jacW : comp1); -- recomputes the same GB 150 times in 1.8.  We want
 -- version 1.8: 17.5 seconds
 -- after fix: .166 seconds
 assert Equation(numgens tim#1, 33)
+
+-- version 1.17: as much as 2 seconds on Ubuntu armhf/i386 build machines
+-- previous upper bounds of .5 * standardSecond and .6 * standardSecond
+-- occassionally caused build failures, see:
+-- https://github.com/Macaulay2/M2/issues/1804
+-- https://github.com/Macaulay2/M2/pull/1811
+-- https://github.com/Macaulay2/M2/pull/1957
 assert BinaryOperation {symbol <, tim#0, standardSecond}
 
 P=QQ[x,y,z,MonomialOrder=>Lex];

--- a/M2/Macaulay2/tests/normal/timing-quotient.m2
+++ b/M2/Macaulay2/tests/normal/timing-quotient.m2
@@ -214,7 +214,7 @@ tim = timing(jacW : comp1); -- recomputes the same GB 150 times in 1.8.  We want
 -- version 1.8: 17.5 seconds
 -- after fix: .166 seconds
 assert Equation(numgens tim#1, 33)
-assert BinaryOperation {symbol <, tim#0, .6 * standardSecond}
+assert BinaryOperation {symbol <, tim#0, standardSecond}
 
 P=QQ[x,y,z,MonomialOrder=>Lex];
 d=z^4+z^2*x*y^9+z*x^9*y+x^5*y^5;


### PR DESCRIPTION
We previously increased it from `.5 * standardSecond` to `.6 * standardSecond` in 5452c3a507863b9779563f897f9eb5af3fe45e0, but this wasn't sufficient for a [recent PPA build](https://launchpadlibrarian.net/524666984/buildlog_ubuntu-bionic-i386.macaulay2_1.17.2.1+git202102221804-0ppa202102211820~ubuntu18.04.1_BUILDING.txt.gz):

```m2
testing: timing-quotient.m2
      -- version 1.8: 17.5 seconds
      -- after fix: .166 seconds
      assert Equation(numgens tim#1, 33)

ii9 : assert BinaryOperation {symbol <, tim#0, .6 * standardSecond}
timing-quotient.m2:217:1:(3):[4]: error: assertion failed:
2.05538<1.8745 is false
Command exited with non-zero status 1
6.23user 0.24system 0:06.29elapsed 102%CPU (0avgtext+0avgdata 96220maxresident)k
0inputs+48outputs (0major+22069minor)pagefaults 0swaps
timing-quotient.errors:0: error output left here for the errors above:
../Makefile.test:66: recipe for target 'timing-quotient.out' failed
```

In this case, the actual timing result was about `0.658 * standardSecond`.  I propose we just go all the way up to a full `standardSecond`, still significantly smaller than the 17.5 seconds mentioned in the comment above the test that prompted it in the first place.