### PR TITLE
Add grammar for highlight.js

### DIFF
--- a/M2/Macaulay2/editors/.gitignore
+++ b/M2/Macaulay2/editors/.gitignore
@@ -1,6 +1,7 @@
 emacs/M2-emacs-hlp.txt
 emacs/M2-emacs.m2
 emacs/M2-symbols.el
+highlightjs/macaulay2.js
 prism/macaulay2.js
 pygments/macaulay2.py
 rouge/macaulay2.rb

--- a/M2/Macaulay2/editors/highlightjs/README.md
+++ b/M2/Macaulay2/editors/highlightjs/README.md
@@ -1,0 +1,66 @@
+Macaulay2 in highlight.js
+=========================
+
+[highlight.js](https://highlightjs.org/) is a JavaScript syntax highlighter
+with language auto-detection and zero dependencies.
+
+Building
+--------
+
+You will need [node](https://nodejs.org/) and [git](https://git-scm.com/)
+installed.  You should also have the Macaulay2 source repository cloned, say
+at `/path/to/M2/source`.
+
+First, clone the highlight.js repository:
+
+```
+git clone https://github.com/highlightjs/highlight.js
+cd highlight.js
+npm install
+```
+
+Next, generate the Macaulay2 language file:
+
+```
+mkdir -p extra/highlightjs-macaulay2/src/languages
+M2 --script /path/to/M2/source/M2/Macaulay2/editors/make-M2-symbols.m2
+cp highlightjs/macaulay2.js extra/highlightjs-macaulay2/src/languages
+```
+
+Finally, build:
+
+```
+node ./tools/build.js -t cdn
+```
+
+The generated files should now be in the `build` directory.  Copy the
+following files to your project:
+
+* `build/highlight.min.js`
+* `build/languages/macaulay2.min.js`
+* `build/styles/default.min.css` (or any of the other styles in `build/styles`)
+
+Using
+-----
+
+In your html file, include the following, adjusting the paths to the css and
+js files as necessary:
+
+```html
+<link rel="stylesheet" href="/path/to/default.min.css">
+<script type="text/javascript" src="/path/to/highlight.min.js"></script>
+<script type="text/javascript" src="/path/to/macaulay2.min.js"></script>
+<script type="text/javascript">
+  hljs.highlightAll();
+</script>
+```
+
+Then include your Macaulay2 code:
+
+```html
+<pre>
+<code class="language-macaulay2">
+-- Macaulay2 code goes here
+</code>
+</pre>
+```

--- a/M2/Macaulay2/editors/highlightjs/macaulay2.js.in
+++ b/M2/Macaulay2/editors/highlightjs/macaulay2.js.in
@@ -1,0 +1,43 @@
+/*
+Language: Macaulay2
+Author: Doug Torrance <dtorrance@piedmont.edu>
+Description: Macaulay2 is a software system devoted to supporting research in algebraic geometry and commutative algebra
+Website: https://faculty.math.illinois.edu/Macaulay2/
+Category: scientific
+*/
+
+export default function(hljs) {
+  return {
+    name: "Macaulay2",
+    contains: [
+      hljs.NUMBER_MODE,
+      hljs.QUOTE_STRING_MODE,
+      {
+	scope: "string",
+	begin: "///",
+	end: "(?<!/)/(//)+(?!/)"
+      },
+      hljs.COMMENT("--", "$"),
+      hljs.COMMENT("-\\*", "\\*-")
+    ],
+
+    // @M2BANNER@
+    // see M2/Macaulay2/editors/make-M2-symbols.m2 in the Macaulay2 source
+    // https://github.com/Macaulay2/M2
+
+    keywords: {
+      keyword: [
+	@M2KEYWORDS@
+      ],
+      type: [
+	@M2DATATYPES@
+      ],
+      built_in: [
+	@M2FUNCTIONS@
+      ],
+      literal: [
+	@M2CONSTANTS@
+      ]
+    }
+  }
+}

--- a/M2/Macaulay2/editors/make-M2-symbols.m2
+++ b/M2/Macaulay2/editors/make-M2-symbols.m2
@@ -8,6 +8,7 @@
 --  - Atom & Linguist: https://github.com/Macaulay2/language-macaulay2
 --  - Rouge
 --  - Pygments
+--  - highlight.js
 
 -------------------------------------------------------------------------------
 -- TODO: Move these two elsewhere:
@@ -133,6 +134,16 @@ symbolsForPygments = template -> (
     output = replace("@M2STRINGS@",                  STRINGS,   output);
     output)
 
+hljsformat = symlist -> demark("," | newline | "	", format \ symlist)
+symbolsForHighlightJS = template -> (
+    output := replace("@M2BANNER@",   banner,               template);
+    output = replace("@M2VERSION@",   version#"VERSION",    output);
+    output = replace("@M2KEYWORDS@",  hljsformat KEYWORDS,  output);
+    output = replace("@M2DATATYPES@", hljsformat DATATYPES, output);
+    output = replace("@M2FUNCTIONS@", hljsformat FUNCTIONS, output);
+    output = replace("@M2CONSTANTS@", hljsformat CONSTANTS, output);
+    output)
+
 -------------------------------------------------------------------------------
 -- Generate syntax files from templates in the same directory
 
@@ -163,6 +174,9 @@ generateGrammar("vim/m2.vim.dict", symbolsForVim); -- TODO: is this necessary?
 
 -- Pygments: Write macaulay2.py
 generateGrammar("pygments/macaulay2.py", symbolsForPygments)
+
+-- highlight.js: Write macaulay2.js
+generateGrammar("highlightjs/macaulay2.js", symbolsForHighlightJS)
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/emacs M2-symbols "


### PR DESCRIPTION
[highlight.js](https://highlightjs.org/) is a JavaScript syntax highlighter with language auto-detection and zero dependencies.

With this PR, `make-M2-symbols.m2` generates a `macaulay2.js` file that can be used with highlight.js to syntax highlight Macaulay2 code, such as [this example](https://webwork.piedmont.edu/~dtorrance/highlightjs-macaulay2).
