### PR TITLE
Fix "misleading-indentation" compiler warnings

### DIFF
--- a/M2/Macaulay2/c/type.c
+++ b/M2/Macaulay2/c/type.c
@@ -220,7 +220,10 @@ node type(node e){		/* assume e is checked previously */
 			 assert(FALSE);
 		    	 return caddr(ht);
 			 }
-		    else assert(FALSE); return NULL;
+		    else {
+			 assert(FALSE);
+			 return NULL;
+			 }
 		    }
 	       assert(FALSE); return NULL;
 	       }
@@ -458,7 +461,10 @@ node ExpandType(node t, node *f) {
 		    *f = cons(newN,*f);
 		    return newN;
 		    }
-	       else assert(FALSE); return NULL;
+	       else {
+		    assert(FALSE);
+		    return NULL;
+		    }
 	       }
 	  default: assert(FALSE); return NULL;
 	  }


### PR DESCRIPTION
```
type.c: In function 'type':
type.c:223:21: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
  223 |                     else assert(FALSE); return NULL;
      |                     ^~~~
type.c:223:41: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
  223 |                     else assert(FALSE); return NULL;
      |                                         ^~~~~~
type.c: In function 'ExpandType':
type.c:461:16: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
  461 |                else assert(FALSE); return NULL;
      |                ^~~~
type.c:461:36: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
  461 |                else assert(FALSE); return NULL;
      |                                    ^~~~~~
```