### PR TITLE
Fix (value, Expression) for ^^

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -480,7 +480,8 @@ binaryOperatorFunctions := new HashTable from {
      symbol < => ((x,y) -> x < y),
      symbol <= => ((x,y) -> x <= y),
      symbol > => ((x,y) -> x > y),
-     symbol >= => ((x,y) -> x >= y)
+     symbol >= => ((x,y) -> x >= y),
+     symbol ^^ => ((x,y) -> x ^^ y)
      }
 
 expressionBinaryOperators =

--- a/M2/Macaulay2/tests/normal/boolean.m2
+++ b/M2/Macaulay2/tests/normal/boolean.m2
@@ -35,3 +35,9 @@ assert Equation(1 ^^ 1 | 1, 1)
 assert Equation(1 | 1 ^^ 1, 1)
 assert Equation(1 ^^ 0 | 1, 1)
 assert Equation(1 | 0 ^^ 1, 1)
+
+-----------------
+-- expressions --
+-----------------
+assert Equation(value BinaryOperation(symbol xor, true, true), false)
+assert Equation(value BinaryOperation(symbol ^^, 1, 1), 0)


### PR DESCRIPTION
This is a quick follow-up to #2131.   It turns out that `(value, Expression)` wasn't working properly with `^^` since it hadn't been added to the `binaryOperatorFunctions` hash table in `expressions.m2`.

### Before
```m2
i1 : value BinaryOperation(symbol ^^, 1, 1)

o1 = 1^^1

o1 : Expression of class BinaryOperation
```

### After 
```m2
i1 : value BinaryOperation(symbol ^^, 1, 1)

o1 = 0
```

I also added a couple of related tests.
