### PR TITLE
Add boolean return value to captureExampleOutput

### DIFF
--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -190,7 +190,7 @@ storeExampleOutput = (pkg, fkey, outf, verboseLog) -> (
 
 -- used in installPackage.m2
 -- TODO: reduce the inputs to this function
-captureExampleOutput = (desc, inputs, pkg, cacheFunc, inf, outf, errf, data, inputhash, changeFunc, usermode) -> (
+captureExampleOutput = (desc, inputs, pkg, inf, outf, errf, data, inputhash, changeFunc, usermode) -> (
     stdio << flush; -- just in case previous timing information hasn't been flushed yet
     -- try capturing in the same process
     if isCapturable(inputs, pkg, false) then (
@@ -202,8 +202,9 @@ captureExampleOutput = (desc, inputs, pkg, cacheFunc, inf, outf, errf, data, inp
     -- fallback to using an external process
     stderr << commentize pad("making " | desc, 72) << flush;
     inf << replace("-\\* no-capture-flag \\*-", "", inputs) << endl << close;
-    if runFile(inf, inputhash, outf, errf, pkg, changeFunc, usermode, data)
-    then ( removeFile inf; cacheFunc() ))
+    r := runFile(inf, inputhash, outf, errf, pkg, changeFunc, usermode, data);
+    if r then removeFile inf;
+    r)
 
 -----------------------------------------------------------------------------
 -- process examples

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -198,7 +198,8 @@ captureExampleOutput = (desc, inputs, pkg, inf, outf, errf, data, inputhash, cha
 	stderr << commentize pad("capturing " | desc, 72) << flush; -- the timing info will appear at the end
 	(err, output) := capture(inputs, UserMode => false, PackageExports => pkg);
 	if err then printerr "capture failed; retrying ..."
-	else return outf << M2outputHash << inputhash << endl << output << close);
+	else (outf << M2outputHash << inputhash << endl << output << close;
+	    return true));
     -- fallback to using an external process
     stderr << commentize pad("making " | desc, 72) << flush;
     inf << replace("-\\* no-capture-flag \\*-", "", inputs) << endl << close;

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -534,12 +534,11 @@ generateExampleResults := (pkg, rawDocumentationCache, exampleDir, exampleOutput
 		verboseLog("using cached " | desc)
 		)
 	    -- run and capture example results
-	    else elapsedTime captureExampleOutput(
+	    else if elapsedTime captureExampleOutput(
 		desc, demark_newline inputs, pkg,
-		possiblyCache(outf, outf', fkey),
 		inpf, outf, errf, data,
 		inputhash, changeFunc fkey,
-		usermode);
+		usermode) then (possiblyCache(outf, outf', fkey))();
 	    storeExampleOutput(pkg, fkey, outf, verboseLog)));
 
     -- check for obsolete example output files and remove them


### PR DESCRIPTION
This accomplishes two things:
* We can use the return value to decide whether to run `possiblyCache` from inside `generateExampleResults`, which means we no longer need to pass it to `captureExampleOutput`.
* In verbose mode, the caching log no longer occurs before `elapsedTime` prints the timing results.

### Before
```m2
 -- making example result files in ../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/
 -- making example results for "foo"                                         -- caching example results for foo in /home/profzoom/tmp/Foo/examples/_foo.out
 -- copying: /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out -> /home/profzoom/tmp/Foo/examples/_foo.out
 -- 0.829066 seconds elapsed
 -- storing example results in ../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out
```

### After
```m2
 -- making example result files in ../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/
 -- making example results for "foo"                                         -- 1.15328 seconds elapsed
 -- caching example results for foo in /home/profzoom/tmp/Foo/examples/_foo.out
 -- copying: /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out -> /home/profzoom/tmp/Foo/examples/_foo.out
 -- storing example results in ../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out
```