### PR TITLE
solve accepts Vector and correctly treats null output

### DIFF
--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -227,9 +227,16 @@ solve(Matrix,Matrix) := opts -> (A,b) -> (
      if ultimate(coefficientRing, ring A) === ZZ then (
          return (b // A);
         );
-     matrix solve(mutableMatrix(A,Dense=>true),
+     ans := solve(mutableMatrix(A,Dense=>true),
                   mutableMatrix(b,Dense=>true),
-		  opts))
+		  opts);
+     if ans === null then null else matrix ans
+     )
+
+solve(Matrix,Vector) := opts -> (A,b) -> (
+    ans := solve(A,b#0,opts);
+    if ans === null then null else vector ans
+    )
 
 eigenvalues = method(Options => {Hermitian => false})
 eigenvalues(MutableMatrix) := o -> (A) -> (


### PR DESCRIPTION
this is a minor bug of `solve` so I didn't create an issue:
before
```
i1 : A=mutableMatrix {{1,2},{1,2/1}}

o1 = | 1 2 |
     | 1 2 |

o1 : MutableMatrix

i2 : b=mutableMatrix {{1},{2/1}}

o2 = | 1 |
     | 2 |

o2 : MutableMatrix

i3 : solve(A,b) -- expected behavior: null

i4 : A=matrix {{1,2},{1,2/1}}

o4 = | 1 2 |
     | 1 2 |

              2        2
o4 : Matrix QQ  <--- QQ

i5 : b=matrix {{1},{2/1}}

o5 = | 1 |
     | 2 |

              2        1
o5 : Matrix QQ  <--- QQ

i6 : solve(A,b) -- bug
stdio:6:1:(3): error: no method found for applying matrix to:
     argument   :  null (of class Nothing)
```
now line 6 will also produce null.

I took this opportunity to add the possibility that the second argument of `solve` be a `Vector`, which seems fairly natural.