### PR TITLE
Replace GC_MALLOC with macros that check for NULL

### DIFF
--- a/M2/Macaulay2/e/dmat.hpp
+++ b/M2/Macaulay2/e/dmat.hpp
@@ -88,7 +88,7 @@ class DMat
       mArray = nullptr;
     else
       {
-        mArray = static_cast<ElementType*>(GC_MALLOC_UNCOLLECTABLE(sizeof(ElementType) * len));
+        mArray = newarray(ElementType,len);
         //        mArray = new ElementType[len];
         for (size_t i = 0; i < len; i++)
           {
@@ -105,7 +105,7 @@ class DMat
       mArray = nullptr;
     else
       {
-        mArray = static_cast<ElementType*>(GC_MALLOC_UNCOLLECTABLE(sizeof(ElementType) * len));
+        mArray = newarray(ElementType,len);
         //        mArray = new ElementType[len];
         for (size_t i = 0; i < len; i++)
           ring().init_set(mArray[i], M.array()[i]);

--- a/M2/Macaulay2/e/interface/gmp-util.h
+++ b/M2/Macaulay2/e/interface/gmp-util.h
@@ -15,7 +15,7 @@ inline void mpz_reallocate_limbs (mpz_ptr _z)
 { 
   int _s = _z->_mp_size;
   int _as = (_s>0)?_s:-_s;
-  mp_limb_t *_p = (mp_limb_t*) GC_MALLOC_ATOMIC(_as*sizeof(mp_limb_t));
+  mp_limb_t *_p = (mp_limb_t*) getmem_atomic(_as*sizeof(mp_limb_t));
   memcpy(_p,_z->_mp_d,_as*sizeof(mp_limb_t));
   mpz_clear(_z);
   _z->_mp_d = _p;
@@ -58,13 +58,13 @@ inline gmp_ZZ mpzToZZ(mpz_srcptr z)
   return result;
 }
 */
-   
+
 inline void mpfr_reallocate_limbs (mpfr_ptr _z)
 {
   __mpfr_struct tmp;
   tmp = *_z;
   int limb_size = (_z->_mpfr_prec - 1) / GMP_NUMB_BITS + 1;
-  mp_limb_t *p = (mp_limb_t*) GC_MALLOC_ATOMIC(limb_size * sizeof(mp_limb_t));
+  mp_limb_t *p = (mp_limb_t*) getmem_atomic(limb_size * sizeof(mp_limb_t));
   memcpy(p, _z->_mpfr_d, limb_size * sizeof(mp_limb_t));
   mpfr_clear(_z);
   _z->_mpfr_prec = tmp._mpfr_prec;


### PR DESCRIPTION
Fixes #2027. As a note, there is still one use of `GC_MALLOC` in `system/m2util.hpp`, but that code appears to be entirely unused and probably should just be deleted, but I can change that one as well if there's some use for that file I'm not aware of.