### PR TITLE
Don't include tbb header file in FreeMonoid.cpp

### DIFF
--- a/M2/Macaulay2/e/NCAlgebras/FreeMonoid.cpp
+++ b/M2/Macaulay2/e/NCAlgebras/FreeMonoid.cpp
@@ -10,8 +10,6 @@
 #include <ostream>                     // for string, operator<<, ostream
 #include <utility>                     // for pair
 
-#include <tbb/tbb.h>                   // for locks
-
 size_t FreeMonoidLogger::mCompares = 0;
 
 std::ostream& operator<<(std::ostream& o, FreeMonoidLogger a)


### PR DESCRIPTION
Nothing declared in the header is used in this file, and including it was raising deprecation warnings during builds.

```
In file included from NCAlgebras/FreeMonoid.cpp:13:
/usr/include/tbb/tbb.h:21:154: note: '#pragma message: TBB Warning: tbb.h contains deprecated functionality. For details, please see Deprecated Features appendix in the TBB reference manual.'
   21 | #pragma message("TBB Warning: tbb.h contains deprecated functionality. For details, please see Deprecated Features appendix in the TBB reference manual.")
      |                                                                                                                                                          ^
```