### PR TITLE
COMPILE_FLAGS in C/CXXFLAGS instead of CPPFLAGS

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -28,6 +28,9 @@ add_custom_target(clean-stamps
 
 # Preprocessor flags
 set(CPPFLAGS "$ENV{CPPFLAGS}")
+foreach(FLAG ${COMPILE_DEFINITIONS})
+  set(CPPFLAGS "-D${FLAG} ${CPPFLAGS}")
+endforeach()
 
 # General compile flags
 string(REPLACE ";" " " COMPILEFLAGS "${COMPILE_OPTIONS}")

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -27,13 +27,16 @@ add_custom_target(clean-stamps
 ## Set the default compile and link flags for external projects
 
 # Preprocessor flags
-string(REPLACE ";" " " CPPFLAGS "$ENV{CPPFLAGS} ${COMPILE_OPTIONS}")
+set(CPPFLAGS "$ENV{CPPFLAGS}")
+
+# General compile flags
+string(REPLACE ";" " " COMPILEFLAGS "${COMPILE_OPTIONS}")
 
 # C compiler flags
-set(CFLAGS   "${CPPFLAGS} -w -Wimplicit -Werror")
+set(CFLAGS   "${COMPILEFLAGS} -w -Wimplicit -Werror")
 
 # C++ compiler flags
-set(CXXFLAGS "${CPPFLAGS} -std=gnu++11 -w -Wno-mismatched-tags -Wno-deprecated-register")
+set(CXXFLAGS "${COMPILEFLAGS} -std=gnu++11 -w -Wno-mismatched-tags -Wno-deprecated-register")
 
 # Linker flags
 string(REPLACE ";" " " LDFLAGS "${LINK_OPTIONS}")

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -195,10 +195,11 @@ endif()
 
 # Flags based on options
 if(MEMDEBUG)
-  add_compile_options(-DMEMDEBUG)
+  add_compile_definitions(MEMDEBUG)
 endif()
 if(PROFILING)
-  add_compile_options(-pg -DPROFILING)
+  add_compile_definitions(PROFILING)
+  add_compile_options(-pg)
   add_link_options(-pg)
 endif()
 
@@ -206,9 +207,11 @@ endif()
 # Note: certain flags are initialized by CMake based on the compiler and build type.
 if(CMAKE_BUILD_TYPE MATCHES "Debug") # Debugging
   # INIT: -g
-  add_compile_options(-O0 -DGC_DEBUG -DMEMT_DEBUG -DMATHIC_DEBUG -DMATHICGB_DEBUG)
+  add_compile_definitions(GC_DEBUG MEMT_DEBUG MATHIC_DEBUG MATHICGB_DEBUG)
+  add_compile_options(-O0)
 else()
-  add_compile_options(-DNDEBUG -DOM_NDEBUG -DSING_NDEBUG -Wuninitialized)
+  add_compile_definitions(NDEBUG OM_NDEBUG SING_NDEBUG)
+  add_compile_options(-Wuninitialized)
 endif()
 if(CMAKE_BUILD_TYPE MATCHES "MinSizeRel")
   # INIT: -Os
@@ -243,6 +246,7 @@ add_compile_options(
   )
 
 # Querying the options so we can print them
+get_property(COMPILE_DEFINITIONS DIRECTORY PROPERTY COMPILE_DEFINITIONS)
 get_property(COMPILE_OPTIONS DIRECTORY PROPERTY COMPILE_OPTIONS)
 get_property(LINK_OPTIONS    DIRECTORY PROPERTY LINK_OPTIONS)
 
@@ -253,6 +257,7 @@ message("\n## Compiler information
 
 if(VERBOSE)
   message("## Build flags (excluding standard ${CMAKE_BUILD_TYPE} flags)
+     Compiler preprocessor options = ${COMPILE_DEFINITIONS}
      Compiler flags    = ${COMPILE_OPTIONS}
      Linker flags      = ${LINK_OPTIONS}\n")
   message("## CMake path variables


### PR DESCRIPTION
Put COMPILE_FLAGS in the corresponding C/CXXFLAGS variable, instead of CPPFLAGS which is for pre-processor flags.

This fixes a bug where when `-march=native` was in COMPILE_FLAGS (for example when BUILD_NATIVE is on), `./configure` would fail to pick up the proper architecture in the 4ti2 compilation as autoconf uses non-standard flags ordering and thus `-march=native` would shadow whatever `-march=` flag was being tested, falsifying the result, and leading to a failing compilation.

See https://savannah.gnu.org/support/?110484 for more.