### PR TITLE
Dummy pull request to debug findProgram example errors

### DIFF
--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -27,10 +27,15 @@ checkProgramPath = (name, cmds, pathToTry, prefix, opts) -> (
 	replace(///\\([ ()])///, ///\1///, pathToTry));
     found := if all(apply(cmds, cmd -> addPrefix(cmd, prefix)), cmd -> (
 	exe := unescapedPathToTry | first separate(" ", cmd);
-	if not fileExists exe then false else
+	if not fileExists exe then (
+	    printerr(exe, " does not exist"); false) else
 	-- check executable bit (0111)
-	if fileMode exe & 73 == 0 then false else
-	run(pathToTry | cmd | " > /dev/null 2>&1") == 0)) then 0 else 1;
+	if fileMode exe & 73 == 0 then (
+	    printerr(exe, " exists but is not executable"); false) else (
+	    printerr(exe, " exists and is executable. running ...");
+	    ret := run(pathToTry | cmd);
+	    printerr("return value: " | ret);
+	    ret == 0))) then 0 else 1;
     msg := "";
     thisVersion := null;
     if found == 0 then (


### PR DESCRIPTION
I've temporarily added some extra verbosity to `findProgram` so hopefully we can figure out why the `cmake-macos-10.15-clang-11` builds have been failing for the last few days.

For example, this is what *should* happen:

```m2
i1 : findProgram("gfan", "gfan --help")
 -- /usr/libexec/Macaulay2/bin/gfan does not exist
 -- /home/profzoom/.local/bin/gfan does not exist
 -- /usr/local/sbin/gfan does not exist
 -- /usr/local/bin/gfan does not exist
 -- /usr/sbin/gfan does not exist
 -- /usr/bin/gfan exists and is executable. running ...
This is a program for computing all reduced Groebner bases of a polynomial ideal. It takes the ring and a generating set for the ideal as input. By default the enumeration is done by an almost memoryless reverse search. If the ideal is symmetric the symmetry option is useful and enumeration will be done up to symmetry using a breadth first search. The program needs a starting Groebner basis to do its computations. If the -g option is not specified it will compute one using Buchberger's algorithm.
Options:
-g:
 Tells the program that the input is already a Groebner basis (with the initial term of each polynomial being the first ones listed). Use this option if it takes too much time to compute the starting (standard degree lexicographic) Groebner basis and the input is already a Groebner basis.

--symmetry:
 Tells the program to read in generators for a group of symmetries (subgroup of $S_n$) after having read in the ideal. The program checks that the ideal stays fixed when permuting the variables with respect to elements in the group. The program uses breadth first search to compute the set of reduced Groebner bases up to symmetry with respect to the specified subgroup.

-e:
 Echo. Output the generators for the symmetry group.

--disableSymmetryTest:
 When using --symmetry this option will disable the check that the group read off from the input actually is a symmetry group with respect to the input ideal.

--parameters value:
 With this option you can specify how many variables to treat as parameters instead of variables. This makes it possible to do computations where the coefficient field is the field of rational functions in the parameters.
--interrupt value:
 Interrupt the enumeration after a specified number of facets have been computed (works for usual symmetric traversals, but may not work in general for non-symmetric traversals or for traversals restricted to fans).
 -- return value: 0

o1 = gfan

o1 : Program
```