### PR TITLE
Recursively call "info" in (info, PRE)

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -176,7 +176,8 @@ net CODE  :=
 info TT   :=
 info CODE :=  x -> horizontalJoin apply(noopts x,net)
 
-info PRE  := x -> wrap(printWidth, "-", concatenate apply(noopts x,toString))
+info PRE  := x ->
+    wrap(printWidth, "-", concatenate apply(noopts x,toString @@ info))
 
 net TH := Hop(net, "-")
 


### PR DESCRIPTION
`PRE` objects may contain other objects (e.g., `CODE` objects with at least one option) for which `toString` isn't sufficient for proper formatting.

---

This issue became apparent after #2391.

### Before
```m2
i2 : info PRE M2CODE "foo"

o2 = CODE{class => language-macaulay2, foo}
```

### After
```m2
i6 : info PRE M2CODE "foo"

o6 = foo
```