### PR TITLE
Print entire example/test error output in verbose mode

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -93,7 +93,7 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
 	if opts.Verbose then apply(errorList, (j, k) -> (
 		(filename, lineno, teststring) := pkg#"test inputs"#j;
 		stderr << filename << ":" << lineno - 1 << ":1: error:" << endl;
-		printerr get("!tail " | outfile k)));
+		printerr getErrors(outfile k)));
 	error("test(s) #", demark(", ", toString \ first \ errorList), " of package ", toString pkg, " failed.")))
 
 checkAllPackages = () -> (


### PR DESCRIPTION
We currently use `tail` to retrieve the last 10 lines of the log when an example or test fails in verbose mode.  This may not be sufficient to really see what happened, especially in the case of segmentation faults with long stack traces.  See, for example, https://github.com/Macaulay2/M2/issues/1539#issuecomment-810685874.

Instead, we use a regular expression to determine where the error occurred, print the 9 previous lines (mimicking the previous
behavior), and then everything afterwards.

If the regular expression doesn't match anything, then we fall back on the previous behavior and use `tail`.

---

For example, consider the following simple package:

```m2
newPackage("Segfault", Headline => "segfault!")

importFrom_Core {"segmentationFault"}
export {"foo"}

foo = () -> 1/0

beginDocumentation()

doc ///
  Key
    segmentationFault
  Description
    Example
      importFrom_Core {"segmentationFault"}
      segmentationFault()
///

doc ///
  Key
    foo
  Description
    Example
      scan(30, print)
      foo()
///
```

### Before

We're missing a big chunk of the stack trace.
```m2
i1 : installPackage("Segfault", FileName => "~/tmp/Segfault.m2", Verbose => true)
 -- installing package Segfault in ../../../../.Macaulay2/local/ with layout #1
 -- using package sources found in ../../../../tmp/
 -- storing raw documentation in ../../../../.Macaulay2/local/lib/x86_64-linux-gnu/Macaulay2/Segfault/cache/rawdocumentation-dcba-8.db
 -- new raw documentation, not already in database, for foo
 -- new raw documentation, not already in database, for segmentationFault
 -- closed the database
 -- running tests that are functions
 -- making example result files in ../../../../.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/
 -- making example results for "segmentationFault"                          
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-1063107-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --int --no-randomize --no-readline --silent --stop --print-width 77 -e 'needsPackage("Segfault",Reload=>true,FileName=>"/home/profzoom/tmp/Segfault.m2")' <"/tmp/M2-1063107-0/0_segmentation__Fault.m2" >>"/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_segmentation__Fault.errors" 2>&1
/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_segmentation__Fault.errors:0:1: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-1063107-0/0_segmentation__Fault.m2:0:1: (input file)
M2: *** Error 1
 -- 0.929759 seconds elapsed
 -- storing example results in ../../../../.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_segmentation__Fault.out
 -- warning: missing file /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_segmentation__Fault.out
 -- making example results for "foo"                                        
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-1063107-0/2-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --int --no-randomize --no-readline --silent --stop --print-width 77 -e 'needsPackage("Segfault",Reload=>true,FileName=>"/home/profzoom/tmp/Segfault.m2")' <"/tmp/M2-1063107-0/0_foo.m2" >>"/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_foo.errors" 2>&1
/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_foo.errors:0:1: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-1063107-0/0_foo.m2:0:1: (input file)
M2: *** Error 1
 -- 0.633634 seconds elapsed
 -- storing example results in ../../../../.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_foo.out
 -- warning: missing file /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_foo.out
stdio:1:1:(3): error: installPackage: 2 error(s) occurred running examples for package Segfault:

_foo.errors
***********
23
24
25
26
27
28
29

i2 : foo()
stdio:2:1:(3): error: division by zero
_segmentation__Fault.errors
***************************
16# interp_process at ./M2/Macaulay2/d/interp.dd:605
17# interpFunc(ArgCell*) at ./M2/Macaulay2/d/main.cpp:193
18# ThreadTask::run(SupervisorThread*) at ./M2/Macaulay2/system/supervisor.cpp:377
19# SupervisorThread::threadEntryPoint() at ./M2/Macaulay2/system/supervisor.cpp:426
20# SupervisorThread::threadEntryPoint(void*) at ./M2/Macaulay2/system/supervisor.hpp:100
21# GC_inner_start_routine in /lib/x86_64-linux-gnu/libgc.so.1
22# GC_call_with_stack_base in /lib/x86_64-linux-gnu/libgc.so.1
23# start_thread at ./nptl/pthread_create.c:464
24# __clone in /lib/x86_64-linux-gnu/libc.so.6
-- end stack trace *-

```

### After
The stack trace is all there, but we still have a nice short log for the other example that didn't have an error until the very end.
```
i1 :  installPackage("Segfault", FileName => "~/tmp/Segfault.m2", Verbose => true)
 -- installing package Segfault in ../../../.Macaulay2/local/ with layout #1
 -- using package sources found in ../../../tmp/
 -- storing raw documentation in ../../../.Macaulay2/local/lib/x86_64-linux-gnu/Macaulay2/Segfault/cache/rawdocumentation-dcba-8.db
 -- new raw documentation, not already in database, for foo
 -- new raw documentation, not already in database, for segmentationFault
 -- closed the database
 -- running tests that are functions
 -- making example result files in ../../../.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/
 -- making example results for "segmentationFault"                          
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-1717049-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --int --no-randomize --no-readline --silent --stop --print-width 77 --srcdir "M2/" -e 'needsPackage("Segfault",Reload=>true,FileName=>"/home/profzoom/tmp/Segfault.m2")' <"/tmp/M2-1717049-0/0_segmentation__Fault.m2" >>"/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_segmentation__Fault.errors" 2>&1
/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_segmentation__Fault.errors:0:1: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-1717049-0/0_segmentation__Fault.m2:0:1: (input file)
M2: *** Error 1
 -- 0.883445 seconds elapsed
 -- storing example results in ../../../.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_segmentation__Fault.out
 -- warning: missing file /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_segmentation__Fault.out
 -- making example results for "foo"                                        
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-1717049-0/2-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --int --no-randomize --no-readline --silent --stop --print-width 77 --srcdir "M2/" -e 'needsPackage("Segfault",Reload=>true,FileName=>"/home/profzoom/tmp/Segfault.m2")' <"/tmp/M2-1717049-0/0_foo.m2" >>"/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_foo.errors" 2>&1
/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_foo.errors:0:1: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-1717049-0/0_foo.m2:0:1: (input file)
M2: *** Error 1
 -- 0.601868 seconds elapsed
 -- storing example results in ../../../.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_foo.out
 -- warning: missing file /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Segfault/example-output/_foo.out
stdio:1:2:(3): error: installPackage: 2 error(s) occurred running examples for package Segfault:

_foo.errors
***********
23
24
25
26
27
28
29

i2 : foo()
stdio:2:1:(3): error: division by zero
_segmentation__Fault.errors
***************************
-- -*- M2-comint -*- hash: -952036124

i1 : importFrom_Core {"segmentationFault"}

o1 = {segmentationFault}

o1 : List

i2 : segmentationFault()
-- SIGSEGV
-* stack trace, pid: 1722923
 0# stack_trace(std::ostream&, bool) at ./M2/Macaulay2/d/main.cpp:124
 1# segv_handler at ./M2/Macaulay2/d/main.cpp:241
 2# 0x00007FE17FB37950 in /lib/x86_64-linux-gnu/libc.so.6
 3# system_segmentationFault at ./M2/Macaulay2/d/system.d:184
 4# segmentationFault at ./M2/Macaulay2/d/actors4.d:1506
 5# evaluate_evalraw at ./M2/Macaulay2/d/evaluate.d:1297
 6# evaluate_evalexcept at ./M2/Macaulay2/d/evaluate.d:1438
 7# readeval3 at ./M2/Macaulay2/d/interp.dd:270
 8# loadprint at ./M2/Macaulay2/d/interp.dd:345
 9# commandInterpreter_2 at ./M2/Macaulay2/d/interp.dd:458
10# evaluate_evalraw at ./M2/Macaulay2/d/evaluate.d:1297
11# evaluate_evalraw at ./M2/Macaulay2/d/evaluate.d:1257
12# evaluate_evalraw at ./M2/Macaulay2/d/evaluate.d:1257
13# evaluate_evalexcept at ./M2/Macaulay2/d/evaluate.d:1438
14# readeval3 at ./M2/Macaulay2/d/interp.dd:270
15# readeval at ./M2/Macaulay2/d/interp.dd:283
16# interp_process at ./M2/Macaulay2/d/interp.dd:605
17# interpFunc(ArgCell*) at ./M2/Macaulay2/d/main.cpp:193
18# ThreadTask::run(SupervisorThread*) at ./M2/Macaulay2/system/supervisor.cpp:377
19# SupervisorThread::threadEntryPoint() at ./M2/Macaulay2/system/supervisor.cpp:426
20# SupervisorThread::threadEntryPoint(void*) at ./M2/Macaulay2/system/supervisor.hpp:100
21# GC_inner_start_routine in /lib/x86_64-linux-gnu/libgc.so.1
22# GC_call_with_stack_base in /lib/x86_64-linux-gnu/libgc.so.1
23# start_thread at ./nptl/pthread_create.c:464
24# __clone in /lib/x86_64-linux-gnu/libc.so.6
-- end stack trace *-
```