### PR TITLE
Drop minimum autoconf version back to 2.68

### DIFF
--- a/M2/Makefile
+++ b/M2/Makefile
@@ -17,7 +17,7 @@ LIBTOOL_BABY  = 4
 LIBTOOL_VERSION = $(LIBTOOL_MAJOR).$(LIBTOOL_MINOR).$(LIBTOOL_BABY)
 
 AUTOCONF_MAJOR = 2
-AUTOCONF_MINOR = 71
+AUTOCONF_MINOR = 68
 # version 2.60 was the first one with the macro AC_PROG_MKDIR_P
 # version 2.62 is required by the configure.ac in gc/libatomic_ops
 # version 2.68 is required by mpir 2.6.0


### PR DESCRIPTION
As discussed in #2122