### PR TITLE
lngamma updates

### DIFF
--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -267,11 +267,11 @@ CatalanConstant = new Constant from { symbol CatalanConstant, mpfrConstantCatala
 ii = new Constant from { symbol ii, ConstantII}
 
 lngamma = method()
-lngamma ZZ := lngamma QQ := lngamma RR := x -> (
+lngamma RR := x -> (
      (y,s) := lgamma x;
      if s == -1 then y + ii * numeric_(precision y) pi else y
      )
-lngamma Constant := lngamma @@ numeric
+lngamma ZZ := lngamma QQ := lngamma Constant := lngamma @@ numeric
 
 expression Constant := hold
 toString Constant := net Constant := c -> toString c#0

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc14.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc14.m2
@@ -105,18 +105,6 @@ document { Key => {Digamma,(Digamma, RR)},
      PARA {"See ", wikipedia "Digamma function", "."},
      SeeAlso => {Gamma}
      }
-document { Key => {lngamma,(lngamma, RR)},
-     Usage => "lngamma x",
-     Headline => "logarithm of the Gamma function",
-     Inputs => { "x" },
-     Outputs => {{ "the logarithm of the gamma function of ", TT "x", " as a real or imaginary number" }},
-     EXAMPLE lines ///
-     	  lngamma 2.1
-	  lngamma(-1.1)
-	  lngamma(-2.1)
-	  lngamma (-2.000000000000000000000000000000001p120)
-     ///
-     }
 document { Key => {zeta,(zeta, RR)},
      Usage => "zeta x",
      Headline => "Riemann zeta function",

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/Gamma-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/Gamma-doc.m2
@@ -81,3 +81,30 @@ doc ///
     Gamma
     inverseRegularizedGamma
 ///
+
+doc ///
+  Key
+    lngamma
+    (lngamma, RR)
+    (lngamma, ZZ)
+    (lngamma, QQ)
+    (lngamma, Constant)
+  Headline
+    logarithm of the Gamma function
+  Usage
+    lngamma x
+  Inputs
+    x:RR
+  Outputs
+    :{RR, CC}
+      the logarithm of the @TO Gamma@ function of @TT "x"@ as a real
+      or complex number.
+  Description
+    Example
+      lngamma 2.1
+      lngamma(-1.1)
+      lngamma(-2.1)
+      lngamma (-2.000000000000000000000000000000001p120)
+  SeeAlso
+    Gamma
+///

--- a/M2/Macaulay2/tests/normal/numbers.m2
+++ b/M2/Macaulay2/tests/normal/numbers.m2
@@ -854,6 +854,11 @@ assert small(Gamma(1/2, 5) / Gamma(1/2) - regularizedGamma(1/2, 5))
 assert small(5 - inverseRegularizedGamma(1/2, regularizedGamma(1/2, 5)))
 assert small(1/5 - regularizedGamma(1/2, inverseRegularizedGamma(1/2, 1/5)))
 
+assert small(lngamma 0.5 - log sqrt pi)
+assert small(lngamma(1/2) - log sqrt pi)
+assert small(lngamma 4 - log 6)
+assert small(lngamma pi - log Gamma pi)
+
 assert small(regularizedBeta(1/3, 4, 1) - 1/81)
 assert small(regularizedBeta(1/3, 4, 5) -
     (regularizedBeta(1/3, 3, 5) - (1/3)^3 * (2/3)^5 / (3 * Beta(3, 5))))


### PR DESCRIPTION
I found a bug in `lngamma` where we got errors with rational or integer arguments.  Also took the opportunity to add some unit tests and update the documentation.

### Before
```m2
i1 : lngamma 2
stdio:1:1:(3): error: expected a number

i2 : lngamma(1/2)
stdio:2:1:(3): error: expected a number
```

### After
```m2
i1 : lngamma 2

o1 = 0

o1 : RR (of precision 53)

i2 : lngamma(1/2)

o2 = .5723649429247

o2 : RR (of precision 53)
```