### PR TITLE
Add support for --disable-build-mathicgb/etc. to check-configure

### DIFF
--- a/M2/check-configure/Makefile.in
+++ b/M2/check-configure/Makefile.in
@@ -1,6 +1,9 @@
 VPATH = @srcdir@
 LDFLAGS = -L$(BUILTLIBPATH)/lib
 CPPFLAGS = -I$(BUILTLIBPATH)/include
+BUILD_MEMTAILOR = $(if $(filter memtailor, @BUILDSUBLIST@),yes,no)
+BUILD_MATHIC    = $(if $(filter mathic   , @BUILDSUBLIST@),yes,no)
+BUILD_MATHICGB  = $(if $(filter mathicgb , @BUILDSUBLIST@),yes,no)
 include ../include/config.Makefile
 check: clean-and-config
 clean:; rm -rf tmp
@@ -23,6 +26,9 @@ check-config:
 	    CFLAGS="$(CFLAGS)"							\
 	    CXXFLAGS="$(CXXFLAGS)"						\
 	    --build="@build_alias@"						\
+	    --enable-build-memtailor=$(BUILD_MEMTAILOR)				\
+	    --enable-build-mathic=$(BUILD_MATHIC)				\
+	    --enable-build-mathicgb=$(BUILD_MATHICGB)				\
 	    --disable-building
 distclean:: clean; rm -f Makefile
 Makefile: Makefile.in ; cd .. && ./config.status check-configure/Makefile


### PR DESCRIPTION
This is a quick followup to #2394.

Currently `make -C check-configure` might fail if building mathicgb is disabled and googletest >= 0.10.0 isn't available, as is the case in Ubuntu 18.04.  See, for example, [this PPA build](https://launchpadlibrarian.net/591330262/buildlog_ubuntu-bionic-i386.macaulay2_1.19.1.1+git202203171800-0ppa202203180307~ubuntu18.04.1_BUILDING.txt.gz):

### configure

```
checking for library containing MATHICGB_VERSION_STRING... -lmathicgb
checking mathicgb.h usability... yes
checking mathicgb.h presence... yes
checking for mathicgb.h... yes
checking gtest/gtest.h usability... yes
checking gtest/gtest.h presence... yes
checking for gtest/gtest.h... yes
checking for /usr/src/gtest/src/gtest-all.cc... yes
checking for /usr/src/gtest/src/gtest_main.cc... yes
configure: we have found gtest
```

### check-configure
```
checking gtest/gtest.h usability... yes
checking gtest/gtest.h presence... yes
checking for gtest/gtest.h... yes
checking for /usr/src/gtest/src/gtest-all.cc... yes
checking for /usr/src/gtest/src/gtest_main.cc... yes
checking for gtest version... < 1.10.0
configure: WARNING: mathicgb unit tests require gtest >= 1.10.0; we will download a newer version
configure: we will build gtest

...

configure: error:  *** - automatic building of libraries disabled, but some must be built: gtest 
Makefile:9: recipe for target 'check-config' failed
```
