### PR TITLE
fix #2245

### DIFF
--- a/M2/Macaulay2/e/ZZ.cpp
+++ b/M2/Macaulay2/e/ZZ.cpp
@@ -292,7 +292,9 @@ ring_elem RingZZ::invert(const ring_elem f) const
 ring_elem RingZZ::divide(const ring_elem f, const ring_elem g) const
 {
   mpz_ptr result = new_elem();
-  mpz_fdiv_q(result, f.get_mpz(), g.get_mpz());
+  mpz_ptr rem = new_elem();
+  mpz_fdiv_qr(result, rem, f.get_mpz(), g.get_mpz());
+  if (mpz_sgn(rem)) ERROR("not divisible");
   mpz_reallocate_limbs(result);
   return ring_elem(result);
 }

--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -345,7 +345,7 @@ sub2 = (S,R,v) -> (				   -- S is the target ring or might be null, meaning targ
      local dummy;
      g := generators R;
      A := R;
-     while try (A = coefficientRing A; true) else false
+     while try (A = if instance(A,FractionField) then frac coefficientRing A else coefficientRing A; true) else false
      do g = join(g, generators A);
      h := new MutableHashTable;
      for i from 0 to #g-1 do h#(g#i) = if h#?(g#i) then (h#(g#i),i) else 1:i;


### PR DESCRIPTION
- trying to *divide* (not quotient, i.e., division with remainder) an integer by another integer will cause an error:
```
 i1 : R=frac(QQ[x])

o1 = R

o1 : FractionField

i2 : f=map(ZZ,R,{-12})

o2 = map (ZZ, R, {-12})

o2 : RingMap ZZ <--- R

i3 : f(1/x)
stdio:3:1:(3): error: not divisible
```
this is in the same spirit as https://github.com/Macaulay2/M2/pull/2241.
- `sub` will no longer be fooled by `frac`:
```
i1 : R=frac(ZZ[u])

o1 = R

o1 : FractionField

i2 : sub(u^-1,u=>-12)

        1
o2 = - --
       12

o2 : QQ

i3 : sub(u^-1,u=>31)

      1
o3 = --
     31

o3 : QQ

```
