### PR TITLE
Set VERBOSE during cmake github builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -134,7 +134,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release -DBUILD_NATIVE=OFF \
             -DCMAKE_PREFIX_PATH=`brew --prefix` \
             -DCMAKE_INSTALL_PREFIX=/usr \
-            --debug-trycompile
+            --debug-trycompile \
+            -DVERBOSE=ON
 
       - name: Build libraries using Ninja
         if: matrix.build-system == 'cmake'


### PR DESCRIPTION
This is a companion to #2049, but for cmake builds.  Rather than using `VERBOSE` from the environment, the cmake build expects it to be passed on the command line.