### PR TITLE
fix #1959, #2002, VectorGraphics minor update, expression mutableMatrix

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -533,21 +533,21 @@ toString'(Function, SparseMonomialVectorExpression) := (fmt,v) -> toString (
 MatrixExpression = new HeaderType of Expression
 MatrixExpression.synonym = "matrix expression"
 matrixOpts := x -> ( -- helper function
-    opts := hashTable{CompactMatrix=>compactMatrixForm,BlockMatrix=>null,Degrees=>null,mutable=>false};
+    opts := hashTable{CompactMatrix=>compactMatrixForm,BlockMatrix=>null,Degrees=>null,MutableMatrix=>false};
     (opts,x) = override(opts,toSequence x);
     if class x === Sequence then x = toList x else if #x === 0 or class x#0 =!= List then x = { x }; -- for backwards compatibility
     (opts,x)
     )
 expressionValue MatrixExpression := x -> (
     (opts,m) := matrixOpts x;
-    m = (if opts#mutable then mutableMatrix else matrix) applyTable(m,expressionValue);
+    m = (if opts#MutableMatrix then mutableMatrix else matrix) applyTable(m,expressionValue);
     if opts.Degrees === null then m else (
     R := ring m;
     map(R^(-opts.Degrees#0),R^(-opts.Degrees#1),entries m)
     ))
 toString'(Function, MatrixExpression) := (fmt,x) -> concatenate(
     (opts,m) := matrixOpts x;
-    if opts#mutable then "mutableMatrix {" else "matrix {",
+    if opts#MutableMatrix then "mutableMatrix {" else "matrix {",
     between(", ",apply(m,row->("{", between(", ",apply(row,fmt)), "}"))),
     "}" )
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -533,21 +533,21 @@ toString'(Function, SparseMonomialVectorExpression) := (fmt,v) -> toString (
 MatrixExpression = new HeaderType of Expression
 MatrixExpression.synonym = "matrix expression"
 matrixOpts := x -> ( -- helper function
-    opts := hashTable{CompactMatrix=>compactMatrixForm,BlockMatrix=>null,Degrees=>null};
+    opts := hashTable{CompactMatrix=>compactMatrixForm,BlockMatrix=>null,Degrees=>null,mutable=>false};
     (opts,x) = override(opts,toSequence x);
     if class x === Sequence then x = toList x else if #x === 0 or class x#0 =!= List then x = { x }; -- for backwards compatibility
     (opts,x)
     )
 expressionValue MatrixExpression := x -> (
     (opts,m) := matrixOpts x;
-    m = matrix applyTable(m,expressionValue);
+    m = (if opts#mutable then mutableMatrix else matrix) applyTable(m,expressionValue);
     if opts.Degrees === null then m else (
     R := ring m;
     map(R^(-opts.Degrees#0),R^(-opts.Degrees#1),entries m)
     ))
-toString'(Function,MatrixExpression) := (fmt,x) -> concatenate(
+toString'(Function, MatrixExpression) := (fmt,x) -> concatenate(
     (opts,m) := matrixOpts x;
-    "matrix {",
+    if opts#mutable then "mutableMatrix {" else "matrix {",
     between(", ",apply(m,row->("{", between(", ",apply(row,fmt)), "}"))),
     "}" )
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/indeterminates.m2
+++ b/M2/Macaulay2/m2/indeterminates.m2
@@ -40,7 +40,7 @@ for i from 0 to 50 do succS#(varName i) = varName(i+1)
 succ = method()
 succ(ZZ,ZZ) := (x,y) -> x+1 === y
 succ(Sequence,Sequence) := (x,y) -> ( -- for multiple indices
-    #x === #y and all(#x-1,i-> x#i === y#i) and x#(#x-1)+1 === y#(#x-1)
+    #x === #y and all(#x-1,i-> x#i === y#i) and succ(last x,last y)
 )
 succ(BinaryOperation,BinaryOperation) := (x,y) -> x#0 === symbol .. and y#0 === symbol .. and (
     succ (x#2,y#1) or (

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -353,17 +353,16 @@ addHook((quotient, Matrix, Matrix), Strategy => Default, (opts, f, g) -> (
 	  Degree => degree f' - degree g'  -- set the degree in the engine instead
 	  )))
 
-RingElement // Matrix      := (r,f) -> (r * id_(target f)) // f
-Matrix      \\ RingElement := (f,r) -> r // f
+Number // Matrix :=
+RingElement // Matrix := (r,f) -> (r * id_(target f)) // f
+Matrix \\ Number :=
+Matrix \\ RingElement := (f,r) -> r // f
 
-Number // Matrix := (r,f) -> matrix{{promote(r,ring f)}} // f
-Matrix \\ Number := (f,r) -> r // f
-
-Matrix      // RingElement := (f,r) -> f // (r * id_(target f))
+Matrix // Number :=
+Matrix // RingElement := (f,r) -> f // (r * id_(target f))
+Number \\ Matrix :=
 RingElement \\ Matrix      := (r,f) -> f // r
 
-Matrix // Number := (f,r) -> f // promote(r,ring f)
-Number \\ Matrix := (r,f) -> f // r
 
 remainder'(Matrix,Matrix) := Matrix => (f,g) -> (
      if not isFreeModule source f or not isFreeModule source g

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -13,7 +13,7 @@ entries MutableMatrix := m -> (
      applyTable(entries raw m, r -> promote(r,R)))
 toString MutableMatrix := m -> "mutableMatrix " | toString entries m
 precision MutableMatrix := precision @@ ring
-expression MutableMatrix := m -> MatrixExpression {applyTable(entries m, expression), mutable => true}
+expression MutableMatrix := m -> MatrixExpression {applyTable(entries m, expression), MutableMatrix => true}
 texMath MutableMatrix := m -> texMath expression m
 net MutableMatrix := m -> net expression m
 

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -13,7 +13,7 @@ entries MutableMatrix := m -> (
      applyTable(entries raw m, r -> promote(r,R)))
 toString MutableMatrix := m -> "mutableMatrix " | toString entries m
 precision MutableMatrix := precision @@ ring
-expression MutableMatrix := m -> MatrixExpression applyTable(entries m, expression)
+expression MutableMatrix := m -> MatrixExpression {applyTable(entries m, expression), mutable => true}
 texMath MutableMatrix := m -> texMath expression m
 net MutableMatrix := m -> net expression m
 

--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -155,8 +155,9 @@ RingMap Number := (p,m) -> fff(p, promote(m,source p))
 RingMap Matrix := Matrix => (p,m) -> (
      R := source p;
      S := target p;
-     if R =!= ring m 
-     then error "expected source of ring map to be the same as ring of matrix";
+     if R =!= ring m then (
+	  m = try promote(m,R) else error "ring of matrix not source of ring map, and not promotable to it";
+	  );
      F := p target m;
      E := p source m;
      map(F,E,map(S,rawRingMapEval(raw p, raw cover F, raw m)), Degree => p.cache.DegreeMap degree m))

--- a/M2/Macaulay2/packages/VectorGraphics.m2
+++ b/M2/Macaulay2/packages/VectorGraphics.m2
@@ -497,8 +497,13 @@ new SVG from GraphicsObject := (S,g) -> (
 --	"id" => tag,
 	"style" => concatenate("width:",toString g.cache.SizeX,"em;",
 	    "height:",toString g.cache.SizeY,"em;",
-	    "stroke-linejoin:round;",
-	    if not g#?"stroke-width" then "stroke-width:1%", -- define a default stroke-width
+	    if not g#?"stroke-linejoin" then "stroke-linejoin:round;",
+	    if not g#?"stroke" then "stroke:black;",
+	    if not g#?"stroke-opacity" then "stroke-opacity:1;",
+	    if not g#?"fill" then "fill:none;",
+	    if not g#?"fill-opacity" then "fill-opacity:1;",
+	    if not g#?"vertical-align" then "vertical-align:middle;",
+	    if not g#?"stroke-width" then "stroke-width:1%;", -- define a default stroke-width
 	),
 	"viewBox" => concatenate between(" ",toString \ {r#0_0,-r#1_1,r#1_0-r#0_0,r#1_1-r#0_1}),
 	"data-pmatrix" => jsString p
@@ -1164,7 +1169,7 @@ multidoc ///
   Key
    GraphicsType
   Headline
-   A particular type of type used by VectorGraphics, similar to @ TO{SelfInitializingType}.
+   A particular type of type used by VectorGraphics, similar to SelfInitializingType.
 ///
 undocumented { -- there's an annoying conflict with NAG for Point, Points
     Contents, TextContent, HtmlContent, SVGElement, Point, Points, Specular, Radius, Point1, Point2, PathList, Mesh, FontSize, RadiusX, RadiusY,

--- a/M2/Macaulay2/packages/VectorGraphics/VectorGraphics.css
+++ b/M2/Macaulay2/packages/VectorGraphics/VectorGraphics.css
@@ -1,13 +1,8 @@
 /* svg stuff (used by VectorGraphics.m2) */
 
 svg.M2Svg {
-    vertical-align: middle;
     position: relative;
     display: inline;
-    stroke: black;
-    stroke-opacity: 1;
-    fill: none;
-    fill-opacity: 1;
 }
 
 svg.M2SvgClickable {


### PR DESCRIPTION
- fix #1959. I understand that eventually one may want to rethink how the two types `Number` and `RingElement` interact, but in the meantime we need to fix this.
- fix #2002. I did not rewrite the part of mutable matrices due to #2192.
- value expression MutableMatrix now correctly produces a mutable matrix.
- minor VectorGraphics update