### PR TITLE
Remove hardcoded paths in FindRealine.cmake

### DIFF
--- a/M2/cmake/FindReadline.cmake
+++ b/M2/cmake/FindReadline.cmake
@@ -23,8 +23,7 @@
 
 find_path(READLINE_ROOT_DIR
     NAMES include/readline/readline.h
-    PATHS ${HOMEBREW_PREFIX}/opt/readline /opt/local /usr/local /usr
-    NO_DEFAULT_PATH
+    PATHS ${HOMEBREW_PREFIX}/opt/readline
 )
 
 find_path(READLINE_INCLUDE_DIR


### PR DESCRIPTION
Fixes builds in systems where the wrong version of readline is present in `/opt/local`, `/usr/local`, or  `/usr`. See issue #2218 .