### PR TITLE
Make ComputationsBook output consistent with other tests

### DIFF
--- a/M2/Macaulay2/tests/ComputationsBook/Makefile.chapter.in
+++ b/M2/Macaulay2/tests/ComputationsBook/Makefile.chapter.in
@@ -6,7 +6,7 @@ include ../../../../include/config.Makefile
 all: check
 # we depend on "diff" accepting some options that perhaps only GNU diff does
 check: test.out.expected.trim test.out.trim
-	if ! diff -B -b -u test.out.expected.trim test.out.trim ;\
+	@if ! diff -B -b -u test.out.expected.trim test.out.trim ;\
 	then echo 'make[$(MAKELEVEL)]: *''** test failed: [Macaulay2/tests/ComputationsBook/$(shell basename $(chapter_srcdir))]' ;\
 	     false ;\
 	fi
@@ -29,7 +29,7 @@ endif
 
 
 PATHJOIN := 'path = join({"./","$(chapter_srcdir)/"},path)'
-M2CMD := time nice -18 @pre_exec_prefix@/bin/M2 --stop -q -e $(PATHJOIN) --print-width 0
+M2CMD := nice -18 @pre_exec_prefix@/bin/M2 --stop -q -e $(PATHJOIN) --print-width 0 --silent
 EXIT := -e "exit 0"
 INPUT = -e 'input "$<"'
 
@@ -37,14 +37,14 @@ book_patterns := $(chapter_srcdir)/../patterns
 chapter_patterns := $(chapter_srcdir)/patterns
 
 test.out.trim: test.out $(book_patterns) $(chapter_patterns)
-	<$< sed -f $(book_patterns) -f $(chapter_patterns) >$@
+	@<$< sed -f $(book_patterns) -f $(chapter_patterns) >$@
 
 test.out.expected.trim: $(EXPECTED) $(book_patterns) $(chapter_patterns)
-	<$< sed -f $(book_patterns) -f $(chapter_patterns) >$@
+	@<$< sed -f $(book_patterns) -f $(chapter_patterns) >$@
 
 test.out: test.m2 always
-	$(LIMIT) $(M2CMD) $(INPUT) $(EXIT) >test.out.tmp
-	mv test.out.tmp test.out
+	@$(LIMIT) $(M2CMD) $(INPUT) $(EXIT) >test.out.tmp
+	@mv test.out.tmp test.out
 
 clean:; rm -f *.trim
 

--- a/M2/Macaulay2/tests/ComputationsBook/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/Makefile.in
@@ -8,7 +8,8 @@ all:
 $(CHAPTERS):; $(MKDIR_P) "$@"
 check capture changes :: Makefile.chapter $(CHAPTERS)
 $(foreach d,$(CHAPTERS),											\
-	$(eval capture check ::; + $(MAKE) -C $d -I .. $$@)							\
+	$(eval capture check ::; + @echo "testing: ComputationsBook::$d"; \
+		$(MAKE) --no-print-directory -C $d -I .. $$@) \
 	$(eval changes::; diff -u @srcdir@/$d/chapter.m2 @srcdir@/$d/test.m2 || true)				\
 	$(eval changes::; diff -u @srcdir@/$d/chapter.out.expected @srcdir@/$d/test.out.expected || true))
 clean:; rm -f */*.trim */*.out programming/foo */*.tmp


### PR DESCRIPTION
This is just a cosmetic change to the autotools build output to make the `ComputationsBook` tests look like the other tests in `Macaulay2/tests`.

### Before
```shell
dtorrance@mixtuppa:~/src/macaulay2/M2/M2/BUILD/doug$ make -C Macaulay2/tests/ComputationsBook/ check
make: Entering directory '/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/Macaulay2/tests/ComputationsBook'
make -C completeIntersections -I .. check
make[1]: Entering directory '/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/Macaulay2/tests/ComputationsBook/completeIntersections'
ulimit -t 1200 ; ulimit -v 1600000 ; ulimit -m 800000 ; ulimit -s 8192 ; time nice -18 /home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/usr-dist/x86_64-Linux-Ubuntu-21.04/bin/M2 --stop -q -e 'path = join({"./","../../../../../../Macaulay2/tests/ComputationsBook/completeIntersections/"},path)' --print-width 0 -e 'input "../../../../../../Macaulay2/tests/ComputationsBook/completeIntersections/test.m2"' -e "exit 0" >test.out.tmp
Macaulay2, version 1.17.2.1
with packages: ConwayPolynomials, Elimination, IntegralClosure, InverseSystems, LLLBases, MinimalPrimes, PrimaryDecomposition, ReesAlgebra, Saturation, TangentCone
11.03user 0.08system 0:10.13elapsed 109%CPU (0avgtext+0avgdata 130464maxresident)k
0inputs+104outputs (0major+30766minor)pagefaults 0swaps
mv test.out.tmp test.out
<test.out sed -f ../../../../../../Macaulay2/tests/ComputationsBook/completeIntersections/../patterns -f ../../../../../../Macaulay2/tests/ComputationsBook/completeIntersections/patterns >test.out.trim
if ! diff -B -b -u test.out.expected.trim test.out.trim ;\
then echo 'make[1]: *''** test failed: [Macaulay2/tests/ComputationsBook/completeIntersections]' ;\
     false ;\
fi
make[1]: Leaving directory '/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/Macaulay2/tests/ComputationsBook/completeIntersections'
make -C constructions -I .. check
make[1]: Entering directory '/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/Macaulay2/tests/ComputationsBook/constructions'
...
```

### After
```shell
dtorrance@mixtuppa:~/src/macaulay2/M2/M2/BUILD/doug$ make -C Macaulay2/tests/ComputationsBook/ check
make: Entering directory '/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/Macaulay2/tests/ComputationsBook'
testing: ComputationsBook::completeIntersections
testing: ComputationsBook::constructions
testing: ComputationsBook::d-modules
...
``` 

Compare with:
```shell
dtorrance@mixtuppa:~/src/macaulay2/M2/M2/BUILD/doug$ make -C Macaulay2/tests/normal check
make: Entering directory '/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/Macaulay2/tests/normal'
testing: ../../../../../Macaulay2/tests/normal/00vars.m2
testing: ../../../../../Macaulay2/tests/normal/0-homog.m2
testing: ../../../../../Macaulay2/tests/normal/4a.m2
testing: ../../../../../Macaulay2/tests/normal/4-b.m2
testing: ../../../../../Macaulay2/tests/normal/4b.m2
...
```
