### PR TITLE
Remove Python from list of "improved packages" in 1.19 changes.

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -72,8 +72,7 @@ document {
 	     	    },
 	       LI { "improved packages:",
 	    	    UL {
-		     	 LI { "The package ", TO "MonodromySolver::MonodromySolver", " includes several new convenience functions for manipulating systems and creating seed pairs."},
-		     	 LI { "The package ", TO "Python", " is once again distributed.  It now has support for Python 3 and includes many new features."}
+		     	 LI { "The package ", TO "MonodromySolver::MonodromySolver", " includes several new convenience functions for manipulating systems and creating seed pairs."}
 			 }
 	    	    },
 	       LI { "functionality added:",


### PR DESCRIPTION
It's also listed in "new packages", which is more appropriate because it hasn't been distributed before.