### PR TITLE
Issue/polyhedra/dim of empty

### DIFF
--- a/M2/Macaulay2/packages/Polyhedra/core/polyhedron/properties.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/polyhedron/properties.m2
@@ -49,8 +49,11 @@ compute#Polyhedron#rays Polyhedron := P -> (
 
 compute#Polyhedron#computedDimension = method()
 compute#Polyhedron#computedDimension Polyhedron := P -> (
-   C := getProperty(P, underlyingCone);
-   dim C - 1
+   if isEmpty P then
+      return -1
+   else
+      C := getProperty(P, underlyingCone);
+      dim C - 1
 )
 
 

--- a/M2/Macaulay2/packages/Polyhedra/tests/core/polyhedron_basics.m2
+++ b/M2/Macaulay2/packages/Polyhedra/tests/core/polyhedron_basics.m2
@@ -10,6 +10,13 @@ assert(linSpace P == 0)
 M = promote(matrix {{3,4,1}},QQ);
 v = promote(matrix {{10}},QQ);
 assert(hyperplanes P == (M,v) or hyperplanes P == (-M,-v))
+
+Q = convexHull transpose matrix {{1,2,3}}
+C1 = coneFromVData transpose matrix {{1,0,0}}
+C2 = coneFromVData  transpose matrix {{0,1,0},{1,0,0}}
+I = intersection(Q+C1, C2)
+assert(dim I == -1)
+assert(isEmpty I)
 ///
 
 -- Test 1


### PR DESCRIPTION
Since Polyhedra are now treated internally as cones, it is necessary to check whether the intersection with the hyperplane at height 1 is empty before giving the dimension.