### PR TITLE
A few html-check-links fixes

### DIFF
--- a/M2/Macaulay2/Makefile.in
+++ b/M2/Macaulay2/Makefile.in
@@ -3,7 +3,8 @@
 VPATH = @srcdir@
 include ../include/config.Makefile
 all: @pre_docdir@/COPYING-GPL-2 @pre_docdir@/COPYING-GPL-3 @pre_docdir@/README @pre_docdir@/LAYOUT
-SUBDIRS = util c d e system bin m2 man packages editors html-check-links tests
+SUBDIRS = util c d e system bin m2 man packages editors \
+	$(if $(filter html, @DOCUMENTATION@), html-check-links) tests
 
 define do-in-subdirs
 $(foreach d,$(SUBDIRS),

--- a/M2/Macaulay2/packages/HomotopyLieAlgebra.m2
+++ b/M2/Macaulay2/packages/HomotopyLieAlgebra.m2
@@ -4,7 +4,7 @@ newPackage(
                 Version => "0.9",                                                
                 Date => "October 19, 2021",                                        
                 Authors => {                                                     
-                    {Name => "David Eisenbud", Email => "de@msri.org", HomePage => "www.msri.org/~de"}
+                    {Name => "David Eisenbud", Email => "de@msri.org", HomePage => "https://www.msri.org/~de"}
 		    },
                 DebuggingMode => false,
 		PackageExports => {"DGAlgebras"}

--- a/M2/Macaulay2/packages/Tropical.m2
+++ b/M2/Macaulay2/packages/Tropical.m2
@@ -832,7 +832,7 @@ doc ///
 	       {HREF("https://math.berkeley.edu/~yelena/", "Yelena Mandelshtam")},
 	       {HREF("https://alessioborzi.github.io/", "Alessio Borzì")},
 	       {HREF("https://www.linkedin.com/in/timothyxu/", "Timothy Xu")},
-	       {HREF{"publish.uwo.ca/~aashra9/","Ahmed Umer Ashraf"}}
+	       {HREF{"https://publish.uwo.ca/~aashra9/","Ahmed Umer Ashraf"}}
     	     }@
 ///
 


### PR DESCRIPTION
So it turns out that I broke `make -C html-check-links` last year in #1875...  By switching from using `xargs` to `find`'s `-exec` option, we ended up not checking *any* of the html documentation for broken links.  Oops!

An alternate solution to the original problem (when `find` doesn't find anything, e.g., when not building the documentation,`ls` gets empty input, and so we end up checking all the non-html files in the directory for broken links) is to go back to using `xargs` but pass its `-r` option (or `--no-run-if-empty`), which means that we own't even bother running `ls` if `find` doesn't find anything.  (Note that this is a GNU extension to `xargs`, but this is already the default behavior for the BSD `find` and `-r` exists as a noop for compatibility with the GNU version.  So I believe this change should be fine on macOS.)

After getting the check working again, I found two failures in the documentation (author homepages that were missing `https://`'s), which I fixed.  Note that one of these (David Eisenbud's) gives a 404 error: https://www.msri.org/~de.  It appears 31 times in various package files, so it should probably be updated.