### PR TITLE
Small tweaks to html comments

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -139,7 +139,9 @@ html TT :=
 html CODE := (lookup(html, Hypertext)) @@ (x -> apply(x,fixNewLines))
 
 html CDATA   := x -> concatenate("<![CDATA[", x ,"]]>", newline)
-html COMMENT := x -> concatenate("<!--", x, "-->", newline)
+html COMMENT := x -> if match("--", concatenate x) then
+    error ///html comments cannot contain "--"/// else
+    concatenate("<!--", x, "-->", newline)
 
 html HREF := x -> (
      r := concatenate apply(splice if #x > 1 then drop(x, 1) else x, html1);

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -155,8 +155,9 @@ html TO2  := x -> (
     fkey := format tag;
     -- TODO: add this to htmlLiteral?
     name := if match("^ +$", x#1) then #x#1 : "&nbsp;&nbsp;" else x#1;
-    if isUndocumented tag then concatenate(html TT name, " (missing documentation<!-- tag: ", toString tag.Key, " -->)") else
-    if isMissingDoc   tag then concatenate(html TT name, " (missing documentation<!-- tag: ", toString tag.Key, " -->)") else
+    if isUndocumented tag or isMissingDoc tag then concatenate(
+	html TT name, " (missing documentation)",
+	html COMMENT("tag: ", toString tag.Key)) else
     concatenate(html ANCHOR{"title" => htmlLiteral headline tag, "href"  => toURL htmlFilename tag, name}))
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
Two little tweaks to prevent issues like #2071 going forward:

* Use `(html, COMMENT)` for undocumented and missing tags instead of hard-coding `<!--` and `-->`.
* Raise an error in `(html, COMMENT)` if the comment contains a `--`. That way we'll know there's an issue right off the bat instead of getting html validation errors later down the road.  Note that `--` in a comment is invalid XML 1.0 -- see https://www.w3.org/TR/REC-xml/#sec-comments.