### PR TITLE
Fix MonomialIdeal::sat crash, see issue #1742

### DIFF
--- a/M2/Macaulay2/e/finalize.cpp
+++ b/M2/Macaulay2/e/finalize.cpp
@@ -3,6 +3,12 @@
 #include "finalize.hpp"
 #include "engine-includes.hpp"
 
+void keepAlive(const void*)
+{
+  // do nothing.  This is just present to make sure the argument is
+  // not garbage collected earlier than it should be.
+}
+
 #include <atomic_ops.h>
 // AO_fetch_and_add1 is not available on some architectures (e.g., hppa)
 #ifndef AO_HAVE_fetch_and_add1

--- a/M2/Macaulay2/e/finalize.hpp
+++ b/M2/Macaulay2/e/finalize.hpp
@@ -7,6 +7,31 @@ class GBComputation;
 class ResolutionComputation;
 class SchreyerOrder;
 
+//* keepAlive: call at the end of a function when using a
+//* finialized object.  More specifically: if you are using an
+//* iterator into a data structure, or any pointers into such, which
+//* are pointed to by the finalized object, call this at the end of
+//* the function in question.
+//*
+//* The reason for this is that the optimizer can potentially elide
+//* the finalized object and the GC finalizer might get called
+//* otherwise on this object.  The finalizer function might then free
+//* the data you are using from underneath you.
+//* 
+//* This happened for instance in the MonomialIdeal class, in
+//* e.g. MonomialIdeal::sat.  If a pointer to the MonomialIdeal is not
+//* being kept in the frontend (as a RawMonomialIdeal) then it was
+//* happening that the optimizer was optimizing out the local
+//* existence of the pointer to this object.  This in turn caused the
+//* destructor of the object to be called, which then left the
+//* iterator traversing the data structure in a bad state (in fact,
+//* all nodes of the data structure were deleted by the destructor).
+//* 
+//* Adding in e.g. `nopAndKeepAlive(&J)` at the end of
+//* MonomialIdeal::sat allows this to not occur.
+
+void keepAlive(const void*);
+
 // These functions should be called if G will not be freed by its owner
 void intern_polyring(const PolynomialRing *G);
 void intern_monideal(MonomialIdeal *G);

--- a/M2/Macaulay2/e/monideal.cpp
+++ b/M2/Macaulay2/e/monideal.cpp
@@ -3,6 +3,7 @@
 #include "monideal.hpp"
 #include "monoid.hpp"
 #include "text-io.hpp"
+#include "finalize.hpp" // for keepAlive
 
 unsigned int MonomialIdeal::computeHashValue() const
 {
@@ -174,6 +175,7 @@ bool MonomialIdeal::is_equal(const MonomialIdeal &mi0) const
       i++;
       j++;
     }
+  keepAlive(&mi0);
   return true;
 }
 
@@ -619,6 +621,7 @@ MonomialIdeal *MonomialIdeal::intersect(const MonomialIdeal &J) const
           }
     }
   MonomialIdeal *result = new MonomialIdeal(get_ring(), new_elems);
+  keepAlive(&J);
   return result;
 }
 
@@ -649,6 +652,7 @@ MonomialIdeal *MonomialIdeal::operator*(const MonomialIdeal &J) const
         new_elems.insert(b);
       }
   MonomialIdeal *result = new MonomialIdeal(get_ring(), new_elems);
+  keepAlive(&J);
   return result;
 }
 
@@ -666,6 +670,7 @@ MonomialIdeal *MonomialIdeal::operator+(const MonomialIdeal &J) const
       new_elems.insert(b);
     }
   MonomialIdeal *result = new MonomialIdeal(get_ring(), new_elems);
+  keepAlive(&J);
   return result;
 }
 
@@ -683,6 +688,7 @@ MonomialIdeal *MonomialIdeal::operator-(const MonomialIdeal &J) const
           result->insert_minimal(b);
         }
     }
+  keepAlive(&J);
   return result;
 }
 
@@ -714,6 +720,7 @@ MonomialIdeal *MonomialIdeal::quotient(const MonomialIdeal &J) const
       delete result;
       result = next_result;
     }
+  keepAlive(&J);
   return result;
 }
 
@@ -792,6 +799,7 @@ MonomialIdeal *MonomialIdeal::sat(const MonomialIdeal &J) const
       delete result;
       result = next_result;
     }
+  keepAlive(&J);
   return result;
 }
 


### PR DESCRIPTION
This pull request (hopefully) fixes the MonomialIdeal::sat crashes we have been seeing for quite some time now.  See issue #1742.

The bug is somewhat subtle.  In the function `MonomialIdeal::sat`, a `MonomialIdeal` is passed in as a pointer (reference).  An iterator traverses the data structure.  While the iteration was going on, every now and then, the garbage collector would run, and would seemingly erroneously free the passed in MonomialIdeal.  This left the iterators in a bad state, causing the crash.

The problem is, I believe, that there were no pointers to this MonomialIdeal object anywhere on the stack: at the front end, in `Saturation.m2`, this function was being called via `rawSaturate(raw monomialIdeal I, raw monomialIdeal J)`, which does not keep a pointer.  It seems the optimizer was removing all of the uses of this object on the stack as well.

When it was collected (during the loop in `MonomialIdeal::sat`), it sometimes freed the entire data structure, so the iterators don't point anywhere good anymore.  How could this be?  Well, the iterator itself doesn't need the container (the MonomialIdeal) to traverse the data structure.  Even though the iterator is a struct, with one member being the pointer to the MonomialIdeal, the optimizer is eliding this variable (i.e. destructing the struct)!  And then the object was being collected prematurely.  And. even though it seemed to be on the call stack, it probably was in a register, and then getting reused.

The fix we decided on (@DanGrayson  and I discussed this): call a new function (in `finalize.{hpp,cpp}`) called `keepAlive` at the end of the function `MonomialIdeal::sat` as in `keepAlive(&J)`.  This prevents the optimizer from removing this function early.

To see the bug in action (every time, not just intermittently), place `GC_gcollect()` inside the loop as 
the last line, and remove the `keepAlive` call.  Then run the following lines of code.  The last line will (as far as I can tell) always crash.  Placing the keepAlive call back in, even with the `GC_gcollect`, keeps it from crashing.
```
    R = ZZ/101[x,y,u,v]
    I = ideal(x*u, y*u, y*v)
    NN = ideal (x*u, x*v, y*u, y*v)
    saturate(I, NN)
```