### PR TITLE
Include header for std::numeric_limits

### DIFF
--- a/M2/Macaulay2/e/mathicgb/RawVector.hpp
+++ b/M2/Macaulay2/e/mathicgb/RawVector.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <cstring>
+#include <limits>
 
 MATHICGB_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Otherwise, mathicgb fails to compile using gcc 11.

See: #2179, Macaulay2/mathicgb#25, Macaulay2/mathicgb#26,
Macaulay2/mathicgb#27