### PR TITLE
Dust off the Python interface

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -72,7 +72,10 @@ int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[]
   system_cpuTime_init();
 
 #ifdef WITH_PYTHON
-  Py_SetProgramName(argv[0]);
+  wchar_t *program;
+
+  program = Py_DecodeLocale(argv[0], NULL);
+  Py_SetProgramName(program);
   Py_Initialize();
 #endif
 

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -23,7 +23,7 @@ header "// required for toString routines
 header "
 #ifndef WITH_PYTHON
 #  define PyObject_Str(o)       0
-#  define PyString_AS_STRING(o) 0
+#  define PyBytes_AS_STRING(o)  0
 #  define Py_DECREF(o)          0
 #else
 #  include <Python.h>

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -25,6 +25,8 @@ header "
 #  define PyObject_Str(o)       0
 #  define PyString_AS_STRING(o) 0
 #  define Py_DECREF(o)          0
+#else
+#  include <Python.h>
 #endif";
 
 internalName(s:string):string := (
@@ -1010,7 +1012,7 @@ tostringfun(e:Expr):Expr := (
      is po:pythonObjectCell do (
 	  -- Expr("<<a python object>>")
 	  str := Ccode(pythonObject,"PyObject_Str(",po.v,")");
-	  r := toExpr(tostring(Ccode(constcharstarOrNull,"PyString_AS_STRING(",str,")")));
+	  r := toExpr(tostring(Ccode(constcharstarOrNull,"PyBytes_AS_STRING(",str,")")));
 	  Ccode(void,"Py_DECREF(",str,")");
 	  r)
      is x:xmlNodeCell do toExpr(toString(x.v))

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -23,7 +23,7 @@ header "// required for toString routines
 header "
 #ifndef WITH_PYTHON
 #  define PyObject_Str(o)       0
-#  define PyBytes_AS_STRING(o)  0
+#  define PyUnicode_AsUTF8(o)   0
 #  define Py_DECREF(o)          0
 #else
 #  include <Python.h>
@@ -1012,7 +1012,7 @@ tostringfun(e:Expr):Expr := (
      is po:pythonObjectCell do (
 	  -- Expr("<<a python object>>")
 	  str := Ccode(pythonObject,"PyObject_Str(",po.v,")");
-	  r := toExpr(tostring(Ccode(constcharstarOrNull,"PyBytes_AS_STRING(",str,")")));
+	  r := toExpr(tostring(Ccode(constcharstarOrNull,"PyUnicode_AsUTF8(",str,")")));
 	  Ccode(void,"Py_DECREF(",str,")");
 	  r)
      is x:xmlNodeCell do toExpr(toString(x.v))

--- a/M2/Macaulay2/d/python-c.c
+++ b/M2/Macaulay2/d/python-c.c
@@ -49,8 +49,8 @@ PyObject *python_RunString(M2_string s) {
 }
 
 int python_Main() {
-  static char pn[3] = "M2";
-  static char *argv[2] = {pn,NULL};
+  static wchar_t pn[3] = L"M2";
+  static wchar_t *argv[2] = {pn,NULL};
   static int argc = 1;
   return Py_Main(argc,argv);
 }
@@ -80,10 +80,13 @@ static PyMethodDef SpamMethods[] = {
   {"system",  spam_system, METH_VARARGS, "Execute a shell command."},
   {NULL, NULL, 0, NULL}
 };
+static struct PyModuleDef moduledef = {
+  PyModuleDef_HEAD_INIT, "spam", NULL, -1, SpamMethods, NULL, NULL, NULL, NULL}
+;
 void python_initspam() {
   static char name[] = "spam.error";
   PyObject *m;
-  m = Py_InitModule("spam", SpamMethods);
+  m = PyModule_Create(&moduledef);
   if (m == NULL) return;
   SpamError = PyErr_NewException(name, NULL, NULL);
   Py_INCREF(SpamError);

--- a/M2/Macaulay2/d/python-c.c
+++ b/M2/Macaulay2/d/python-c.c
@@ -92,6 +92,23 @@ void python_initspam() {
   Py_INCREF(SpamError);
   PyModule_AddObject(m, "error", SpamError);
 }
+
+PyObject *python_NumberAdd(PyObject *o1, PyObject *o2) {
+	return PyNumber_Add(o1, o2);
+}
+
+PyObject *python_NumberSubtract(PyObject *o1, PyObject *o2) {
+	return PyNumber_Subtract(o1, o2);
+}
+
+PyObject *python_NumberMultiply(PyObject *o1, PyObject *o2) {
+	return PyNumber_Multiply(o1, o2);
+}
+
+PyObject *python_NumberTrueDivide(PyObject *o1, PyObject *o2) {
+	return PyNumber_TrueDivide(o1, o2);
+}
+
 #if 0
 Local Variables:
 compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d python-c.o "

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -13,7 +13,7 @@ setupfun("runSimpleString",PyRunSimpleString);
 
 import RunString(s:string):pythonObjectOrNull;
 PyRunString(e:Expr):Expr := when e is s:stringCell do toExpr(RunString(s.v)) else WrongArgString();
-setupfun("runString",PyRunString);
+setupfun("runPythonString",PyRunString);
 
 import Main():int;
 PyMain(e:Expr):Expr := toExpr(Main());

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -31,6 +31,70 @@ import initspam():void;
 runinitspam(e:Expr):Expr := (initspam(); nullE);
 setupfun("initspam",runinitspam);
 
+import NumberAdd(o1:pythonObject,o2:pythonObject):pythonObjectOrNull;
+PyNumberAdd(lhs:Expr,rhs:Expr):Expr :=
+    when lhs
+    is x:pythonObjectCell do
+	when rhs
+	is y:pythonObjectCell do toExpr(NumberAdd(x.v, y.v))
+	else WrongArg(2, "a python object")
+    else WrongArg(1, "a python object");
+PyNumberAdd(e:Expr):Expr :=
+    when e
+    is a:Sequence do
+	if length(a) == 2 then PyNumberAdd(a.0, a.1)
+	else WrongNumArgs(2)
+    else WrongNumArgs(2);
+setupfun("pythonNumberAdd",PyNumberAdd);
+
+import NumberSubtract(o1:pythonObject,o2:pythonObject):pythonObjectOrNull;
+PyNumberSubtract(lhs:Expr,rhs:Expr):Expr :=
+    when lhs
+    is x:pythonObjectCell do
+	when rhs
+	is y:pythonObjectCell do toExpr(NumberSubtract(x.v, y.v))
+	else WrongArg(2, "a python object")
+    else WrongArg(1, "a python object");
+PyNumberSubtract(e:Expr):Expr :=
+    when e
+    is a:Sequence do
+	if length(a) == 2 then PyNumberSubtract(a.0, a.1)
+	else WrongNumArgs(2)
+    else WrongNumArgs(2);
+setupfun("pythonNumberSubtract",PyNumberSubtract);
+
+import NumberMultiply(o1:pythonObject,o2:pythonObject):pythonObjectOrNull;
+PyNumberMultiply(lhs:Expr,rhs:Expr):Expr :=
+    when lhs
+    is x:pythonObjectCell do
+	when rhs
+	is y:pythonObjectCell do toExpr(NumberMultiply(x.v, y.v))
+	else WrongArg(2, "a python object")
+    else WrongArg(1, "a python object");
+PyNumberMultiply(e:Expr):Expr :=
+    when e
+    is a:Sequence do
+	if length(a) == 2 then PyNumberMultiply(a.0, a.1)
+	else WrongNumArgs(2)
+    else WrongNumArgs(2);
+setupfun("pythonNumberMultiply",PyNumberMultiply);
+
+import NumberTrueDivide(o1:pythonObject,o2:pythonObject):pythonObjectOrNull;
+PyNumberTrueDivide(lhs:Expr,rhs:Expr):Expr :=
+    when lhs
+    is x:pythonObjectCell do
+	when rhs
+	is y:pythonObjectCell do toExpr(NumberTrueDivide(x.v, y.v))
+	else WrongArg(2, "a python object")
+    else WrongArg(1, "a python object");
+PyNumberTrueDivide(e:Expr):Expr :=
+    when e
+    is a:Sequence do
+	if length(a) == 2 then PyNumberTrueDivide(a.0, a.1)
+	else WrongNumArgs(2)
+    else WrongNumArgs(2);
+setupfun("pythonNumberTrueDivide",PyNumberTrueDivide);
+
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d python.o "
 -- End:

--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -225,3 +225,4 @@ SuperLinearAlgebra
 SubalgebraBases
 AInfinity
 LinearTruncations
+Python

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -6,7 +6,13 @@ newPackage "Python"
 
 try exportFrom_Core {
      "runSimpleString", "PythonObject", "runPythonString", "sysGetObject", "objectType", "initspam"
-     } then print "-- success: python is present" else error "specify --with-python in `configure` options and recompile M2"
+     } then print " -- success: python is present" else (
+	 stderr << " -- warning: python is not present" << endl;
+	 stderr <<
+	     " -- specify --with-python in `configure` options and recompile M2"
+	      << endl;
+	 end
+     )
 
 importFrom_Core {
     "pythonNumberAdd",

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -8,6 +8,13 @@ try exportFrom_Core {
      "runSimpleString", "PythonObject", "runPythonString", "sysGetObject", "objectType", "initspam"
      } then print "-- success: python is present" else error "specify --with-python in `configure` options and recompile M2"
 
+importFrom_Core {
+    "pythonNumberAdd",
+    "pythonNumberSubtract",
+    "pythonNumberMultiply",
+    "pythonNumberTrueDivide"
+}
+
 export { "pythonHelp", "context", "rs", "Preprocessor" }
 
 exportMutable { "val", "eval", "valuestring", "stmt", "expr", "dict", "symbols", "stmtexpr" }
@@ -78,6 +85,12 @@ context String := opts -> init -> (
 	  global symbols => symbols
 	  })
 Context String := (c,s) -> c.stmtexpr s
+
+PythonObject + PythonObject := (x, y) -> pythonNumberAdd(x, y)
+PythonObject - PythonObject := (x, y) -> pythonNumberSubtract(x, y)
+PythonObject * PythonObject := (x, y) -> pythonNumberMultiply(x, y)
+PythonObject / PythonObject := (x, y) -> pythonNumberTrueDivide(x, y)
+
 end --------------------------------------------------------
 
 

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -5,14 +5,14 @@ this does not work uless M2 is compiled --with-python
 newPackage "Python"
 
 try exportFrom_Core {
-     "runSimpleString", "PythonObject", "runString", "sysGetObject", "objectType", "initspam"
+     "runSimpleString", "PythonObject", "runPythonString", "sysGetObject", "objectType", "initspam"
      } then print "-- success: python is present" else error "specify --with-python in `configure` options and recompile M2"
 
 export { "pythonHelp", "context", "rs", "Preprocessor" }
 
 exportMutable { "val", "eval", "valuestring", "stmt", "expr", "dict", "symbols", "stmtexpr" }
 
-pythonHelp = Command (() -> runString ///help()///)
+pythonHelp = Command (() -> runPythonString ///help()///)
 
 PythonObject#{Standard,AfterPrint} = x -> (
      << endl;
@@ -24,7 +24,7 @@ PythonObject#{Standard,AfterPrint} = x -> (
 rs = s -> ( 
      s = concatenate s;
      if debugLevel > 0 then stderr << "--python command: " << s << endl; 
-     runString s);
+     runPythonString s);
 
 numContexts = 0
 nextContext = method()
@@ -57,7 +57,7 @@ context String := opts -> init -> (
      else (
 	  s -> (
 	       evalstring("tmp = ",opts.Preprocessor,"(",format s,")");
-	       if debugLevel > 0 then stderr << "--intermediate value: tmp = " << format toString runString access "tmp" << endl;
+	       if debugLevel > 0 then stderr << "--intermediate value: tmp = " << format toString runPythonString access "tmp" << endl;
 	       eval access "tmp";
 	       null)
 	  );
@@ -66,7 +66,7 @@ context String := opts -> init -> (
 	  stmt s;
 	  val "temp");
      stmtexpr := s -> if match(";$",s) then stmt s else expr s;
-     symbols := () -> runString concatenate("__builtins__[",format dict,"].keys()");
+     symbols := () -> runPythonString concatenate("__builtins__[",format dict,"].keys()");
      use new Context from {
 	  global dict => dict,
 	  global val => val,

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -2,8 +2,9 @@
 this does not work uless M2 is compiled --with-python
 *-
 
-newPackage "Python"
-
+newPackage("Python",
+    Headline => "interface to Python"
+    )
 try exportFrom_Core {
      "runSimpleString", "PythonObject", "runPythonString", "sysGetObject", "objectType", "initspam"
      } then print " -- success: python is present" else (

--- a/M2/config/ax_python.m4
+++ b/M2/config/ax_python.m4
@@ -1,0 +1,97 @@
+# ===========================================================================
+#        https://www.gnu.org/software/autoconf-archive/ax_python.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PYTHON
+#
+# DESCRIPTION
+#
+#   This macro does a complete Python development environment check.
+#
+#   It checks for all known versions. When it finds an executable, it looks
+#   to find the header files and library.
+#
+#   It sets PYTHON_BIN to the name of the python executable,
+#   PYTHON_INCLUDE_DIR to the directory holding the header files, and
+#   PYTHON_LIB to the name of the Python library.
+#
+#   This macro calls AC_SUBST on PYTHON_BIN (via AC_CHECK_PROG),
+#   PYTHON_INCLUDE_DIR and PYTHON_LIB.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Michael Tindal
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 19
+
+AC_DEFUN([AX_PYTHON],
+[AC_MSG_CHECKING(for python build information)
+AC_MSG_RESULT([])
+for python in python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
+AC_CHECK_PROGS(PYTHON_BIN, [$python])
+ax_python_bin=$PYTHON_BIN
+if test x$ax_python_bin != x; then
+   AC_CHECK_LIB($ax_python_bin, main, ax_python_lib=$ax_python_bin, ax_python_lib=no)
+   if test x$ax_python_lib == xno; then
+     AC_CHECK_LIB(${ax_python_bin}m, main, ax_python_lib=${ax_python_bin}m, ax_python_lib=no)
+   fi
+   if test x$ax_python_lib != xno; then
+     ax_python_header=`$ax_python_bin -c "from distutils.sysconfig import *; print(get_config_var('CONFINCLUDEPY'))"`
+     if test x$ax_python_header != x; then
+       break;
+     fi
+   fi
+fi
+done
+if test x$ax_python_bin = x; then
+   ax_python_bin=no
+fi
+if test x$ax_python_header = x; then
+   ax_python_header=no
+fi
+if test x$ax_python_lib = x; then
+   ax_python_lib=no
+fi
+
+AC_MSG_RESULT([  results of the Python check:])
+AC_MSG_RESULT([    Binary:      $ax_python_bin])
+AC_MSG_RESULT([    Library:     $ax_python_lib])
+AC_MSG_RESULT([    Include Dir: $ax_python_header])
+
+if test x$ax_python_header != xno; then
+  PYTHON_INCLUDE_DIR=$ax_python_header
+  AC_SUBST(PYTHON_INCLUDE_DIR)
+fi
+if test x$ax_python_lib != xno; then
+  PYTHON_LIB=$ax_python_lib
+  AC_SUBST(PYTHON_LIB)
+fi
+])dnl

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -20,6 +20,7 @@ m4_include(config/openmp.m4)
 m4_include(config/search-libraries.m4)
 m4_include(config/ax_boost_base.m4)
 m4_include(config/ax_boost_regex.m4)
+m4_include(config/ax_python.m4)
 
 dnl define(TO_UPPER,[translit($1, [a-z], [A-Z])])
 
@@ -415,21 +416,11 @@ if test "$XML" = yes
 then AC_DEFINE(WITH_XML,1,[whether we are linking with the xml library])
 fi
 
-AC_SUBST(PYTHON,no)
-AC_ARG_WITH(python, AS_HELP_STRING(--with-python,[link with libpython]), PYTHON=$withval)
-if test "$PYTHON" = yes
-then AC_DEFINE(WITH_PYTHON,1,[whether we are linking with the python library])
-fi
-
 AC_SUBST(MYSQL,no)
 AC_ARG_WITH(mysql, AS_HELP_STRING(--with-mysql,[link with mysql]), MYSQL=$withval)
 if test "$MYSQL" = yes
 then AC_DEFINE(WITH_MYSQL,1,[whether we are linking with the mysql library])
 fi
-
-LIBPYTHONORIG=-lpython2.7
-AC_SUBST(LIBPYTHON,$LIBPYTHONORIG)
-AC_ARG_WITH(libpython, AS_HELP_STRING(--with-libpython=...,specify the python library ($LIBPYTHON)),LIBPYTHON=$withval)
 
 AC_ARG_ENABLE(altivec, AS_HELP_STRING(--enable-altivec,compile with "-faltivec" option))
 if test "$enable_altivec" = yes
@@ -1276,13 +1267,14 @@ else
 fi
 AC_SUBST(GTEST_PATH)
 
+AC_SUBST(PYTHON,no)
+AC_ARG_WITH(python, AS_HELP_STRING(--with-python,[link with libpython]), PYTHON=$withval)
 if test "$PYTHON" = yes
-then AC_LANG(C)
-     if test "$LIBPYTHON" = "$LIBPYTHONORIG"
-     then AC_SEARCH_LIBS(Py_Initialize,python2.7,,AC_MSG_ERROR(libpython2.7 not found))
-     else LIBS="$LIBPYTHON $LIBS"
-     fi
-     AC_CHECK_HEADER(python2.7/Python.h,,AC_MSG_ERROR(include file python2.7/Python.h not found))
+then AC_DEFINE(WITH_PYTHON,1,[whether we are linking with the python library])
+    AX_PYTHON
+    CPPFLAGS="$CPPFLAGS -I$PYTHON_INCLUDE_DIR"
+    AC_CHECK_HEADER(Python.h,,AC_MSG_ERROR(Python.h not found))
+    AC_SEARCH_LIBS(Py_Initialize, $PYTHON_LIB,,AC_MSG_ERROR(libpython not found))
 fi
 
 dnl boost 1.65 was the first release containing the stacktrace library


### PR DESCRIPTION
I've often been curious about the bits of Python-related code in the source, so I figured I'd play around with it and try to get it running with Python 3.

I'm not sure how useful it is, but running `./configure --with-python` works now, and we can do some simple things:

```m2
i1 : importFrom_Core {"runSimpleString"};

i2 : runSimpleString "print('Hello, world!')"
Hello, world!

i3 : runSimpleString "import sys"

i4 : runSimpleString "print(sys.version)"
3.9.5 (default, May 11 2021, 08:20:37) 
[GCC 10.3.0]

i5 : version#"python version"

o5 = 3.9.5
```