### PR TITLE
findProgram updates

### DIFF
--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -74,6 +74,17 @@ findProgram = method(TypicalValue => Program,
 findProgram(String, String) := opts -> (name, cmd) ->
     findProgram(name, {cmd}, opts)
 findProgram(String, List) := opts -> (name, cmds) -> (
+    if not (instance(opts.Prefix, List) and
+	all(opts.Prefix, x -> instance(x, Sequence)) and
+	all(opts.Prefix, x -> class \ x === (String, String))) then
+	error "expected Prefix to be a list of sequences of two strings";
+    if not (instance(opts.AdditionalPaths, List) and
+	all(opts.AdditionalPaths, x -> instance(x, String))) then
+	error "expected AdditionalPaths to be a list of strings";
+    if opts.MinimumVersion =!= null and not(
+	instance(opts.MinimumVersion, Sequence) and
+	class \ opts.MinimumVersion === (String, String)) then
+	error "expected MinimumVersion to be a sequence of two strings";
     pathsToTry := {};
     -- try user-configured path first
     if programPaths#?name then

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -124,7 +124,7 @@ document {
 	"file."},
     EXAMPLE lines ///
 	programPaths#"gfan" = "/path/to/gfan/"
-	gfan = findProgram("gfan", "gfan --help", Verbose => true)///,
+	gfan = findProgram("gfan", "gfan _version --help", Verbose => true)///,
     PARA {"One program that is shipped with a variety of prefixes in ",
 	"different distributions and for which the ", TT "Prefix",
 	" option is useful is TOPCOM:"},
@@ -138,7 +138,7 @@ document {
 	"trailing whitespace.  Piping with standard UNIX utilities such as ",
 	TT "sed", ", ", TT "head", ", ", TT "tail", ", ", TT "cut", ", and ",
 	TT "tr", " may be useful."},
-    EXAMPLE {///findProgram("gfan", "gfan --help", Verbose => true,
+    EXAMPLE {///findProgram("gfan", "gfan _version --help", Verbose => true,
   MinimumVersion => ("0.5",
     "gfan _version | head -2 | tail -1 | sed 's/gfan//'"))
     ///},


### PR DESCRIPTION
Prompted by #2094 to diagnose the current issues with `findProgram` on the Github builds, we make the `Verbose` option more informative.

### Before
```
i1 : findProgram("gfan", "gfan _version --help", Verbose => true)
checking for gfan in /usr/libexec/Macaulay2/bin/...
    not found
checking for gfan in /home/profzoom/.local/bin/...
    not found
checking for gfan in /usr/local/sbin/...
    not found
checking for gfan in /usr/local/bin/...
    not found
checking for gfan in /usr/sbin/...
    not found
checking for gfan in /usr/bin/...
    found

o1 = gfan

o1 : Program
```

### After
```m2
i1 : findProgram("gfan", "gfan _version --help", Verbose => true)
 -- /usr/libexec/Macaulay2/bin/gfan does not exist
 -- /home/profzoom/.local/bin/gfan exists but is not executable
 -- /usr/local/sbin/gfan does not exist
 -- /usr/local/bin/gfan does not exist
 -- /usr/sbin/gfan does not exist
 -- /usr/bin/gfan exists and is executable
 -- running "/usr/bin/gfan _version --help":
This program writes out version information of the Gfan installation.
 -- return value: 0

o1 = gfan

o1 : Program
```

Also took the opportunity to make several other improvements to the code.