### PR TITLE
better fix for module == comparison

### DIFF
--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -230,7 +230,7 @@ describe Module := M -> Describe (
      )
 toExternalString Module := M -> toString describe M
 
-Module == Module := (M,N) -> (
+Module == Module := (M,N) -> M === N or (
      -- this code might not be the quickest - Mike should check it
      ring M === ring N
      and degrees ambient M === degrees ambient N
@@ -242,6 +242,8 @@ Module == Module := (M,N) -> (
 	       -- else 
 		    (
 		    -- temporary
+		    M.relations === N.relations
+		    or
 		    isSubset(image M.relations, image N.relations)
 		    and
 		    isSubset(image N.relations, image M.relations)

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -232,62 +232,62 @@ toExternalString Module := M -> toString describe M
 
 Module == Module := (M,N) -> (
      -- this code might not be the quickest - Mike should check it
-     M === N or (
-	  ring M === ring N
-	  and degrees ambient M === degrees ambient N
-	  and (
-	       if M.?relations 
-	       then N.?relations and (
-		    -- if isHomogeneous N.relations and isHomogeneous M.relations
-		    -- then gb N.relations == gb M.relations
+     ring M === ring N
+     and degrees ambient M === degrees ambient N
+     and (
+	  if M.?relations 
+	  then N.?relations and (
+	       -- if isHomogeneous N.relations and isHomogeneous M.relations
+	       -- then gb N.relations == gb M.relations
+	       -- else 
+		    (
+		    -- temporary
+		    isSubset(image M.relations, image N.relations)
+		    and
+		    isSubset(image N.relations, image M.relations)
+		    )
+	       )
+     	  else not N.?relations
+	  )
+     and (
+	  if M.?generators then (
+	       if N.?generators then (
+		    f := (
+			 if M.?relations 
+			 then M.relations|M.generators
+		    	 else M.generators);
+		    g := (
+			 if N.?relations
+			 then N.relations|N.generators
+			 else N.generators);
+		    -- if isHomogeneous f and isHomogeneous g
+		    -- then gb f == gb g
 		    -- else 
 			 (
 			 -- temporary
-			 M.relations === N.relations
-			 or (
-			      isSubset(image M.relations, image N.relations)
-			      and
-			      isSubset(image N.relations, image M.relations))))
-	       else not N.?relations or N.relations == 0)
-	  and (
-	       if M.?generators then (
-		    if N.?generators then (
-			 f := (
-			      if M.?relations 
-			      then M.relations|M.generators
-			      else M.generators);
-			 g := (
-			      if N.?relations
-			      then N.relations|N.generators
-			      else N.generators);
-			 -- if isHomogeneous f and isHomogeneous g
-			 -- then gb f == gb g
-			 -- else 
-			      (
-			      -- temporary
-			      isSubset(image f, image g)
-			      and
-			      isSubset(image g, image f)
-			      )
+		    	 isSubset(image f, image g)
+		    	 and
+		    	 isSubset(image g, image f)
 			 )
-		    else (
-			 f = (
-			      if M.?relations
-			      then M.relations|M.generators
-			      else M.generators
-			      );
-			 if isHomogeneous f then f = substitute(f,0);
-			 isSubset(ambient N, image f)))
+		    )
 	       else (
-		    if N.?generators then (
-			 g = (
-			      if N.?relations 
-			      then N.relations|N.generators 
-			      else N.generators
-			      );
-			 if isHomogeneous g then g = substitute(g,0);
-			 isSubset(ambient M, image g))
-		    else true))))
+		    f = (
+			 if M.?relations
+			 then M.relations|M.generators
+			 else M.generators
+			 );
+		    if isHomogeneous f then f = substitute(f,0);
+		    isSubset(ambient N, image f)))
+	  else (
+	       if N.?generators then (
+		    g = (
+			 if N.?relations 
+			 then N.relations|N.generators 
+			 else N.generators
+			 );
+		    if isHomogeneous g then g = substitute(g,0);
+		    isSubset(ambient M, image g))
+	       else true)))
 
 degrees Module := N -> if N.?degrees then N.cache.degrees else N.cache.degrees = (
      if not isFreeModule N then N = cover N;

--- a/M2/Macaulay2/tests/normal/matRR.m2
+++ b/M2/Macaulay2/tests/normal/matRR.m2
@@ -3,3 +3,9 @@ matrix(RR,{{1.2}})
 matrix(CC,{{1.2}})
 matrix{{1.0+ii,3.2+.3*ii}}
 
+
+-- issue #2405
+f = matrix{{1.3, 1.4}, {1.1, 1.5}, {.3, .6}}
+M = image f
+assert(M == M)
+assert(M == image f)

--- a/M2/Macaulay2/tests/normal/matRR.m2
+++ b/M2/Macaulay2/tests/normal/matRR.m2
@@ -3,9 +3,3 @@ matrix(RR,{{1.2}})
 matrix(CC,{{1.2}})
 matrix{{1.0+ii,3.2+.3*ii}}
 
-
--- issue #2405
-f = matrix{{1.3, 1.4}, {1.1, 1.5}, {.3, .6}}
-M = image f
-assert(M == M)
-assert(M == image f)


### PR DESCRIPTION
Reverts Macaulay2/M2#2406 and applies simpler fix for it.

Also I removed the `N.relations == 0` that was added here:
https://github.com/Macaulay2/M2/blob/0b0159476fbb752b5c0bfd9a50a50b41c0cf95a5/M2/Macaulay2/m2/modules.m2#L251

This is either superfluous or wrong, and here is why: suppose it is necessary to check the case when M doesn't have relations but N does and they are just 0, then the result of `M == N` and `N == M` would be different, because then this part would return false:
https://github.com/Macaulay2/M2/blob/0b0159476fbb752b5c0bfd9a50a50b41c0cf95a5/M2/Macaulay2/m2/modules.m2#L239-L240

If it is necessary then there should be a check for both M and N, and there should be a test for it.