### PR TITLE
Use a nonrecursive algorithms for KBasis

### DIFF
--- a/M2/Macaulay2/e/matrix-kbasis.cpp
+++ b/M2/Macaulay2/e/matrix-kbasis.cpp
@@ -198,6 +198,7 @@ void KBasis::basis0_full(int firstvar)
   if (kb_monideal->search_expvector(kb_exp, b)) return;
   insert();
   if (limit == 0) return;
+  if (firstvar >= vars->len) return;
 
   int curr = firstvar;
   do {
@@ -244,6 +245,8 @@ void KBasis::basis0_singly_graded(int firstvar)
       if (limit == 0) return;
     }
   if (hi_degree && kb_exp_weight == kb_target_hi_weight) return;
+
+  if (firstvar >= vars->len) return;
 
   int curr = firstvar;
   do {

--- a/M2/Macaulay2/e/matrix-kbasis.cpp
+++ b/M2/Macaulay2/e/matrix-kbasis.cpp
@@ -283,7 +283,7 @@ inline bool KBasis::backtrack_mg(int &curr)
       kb_exp_weight -= var_wts[curr] * kb_exp[vcurr];
       ntuple::multpower(heft_vector->len,
                         kb_exp_multidegree,
-                        var_degs + (heft_vector->len * vcurr),
+                        var_degs + (heft_vector->len * curr),
                         -kb_exp[vcurr],
                         kb_exp_multidegree);
       kb_exp[vcurr] = 0;
@@ -297,7 +297,7 @@ inline bool KBasis::backtrack_mg(int &curr)
   kb_exp_weight -= var_wts[curr];
   ntuple::divide(heft_vector->len,
                  kb_exp_multidegree,
-                 var_degs + (heft_vector->len * vcurr),
+                 var_degs + (heft_vector->len * curr),
                  kb_exp_multidegree);
   curr++;
   return true;
@@ -338,7 +338,7 @@ void KBasis::basis0_multi_graded()
           kb_exp_weight += var_wts[curr];
           ntuple::mult(heft_vector->len,
                        kb_exp_multidegree,
-                       var_degs + (heft_vector->len * vcurr),
+                       var_degs + (heft_vector->len * curr),
                        kb_exp_multidegree);
       } while (try_insert_mg());
   } while (backtrack_mg(curr));

--- a/M2/Macaulay2/e/ntuple.hpp
+++ b/M2/Macaulay2/e/ntuple.hpp
@@ -17,6 +17,11 @@ class ntuple
   static bool is_one(int nvars, int *a);
   static void mult(int nvars, const int *a, const int *b, int *result);
   static void power(int nvars, const int *a, int n, int *result);
+  static void multpower(int nvars,
+                        const int *a,
+                        const int *b,
+                        int n,
+                        int *result);
   static void divide(int nvars, const int *a, const int *b, int *result);
   // result = a - b
   static void quotient(int nvars, const int *a, const int *b, int *result);
@@ -58,6 +63,16 @@ inline void ntuple::mult(int nvars, const int *a, const int *b, int *result)
 inline void ntuple::power(int nvars, const int *a, int n, int *result)
 {
   for (int i = nvars; i > 0; i--) *result++ = safe::mult(*a++, n);
+}
+
+inline void ntuple::multpower(int nvars,
+                              const int *a,
+                              const int *b,
+                              int n,
+                              int *result)
+{
+  for (int i = nvars; i > 0; i--)
+    *result++ = safe::add(*a++, safe::mult(*b++, n));
 }
 
 inline void ntuple::divide(int nvars, const int *a, const int *b, int *result)

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -755,10 +755,12 @@ basis(List,List,Module) := opts -> (lo,hi,M) -> (
      (varlist, heftvec) := if #lo == 0 and #hi == 0
                         then (var, () ) 
 			else findHeftandVars(R, var, max(#hi,#lo));
-
+    varlist' := if #lo == degreeLength R
+                then var --full degree, use all variables regardless of if they are degree 0
+                else varlist; --partial degree, use only variables of non-zero degree in the appropriate entries
      pres := generators gb presentation M;
 
-     M.cache#"rawBasis log" = log := FunctionApplication { rawBasis, (raw pres, lo, hi, heftvec, var, opts.Truncate, opts.Limit) };
+     M.cache#"rawBasis log" = log := FunctionApplication { rawBasis, (raw pres, lo, hi, heftvec, varlist', opts.Truncate, opts.Limit) };
      f := value log;
      S := opts.SourceRing;
      off := splice opts.Degree;

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -755,12 +755,10 @@ basis(List,List,Module) := opts -> (lo,hi,M) -> (
      (varlist, heftvec) := if #lo == 0 and #hi == 0
                         then (var, () ) 
 			else findHeftandVars(R, var, max(#hi,#lo));
-    varlist' := if #lo == degreeLength R
-                then var --full degree, use all variables regardless of if they are degree 0
-                else varlist; --partial degree, use only variables of non-zero degree in the appropriate entries
+
      pres := generators gb presentation M;
 
-     M.cache#"rawBasis log" = log := FunctionApplication { rawBasis, (raw pres, lo, hi, heftvec, varlist', opts.Truncate, opts.Limit) };
+     M.cache#"rawBasis log" = log := FunctionApplication { rawBasis, (raw pres, lo, hi, heftvec, varlist, opts.Truncate, opts.Limit) };
      f := value log;
      S := opts.SourceRing;
      off := splice opts.Degree;

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -758,7 +758,7 @@ basis(List,List,Module) := opts -> (lo,hi,M) -> (
 
      pres := generators gb presentation M;
 
-     M.cache#"rawBasis log" = log := FunctionApplication { rawBasis, (raw pres, lo, hi, heftvec, varlist, opts.Truncate, opts.Limit) };
+     M.cache#"rawBasis log" = log := FunctionApplication { rawBasis, (raw pres, lo, hi, heftvec, var, opts.Truncate, opts.Limit) };
      f := value log;
      S := opts.SourceRing;
      off := splice opts.Degree;


### PR DESCRIPTION
This fixes a stack overflow I was getting running `basis(200000,QQ[x,y])` while testing other things. Additionally, it seems to provide a ~5-10% speedup for basis with large degrees (on a debug build, I didn't test an optimizing build).

Here's what I'm still planning on doing:

- [x] Reduce code duplication between the various `basis0_*` functions
- [x] Reimplement `basis0_multi_graded` in the same way
- [x] Remove the redundant parameter `firstvar`

I wanted to make this pull request to see if there are any thoughts on these changes. This shouldn't impact #1929, but if there's related changes to make I'd be happy to try to make them.