### PR TITLE
Rename rs -> pythonValue in Python package

### DIFF
--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -25,7 +25,7 @@ setupfun("runSimpleString",PyRunSimpleString);
 
 import RunString(s:string):pythonObjectOrNull;
 PyRunString(e:Expr):Expr := when e is s:stringCell do toExpr(RunString(s.v)) else WrongArgString();
-setupfun("runPythonString",PyRunString);
+setupfun("pythonRunString",PyRunString);
 
 import Main():int;
 PyMain(e:Expr):Expr := toExpr(Main());

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -63,7 +63,7 @@ importFrom_Core {
     "pythonUnicodeFromString"
 }
 
-export { "pythonHelp", "context", "rs", "Preprocessor", "toPython",
+export { "pythonHelp", "context", "Preprocessor", "toPython",
     "addPyToM2Function",
     "getattr",
     "getitem",
@@ -72,6 +72,7 @@ export { "pythonHelp", "context", "rs", "Preprocessor", "toPython",
     "iter",
     "iterableToList",
     "next",
+    "pythonValue",
     "setattr",
     "setitem",
     "toFunction"
@@ -79,7 +80,7 @@ export { "pythonHelp", "context", "rs", "Preprocessor", "toPython",
 
 exportMutable { "val", "eval", "valuestring", "stmt", "expr", "dict", "symbols", "stmtexpr"}
 
-pythonHelp = Command (() -> runPythonString ///help()///)
+pythonHelp = Command (() -> pythonValue ///help()///)
 
 toString PythonObject := pythonUnicodeAsUTF8 @@ pythonObjectStr
 
@@ -91,10 +92,11 @@ PythonObject#{Standard,AfterPrint} = x -> (
      << concatenate(interpreterDepth:"o") << lineNumber << " : PythonObject " << t << endl;
      )
 
-rs = s -> ( 
-     s = concatenate s;
-     if debugLevel > 0 then stderr << "--python command: " << s << endl; 
-     runPythonString s);
+pythonValue = method(Dispatch => Thing)
+pythonValue String := s -> (
+    if debugLevel > 0 then printerr("python command: ", s);
+    pythonRunString s)
+pythonValue Sequence := S -> pythonValue \\ concatenate \\ toString \ S
 
 numContexts = 0
 nextContext = method()
@@ -111,10 +113,10 @@ context = method(Options => {
 	  })
 context String := opts -> init -> (
      dict := nextContext();
-     rs("eval(compile( '",dict," = {}','','single' ),__builtins__) ");
+     pythonValue("eval(compile( '",dict," = {}','','single' ),__builtins__) ");
      access := s -> concatenate(dict,"[", format s, "]");
-     val := s -> rs access s;
-     eval := s -> rs concatenate("eval(compile(",s,",'','single' ),",dict,")");
+     val := s -> pythonValue access s;
+     eval := s -> pythonValue concatenate("eval(compile(",s,",'','single' ),",dict,")");
      evalstring := s -> eval replace("\n","\\n",format concatenate s);
      evalstring init;
      valuestring := s -> (
@@ -127,7 +129,7 @@ context String := opts -> init -> (
      else (
 	  s -> (
 	       evalstring("tmp = ",opts.Preprocessor,"(",format s,")");
-	       if debugLevel > 0 then stderr << "--intermediate value: tmp = " << format toString runPythonString access "tmp" << endl;
+	       if debugLevel > 0 then stderr << "--intermediate value: tmp = " << format toString pythonValue access "tmp" << endl;
 	       eval access "tmp";
 	       null)
 	  );
@@ -136,7 +138,7 @@ context String := opts -> init -> (
 	  stmt s;
 	  val "temp");
      stmtexpr := s -> if match(";$",s) then stmt s else expr s;
-     symbols := () -> runPythonString concatenate("__builtins__[",format dict,"].keys()");
+     symbols := () -> pythonValue concatenate("__builtins__[",format dict,"].keys()");
      use new Context from {
 	  global dict => dict,
 	  global val => val,
@@ -318,44 +320,47 @@ TEST ///
 -----------
 -- value --
 -----------
-assert Equation(value rs "True", true)
-assert Equation(value rs "5", 5)
-assert Equation(value rs "3.14159", 3.14159)
-assert Equation(value rs "complex(1, 2)", 1 + 2*ii)
-assert Equation(value rs "'foo'", "foo")
-assert Equation(value rs "(1, 3, 5, 7, 9)", (1, 3, 5, 7, 9))
-assert Equation(value rs "range(5)", (0, 1, 2, 3, 4))
-assert Equation(value rs "[1, 3, 5, 7, 9]", {1, 3, 5, 7, 9})
+assert Equation(value pythonValue "True", true)
+assert Equation(value pythonValue "5", 5)
+assert Equation(value pythonValue "3.14159", 3.14159)
+assert Equation(value pythonValue "complex(1, 2)", 1 + 2*ii)
+assert Equation(value pythonValue "'foo'", "foo")
+assert Equation(value pythonValue "(1, 3, 5, 7, 9)", (1, 3, 5, 7, 9))
+assert Equation(value pythonValue "range(5)", (0, 1, 2, 3, 4))
+assert Equation(value pythonValue "[1, 3, 5, 7, 9]", {1, 3, 5, 7, 9})
 assert BinaryOperation(symbol ===,
-    value rs "{1, 3, 5, 7, 9}", set {1, 3, 5, 7, 9})
-assert BinaryOperation(symbol ===, value rs "frozenset([1, 3, 5, 7, 9])",
+    value pythonValue "{1, 3, 5, 7, 9}", set {1, 3, 5, 7, 9})
+assert BinaryOperation(symbol ===,
+    value pythonValue "frozenset([1, 3, 5, 7, 9])",
     set {1, 3, 5, 7, 9})
-assert BinaryOperation(symbol ===, value rs "{'a':1, 'b':2, 'c':3}",
+assert BinaryOperation(symbol ===, value pythonValue "{'a':1, 'b':2, 'c':3}",
     hashTable{"a" => 1, "b" => 2, "c" => 3})
-assert Equation((value rs "abs")(-1), rs "1")
-assert Equation(value rs "None", null)
+assert Equation((value pythonValue "abs")(-1), pythonValue "1")
+assert Equation(value pythonValue "None", null)
 ///
 
 TEST ///
 ----------------------
 -- nested iterators --
 ----------------------
-assert Equation(value rs "[[1,2]]", {{1,2}})
-assert Equation(value rs "[(1,2)]", {(1,2)})
-assert BinaryOperation(symbol ===, value rs "[{1,2}]", {set {1,2}})
-assert BinaryOperation(symbol ===, value rs "[{1:2}]", {hashTable {1 => 2}})
-assert Equation(value rs "([1,2],)", 1:{1,2})
-assert Equation(value rs "((1,2),)", 1:(1,2))
-assert BinaryOperation(symbol ===, value rs "({1,2},)", 1:set {1,2})
-assert BinaryOperation(symbol ===, value rs "({1:2},)", 1:hashTable {1 => 2})
-assert BinaryOperation(symbol ===, value rs "{(1,2)}", set {(1,2)})
-assert BinaryOperation(symbol ===, value rs "{(1,2):[3,4]}",
+assert Equation(value pythonValue "[[1,2]]", {{1,2}})
+assert Equation(value pythonValue "[(1,2)]", {(1,2)})
+assert BinaryOperation(symbol ===, value pythonValue "[{1,2}]", {set {1,2}})
+assert BinaryOperation(symbol ===, value pythonValue "[{1:2}]",
+    {hashTable {1 => 2}})
+assert Equation(value pythonValue "([1,2],)", 1:{1,2})
+assert Equation(value pythonValue "((1,2),)", 1:(1,2))
+assert BinaryOperation(symbol ===, value pythonValue "({1,2},)", 1:set {1,2})
+assert BinaryOperation(symbol ===, value pythonValue "({1:2},)",
+    1:hashTable {1 => 2})
+assert BinaryOperation(symbol ===, value pythonValue "{(1,2)}", set {(1,2)})
+assert BinaryOperation(symbol ===, value pythonValue "{(1,2):[3,4]}",
     hashTable {(1,2) => {3,4}})
-assert BinaryOperation(symbol ===, value rs "{(1,2):(3,4)}",
+assert BinaryOperation(symbol ===, value pythonValue "{(1,2):(3,4)}",
     hashTable {(1,2) => (3,4)})
-assert BinaryOperation(symbol ===, value rs "{(1,2):{3,4}}",
+assert BinaryOperation(symbol ===, value pythonValue "{(1,2):{3,4}}",
     hashTable {(1,2) => set {3,4}})
-assert BinaryOperation(symbol ===, value rs "{(1,2):{3:4}}",
+assert BinaryOperation(symbol ===, value pythonValue "{(1,2):{3:4}}",
     hashTable {(1,2) => hashTable {3 => 4}})
 ///
 
@@ -363,75 +368,75 @@ TEST ///
 -----------------------
 -- binary operations --
 -----------------------
-x = rs "5"
-y = rs "2"
+x = pythonValue "5"
+y = pythonValue "2"
 
 -- addition
-assert Equation(x + y, rs "7")
+assert Equation(x + y, pythonValue "7")
 assert Equation(x + 2, 7)
 assert Equation(5 + y, 7)
 
 -- subtraction
-assert Equation(x - y, rs "3")
+assert Equation(x - y, pythonValue "3")
 assert Equation(x - 2, 3)
 assert Equation(5 - y, 3)
 
 -- multiplication
-assert Equation(x * y, rs "10")
+assert Equation(x * y, pythonValue "10")
 assert Equation(x * 2, 10)
 assert Equation(5 * y, 10)
 
 -- true division
-assert Equation(x / y, rs "2.5")
+assert Equation(x / y, pythonValue "2.5")
 assert Equation(x / 2, 2.5)
 assert Equation(5 / y, 2.5)
 
 -- floor division
-assert Equation(x // y, rs "2")
+assert Equation(x // y, pythonValue "2")
 assert Equation(x // 2, 2)
 assert Equation(5 // y, 2)
 
 -- modulo
-assert Equation(x % y, rs "1")
+assert Equation(x % y, pythonValue "1")
 assert Equation(x % 2, 1)
 assert Equation(5 % y, 1)
 
 -- power
-assert Equation(x ^ y, rs "25")
+assert Equation(x ^ y, pythonValue "25")
 assert Equation(x ^ 2, 25)
 assert Equation(5 ^ y, 25)
 
 -- left shift
-assert Equation(x << y, rs "20")
+assert Equation(x << y, pythonValue "20")
 assert Equation(x << 2, 20)
 assert Equation(5 << y, 20)
 
 -- right shift
-assert Equation(x >> y, rs "1")
+assert Equation(x >> y, pythonValue "1")
 assert Equation(x >> 2, 1)
 assert Equation(5 >> y, 1)
 
 -- and
-assert Equation(x & y, rs "0")
+assert Equation(x & y, pythonValue "0")
 assert Equation(x & 2, 0)
 assert Equation(5 & y, 0)
-assert Equation(x and y, rs "0")
+assert Equation(x and y, pythonValue "0")
 assert Equation(x and 2, 0)
 assert Equation(5 and y, 0)
 
 -- or
-assert Equation(x | y, rs "7")
+assert Equation(x | y, pythonValue "7")
 assert Equation(x | 2, 7)
 assert Equation(5 | y, 7)
-assert Equation(x or y, rs "7")
+assert Equation(x or y, pythonValue "7")
 assert Equation(x or 2, 7)
 assert Equation(5 or y, 7)
 
 -- xor
-assert Equation(x ^^ y, rs "7")
+assert Equation(x ^^ y, pythonValue "7")
 assert Equation(x ^^ 2, 7)
 assert Equation(5 ^^ y, 7)
-assert Equation(x xor y, rs "7")
+assert Equation(x xor y, pythonValue "7")
 assert Equation(x xor 2, 7)
 assert Equation(5 xor y, 7)
 
@@ -446,29 +451,29 @@ TEST ///
 -----------------------
 -- string operations --
 -----------------------
-foo = rs "'foo'"
-bar = rs "'bar'"
+foo = pythonValue "'foo'"
+bar = pythonValue "'bar'"
 
 -- concatenation
-assert Equation(foo + bar, rs "'foobar'")
+assert Equation(foo + bar, pythonValue "'foobar'")
 assert Equation(foo + "bar", "foobar")
 assert Equation("foo" + bar, "foobar")
 
 -- repetition
-assert Equation(foo * rs "2", rs "'foofoo'")
+assert Equation(foo * pythonValue "2", pythonValue "'foofoo'")
 assert Equation(foo * 2, "foofoo")
-assert Equation("foo" * rs "2", "foofoo")
-assert Equation(rs "2" * foo, rs "'foofoo'")
+assert Equation("foo" * pythonValue "2", "foofoo")
+assert Equation(pythonValue "2" * foo, pythonValue "'foofoo'")
 assert Equation(2 * foo, "foofoo")
-assert Equation(rs "2" * "foo", "foofoo")
+assert Equation(pythonValue "2" * "foo", "foofoo")
 
 -- check a few methods
-assert Equation(foo@@capitalize(), rs "'Foo'")
-assert Equation(foo@@center(5, "x"), rs "'xfoox'")
-assert Equation((rs "'{0}, {1}!'")@@format("Hello", "world"),
-    rs "'Hello, world!'")
-assert Equation(foo@@replace("f", "F"), rs "'Foo'")
-assert Equation(foo@@upper(), rs "'FOO'")
+assert Equation(foo@@capitalize(), pythonValue "'Foo'")
+assert Equation(foo@@center(5, "x"), pythonValue "'xfoox'")
+assert Equation((pythonValue "'{0}, {1}!'")@@format("Hello", "world"),
+    pythonValue "'Hello, world!'")
+assert Equation(foo@@replace("f", "F"), pythonValue "'Foo'")
+assert Equation(foo@@upper(), pythonValue "'FOO'")
 ///
 
 end --------------------------------------------------------

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -2,7 +2,7 @@
 this does not work unless M2 is compiled --with-python
 *-
 
-pythonPresent := Core#"private dictionary"#?"runPythonString"
+pythonPresent := Core#"private dictionary"#?"pythonRunString"
 
 newPackage("Python",
     Version => "0.2",
@@ -32,7 +32,6 @@ if pythonPresent then verboseLog "success: python is present" else (
 exportFrom_Core {
     "runSimpleString",
     "PythonObject",
-    "runPythonString",
     "objectType"}
 
 importFrom_Core {
@@ -54,6 +53,7 @@ importFrom_Core {
     "pythonObjectSetAttrString",
     "pythonObjectCall",
     "pythonObjectStr",
+    "pythonRunString",
     "pythonSetNew",
     "pythonTrue",
     "pythonTupleNew",

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -12,7 +12,7 @@ doc ///
       objects.
     Example
       toPython {1, 2/3, "foo", (1, 2, 3), hashTable {"foo" => "bar"}}
-      value rs "[1, 2/3, 'foo', (1, 2, 3), {'foo' : 'bar'}]"
+      value pythonValue "[1, 2/3, 'foo', (1, 2, 3), {'foo' : 'bar'}]"
       math = import "math"
       math@@sqrt 2
 ///
@@ -84,8 +84,8 @@ doc ///
     Text
       You can perform basic arithmetic on python objects.
     Example
-      x = rs "5"
-      y = rs "2"
+      x = pythonValue "5"
+      y = pythonValue "2"
       x + y
       x - y
       x * y
@@ -145,13 +145,13 @@ doc ///
       or the shortcut @TT "_"@.  This is equivalent to square brackets
       (@TT "[]"@) in Python. For example, this works for lists.
     Example
-      x = rs "[1,2,3,4]"
+      x = pythonValue "[1,2,3,4]"
       getitem(x, 0)
       x_1
     Text
       It also works for dictionaries.
     Example
-      x = rs "{'spam':1,'eggs':2}"
+      x = pythonValue "{'spam':1,'eggs':2}"
       getitem(x, "spam")
       x_"eggs"
 ///
@@ -176,38 +176,46 @@ doc ///
       or the shortcut @TT "_"@.  This is equivalent to square brackets
       (@TT "[]"@) in Python. For example, this works for lists.
     Example
-      x = rs "[1,2,3,4]"
+      x = pythonValue "[1,2,3,4]"
       setitem(x, 0, 5)
       x
     Text
       It also works for dictionaries.
     Example
-      x = rs "{'spam':1,'eggs':2}"
+      x = pythonValue "{'spam':1,'eggs':2}"
       x_"ham" = 3
       x
 ///
 
 doc ///
   Key
-    rs
-    runPythonString
+    pythonValue
+    (pythonValue, String)
+    (pythonValue, Sequence)
   Headline
     execute Python source code from a string
   Usage
-    rs s
-    runPythonString s
+    pythonValue s
   Inputs
-    s:String -- containing Python source code
+    s:{String, Sequence} -- containing Python source code
   Outputs
     :PythonObject -- the return value of the given code
   Description
     Text
       This function a is wrapper around the function @TT
       HREF{"https://docs.python.org/3/c-api/veryhigh.html#c.PyRun_String",
-      "PyRun_String"}@ from the Python C API.  It is also available
-      as @TT "runPythonString"@.
+      "PyRun_String"}@ from the Python C API.
     Example
-      rs "2 + 2"
+      pythonValue "2 + 2"
+    Text
+      If a sequence is given, then its elements are converted to strings using
+      @TO "toString"@ and then joined using @TO "concatenate"@.  You can see the
+       expression sent to the Python interpreter by setting @TO "debugLevel"@
+       to a positive value.
+    Example
+      debugLevel = 1
+      x = 5
+      pythonValue("3 + ", x)
   SeeAlso
     runSimpleString
 ///
@@ -226,11 +234,11 @@ doc ///
       This function a is wrapper around the function @TT
       HREF{"https://docs.python.org/3/c-api/veryhigh.html#c.PyRun_SimpleString",
       "PyRun_SimpleString"}@ from the Python C API.  Note that, unlike
-      @TO "rs"@, it has no return value.
+      @TO "pythonValue"@, it has no return value.
     Example
       runSimpleString "print('Hello, world!')"
   SeeAlso
-    rs
+    pythonValue
 ///
 
 doc ///
@@ -252,7 +260,7 @@ doc ///
       "Python counterpart"}@.  In particular, @TT "i"@ is an iterator
       for the iterable object @TT "x"@.
     Example
-      x = rs "range(3)"
+      x = pythonValue "range(3)"
       i = iter x
   SeeAlso
     next
@@ -276,7 +284,7 @@ doc ///
       "Python counterpart"}@.  In particular, it retrieves the next item
       from an iterator.
     Example
-      x = rs "range(3)"
+      x = pythonValue "range(3)"
       i = iter x
       next i
       next i
@@ -308,7 +316,7 @@ doc ///
       The elements are converted to Macaulay2 objects (if
       possible) using @TO "value"@.
     Example
-      x = rs "range(3)"
+      x = pythonValue "range(3)"
       iterableToList x
       class \ oo
   SeeAlso
@@ -340,7 +348,7 @@ doc ///
     Text
       Optional arguments can be provided using options.
     Example
-      int = toFunction rs "int"
+      int = toFunction pythonValue "int"
       int("deadbeef", "base" => 16)
     Text
       If a python object and a Macaulay2 thing are separated by a space, then
@@ -366,8 +374,8 @@ doc ///
       This is equivalent the Python @HREF {
       "https://docs.python.org/3/library/functions.html#len", "len"}@ function.
     Example
-      length rs "'Hello, world!'"
-      length rs "[1,2,3,4,5]"
+      length pythonValue "'Hello, world!'"
+      length pythonValue "[1,2,3,4,5]"
 ///
 
 doc ///
@@ -386,7 +394,7 @@ doc ///
       This function attempts to convert @TT "x"@ to its corresponding
       Macaulay2 equivalent.
     Example
-      value rs "[1, 3.14159, 'foo', (1,2,3), {'foo':'bar'}]"
+      value pythonValue "[1, 3.14159, 'foo', (1,2,3), {'foo':'bar'}]"
       class \ oo
     Text
       Since the type of @TT "x"@ is not initially known, a sequence of
@@ -397,7 +405,7 @@ doc ///
     Text
       If no conversion can be done, then @TT "x"@ is returned.
     Example
-      rs "int"
+      pythonValue "int"
       value oo
     Text
       Users may add additional hooks using @TO "addHook"@ or the
@@ -531,7 +539,7 @@ doc ///
       "https://docs.python.org/3/library/functions.html#getattr", "getattr"}@
       function.
     Example
-      foo = rs "'Hello, world!'"
+      foo = pythonValue "'Hello, world!'"
       (getattr(foo, "upper"))()
     Text
       In Python, "." is generally used as a shortcut for this function, but
@@ -561,7 +569,7 @@ doc ///
       "https://docs.python.org/3/library/functions.html#hasattr", "hasattr"}@
       function.
     Example
-      foo = rs "'Hello, world!'"
+      foo = pythonValue "'Hello, world!'"
       hasattr(foo, "upper")
       hasattr(foo, "bar")
 ///
@@ -615,6 +623,6 @@ doc ///
       "https://docs.python.org/3/library/functions.html#type", "type"}@ function
       in Python.
     Example
-      objectType rs "2"
-      objectType rs "'Hello, world!'"
+      objectType pythonValue "2"
+      objectType pythonValue "'Hello, world!'"
 ///

--- a/M2/Macaulay2/packages/Python/examples/___Python.out
+++ b/M2/Macaulay2/packages/Python/examples/___Python.out
@@ -1,4 +1,4 @@
--- -*- M2-comint -*- hash: -846338172
+-- -*- M2-comint -*- hash: 636783514
 
 i1 : toPython {1, 2/3, "foo", (1, 2, 3), hashTable {"foo" => "bar"}}
 
@@ -6,7 +6,7 @@ o1 = [1, 0.6666666666666666, 'foo', (1, 2, 3), {'foo': 'bar'}]
 
 o1 : PythonObject of class list
 
-i2 : value rs "[1, 2/3, 'foo', (1, 2, 3), {'foo' : 'bar'}]"
+i2 : value pythonValue "[1, 2/3, 'foo', (1, 2, 3), {'foo' : 'bar'}]"
 
 o2 = {1, .666667, foo, (1, 2, 3), HashTable{foo => bar}}
 

--- a/M2/Macaulay2/packages/Python/examples/___Python__Object.out
+++ b/M2/Macaulay2/packages/Python/examples/___Python__Object.out
@@ -1,12 +1,12 @@
--- -*- M2-comint -*- hash: 69153162
+-- -*- M2-comint -*- hash: 658999336
 
-i1 : x = rs "5"
+i1 : x = pythonValue "5"
 
 o1 = 5
 
 o1 : PythonObject of class int
 
-i2 : y = rs "2"
+i2 : y = pythonValue "2"
 
 o2 = 2
 

--- a/M2/Macaulay2/packages/Python/examples/_getattr.out
+++ b/M2/Macaulay2/packages/Python/examples/_getattr.out
@@ -1,6 +1,6 @@
--- -*- M2-comint -*- hash: -1348121585
+-- -*- M2-comint -*- hash: 1790491913
 
-i1 : foo = rs "'Hello, world!'"
+i1 : foo = pythonValue "'Hello, world!'"
 
 o1 = Hello, world!
 

--- a/M2/Macaulay2/packages/Python/examples/_getitem.out
+++ b/M2/Macaulay2/packages/Python/examples/_getitem.out
@@ -1,6 +1,6 @@
--- -*- M2-comint -*- hash: -256566628
+-- -*- M2-comint -*- hash: -842121848
 
-i1 : x = rs "[1,2,3,4]"
+i1 : x = pythonValue "[1,2,3,4]"
 
 o1 = [1, 2, 3, 4]
 
@@ -18,7 +18,7 @@ o3 = 2
 
 o3 : PythonObject of class int
 
-i4 : x = rs "{'spam':1,'eggs':2}"
+i4 : x = pythonValue "{'spam':1,'eggs':2}"
 
 o4 = {'spam': 1, 'eggs': 2}
 

--- a/M2/Macaulay2/packages/Python/examples/_hasattr.out
+++ b/M2/Macaulay2/packages/Python/examples/_hasattr.out
@@ -1,6 +1,6 @@
--- -*- M2-comint -*- hash: 1419129866
+-- -*- M2-comint -*- hash: 262776068
 
-i1 : foo = rs "'Hello, world!'"
+i1 : foo = pythonValue "'Hello, world!'"
 
 o1 = Hello, world!
 

--- a/M2/Macaulay2/packages/Python/examples/_iter.out
+++ b/M2/Macaulay2/packages/Python/examples/_iter.out
@@ -1,6 +1,6 @@
--- -*- M2-comint -*- hash: -256197891
+-- -*- M2-comint -*- hash: -968680977
 
-i1 : x = rs "range(3)"
+i1 : x = pythonValue "range(3)"
 
 o1 = range(0, 3)
 
@@ -8,7 +8,7 @@ o1 : PythonObject of class range
 
 i2 : i = iter x
 
-o2 = <range_iterator object at 0x7f4fd3629c30>
+o2 = <range_iterator object at 0x7f3350e77990>
 
 o2 : PythonObject of class range_iterator
 

--- a/M2/Macaulay2/packages/Python/examples/_iterable__To__List.out
+++ b/M2/Macaulay2/packages/Python/examples/_iterable__To__List.out
@@ -1,6 +1,6 @@
--- -*- M2-comint -*- hash: -1865839374
+-- -*- M2-comint -*- hash: 20170580
 
-i1 : x = rs "range(3)"
+i1 : x = pythonValue "range(3)"
 
 o1 = range(0, 3)
 

--- a/M2/Macaulay2/packages/Python/examples/_length_lp__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_length_lp__Python__Object_rp.out
@@ -1,10 +1,10 @@
--- -*- M2-comint -*- hash: -136132636
+-- -*- M2-comint -*- hash: 1577276388
 
-i1 : length rs "'Hello, world!'"
+i1 : length pythonValue "'Hello, world!'"
 
 o1 = 13
 
-i2 : length rs "[1,2,3,4,5]"
+i2 : length pythonValue "[1,2,3,4,5]"
 
 o2 = 5
 

--- a/M2/Macaulay2/packages/Python/examples/_next.out
+++ b/M2/Macaulay2/packages/Python/examples/_next.out
@@ -1,6 +1,6 @@
--- -*- M2-comint -*- hash: 799998303
+-- -*- M2-comint -*- hash: -289822447
 
-i1 : x = rs "range(3)"
+i1 : x = pythonValue "range(3)"
 
 o1 = range(0, 3)
 
@@ -8,7 +8,7 @@ o1 : PythonObject of class range
 
 i2 : i = iter x
 
-o2 = <range_iterator object at 0x7f83f73cbc30>
+o2 = <range_iterator object at 0x7f4e4babf990>
 
 o2 : PythonObject of class range_iterator
 

--- a/M2/Macaulay2/packages/Python/examples/_object__Type.out
+++ b/M2/Macaulay2/packages/Python/examples/_object__Type.out
@@ -1,12 +1,12 @@
--- -*- M2-comint -*- hash: 935509013
+-- -*- M2-comint -*- hash: 42511345
 
-i1 : objectType rs "2"
+i1 : objectType pythonValue "2"
 
 o1 = <class 'int'>
 
 o1 : PythonObject of class type
 
-i2 : objectType rs "'Hello, world!'"
+i2 : objectType pythonValue "'Hello, world!'"
 
 o2 = <class 'str'>
 

--- a/M2/Macaulay2/packages/Python/examples/_python__Value.out
+++ b/M2/Macaulay2/packages/Python/examples/_python__Value.out
@@ -1,0 +1,24 @@
+-- -*- M2-comint -*- hash: 170764785
+
+i1 : pythonValue "2 + 2"
+
+o1 = 4
+
+o1 : PythonObject of class int
+
+i2 : debugLevel = 1
+
+o2 = 1
+
+i3 : x = 5
+
+o3 = 5
+
+i4 : pythonValue("3 + ", x)
+ -- python command: 3 + 5
+
+o4 = 8
+
+o4 : PythonObject of class int
+
+i5 : 

--- a/M2/Macaulay2/packages/Python/examples/_rs.out
+++ b/M2/Macaulay2/packages/Python/examples/_rs.out
@@ -1,9 +1,0 @@
--- -*- M2-comint -*- hash: -99396530
-
-i1 : rs "2 + 2"
-
-o1 = 4
-
-o1 : PythonObject of class int
-
-i2 : 

--- a/M2/Macaulay2/packages/Python/examples/_setitem.out
+++ b/M2/Macaulay2/packages/Python/examples/_setitem.out
@@ -1,6 +1,6 @@
--- -*- M2-comint -*- hash: 1819488742
+-- -*- M2-comint -*- hash: 1233933522
 
-i1 : x = rs "[1,2,3,4]"
+i1 : x = pythonValue "[1,2,3,4]"
 
 o1 = [1, 2, 3, 4]
 
@@ -14,7 +14,7 @@ o3 = [5, 2, 3, 4]
 
 o3 : PythonObject of class list
 
-i4 : x = rs "{'spam':1,'eggs':2}"
+i4 : x = pythonValue "{'spam':1,'eggs':2}"
 
 o4 = {'spam': 1, 'eggs': 2}
 

--- a/M2/Macaulay2/packages/Python/examples/_to__Function.out
+++ b/M2/Macaulay2/packages/Python/examples/_to__Function.out
@@ -1,4 +1,4 @@
--- -*- M2-comint -*- hash: -454216416
+-- -*- M2-comint -*- hash: -1691897374
 
 i1 : math = import "math"
 
@@ -18,7 +18,7 @@ o3 = 1.4142135623730951
 
 o3 : PythonObject of class float
 
-i4 : int = toFunction rs "int"
+i4 : int = toFunction pythonValue "int"
 
 o4 = int
 

--- a/M2/Macaulay2/packages/Python/examples/_value_lp__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_value_lp__Python__Object_rp.out
@@ -1,6 +1,6 @@
--- -*- M2-comint -*- hash: -1994211580
+-- -*- M2-comint -*- hash: 2033858126
 
-i1 : value rs "[1, 3.14159, 'foo', (1,2,3), {'foo':'bar'}]"
+i1 : value pythonValue "[1, 3.14159, 'foo', (1,2,3), {'foo':'bar'}]"
 
 o1 = {1, 3.14159, foo, (1, 2, 3), HashTable{foo => bar}}
 
@@ -29,7 +29,7 @@ o3 = {0 => (value, PythonObject, Strategy => unknown -> PythonObject)    }
 
 o3 : NumberedVerticalList
 
-i4 : rs "int"
+i4 : pythonValue "int"
 
 o4 = <class 'int'>
 

--- a/M2/Macaulay2/packages/Python/no-python.m2
+++ b/M2/Macaulay2/packages/Python/no-python.m2
@@ -10,13 +10,12 @@ export {
     "iter",
     "iterableToList",
     "next",
+    "pythonValue",
     "setattr",
     "setitem",
     "toFunction",
     "toPython",
-    "rs",
     "objectType",
-    "runPythonString",
     "runSimpleString"}
 
 errmsg = "Macaulay2 was built without Python support"
@@ -46,6 +45,10 @@ iterableToList PythonObject := err
 
 next = method()
 next PythonObject := err
+
+pythonValue = method(Dispatch => Thing)
+pythonValue String :=
+pythonValue Sequence := err
 
 setattr = method()
 setattr(PythonObject, String, Thing) := err
@@ -88,7 +91,5 @@ PythonObject_Thing :=
 +PythonObject :=
 -PythonObject := err
 
-rs = x -> error errmsg
 objectType = x -> error errmsg
-runPythonString = x -> error errmsg
 runSimpleString = x -> error errmsg


### PR DESCRIPTION
As suggested in https://github.com/Macaulay2/M2/pull/2316#issuecomment-975969351.

We also rename `runPythonString` to `pythonRunString` for consistency with the other wrappers around the Python C API and stop exporting it.