### PR TITLE
Allow Constant objects in substitute

### DIFF
--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -356,6 +356,7 @@ sub2 = (S,R,v) -> (				   -- S is the target ring or might be null, meaning targ
 	  if class opt =!= Option or #opt =!= 2 then error "expected a list of options";
 	  x := opt#0;
 	  y := opt#1;
+	  if instance(y, Constant) then y = numeric y;
 	  if not instance(y,RingElement) and not instance(y,Number) then error "expected substitution values to be ring elements or numbers";
 	  if S === null
 	  then try commonzero = commonzero + 0_(ring y) else error "expected substitution values to be in compatible rings"


### PR DESCRIPTION
Related to #2404, currently `substitute` doesn't work with `Constant` objects:

```m2
i1 : R = QQ[x];

i2 : sub(x^2 + 1, x => ii)
stdio:2:1:(3): error: expected substitution values to be ring elements or numbers
```
This PR adds support for this feature by calling `numeric` on any `Constant` objects that are passed to `subsitute`:

```m2
i1 : R = QQ[x];

i2 : sub(x^2 + 1, x => ii)

o2 = 0

o2 : CC (of precision 53)
```
