### PR TITLE
Fix git issues #1856, #638

### DIFF
--- a/M2/Macaulay2/e/GF.cpp
+++ b/M2/Macaulay2/e/GF.cpp
@@ -35,7 +35,6 @@ private:
 #include "interrupted.hpp"
 
 #include "aring-m2-gf.hpp"
-#include <iostream>
 
 bool GF::initialize_GF(const RingElement *prim)
 {
@@ -121,9 +120,6 @@ bool GF::initialize_GF(const RingElement *prim)
   zeroV = from_long(0);
   oneV = from_long(1);
   minus_oneV = from_long(-1);
-
-  // M2::GaloisFieldTable G(*_originalR, primelem);
-  //  G.display(std::cout);
 
   return true;
 }
@@ -382,18 +378,33 @@ ring_elem GF::mult(const ring_elem f, const ring_elem g) const
 
 ring_elem GF::power(const ring_elem f, int n) const
 {
-  if (f.get_int() == _ZERO) return ring_elem(_ZERO);
-  int m = (f.get_int() * n) % Q1_;
-  if (m <= 0) m += Q1_;
-  return ring_elem(m);
+  if (f.get_int() != _ZERO)
+    {
+      int m = (f.get_int() * n) % Q1_;
+      if (m <= 0) m += Q1_;
+      return ring_elem(m);
+    }
+  else
+    {
+      // f == 0 element.
+      if (n == 0) return ring_elem(_ONE);
+      return ring_elem(_ZERO);
+    }
 }
 ring_elem GF::power(const ring_elem f, mpz_srcptr n) const
 {
-  if (f.get_int() == _ZERO) return ring_elem(_ZERO);
-  int exp = RingZZ::mod_ui(n, Q1_);
-  int m = (f.get_int() * exp) % Q1_;
-  if (m <= 0) m += Q1_;
-  return ring_elem(m);
+  if (f.get_int() != _ZERO)
+    {
+      int exp = RingZZ::mod_ui(n, Q1_);
+      int m = (f.get_int() * exp) % Q1_; // WARNING TODO: possible overflow! Check!
+      if (m <= 0) m += Q1_;
+      return ring_elem(m);
+    }
+  else
+    {
+      if (mpz_sgn(n) == 0) return ring_elem(_ONE);
+      return ring_elem(_ZERO);
+    }
 }
 
 ring_elem GF::invert(const ring_elem f) const

--- a/M2/Macaulay2/e/ZZp.cpp
+++ b/M2/Macaulay2/e/ZZp.cpp
@@ -249,7 +249,10 @@ ring_elem Z_mod::mult(const ring_elem f, const ring_elem g) const
 ring_elem Z_mod::power(const ring_elem f, int n) const
 {
   if (f.get_int() == _ZERO) {
-    if (n<0) ERROR("division by zero");
+    if (n < 0)
+      ERROR("division by zero");
+    else if (n == 0)
+      return ring_elem(0); // this is the element one in this ring.  (P-1) is the zero element...
     return ring_elem(_ZERO);
   }
   int m = (f.get_int() * n) % _P1;
@@ -260,6 +263,8 @@ ring_elem Z_mod::power(const ring_elem f, mpz_srcptr n) const
 {
   if (f.get_int() == _ZERO) {
     if (mpz_sgn(n)<0) ERROR("division by zero");
+    else if (mpz_sgn(n) == 0)
+      return ring_elem(0);
     return ring_elem(_ZERO);
   }
   int n1 = RingZZ::mod_ui(n, _P1);

--- a/M2/Macaulay2/e/aring-gf-flint-big.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint-big.hpp
@@ -237,9 +237,7 @@ class ARingGFFlintBig : public RingInterface
 
   void power(ElementType& result, const ElementType& a, int n) const
   {
-    if (is_zero(a))
-      set_zero(result);
-    else if (n < 0)
+    if (n < 0)
       {
         invert(result, a);
         fq_nmod_pow_ui(&result, &result, -n, mContext);
@@ -250,87 +248,21 @@ class ARingGFFlintBig : public RingInterface
 
   void power_mpz(ElementType& result, const ElementType& a, mpz_srcptr n) const
   {
-#if 0
-    std::cout << "entering GFBigFLint::power_mpz" << std::endl;
-
-    if (mGeneratorComputed)
-      {
-        std::cout << " gen: " <<  " limbs: " << mCachedGenerator.coeffs << std::endl;
-        std::cout << " gen: " <<  " alloc: " << mCachedGenerator.alloc << std::endl;
-        std::cout << " gen: " <<  " length: " << mCachedGenerator.length << std::endl;
-        std::cout << " sizeof(nmod_poly_struct) = " << sizeof(ElementType) << std::endl;
-        std::cout << " sizeof(nmod_t) = " << sizeof(nmod_t) << std::endl;
-
-        
-      }
-    std::cout << " a: " <<  " limbs: " << a.coeffs << std::endl;
-    std::cout << " a: " <<  " alloc: " << a.alloc << std::endl;
-    std::cout << " a: " <<  " length: " << a.length << std::endl;
-#endif    
-    if (is_zero(a))
-      {
-        set_zero(result);
-        return;
-      }
     mpz_t abs_n;
     mpz_init(abs_n);
-#if 0    
-    mpz_set_si(abs_n, 3);
-    std::cout << " abs_n: " << static_cast<void*>(abs_n) << " limbs: " << abs_n[0]._mp_d << std::endl;
-#endif
     mpz_abs(abs_n, n);
-    //    std::cout << " abs_n: " << static_cast<void*>(abs_n) << " limbs: " << abs_n[0]._mp_d << std::endl;    
     ElementType base;
     init(base);
-#if 0    
-    std::cout << " base: " <<  " limbs: " << base.coeffs << std::endl;
-    std::cout << " base: " <<  " alloc: " << base.alloc << std::endl;
-    std::cout << " base: " <<  " length: " << base.length << std::endl;
-    std::cout << " sizeof(nmod_poly_struct) = " << sizeof(ElementType) << std::endl;
-    std::cout << " sizeof(nmod_t) = " << sizeof(nmod_t) << std::endl;
-#endif    
     if (mpz_sgn(n) < 0)
       invert(base, a);
     else
       copy(base, a);
-#if 0    
-    std::cout << " base: " <<  " limbs: " << base.coeffs << std::endl;
-    std::cout << " base: " <<  " alloc: " << base.alloc << std::endl;
-    std::cout << " base: " <<  " length: " << base.length << std::endl;
-    std::cout << " sizeof(nmod_poly_struct) = " << sizeof(ElementType) << std::endl;
-    std::cout << " sizeof(nmod_t) = " << sizeof(nmod_t) << std::endl;
-#endif
     fmpz_t fn;
-#if 1
     fmpz_init_set_readonly(fn, abs_n);
-    // std::cout << "  about to call fq_nmod_pow" << std::endl;    
-    // std::cout << " abs_n: " << static_cast<void*>(abs_n) << " limbs: " << abs_n[0]._mp_d << std::endl;
     fq_nmod_pow(&result, &base, fn, mContext);
-    // std::cout << "  done calling fq_nmod_pow" << std::endl;
-    // std::cout << " abs_n: " << static_cast<void*>(abs_n) << " limbs: " << abs_n[0]._mp_d << std::endl;
     fmpz_clear_readonly(fn);
-#else
-    fmpz_init(fn);
-    fmpz_set_si(fn, 3);
-
-    std::cout << "  about to call fq_nmod_pow" << std::endl;    
-    std::cout << " abs_n: " << static_cast<void*>(abs_n) << " limbs: " << abs_n[0]._mp_d << std::endl;
-    fq_nmod_pow(&result, &base, fn, mContext);
-    std::cout << "  done calling fq_nmod_pow" << std::endl;
-    std::cout << " abs_n: " << static_cast<void*>(abs_n) << " limbs: " << abs_n[0]._mp_d << std::endl;
-#endif
-
-#if 0
-    std::cout << "  about to clear abs_n" << std::endl;
-    std::cout << " abs_n: " << static_cast<void*>(abs_n) << " limbs: " << abs_n[0]._mp_d << std::endl;
-#endif    
     mpz_clear(abs_n);
-#if 0    
-    std::cout << " abs_n: " << static_cast<void*>(abs_n) << " limbs: " << abs_n[0]._mp_d << std::endl;
-    std::cout << "  about to clear base" << std::endl;
-#endif
     clear(base);
-    //    std::cout << " ... leaving GFBigFLint::power_mpz" << std::endl;
   }
 
   void swap(ElementType& a, ElementType& b) const

--- a/M2/Macaulay2/e/aring-gf-flint.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint.hpp
@@ -226,19 +226,12 @@ class ARingGFFlint : public RingInterface
         invert(result, a);
         fq_zech_pow_ui(&result, &result, -n, mContext);
       }
-    else if (is_zero(a))
-      set_zero(result);
     else
       fq_zech_pow_ui(&result, &a, n, mContext);
   }
 
   void power_mpz(ElementType& result, const ElementType& a, mpz_srcptr n) const
   {
-    if (is_zero(a) && mpz_sgn(n)>=0)
-      {
-        set_zero(result);
-        return;
-      }
     mpz_t abs_n;
     mpz_init(abs_n);
     mpz_abs(abs_n, n);

--- a/M2/Macaulay2/e/aring-m2-gf.hpp
+++ b/M2/Macaulay2/e/aring-m2-gf.hpp
@@ -273,13 +273,34 @@ class ARingGFM2 : public RingInterface
         if (result <= 0) result += mGF.orderMinusOne();
       }
     else
-      result = 0;
+      {
+        // a is the zero element
+        if (n > 0)
+          result = 0;
+        else if (n == 0)
+          result = mGF.one();
+        else
+          ERROR("division by zero");
+      }
   }
 
   void power_mpz(elem &result, elem a, mpz_srcptr n) const
   {
-    long n1 = mpz_fdiv_ui(n, mGF.orderMinusOne());
-    power(result, a, n1);
+    if (a != 0)
+      {
+        long n1 = mpz_fdiv_ui(n, mGF.orderMinusOne());
+        power(result, a, n1);
+      }
+    else
+      {
+        // a is the zero element
+        if (mpz_sgn(n) > 0)
+          result = 0;
+        else if (mpz_sgn(n) == 0)
+          result = mGF.one();
+        else
+          ERROR("division by zero");
+      }
   }
 
   void swap(ElementType &a, ElementType &b) const

--- a/M2/Macaulay2/e/aring-zzp-ffpack.cpp
+++ b/M2/Macaulay2/e/aring-zzp-ffpack.cpp
@@ -196,6 +196,7 @@ void ARingZZpFFPACK::power(ElementType &result,
         set_from_long(result, 1);
       else
         set_zero(result);
+      return;
     }
   ElementType base;
   set(base, a);

--- a/M2/Macaulay2/e/aring-zzp-ffpack.cpp
+++ b/M2/Macaulay2/e/aring-zzp-ffpack.cpp
@@ -190,9 +190,12 @@ void ARingZZpFFPACK::power(ElementType &result,
 {
   if (is_zero(a))
     {
-      if (n < 0) ERROR("division by zero");
-      set(result, a);
-      return;
+      if (n < 0)
+        ERROR("division by zero");
+      else if (n == 0)
+        set_from_long(result, 1);
+      else
+        set_zero(result);
     }
   ElementType base;
   set(base, a);
@@ -224,9 +227,21 @@ void ARingZZpFFPACK::power_mpz(ElementType &result,
                                const ElementType a,
                                mpz_srcptr n) const
 {
-  if (is_zero(a) && mpz_sgn(n)<0) ERROR("division by zero");
-  STT n1 = static_cast<STT>(mpz_fdiv_ui(n, mFfpackField.cardinality() - 1));
-  power(result, a, n1);
+  if (is_zero(a))
+    {
+      if (mpz_sgn(n) < 0)
+        ERROR("division by zero");
+      else if (mpz_sgn(n) == 0)
+        set_from_long(result, 1);
+      else
+        set_zero(result);
+    }
+  else
+    {
+      // a != 0
+      STT n1 = static_cast<STT>(mpz_fdiv_ui(n, mFfpackField.cardinality() - 1));
+      power(result, a, n1);
+    }
 }
 
 ///@note duplicate code

--- a/M2/Macaulay2/e/aring-zzp-flint.hpp
+++ b/M2/Macaulay2/e/aring-zzp-flint.hpp
@@ -171,17 +171,36 @@ class ARingZZpFlint : public RingInterface
 
   void power(ElementType &result, ElementType a, long n) const
   {
-    //    assert(a != 0 || n>=0 );
-    if (a==0 && n<0) ERROR("division by zero");
-    result = n_powmod2_preinv(a, n, mModulus.n, mModulus.ninv);
+    if (a != 0)
+      {
+        result = n_powmod2_preinv(a, n, mModulus.n, mModulus.ninv);
+      }
+    else
+      {
+        // case a == 0
+        if (n < 0) ERROR("division by zero"); // TODO: throw error.
+        if (n == 0) return set_from_long(result, 1);
+        if (n > 0) return set_zero(result);
+      }
   }
 
   void power_mpz(ElementType &result, ElementType a, mpz_srcptr n) const
   {
-    //    assert( a != 0 || mpz_sgn(n)>=0);
-    if (a==0 && mpz_sgn(n)<0) ERROR("division by zero");
-    unsigned long nbar = mpz_fdiv_ui(n, mCharac - 1);
-    result = n_powmod2_ui_preinv(a, nbar, mModulus.n, mModulus.ninv);
+    if (a != 0)
+      {
+        unsigned long nbar = mpz_fdiv_ui(n, mCharac - 1);
+        result = n_powmod2_ui_preinv(a, nbar, mModulus.n, mModulus.ninv);
+      }
+    else
+      {
+        // case a == 0
+        if (mpz_sgn(n) == 0)
+          set_from_long(result, 1);
+        else if (mpz_sgn(n) > 0)
+          set_zero(result);
+        else
+          ERROR("division by zero"); // TODO: throw error.
+      }
   }
 
   void swap(ElementType &a, ElementType &b) const

--- a/M2/Macaulay2/e/aring-zzp.hpp
+++ b/M2/Macaulay2/e/aring-zzp.hpp
@@ -228,15 +228,27 @@ class ARingZZp : public RingInterface
         if (result <= 0) result += p1;
       }
     else
-      result = 0;
+      {
+        // a == 0
+        if (n == 0) result = p1; // the element 1 in this ring.
+        else if (n < 0) ERROR("division by zero");
+        else result = 0;
+      }
   }
 
   void power_mpz(elem &result, elem a, mpz_srcptr n) const
   {
-    //    assert( a != 0 || mpz_sgn(n)>=0);
-    if (a==0 && mpz_sgn(n)<0) ERROR("division by zero");
-    int n1 = static_cast<int>(mpz_fdiv_ui(n, p1));
-    power(result, a, n1);
+    if (a != 0)
+      {
+        int n1 = static_cast<int>(mpz_fdiv_ui(n, p1));
+        power(result, a, n1);
+      }
+    else
+      {
+        if (mpz_sgn(n) == 0) result = p1; // the element 1 in this ring.
+        else if (mpz_sgn(n) < 0) ERROR("division by zero");
+        else result = 0; // result is 0 in the ring.
+      }
   }
 
   void swap(ElementType &a, ElementType &b) const

--- a/M2/Macaulay2/e/weylalg.cpp
+++ b/M2/Macaulay2/e/weylalg.cpp
@@ -49,8 +49,25 @@ bool WeylAlgebra::initialize_weyl(M2_arrayint derivs,
 
   // Now set whether this ring is graded.  This will be the case iff
   // deg(x_i) + deg(D_i) = 2 deg(h), for every i.
+
   if (_homog_var < 0)
-    this->setIsGraded(false);
+    {
+      bool isgraded = true;
+      const Monoid *D = degree_monoid();
+      int *degxD = D->make_one();
+      for (int j = 0; j < _nderivatives; j++)
+        {
+          const int *degx = M_->degree_of_var(_commutative[j]);
+          const int *degD = M_->degree_of_var(_derivative[j]);
+          D->mult(degx, degD, degxD);
+          if (not D->is_one(degxD))
+            {
+              isgraded = false;
+              break;
+            }
+        }
+      this->setIsGraded(isgraded);
+    }
   else
     {
       this->setIsGraded(true);

--- a/M2/Macaulay2/tests/normal/powers-of-zero.m2
+++ b/M2/Macaulay2/tests/normal/powers-of-zero.m2
@@ -1,0 +1,98 @@
+-- git issue 1856: powers of 0 were inconsistent.
+-- e.g. 0^0 is sometimes 1, sometimes 0 (inconsistent choice of convention)
+--      0^n is sometimes non-zero, for n > 0 (bug)
+-- These are fixed in April 2022, these checks make sure it is fixed correctly.
+checkPowersOfZero = (n, F) -> (
+    vals := (0..n) / (i -> 0_F^i);
+    vals == prepend(1_F, n:0_F)
+    )
+previousPrime = (n) -> if n < 2 then null else (while not isPrime n do n = n-1; n)
+
+assert checkPowersOfZero(30, ZZ/5)
+assert checkPowersOfZero(30, ZZ/32003)
+assert checkPowersOfZero(30, ZZ/1048583) -- nextPrime 2^20
+assert checkPowersOfZero(30, ZZ/(nextPrime 2^40)) -- nextPrime 2^40
+assert checkPowersOfZero(30, ZZ/(nextPrime 2^60)) -- nextPrime 2^60
+assert checkPowersOfZero(30, ZZ/(nextPrime 2^63)) -- nextPrime 2^63
+assert checkPowersOfZero(30, GF 5)
+
+assert checkPowersOfZero(30, GF 5)
+assert checkPowersOfZero(30, GF 25)
+assert checkPowersOfZero(30, GF(3^10))
+assert checkPowersOfZero(30, GF(3^50))
+
+assert checkPowersOfZero(30, GF(5, Strategy => "Flint"))
+assert checkPowersOfZero(30, GF(5, Strategy => "FlintBig"))
+assert checkPowersOfZero(30, GF(25, Strategy => "Flint"))
+assert checkPowersOfZero(30, GF(25, Strategy => "FlintBig"))
+assert checkPowersOfZero(30, GF(3^10, Strategy => "Flint"))
+assert checkPowersOfZero(30, GF(3^50, Strategy => "FlintBig"))
+
+assert checkPowersOfZero(30, GF(2, Strategy => "Flint"))
+assert checkPowersOfZero(30, GF(2, Strategy => "FlintBig"))
+assert checkPowersOfZero(30, GF(2^2, Strategy => "Flint"))
+assert checkPowersOfZero(30, GF(2^2, Strategy => "FlintBig"))
+assert checkPowersOfZero(30, GF(2^10, Strategy => "Flint"))
+assert checkPowersOfZero(30, GF(2^80, Strategy => "FlintBig"))
+
+-- Now we check the non-exported ZZ/p, GF types.  Note: Givaro GF are not considered here, as they
+--  have been removed on a branch that will soon get pulled into the development branch (April 2022).
+-- (ZZ/p: Aring, Old, Ffpack).  Status: Aring, Old are likely to be removed.  Ffpack might also be changed?
+-- GF: Old, New (both are old though!) and require not large. Status: both of these to be removed.
+debug Core
+assert checkPowersOfZero(30, ZZp(5, Strategy => "Ffpack"))
+assert checkPowersOfZero(30, ZZp(5, Strategy => "Aring"))
+assert checkPowersOfZero(30, ZZp(5, Strategy => "Old"))
+
+assert checkPowersOfZero(30, ZZp((previousPrime 2^15), Strategy => "Ffpack"))
+assert checkPowersOfZero(30, ZZp((previousPrime 2^15), Strategy => "Aring"))
+assert checkPowersOfZero(30, ZZp((previousPrime 2^15), Strategy => "Old"))
+
+assert checkPowersOfZero(30, GF(5, Strategy => "Old")) -- ZZp.cpp ("Old")
+assert checkPowersOfZero(30, GF(25, Strategy => "Old"))
+assert checkPowersOfZero(30, GF(5^5, Strategy => "Old")) -- GF.cpp ("Old")
+assert checkPowersOfZero(30, GF(5^10, Strategy => "Old")) -- FlintBig
+assert checkPowersOfZero(30, GF(5^12, Strategy => "Old")) -- FlintBig
+assert checkPowersOfZero(30, GF(5^15, Strategy => "Old")) -- FlintBig
+
+assert checkPowersOfZero(30, GF(2, Strategy => "Old")) -- ZZp.cpp ("Old")
+assert checkPowersOfZero(30, GF(8, Strategy => "Old"))
+assert checkPowersOfZero(30, GF(2^5, Strategy => "Old")) -- GF.cpp ("Old")
+assert checkPowersOfZero(30, GF(2^10, Strategy => "Old")) -- FlintBig
+assert checkPowersOfZero(30, GF(2^12, Strategy => "Old")) -- FlintBig
+assert checkPowersOfZero(30, GF(2^15, Strategy => "Old")) -- FlintBig
+
+assert checkPowersOfZero(30, GF(5, Strategy => "New")) -- ZZp.cpp ("New")
+assert checkPowersOfZero(30, GF(25, Strategy => "New"))
+assert checkPowersOfZero(30, GF(5^5, Strategy => "New")) -- GF.cpp ("New")
+assert checkPowersOfZero(30, GF(5^10, Strategy => "New")) -- FlintBig
+assert checkPowersOfZero(30, GF(5^12, Strategy => "New")) -- FlintBig
+assert checkPowersOfZero(30, GF(5^15, Strategy => "New")) -- FlintBig
+
+assert checkPowersOfZero(30, GF(2, Strategy => "New"))
+assert checkPowersOfZero(30, GF(8, Strategy => "New"))
+assert checkPowersOfZero(30, GF(2^5, Strategy => "New"))
+assert checkPowersOfZero(30, GF(2^10, Strategy => "New"))
+
+assert checkPowersOfZero(30, GF(2^12, Strategy => "New")) -- FlintBig
+elapsedTime assert checkPowersOfZero(30, GF(2^15, Strategy => "New", SizeLimit => 2^15)) -- takes awhile
+
+assert checkPowersOfZero(30, ZZ)
+assert checkPowersOfZero(30, QQ)
+assert checkPowersOfZero(30, RR_53)
+assert checkPowersOfZero(30, RR_100)
+assert checkPowersOfZero(30, RR_1000)
+assert checkPowersOfZero(30, CC_53)
+assert checkPowersOfZero(30, CC_100)
+assert checkPowersOfZero(30, CC_1000)
+
+assert checkPowersOfZero(30, ZZ/101[a..d])
+assert checkPowersOfZero(30, ZZ/101[a..d]/(a^2-b^3, b^2-c^3))
+assert checkPowersOfZero(30, frac(ZZ/101[a..d]))
+assert checkPowersOfZero(30, frac(ZZ[a..d]))
+assert checkPowersOfZero(30, frac(QQ[a..d]))
+assert checkPowersOfZero(30, frac(QQ[a..d]/(a^2-b^3)))
+
+assert checkPowersOfZero(30, frac(QQ[a]))
+assert checkPowersOfZero(30, frac(QQ[a,b,c]/(a^2+b^3+c^4)))
+


### PR DESCRIPTION
This is the first of several pull requests (I hope) for fixing bugs in the engine.  This one fixes the two bugs mentioned.  I might still need to add a test file for #638, but I have added one for #1856.

0^0 should consistently be 1.  0^n, for n>0 should consistently be 0 (this was a bug in some GF rings).

Elements in Weyl algebras were always coming out inhomogeneous.  Now, if the x and dx variables have degrees which are negative of each other, homogeneous elements should be recognized as such (fixed with @antonleykin )