### PR TITLE
Use AC_ARG_WITH instead of AC_ARG_ENABLE for mathicgb/etc. checks

### DIFF
--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -64,12 +64,18 @@ Macaulay2.  If your operating system distinguishes between development
 versions and run-time versions of the libraries, you will need the development
 version.
 
+Some libraries (gc, mathic, mathicgb, and memtailor) are built from source
+by default.  If you would prefer to use the versions of these libraries
+already available on your system, then add the option "--with-system-X" to
+the "configure" command line below, where X is the corresponding library,
+e.g., "--with-system-memtailor".
+
 Here are commands that will get you a good development environment under
 various modern operating systems:
 
   Ubuntu and Debian:
     Install packages as root with:
-      apt-get install -y -q sudo 4ti2 autoconf bison curl emacs fflas-ffpack flex g++ gcc gfortran install-info libatomic-ops-dev libboost-dev libboost-math-dev libboost-regex-dev libboost-stacktrace-dev libc6-dev libcdd-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfi-dev libmpfr-dev libncurses-dev libncurses5-dev libntl-dev libreadline-dev libsingular-dev libtool libxml2-dev libz-dev lrslib lsb-release make normaliz npm openssh-server patch pinentry-curses pkg-config singular-data time unzip xbase-clients yasm zlib1g-dev polymake w3c-markup-validator git dpkg-dev gfan libeigen3-dev libtool-bin frobby libfrobby-dev libnauty2-dev libnauty2 nauty nauty-doc coinor-csdp coinor-csdp-doc libflint-dev libtbb-dev
+      apt-get install -y -q sudo 4ti2 autoconf bison curl emacs fflas-ffpack flex g++ gcc gfortran install-info libatomic-ops-dev libboost-dev libboost-math-dev libboost-regex-dev libboost-stacktrace-dev libc6-dev libcdd-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfi-dev libmpfr-dev libncurses-dev libncurses5-dev libntl-dev libreadline-dev libsingular-dev libtool libxml2-dev libz-dev lrslib lsb-release make normaliz npm openssh-server patch pinentry-curses pkg-config singular-data time unzip xbase-clients yasm zlib1g-dev polymake w3c-markup-validator git dpkg-dev gfan libeigen3-dev libtool-bin frobby libfrobby-dev libnauty2-dev libnauty2 nauty nauty-doc coinor-csdp coinor-csdp-doc libflint-dev libtbb-dev
         # note: libz-dev seems to have been replaced by zlib1g-dev
         # note: libncurses-dev seems to have been replaced by libncurses5-dev
         # note: libreadline-gplv2-dev is an older GPL v2 version of libreadline
@@ -77,6 +83,12 @@ various modern operating systems:
         # note: libflint-dev will work starting with Ubuntu 20.10 and Debian 11 (version >= 2.6.0 is required)
         # note: libmps-dev is available only starting with Ubuntu 21.04 and Debian 11
         # note: topcom is available only starting with Ubuntu 20.10 and Debian 11
+    If configuring with "--with-system-X", then also install the following
+    packages for each value of X:
+      - gc:        libgc-dev
+      - mathic:    libmathic-dev
+      - mathicgb:  libmathicgb-dev
+      - memtailor: libmemtailor-dev
     On some systems, you may have to add
         FC=gfortran
       to the environment or to the "configure" command line below, if the "make" default fortran

--- a/M2/check-configure/Makefile.in
+++ b/M2/check-configure/Makefile.in
@@ -1,9 +1,9 @@
 VPATH = @srcdir@
 LDFLAGS = -L$(BUILTLIBPATH)/lib
 CPPFLAGS = -I$(BUILTLIBPATH)/include
-BUILD_MEMTAILOR = $(if $(filter memtailor, @BUILDSUBLIST@),yes,no)
-BUILD_MATHIC    = $(if $(filter mathic   , @BUILDSUBLIST@),yes,no)
-BUILD_MATHICGB  = $(if $(filter mathicgb , @BUILDSUBLIST@),yes,no)
+SYSTEM_MEMTAILOR = $(if $(filter memtailor, @BUILDSUBLIST@),no,yes)
+SYSTEM_MATHIC    = $(if $(filter mathic   , @BUILDSUBLIST@),no,yes)
+SYSTEM_MATHICGB  = $(if $(filter mathicgb , @BUILDSUBLIST@),no,yes)
 include ../include/config.Makefile
 check: clean-and-config
 clean:; rm -rf tmp
@@ -26,9 +26,9 @@ check-config:
 	    CFLAGS="$(CFLAGS)"							\
 	    CXXFLAGS="$(CXXFLAGS)"						\
 	    --build="@build_alias@"						\
-	    --enable-build-memtailor=$(BUILD_MEMTAILOR)				\
-	    --enable-build-mathic=$(BUILD_MATHIC)				\
-	    --enable-build-mathicgb=$(BUILD_MATHICGB)				\
+	    --with-system-memtailor=$(SYSTEM_MEMTAILOR)				\
+	    --with-system-mathic=$(SYSTEM_MATHIC)				\
+	    --with-system-mathicgb=$(SYSTEM_MATHICGB)				\
 	    --disable-building
 distclean:: clean; rm -f Makefile
 Makefile: Makefile.in ; cd .. && ./config.status check-configure/Makefile

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1257,11 +1257,11 @@ then AC_MSG_NOTICE(readline library will be compiled)
      BUILTLIBS="-lreadline -lhistory $BUILTLIBS"
 fi
 
-AC_ARG_ENABLE([build-memtailor],
-    [AS_HELP_STRING([--disable-build-memtailor],
+AC_ARG_WITH([system-memtailor],
+    [AS_HELP_STRING([--with-system-memtailor],
 	[use system memtailor instead of building git submodule])],,
-    [enable_build_memtailor=yes])
-if test $enable_build_memtailor = yes
+    [with_system_memtailor=no])
+if test $with_system_memtailor = no
 then
     BUILD_memtailor=yes
     BUILTLIBS="-lmemtailor $BUILTLIBS"
@@ -1270,11 +1270,11 @@ else AC_LANG(C++)
     AC_CHECK_HEADER(memtailor.h,,BUILD_memtailor=yes)
 fi
 
-AC_ARG_ENABLE([build-mathic],
-    [AS_HELP_STRING([--disable-build-mathic],
+AC_ARG_WITH([system-mathic],
+    [AS_HELP_STRING([--with-system-mathic],
 	[use system mathic instead of building git submodule])],,
-    [enable_build_mathic=yes])
-if test $enable_build_mathic = yes
+    [with_system_mathic=no])
+if test $with_system_mathic = no
 then
     BUILD_mathic=yes
     BUILTLIBS="-lmathic $BUILTLIBS"
@@ -1283,11 +1283,11 @@ else AC_LANG(C++)
     AC_CHECK_HEADER(mathic.h,,BUILD_mathic=yes)
 fi
 
-AC_ARG_ENABLE([build-mathicgb],
-    [AS_HELP_STRING([--disable-build-mathicgb],
+AC_ARG_WITH([system-mathicgb],
+    [AS_HELP_STRING([--with-system-mathicgb],
 	[use system mathicgb instead of building git submodule])],,
-    [enable_build_mathicgb=yes])
-if test $enable_build_mathicgb = yes
+    [with_system_mathicgb=no])
+if test $with_system_mathicgb = no
 then
     BUILD_mathicgb=yes
     BUILTLIBS="-lmathicgb $BUILTLIBS"


### PR DESCRIPTION
It's a subtle difference, but `AC_ARG_ENABLE` is intended for use with internal features and `AC_ARG_WITH` for external packages, so the latter is more appropriate in this case.

So to use the mathicgb library already available on the system, we now use `--with-system-mathicgb` instead of `--disable-build-mathicgb`.

This also adds consistency with the [new `--with-system-gc` option](https://github.com/Macaulay2/M2/pull/2452).