### PR TITLE
Move banner down a few lines when generating Pygments lexer

### DIFF
--- a/M2/Macaulay2/editors/make-M2-symbols.m2
+++ b/M2/Macaulay2/editors/make-M2-symbols.m2
@@ -124,7 +124,7 @@ symbolsForRouge = template -> (
 
 pygmentsformat = symlist -> demark("," | newline | "    ", format \ symlist)
 symbolsForPygments = template -> (
-    output := concatenate("# ", banner, newline, newline, template);
+    output := replace("@M2BANNER@", "# " | banner, template);
     output = replace("@M2VERSION@",   version#"VERSION",        output);
     output = replace("@M2KEYWORDS@",  pygmentsformat KEYWORDS,  output);
     output = replace("@M2DATATYPES@", pygmentsformat DATATYPES, output);

--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -1,6 +1,6 @@
 """
     pygments.lexers.macaulay2
-    ~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
     Lexer for Macaulay2.
 
     :copyright: Copyright 2006-2021 by the Pygments team, see AUTHORS.

--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -12,6 +12,8 @@ from pygments.token import Comment, Keyword, Name, String, Text
 
 __all__ = ['Macaulay2Lexer']
 
+@M2BANNER@
+
 M2KEYWORDS = (
     @M2KEYWORDS@
     )


### PR DESCRIPTION
Otherwise, a Pygments test will fail, as it expects each file to begin with a docstring.  See https://github.com/pygments/pygments/pull/1791#issuecomment-974851300.