### PR TITLE
Warn when example errors occur if IgnoreExampleErrors is true

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -720,11 +720,14 @@ installPackage Package := opts -> pkg -> (
 	(hadError, numErrors) = (false, 0); -- declared in run.m2
 	generateExampleResults(pkg, rawDocumentationCache, exampleDir, exampleOutputDir, verboseLog, pkgopts, opts);
 
-	if not opts.IgnoreExampleErrors and hadError
-	then error("installPackage: ", toString numErrors, " error(s) occurred running examples for package ", pkg#"pkgname",
+	if hadError then (
+	    errmsg := ("installPackage: ", toString numErrors, " error(s) occurred running examples for package ", pkg#"pkgname",
 	    if opts.Verbose or debugLevel > 0 then ":" | newline | newline |
 	    concatenate apply(select(readDirectory exampleOutputDir, file -> match("\\.errors$", file)), err ->
 		err | newline |	concatenate(width err : "*") | newline | getErrors(exampleOutputDir | err)) else "");
+	    if opts.IgnoreExampleErrors
+	    then stderr << " -- warning: " << concatenate errmsg << endl
+	    else error errmsg);
 
 	-- if no examples were generated, then remove the directory
 	if length readDirectory exampleOutputDir == 2 then removeDirectory exampleOutputDir;


### PR DESCRIPTION
This may still be useful information.  In particular, if `Verbose` is true or `debugLevel` is positive, then we also see the content of the failing error.

### Before
```m2
i1 : get "~/tmp/Foo.m2"

o1 = newPackage("Foo", Headline => "foo!")

     export {"foo"}

     foo = () -> "foo!"

     beginDocumentation()

     doc ///
       Key
         foo
       Description
         Example
           1/0
     ///


i2 : installPackage("Foo", FileName => "~/tmp/Foo.m2", IgnoreExampleErrors => true, Verbose => true)
 -- installing package Foo in ../../../.Macaulay2/local/ with layout #1
 -- using package sources found in ../../../tmp/
 -- storing raw documentation in ../../../.Macaulay2/local/lib/x86_64-linux-gnu/Macaulay2/Foo/cache/rawdocumentation-dcba-8.db
 -- closed the database
 -- running tests that are functions
 -- making example result files in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/
 -- making example results for "foo"                                        
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-3306496-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --int --no-randomize --no-readline --silent --stop --print-width 77 -e 'needsPackage("Foo",Reload=>true,FileName=>"/home/profzoom/tmp/Foo.m2")' <"/tmp/M2-3306496-0/0_foo.m2" >>"/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.errors" 2>&1
/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.errors:0:1: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-3306496-0/0_foo.m2:0:1: (input file)
M2: *** Error 1
 -- 0.727078 seconds elapsed
 -- storing example results in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out
 -- warning: missing file /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out
 -- processing documentation nodes...
 -- processing   Foo :: foo
 -- processing   Foo :: Foo
 -- assembling table of contents
 -- warning: found 1 documentation node(s) not listed as a subnode
 -- making info file /home/profzoom/.Macaulay2/local/share/info/Foo.info
 -- making html pages in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/html/
 -- creating empty html page ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/html/index.html
 -- creating empty html page ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/html/master.html
 -- creating empty html page ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/html/toc.html
 -- making html page for Foo :: foo
 -- warning: missing node: Foo cited by foo
 -- making html page for Foo :: Foo
 -- making "Foo : Index" in /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/html/master.html
 -- making  "Foo : Table of Contents" in /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/html/toc.html
 -- not making documentation in PDF format
 -- warning: 1 warning(s) occurred in documentation for package Foo
 -- installed package Foo in /home/profzoom/.Macaulay2/local/

o2 = Foo

o2 : Package
```

### After
```m2
i1 : installPackage("Foo", FileName => "~/tmp/Foo.m2", IgnoreExampleErrors => true, Verbose => true)
 -- installing package Foo in ../../../.Macaulay2/local/ with layout #1
 -- using package sources found in ../../../tmp/
 -- copying auxiliary source files from /home/profzoom/tmp/Foo
 -- storing raw documentation in ../../../.Macaulay2/local/lib/x86_64-linux-gnu/Macaulay2/Foo/cache/rawdocumentation-dcba-8.db
 -- closed the database
 -- running tests that are functions
 -- making example result files in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/
 -- making example results for "foo"                                        
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-3303175-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --int --no-randomize --no-readline --silent --stop --print-width 77 --srcdir "/home/profzoom/src/macaulay2/M2/M2" -e 'needsPackage("Foo",Reload=>true,FileName=>"/home/profzoom/tmp/Foo.m2")' <"/tmp/M2-3303175-0/0_foo.m2" >>"/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.errors" 2>&1
/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.errors:0:1: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-3303175-0/0_foo.m2:0:1: (input file)
M2: *** Error 1
 -- 0.661642 seconds elapsed
 -- storing example results in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out
 -- warning: missing file /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/_foo.out
 -- warning: installPackage: 1 error(s) occurred running examples for package Foo:

_foo.errors
***********
-- -*- M2-comint -*- hash: -1128328982

i1 : 1/0
stdio:1:2:(3): error: division by zero

 -- processing documentation nodes...
 -- processing   Foo :: foo
 -- processing   Foo :: Foo
 -- assembling table of contents
 -- warning: found 1 documentation node(s) not listed as a subnode
 -- making info file /home/profzoom/.Macaulay2/local/share/info/Foo.info
 -- making html pages in ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/html/
 -- creating empty html page ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/html/index.html
 -- creating empty html page ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/html/master.html
 -- creating empty html page ../../../.Macaulay2/local/share/doc/Macaulay2/Foo/html/toc.html
 -- making html page for Foo :: foo
 -- warning: missing node: Foo cited by foo
 -- making html page for Foo :: Foo
 -- making "Foo : Index" in /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/html/master.html
 -- making  "Foo : Table of Contents" in /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/html/toc.html
 -- not making documentation in PDF format
 -- warning: 1 warning(s) occurred in documentation for package Foo
 -- installed package Foo in /home/profzoom/.Macaulay2/local/

o1 = Foo

o1 : Package
```
