### PR TITLE
Add --with-system-gc configure option to use existing gc on system

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -166,7 +166,7 @@ jobs:
           export CPPFLAGS="-I`brew --prefix`/include"
           export  LDFLAGS="-L`brew --prefix`/lib \
             -L`brew --prefix python`/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
-          ../../configure --enable-download --with-python
+          ../../configure --enable-download --with-python --with-system-gc
 
       - name: Build Macaulay2 using Make
         if: matrix.build-system == 'autotools'

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -783,24 +783,30 @@ else if test $SHARED = no -a $TRY_STATIC = yes
      fi
 fi
 
-## we always build gc so we can configure it for large memory spaces
+## we build gc by default so we can configure it for large memory spaces
 ## see issue #2445
-BUILD_gc=yes
-BUILD_ALWAYS="$BUILD_ALWAYS gc"
+AC_ARG_WITH([system-gc],
+    [AS_HELP_STRING([--with-system-gc],
+        [use system gc instead of building it])],
+    [],
+    [with_system_gc=no])
 
-AC_MSG_CHECKING(whether package bdw-gc is provided)
+AS_IF([test "x$with_system_gc" = xyes],
+    [AC_MSG_CHECKING(whether package bdw-gc is provided)
 dnl Note: we don't include -lgccpp below, because linking with that library is what replaces ::new and friends with GC_MALLOC_UNCOLLECTABLE and friends:
-if [ pkg-config --exists bdw-gc ]
-then AC_MSG_RESULT(yes)
-     CPPFLAGS="`pkg-config --cflags-only-I bdw-gc | sed -e 's=^-I/=-isystem /=g' -e 's= -I/= -isystem /=g'` $CPPFLAGS"
-     dnl should probably use `pkg-config --libs bdw-gc` here instead
-     FOUND_gc=yes
-else AC_MSG_RESULT(no)
-     BUILD_gc=yes
-fi
+     if [ pkg-config --exists bdw-gc ]
+     then AC_MSG_RESULT(yes)
+          CPPFLAGS="`pkg-config --cflags-only-I bdw-gc | sed -e 's=^-I/=-isystem /=g' -e 's= -I/= -isystem /=g'` $CPPFLAGS"
+          dnl should probably use `pkg-config --libs bdw-gc` here instead
+          FOUND_gc=yes
+     else AC_MSG_RESULT(no)
+          BUILD_gc=yes
+     fi],
+    [BUILD_gc=yes])
 
 if test $BUILD_gc = yes
 then BUILTLIBS="-lgc -lpthread $BUILTLIBS"
+     BUILD_ALWAYS="$BUILD_ALWAYS gc"
 else if test $SHARED = no -a $TRY_STATIC = yes
      then SEARCH_LIBRARIES(GC_malloc,"/usr/lib/libgc.a" "/usr/local/lib/libgc.a",,
           [AC_MSG_ERROR([libgc.a not found])])


### PR DESCRIPTION
This option restores the pre-#2446 behavior of using the system gc when available.  If merged, I plan to use it for the Debian package so I don't need to [patch `configure.ac` directly](https://salsa.debian.org/math-team/macaulay2/-/blob/a9c27f627ac2ac9fb8977b68a9fdbc34d6c68ad8/debian/patches/use-debian-gc.patch).  I also propose that we use it for the GitHub builds so we're not rebuilding gc every time.