### PR TITLE
Numerical integration updates

### DIFF
--- a/M2/Macaulay2/m2/integrate.m2
+++ b/M2/Macaulay2/m2/integrate.m2
@@ -104,6 +104,66 @@ gauss := (f,a,b,k,n) -> (
 integrate = method()
 integrate(Function, Number, Number) := (f,a,b) -> gauss(f,a,b,4,6)
 
+-- nodes and weights for 20-point gauss-laguerre formula
+-- https://dlmf.nist.gov/3.5.27
+gaussLaguerreNodes = {
+    0.705398896919887533667e-1,
+    0.372126818001611443794,
+    0.916582102483273564668,
+    0.170730653102834388069e1,
+    0.274919925530943212965e1,
+    0.404892531385088692237e1,
+    0.561517497086161651410e1,
+    0.745901745367106330977e1,
+    0.959439286958109677247e1,
+    0.120388025469643163096e2,
+    0.148142934426307399785e2,
+    0.179488955205193760174e2,
+    0.214787882402850109757e2,
+    0.254517027931869055035e2,
+    0.299325546317006120067e2,
+    0.350134342404790000063e2,
+    0.408330570567285710620e2,
+    0.476199940473465021399e2,
+    0.558107957500638988908e2,
+    0.665244165256157538186e2
+    }
+
+gaussLaguerreWeights = {
+    0.168746801851113862149,
+    0.291254362006068281717,
+    0.266686102867001288550,
+    0.166002453269506840031,
+    0.748260646687923705401e-1,
+    0.249644173092832210728e-1,
+    0.620255084457223684745e-2,
+    0.114496238647690824204e-2,
+    0.155741773027811974780e-3,
+    0.154014408652249156894e-4,
+    0.108648636651798235148e-5,
+    0.533012090955671475093e-7,
+    0.175798117905058200358e-8,
+    0.372550240251232087263e-10,
+    0.476752925157819052449e-12,
+    0.337284424336243841237e-14,
+    0.115501433950039883096e-16,
+    0.153952214058234355346e-19,
+    0.528644272556915782880e-23,
+    0.165645661249902329591e-27
+    }
+
+integrate(Function, Number, InfiniteNumber) := (f, a, b) -> (
+    if b == infinity then (
+	g := x -> exp x * f(x + a);
+	sum(20, i -> gaussLaguerreWeights_i * g(gaussLaguerreNodes_i)))
+    else if b == -infinity then -integrate(f, -infinity, a)
+    else error "expected infinity or -infinity")
+
+integrate(Function, InfiniteNumber, Number) := (f, a, b) -> (
+    if a == infinity then -integrate(f, b, infinity)
+    else if a == -infinity then integrate(x -> f(-x), -b, infinity)
+    else error "expected infinity or -infinity")
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/m2/integrate.m2
+++ b/M2/Macaulay2/m2/integrate.m2
@@ -164,6 +164,44 @@ integrate(Function, InfiniteNumber, Number) := (f, a, b) -> (
     else if a == -infinity then integrate(x -> f(-x), -b, infinity)
     else error "expected infinity or -infinity")
 
+-- nodes and weights for 20-point gauss-hermite formula
+-- https://dlmf.nist.gov/3.5.28
+gaussHermiteNodes = {
+    0.245340708300901249904,
+    0.737473728545394358706,
+    0.123407621539532300789e1,
+    0.173853771211658620678e1,
+    0.225497400208927552308e1,
+    0.278880605842813048053e1,
+    0.334785456738321632691e1,
+    0.394476404011562521038e1,
+    0.460368244955074427308e1,
+    0.538748089001123286202e1
+    }
+
+gaussHermiteWeights = {
+    0.462243669600610089650,
+    0.286675505362834129720,
+    0.109017206020023320014,
+    0.248105208874636108822e-1,
+    0.324377334223786183218e-2,
+    0.228338636016353967257e-3,
+    0.780255647853206369415e-5,
+    0.108606937076928169400e-6,
+    0.439934099227318055363e-9,
+    0.222939364553415129252e-12
+    }
+
+integrate(Function, InfiniteNumber, InfiniteNumber) := (f, a, b) -> (
+    if a == b then 0
+    else if a == -infinity and b == infinity then (
+	g := x -> exp(x^2) * f(x);
+	sum(10, i ->  (
+		x := gaussHermiteNodes_i;
+		gaussHermiteWeights_i * (g(x) + g(-x)))))
+    else if a == infinity and b == -infinity then -integrate(f, b, a)
+    else error "expected infinity and/or -infinity")
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/m2/integrate.m2
+++ b/M2/Macaulay2/m2/integrate.m2
@@ -202,6 +202,13 @@ integrate(Function, InfiniteNumber, InfiniteNumber) := (f, a, b) -> (
     else if a == infinity and b == -infinity then -integrate(f, b, a)
     else error "expected infinity and/or -infinity")
 
+integrate(Function, Constant, Constant) :=
+integrate(Function, Constant, Number) :=
+integrate(Function, Constant, InfiniteNumber) :=
+integrate(Function, Number, Constant) :=
+integrate(Function, InfiniteNumber, Constant) :=
+    (f, a, b) -> integrate(f, a + 0, b + 0)
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/m2/integrate.m2
+++ b/M2/Macaulay2/m2/integrate.m2
@@ -101,14 +101,8 @@ gauss := (f,a,b,k,n) -> (
      int
      )
 
-integrate = (f,a,b) -> (
-     if not instance(f, Function) then error (
-	  "'integrate' expected argument 1 to be a function");
-     try a = a + 0. else error (
-	  "'integrate' expected argument 2 to be a number");
-     try b = b + 0. else error (
-	  "'integrate' expected argument 3 to be a number");
-     gauss(f,a,b,4,6))
+integrate = method()
+integrate(Function, Number, Number) := (f,a,b) -> gauss(f,a,b,4,6)
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/integrate-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/integrate-doc.m2
@@ -1,8 +1,39 @@
-document {
-     Key => integrate,
-     Headline => "numerical integration",
-     TT "integrate(f,a,b)", " -- integrate f from a to b numerically, using
-     Gaussian quadrature.",
-     EXAMPLE "integrate(sin,0,pi)"
-     }
-
+doc ///
+  Key
+    integrate
+    (integrate, Function, Constant, Constant)
+    (integrate, Function, Constant, InfiniteNumber)
+    (integrate, Function, Constant, Number)
+    (integrate, Function, InfiniteNumber, Constant)
+    (integrate, Function, InfiniteNumber, InfiniteNumber)
+    (integrate, Function, InfiniteNumber, Number)
+    (integrate, Function, Number, Constant)
+    (integrate, Function, Number, InfiniteNumber)
+    (integrate, Function, Number, Number)
+  Headline
+    numerical integration
+  Usage
+    integrate(f, a, b)
+  Inputs
+    f:Function
+    a:{Number, InfiniteNumber, Constant}
+    b:{Number, InfiniteNumber, Constant}
+  Outputs
+    :RR
+  Description
+    Text
+      Integrate @TT "f"@ from @TT "a"@ to @TT "b"@ numerically, using
+      @wikipedia "Gaussian quadrature"@.
+    Example
+      integrate(sin, 0, pi)
+    Text
+      For half-infinite intervals, 20-point
+      @wikipedia "Gauss-Laguerre quadrature"@ is used.
+    Example
+      integrate(x -> exp(-x), 0, infinity)
+    Text
+      For infinite intervals, 20-point
+      @wikipedia "Gauss-Hermite quadrature"@ is used.
+    Example
+      integrate(x -> exp(-x^2), -infinity, infinity)
+///

--- a/M2/Macaulay2/tests/normal/realfuns.m2
+++ b/M2/Macaulay2/tests/normal/realfuns.m2
@@ -2,4 +2,6 @@ eps = 2.^-50
 chk = (x,y) -> abs(x-y) < eps
 assert chk ( integrate(sin,0,pi/2), 1 )
 assert chk ( integrate(zeta,2,3), 1.3675256886839791457066699268939213778115038258418219887541718201423885236150082812747931 )
+assert chk ( integrate(x -> exp(-x), 0, infinity), 1 )
+assert chk ( integrate(x -> exp(-x^2), -infinity, infinity), sqrt(pi + 0))
 


### PR DESCRIPTION
Here are some improvements to `integrate` that I wrote for use in a [probability package](https://github.com/d-torrance/M2/blob/3bb390303912aa6a630b3715d1daeef170808636/M2/Macaulay2/packages/Probability.m2) I'm working on.  In particular:

* Make `integrate` a method.
* Allow integration over half-infinite and infinite intervals (using Gauss-Laguerre and Gauss-Hermite quadrature, respectively).