### PR TITLE
More autotools documentation config updates

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -208,11 +208,11 @@ then AC_MSG_RESULT(yes)
 else AC_MSG_ERROR($TAR: GNU tar is required)
 fi
 
-AC_ARG_WITH([documentation],
-    [AC_HELP_STRING([--with-documentation=...],
+AC_ARG_ENABLE([documentation],
+    [AC_HELP_STRING([--enable-documentation=...],
         [space-delimited list of types of documentation to build; available
          options are "html", "info", and "pdf"; default value is "html info"])],
-    [DOCUMENTATION=$withval],
+    [DOCUMENTATION=$enableval],
     [DOCUMENTATION="html info"])
 
 if test "$DOCUMENTATION" = no

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -209,7 +209,7 @@ else AC_MSG_ERROR($TAR: GNU tar is required)
 fi
 
 AC_ARG_ENABLE([documentation],
-    [AC_HELP_STRING([--enable-documentation=...],
+    [AS_HELP_STRING([--enable-documentation=...],
         [space-delimited list of types of documentation to build; available
          options are "html", "info", and "pdf"; default value is "html info"])],
     [DOCUMENTATION=$enableval],


### PR DESCRIPTION
Another short followup to #2389 and #2393:

* `--enable-documentation` is more appropriate than `--with-documentation`, as according to the autoconf docs, the [former](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/html_node/Package-Options.html) should be used for package features and the [latter](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/html_node/External-Software.html) for external packages.
* `AC_HELP_STRING` -> `AS_HELP_STRING` (see #2395)