### PR TITLE
Reconcile declaration & definition of regex_search

### DIFF
--- a/M2/Macaulay2/d/boost-regex.cpp
+++ b/M2/Macaulay2/d/boost-regex.cpp
@@ -48,8 +48,8 @@ extern "C" {
 /* returns an array of pairs (s, r), indicating starting point
  * and length of the first match and its capture groups */
 M2_arrayint regex_search(const M2_string pattern,
-                         const size_t start,
-                         const size_t range,
+                         const int start,
+                         const int range,
                          const M2_string text,
                          int regex_flags,
                          int match_flags)


### PR DESCRIPTION
Fedora is building packages with Link Time Optimization (LTO) enabled.  When building Macaulay2, a few warnings are emitted by the link time optimizer about mismatched declarations and definitions.  This patch fixes one of them.  The `start` and `range` parameters are declared as `int` in M2/Macaulay2/d/regex.dd, but defined as `size_t` in `M2/Macaulay2/d/boost-regex.cpp`.  Those types may have different bit widths (e.g., on 64-bit Linux systems, `int` is 32 bits and `size_t` is 64 bits).  Since the other regex functions define `start` and `range` as `int`, I chose to do likewise with `regex_search`.