### PR TITLE
Load package documentation in "tests"

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -86,6 +86,7 @@ loadTestDir := pkg -> (
 tests = method()
 tests Package := pkg -> (
     if not pkg#?"test directory loaded" then loadTestDir pkg;
+    if pkg#?"documentation not loaded" then pkg = loadPackage(pkg#"pkgname", LoadDocumentation => true, Reload => true);
     previousMethodsFound = new HashTable from pkg#"test inputs"
     )
 tests String := pkg -> tests needsPackage(pkg, LoadDocumentation => true)
@@ -101,7 +102,6 @@ check(ZZ, Package) := opts -> (n, pkg) -> (
     usermode := if opts.UserMode === null then not noinitfile else opts.UserMode;
     --
     use pkg;
-    if pkg#?"documentation not loaded" then pkg = loadPackage(pkg#"pkgname", LoadDocumentation => true, Reload => true);
     tmp := previousMethodsFound;
     inputs := tests pkg;
     previousMethodsFound = tmp;


### PR DESCRIPTION
*EDIT:*  This PR now only deals with the second issue mentioned in this original post, and doesn't touch `needsPackage` at all.

---

This fixes two small bugs when calling `needsPackage` twice on the same package but with different options:

## Change in `FileName`
### Before
```m2
i1 : needsPackage "Graphs"
--warning: symbol "diameter" in Core.Dictionary is shadowed by a symbol in Graphs.Dictionary
--  use the synonym Core$diameter

o1 = Graphs

o1 : Package

i2 : needsPackage("Graphs", FileName => "~/tmp/Graphs.m2")
tmp/Graphs.m2:27:1:(3):[10]: error: package Graphs not reloaded; try Reload => true
tmp/Graphs.m2:27:1:(3):[10]: --entering debugger (type help to see debugger commands)
tmp/Graphs.m2:27:1-50:23: --source code:
newPackage select((
    "Graphs",
        Version => "0.3.4",
        Date => "May 15, 2021",
        Authors => {
            {Name => "Jack Burkart", Email => "jburkar1@nd.edu"},
            {Name => "David Cook II", Email => "dwcook@eiu.edu", HomePage => "http://ux1.eiu.edu/~dwcook/"},
            {Name => "Caroline Jansen", Email => "cjansen@nd.edu"},
                {Name => "Amelia Taylor", Email => "originalbrickhouse@gmail.com"},
            {Name => "Augustine O'Keefe", Email => "aokeefe@tulane.edu"},
            {Name => "Contributors of note: Carlos Amendola, Alex Diaz, Luis David Garcia Puente, Roser Homs Pons, Olga Kuznetsova,  Shaowei Lin, Sonja Mapes, Harshit J Motwani, Mike Stillman, Doug Torrance"}
        },
        Headline => "graphs and directed graphs (digraphs)",
        Keywords => {"Graph Theory"},
        Configuration => {
            "DotBinary" => "dot",
            "JpgViewer" => ""
            },
        PackageImports => { "PrimaryDecomposition" },
        PackageExports => {
            "SimplicialComplexes"
            },
        DebuggingMode => false,
        ), x -> x =!= null)
```

### After
```m2
i1 : needsPackage "Graphs"
--warning: symbol "diameter" in Core.Dictionary is shadowed by a symbol in Graphs.Dictionary
--  use the synonym Core$diameter

o1 = Graphs

o1 : Package

i2 : needsPackage("Graphs", FileName => "~/tmp/Graphs.m2")
--warning: symbol "diameter" in Core.Dictionary is shadowed by a symbol in Graphs.Dictionary
--  use the synonym Core$diameter

o2 = Graphs

o2 : Package
```

## Change in `LoadDocumentation`
This is apparent in `tests`, which calls `needsPackage(..., LoadDocumentation => true)`.

### Before
```m2
i1 : needsPackage "Graphs"
--warning: symbol "diameter" in Core.Dictionary is shadowed by a symbol in Graphs.Dictionary
--  use the synonym Core$diameter

o1 = Graphs

o1 : Package

i2 : tests "Graphs"

o2 = HashTable{}

o2 : HashTable
```

### After
```m2
i1 : needsPackage "Graphs"
--warning: symbol "diameter" in Core.Dictionary is shadowed by a symbol in Graphs.Dictionary
--  use the synonym Core$diameter

o1 = Graphs

o1 : Package

i2 : tests "Graphs"
--warning: symbol "diameter" in Core.Dictionary is shadowed by a symbol in Graphs.Dictionary
--  use the synonym Core$diameter

o2 = HashTable{0 =>                                                }
                    M2/Macaulay2/packages/Graphs.m2:5355:1-5360:1:
               1 => 
                    M2/Macaulay2/packages/Graphs.m2:5361:1-5370:1:
               2 => 
                    M2/Macaulay2/packages/Graphs.m2:5371:1-5383:1:
               3 => 
                    M2/Macaulay2/packages/Graphs.m2:5384:1-5390:1:
               4 => 
                    M2/Macaulay2/packages/Graphs.m2:5391:1-5395:1:
               5 => 
                    M2/Macaulay2/packages/Graphs.m2:5396:1-5404:1:
               6 => 
                    M2/Macaulay2/packages/Graphs.m2:5405:1-5419:1:
               7 => 
                    M2/Macaulay2/packages/Graphs.m2:5420:1-5441:1:
               8 => 
                    M2/Macaulay2/packages/Graphs.m2:5442:1-5449:1:
               9 => 
                    M2/Macaulay2/packages/Graphs.m2:5450:1-5455:1:
               10 => 
                     M2/Macaulay2/packages/Graphs.m2:5457:1-5464:1:

o2 : HashTable
```

