### PR TITLE
Tor algebra

### DIFF
--- a/M2/Macaulay2/packages/TorAlgebra.m2
+++ b/M2/Macaulay2/packages/TorAlgebra.m2
@@ -650,7 +650,7 @@ isGorenstein( QuotientRing) := R -> (
     (torAlgData R)#"isGorenstein"
     )
 
-isGorenstein( Ideal ) := I -> isCI((ring I)/I)
+isGorenstein( Ideal ) := I -> isGorenstein((ring I)/I)
 
 ----------------------------------------------------------------------------
 -- isGolod


### PR DESCRIPTION
For a quotient R = Q/I the function isGorenstein( I) wrongly retuned the value of isCI( R ); it has been fixed so that it now calls isGorenstein( R ) .