### PR TITLE
Binary/octal/hexadecimal fixes

### DIFF
--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -325,34 +325,31 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 	       tokenbuf << char(getc(file));
 	       while isalnum(peek(file)) do tokenbuf << char(getc(file));
 	       return Token(makeUniqueWord(takestring(tokenbuf),parseWORD),file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline))
-	  else if ch == int('0') && (
-	      peek(file,1) == int('b') || peek(file,1) == int('B') ||
-	      peek(file,1) == int('o') || peek(file,1) == int('O') ||
-	      peek(file,1) == int('x') || peek(file,1) == int('X')) then (
-	       typecode := TCint;
-	       tokenbuf << char(getc(file));
-	       c := peek(file);
-	       if c == int('b') || c == int('B') then (
-		    tokenbuf << char(getc(file));
-		    while isbindigit(peek(file)) do
-			 tokenbuf << char(getc(file)))
-	       else if c == int('o') || c == int('O') then (
-		    tokenbuf << char(getc(file));
-		    while isoctdigit(peek(file)) do
-			 tokenbuf << char(getc(file)))
-	       else if c == int('x') || c == int('X') then (
-		    tokenbuf << char(getc(file));
-		    while ishexdigit(peek(file)) do
-			 tokenbuf << char(getc(file)));
-	       c = peek(file);
-	       if isalpha(c) then printWarningMessage(position(file),"character '"+char(c)+"' immediately following number");
-	       s := takestring(tokenbuf);
-	       return Token(Word(s,typecode,0, parseWORD),file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline)) 
 	  else if isdigit(ch) || ch==int('.') && isdigit(peek(file,1)) then (
 	       typecode := TCint;
-	       while isdigit(peek(file)) do (
-		    tokenbuf << char(getc(file))
-		    );
+	       if ch == int('0') then (
+		    tokenbuf << char(getc(file));
+		    c := peek(file);
+		    if (c == int('b') || c == int('B')) &&
+			isbindigit(peek(file,1)) then (
+			 tokenbuf << char(getc(file));
+			 while isbindigit(peek(file)) do
+			      tokenbuf << char(getc(file)))
+		    else if (c == int('o') || c == int('O')) &&
+			     isoctdigit(peek(file,1)) then (
+			 tokenbuf << char(getc(file));
+			 while isoctdigit(peek(file)) do
+			      tokenbuf << char(getc(file)))
+		    else if (c == int('x') || c == int('X')) &&
+			     ishexdigit(peek(file,1)) then (
+			 tokenbuf << char(getc(file));
+			 while ishexdigit(peek(file)) do
+			      tokenbuf << char(getc(file)))
+		    else while isdigit(peek(file)) do
+			      tokenbuf << char(getc(file))
+		   )
+	       else while isdigit(peek(file)) do
+		    tokenbuf << char(getc(file));
 	       c := peek(file);
 	       if c == int('.') && peek(file,1) != int('.') || c == int('p') || c == int('e')
 	       then (

--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -327,21 +327,25 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 	       return Token(makeUniqueWord(takestring(tokenbuf),parseWORD),file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline))
 	  else if isdigit(ch) || ch==int('.') && isdigit(peek(file,1)) then (
 	       typecode := TCint;
+	       decimal := true;
 	       if ch == int('0') then (
 		    tokenbuf << char(getc(file));
 		    c := peek(file);
 		    if (c == int('b') || c == int('B')) &&
 			isbindigit(peek(file,1)) then (
+			 decimal = false;
 			 tokenbuf << char(getc(file));
 			 while isbindigit(peek(file)) do
 			      tokenbuf << char(getc(file)))
 		    else if (c == int('o') || c == int('O')) &&
 			     isoctdigit(peek(file,1)) then (
+			 decimal = false;
 			 tokenbuf << char(getc(file));
 			 while isoctdigit(peek(file)) do
 			      tokenbuf << char(getc(file)))
 		    else if (c == int('x') || c == int('X')) &&
 			     ishexdigit(peek(file,1)) then (
+			 decimal = false;
 			 tokenbuf << char(getc(file));
 			 while ishexdigit(peek(file)) do
 			      tokenbuf << char(getc(file)))
@@ -351,7 +355,7 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 	       else while isdigit(peek(file)) do
 		    tokenbuf << char(getc(file));
 	       c := peek(file);
-	       if c == int('.') && peek(file,1) != int('.') || c == int('p') || c == int('e')
+	       if decimal && (c == int('.') && peek(file,1) != int('.') || c == int('p') || c == int('e'))
 	       then (
 		    typecode = TCRR;
 		    if c == int('.') then (

--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -48,7 +48,8 @@ export hexvalue   (c:int ):int  := hexvalue(char(c));
 export parseInt(s:string):ZZ := (
      i := zeroZZ;
      n := length(s);
-     if s.0 == '0' && (s.1  == 'b' || s.1 == 'B') then
+     if n == 1 then i = toInteger(s.0 - '0')
+     else if s.0 == '0' && (s.1  == 'b' || s.1 == 'B') then
      	  for j from 2 to n - 1 do i = 2 * i + (s.j - '0')
      else if s.0 == '0' && (s.1 == 'o' || s.1 == 'O') then
      	  for j from 2 to n - 1 do i = 8 * i + (s.j - '0')


### PR DESCRIPTION
These commits address #2150.

For example:

```m2
i1 : 0b
stdio:1:2:(3): warning: character 'b' immediately following number
stdio:1:1:(3): error: no method for adjacent objects:
--            0 (of class ZZ)
--    SPACE   b (of class Symbol)

i2 : 0b10

o2 = 2
```
