### PR TITLE
"diameter" in Core and Graphs

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1339,31 +1339,31 @@ setupfun("toRRi",toRRi);
 rightRR(e:Expr):Expr := (
      when e
         is x:RRicell do toExpr(rightRR(x.v))
-        else WrongArg("expected an interval"));
+        else WrongArg("an interval"));
 setupfun("right",rightRR);
                                                      
 leftRR(e:Expr):Expr := (
      when e
         is x:RRicell do toExpr(leftRR(x.v))
-        else WrongArg("expected an interval"));
+        else WrongArg("an interval"));
 setupfun("left",leftRR);
                                                      
 widthRR(e:Expr):Expr := (
      when e
         is x:RRicell do toExpr(widthRR(x.v))
-        else WrongArg("expected an interval"));
+        else WrongArg("an interval"));
 setupfun("diameter",widthRR).Protected = false;
                                                      
 midpointRR(e:Expr):Expr := (
      when e
         is x:RRicell do toExpr(midpointRR(x.v))
-        else WrongArg("expected an interval"));
+        else WrongArg("an interval"));
 setupfun("midpoint",midpointRR);
                                                      
 isEmptyRRi(e:Expr):Expr := (
      when e
         is x:RRicell do toExpr(isEmpty(x.v))
-        else WrongArg("expected an interval"));
+        else WrongArg("an interval"));
 setupfun("isEmptyRRi",isEmptyRRi);
                                                      
 subsetRRi(e:Expr):Expr := (

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1352,7 +1352,7 @@ widthRR(e:Expr):Expr := (
      when e
         is x:RRicell do toExpr(widthRR(x.v))
         else WrongArg("expected an interval"));
-setupfun("diameter",widthRR);
+setupfun("diameter",widthRR).Protected = false;
                                                      
 midpointRR(e:Expr):Expr := (
      when e

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -87,6 +87,10 @@ precision InexactField := R -> R.precision
 InexactFieldFamily _ ZZ := (T,prec) -> new T.InexactField of T#(symbol _*) from prec -- oops...
 default InexactFieldFamily := R -> R_defaultPrecision
 
+diameter' = diameter
+diameter = method()
+diameter RRi := diameter'
+
 -- lift and promote between real or complex rings
 
 Number _ InexactFieldFamily := (x,RR) -> x_(default RR)

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -144,7 +144,6 @@ export {
     "DFS",
     "descendants",
     "descendents",
-    "diameter",
     "distance",
     "distanceMatrix",
     "eccentricity",
@@ -897,7 +896,6 @@ descendants = method()
 descendants (Digraph, Thing) := Set => (D,v) -> set flatten breadthFirstSearch(D, v)
 descendents = descendants
 
-diameter = method()
 diameter Graph := ZZ => G -> (
     allEntries := flatten entries distanceMatrix G;
     if member(-1, allEntries) then infinity else max allEntries

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -3432,7 +3432,6 @@ doc ///
 --diameter
 doc ///
     Key
-        diameter
         (diameter, Graph)
     Headline
         Computes the diameter of a graph

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -3480,7 +3480,7 @@ doc ///
             G = graph({1,2,3,4},{{2,3},{3,4}});
             d = distance(G, 1, 4)
     SeeAlso
-        diameter
+        (diameter, Graph)
         distanceMatrix
 ///
 
@@ -3507,7 +3507,7 @@ doc ///
             G = digraph({1,2,3,4},{{2,3},{3,4}},EntryMode=>"edges");
             d = distanceMatrix G
     SeeAlso
-        diameter
+        (diameter, Graph)
         distance
 ///
 
@@ -4856,7 +4856,7 @@ doc ///
             graphPower(G,2)
     SeeAlso
         distance
-        diameter
+        (diameter, Graph)
 ///
 
 --strongProuduct

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc15.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc15.m2
@@ -61,6 +61,7 @@ SeeAlso
 doc ///
 Key
     diameter
+    (diameter, RRi)
 Headline
     diameter of an interval
 Usage


### PR DESCRIPTION
This fixes a warning message I noticed while working on #2099.  Since #1465 was merged, there have been two exported `diameter` symbols -- one from `Core` (a compiled function that expects `RRi` objects) and one from `Graphs` (a method function with one installed method -- `(diameter, Graph)`) that shadows the one from `Core`:

```m2
i1 : needsPackage "Graphs"
--warning: symbol "diameter" in Core.Dictionary is shadowed by a symbol in Graphs.Dictionary
--  use the synonym Core$diameter
```

These have been united so that `diameter` is declared as a method function in `Core`, and two methods are installed -- `(diameter, RRi)` in `Core` and `(diameter, Graph)` in `Graphs`:

```m2
i1 : needsPackage "Graphs"

o1 = Graphs

o1 : Package

i2 : methods diameter

o2 = {0 => (diameter, Graph)}
     {1 => (diameter, RRi)  }

o2 : NumberedVerticalList
```