### PR TITLE
Include <utility> before we redefine bool_constant

### DIFF
--- a/M2/Macaulay2/e/aring-zzp-ffpack.hpp
+++ b/M2/Macaulay2/e/aring-zzp-ffpack.hpp
@@ -8,6 +8,7 @@
 #include "ringelem.hpp"
 
 #include <type_traits> // define bool_constant to fix issue #2347
+#include <utility>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"


### PR DESCRIPTION
It's included by `<fflas-ffpack/ffpack/ffpack.h>` and uses `bool_constant`, which we were redefining.  This was causing an error in Debian and Gentoo with GCC 11.  So we include it before redefining `bool_constant`, as suggested by @jkyang92  in https://github.com/Macaulay2/M2/issues/2347#issuecomment-1005021141.

Closes: #2347