### PR TITLE
Null out values in the dictionaries created by capture before returning

### DIFF
--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -89,6 +89,8 @@ capture String := opts -> s -> if opts.UserMode then capture' s else (
     if not hasmode ArgNoPreload then
     scan(Core#"pre-installed packages", needsPackage);
     needsPackage \ toString \ flatten { if opts.PackageExports === null then currentPackage else opts.PackageExports };
+    --shallow copy, but we only need to remember which things started with attributes
+    oldAttributes := copy Attributes;
     -- TODO: is this still necessary? If so, add a test in tests/normal/capture.m2
     -- dictionaryPath = prepend(oldPrivateDictionary,      dictionaryPath); -- this is necessary mainly due to T from degreesMonoid
     dictionaryPath = prepend(User#"private dictionary", dictionaryPath); -- this is necessary mainly due to indeterminates.m2
@@ -97,14 +99,16 @@ capture String := opts -> s -> if opts.UserMode then capture' s else (
     ret := capture' s;
     collectGarbage();
 
+    --Without the toSequence {v}, if v is a Sequence, hasAnAttribute breaks
     scan(value \ values User#"private dictionary", v ->
-	if hasAttribute(v, ReverseDictionary) then removeAttribute(v, ReverseDictionary));
+        if hasAnAttribute toSequence {v} and not oldAttributes#?v
+        then remove(Attributes,v));
     -- null out all symbols in the private dictionary, otherwise those values leak
     -- See bug #2330 for details.
-    scan(values User#"private dictionary", s -> s <- null);
+    scan(values User#"private dictionary", s -> (if mutable s then s <- null));
     User#"private dictionary" = oldPrivateDictionary;
     -- null out the symbols in the OutputDictionary as well
-    scan(values OutputDictionary, s -> s <- null);
+    scan(values OutputDictionary, s -> (if mutable s then s <- null));
     popvar symbol OutputDictionary;
     -- TODO: this should eventually be unnecessary
     scan(keys oldMutableVars, symb -> symb <- oldMutableVars#symb);
@@ -136,8 +140,7 @@ isCapturable = (inputs, pkg, isTest) -> (
     and not match("(addHook|export|newPackage)",              inputs) -- these commands have permanent effects
     and not match("(installMethod|installAssignmentMethod)",  inputs) -- same as above
     and not match("(Global.*Hook|add.*Function|Echo|Print)",  inputs) -- same as above
-    and not match("(method)",                                 inputs) -- same as above
-    and not match("(protect)",                                inputs) -- currently capture tries to clear all symbols, so protect breaks it
+    and not match("(importFrom|exportFrom)",                  inputs) -- currently capture tries to clear all symbols created, these break it
     )
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -136,6 +136,8 @@ isCapturable = (inputs, pkg, isTest) -> (
     and not match("(addHook|export|newPackage)",              inputs) -- these commands have permanent effects
     and not match("(installMethod|installAssignmentMethod)",  inputs) -- same as above
     and not match("(Global.*Hook|add.*Function|Echo|Print)",  inputs) -- same as above
+    and not match("(method)",                                 inputs) -- same as above
+    and not match("(protect)",                                inputs) -- currently capture tries to clear all symbols, so protect breaks it
     )
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -99,7 +99,12 @@ capture String := opts -> s -> if opts.UserMode then capture' s else (
 
     scan(value \ values User#"private dictionary", v ->
 	if hasAttribute(v, ReverseDictionary) then removeAttribute(v, ReverseDictionary));
+    -- null out all symbols in the private dictionary, otherwise those values leak
+    -- See bug #2330 for details.
+    scan(values User#"private dictionary", s -> s <- null);
     User#"private dictionary" = oldPrivateDictionary;
+    -- null out the symbols in the OutputDictionary as well
+    scan(values OutputDictionary, s -> s <- null);
     popvar symbol OutputDictionary;
     -- TODO: this should eventually be unnecessary
     scan(keys oldMutableVars, symb -> symb <- oldMutableVars#symb);

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -128,8 +128,8 @@ isCapturable = (inputs, pkg, isTest) -> (
     inputs = replace("-\\*.*?\\*-", "", inputs);
     -- TODO: remove this when the effects of capture on other packages is reviewed
     (isTest or match({"FirstPackage", "Macaulay2Doc"},            pkg#"pkgname"))
-    and not match({"MultiprojectiveVarieties", "EngineTests", "ThreadedGB", "RunExternalM2", "DiffAlg", "SpecialFanoFourfolds"}, pkg#"pkgname")
-    and not (match({"Core", "Cremona"}, pkg#"pkgname") and version#"pointer size" == 4)
+    and not match({"MultiprojectiveVarieties", "EngineTests","ThreadedGB","RunExternalM2","SpecialFanoFourfolds"}, pkg#"pkgname")
+    and not (match({"Cremona"}, pkg#"pkgname") and version#"pointer size" == 4)
     -- FIXME: these are workarounds to prevent bugs, in order of priority for being fixed:
     and not match("(gbTrace|NAGtrace)",                       inputs) -- cerr/cout directly from engine isn't captured
     and not match("(notify|stopIfError|debuggingMode)",       inputs) -- stopIfError and debuggingMode may be fixable

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_assignment.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_assignment.m2
@@ -242,6 +242,7 @@ document {
 		    }},
 	  "The first line of the following example illustrates the syntax above.",
 	  EXAMPLE lines ///
+               -* no-capture-flag *-
 	       String * String = peek;
 	       "left" * "right" = "value"
 	  ///,
@@ -516,6 +517,7 @@ document {
 		    }},
 	  "The first line of the following example illustrates the syntax above.",
 	  EXAMPLE lines ///
+              -* no-capture-flag *-
 	       String * String := peek;
 	       "left" * "right"
 	  ///,


### PR DESCRIPTION
This will partially fix #2330. Each time `new Dictionary` is called at the M2 level, and then values stored to symbols from that dictionary, the values actually go into `globalFrame` and thus require an entry in that frame. However these entries are not reclaimable in any way.

This change at least prevents those values from leaking by nulling out those entries before the exit from capture. This does not prevent the `globalFrame` itself from getting larger, but that is a much smaller issue.

This is not the optimal fix, a better fix would be to allow the explicit creation of a Dictionary at the M2 level with a temporary frame, but that's a much larger change. This also does not fix that the Dictionary and the associated symbols leak, but that's a much smaller leak, and also somewhat harder to fix. 

@d-torrance This probably fixes one of the culprits of the out of memory test failures with capture, so it's worth testing to see which of those still occur with this. For that it's probably necessary to disable some of the checks in `isCapturable`.