### PR TITLE
Increase sleep interval in cancelTask example

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -132,7 +132,7 @@ Node
    n
    isReady t
    cancelTask t
-   sleep 1
+   sleep 2
    t
    n
    sleep 1


### PR DESCRIPTION
Occasionally, the interruption messed up the example output, causing
build failures.

Closes: #2021