### PR TITLE
Define MPFR_USE_NO_MACRO in M2/math-include.h (Fix #2145)

### DIFF
--- a/M2/include/M2/math-include.h
+++ b/M2/include/M2/math-include.h
@@ -28,6 +28,7 @@
   #include <gmp.h>
   #endif
 
+  #define MPFR_USE_NO_MACRO
   #include <mpfr.h>
   #include <mpfi.h>
 


### PR DESCRIPTION
This fixes #2145, by telling `mpfr.h` not to define macros for some of its functions. These macros break in the context of mpreal.h, because that file defines functions (in a namespace) with the same name as some types used in the macros.

A note is `mpfr.h` presumably defines these macros for a performance advantage, so the better thing would be to only define this when needed. But this is a bit fragile because "when needed" is whenever `mpreal.h` is included, and it must be defined before `mpfr.h` is included, which for us happens inside `M2/math-include.h`.