### PR TITLE
Support for unicode synonyms (#1186)

### DIFF
--- a/M2/Macaulay2/d/ctype.d
+++ b/M2/Macaulay2/d/ctype.d
@@ -25,7 +25,7 @@ foreach c in " \t\r"	                   do setchartype(c,WHITE);
 foreach c in "\n"                          do setchartype(c,NEWLINE);
 foreach c in "$"                           do setchartype(c,DOLLAR);
 
-for c from 128 to 225	       	    	   do setchartype(char(c),ALPHA);
+for c from 128 to 225	       	    	   do setchartype(char(c),ALPHA);  -- 226 is unicode math symbol
 for c from 227 to 255	       	    	   do setchartype(char(c),ALPHA);
 					      setchartype('\'',ALPHA);
 					      setchartype('\"',QUOTE);
@@ -54,6 +54,7 @@ export isnewline  (c:char):bool := (chartype(c) & NEWLINE  ) != 0;
 export isquote    (c:char):bool := (chartype(c) & QUOTE    ) != 0;
 
 export isalnum  (s:string):bool := (
+     if int(uchar(s.0)) == 226 && length(s) == 3 then return true; -- unicode math symbol
      foreach c in s do if !isalnum(c) then return false;
      true);
 

--- a/M2/Macaulay2/d/ctype.d
+++ b/M2/Macaulay2/d/ctype.d
@@ -25,7 +25,8 @@ foreach c in " \t\r"	                   do setchartype(c,WHITE);
 foreach c in "\n"                          do setchartype(c,NEWLINE);
 foreach c in "$"                           do setchartype(c,DOLLAR);
 
-for c from 128 to 255	       	    	   do setchartype(char(c),ALPHA);
+for c from 128 to 225	       	    	   do setchartype(char(c),ALPHA);
+for c from 227 to 255	       	    	   do setchartype(char(c),ALPHA);
 					      setchartype('\'',ALPHA);
 					      setchartype('\"',QUOTE);
 

--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -410,6 +410,11 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 		    return errorToken
 		    )
 	       is word:Word do return Token(word,file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline))
+	  else if ch == 226 then (
+	       tokenbuf << char(getc(file));
+	       tokenbuf << char(getc(file));
+	       tokenbuf << char(getc(file));
+	       return Token(makeUniqueWord(takestring(tokenbuf),parseWORD),file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline))
 	  else (
 	       when recognize(file)
 	       is null do (

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1244,7 +1244,33 @@ export {
         "numcols" => "numColumns",
         "numrows" => "numRows",
         "res" => "resolution",
-        "sub" => "substitute"
+        "sub" => "substitute",
+	-- unicode synonyms:
+	"ℚ" => "QQ",
+	"ℝ" => "RR",
+	"ℤ" => "ZZ",
+	"ℂ" => "CC",
+	"∞" => "infinity",
+	"⊗" => "**",
+	"←" => "<-",
+	"→" => "->",
+	"⇒" => "=>",
+	"≠" => "!=",
+	"⊕" => "++",
+	"≪" => "<<",
+	"≫" => ">>",
+	"∀" => "all",
+	"∃" => "any",
+	"∈" => "member",
+	"∏" => "product",
+	"∑" => "sum",
+	"√" => "sqrt",
+	"∧" => "and",
+	"∨" => "or",
+	"∫" => "integrate",
+	"≤" => "<=",
+	"≥" => ">=",
+	"⊢" => "|-"
 }
 
 exportMutable {


### PR DESCRIPTION
This implements #1186. It adds a bunch of unicode synonyms; the workaround for the problem in the discussion, namely that `R ⊗ S` works but not `R⊗S`, is to consider all unicode starting with 0xE2 (which includes all mathematical operators) as special (non alphanumeric) symbols that cannot be part of the name of a symbol. The advantage is that it doesn't force to rewrite the parser to fully support unicode, which would be a serious rewrite; of course, it doesn't solve other unicode-related issues (cf #1069).