### PR TITLE
Begin 1.19 changelog

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -42,7 +42,9 @@ document {
     UL {
 	LI { "functionality added:",
 	    UL {
-		LI { "Integers may now be entered using the binary, octal, and hexadecimal numeral systems with with \"0b\", \"0o\", and \"0x\" prefixes, respectively."}
+		LI { "Integers may now be entered using the binary, octal, and hexadecimal numeral systems with with \"0b\", \"0o\", and \"0x\" prefixes, respectively."},
+		LI { "A new binary operator, ", TO2 {(symbol ^^, ZZ, ZZ), "^^"}, ", has been added for computing the bitwise XOR of two integers.  This replaces the \"xor\" method."},
+		LI { "A new keyword, ", TO2 {(symbol xor, Boolean, Boolean), "xor"}, ", has been added for finding the logical XOR of two boolean objects."}
 		}
 	    }
 	}

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -38,6 +38,17 @@ document {
      }
 
 document {
+    Key => "changes, 1.19",
+    UL {
+	LI { "functionality added:",
+	    UL {
+		LI { "Integers may now be entered using the binary, octal, and hexadecimal numeral systems with with \"0b\", \"0o\", and \"0x\" prefixes, respectively."}
+		}
+	    }
+	}
+    }
+
+document {
      Key => "changes, 1.18",
      UL {
      	 LI { "packages that have been published and certified:",

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -42,7 +42,7 @@ document {
     UL {
 	LI { "functionality added:",
 	    UL {
-		LI { "Integers may now be entered using the binary, octal, and hexadecimal numeral systems with with \"0b\", \"0o\", and \"0x\" prefixes, respectively."},
+		LI { "Integers may now be entered using the binary, octal, and hexadecimal numeral systems with the prefixes \"0b\", \"0o\", and \"0x\", respectively."},
 		LI { "A new binary operator, ", TO2 {(symbol ^^, ZZ, ZZ), "^^"}, ", has been added for computing the bitwise XOR of two integers.  This replaces the \"xor\" method."},
 		LI { "A new keyword, ", TO2 {(symbol xor, Boolean, Boolean), "xor"}, ", has been added for finding the logical XOR of two boolean objects."},
 		LI { "The function ", TO printerr, ", for printing warning messages and logs to ", TO stderr, ", is now exported."}

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -44,7 +44,8 @@ document {
 	    UL {
 		LI { "Integers may now be entered using the binary, octal, and hexadecimal numeral systems with with \"0b\", \"0o\", and \"0x\" prefixes, respectively."},
 		LI { "A new binary operator, ", TO2 {(symbol ^^, ZZ, ZZ), "^^"}, ", has been added for computing the bitwise XOR of two integers.  This replaces the \"xor\" method."},
-		LI { "A new keyword, ", TO2 {(symbol xor, Boolean, Boolean), "xor"}, ", has been added for finding the logical XOR of two boolean objects."}
+		LI { "A new keyword, ", TO2 {(symbol xor, Boolean, Boolean), "xor"}, ", has been added for finding the logical XOR of two boolean objects."},
+		LI { "The function ", TO printerr, ", for printing warning messages and logs to ", TO stderr, ", is now exported."}
 		}
 	    }
 	}


### PR DESCRIPTION
This begins the 1.19 portion of `changes.m2` and documents two of the changes to `Core` that I've made in the past few months: binary/octal/hexadecimal integers (#2138) and the two XOR operations (#2131).