### PR TITLE
Don't update the package cache after adding PPA during Github builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install requirements for Linux
         if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository -y ppa:macaulay2/macaulay2
+          sudo add-apt-repository -y -n ppa:macaulay2/macaulay2
           sudo apt-get update
           sudo apt-get install -y -q --no-install-recommends clang-11 gfortran libtool-bin ninja-build yasm ccache
           sudo apt-get install -y -q --no-install-recommends libatomic-ops-dev libboost-stacktrace-dev \


### PR DESCRIPTION
We call "apt-get update" immediately afterwards, so this ends up being
redundant.