### PR TITLE
A couple Pygments updates

### DIFF
--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -32,6 +32,7 @@ M2CONSTANTS = (
 
 class Macaulay2Lexer(RegexLexer):
     name = 'Macaulay2'
+    url = 'https://faculty.math.illinois.edu/Macaulay2/'
     aliases = ['macaulay2']
     filenames = ['*.m2']
 

--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -3,7 +3,7 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~
     Lexer for Macaulay2.
 
-    :copyright: Copyright 2006-2021 by the Pygments team, see AUTHORS.
+    :copyright: Copyright 2006-2022 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
 


### PR DESCRIPTION
I forgot to include these in #2462.  There were a couple of changes to the unit tests in Pygments 2.12.0 that required some adjustments so the Macaulay2 lexer's tests would pass:

* Update the copyright years.
* Add a `url` attribute to the `Macaulay2Lexer` class.
