### PR TITLE
Quote option default values that are strings in documentation

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -452,7 +452,8 @@ processSignature := (tag, fn) -> item -> (
 	opttag := getPrimaryTag makeDocumentTag([fn, optsymb], Package => package tag);
 	name := if tag === opttag then TT toString optsymb else TO2 { opttag, toString optsymb };
 	type  = if type =!= null and type =!= Nothing then ofClass type else TT "..."; -- type Nothing is treated as above
-	defval := SPAN{"default value ", reproduciblePaths replace("^-\\*Function.*?\\*-", "-*Function*-", toString opts#optsymb)};
+	maybeformat := if instance(opts#optsymb, String) then format else identity;
+	defval := SPAN{"default value ", maybeformat reproduciblePaths replace("^-\\*Function.*?\\*-", "-*Function*-", toString opts#optsymb)};
 	text = if text =!= null and #text > 0 then text else if tag =!= opttag then LATER {() -> headline opttag};
 	text = if text =!= null and #text > 0 then (", ", text);
 	-- e.g: Key => an integer, default value 42, the meaning of the universe


### PR DESCRIPTION
This is a minor documentation issue I noticed.  When the default value of an option is a string, it wasn't quite clear because the string wasn't quoted.

### Before
```m2
i2 : help foo

o2 = foo
     ***

     Synopsis
     ========

       * Usage: 
             foo x
       * Inputs:
           * x, a "string", 
       * "Optional inputs":
           * "Bar" => a "string", default value bar, which we would like to be
             quoted in the documentation;
```

### After
```m2
i2 : help foo

o2 = foo
     ***

     Synopsis
     ========

       * Usage: 
             foo x
       * Inputs:
           * x, a "string", 
       * "Optional inputs":
           * "Bar" => a "string", default value "bar", which we would like to be
             quoted in the documentation;
```