### PR TITLE
Use GC_reachable_here instead of keepAlive

### DIFF
--- a/M2/Macaulay2/e/finalize.cpp
+++ b/M2/Macaulay2/e/finalize.cpp
@@ -3,12 +3,6 @@
 #include "finalize.hpp"
 #include "engine-includes.hpp"
 
-void keepAlive(const void*)
-{
-  // do nothing.  This is just present to make sure the argument is
-  // not garbage collected earlier than it should be.
-}
-
 #include <atomic_ops.h>
 // AO_fetch_and_add1 is not available on some architectures (e.g., hppa)
 #ifndef AO_HAVE_fetch_and_add1

--- a/M2/Macaulay2/e/finalize.hpp
+++ b/M2/Macaulay2/e/finalize.hpp
@@ -7,31 +7,6 @@ class GBComputation;
 class ResolutionComputation;
 class SchreyerOrder;
 
-//* keepAlive: call at the end of a function when using a
-//* finialized object.  More specifically: if you are using an
-//* iterator into a data structure, or any pointers into such, which
-//* are pointed to by the finalized object, call this at the end of
-//* the function in question.
-//*
-//* The reason for this is that the optimizer can potentially elide
-//* the finalized object and the GC finalizer might get called
-//* otherwise on this object.  The finalizer function might then free
-//* the data you are using from underneath you.
-//* 
-//* This happened for instance in the MonomialIdeal class, in
-//* e.g. MonomialIdeal::sat.  If a pointer to the MonomialIdeal is not
-//* being kept in the frontend (as a RawMonomialIdeal) then it was
-//* happening that the optimizer was optimizing out the local
-//* existence of the pointer to this object.  This in turn caused the
-//* destructor of the object to be called, which then left the
-//* iterator traversing the data structure in a bad state (in fact,
-//* all nodes of the data structure were deleted by the destructor).
-//* 
-//* Adding in e.g. `nopAndKeepAlive(&J)` at the end of
-//* MonomialIdeal::sat allows this to not occur.
-
-void keepAlive(const void*);
-
 // These functions should be called if G will not be freed by its owner
 void intern_polyring(const PolynomialRing *G);
 void intern_monideal(MonomialIdeal *G);

--- a/M2/Macaulay2/e/monideal.cpp
+++ b/M2/Macaulay2/e/monideal.cpp
@@ -3,7 +3,6 @@
 #include "monideal.hpp"
 #include "monoid.hpp"
 #include "text-io.hpp"
-#include "finalize.hpp" // for keepAlive
 
 unsigned int MonomialIdeal::computeHashValue() const
 {
@@ -175,7 +174,7 @@ bool MonomialIdeal::is_equal(const MonomialIdeal &mi0) const
       i++;
       j++;
     }
-  keepAlive(&mi0);
+  GC_reachable_here(&mi0);
   return true;
 }
 
@@ -621,7 +620,7 @@ MonomialIdeal *MonomialIdeal::intersect(const MonomialIdeal &J) const
           }
     }
   MonomialIdeal *result = new MonomialIdeal(get_ring(), new_elems);
-  keepAlive(&J);
+  GC_reachable_here(&J);
   return result;
 }
 
@@ -652,7 +651,7 @@ MonomialIdeal *MonomialIdeal::operator*(const MonomialIdeal &J) const
         new_elems.insert(b);
       }
   MonomialIdeal *result = new MonomialIdeal(get_ring(), new_elems);
-  keepAlive(&J);
+  GC_reachable_here(&J);
   return result;
 }
 
@@ -670,7 +669,7 @@ MonomialIdeal *MonomialIdeal::operator+(const MonomialIdeal &J) const
       new_elems.insert(b);
     }
   MonomialIdeal *result = new MonomialIdeal(get_ring(), new_elems);
-  keepAlive(&J);
+  GC_reachable_here(&J);
   return result;
 }
 
@@ -688,7 +687,7 @@ MonomialIdeal *MonomialIdeal::operator-(const MonomialIdeal &J) const
           result->insert_minimal(b);
         }
     }
-  keepAlive(&J);
+  GC_reachable_here(&J);
   return result;
 }
 
@@ -720,7 +719,7 @@ MonomialIdeal *MonomialIdeal::quotient(const MonomialIdeal &J) const
       delete result;
       result = next_result;
     }
-  keepAlive(&J);
+  GC_reachable_here(&J);
   return result;
 }
 
@@ -799,7 +798,7 @@ MonomialIdeal *MonomialIdeal::sat(const MonomialIdeal &J) const
       delete result;
       result = next_result;
     }
-  keepAlive(&J);
+  GC_reachable_here(&J);
   return result;
 }
 


### PR DESCRIPTION
As suggested by @jkyang92 in yesterday's M2internals.

I applied this as a patch to the PPA builds last night, and the one remnant of #1742 I had been getting even with `keepAlive` (in the `SimplicialDecomposibility::isSheddingVertex` example) ran without problems.
