### PR TITLE
Generalize unique to work for all visible lists

### DIFF
--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -80,7 +80,7 @@ product Set := s -> product toList s
 
 unique = method(Dispatch => Thing, TypicalValue => List)
 unique Sequence := x -> unique toList x
-unique List := x -> (
+unique VisibleList := x -> (
      -- old faster way: keys set x
      -- new way preserves order:
      seen := new MutableHashTable;

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/unique-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/unique-doc.m2
@@ -4,7 +4,7 @@
 doc///
  Key
   unique
-  (unique, List)
+  (unique, VisibleList)
   (unique, Sequence)
  Headline
   eliminate duplicates from a list


### PR DESCRIPTION
For example:

```m2
i1 : unique [1, 1, 2, 3]

o1 = [1, 2, 3]

o1 : Array

i2 : unique <|1, 1, 2, 3|>

o2 = <|1, 2, 3|>

o2 : AngleBarList
```