### PR TITLE
Don't capture the example output for "findProgram"

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -123,7 +123,7 @@ document {
 	"file, then ", TT "name", " should coincide with the name of this ",
 	"file."},
     EXAMPLE lines ///
-	programPaths#"gfan" = "/path/to/gfan/"
+	programPaths#"gfan" = "/path/to/gfan/" -* no-capture-flag *-
 	gfan = findProgram("gfan", "gfan _version --help", Verbose => true)///,
     PARA {"One program that is shipped with a variety of prefixes in ",
 	"different distributions and for which the ", TT "Prefix",


### PR DESCRIPTION
Since #2096, the `Verbose => true` option to `findProgram` includes the output from the program we're finding, and this isn't being captured.

For example, from the [website](https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.18/share/doc/Macaulay2/Macaulay2Doc/html/_find__Program.html):

```m2
i2 : gfan = findProgram("gfan", "gfan _version --help", Verbose => true)
 -- /path/to/gfan/gfan does not exist
 -- /usr/libexec/Macaulay2/bin/gfan does not exist
 -- /home/m2user/src/M2/M2.git/M2/usr-build/bin/gfan does not exist
 -- /home/m2user/src/M2/M2.git/M2/usr-build/bin/gfan does not exist
 -- /home/m2user/src/M2/M2.git/M2/usr-build/bin/gfan does not exist
 -- /home/m2user/bin/gfan does not exist
 -- /home/m2user/local/bin/gfan does not exist
 -- /usr/local/sbin/gfan does not exist
 -- /usr/local/bin/gfan does not exist
 -- /usr/sbin/gfan does not exist
 -- /usr/bin/gfan exists and is executable
 -- running "/usr/bin/gfan _version --help":
 -- return value: 0
```

We should see the output of `/usr/bin/gfan _version --help` there before the final `return value` line.  It ends up showing up in the build logs.  For example, from a [PPA build](https://launchpadlibrarian.net/541590938/buildlog_ubuntu-hirsute-amd64.macaulay2_1.18~rc1+ds-0ppa2~ubuntu21.04.1_BUILDING.txt.gz):

```m2
 -- capturing example results for "findProgram"                             This program writes out version information of the Gfan installation.
[[0,0,0,1],[1,0,0,1],[0,1,0,1],[1,1,0,1],[0,0,1,1],[1,0,1,1],[0,1,1,1],[1,1,1,1]]
[[7,6,5,4,3,2,1,0],[6,7,4,5,2,3,0,1],[4,6,5,7,0,2,1,3],[0,4,2,6,1,5,3,7]]
This program writes out version information of the Gfan installation.
 -- 0.123373 seconds elapsed
```