### PR TITLE
Update Pygments README now that Macaulay2 is available by default

### DIFF
--- a/M2/Macaulay2/editors/pygments/README.md
+++ b/M2/Macaulay2/editors/pygments/README.md
@@ -13,27 +13,35 @@ Or, in Debian-based Linux distributions:
 sudo apt install python3-pygments
 ```
 
-To use Pygments for syntax highlighting Macaulay2 code, generate the
-file `macaulay2.py` by running:
+Beginning with Pygments 2.12.0, Macaulay2 syntax highlighting is available by
+default.  For example:
 
 ```
-M2 --script <path-to-M2-source>/M2/Macaulay2/editors/make-M2-symbols.m2
-```
-
-The file should appear in the `pygments` subdirectory of your current
-directory.  Then, if you want syntax highlighting for a Macaulay2 file,
-you would run:
-
-```
-cd pygments
-pygmentize -x -l macaulay2.py:Macaulay2Lexer <path-to-m2-file>
+pygmentize <path-to-m2-file>
 ```
 
 This will print the syntax-highlighted contents of the Macaulay2 file to
 `stdout`.  For html output:
 
 ```
-pygmentize -x -l macaulay2.py:Macaulay2Lexer -O full -o foo.html <path-to-m2-file>
+pygmentize -O full -o foo.html <path-to-m2-file>
+```
+
+If you have an older version of Pygments, or would like to generate the
+Macaulay2 lexer yourself, run:
+
+
+```
+M2 --script <path-to-M2-source>/M2/Macaulay2/editors/make-M2-symbols.m2
+```
+
+The file `macaulay2.py` should appear in the `pygments` subdirectory of your
+current directory.  Then, if you want syntax highlighting for a Macaulay2 file,
+you would run:
+
+```
+cd pygments
+pygmentize -x -l macaulay2.py:Macaulay2Lexer <path-to-m2-file>
 ```
 
 For more information, please refer to the [Pygments


### PR DESCRIPTION
Pygments [2.12.0](https://github.com/pygments/pygments/releases/tag/2.12.0) was released today.  It's the first release that supports syntax highlighting Macaulay2 code natively.

We update the README to reflect this.