### PR TITLE
Don't include "needsPackage" in runFile when package is User

### DIFF
--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -123,7 +123,7 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
      cmd = cmd | concatenate apply(srcdirs, d -> (" --srcdir ", format d));
      -- TODO: fix capture, add preloaded packages to Macaulay2Doc, then delete the following two lines
      needsline := concatenate(" -e 'needsPackage(",format pkgname,",Reload=>true,FileName=>",format pkg#"source file",")'");
-     cmd = cmd | if pkgname != "Macaulay2Doc" and pkgname != "Core" then needsline else "";
+     cmd = cmd | if not member(pkgname, {"Macaulay2Doc", "Core", "User"}) then needsline else "";
      cmd = cmd | readmode(SetInputFile,   "<" | format inf);
      cmd = cmd | readmode(SetOutputFile,  ">>" | format toAbsolutePath tmpf);
      cmd = cmd | readmode(SetCaptureErr,  "2>&1");


### PR DESCRIPTION
Otherwise, we try to load startup.m2.in, which doesn't exist.

### Before
```m2
i1 : TEST "assert false"

i2 : check(User, Verbose => true)
 -- capturing check(0, "User")                                               -- capture failed; retrying ...
 -- running   check(0, "User")                                              
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-632159-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --int --no-randomize --no-readline --silent --stop --print-width 77 -e 'needsPackage("User",Reload=>true,FileName=>"/home/dtorrance/Macaulay2/Core/startup.m2.in")' <"/tmp/M2-632159-0/0.m2" >>"/tmp/M2-632159-0/0.tmp" 2>&1
/tmp/M2-632159-0/0.tmp:0:1: (output file) error: Macaulay2 exited with status code 1
/usr/share/Macaulay2/Core/debugging.m2:23:6:(1):[11]: error: file not found: "/home/dtorrance/Macaulay2/Core/startup.m2.in"
/usr/share/Macaulay2/Core/Core.m2:109:5:(1):[10]: --back trace--
/usr/share/Macaulay2/Core/Core.m2:114:22:(1):[9]: --back trace--
/usr/share/Macaulay2/Core/packages.m2:172:5:(1):[8]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:108:80:(1):[7]: --back trace--
/usr/share/Macaulay2/Core/option.m2:17:8:(1):[6]: --back trace--
/usr/share/Macaulay2/Core/packages.m2:186:10:(1):[5]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:108:80:(1):[4]: --back trace--
/usr/share/Macaulay2/Core/option.m2:17:8:(1):[3]: --back trace--
currentString:1:1:(3):[2]: --back trace--
Macaulay2/Core/startup.m2.in:558:33:(0):[1]: --back trace--
Macaulay2/Core/startup.m2.in:658:6:(0): --back trace--
/tmp/M2-632159-0/0.m2:0:1: (input file)
M2: *** Error 1
 -- 0.490504 seconds elapsed
stdio:1:1-2:1: error:
 -- -- -*- M2-comint -*- hash: 1792453309
 -- /usr/share/Macaulay2/Core/debugging.m2:23:6:(1):[11]: error: file not found: "/home/dtorrance/Macaulay2/Core/startup.m2.in"
 -- /usr/share/Macaulay2/Core/Core.m2:109:5:(1):[10]: --back trace--
 -- /usr/share/Macaulay2/Core/Core.m2:114:22:(1):[9]: --back trace--
 -- /usr/share/Macaulay2/Core/packages.m2:172:5:(1):[8]: --back trace--
 -- /usr/share/Macaulay2/Core/methods.m2:108:80:(1):[7]: --back trace--
 -- /usr/share/Macaulay2/Core/option.m2:17:8:(1):[6]: --back trace--
 -- /usr/share/Macaulay2/Core/packages.m2:186:10:(1):[5]: --back trace--
 -- /usr/share/Macaulay2/Core/methods.m2:108:80:(1):[4]: --back trace--
 -- /usr/share/Macaulay2/Core/option.m2:17:8:(1):[3]: --back trace--
 -- currentString:1:1:(3):[2]: --back trace--
 -- Macaulay2/Core/startup.m2.in:558:33:(0):[1]: --back trace--
 -- Macaulay2/Core/startup.m2.in:658:6:(0): --back trace--
 -- 
stdio:2:1:(3): error: test(s) #0 of package User failed.
```
### After
```m2
i1 : TEST "assert false"

i2 : check(User, Verbose => true)
 -- capturing check(0, "User")                                               -- capture failed; retrying ...
 -- running   check(0, "User")                                              
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-632087-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --int --no-randomize --no-readline --silent --stop --print-width 77 --srcdir "M2" <"/tmp/M2-632087-0/0.m2" >>"/tmp/M2-632087-0/0.tmp" 2>&1
/tmp/M2-632087-0/0.tmp:0:1: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-632087-0/0.m2:0:1: (input file)
M2: *** Error 1
 -- 0.486478 seconds elapsed
stdio:1:1-2:1: error:
 -- -- -*- M2-comint -*- hash: 1792453309
 -- 
 -- i1 : --stdio:2: location of test code
 --      assert false
 -- stdio:2:1:(3): error: assertion failed
 -- 
stdio:2:1:(3): error: test(s) #0 of package User failed.
```