### PR TITLE
Generate grammar file for Pygments

### DIFF
--- a/M2/Macaulay2/editors/.gitignore
+++ b/M2/Macaulay2/editors/.gitignore
@@ -1,5 +1,6 @@
 emacs/M2-emacs-hlp.txt
 emacs/M2-emacs.m2
 emacs/M2-symbols.el
+pygments/macaulay2.py
 rouge/macaulay2.rb
 atom/macaulay2.cson

--- a/M2/Macaulay2/editors/CMakeLists.txt
+++ b/M2/Macaulay2/editors/CMakeLists.txt
@@ -16,6 +16,7 @@ set(M2_ARGS --script)
 set(GRAMMAR_FILES
   atom/macaulay2.cson
   prism/macaulay2.js
+  pygments/macaulay2.py
 #  rouge/macaulay2.rb
   vim/m2.vim.syntax
   vim/m2.vim.dict

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -19,7 +19,7 @@ emacs/M2-symbols.el : make-M2-symbols.m2 ../m2/exports.m2 @pre_exec_prefix@/bin/
 emacs/M2-emacs.m2 emacs/M2-emacs-help.txt: emacs/make-M2-emacs-help.m2 @pre_exec_prefix@/bin/M2@EXE@ @pre_exec_prefix@/bin/M2
 	cd emacs; @pre_exec_prefix@/bin/M2 $(ARGS) @abs_srcdir@/emacs/make-M2-emacs-help.m2 -e 'exit 0'
 
-clean::; rm -rf @pre_emacsdir@/* atom emacs prism vim
+clean::; rm -rf @pre_emacsdir@/* atom emacs prism pygments vim
 distclean:: clean; rm -f Makefile
 
 # Local Variables:

--- a/M2/Macaulay2/editors/make-M2-symbols.m2
+++ b/M2/Macaulay2/editors/make-M2-symbols.m2
@@ -7,6 +7,7 @@
 --  - Emacs
 --  - Atom & Linguist: https://github.com/Macaulay2/language-macaulay2
 --  - Rouge
+--  - Pygments
 
 -------------------------------------------------------------------------------
 -- TODO: Move these two elsewhere:
@@ -121,6 +122,17 @@ symbolsForRouge = template -> (
     output = replace("@M2STRINGS@",               STRINGS,    output);
     output)
 
+pygmentsformat = symlist -> demark("," | newline | "    ", format \ symlist)
+symbolsForPygments = template -> (
+    output := concatenate("# ", banner, newline, newline, template);
+    output = replace("@M2VERSION@",   version#"VERSION",        output);
+    output = replace("@M2KEYWORDS@",  pygmentsformat KEYWORDS,  output);
+    output = replace("@M2DATATYPES@", pygmentsformat DATATYPES, output);
+    output = replace("@M2FUNCTIONS@", pygmentsformat FUNCTIONS, output);
+    output = replace("@M2CONSTANTS@", pygmentsformat CONSTANTS, output);
+    output = replace("@M2STRINGS@",                  STRINGS,   output);
+    output)
+
 -------------------------------------------------------------------------------
 -- Generate syntax files from templates in the same directory
 
@@ -148,6 +160,9 @@ generateGrammar("vim/m2.vim.dict", symbolsForVim); -- TODO: is this necessary?
 
 -- Rouge: Write macaulay2.rb
 --generateGrammar("rouge/macaulay2.rb", symbolsForRouge);
+
+-- Pygments: Write macaulay2.py
+generateGrammar("pygments/macaulay2.py", symbolsForPygments)
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/emacs M2-symbols "

--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -1,0 +1,37 @@
+from pygments.lexer import RegexLexer, words
+from pygments.token import Comment, Keyword, Name, String, Text
+
+M2KEYWORDS = (
+    @M2KEYWORDS@
+    )
+
+M2DATATYPES = (
+    @M2DATATYPES@
+    )
+
+M2FUNCTIONS = (
+    @M2FUNCTIONS@
+    )
+
+M2CONSTANTS = (
+    @M2CONSTANTS@
+    )
+
+class Macaulay2Lexer(RegexLexer):
+    name = 'Macaulay2'
+    aliases = ['macaulay2']
+    filenames = ['*.m2']
+
+    tokens = {
+        'root': [
+            (r'--.*$', Comment.Single),
+            (r'-\*[\w\W]*?\*-', Comment.Multiline),
+            (r'".*?"', String),
+            (r'///[\w\W]*?///', String),
+            (words(M2KEYWORDS, prefix=r'\b', suffix=r'\b'), Keyword),
+            (words(M2DATATYPES, prefix=r'\b', suffix=r'\b'), Name.Builtin),
+            (words(M2FUNCTIONS, prefix=r'\b', suffix=r'\b'), Name.Function),
+            (words(M2CONSTANTS, prefix=r'\b', suffix=r'\b'), Name.Constant),
+            (r'.', Text)
+        ]
+    }


### PR DESCRIPTION
Pygments is a Python syntax highlighter.  See https://pygments.org/.  It's also the syntax highlighter used by [minted](https://ctan.org/pkg/minted?lang=en).

For example:

```
profzoom@peg-amy:~/src/macaulay2/M2/M2/Macaulay2/editors/pygments$ pygmentize -O full -x -l macaulay2.py:Macaulay2Lexer -o foo.html ../make-M2-symbols.m2 
```

Creates the following:
https://jsfiddle.net/mj8p67bw/show

