### PR TITLE
Use givaro/fflas-ffpack PPA packages for Ubuntu CMake builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -134,7 +134,6 @@ jobs:
         if: matrix.build-system == 'cmake'
         run: |
           cmake -S../.. -B. -GNinja \
-            -DBUILD_LIBRARIES="Givaro;FFLAS_FFPACK" \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_NATIVE=OFF \
             -DCMAKE_PREFIX_PATH=`brew --prefix` \
             -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
As discussed in #1982, I've packaged git snapshots of givaro and fflas-ffpack for the PPA.  ~This PR is just to test the Github builds and isn't intended to be merged.~