### PR TITLE
Replace spaces in wikipedia links with underscores

### DIFF
--- a/M2/Macaulay2/packages/SimpleDoc/helpers.m2
+++ b/M2/Macaulay2/packages/SimpleDoc/helpers.m2
@@ -1,6 +1,7 @@
 wikipedia = method(TypicalValue => Hypertext)
 wikipedia String          :=       title  -> wikipedia(title, title)
-wikipedia(String, String) := (url, title) -> HREF{ "https://en.wikipedia.org/wiki/" |   url, title }
+wikipedia(String, String) := (url, title) ->
+    HREF{"https://en.wikipedia.org/wiki/" | replace(" ", "_", url), title}
 
 arXiv = method(TypicalValue => Hypertext)
 arXiv String          :=  ref         -> HREF{ "https://arxiv.org/abs/" | ref, "arXiv:" | ref }

--- a/M2/Macaulay2/packages/SimpleDoc/helpers.m2
+++ b/M2/Macaulay2/packages/SimpleDoc/helpers.m2
@@ -1,5 +1,5 @@
 wikipedia = method(TypicalValue => Hypertext)
-wikipedia String          :=       title  -> HREF{ "https://en.wikipedia.org/wiki/" | title, title }
+wikipedia String          :=       title  -> wikipedia(title, title)
 wikipedia(String, String) := (url, title) -> HREF{ "https://en.wikipedia.org/wiki/" |   url, title }
 
 arXiv = method(TypicalValue => Hypertext)


### PR DESCRIPTION
This gives the canonical link to articles with spaces in their titles (see https://en.wikipedia.org/wiki/Wikipedia:Linking_to_Wikipedia).

This way, when using `wikipedia(String)`, we can give more human-readable names to articles (with a space), but the actual link will use an underscore.  This is helpful, for example,  for viewing the documentation in Emacs while using [`goto-address-mode`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Goto-Address-mode.html) to get clickable links.  Previously, only the part of the url before a space would have been clickable.

### Before
```m2
i1 : wikipedia "foo bar"

o1 = foo bar (see https://en.wikipedia.org/wiki/foo bar )

o1 : HREF
```

### After
```m2
i1 : wikipedia "foo bar"

o1 = foo bar (see https://en.wikipedia.org/wiki/foo_bar )

o1 : HREF
```