### PR TITLE
Use realpath when resolving filenames for needsPackage

### DIFF
--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -181,7 +181,8 @@ needsPackage = method(TypicalValue => Package, Options => options loadPackage)
 needsPackage String  := opts -> pkgname -> (
     if PackageDictionary#?pkgname
     and instance(pkg := value PackageDictionary#pkgname, Package)
-    and (opts.FileName === null or opts.FileName == pkg#"source file")
+    and (opts.FileName === null or
+	realpath opts.FileName == realpath pkg#"source file")
     then use value PackageDictionary#pkgname
     else loadPackage(pkgname, opts))
 


### PR DESCRIPTION
Otherwise, we may not recognize that the two paths actually refer to
the same file and so there's not need to reload the package.

Closes: #2227