### PR TITLE
fix missing Core source

### DIFF
--- a/M2/Macaulay2/m2/loadsequence
+++ b/M2/Macaulay2/m2/loadsequence
@@ -61,6 +61,7 @@ matrix2.m2
 galois.m2
 ringmap.m2
 newring.m2
+genmat.m2
 matrix3.m2
 ext.m2
 tor.m2


### PR DESCRIPTION
Fixes #2155, but let's not close that, since all `.m2` files should be installed.