### PR TITLE
A few Python updates

### DIFF
--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -190,6 +190,8 @@ addHook((value, PythonObject),
     Strategy => "unknown -> PythonObject")
 addPyToM2Function({"function", "builtin_function_or_method", "method-wrapper"},
     toFunction, "function -> FunctionClosure")
+addPyToM2Function("Counter", x -> new Tally from dictToHashTable x,
+    "Counter -> Tally")
 addPyToM2Function({"dict", "defaultdict"}, dictToHashTable, "dict -> HashTable")
 addPyToM2Function({"set", "frozenset"}, set @@ iterableToList, "set -> Set")
 addPyToM2Function("list", iterableToList, "list -> List")

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -434,6 +434,12 @@ assert Equation(5 ^^ y, 7)
 assert Equation(x xor y, rs "7")
 assert Equation(x xor 2, 7)
 assert Equation(5 xor y, 7)
+
+----------------------
+-- unary operations --
+----------------------
+assert Equation(-x, -5)
+assert Equation(+x, 5)
 ///
 
 TEST ///

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -190,7 +190,7 @@ addHook((value, PythonObject),
     Strategy => "unknown -> PythonObject")
 addPyToM2Function({"function", "builtin_function_or_method", "method-wrapper"},
     toFunction, "function -> FunctionClosure")
-addPyToM2Function("dict", dictToHashTable, "dict -> HashTable")
+addPyToM2Function({"dict", "defaultdict"}, dictToHashTable, "dict -> HashTable")
 addPyToM2Function({"set", "frozenset"}, set @@ iterableToList, "set -> Set")
 addPyToM2Function("list", iterableToList, "list -> List")
 addPyToM2Function({"tuple", "range"}, toSequence @@ iterableToList,

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -250,6 +250,9 @@ scan({
 	)
     )
 
+-PythonObject := o -> o@@"__neg__"()
++PythonObject := o -> o@@"__pos__"()
+
 PythonObject Thing := (o, x) -> (toFunction o) x
 
 length PythonObject := x -> value x@@"__len__"()

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -166,7 +166,7 @@ dictToHashTable(PythonObject) := x -> (
 toFunction = method()
 toFunction PythonObject := x -> y -> (
     p := partition(a -> instance(a, Option),
-	if instance(y, VisibleList) then y else {y});
+	if instance(y, Sequence) then y else 1:y);
     args := toPython if p#?false then toSequence p#false else ();
     kwargs := toPython hashTable if p#?true then toList p#true else {};
     if debugLevel > 0 then printerr(

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -293,7 +293,7 @@ toPython Sequence := L -> (
     result := pythonTupleNew n;
     for i to n - 1 do pythonTupleSetItem(result, i, toPython L_i);
     result)
-toPython List := L -> (
+toPython VisibleList := L -> (
     n := #L;
     result := pythonListNew n;
     for i to n - 1 do pythonListSetItem(result, i, toPython L_i);

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -446,7 +446,6 @@ doc ///
     (toPython,CC)
     (toPython,Constant)
     (toPython,HashTable)
-    (toPython,List)
     (toPython,Nothing)
     (toPython,PythonObject)
     (toPython,QQ)
@@ -454,6 +453,7 @@ doc ///
     (toPython,Sequence)
     (toPython,Set)
     (toPython,String)
+    (toPython,VisibleList)
     (toPython,ZZ)
   Headline
     convert Macaulay2 things to Python objects

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -71,6 +71,8 @@ doc ///
     (symbol ?, PythonObject, PythonObject)
     (symbol ?, PythonObject, Thing)
     (symbol ?, Thing, PythonObject)
+    (symbol +, PythonObject)
+    (symbol -, PythonObject)
   Headline
     a python object
   Description
@@ -103,8 +105,10 @@ doc ///
       dunder method in Python.  In particular,
     Code
       UL {
-        LI {TT "+", " → ", TT "__add__"},
-        LI {TT "-", " → ", TT "__sub__"},
+        LI {TT "+", " → ", TT "__add__", " (binary), ",
+	    TT "__pos__", " (unary)"},
+        LI {TT "-", " → ", TT "__sub__", " (binary), ",
+	    TT "__neg__", " (unary)"},
         LI {TT "*", " → ", TT "__mul__"},
         LI {TT "/", " → ", TT "__truediv__"},
         LI {TT "//", " → ", TT "__floordiv__"},

--- a/M2/Macaulay2/packages/Python/examples/_add__Py__To__M2__Function.out
+++ b/M2/Macaulay2/packages/Python/examples/_add__Py__To__M2__Function.out
@@ -34,16 +34,17 @@ i7 : hooks value
 
 o7 = {0 => (value, PythonObject, Strategy => unknown -> PythonObject)    }
      {1 => (value, PythonObject, Strategy => function -> FunctionClosure)}
-     {2 => (value, PythonObject, Strategy => dict -> HashTable)          }
-     {3 => (value, PythonObject, Strategy => set -> Set)                 }
-     {4 => (value, PythonObject, Strategy => list -> List)               }
-     {5 => (value, PythonObject, Strategy => tuple -> Sequence)          }
-     {6 => (value, PythonObject, Strategy => str -> String)              }
-     {7 => (value, PythonObject, Strategy => complex -> CC)              }
-     {8 => (value, PythonObject, Strategy => float -> RR)                }
-     {9 => (value, PythonObject, Strategy => int -> ZZ)                  }
-     {10 => (value, PythonObject, Strategy => bool -> Boolean)           }
-     {11 => (value, PythonObject, Strategy => Fraction -> QQ)            }
+     {2 => (value, PythonObject, Strategy => Counter -> Tally)           }
+     {3 => (value, PythonObject, Strategy => dict -> HashTable)          }
+     {4 => (value, PythonObject, Strategy => set -> Set)                 }
+     {5 => (value, PythonObject, Strategy => list -> List)               }
+     {6 => (value, PythonObject, Strategy => tuple -> Sequence)          }
+     {7 => (value, PythonObject, Strategy => str -> String)              }
+     {8 => (value, PythonObject, Strategy => complex -> CC)              }
+     {9 => (value, PythonObject, Strategy => float -> RR)                }
+     {10 => (value, PythonObject, Strategy => int -> ZZ)                 }
+     {11 => (value, PythonObject, Strategy => bool -> Boolean)           }
+     {12 => (value, PythonObject, Strategy => Fraction -> QQ)            }
 
 o7 : NumberedVerticalList
 

--- a/M2/Macaulay2/packages/Python/examples/_value_lp__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_value_lp__Python__Object_rp.out
@@ -16,15 +16,16 @@ i3 : hooks value
 
 o3 = {0 => (value, PythonObject, Strategy => unknown -> PythonObject)    }
      {1 => (value, PythonObject, Strategy => function -> FunctionClosure)}
-     {2 => (value, PythonObject, Strategy => dict -> HashTable)          }
-     {3 => (value, PythonObject, Strategy => set -> Set)                 }
-     {4 => (value, PythonObject, Strategy => list -> List)               }
-     {5 => (value, PythonObject, Strategy => tuple -> Sequence)          }
-     {6 => (value, PythonObject, Strategy => str -> String)              }
-     {7 => (value, PythonObject, Strategy => complex -> CC)              }
-     {8 => (value, PythonObject, Strategy => float -> RR)                }
-     {9 => (value, PythonObject, Strategy => int -> ZZ)                  }
-     {10 => (value, PythonObject, Strategy => bool -> Boolean)           }
+     {2 => (value, PythonObject, Strategy => Counter -> Tally)           }
+     {3 => (value, PythonObject, Strategy => dict -> HashTable)          }
+     {4 => (value, PythonObject, Strategy => set -> Set)                 }
+     {5 => (value, PythonObject, Strategy => list -> List)               }
+     {6 => (value, PythonObject, Strategy => tuple -> Sequence)          }
+     {7 => (value, PythonObject, Strategy => str -> String)              }
+     {8 => (value, PythonObject, Strategy => complex -> CC)              }
+     {9 => (value, PythonObject, Strategy => float -> RR)                }
+     {10 => (value, PythonObject, Strategy => int -> ZZ)                 }
+     {11 => (value, PythonObject, Strategy => bool -> Boolean)           }
 
 o3 : NumberedVerticalList
 

--- a/M2/Macaulay2/packages/Python/no-python.m2
+++ b/M2/Macaulay2/packages/Python/no-python.m2
@@ -57,8 +57,21 @@ toFunction = method()
 toFunction PythonObject := err
 
 toPython = method()
-for type in {Boolean, CC, Constant, HashTable, List, Nothing, PythonObject, QQ,
-    RR, Sequence, Set, String, ZZ} do installMethod(toPython, type, err)
+for type in {
+    Boolean,
+    CC,
+    Constant,
+    HashTable,
+    Nothing,
+    PythonObject,
+    QQ,
+    RR,
+    Sequence,
+    Set,
+    String,
+    VisibleList,
+    ZZ
+    } do installMethod(toPython, type, err)
 
 for op in {symbol +, symbol -, symbol *, symbol /, symbol //, symbol %,
     symbol ^, symbol <<, symbol >>, symbol &, symbol |, symbol ^^, symbol and,

--- a/M2/Macaulay2/packages/Python/no-python.m2
+++ b/M2/Macaulay2/packages/Python/no-python.m2
@@ -84,7 +84,9 @@ PythonObject Thing :=
 length PythonObject :=
 value PythonObject :=
 PythonObject @@ Thing :=
-PythonObject_Thing := err
+PythonObject_Thing :=
++PythonObject :=
+-PythonObject := err
 
 rs = x -> error errmsg
 objectType = x -> error errmsg


### PR DESCRIPTION
* Interpret lists (and other non-sequence visible lists) as arguments themselves and not as lists of arguments for `toFunction` (addressing part of [#2315 (comment)](https://github.com/Macaulay2/M2/issues/2315#issue-1057501584)).

### Before
```m2
i1 : loadPackage "Python"

o1 = Python

o1 : Package

i2 : (rs "len") {1, 2, 3}
TypeError: len() takes exactly one argument (3 given)
stdio:2:1:(3): error: python error
```

### After
```m2
i2 : (rs "len") {1, 2, 3}

o2 = 3

o2 : PythonObject of class int
```

* Convert all visible lists to Python lists with `toPython` unless another method function is installed (like `toPython(Sequence)`, which converts sequences to tuples).

```m2
i3 : toPython [1, 2, 3]

o3 = [1, 2, 3]

o3 : PythonObject of class list

i4 : toPython <|1, 2, 3|>

o4 = [1, 2, 3]

o4 : PythonObject of class list
```

* Add a couple more `value(PythonObject)` hooks for useful classes from the `collections` module.

```m2
i7 : c = import "collections"

o7 = <module 'collections' from '/usr/lib/python3.9/collections/__init__.py'>

o7 : PythonObject of class module

i8 : d = c@@defaultdict rs "int"

o8 = defaultdict(<class 'int'>, {})

o8 : PythonObject of class collections.defaultdict

i9 : d_"foo"

o9 = 0

o9 : PythonObject of class int

i10 : value d

o10 = HashTable{foo => 0}

o10 : HashTable

i11 : c@@Counter "foo"

o11 = Counter({'o': 2, 'f': 1})

o11 : PythonObject of class collections.Counter

i12 : value oo

o12 = Tally{f => 1}
            o => 2

o12 : Tally
```
