### PR TITLE
address a bug in Schubert2

### DIFF
--- a/M2/Macaulay2/packages/Schubert2.m2
+++ b/M2/Macaulay2/packages/Schubert2.m2
@@ -1164,7 +1164,7 @@ blowup(AbstractVarietyMap) :=
      Ytilde.TangentBundle = abstractSheaf(Ytilde,
 	  Rank => dim Y,
 	  ChernClass => promote(chern(tangentBundle Y), D) + jLower (chern(g^* tangentBundle X) * alpha),
-          ChernCharacter => ch tangentBundle Y - jLower(ch(dual first bundles PN) * (todd OO(-x))^-1));
+          ChernCharacter => ch tangentBundle Y - jLower(ch dual first bundles PN * todd (- OO(-x))));
      -- to pull back a class from the blowup to PN we take E_i to -x*alphas#i; this corresponds to
      -- the fact that pushing forward and then pulling back a class on PN is the same as multiplying by x = c_1(O(1))
      jUpper := map(C, D, (for i from 0 to n-1 list -x * alphas#i) | flatten entries promote(iuppermatrix,C));


### PR DESCRIPTION
This partially addresses the bug reported in https://github.com/Macaulay2/M2/issues/2051.
We artificially avoid the use of reciprocal in towers of polynomial rings.