### PR TITLE
Copy all Visualize assets into temporary directory (again)

### DIFF
--- a/M2/Macaulay2/packages/Visualize.m2
+++ b/M2/Macaulay2/packages/Visualize.m2
@@ -546,8 +546,13 @@ copyJS(String) := opts -> dst -> (
 	    );
 	);
 
-    for dir in existingDirs do removeFile concatenate(dst, dir);
-    for dir in dirs do symlinkFile(basePath | "Visualize/" | dir, dst | dir);
+    for dir in dirs do (
+	makeDirectory(dst | dir);
+	for file in readDirectory(basePath | "Visualize/" | dir) do (
+	    if not member(file, {".", ".."}) then (
+		copyFile(realpath(basePath | "Visualize/" | dir | "/" | file),
+		    dst | dir | "/" | file)))
+    );
 
     return "Created directories at "|dst;
 )


### PR DESCRIPTION
We replace the copyJS method (which originally copied the assets, but
more recently created symlinks to them) with a new (unexported)
method, fixAssetPaths, that replaces the relative paths in each
template html file with their real, non-symlinked, paths.  This avoids
a bug (feature?) in Firefox that was preventing the previous behavior
from working.  See https://bugzilla.mozilla.org/803999.

---

It turned out that my previous fix for Visualize not working in the Debian/Ubuntu package because of trying to copy symlinked Javascript/CSS/etc files (#2084) broke Visualize completely for Firefox users because of the bug mentioned above!

So now we just replace the links themselves in the generated html files so they point to the right place, no copying or symlinking required, e.g.,

```html
  <script src="/usr/share/javascript/jquery/jquery.min.js"></script>
  <script src="/usr/share/Macaulay2/Visualize/js/BootSideMenu.js"></script>
  <script src="/usr/share/javascript/d3/d3.min.js"></script>
  <script src="/usr/share/Macaulay2/Visualize/js/visSimplicialComplex2d.js"></script>
  <script src="/usr/share/javascript/bootstrap/js/bootstrap.min.js"></script>
  <script src="/usr/share/nodejs/clipboard/dist/clipboard.js"></script>
  <script src="/usr/share/Macaulay2/Visualize/js/nouislider.min.js"></script>
```