### PR TITLE
Fix setting of "bmload" environment variable in bergman

### DIFF
--- a/M2/Macaulay2/packages/NCAlgebra.m2
+++ b/M2/Macaulay2/packages/NCAlgebra.m2
@@ -1410,7 +1410,7 @@ writeBergmanInputFile (NCRing,String,String) := opts -> (B,genListString,tempInp
       -- if we don't want to recompute the GB, we need to tell Bergman that there are no
       -- Spairs to work on for twice the max degree of the gens we send it so it
       -- doesn't try to create any more Spairs.
-      fil << "(load (mkbmpathexpand \"$bmload/lap/clisp/unix/hseries.fas\"))" << endl;
+      fil << "(load (mkbmpathexpand \"$bmload/hseries.fas\"))" << endl;
       fil << "(setinterruptstrategy minhilblimits)" << endl;
       fil << "(setinterruptstrategy minhilblimits)" << endl;
       fil << "(sethseriesminima" << concatenate(opts#DegreeLimit:" skipcdeg") << ")" << endl;
@@ -1531,7 +1531,7 @@ twoSidedNCGroebnerBasisBergman NCIdeal := opts -> I -> (
                         NumModuleVars=>opts#NumModuleVars);
   writeGBInitFile(tempInit,tempInput,tempOutput);
   stderr << "--Calling Bergman for NCGB calculation." << endl;
-  runCommand("bergman -i " | tempInit | " -on-error exit --silent > " | tempTerminal);
+  runCommand("bergman -on-error exit --silent < " | tempInit | " > " | tempTerminal);
   retVal := gbFromOutputFile(ring I,
                              tempOutput,
                              MakeMonic=>opts#MakeMonic,
@@ -1648,7 +1648,7 @@ normalFormBergman (List, NCGroebnerBasis) := opts -> (fList, ncgb) -> (
    << "Writing bergman init file." << endl;
    writeNFInitFile(tempInit,tempGBInput,tempNFInput,tempOutput);
    stderr << "--Calling Bergman for NF calculation for " << #nonConstantIndices << " elements." << endl;
-   runCommand("bergman -i " | tempInit | " -on-error exit --silent > " | tempTerminal);
+   runCommand("bergman -on-error exit --silent < " | tempInit | " > " | tempTerminal);
    -- these are now the nfs of the nonzero entries.  Need to splice back in
    -- the zeros where they were.
    nfList := nfFromTerminalFile(A,tempTerminal);
@@ -1672,7 +1672,7 @@ writeHSInitFile := (tempInit,
 		    tempPBOutput,
 		    tempHSOutput) -> (
    fil := openOut tempInit;
-   fil << "(setf (getenv \"bmload\") (mkbmpathexpand \"$bmload/lap/clisp/unix\"))" << endl;
+   fil << "(setf (getenv \"bmload\") (mkbmpathexpand \"$bmload\"))" << endl;
    fil << "(ncpbhgroebner " 
        << "\"" << tempInput << "\" "
        << "\"" << tempGBOutput << "\" "
@@ -1720,7 +1720,7 @@ hilbertBergman NCQuotientRing := opts -> B -> (
 			DegreeLimit=>opts#DegreeLimit);
   writeHSInitFile(tempInit,tempInput,tempGBOutput,tempPBOutput,tempHSOutput);
   stderr << "--Calling bergman for HS computation." << endl;
-  runCommand("bergman -i " | tempInit | " -on-error exit --silent > " | tempTerminal);
+  runCommand("bergman -on-error exit --silent < " | tempInit | " > " | tempTerminal);
   I.cache#gb = gbFromOutputFile(ring I,tempGBOutput);
   hsFromOutputFiles(B,tempHSOutput,tempTerminal)
 )


### PR DESCRIPTION
There were two problems:
* $bmload is already defined as "$bmroot/lap/clisp/unix", but we were adding an additional, redundant "/lap/clisp/unix".
* We were running bergman with the -i command line option, but this specifies the initialization file, and so we ended up running the M2-generated file (which tried to load a file under $bmload) before bergman knew the value of $bmload.

### Before
```m2
i1 : loadPackage("NCAlgebra", FileName => "/usr/share/Macaulay2/NCAlgebra.m2")

o1 = NCAlgebra

o1 : Package

i2 :  R = fourDimSklyanin(QQ,{a,b,c,d})
--Calling Bergman for NCGB calculation.
Complete!

o2 = R

o2 : NCQuotientRing

i3 : hilbertBergman(R, DegreeLimit => 6)
--Calling bergman for HS computation.
Failed!
stdio:3:1:(3): --command failed, error return code 256
```

Looking at the output from bergman:

```
profzoom@peg-amy:~$ cat /tmp/M2-98250-0/10.ter 

"***** environment variable $bmload not defined" *** We turn on noncommutativity

NIL 
T 
NIL 
NIL algebraic form input> 
T 
#\X 
*** - LOAD: A file with name $bmload/lap/clisp/unix/hseries.fas does not exist
```

### After

```m2
i1 : loadPackage("NCAlgebra", FileName => "~/src/macaulay2/M2/M2/Macaulay2/packages/NCAlgebra.m2")

o1 = NCAlgebra

o1 : Package

i2 : R = fourDimSklyanin(QQ,{a,b,c,d})
--Calling Bergman for NCGB calculation.
Complete!

o2 = R

o2 : NCQuotientRing

i3 : hilbertBergman(R, DegreeLimit => 6)
--Calling bergman for HS computation.
Complete!

                 2      3      4      5      6
o3 = 1 + 4T + 10T  + 20T  + 35T  + 56T  + 84T

o3 : ZZ[T]
```

(This was on Ubuntu 21.04, building bergman 1.001 with clisp 2.49.92.)