### PR TITLE
Fixes for help

### DIFF
--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -5,7 +5,6 @@ needs "gateway.m2"
 needs "lists.m2"
 needs "methods.m2"
 needs "nets.m2"
-needs "packages.m2"
 
 -----------------------------------------------------------------------------
 -- code
@@ -172,8 +171,6 @@ methods Thing  := F -> (
     if nullaryMethods#?(1:F) then found#(1:F) = true;
     searchAllDictionaries(Type, T -> scan(thingMethods(T, F), key -> found#key = true));
     previousMethodsFound = new NumberedVerticalList from sortByName keys found)
-
-methods Package := P -> select(methods(), m -> package m === P)
 
 -- this one is here because it needs previousMethodsFound
 options ZZ := i -> options previousMethodsFound#i

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -396,7 +396,7 @@ locate DocumentTag := tag -> (
 
 emptyOptionTable := new OptionTable from {}
 getOptionDefaultValues := method(Dispatch => Thing)
-getOptionDefaultValues Symbol   := x -> if value x =!= x then getOptionDefaultValues value x else emptyOptionTable
+getOptionDefaultValues Symbol   := x -> if instance(f := value x, Function) then getOptionDefaultValues f else emptyOptionTable
 getOptionDefaultValues Thing    := x -> emptyOptionTable
 getOptionDefaultValues Function := f -> (
      o := options f;

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -403,7 +403,6 @@ getBody := (key, tag, rawdoc) -> (
 -- View help within Macaulay2
 -----------------------------------------------------------------------------
 
--- TODO: help symbol% before Macaulay2Doc is installed doesn't work
 help = method(Dispatch => Thing)
 help DocumentTag := tag -> (
     rawdoc := fetchAnyRawDocumentation tag;

--- a/M2/Macaulay2/m2/loadsequence
+++ b/M2/Macaulay2/m2/loadsequence
@@ -27,6 +27,7 @@ hypertext.m2
 validate.m2
 expressions.m2
 peek.m2
+code.m2
 printing.m2
 http.m2
 
@@ -83,7 +84,6 @@ schubert.m2
 local.m2
 
 packages.m2
-code.m2
 examples.m2
 document.m2
 installPackage.m2

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -1,6 +1,7 @@
 --		Copyright 1993-2003 by Daniel R. Grayson
 -- TODO: eventually we won't be able to keep all packages open, anyway, since 256 can be our limit on open file descriptors
 
+needs "code.m2"
 needs "files.m2"
 needs "fold.m2"
 needs "lists.m2"
@@ -112,6 +113,7 @@ net      Package :=
 toString Package := pkg -> if pkg#?"pkgname" then pkg#"pkgname" else "-*package*-"
 texMath  Package := pkg -> texMath toString pkg
 options  Package := pkg -> pkg.Options
+methods  Package := memoize(pkg -> select(methods(), m -> package m === pkg))
 
 -- TODO: should this go elsewhere?
 toString Dictionary := dict -> (


### PR DESCRIPTION
@DanGrayson I think this should at least alleviate the slowdown problem from https://github.com/Macaulay2/M2/pull/2325#issuecomment-980467493, which is that truly finding all methods installed by a package (i.e., including methods installed on shared symbols and types from other packages), takes time:
https://github.com/Macaulay2/M2/blob/111568ca104e0979f195ed30e058207860a7ecf0/M2/Macaulay2/m2/packages.m2#L115

If there was a way for the `Package` object to have that list from when it is being loaded, that would help a lot.