### PR TITLE
OnlineLookup update: isc, fix #2414 and #2408

### DIFF
--- a/M2/Macaulay2/m2/http.m2
+++ b/M2/Macaulay2/m2/http.m2
@@ -21,14 +21,14 @@ GET := (host,url,connection) -> (
 POST := (host,url,body,connection) -> (
      connection = 
      openInOut connection
-     << "POST " << url << " HTTP/1.1" << endl
-     << "User-Agent: " << httpProduct << endl
-     << "Connection: close" << endl
-     << "Host: " << host << endl
-     << "Content-type: application/x-www-form-urlencoded" << endl
-     << "Content-length: " << # body << endl << endl
-     << body << endl
-     << endl << flush;
+     << "POST " << url << " HTTP/1.1" << crlf
+     << "User-Agent: " << httpProduct << crlf
+     << "Connection: close" << crlf
+     << "Host: " << host << crlf
+     << "Content-type: application/x-www-form-urlencoded" << crlf
+     << "Content-length: " << # body << crlf << crlf
+     << body << crlf
+     << crlf << flush;
      first( get connection, close connection )
      )
 

--- a/M2/Macaulay2/m2/http.m2
+++ b/M2/Macaulay2/m2/http.m2
@@ -5,14 +5,16 @@ needs "methods.m2"
 getWWW = method()
 httpProduct := concatenate("Macaulay2/", version#"VERSION")
 
+crlf := "\r\n";
+
 GET := (host,url,connection) -> (
      connection = 
      openInOut connection
-     << "GET " << url << " HTTP/1.1" << endl
-     << "User-Agent: " << httpProduct << endl
-     << "Connection: close" << endl
-     << "Host: " << host << endl
-     << endl << flush;
+     << "GET " << url << " HTTP/1.1" << crlf
+     << "User-Agent: " << httpProduct << crlf
+     << "Connection: close" << crlf
+     << "Host: " << host << crlf
+     << crlf << flush;
      first( get connection, close connection )
      )
 

--- a/M2/Macaulay2/packages/OnlineLookup.m2
+++ b/M2/Macaulay2/packages/OnlineLookup.m2
@@ -1,7 +1,7 @@
 -- -*- coding: utf-8 -*-
 newPackage(
         "OnlineLookup",
-        Version => "0.5",
+        Version => "0.6",
         Date => "Mar 2, 2022",
         Authors => {{Name => "Paul Zinn-Justin",
                   Email => "pzinn@unimelb.edu.au",
@@ -9,29 +9,38 @@ newPackage(
         Headline => "Look up mathematical information online",
 	Keywords => {"System"},
         DebuggingMode => false,
-	AuxiliaryFiles => false,
+	AuxiliaryFiles => true,
+	CacheExampleOutput => true,
 	PackageImports => {"Text"}
         )
 
-export {"oeis","urlEncode"}
+export {"oeis","urlEncode","isc"}
 
--- TODO might need more encoding. see also html.m2
-urlEncode = s -> if s === null then s else (
-     s = replace("\\s", "%20", s);
-     s = replace(",", "%2C", s);
-     s = replace("/", "%2F", s);
-     s
-     )
+percentEncoding = hashTable transpose {
+    {"␣", "!", "#", "$", "%", "&", "'", "(", ")", "*", "+", ",", "/", ":", ";", "=", "?", "@", "[", "]"},
+    {"%20", "%21", "%23", "%24", "%25", "%26", "%27", "%28", "%29", "%2A", "%2B", "%2C", "%2F", "%3A", "%3B", "%3D", "%3F", "%40", "%5B", "%5D"}
+    }
+
+-- TODO: use to/move in html.m2
+urlEncode = method()
+urlEncode Nothing := identity
+urlEncode String := s -> concatenate apply(s, c -> if percentEncoding#?c then percentEncoding#c else c)
 
 oeisHTTP := "http://oeis.org";
 oeisHTTPS := "https://oeis.org";
+
+tryWWW = url -> try last splitWWW getWWW url else (
+    << "--warning: failed to fetch from the web" << endl;
+    return "";
+    )
+
 
 oeis = method(TypicalValue => NumberedVerticalList,
     Options => {Limit => 100, Position => 0})
 oeis VisibleList := o -> L -> oeis (demark(",",toString\L),o)
 oeis String := o -> search -> (
     url:=oeisHTTP|"/search?q="|urlEncode search|"&fmt=text&start="|o.Position|"&n="|o.Limit; -- limit the number of results
-    www := last splitWWW getWWW url;
+    www :=  tryWWW url;
     ans := select("(?<=^%N ).*$",www);    
     NumberedVerticalList apply(ans, line -> SPAN(
             blank := regex(" ",line);
@@ -44,6 +53,24 @@ oeis String := o -> search -> (
     )
 -- e.g. oeis {1,2,7,42}
 
+isc = method()
+
+isc Constant := isc @@ numeric
+isc RR := x -> (
+    s := format(0,-1,1000,1000,"",x);
+    isc substring(s,0,#s-1) -- remove last digit for now... TODO better
+    )
+isc String := s -> (
+    url := "http://wayback.cecm.sfu.ca/cgi-bin/isc/lookup?number="|urlEncode s|"&lookup_type=simple";
+    www := tryWWW url;
+    ans := select("(?<=<PRE>)[\\s\\S]*?(?=</PRE>)",www);
+    if #ans == 0 then return {};
+    ans = first ans;
+    lst := select(separate("\n\n",ans),x->#x>3 and substring(x,0,3)=="<B>");
+    VerticalList apply(lst,x->SPAN replace("<.*?>","",x))
+    )
+
+
 beginDocumentation()
 multidoc ///
  Node
@@ -55,7 +82,7 @@ multidoc ///
    Text
     The purpose of this package is to collect helper functions that allow to query web sites for mathematical
     information and format it into Macaulay2 output.
-    At present, it only contains one such function, @TO{oeis}@, but more will be implemented in the future.
+    At present, it contains two such functions, @TO{oeis}@ and @TO{isc}@, but more will be implemented in the future.
  Node
   Key
    oeis
@@ -67,7 +94,8 @@ multidoc ///
    OEIS lookup
   Description
    Text
-    This function looks up the argument (a list of integers or a string) in the Online Encyclopedia of Integer Sequences (@HREF "http://oeis.org/"@).
+    This function looks up the argument (a list of integers or a string) in the Online Encyclopedia of Integer Sequences
+    (@HREF "http://oeis.org/"@).
    Example
     oeis {1,3,31,1145}
    Text
@@ -76,6 +104,19 @@ multidoc ///
     L = apply(5,n->n!);
     oeis (L,Limit=>5)
     oeis (L,Limit=>1,Position=>2)
+ Node
+  Key
+   isc
+   (isc, String)
+   (isc, RR)
+  Headline
+   ISC lookup
+  Description
+   Text
+    This function looks up the argument (a real number or a string) in the Inverse Symbolic Calculator.
+    (@HREF "http://wayback.cecm.sfu.ca/projects/ISC/"@).
+   Example
+    isc (sqrt 2*pi)
  Node
   Key
    urlEncode

--- a/M2/Macaulay2/packages/OnlineLookup/examples/_isc.out
+++ b/M2/Macaulay2/packages/OnlineLookup/examples/_isc.out
@@ -1,0 +1,19 @@
+-- -*- M2-comint -*- hash: 674672945
+
+i1 : isc (sqrt 2*pi)
+
+o1 = {Mixed constants with 5 operations                                 }
+     {4442882938158366 = 2*Pi/sr(2)                                     }
+     {Beta(a,b), a and b elements of F24: GAMMA function                }
+     {4442882938158366 = Beta(1/4,3/4)                                  }
+     {Mixed constants, 2 with elementary transforms.                    }
+     {4442882938158366 = GAM(1/4)*GAM(3/4)                              }
+     {Mixed constants with 5 operations                                 }
+     {4442882938158366 = GAM(1/6)/sr(2)*GAM(5/6)                        }
+     {Dirichlet constants, sums of Digamma function with rat. arguments.}
+     {4442882938158366 = -Psi(1/4)-Psi(3/8)+Psi(5/8)+Psi(3/4)           }
+     {                                                                  }
+
+o1 : VerticalList
+
+i2 : 

--- a/M2/Macaulay2/packages/OnlineLookup/examples/_oeis.out
+++ b/M2/Macaulay2/packages/OnlineLookup/examples/_oeis.out
@@ -1,0 +1,28 @@
+-- -*- M2-comint -*- hash: 1103500785
+
+i1 : oeis {1,3,31,1145}
+
+o1 = {0 => (A029729 (see https://oeis.org/A029729 ) Degree of the variety of pairs of commuting n X n matrices.)}
+     {1 => (A094579 (see https://oeis.org/A094579 ) Duplicate of A029729.)                                      }
+
+o1 : NumberedVerticalList
+
+i2 : L = apply(5,n->n!);
+
+i3 : oeis (L,Limit=>5)
+
+o3 = {0 => (A000142 (see https://oeis.org/A000142 ) Factorial numbers: n! = 1*2*3*4*...*n (order of symmetric group S_n, number of permutations of n letters).)}
+     {1 => (A072856 (see https://oeis.org/A072856 ) Number of permutations satisfying i-4<=p(i)<=i+4, i=1..n (permutations of length n within distance 4).)    }
+     {2 => (A061602 (see https://oeis.org/A061602 ) Sum of factorials of the digits of n.)                                                                     }
+     {3 => (A177523 (see https://oeis.org/A177523 ) Number of permutations of 1..n avoiding adjacent step pattern up, up, up, up.)                             }
+     {4 => (A263777 (see https://oeis.org/A263777 ) Number of inversion sequences avoiding pattern 201 (or 210).)                                              }
+
+o3 : NumberedVerticalList
+
+i4 : oeis (L,Limit=>1,Position=>2)
+
+o4 = {0 => (A061602 (see https://oeis.org/A061602 ) Sum of factorials of the digits of n.)}
+
+o4 : NumberedVerticalList
+
+i5 : 


### PR DESCRIPTION
- `OnlineLookup` now allows to query the Inverse Symbolic Calculator. This required fixing #2414.
- `OnlineLookup` now gracefully warns user when no internet is available, which should solve #2408.
also, examples are now cached.