### PR TITLE
Export printerr

### DIFF
--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -978,6 +978,7 @@ export {
 	"presentation",
 	"pretty",
 	"print",
+	"printerr",
 	"printString",
 	"printingTimeLimit",
 	"processID",

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -52,7 +52,6 @@ newPackage select((
 -- Load configurations
 graphs'DotBinary = if instance((options Graphs).Configuration#"DotBinary", String) then (options Graphs).Configuration#"DotBinary" else "dot";
 
-importFrom_Core {"printerr"}
 if (options Graphs).Configuration#"JpgViewer" != "" then
     printerr "warning: the \"JpgViewer\" configuration option is deprecated"
 

--- a/M2/Macaulay2/packages/LocalRings.m2
+++ b/M2/Macaulay2/packages/LocalRings.m2
@@ -40,7 +40,7 @@ newPackage(
     AuxiliaryFiles => true
     )
 
-importFrom_Core { "ContainmentHooks", "ReduceHooks", "printerr",
+importFrom_Core { "ContainmentHooks", "ReduceHooks",
     "raw", "rawLiftLocalMatrix", "rawMatrixRemake2", "rawSource" }
 
 -- see m2/localring.m2

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc12.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc12.m2
@@ -514,6 +514,30 @@ document {
      "The return value is ", TO "null", "."
      }
 
+doc ///
+  Key
+    printerr
+  Headline
+    print something to stderr
+  Usage
+    printerr x
+  Inputs
+    x:{String,Net,BasicList}
+  Description
+    Text
+      Print @TT "x"@, each line prepended with @TT "--"@, to @TO
+      stderr@.  This is useful for displaying warning messages and
+      verbose logs.
+    Example
+      printerr "Hello, world!"
+      printerr("foo" || "bar")
+    Text
+      If @TT "x"@ is @ofClass BasicList@, then its elements are first
+      joined with @TO horizontalJoin@.
+    Example
+      printerr("foo", "bar")
+///
+
 document {
      Key => hold,
      Headline => "hold something in a holder expression",

--- a/M2/Macaulay2/packages/MinimalPrimes.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes.m2
@@ -69,7 +69,7 @@ newPackage(
 
 export { "Hybrid", "minimalPrimes", "minprimes" => "minimalPrimes", "radical", "radicalContainment", "installMinprimes" }
 
-importFrom_Core { "printerr", "raw", "rawCharSeries", "rawGBContains", "rawRadical", "newMonomialIdeal" }
+importFrom_Core { "raw", "rawCharSeries", "rawGBContains", "rawRadical", "newMonomialIdeal" }
 
 -*------------------------------------------------------------------
 -- Can we use these as keys to a ring's HashTable without exporting them?

--- a/M2/Macaulay2/packages/Posets.m2
+++ b/M2/Macaulay2/packages/Posets.m2
@@ -51,7 +51,6 @@ newPackage select((
 posets'Precompute = if instance((options Posets).Configuration#"DefaultPrecompute", Boolean) then (options Posets).Configuration#"DefaultPrecompute" else true;
 posets'SuppressLabels = if instance((options Posets).Configuration#"DefaultSuppressLabels", Boolean) then (options Posets).Configuration#"DefaultSuppressLabels" else true;
 
-importFrom_Core {"printerr"}
 if (options Posets).Configuration#"DefaultPDFViewer" != "" then
     printerr "warning: the \"DefaultPDFViewer\" configuration option is deprecated"
 

--- a/M2/Macaulay2/packages/PrimaryDecomposition.m2
+++ b/M2/Macaulay2/packages/PrimaryDecomposition.m2
@@ -54,7 +54,7 @@ export {
 -- TODO: this is only declared there for technical reasons
 exportFrom_MinimalPrimes { "removeLowestDimension" }
 
-importFrom_Core { "printerr", "raw", "rawIndices", "rawGBContains", "rawRemoveScalarMultiples" }
+importFrom_Core { "raw", "rawIndices", "rawGBContains", "rawRemoveScalarMultiples" }
 
 algorithms = new MutableHashTable from {}
 

--- a/M2/Macaulay2/packages/PruneComplex.m2
+++ b/M2/Macaulay2/packages/PruneComplex.m2
@@ -25,7 +25,7 @@ newPackage(
 
 importFrom_Core {
     "LocalRing",
-    "raw", "printerr",
+    "raw",
     "rawDeleteColumns",
     "rawDeleteRows",
     "rawMutableComplex",

--- a/M2/Macaulay2/packages/Saturation.m2
+++ b/M2/Macaulay2/packages/Saturation.m2
@@ -32,7 +32,7 @@ export { "isSupportedInZeroLocus" }
 
 exportFrom_Core { "saturate", "annihilator" }
 
-importFrom_Core { "nonnull", "printerr", "raw", "rawColon", "rawSaturate", "newMonomialIdeal", "eliminationInfo" }
+importFrom_Core { "nonnull", "raw", "rawColon", "rawSaturate", "newMonomialIdeal", "eliminationInfo" }
 
 -- TODO: where should these be placed?
 trim MonomialIdeal := MonomialIdeal => opts -> (cacheValue (symbol trim => opts)) ((I) -> monomialIdeal trim(module I, opts))

--- a/M2/Macaulay2/packages/VirtualResolutions.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions.m2
@@ -44,7 +44,7 @@ newPackage ("VirtualResolutions",
 	 }
     )
 
-importFrom_Core { "printerr", "raw", "rawKernelOfGB" }
+importFrom_Core { "raw", "rawKernelOfGB" }
 importFrom_LinearTruncations { "gradedPolynomialRing" }
 
 export{


### PR DESCRIPTION
`printerr` is very useful for displaying warning messages and verbose logs and is already being imported in 8 different packages.  We export it in `Core` and add documentation:

```m2
i1 : help printerr

o1 = printerr -- print something to stderr
     *************************************

     Synopsis
     ========

       * Usage: 
             printerr x
       * Inputs:
           * x, a string, or a net or a basic list; 

     Description
     ===========

     Print x, each line prepended with --, to "stderr".  This is useful for
     displaying warning messages and verbose logs.

     +---------------------------------+
     |  i1 : printerr "Hello, world!"  |
     |   -- Hello, world!              |
     +---------------------------------+
     |  i2 : printerr("foo" || "bar")  |
     |   -- foo                        |
     |   -- bar                        |
     +---------------------------------+

     If x is a basic list, then its elements are first joined with
     "horizontalJoin".

     +-------------------------------+
     |  i3 : printerr("foo", "bar")  |
     |   -- foobar                   |
     +-------------------------------+

     For the programmer
     ==================

     The object "printerr" is a function closure.

o1 : DIV
```