### PR TITLE
Define AO_fetch_and_add1 using atomic builtins if not available

### DIFF
--- a/M2/Macaulay2/e/finalize.cpp
+++ b/M2/Macaulay2/e/finalize.cpp
@@ -4,6 +4,14 @@
 #include "engine-includes.hpp"
 
 #include <atomic_ops.h>
+// AO_fetch_and_add1 is not available on some architectures (e.g., hppa)
+#ifndef AO_HAVE_fetch_and_add1
+  AO_INLINE AO_t AO_fetch_and_add1(volatile AO_t *addr)
+  {
+    return __atomic_fetch_add(addr, 1, __ATOMIC_RELAXED);
+  }
+#endif
+
 #include "monideal.hpp"
 #include "comp-gb.hpp"
 #include "comp-res.hpp"

--- a/M2/Macaulay2/e/finalize.cpp
+++ b/M2/Macaulay2/e/finalize.cpp
@@ -3,7 +3,7 @@
 #include "finalize.hpp"
 #include "engine-includes.hpp"
 
-#include "atomic_ops.h"
+#include <atomic_ops.h>
 #include "monideal.hpp"
 #include "comp-gb.hpp"
 #include "comp-res.hpp"


### PR DESCRIPTION
`finalize.cpp` isn't compiling on hppa machines because `AO_fetch_and_add1` isn't defined (see #1555).  So we define an alternate version using atomic builtins, adapted from https://github.com/ivmai/libatomic_ops/blob/044317a0cbc17c33820c6cf50af300cf0150d0ba/src/atomic_ops/sysdeps/gcc/generic-arithm.h#L182-L187.

I tested this branch on a Debian hppa porterbox, and the file compiles correctly:
```m2
(sid_hppa-dchroot)dtorrance@panama:~/M2/M2/BUILD/doug$ make -C Macaulay2/e finalize.o
make: Entering directory '/home/dtorrance/M2/M2/BUILD/doug/Macaulay2/e'
CXX finalize.cpp
make: Leaving directory '/home/dtorrance/M2/M2/BUILD/doug/Macaulay2/e'
```