### PR TITLE
Update Pygments lexer

### DIFF
--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -36,13 +36,30 @@ class Macaulay2Lexer(RegexLexer):
     tokens = {
         'root': [
             (r'--.*$', Comment.Single),
-            (r'-\*[\w\W]*?\*-', Comment.Multiline),
-            (r'".*?"', String),
-            (r'///[\w\W]*?///', String),
+            (r'-\*', Comment.Multiline, 'block comment'),
+            (r'"', String, 'quote string'),
+            (r'///', String, 'slash string'),
             (words(M2KEYWORDS, prefix=r'\b', suffix=r'\b'), Keyword),
             (words(M2DATATYPES, prefix=r'\b', suffix=r'\b'), Name.Builtin),
             (words(M2FUNCTIONS, prefix=r'\b', suffix=r'\b'), Name.Function),
             (words(M2CONSTANTS, prefix=r'\b', suffix=r'\b'), Name.Constant),
+            (r'\s+', Text.Whitespace),
             (r'.', Text)
+        ],
+        'block comment' : [
+            (r'[^*-]+', Comment.Multiline),
+            (r'\*-', Comment.Multiline, '#pop'),
+            (r'[*-]', Comment.Multiline)
+        ],
+        'quote string' : [
+            (r'[^\\"]+', String),
+            (r'"', String, '#pop'),
+            (r'\\"?', String),
+        ],
+        'slash string' : [
+            (r'[^/]+', String),
+            (r'(//)+(?!/)', String),
+            (r'/(//)+(?!/)', String, '#pop'),
+            (r'/', String)
         ]
     }


### PR DESCRIPTION
Based on comments from the Pygments developers, we now use separate states for comments and strings.

See https://github.com/pygments/pygments/pull/1791, which should be merged soon.  Macaulay2 will likely be supported natively in Pygments starting in v2.11.0, which should be released in November.