### PR TITLE
Fix "realpath" bug when dealing with root directory

### DIFF
--- a/M2/Macaulay2/d/scclib.c
+++ b/M2/Macaulay2/d/scclib.c
@@ -343,7 +343,7 @@ M2_string system_realpath(M2_string filename) {
   char *fn = M2_tocharstar(filename);
   char buf[PATH_MAX+1];
   char *r = realpath(*fn ? fn : ".",buf);
-  if (isDirectory(r)) strcat(r,"/");
+  if (isDirectory(r) && r[1] != 0) strcat(r,"/");
   GC_FREE(fn);
   return r == NULL ? NULL : M2_tostring(buf);
  #else

--- a/M2/Macaulay2/m2/basictests/A77.m2
+++ b/M2/Macaulay2/m2/basictests/A77.m2
@@ -99,6 +99,7 @@ assert( relativizeFilename ( "/a/b/c/d/e/" , "/a/b/c/f/g/" ) === "../../f/g/" )
 
 assert( realpath "." == currentDirectory () )
 assert( realpath ".." == toAbsolutePath "../" )
+assert( realpath "/" == "/" )
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/basictests A77.okay"


### PR DESCRIPTION
We were always appending a slash at the end of directories, even in
the case of the root directory /, which incorrectly gave us //.

### Before

```m2
i1 : realpath "/"

o1 = //
```

Compare to:
```
profzoom@peg-amy:~$ realpath /
/
```

### After
```m2
i1 : realpath "/"

o1 = /
```

This bug was actually causing one the basic tests to fail when run from the root directories or one of its immediate subdirectories:

https://github.com/Macaulay2/M2/blob/104c35429dbc9d0a9defe0443f82caeaaf440679/M2/Macaulay2/m2/basictests/A77.m2#L100-L101

```m2
profzoom@peg-amy:/$ M2 --check 1
-- testing Macaulay2/Core/basictests/A01.m2
-- testing Macaulay2/Core/basictests/A02.m2
-- testing Macaulay2/Core/basictests/A03.m2
-- testing Macaulay2/Core/basictests/A04.m2
-- testing Macaulay2/Core/basictests/A05.m2
-- testing Macaulay2/Core/basictests/A06.m2
-- testing Macaulay2/Core/basictests/A07.m2
-- testing Macaulay2/Core/basictests/A08.m2
-- testing Macaulay2/Core/basictests/A10.m2
-- testing Macaulay2/Core/basictests/A44.m2
-- testing Macaulay2/Core/basictests/A66.m2
-- testing Macaulay2/Core/basictests/A77.m2
Macaulay2/Core/basictests/A77.m2:100:1:(0):[2]: error: assertion failed
Macaulay2/Core/basictests/A77.m2:100:1:(0):[2]: --entering debugger (type help to see debugger commands)
```