### PR TITLE
Add "--with-documentation" option to configure (autotools build)

### DIFF
--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -12,7 +12,10 @@ PACKAGES = $(ALL_PACKAGES)
 # packages under development that should be checked but not installed:
 DEVEL = EngineTests
 
-MakeDocumentation ?= true
+MakeDocumentation ?= $(if @DOCUMENTATION@,true,false)
+MakeHTML ?= $(if $(filter html, @DOCUMENTATION@),true,false)
+MakeInfo ?= $(if $(filter info, @DOCUMENTATION@),true,false)
+MakePDF  ?= $(if $(filter pdf , @DOCUMENTATION@),true,false)
 RemakeAllDocumentation ?= false
 IgnoreExampleErrors ?= false
 CheckDocumentation ?= true
@@ -22,6 +25,9 @@ debugLevel ?= 0
 errorDepth ?= 0
 
 ARGS := MakeDocumentation => $(MakeDocumentation),		\
+	MakeHTML => $(MakeHTML),				\
+	MakeInfo => $(MakeInfo),				\
+	MakePDF => $(MakePDF),					\
 	RemakeAllDocumentation => $(RemakeAllDocumentation),	\
 	IgnoreExampleErrors => $(IgnoreExampleErrors),		\
 	RerunExamples => $(RerunExamples),			\

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -174,6 +174,30 @@ AC_CHECK_TOOL(DLLTOOL,dlltool,false)
 AC_CHECK_TOOL(LD,ld,false)
 AC_CHECK_TOOL(STRIP,strip,false)
 
+AC_ARG_WITH([documentation],
+    [AC_HELP_STRING([--with-documentation=...],
+        [space-delimited list of types of documentation to build; available
+         options are "html", "info", and "pdf"; default value is "html info"])],
+    [DOCUMENTATION=$withval],
+    [DOCUMENTATION="html info"])
+
+if test "$DOCUMENTATION" = no
+then DOCUMENTATION=""
+elif test "$DOCUMENTATION" = yes
+then DOCUMENTATION="html info"
+else for DOCTYPE in $DOCUMENTATION
+    do case $DOCTYPE in
+            html|info|pdf)
+                ;;
+            *)
+                AC_MSG_ERROR([unknown documentation type ($DOCTYPE); expected html, info, or pdf])
+                ;;
+        esac
+    done
+fi
+
+AC_SUBST(DOCUMENTATION)
+
 if test "$STRIP" != "false"
 then AC_MSG_CHECKING(whether $STRIP accepts the remove-section option)
      if "$STRIP" --help 2>&1 | grep remove-section >/dev/null


### PR DESCRIPTION
This gives some finer control over which types of documentation (html, info, and/or pdf) are built when first calling the `configure` script.  For example `./configure --without-documentation` would build no documentation, and `./configure --with-documentation=pdf` would only build the pdf documentation.

Note that `./configure --with-documentation` or just `./configure` will build the html and info documentation (the current default).