### PR TITLE
CMake on gentoo

### DIFF
--- a/M2/Macaulay2/bin/CMakeLists.txt
+++ b/M2/Macaulay2/bin/CMakeLists.txt
@@ -46,11 +46,13 @@ add_custom_target(man COMMAND zcat ${MAN} | groff -man -Tascii DEPENDS ${MAN})
 add_executable(M2-binary timestamp.cpp main.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/startup.c ${TAGS} ${MAN})
 target_link_libraries(M2-binary
-  Boost::${Boost_stacktrace}
+  ${Boost_stacktrace_lib}
   M2-engine M2-interpreter M2-supervisor ${CMAKE_DL_LIBS})
 
-# Force using libboost_stacktrace library
-target_compile_definitions(M2-binary PUBLIC BOOST_STACKTRACE_LINK)
+#if we have a usuable link time stacktrace library, force boost to use it
+if(NOT Boost_stacktrace_header_only)
+  target_compile_definitions(M2-binary PUBLIC BOOST_STACKTRACE_LINK)
+endif()
 
 # Set where the executable should be store and get its RPATH
 set_target_properties(M2-binary PROPERTIES

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -40,7 +40,16 @@ endif()
 
 find_package(Threads	REQUIRED QUIET)
 find_package(LAPACK	REQUIRED QUIET)
-find_package(Boost	REQUIRED QUIET COMPONENTS regex ${Boost_stacktrace})
+find_package(Boost	REQUIRED QUIET COMPONENTS regex OPTIONAL_COMPONENTS stacktrace_backtrace stacktrace_addr2line)
+if(Boost_STACKTRACE_BACKTRACE_FOUND)
+  set(Boost_stacktrace_lib "Boost::stacktrace_backtrace")
+elseif(Boost_STACKTRACE_ADDR2LINE_FOUND)
+  set(Boost_stacktrace_lib "Boost::stacktrace_addr2line")
+else()
+  #fallback to header only mode
+  set(Boost_stacktrace_header_only YES)
+endif()
+
 find_package(TBB	REQUIRED QUIET) # See FindTBB.cmake
 # TODO: replace gdbm, see https://github.com/Macaulay2/M2/issues/594
 find_package(GDBM	REQUIRED QUIET) # See FindGDBM.cmake

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -233,15 +233,6 @@ endif()
 # TODO: look into compiler features:
 # https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
 
-# Flags based on OS
-if(ISSUE MATCHES Ubuntu)
-  # Apparently libboost_stacktrace_backtrace is not reliably available on all platforms.
-  set(Boost_stacktrace stacktrace_backtrace)
-else()
-  # addr2line is more readily available, but does not work well with -fPIE
-  set(Boost_stacktrace stacktrace_addr2line)
-endif()
-
 # Common flags
 # TODO: reduce these if possible
 add_link_options(-L${M2_HOST_PREFIX}/lib)

--- a/M2/cmake/gmp_version.c
+++ b/M2/cmake/gmp_version.c
@@ -1,0 +1,12 @@
+#include <gmp.h>
+
+#define MSG(s) (#s " " STR(s))
+#define STR(s) #s
+
+#pragma message MSG(__GNU_MP_VERSION)
+#pragma message MSG(__GNU_MP_VERSION_MINOR)
+#pragma message MSG(__GNU_MP_VERSION_PATCHLEVEL)
+
+int main(){
+    return 0;
+};


### PR DESCRIPTION
This fixes two issues with building with cmake on gentoo.

1. Gentoo installs it's multilib headers in a different way than most distros. In particular for gmp, the real header goes in `/usr/include/<arch>/gmp.h`. Then `/usr/include/gmp.h` is a wrapper around it. In contrast most other systems put the real header in `/usr/include/gmp-64.h` (or `gmp-32.h`). This difference breaks the search method `FindGMP` uses to find the gmp version.
2. Gentoo installs boost such that the stacktrace library is header only. The autotools build correctly detects this, but the cmake build had required a linked stacktrace library.

@mahrud You might want to make sure both of these changes are reasonable.

Additionally, it is theoretically possible to use libbacktrace or addr2line with Boost.Stacktrace in header only mode by setting the right macros, see [https://www.boost.org/doc/libs/1_75_0/doc/html/stacktrace/configuration_and_build.html](https://www.boost.org/doc/libs/1_75_0/doc/html/stacktrace/configuration_and_build.html). But then for libbacktrace we'd have to link against libbacktrace ourselves, and it turns out `FindBacktrace` doesn't find `libbacktrace` but rather something else, and so I gave up on that for now.