### PR TITLE
Mention "assert" changes in changes.m2 for 1.18

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -89,7 +89,9 @@ document {
 		      to Michael Burr, with help from Anton Leykin."},
 		 LI {"The function ", TO tests, " has been added, for getting information about a package's tests."},
 		 LI {"A new type of list, ", TO AngleBarList, ", has been added, for use in forming free associative algebras.
-		      An instance can be created with the notation ", TT "<|x,y,z|>", "." }
+		      An instance can be created with the notation ", TT "<|x,y,z|>", "." },
+	         LI {"The function ", TO assert, " now accepts an ", TO Expression, " object as its argument.  ",
+		     "This may provide more useful error messages for debugging."}
 		 }
 	     },
 	LI { "functionality removed",


### PR DESCRIPTION
The new feature may be worth mentioning:

```m2
i1 : assert Equation(2 + 2, 5)
stdio:1:1:(3): error: assertion failed:
4 == 5 is false
```