### PR TITLE
Use TO2 (or TT) for synonym links in documentation

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -287,7 +287,7 @@ net TO  := x -> (
      then concatenate( "\"", format x#0, "\"", if x#?1 then x#1)
      else horizontalJoin( "\"", net x#0, "\"", if x#?1 then x#1)
      )
-net TO2 := x -> x#1
+net TO2 := x -> format x#1
 
 -- TODO: move this back from help.m2
 net  MENU := x -> net redoMENU x

--- a/M2/Macaulay2/packages/Macaulay2Doc/groebner.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/groebner.m2
@@ -375,7 +375,7 @@ document {
      is continued by re-issuing the same command.  Alternatively, the
      command can be issued with the option ", TT "StopBeforeComputation => true", ".
      It will stop immediately, and return a Groebner basis object that can
-     be inspected with ", TO "gens", " or ", TO "syz", ".
+     be inspected with ", TO2(generators, "gens"), " or ", TO "syz", ".
      The computation can be continued later.",
 	EXAMPLE {
 		   "R = ZZ/1277[x..z];",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_ideals.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_ideals.m2
@@ -260,7 +260,7 @@ document {
 	    },
 
      SUBSECTION "the generators as a matrix or list of elements",
-       "Use ", TO "generators", " or its abbreviation ", TO "gens", " to 
+       "Use ", TO "generators", " or its abbreviation ", TT "gens", " to
        get the generators of an ideal ", TT "I", " as a matrix.  
        Applying ", TT "first entries", " to this matrix converts it 
        to a list.",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_matrices.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_matrices.m2
@@ -347,7 +347,7 @@ document {
 
 document {
      Key => "determinants and minors",
-     "The command ", TO "det", " can be used to compute the determinant of 
+     "The command ", TO2(determinant, "det"), " can be used to compute the determinant of
      a square matrix.",
      EXAMPLE {
 	  "R = ZZ[a..d];",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_ringmaps.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_ringmaps.m2
@@ -347,7 +347,7 @@ document {
 document {
      Key => "kernel and coimage of a ring map",
      "The kernel and coimage of a ring map can be computed
-     using ", TO "coimage", " and ", TO "ker", " .  The output
+     using ", TO "coimage", " and ", TO2(kernel, "ker"), " .  The output
      of ", TT "ker", " is an ideal and the output of ", TT "coimage", " is a
      ring or quotient ring.",
      EXAMPLE {

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview4.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview4.m2
@@ -265,7 +265,7 @@ document {
      projective resolution of ", TT "M", ", then it can be installed
      with ", TT "M.cache.resolution = C", ".",
      PARA{},
-     "There are various optional arguments associated with ", TO "res", "
+     "There are various optional arguments associated with ", TO2(resolution, "res"), "
      which allow detailed control over the progress of the computation."
      }
 

--- a/M2/Macaulay2/packages/QuillenSuslin.m2
+++ b/M2/Macaulay2/packages/QuillenSuslin.m2
@@ -1999,7 +1999,7 @@ document {
      },
      
      PARA{}, "Notice that after multiplying ", TT "U", " by the unimodular matrix ", TT "A", " and applying the
-     change of variables ", TT "B", " (using the ", TO "sub", " command), the first entry in ", TT "U'", " above is now monic in ", TT "x", ".",
+     change of variables ", TT "B", " (using the ", TO2(substitute, "sub"), " command), the first entry in ", TT "U'", " above is now monic in ", TT "x", ".",
      
      PARA{}, "The order of the variables given in the list matter, as changeVar 
      will construct a change of variable so that the new unimodular row is monic in the ", EM "last",


### PR DESCRIPTION
Otherwise, `makeDocumentTag` will replace the synonym with the longer version function name.

Closes: #2352

### Before

The description text doesn't match up with the example:

```m2
i2 : help "determinants and minors"

o2 = determinants and minors
     ***********************

     The command "determinant" can be used to compute the determinant of a
     square matrix.
     +--------------------------------+
     |  i1 : R = ZZ[a..d];            |
     +--------------------------------+
     |  i2 : f = matrix{{a,b},{c,d}}  |
     |                                |
     |  o2 = | a b |                  |
     |       | c d |                  |
     |                                |
     |               2       2        |
     |  o2 : Matrix R  <--- R         |
     +--------------------------------+
     |  i3 : det f                    |
     |                                |
     |  o3 = - b*c + a*d              |
     |                                |
     |  o3 : R                        |
     +--------------------------------+
 ```

### After

Previously, `net(TO2)` didn't call `format`, so we also add that for consistency with `net(TO)`:

```m2
i2 : help "determinants and minors"

o2 = determinants and minors
     ***********************

     The command "det" can be used to compute the determinant of a square
     matrix.
     +--------------------------------+
     |  i1 : R = ZZ[a..d];            |
     +--------------------------------+
     |  i2 : f = matrix{{a,b},{c,d}}  |
     |                                |
     |  o2 = | a b |                  |
     |       | c d |                  |
     |                                |
     |               2       2        |
     |  o2 : Matrix R  <--- R         |
     +--------------------------------+
     |  i3 : det f                    |
     |                                |
     |  o3 = - b*c + a*d              |
     |                                |
     |  o3 : R                        |
     +--------------------------------+
     
 ```