### PR TITLE
Also check path to M2-binary in findProgram

### DIFF
--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -87,22 +87,18 @@ findProgram(String, List) := opts -> (name, cmds) -> (
 	instance(opts.MinimumVersion, Sequence) and
 	class \ opts.MinimumVersion === (String, String)) then
 	error "expected MinimumVersion to be a sequence of two strings";
-    pathsToTry := {};
-    -- try user-configured path first
-    if programPaths#?name then
-	pathsToTry = append(pathsToTry, programPaths#name);
-    -- now try M2-installed path
-    pathsToTry = append(pathsToTry, prefixDirectory | currentLayout#"programs");
-    -- any additional paths specified by the caller
-    pathsToTry = pathsToTry | opts.AdditionalPaths;
-    -- try PATH
-    if getenv "PATH" != "" then
-	pathsToTry = join(pathsToTry,
-	    apply(separate(":", getenv "PATH"), dir ->
-		if dir == "" then "." else dir));
-    -- try directory containing M2-binary
-    pathsToTry = append(pathsToTry, bindir);
-    pathsToTry = fixPath \ pathsToTry;
+    pathsToTry := fixPath \ join(
+	-- try user-configured path first
+	if programPaths#?name then {programPaths#name} else {},
+	-- now try M2-installed path
+	{prefixDirectory | currentLayout#"programs"},
+	-- any additional paths specified by the caller
+	opts.AdditionalPaths,
+	-- try PATH
+	if getenv "PATH" == "" then {} else apply(separate(":", getenv "PATH"),
+	    dir -> if dir == "" then "." else dir),
+	-- try directory containing M2-binary
+	{bindir});
     prefixes := {(".*", "")} | opts.Prefix;
     errorCode := didNotFindProgram;
     versionFound := "0.0";

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -95,11 +95,13 @@ findProgram(String, List) := opts -> (name, cmds) -> (
     pathsToTry = append(pathsToTry, prefixDirectory | currentLayout#"programs");
     -- any additional paths specified by the caller
     pathsToTry = pathsToTry | opts.AdditionalPaths;
-    -- finally, try PATH
+    -- try PATH
     if getenv "PATH" != "" then
 	pathsToTry = join(pathsToTry,
 	    apply(separate(":", getenv "PATH"), dir ->
 		if dir == "" then "." else dir));
+    -- try directory containing M2-binary
+    pathsToTry = append(pathsToTry, bindir);
     pathsToTry = fixPath \ pathsToTry;
     prefixes := {(".*", "")} | opts.Prefix;
     errorCode := didNotFindProgram;

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -100,7 +100,7 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
      cmd = cmd | readmode(GCMAXHEAP,      "GC_MAXIMUM_HEAP_SIZE=400M");
      cmd = cmd | readmode(GCSTATS,        "GC_PRINT_STATS=1");
      cmd = cmd | readmode(GCVERBOSE,      "GC_PRINT_VERBOSE_STATS=1");
-     cmd = cmd | " " | format toAbsolutePath commandLine#0;
+     cmd = cmd | " " | format(bindir | "M2-binary");
      if argmode =!= defaultMode or not usermode then
      cmd = cmd | readmode(ArgQ,           "-q");
      cmd = cmd | readmode(ArgInt,         "--int");

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -316,7 +316,7 @@ dir  := s -> ( m := regex(".*/",s); if m === null or 0 === #m then "./" else sub
 base := s -> ( m := regex(".*/",s); if m === null or 0 === #m then s    else substring(m#0#1,      s))
 initcurrentlayout := () -> (
      issuffix := (s,t) -> t =!= null and s === substring(t,-#s);
-     bindir := dir exe | "/";
+     bindir = dir exe | "/";
      currentLayout = (					    -- see also currentLayoutTable
 	  if issuffix(Layout#2#"bin","/"|bindir) then Layout#2 else
 	  if issuffix(Layout#1#"bin","/"|bindir) then Layout#1

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -110,7 +110,8 @@ document {
 	    ", where the programs shipped with Macaulay2 are installed."},
 	{"Each path specified by the ", TT "AdditionalPaths", " option."},
 	{"Each path specified by the user's ", TT "PATH",
-	    " environment variable."}
+	    " environment variable."},
+	{"The path to ", TT "M2-binary", "."}
     },
     PARA {"For each path, any prefixes specified by the ", TT "Prefix",
 	" option are checked."},


### PR DESCRIPTION
For example, after putting a simple executable script `foo` in the same directory as `M2-binary`:

```m2
i1 : findProgram("foo", "foo", Verbose => true)
 -- /home/profzoom/src/macaulay2/M2/M2/BUILD/doug/usr-dist/x86_64-Linux-Ubuntu-21.04/libexec/Macaulay2/bin/foo does not exist
 -- /home/profzoom/.local/bin/foo does not exist
 -- /usr/local/sbin/foo does not exist
 -- /usr/local/bin/foo does not exist
 -- /usr/sbin/foo does not exist
 -- /usr/bin/foo does not exist
 -- /sbin/foo does not exist
 -- /bin/foo does not exist
 -- /usr/games/foo does not exist
 -- /usr/local/games/foo does not exist
 -- /snap/bin/foo does not exist
 -- /snap/bin/foo does not exist
 -- /home/profzoom/src/macaulay2/M2/M2/BUILD/doug/usr-dist/x86_64-Linux-Ubuntu-21.04/bin/foo exists and is executable
 -- running "/home/profzoom/src/macaulay2/M2/M2/BUILD/doug/usr-dist/x86_64-Linux-Ubuntu-21.04/bin/foo":
Hello world!
 -- return value: 0

o1 = foo

o1 : Program
```

This should fix #2161.