### PR TITLE
division by zero error -- fix #2208

### DIFF
--- a/M2/Macaulay2/e/ZZ.cpp
+++ b/M2/Macaulay2/e/ZZ.cpp
@@ -9,6 +9,7 @@
 
 #include "aring-zz-gmp.hpp"
 #include <utility>
+#include "error.h"
 
 unsigned int computeHashValue_mpz(mpz_srcptr a)
 {
@@ -265,8 +266,10 @@ ring_elem RingZZ::mult(const ring_elem f, const ring_elem g) const
 ring_elem RingZZ::power(const ring_elem f, int n) const
 {
   mpz_ptr result = new_elem();
-  mpz_pow_ui(result, f.get_mpz(), n);
-  mpz_reallocate_limbs(result);
+  if (n<0) ERROR("can only raise to a nonnegative power"); else {
+    mpz_pow_ui(result, f.get_mpz(), n);
+    mpz_reallocate_limbs(result);
+  }
   return ring_elem(result);
 }
 ring_elem RingZZ::power(const ring_elem f, mpz_srcptr n) const

--- a/M2/Macaulay2/e/ZZ.cpp
+++ b/M2/Macaulay2/e/ZZ.cpp
@@ -266,7 +266,7 @@ ring_elem RingZZ::mult(const ring_elem f, const ring_elem g) const
 ring_elem RingZZ::power(const ring_elem f, int n) const
 {
   mpz_ptr result = new_elem();
-  if (n<0) ERROR("can only raise to a nonnegative power"); else {
+  if (n<0 && !is_unit(f)) ERROR("can only raise to a nonnegative power"); else {
     mpz_pow_ui(result, f.get_mpz(), n);
     mpz_reallocate_limbs(result);
   }

--- a/M2/Macaulay2/e/ZZp.cpp
+++ b/M2/Macaulay2/e/ZZp.cpp
@@ -8,6 +8,7 @@
 #include "gbring.hpp"
 
 #include "aring-zzp.hpp"
+#include "error.h"
 
 extern RingZZ *globalZZ;
 
@@ -247,14 +248,20 @@ ring_elem Z_mod::mult(const ring_elem f, const ring_elem g) const
 
 ring_elem Z_mod::power(const ring_elem f, int n) const
 {
-  if (f.get_int() == _ZERO) return ring_elem(_ZERO);
+  if (f.get_int() == _ZERO) {
+    if (n<0) ERROR("division by zero");
+    return ring_elem(_ZERO);
+  }
   int m = (f.get_int() * n) % _P1;
   if (m < 0) m += _P1;
   return ring_elem(m);
 }
 ring_elem Z_mod::power(const ring_elem f, mpz_srcptr n) const
 {
-  if (f.get_int() == _ZERO) return ring_elem(_ZERO);
+  if (f.get_int() == _ZERO) {
+    if (mpz_sgn(n)<0) ERROR("division by zero");
+    return ring_elem(_ZERO);
+  }
   int n1 = RingZZ::mod_ui(n, _P1);
   int m = (f.get_int() * n1) % _P1;
   if (m < 0) m += _P1;
@@ -265,6 +272,7 @@ ring_elem Z_mod::invert(const ring_elem f) const
 {
   // MES: error if f == _ZERO
   int a = f.get_int();
+  if (a == _ZERO) ERROR("division by zero");
   if (a == 0) return 0;  // this is the case f == ONE
   return ring_elem(P - 1 - a);
 }

--- a/M2/Macaulay2/e/aring-gf-flint.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint.hpp
@@ -17,6 +17,7 @@
 #include "aring.hpp"
 #include "buffer.hpp"
 #include "ringelem.hpp"
+#include "error.h"           // for ERROR
 
 class PolynomialRing;
 class RingElement;
@@ -150,8 +151,9 @@ class ARingGFFlint : public RingInterface
 
   void invert(ElementType& result, const ElementType& a) const
   {
-    assert(not is_zero(a));
-    fq_zech_inv(&result, &a, mContext);
+    //    assert(not is_zero(a));
+    if (is_zero(a)) ERROR("division by zero");
+    else fq_zech_inv(&result, &a, mContext);
   }
 
   void add(ElementType& result,
@@ -219,20 +221,20 @@ class ARingGFFlint : public RingInterface
 
   void power(ElementType& result, const ElementType& a, int n) const
   {
-    if (is_zero(a))
-      set_zero(result);
-    else if (n < 0)
+    if (n < 0)
       {
         invert(result, a);
         fq_zech_pow_ui(&result, &result, -n, mContext);
       }
+    else if (is_zero(a))
+      set_zero(result);
     else
       fq_zech_pow_ui(&result, &a, n, mContext);
   }
 
   void power_mpz(ElementType& result, const ElementType& a, mpz_srcptr n) const
   {
-    if (is_zero(a))
+    if (is_zero(a) && mpz_sgn(n)>=0)
       {
         set_zero(result);
         return;

--- a/M2/Macaulay2/e/aring-zz-flint.hpp
+++ b/M2/Macaulay2/e/aring-zz-flint.hpp
@@ -182,6 +182,7 @@ void set_from_mpz(ElementType& result, mpz_srcptr a) const
                  const ElementType& a,
                  mpz_srcptr n) const
   {
+    if (mpz_sgn(n)<0) ERROR("can only raise to a nonnegative power");
     std::pair<bool, int> n1 = RingZZ::get_si(n);
     if (n1.first)
       fmpz_pow_ui(&result, &a, n1.second);

--- a/M2/Macaulay2/e/aring-zzp-ffpack.cpp
+++ b/M2/Macaulay2/e/aring-zzp-ffpack.cpp
@@ -224,6 +224,7 @@ void ARingZZpFFPACK::power_mpz(ElementType &result,
                                const ElementType a,
                                mpz_srcptr n) const
 {
+  if (is_zero(a) && mpz_sgn(n)<0) ERROR("division by zero");
   STT n1 = static_cast<STT>(mpz_fdiv_ui(n, mFfpackField.cardinality() - 1));
   power(result, a, n1);
 }

--- a/M2/Macaulay2/e/aring-zzp-flint.hpp
+++ b/M2/Macaulay2/e/aring-zzp-flint.hpp
@@ -7,6 +7,7 @@
 #include "aring.hpp"
 #include "buffer.hpp"
 #include "ringelem.hpp"
+#include "error.h"           // for ERROR
 
 class RingMap;
 
@@ -162,17 +163,22 @@ class ARingZZpFlint : public RingInterface
 
   void divide(ElementType &result, ElementType a, ElementType b) const
   {
-    assert(b != 0);
+    //    assert(b != 0);
+    if (b == 0) ERROR("division by zero");
     result = nmod_div(a, b, mModulus);
   }
 
   void power(ElementType &result, ElementType a, long n) const
   {
+    //    assert(a != 0 || n>=0 );
+    if (a==0 && n<0) ERROR("division by zero");
     result = n_powmod2_preinv(a, n, mModulus.n, mModulus.ninv);
   }
 
   void power_mpz(ElementType &result, ElementType a, mpz_srcptr n) const
   {
+    //    assert( a != 0 || mpz_sgn(n)>=0);
+    if (a==0 && mpz_sgn(n)<0) ERROR("division by zero");
     unsigned long nbar = mpz_fdiv_ui(n, mCharac - 1);
     result = n_powmod2_ui_preinv(a, nbar, mModulus.n, mModulus.ninv);
   }

--- a/M2/Macaulay2/e/aring-zzp.hpp
+++ b/M2/Macaulay2/e/aring-zzp.hpp
@@ -7,6 +7,7 @@
 #include "aring.hpp"
 #include "buffer.hpp"
 #include "ringelem.hpp"
+#include "error.h"           // for ERROR
 
 class Z_mod;
 class RingMap;
@@ -207,8 +208,9 @@ class ARingZZp : public RingInterface
 
   void divide(elem &result, elem a, elem b) const
   {
-    assert(b != 0);
-    if (a != 0 && b != 0)
+    //    assert(b != 0);
+    if (b == 0) ERROR("division by zero");
+    if (a != 0)
       {
         int c = a - b;
         if (c <= 0) c += p1;
@@ -231,6 +233,8 @@ class ARingZZp : public RingInterface
 
   void power_mpz(elem &result, elem a, mpz_srcptr n) const
   {
+    //    assert( a != 0 || mpz_sgn(n)>=0);
+    if (a==0 && mpz_sgn(n)<0) ERROR("division by zero");
     int n1 = static_cast<int>(mpz_fdiv_ui(n, p1));
     power(result, a, n1);
   }

--- a/M2/Macaulay2/e/interface/mutable-matrix.cpp
+++ b/M2/Macaulay2/e/interface/mutable-matrix.cpp
@@ -787,7 +787,9 @@ MutableMatrix *rawLinAlgInverse(MutableMatrix *A)
 {
   try
     {
-      return internMutableMatrix(A->invert());
+      MutableMatrix *B = A->invert();
+      if (B==0) ERROR("matrix not invertible");
+      return internMutableMatrix(B);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -83,7 +83,7 @@ ZZp Ideal := opts -> (I) -> (
 	  S.order = S.char = n;
 	  S.dim = 0;					    -- n != 0 and n!= 1
 	  expression S := x -> expression rawToInteger raw x;
-	  fraction(S,S) := S / S := (x,y) -> x//y;
+	  fraction(S,S) := S / S := (x,y) -> if y === 0_S then error "division by zero" else x//y;
 	  S.frac = S;		  -- ZZ/n with n PRIME!
       savedQuotients#(typ, n) = S;
       lift(S,QQ) := opts -> liftZZmodQQ;


### PR DESCRIPTION
This adds a bunch of tests / errors when trying to divide by zero or invert a noninvertible matrix.
It fixes #2208 and the 2nd part of #2215.