### PR TITLE
Add support for entering integers in binary, octal, and hexadecimal

### DIFF
--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -150,6 +150,8 @@ getstringslashes(o:PosFile):(null or Word) := (		    -- /// ... ///
      s := takestring(tokenbuf);
      Word(s,TCstring,0,parseWORD));
 
+isbindigit(c:int):bool := c == int('0') || c == int('1');
+isoctdigit(c:int):bool := c >= int('0') && c <= int('7');
 ishexdigit(c:int):bool := (
      c >= int('0') && c <= int('9') ||
      c >= int('a') && c <= int('f') ||
@@ -323,6 +325,29 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 	       tokenbuf << char(getc(file));
 	       while isalnum(peek(file)) do tokenbuf << char(getc(file));
 	       return Token(makeUniqueWord(takestring(tokenbuf),parseWORD),file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline))
+	  else if ch == int('0') && (
+	      peek(file,1) == int('b') || peek(file,1) == int('B') ||
+	      peek(file,1) == int('o') || peek(file,1) == int('O') ||
+	      peek(file,1) == int('x') || peek(file,1) == int('X')) then (
+	       typecode := TCint;
+	       tokenbuf << char(getc(file));
+	       c := peek(file);
+	       if c == int('b') || c == int('B') then (
+		    tokenbuf << char(getc(file));
+		    while isbindigit(peek(file)) do
+			 tokenbuf << char(getc(file)))
+	       else if c == int('o') || c == int('O') then (
+		    tokenbuf << char(getc(file));
+		    while isoctdigit(peek(file)) do
+			 tokenbuf << char(getc(file)))
+	       else if c == int('x') || c == int('X') then (
+		    tokenbuf << char(getc(file));
+		    while ishexdigit(peek(file)) do
+			 tokenbuf << char(getc(file)));
+	       c = peek(file);
+	       if isalpha(c) then printWarningMessage(position(file),"character '"+char(c)+"' immediately following number");
+	       s := takestring(tokenbuf);
+	       return Token(Word(s,typecode,0, parseWORD),file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline)) 
 	  else if isdigit(ch) || ch==int('.') && isdigit(peek(file,1)) then (
 	       typecode := TCint;
 	       while isdigit(peek(file)) do (

--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -2,14 +2,6 @@
 use tokens;
 use lex;
 
-export parseInt(s:string):ZZ := (
-     i := zeroZZ;
-     foreach c in s do (
-	  if c == '\"'
-	  then nothing
-	  else i = 10 * i + (c - '0')
-	  );
-     i);
 export parseRR(s:string):RR := (			    -- 4.33234234234p345e-9
      prec := defaultPrecision;
      ss := new string len length(s) + 1 do (		    -- we add 1 to get at least one null character at the end
@@ -52,6 +44,22 @@ export hexvalue   (c:char ):int  := (
      else 0						    -- we don't expect this to happen
      );
 export hexvalue   (c:int ):int  := hexvalue(char(c));
+
+export parseInt(s:string):ZZ := (
+     i := zeroZZ;
+     n := length(s);
+     if s.0 == '0' && (s.1  == 'b' || s.1 == 'B') then
+     	  for j from 2 to n - 1 do i = 2 * i + (s.j - '0')
+     else if s.0 == '0' && (s.1 == 'o' || s.1 == 'O') then
+     	  for j from 2 to n - 1 do i = 8 * i + (s.j - '0')
+     else if s.0 == '0' && (s.1 == 'x' || s.1 == 'X') then
+     	  for j from 2 to n - 1 do i = 16 * i + hexvalue(s.j)
+     else foreach c in s do (
+	  if c == '\"'
+	  then nothing
+	  else i = 10 * i + (c - '0')
+	  );
+     i);
 
 export parseString(s:string):string := (
      parseError = false;

--- a/M2/Macaulay2/m2/basictests/int.m2
+++ b/M2/Macaulay2/m2/basictests/int.m2
@@ -1,0 +1,11 @@
+assert = x -> if not x then error "assertion failed "
+
+-- test integer literals in different bases
+assert( 0b101010 == 42 )
+assert( 0B101010 == 42 )
+assert( 0o52 == 42 )
+assert( 0O52 == 42 )
+assert( 0x2a == 42 )
+assert( 0x2A == 42 )
+assert( 0X2a == 42 )
+assert( 0X2A == 42 )

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -30,8 +30,8 @@ checkProgramPath = (cmds, pathToTry, prefix, opts) -> (
 	exe := unescapedPathToTry | first separate(" ", cmd);
 	if not fileExists exe then (
 	    verboseLog(exe, " does not exist"); false) else
-	-- check executable bit (0111)
-	if fileMode exe & 73 == 0 then (
+	-- check executable bit
+	if fileMode exe & 0o111 == 0 then (
 	    verboseLog(exe, " exists but is not executable"); false) else (
 	    verboseLog(exe, " exists and is executable");
 	    verboseLog("running ", format(pathToTry | cmd), ":");

--- a/M2/Macaulay2/packages/Macaulay2Doc/overviewC.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overviewC.m2
@@ -22,6 +22,12 @@ document {
       	  "1.234e-20",
       	  "123+4*ii",
 	  },
+     "Integers may be entered in bases 2, 8, or 16 using particular prefixes.",
+     EXAMPLE {
+	  "0b10011010010 -- binary",
+	  "0o2322 -- octal",
+	  "0x4d2 -- hexadecimal",
+	  },
      "The usual arithmetic operations are available.",
      EXAMPLE {
 	  "4/5 + 2/3",

--- a/M2/Macaulay2/tests/normal/programs.m2
+++ b/M2/Macaulay2/tests/normal/programs.m2
@@ -4,11 +4,11 @@ name = baseFilename fn
 dir = replace(name | "$", "", fn)
 programPaths#name = dir
 
-fileMode(6*64 + 4*8 + 4, fn)
+fileMode(0o644, fn)
 program = findProgram(name, name, RaiseError => false)
 assert(program === null)
 
-fileMode(7*64 + 5*8 + 5, fn)
+fileMode(0o755, fn)
 program = findProgram(name, name)
 assert(program#"name" == name)
 assert(program#"path" == dir)


### PR DESCRIPTION
For example:

```m2
i1 : 0b10101

o1 = 21

i2 : 0o755

o2 = 493

i3 : 0xdeadbeef

o3 = 3735928559
```