### PR TITLE
Bump several package version numbers in preparation for 1.18

### DIFF
--- a/M2/Macaulay2/packages/Chordal.m2
+++ b/M2/Macaulay2/packages/Chordal.m2
@@ -1,8 +1,8 @@
 
 newPackage(
     "Chordal",
-    Version => "0.1", 
-    Date => "2 September 2017",
+    Version => "0.2",
+    Date => "May 15, 2021",
     Authors => {
       {Name => "Diego Cifuentes",
        Email => "diegcif@mit.edu",

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -26,8 +26,8 @@ of the License, or any later version.
 
 newPackage select((
     "Graphs",
-        Version => "0.3.3",
-        Date => "21. August 2020",
+        Version => "0.3.4",
+        Date => "May 15, 2021",
         Authors => {
             {Name => "Jack Burkart", Email => "jburkar1@nd.edu"},
             {Name => "David Cook II", Email => "dwcook@eiu.edu", HomePage => "http://ux1.eiu.edu/~dwcook/"},

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -71,7 +71,16 @@ document {
 		   	},
 		   LI { "The package ", TO "NoetherianOperators::NoetherianOperators", " has been improved: the ", TO "NoetherianOperators::DiffOp", " type has
 			 been reworked, and support for Noetherian operators and differential primary decompositions of modules has been added."
-			 }
+			 },
+		   LI { "Several packages (",
+		       TO "Chordal::Chordal", ", ",
+		       TO "Graphs::Graphs", ", ",
+		       TO "Markov::Markov", ", and ",
+		       TO "Posets::Posets",
+		       ") that generate and display visualizations of mathematical objects using external image viewers ",
+		       "have been modified so that they no longer require package-specific configuration of these viewers.  ",
+		       "Instead, ", TO "show", " is used, which opens the images using the system default viewer (using ",
+		       TT "open", " on macOS and ", TT "xdg-open", " on Linux)."}
 		   }
 	      },
 	 LI { "functionality added:",

--- a/M2/Macaulay2/packages/Markov.m2
+++ b/M2/Macaulay2/packages/Markov.m2
@@ -7,7 +7,8 @@ newPackage("Markov",
      DebuggingMode => false,
      Keywords => {"Statistics"},
      Headline => "Markov ideals arising from Bayesian networks in statistics",
-     Version => "1.2",
+     Version => "1.3",
+     Date => "May 15, 2021",
      PackageImports => {"Elimination"}
      )
 

--- a/M2/Macaulay2/packages/Posets.m2
+++ b/M2/Macaulay2/packages/Posets.m2
@@ -11,8 +11,8 @@
 
 newPackage select((
     "Posets",
-        Version => "1.1.2",
-        Date => "07. August 2014",
+        Version => "1.1.3",
+        Date => "May 15, 2021",
         Authors => {
             {Name => "David Cook II", Email => "dwcook@eiu.edu", HomePage => "http://ux1.eiu.edu/~dwcook/"},
             {Name => "Sonja Mapes", Email => "smapes1@nd.edu", HomePage => "http://www.nd.edu/~smapes1/"},

--- a/M2/Macaulay2/packages/gfanInterface.m2
+++ b/M2/Macaulay2/packages/gfanInterface.m2
@@ -5,12 +5,13 @@
 
 newPackage(
 	"gfanInterface",
-	Version => "0.4",
-	Date => "Aug 2012 (updated by Josephine Yu)",
+	Version => "0.5",
+	Date => "May 15, 2021",
 	Authors => {
 		{Name => "Mike Stillman", Email => "mike@math.cornell.edu", HomePage => ""},
 		{Name => "Andrew Hoefel", Email => "andrew.hoefel@gmail.com", HomePage =>"http://www.mast.queensu.ca/~ahhoefel/"},
-	    {Name => "Diane Maclagan (current maintainer)", Email => "D.Maclagan@warwick.ac.uk", HomePage=>"http://homepages.warwick.ac.uk/staff/D.Maclagan/"}},
+	    {Name => "Diane Maclagan (current maintainer)", Email => "D.Maclagan@warwick.ac.uk", HomePage=>"http://homepages.warwick.ac.uk/staff/D.Maclagan/"},
+	    {Name => "Josephine Yu", Email => "jyu@math.gatech.edu", HomePage => "http://people.math.gatech.edu/~jyu67/"}},
 	Headline => "interface to Anders Jensen's Gfan software",
 	Keywords => {"Interfaces"},
 	Configuration => {


### PR DESCRIPTION
I have participated in some nontrivial contributions to several packages which are probably worthy of version bumps before 1.18 is released (`gfanInterface`, `Posets`, `Graphs`, `Chordal`, and `Markov`).  Note that I'm not listed as an author on any of these packages.