### PR TITLE
Stop setting -fno-stack-protector flag

### DIFF
--- a/M2/include/config.Makefile.in
+++ b/M2/include/config.Makefile.in
@@ -126,8 +126,6 @@ M2_BOTH += -Wno-parentheses
 M2_BOTH += -Wno-sign-compare 
 endif
 
-M2_BOTH += -fno-stack-protector
-
 ifeq "@OPTIMIZE@" "yes"
 # gcc 3.3.2 doesn't accept this:
 # M2_BOTH += -Werror=uninitialized


### PR DESCRIPTION
This overwrote any -fstack-protector* flags set by the user, e.g.,
-fstack-protector-strong, which is part of the default flags used
for building Debian packages.  See https://wiki.debian.org/Hardening