### PR TITLE
Fix #2210 in WebApp mode + minor

### DIFF
--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -155,6 +155,13 @@ init():void := (
 	       stdIO.outisatty = false;
 	       )
 	  else
+	  if arg === "--webapp" then (
+	       stdIO.echo = true; -- so echo comes from M2 (need to disable it at level of tty with stty -echo)
+	       stdIO.readline = false; -- don't go thru readline
+	       stdIO.inisatty = true; -- otherwise hangs after first syntax error
+	       stdIO.outisatty = true; -- not so important?
+	  )
+	  else
 	  if arg === "--read-only-files" then (
 	       readonlyfiles = true;
 	       )
@@ -361,6 +368,8 @@ export openListener(filename:string):(file or errmsg) := (
      then opensocket(filename,false,false,true)
      else (file or errmsg)(errmsg("openListener: expected file name starting with '$'")));
 export flushinput(o:file):void := (
+     o.echoindex = o.echoindex - o.insize;
+     if o.echoindex < 0 then o.echoindex = 0;
      o.inindex = 0;
      o.insize = 0;
      o.bol = true;

--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -1170,6 +1170,7 @@ texMath Table := m -> (
 	"{\\begin{array}{", #m#0: "c", "}", newline,
 	apply(m, row -> (between("&",apply(row,texMath)), ///\\///|newline)),
 	"\\end{array}}")
+    else "{}"
     )
 
 texMath MatrixExpression := x -> (

--- a/M2/Macaulay2/packages/VectorGraphics.m2
+++ b/M2/Macaulay2/packages/VectorGraphics.m2
@@ -437,16 +437,25 @@ new SVG from GraphicsObject := (S,g) -> (
     main := svg(g,p,p,lights); -- run this first because it will compute the ranges too
     if main === null then return {};
     if g.?ViewPort then r := g.ViewPort else r = g.cache.ViewPort; -- should be cached at this stage
-    if r === null or r#0 == r#1 then (g.cache.SizeX=g.cache.SizeY=0.; return {}); -- nothing to draw
-    r = apply(r,numeric);
-    rr := r#1 - r#0;
-    if rr_0 == 0 then (
-	rr = vector { rr_1 * 16/10, rr_1 };
-	r = { vector { r#0_0 - 0.5*rr_0, r#0_1 }, vector { r#1_0 + 0.5*rr_0, r#1_1 } };
-	);
-    if rr_1 == 0 then (
-	rr = vector { rr_0, rr_0 * 10/16 };
-	r = { vector { r#0_0, r#0_1 - 0.5*rr_1 }, vector {  r#1_0, r#1_1 + 0.5*rr_1 } };
+--    if r === null or r#0 == r#1 then (g.cache.SizeX=g.cache.SizeY=0.; return {}); -- nothing to draw
+    if r === null or r#0 == r#1 then ( r={vector {0.,0.},vector {0.,0.}}; rr:=vector{0.,0.}; g.cache.SizeX=g.cache.SizeY=0.; ) else (
+	r = apply(r,numeric);
+	rr = r#1 - r#0;
+	if rr_0 == 0 then (
+	    rr = vector { rr_1 * 16/10, rr_1 };
+	    r = { vector { r#0_0 - 0.5*rr_0, r#0_1 }, vector { r#1_0 + 0.5*rr_0, r#1_1 } };
+	    );
+	if rr_1 == 0 then (
+	    rr = vector { rr_0, rr_0 * 10/16 };
+	    r = { vector { r#0_0, r#0_1 - 0.5*rr_1 }, vector {  r#1_0, r#1_1 + 0.5*rr_1 } };
+	    );
+	if g.?SizeX then g.cache.SizeX = numeric g.SizeX;
+	if g.?SizeY then g.cache.SizeY = numeric g.SizeY;
+	if not (g.?SizeX or g.?SizeY) then -- by default, make it fit inside 16 x 10
+	if rr_0 > 1.6*rr_1 then g.cache.SizeX = 16. else g.cache.SizeY = 10.;
+	-- at this stage one of the two is set
+	if not g.cache.?SizeY then g.cache.SizeY = g.cache.SizeX * rr_1/rr_0;
+	if not g.cache.?SizeX then g.cache.SizeX = g.cache.SizeY * rr_0/rr_1;
 	);
     -- axes
     axes:=null; axeslabels:=null; defsList:={};
@@ -479,20 +488,13 @@ new SVG from GraphicsObject := (S,g) -> (
 	axes=svg(axes,p,p);
 	axeslabels=svg(axeslabels,p,p);
 	);
-    if g.?SizeX then g.cache.SizeX = numeric g.SizeX;
-    if g.?SizeY then g.cache.SizeY = numeric g.SizeY;
-    if not (g.?SizeX or g.?SizeY) then -- by default, make it fit inside 16 x 10
-	if rr_0 > 1.6*rr_1 then g.cache.SizeX = 16. else g.cache.SizeY = 10.;
-    -- at this stage one of the two is set
-    if not g.cache.?SizeY then g.cache.SizeY = g.cache.SizeX * rr_1/rr_0;
-    if not g.cache.?SizeX then g.cache.SizeX = g.cache.SizeY * rr_0/rr_1;
-    -- put some extra blank space around picture
-    margin := if g.?Margin then g.Margin else 0.1;
-    r = { r#0-margin*rr, r#1+margin*rr }; rr = (1+2*margin)*rr;
+	-- put some extra blank space around picture
+	margin := if g.?Margin then g.Margin else 0.1;
+	r = { r#0-margin*rr, r#1+margin*rr }; rr = (1+2*margin)*rr;
     --
 --    tag := graphicsId();
     classTag := "M2Svg";
-    ss := SVG {
+    ss := {
 	"preserveAspectRatio" => "none",
 --	"id" => tag,
 	"style" => concatenate("width:",toString g.cache.SizeX,"em;",


### PR DESCRIPTION
- Thanks to the discussion of #2210, the WebApp mode now uses M2's internal echo, rather than (the unreliable) readline, in order for the output to always come out in the right order. (this has been tested live for some time on the Macaulay2Web server)
- in the process, I found a bug in `stdio.d` (mentioned in the comments of #2210) when a counter is not correctly reset after a syntax error . this didn't affect non-interactive mode (say, the capture of examples) because after a syntax error it just hangs, but it does affect WebApp mode. => bug fixed
- there was a bug with texMath of an empty Table, fixed
- minor VectorGraphics bug fix