### PR TITLE
Little-endian code fix for isProductOfHintTrue / isTwoProductsOfHintTrue

### DIFF
--- a/M2/Macaulay2/e/mathicgb/MonoMonoid.hpp
+++ b/M2/Macaulay2/e/mathicgb/MonoMonoid.hpp
@@ -573,7 +573,8 @@ public:
     // for unaligned access. Performance seems to be no worse than for using
     // 32 bit integers directly.
 
-    if (sizeof(Exponent) != 4 || (!StoreHash && !StoreOrder))
+    if (sizeof(Exponent) != 4 || (!StoreHash && !StoreOrder) ||
+        __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
       return isProductOf(a, b, ab);
 
     uint64 orOfXor = 0;
@@ -602,7 +603,8 @@ public:
     ConstMonoRef a1b,
     ConstMonoRef a2b
   ) const {
-    if (sizeof(Exponent) != 4 || (!StoreHash && !StoreOrder))
+    if (sizeof(Exponent) != 4 || (!StoreHash && !StoreOrder) ||
+        __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
       return (isProductOf(a1, b, a1b) && isProductOf(a2, b, a2b));
 
     uint64 orOfXor = 0;


### PR DESCRIPTION
This is a patch written by @jamesjer to port mathicgb to big-endian architectures like s390x -- see https://github.com/Macaulay2/mathicgb/pull/9.  It's been applied to the [Debian](https://salsa.debian.org/science-team/mathicgb/-/blob/master/debian/patches/big-endian.patch) and [Fedora](https://src.fedoraproject.org/rpms/mathicgb/blob/rawhide/f/mathicgb-endian.patch) mathicgb packages for a while now.

Applying it (partially) fixes #2162.