### PR TITLE
Add "degreeSequence" method to Graphs package

### DIFF
--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -253,6 +253,9 @@ runcmd := cmd -> (
 Digraph = new Type of HashTable
 Graph = new Type of Digraph
 
+Digraph.synonym = "digraph"
+Graph.synonym = "graph"
+
 digraph = method(Options => {symbol Singletons => null, symbol EntryMode => "auto"})
 digraph List := Digraph => opts -> L -> (
     mode := if #L == 0 or opts.EntryMode == "edges" then "e" 

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -5485,6 +5485,9 @@ TEST ///
   digraph ({2, 1, 3}, {{2, 1}, {3, 1}})})
 ///
 
+TEST ///
+assert Equation(degreeSequence pathGraph 5, {2, 2, 2, 1, 1})
+///
 
 end;
 

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -1969,6 +1969,26 @@ doc ///
         degree
 ///
 
+doc ///
+    Key
+        degreeSequence
+        (degreeSequence, Graph)
+    Headline
+        the degree sequence of a graph
+    Usage
+        degreeSequence G
+    Inputs
+        G:Graph
+    Outputs
+        :List -- the degree sequence of G
+    Description
+        Text
+            The degree sequence of a graph is the list of the degrees of its
+            vertices sorted in nonincreasing order.
+        Example
+            degreeSequence pathGraph 5
+///
+
 --edges
 doc ///
     Key

--- a/M2/Macaulay2/packages/Graphs.m2
+++ b/M2/Macaulay2/packages/Graphs.m2
@@ -69,6 +69,7 @@ export {
     -- Basic data
     "adjacencyMatrix",
     "degreeMatrix",
+    "degreeSequence",
     "edges",
     "incidenceMatrix",
     "laplacianMatrix",
@@ -363,6 +364,9 @@ degree (Digraph,Thing) := ZZ => (D,v) -> #(children(D,v) + parents(D,v))
 
 degreeMatrix = method()
 degreeMatrix Digraph := Matrix => G -> diagonalMatrix apply(entries transpose adjacencyMatrix G, a -> #positions(a, j -> j != 0))
+
+degreeSequence = method()
+degreeSequence Graph := List => G -> rsort \\ sum \ entries adjacencyMatrix G
 
 edges = method()
 edges Digraph := List => D -> (


### PR DESCRIPTION
The [degree sequence](https://en.wikipedia.org/wiki/Degree_(graph_theory)#Degree_sequence) of a graph is a useful invariant, e.g., we can quickly see that two graphs aren't isomorphic if their degree sequences differ.

We add a new method `degreeSequence` to the `Graphs` package that returns the degree sequence of a given graph as a list:

```m2
i2 : degreeSequence pathGraph 5

o2 = {2, 2, 2, 1, 1}

o2 : List
```
We also take the opportunity to introduce synonyms for the `Graph` and `Digraph` classes to make the documentation look a bit nicer:

#### Before
```m2
i2 : help completeGraph

o2 = completeGraph -- Constructs a complete graph
     ********************************************

     Synopsis
     ========

       * Usage: 
             K = completeGraph n
       * Inputs:
           * n, an "integer", 
       * Outputs:
           * K, an instance of the type "Graph", The complete graph with n vertices
```


#### After
```m2
i2 : help completeGraph

o2 = completeGraph -- Constructs a complete graph
     ********************************************

     Synopsis
     ========

       * Usage: 
             K = completeGraph n
       * Inputs:
           * n, an "integer", 
       * Outputs:
           * K, a "graph", The complete graph with n vertices
```