### PR TITLE
Install QEPCAD from PPA for Ubuntu Github builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -92,7 +92,7 @@ jobs:
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
                   libsingular-dev singular-data libmemtailor-dev libmathic-dev libmathicgb-dev libcdd-dev \
                   cohomcalg topcom 4ti2 normaliz coinor-csdp nauty lrslib polymake phcpack w3c-markup-validator \
-                  libtbb-dev # libomp5-12
+                  libtbb-dev qepcad # libomp5-12
 
 # ----------------------
 #   Steps common to all build variants


### PR DESCRIPTION
I recently finished packaging QEPCAD for Debian and have published it in the Macaulay2 PPA.

In this PR, it's installed for the Ubuntu Github builds to more thoroughly test the `CoincidentRootLoci` package -- see #1955.