### PR TITLE
NoetherianOperators: tweaked package headline

### DIFF
--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -15,7 +15,7 @@ newPackage(
         {Name => "Anton Leykin",
         Email => "anton.leykin@gmail.com"}
     },
-    Headline => "numerically compute local dual spaces, Hilbert functions, and Noetherian operators",
+    Headline => "algorithms for computing local dual spaces and sets of Noetherian operators",
     PackageExports => {"Bertini", "NumericalLinearAlgebra", "NAGtypes"},
     PackageImports => {"PrimaryDecomposition"},
     AuxiliaryFiles => false,


### PR DESCRIPTION
Minor change to the headline of NoetherianOperators: removed the work "numerical", as the package now contains symbolic algorithms as well. Package headline now matched the headline of the NoetherianOperators documentation node.