### PR TITLE
runProgram/CohomCalg updates

### DIFF
--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -143,6 +143,7 @@ runProgram(Program, String, String) := opts -> (program, name, args) -> (
 	    makeDirectory opts.RunDirectory;
 	"cd " | opts.RunDirectory | " && " ) else "";
     cmd = cmd | program#"path" | addPrefix(name, program#"prefix") | " " | args;
+    if match("\\|", cmd) then cmd = "{ " | cmd | ";}";
     returnValue := run (cmd | " > " | outFile | " 2> " | errFile);
     message := "running: " | cmd | "\n";
     output := get outFile;

--- a/M2/Macaulay2/packages/CohomCalg.m2
+++ b/M2/Macaulay2/packages/CohomCalg.m2
@@ -97,7 +97,8 @@ cohomCalg0 = (X,pneeded,issilent) -> (
     H := X.cache.CohomCalg;
     filename := temporaryFileName();
     filename << (toCohomCalg X) | (toCohomCalg pneeded) << close;
-    executable := runProgram(cohomCalgProgram, "--integrated " | filename);
+    executable := runProgram(cohomCalgProgram, "--integrated " | filename |
+	" | tail -1");
     if debugLevel >= 1 then << "-- CohomCalg: using temporary file " << filename << endl;
     if debugLevel >= 2 then << "-- CohomCalg: going to call: " << executable#"command" << endl;
     if not issilent then << executable#"error";

--- a/M2/Macaulay2/packages/CohomCalg.m2
+++ b/M2/Macaulay2/packages/CohomCalg.m2
@@ -13,7 +13,7 @@ newPackage(
         PackageExports => {"NormalToricVarieties"},
         Configuration => {
             "executable" => "",
-            "silent" => "false"
+            "silent" => "true"
             }
         )
 


### PR DESCRIPTION
As reported in #2158, the Debian/Ubuntu cohomcalg package prints lots of extra polylib cruft we don't need, so we pipe to `tail` to extract just the final line of output.  This requires a small update to `runProgram` to support pipes.

We also default to silencing cohomcalg's output, closing #980.