### PR TITLE
Force compiler not to optimize away do_nothing()

### DIFF
--- a/M2/Macaulay2/d/scclib.c
+++ b/M2/Macaulay2/d/scclib.c
@@ -867,7 +867,9 @@ int system_strncmp(M2_string s,M2_string t,int n) {
      return strncmp((char *)s->array,(char *)t->array,n);
 }
 
-void do_nothing () { }
+void do_nothing () {
+     asm volatile ("nop");
+}
 
 /*
 // Local Variables:


### PR DESCRIPTION
This has been known to happen with gcc on newer Ubuntu releases.  When this happens, calling `spin` won't actually take any cycles and tests that rely on this (like `timing-quotient`) will fail.

Closes: #2014

### Before

```m2
i2 : elapsedTime spin 10000
 -- 2.63e-6 seconds elapsed
```

### After

```m2
i2 : elapsedTime spin 10000
 -- 0.776867 seconds elapsed
```