### PR TITLE
Set VERBOSE environment variable during github builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -58,6 +58,8 @@ jobs:
           - build-system: cmake
             os: macos-10.15
             compiler: default
+    env:
+      VERBOSE: 1
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As discussed in M2internals yesterday, for displaying logs of failing examples and tests.

This is a draft for now and includes a commit with an example that fails on purpose just to make sure that the log is displayed correctly.  If all goes well, then I'll remove that commit and mark this as ready for review.