### PR TITLE
Fix some gmp related memory leaks

### DIFF
--- a/M2/Macaulay2/e/ZZ.cpp
+++ b/M2/Macaulay2/e/ZZ.cpp
@@ -292,9 +292,11 @@ ring_elem RingZZ::invert(const ring_elem f) const
 ring_elem RingZZ::divide(const ring_elem f, const ring_elem g) const
 {
   mpz_ptr result = new_elem();
-  mpz_ptr rem = new_elem();
+  mpz_t rem;
+  mpz_init(rem);
   mpz_fdiv_qr(result, rem, f.get_mpz(), g.get_mpz());
   if (mpz_sgn(rem)) ERROR("not divisible");
+  mpz_clear(rem);
   mpz_reallocate_limbs(result);
   return ring_elem(result);
 }

--- a/M2/Macaulay2/e/ZZp.cpp
+++ b/M2/Macaulay2/e/ZZp.cpp
@@ -145,6 +145,7 @@ ring_elem Z_mod::from_int(mpz_srcptr n) const
   mpz_init(result);
   mpz_mod_ui(result, n, P);
   int m = static_cast<int>(mpz_get_si(result));
+  mpz_clear(result);
   //  cout << m << endl;
   if (m < 0) m += P;
   m = _log_table[m];

--- a/M2/Macaulay2/e/aring-RRi.hpp
+++ b/M2/Macaulay2/e/aring-RRi.hpp
@@ -251,14 +251,14 @@ class ARingRRi : public RingInterface
   {
       if (mpz_cmp_si(n,2)>=0)
       {
-          mpz_ptr r = getmemstructtype(mpz_ptr);
+          mpz_t r;
           mpz_init(r);
           mpz_fdiv_r_ui(r,n,2);
           
           ElementType b;
           init(b);
           
-          mpz_ptr m = getmemstructtype(mpz_ptr);
+          mpz_t m;
           mpz_init(m);
           
           if (mpz_cmp_si(r,0) == 0)
@@ -275,6 +275,8 @@ class ARingRRi : public RingInterface
               power_mpz(b,a,m);
               mult(result,a,b);
           }
+          mpz_clear(r);
+          mpz_clear(m);
       }
       else if (mpz_cmp_si(n,1)==0)
           mpfi_set(&result,&a);

--- a/M2/Macaulay2/e/aring-gf-givaro.cpp
+++ b/M2/Macaulay2/e/aring-gf-givaro.cpp
@@ -582,6 +582,9 @@ void ARingGFGivaro::power(ElementType &result,
       assert(tmp >= 0);  // tmp<0 should never occur
       if (tmp < 0) tmp += givaroField.cardinality() - 1;
       result = tmp;
+      mpz_clear(mpz_a);
+      mpz_clear(mpz_n);
+      mpz_clear(mpz_tmp);
     }
   else
     {

--- a/M2/Macaulay2/e/aring-glue.hpp
+++ b/M2/Macaulay2/e/aring-glue.hpp
@@ -523,6 +523,8 @@ class RingQQ : public ConcreteRing<ARingQQ>
     mpz_set(mpq_numref(b), numer);
     mpz_set(mpq_denref(b), denom);
     mpq_canonicalize(b);
+    mpz_reallocate_limbs(mpq_numref(b));
+    mpz_reallocate_limbs(mpq_denref(b));
     return ring_elem(b);
   }
 
@@ -556,6 +558,8 @@ class RingQQ : public ConcreteRing<ARingQQ>
     mpz_gcd(mpq_numref(result), mpq_numref(a), mpq_numref(b));
     mpz_lcm(mpq_denref(result), mpq_denref(a), mpq_denref(b));
     if (s != mpq_sgn(result)) mpq_neg(result, result);
+    mpz_reallocate_limbs(mpq_numref(result));
+    mpz_reallocate_limbs(mpq_denref(result));
     f = ring_elem(result);
     return true;  // the answer could become lower, if a newer g has a larger
                   // denom
@@ -577,6 +581,8 @@ class RingQQ : public ConcreteRing<ARingQQ>
     mpz_gcd(mpq_numref(result), mpq_numref(a), mpq_numref(b));
     mpz_lcm(mpq_denref(result), mpq_denref(a), mpq_denref(b));
     if (sa != mpq_sgn(result)) mpq_neg(result, result);
+    mpz_reallocate_limbs(mpq_numref(result));
+    mpz_reallocate_limbs(mpq_denref(result));
     c = ring_elem(result);
   }
 };

--- a/M2/Macaulay2/e/cra.cpp
+++ b/M2/Macaulay2/e/cra.cpp
@@ -153,6 +153,7 @@ ring_elem ChineseRemainder::CRA(const PolyRing *R,
     }
 
   mpz_clear(result_coeff);
+  mpz_clear(mn_half);
   result->next = nullptr;
   return head.next;
 }

--- a/M2/Macaulay2/e/fplll-interface.cpp
+++ b/M2/Macaulay2/e/fplll-interface.cpp
@@ -64,6 +64,7 @@ bool fp_LLL(MutableMatrix *M, MutableMatrix *U, int strategy)
         ring_elem b = globalZZ->from_int(a);
         M->set_entry(j, i, b);
       }
+  mpz_clear(a);
   return true;
 #endif
 }

--- a/M2/Macaulay2/e/gbring.cpp
+++ b/M2/Macaulay2/e/gbring.cpp
@@ -1196,6 +1196,9 @@ void GBRing::gbvector_combine_lead_terms_ZZ(const FreeModule *F,
   mpz_init(u1);
   mpz_init(v1);
   mpz_gcdext(gab, u1, v1, a.get_mpz(), b.get_mpz());
+  mpz_clear(gab);
+  //these ring_elem must not escape the function, because they aren't allocated on
+  //the gc heap
   ring_elem u = ring_elem(u1);
   ring_elem v = ring_elem(v1);
   if (globalZZ->is_zero(u) || globalZZ->is_zero(v))
@@ -1230,6 +1233,8 @@ void GBRing::gbvector_combine_lead_terms_ZZ(const FreeModule *F,
       gbvector *result_syz1 = mult_by_term(Fsyz, gsyz, v, MONOM2, comp);
       gbvector_add_to(Fsyz, result_syz, result_syz1);
     }
+  mpz_clear(u1);
+  mpz_clear(v1);
 }
 
 void GBRing::gbvector_apply(const FreeModule *F,

--- a/M2/Macaulay2/e/interface/ringelement.cpp
+++ b/M2/Macaulay2/e/interface/ringelement.cpp
@@ -394,6 +394,8 @@ gmp_ZZpairOrNull rawWeightRange(M2_arrayint wts, const RingElement *a)
       p->b = newitem(__mpz_struct);
       mpz_init_set_si(const_cast<mpz_ptr>(p->a), static_cast<long>(lo));
       mpz_init_set_si(const_cast<mpz_ptr>(p->b), static_cast<long>(hi));
+      mpz_reallocate_limbs(const_cast<mpz_ptr>(p->a));
+      mpz_reallocate_limbs(const_cast<mpz_ptr>(p->b));
       return p;
   } catch (const exc::engine_error& e)
     {

--- a/M2/Macaulay2/e/ntl-interface.cpp
+++ b/M2/Macaulay2/e/ntl-interface.cpp
@@ -47,7 +47,7 @@ MutableMatrix *mutableMatrix_from_NTL_mat_ZZ(const NTL::mat_ZZ *A)
             B->set_entry(j, i, ring_elem(a));
           }
       }
-
+  mpz_clear(a);
   return B;
 }
 

--- a/M2/Macaulay2/e/poly.cpp
+++ b/M2/Macaulay2/e/poly.cpp
@@ -903,6 +903,7 @@ ring_elem PolyRing::power_direct(const ring_elem ff, int n) const
             add_to(result, h);
         }
     }
+    mpz_clear(bin_c);
     return result;
 }
 

--- a/M2/Macaulay2/e/schur.cpp
+++ b/M2/Macaulay2/e/schur.cpp
@@ -341,6 +341,7 @@ ring_elem SchurRing::dimension(const ring_elem f) const
       K_->add_to(result, h2);
       K_->remove(h);
     }
+  mpz_clear(dim);
   return result;
 }
 


### PR DESCRIPTION
This mostly fixes #1938. I went through and checked all the times we call `mpz_init` and `mpq_init` or similar functions, and made sure that the output is either cleared (`mpz_clear`), reallocated onto the gc heap (`mpz_reallocate_limbs`), or given to a function that will do that for us.

One thing I didn't fix is that some of the tests leak memory themselves, even when the code they test doesn't.