### PR TITLE
Restore pythonObjectCell case in tostringfun

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1000,6 +1000,7 @@ tostringfun(e:Expr):Expr := (
 	  -- Ccode(string, "IM2_MonomialIdeal_to_string(",x.p,")" )
 	  )
      is c:RawComputationCell do toExpr(Ccode(string, "IM2_GB_to_string(",c.p,")" ))
+     is pythonObjectCell do toExpr("<<a python object>>")
      is x:xmlNodeCell do toExpr(toString(x.v))
      is xmlAttrCell do toExpr("<<libxml attribute>>")
      is x:TaskCell do (
@@ -1017,7 +1018,6 @@ tostringfun(e:Expr):Expr := (
 	       + ">>"
 	       ))
     is x:fileOutputSyncState do toExpr("File Output Sync State")
-    else buildErrorPacket("unable to convert to string")
 );
 setupfun("simpleToString",tostringfun);
 


### PR DESCRIPTION
It was removed to make way for implementing `toString PythonObject` at
top level in a43a9a5.  To avoid compilation errors, an else clause was
added to the end of `tostringfun`.

However, this was not great, as now it's more likely that anyone
wishing to add a new member to the `Expr` union would miss adding
their new case to this function.

Instead, we restore a default version of the `pythonObjectCell` case
that will be overridden at top level.