### PR TITLE
configure --with-documentation updates

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -174,30 +174,6 @@ AC_CHECK_TOOL(DLLTOOL,dlltool,false)
 AC_CHECK_TOOL(LD,ld,false)
 AC_CHECK_TOOL(STRIP,strip,false)
 
-AC_ARG_WITH([documentation],
-    [AC_HELP_STRING([--with-documentation=...],
-        [space-delimited list of types of documentation to build; available
-         options are "html", "info", and "pdf"; default value is "html info"])],
-    [DOCUMENTATION=$withval],
-    [DOCUMENTATION="html info"])
-
-if test "$DOCUMENTATION" = no
-then DOCUMENTATION=""
-elif test "$DOCUMENTATION" = yes
-then DOCUMENTATION="html info"
-else for DOCTYPE in $DOCUMENTATION
-    do case $DOCTYPE in
-            html|info|pdf)
-                ;;
-            *)
-                AC_MSG_ERROR([unknown documentation type ($DOCTYPE); expected html, info, or pdf])
-                ;;
-        esac
-    done
-fi
-
-AC_SUBST(DOCUMENTATION)
-
 if test "$STRIP" != "false"
 then AC_MSG_CHECKING(whether $STRIP accepts the remove-section option)
      if "$STRIP" --help 2>&1 | grep remove-section >/dev/null
@@ -230,6 +206,30 @@ if "$TAR" --version | head -1 | grep "GNU tar" >/dev/null 2>&1
 then AC_MSG_RESULT(yes)
 else AC_MSG_ERROR($TAR: GNU tar is required)
 fi
+
+AC_ARG_WITH([documentation],
+    [AC_HELP_STRING([--with-documentation=...],
+        [space-delimited list of types of documentation to build; available
+         options are "html", "info", and "pdf"; default value is "html info"])],
+    [DOCUMENTATION=$withval],
+    [DOCUMENTATION="html info"])
+
+if test "$DOCUMENTATION" = no
+then DOCUMENTATION=""
+elif test "$DOCUMENTATION" = yes
+then DOCUMENTATION="html info"
+else for DOCTYPE in $DOCUMENTATION
+    do case $DOCTYPE in
+            html|info|pdf)
+                ;;
+            *)
+                AC_MSG_ERROR([unknown documentation type ($DOCTYPE); expected html, info, or pdf])
+                ;;
+        esac
+    done
+fi
+
+AC_SUBST(DOCUMENTATION)
 
 AC_CANONICAL_HOST()
 AC_SUBST(ARCH,$build_cpu)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1880,6 +1880,7 @@ AC_MSG_NOTICE([with  OPTIMIZE          = $OPTIMIZE])
 AC_MSG_NOTICE([with  DEBUG             = $DEBUG])
 AC_MSG_NOTICE([with  GIT_DESCRIPTION   = $GIT_DESCRIPTION])
 AC_MSG_NOTICE([with  USING_MPIR        = $USING_MPIR])
+AC_MSG_NOTICE([with  DOCUMENTATION     = $DOCUMENTATION])
 
 subset() {
     # whether the words of $1 are among the words of $2


### PR DESCRIPTION
This is a short followup to #2389.

Two things:
* I put the `configure --with-documentation` code in a strange place in the file, right in the middle of the check for `strip`.  It's been moved a few lines down, after finishing the checks for various installed programs.
* There's now a report at the end of the script:
<pre>
$ ../../configure --with-documentation="html pdf"
configure: configuring Macaulay2 version 1.19.1.1
.
.
.
configure: with  DEBUG             = no
configure: with  GIT_DESCRIPTION   = version-1.19.1.1-90-885cb67c23-dirty
configure: with  USING_MPIR        = 0
<b>configure: with  DOCUMENTATION     = html pdf</b>
configure: staging area for common files: /home/profzoom/src/macaulay2/M2/M2/BUILD/doug/usr-dist/common
configure: staging area for architecture dependent files: /home/profzoom/src/macaulay2/M2/M2/BUILD/doug/usr-dist/x86_64-Linux-Ubuntu-21.10
</pre>