### PR TITLE
Correct Pappus matroid formulation

### DIFF
--- a/M2/Macaulay2/packages/Matroids.m2
+++ b/M2/Macaulay2/packages/Matroids.m2
@@ -703,7 +703,7 @@ specificMatroid String := Matroid => name -> (
 	) else if name == "vamos" then (
 		relaxation(specificMatroid "V8+", set{4,5,6,7})
 	) else if name == "pappus" then (
-		matroid(toList(0..8), {{0,1,2},{0,3,7},{0,4,8},{1,3,6},{1,5,8},{2,4,6},{2,5,7},{6,7,8}}/set, EntryMode => "nonbases")
+		matroid(toList(0..8), {{0,1,2},{0,4,6},{0,5,7},{1,3,6},{1,5,8},{2,3,7},{2,4,8},{3,4,5},{6,7,8}}/set, EntryMode => "nonbases")
 	) else if name == "nonpappus" then (
 		relaxation(specificMatroid "pappus", set{6,7,8})
 	) else if name == "AG32" then (


### PR DESCRIPTION
The matroids returned by `specficMatroid "pappus"` and `specificMatroid "nonpappus"` are incorrect.

On the diagrams on page 39 of Oxley (provided below), the Pappus matroid has 9 rank-3 circuits (nonbases) and the non-Pappus has 8. 

![image](https://user-images.githubusercontent.com/25068498/116367751-8317d700-a7bc-11eb-8df8-4151b8f6227e.png)


But the provided versions have 8 & 7 respectively. 
```
i2 : nonbases specificMatroid "pappus"

o2 = {set {0,1,2}, set {0,3,7}, set {0,4,8}, set {1,3,6}, set {1,5,8}, set {2,4,6}, set {2,5,7}, set {6,7,8}}

o2 : List

i3 : nonbases specificMatroid "nonpappus"

o3 = {set {0,1,2}, set {1,3,6}, set {2,4,6}, set {0,3,7}, set {2,5,7}, set {0,4,8}, set {1,5,8}}

o3 :  List
```

I have resolved this by adding {3,4,5} to the set of nonbases in the constructor here: https://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/Matroids.m2#L706.

Then the labels 0:8 on this version map to nodes 3,2,1,4,5,6,7,8,9 in the diagrams.



