### PR TITLE
Fix #2437 + minor doc fixes

### DIFF
--- a/M2/Macaulay2/m2/lists.m2
+++ b/M2/Macaulay2/m2/lists.m2
@@ -115,7 +115,7 @@ member(Thing,VisibleList) := Boolean => (c,x) -> any(x, i -> c===i)
 sum List := x -> plus toSequence x
 
 sum(ZZ,Function) := (n,f) -> (
-     if n === 0 then 0
+     if n <= 0 then 0
      else (
 	  s := f 0;
 	  for i from 1 to n-1 do s = s + f i;
@@ -141,7 +141,7 @@ sum(VisibleList, VisibleList, Function) := (x,y,f) -> (
 product List := x -> times toSequence x
 
 product(ZZ,Function) := (n,f) -> (
-     if n === 0 then 1
+     if n <= 0 then 1
      else (
 	  s := f 0;
 	  for i from 1 to n-1 do s = s * f i;

--- a/M2/Macaulay2/m2/powers.m2
+++ b/M2/Macaulay2/m2/powers.m2
@@ -17,7 +17,7 @@ binomial(ZZ,ZZ) := ZZ => memoize (
 	  )
      )
 
-binomial(RingElement, ZZ):= (q,n)->(
+binomial(RingElement, ZZ):= (q,n)-> if n<0 then error "binomial undefined" else (
      product(n, i-> q-i) * (promote(product(n, i->1+i),ring q))^(-1))
 
 -- Local Variables:

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/cohomology-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/cohomology-doc.m2
@@ -266,7 +266,7 @@ document {
 	  "II'Z = sheaf module ideal Z"
 	  },
      PARA{
-	  TEX "The defect of W (that is, $h^{1,1}(W)-1$) can be computed from the 
+	  TEX "The defect of $W$ (that is, $h^{1,1}(W)-1$) can be computed from the
      	  cohomology of the ideal sheaf of the singular locus Z of V twisted by 5 
      	  (see Werner's thesis):"},
      EXAMPLE {          
@@ -274,8 +274,8 @@ document {
 	  "h11 = defect + 1"
 	  },
      PARA{
-     	  TEX "The number $h^{2,1}(W)$ (the dimension of the moduli space of W) can be computed (Clemens-Griffiths, Werner) 
-     	  as $dim H^0({\\bf I}_Z(5))/JacobianIdeal(V)_5$."},
+	  TEX "The number $h^{2,1}(W)$ (the dimension of the moduli space of $W$) can be computed (Clemens-Griffiths, Werner)
+	  as $\\dim H^0({\\mathbf I}_Z(5))/JacobianIdeal(V)_5$."},
      EXAMPLE {
 	  "quinticsJac = numgens source basis(5,ideal Z)", 
           "h21 = rank HH^0(II'Z(5)) - quinticsJac"

--- a/M2/Macaulay2/packages/Macaulay2Doc/methods.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/methods.m2
@@ -6,7 +6,7 @@ document { Key => FunctionClosure,
 document { Key => CompiledFunction,
      Headline => "the class of all compiled functions",
      "Compiled functions in Macaulay2 are written in a special purpose language, translated to C during compilation and not available to general users.",
-     EXAMPLE "class sin"
+     EXAMPLE "class drop"
      }
 document { Key => CompiledFunctionClosure,
      Headline => "the class of all compiled function closures",

--- a/M2/Macaulay2/packages/Macaulay2Doc/types.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/types.m2
@@ -26,7 +26,7 @@ document {
 	       instances of the new type to nets for display."
 	       },
 	  EXAMPLE lines ///
-	       new Type of BasicList from Function := (A,B,f) -> hashTable { net => f }; -* no-capture-flag *-
+	       new Type of BasicList from Function := (A,B,f) -> hashTable { net => f, html => f }; -* no-capture-flag *-
 	  ///,
 	  PARA {
 	       "The hash tables ", TT "AA", ", ", TT "BB", ", and ", TT "C", " will normally be instances of ", TO "Type", "."


### PR DESCRIPTION
- `product` and `sum` behave properly when first `ZZ` argument is negative. (I could add a test if deemed necessary)
- `binomial(ZZ,RingElement)` throws an error if first argument negative
- TeX fix in `cohomology` doc
- because of the recent numeric upgrade, the doc of `CompiledFunction` had become incorrect -- example changed.
- the documentation of `new` was not mode-agnostic -- the example didn't make sense in WebApp mode. fixed by defining html output as well as net output.