### PR TITLE
Autotools build updates for syntax highlighting

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -166,7 +166,7 @@ jobs:
           export CPPFLAGS="-I`brew --prefix`/include"
           export  LDFLAGS="-L`brew --prefix`/lib \
             -L`brew --prefix python`/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
-          ../../configure --enable-download --with-python --with-system-gc
+          ../../configure --enable-download --with-python --with-system-gc --enable-syntax-highlighting
 
       - name: Build Macaulay2 using Make
         if: matrix.build-system == 'autotools'

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -21,6 +21,7 @@ emacs/M2-emacs.m2 emacs/M2-emacs-help.txt: emacs/make-M2-emacs-help.m2 @pre_exec
 
 ifeq (@HIGHLIGHTJS@,yes)
 $(CURDIR)/highlightjs/%: @srcdir@/highlightjs/%
+	$(MKDIR_P) $(@D)
 	cp $< $@
 
 highlightjs/highlight.js: highlightjs/macaulay2.js \

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -19,12 +19,7 @@ emacs/M2-symbols.el highlightjs/macaulay2.js : make-M2-symbols.m2 ../m2/exports.
 emacs/M2-emacs.m2 emacs/M2-emacs-help.txt: emacs/make-M2-emacs-help.m2 @pre_exec_prefix@/bin/M2@EXE@ @pre_exec_prefix@/bin/M2
 	cd emacs; @pre_exec_prefix@/bin/M2 $(ARGS) @abs_srcdir@/emacs/make-M2-emacs-help.m2 -e 'exit 0'
 
-ifeq (@NPM@,false)
-highlightjs/highlight.js:
-	@echo "warning: html docs will not have syntax highlighting"
-	$(MKDIR_P) $(@D)
-	touch $@
-else
+ifeq (@HIGHLIGHTJS@,yes)
 $(CURDIR)/highlightjs/%: @srcdir@/highlightjs/%
 	cp $< $@
 
@@ -34,6 +29,11 @@ highlightjs/highlight.js: highlightjs/macaulay2.js \
 	$(CURDIR)/highlightjs/index.js             \
 	$(CURDIR)/highlightjs/highlight-override.css
 	cd $(dir $@) && $ @NPM@ install && @NPM@ run build
+else
+highlightjs/highlight.js:
+	@echo "warning: html docs will not have syntax highlighting"
+	$(MKDIR_P) $(@D)
+	touch $@
 endif
 
 clean::; rm -rf @pre_emacsdir@/* atom emacs highlightjs prism pygments vim

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -24,12 +24,23 @@ $(CURDIR)/highlightjs/%: @srcdir@/highlightjs/%
 	$(MKDIR_P) $(@D)
 	cp $< $@
 
+highlightjs/node_modules: $(CURDIR)/highlightjs/package.json
+ifeq (@DOWNLOAD@,yes)
+	cd $(@D) && @NPM@ install
+else
+	@echo "error: missing highlightjs dependencies, so either use a \"fat\" tar file" >&2
+	@echo "       of the Macaulay2 source code or rerun the Macaulay2 \"configure\" command" >&2
+	@echo "       with the added option \"--enable-download\" to enable automatic" >&2
+	@echo "       downloading of these dependencies over the internet" >&2
+	@false
+endif
+
 highlightjs/highlight.js: highlightjs/macaulay2.js \
 	$(CURDIR)/highlightjs/package.json         \
 	$(CURDIR)/highlightjs/webpack.config.js    \
 	$(CURDIR)/highlightjs/index.js             \
 	$(CURDIR)/highlightjs/highlight-override.css
-	cd $(dir $@) && $ @NPM@ install && @NPM@ run build
+	cd $(dir $@) && @NPM@ run build
 else
 highlightjs/highlight.js:
 	@echo "warning: html docs will not have syntax highlighting"

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -167,7 +167,6 @@ AC_CHECK_PROGS(OBJDUMP,objdump,false)
 AC_CHECK_PROGS(OBJCOPY,objcopy,false)
 AC_CHECK_PROGS(LDD,ldd,false)
 AC_CHECK_PROGS(GIT,git,false)
-AC_CHECK_PROGS(NPM,npm,false)
 
 AC_CHECK_TOOL(AR,ar,false)
 AC_CHECK_TOOL(AS,as,false)
@@ -231,6 +230,23 @@ else for DOCTYPE in $DOCUMENTATION
 fi
 
 AC_SUBST(DOCUMENTATION)
+
+AC_ARG_ENABLE([syntax-highlighting],
+    [AS_HELP_STRING([--enable-syntax-highlighting],
+	[whether to enable syntax highlighting using highlightjs in the html
+	 documentation])],
+    [HIGHLIGHTJS=$enableval],
+    [HIGHLIGHTJS=no])
+
+if test "x$HIGHLIGHTJS" = xyes
+then AC_CHECK_PROGS(NPM,npm,false)
+     if test "x$NPM" = xfalse
+     then AC_MSG_ERROR([npm is required for syntax highlighting])
+     fi
+else AC_SUBST(NPM,false)
+fi
+
+AC_SUBST(HIGHLIGHTJS)
 
 AC_CANONICAL_HOST()
 AC_SUBST(ARCH,$build_cpu)

--- a/M2/libraries/Makefile.in
+++ b/M2/libraries/Makefile.in
@@ -21,6 +21,11 @@ $(foreach d,@LIBLIST@ @PROGLIST@,		\
 		$(eval $t-all: $t-in-$d)	\
 		$(eval .PHONY: $t-all)))
 
+ifeq (@HIGHLIGHTJS@,yes)
+fetch fetch-all:
+	$(MAKE) -C ../Macaulay2/editors highlightjs/node_modules
+endif
+
 uninstall:; rm -rf */.installed* $(BUILTLIBPATH)
 all:install-programs install-licenses
 install-programs:


### PR DESCRIPTION
A few changes prompted by the discussion in #2408:

* Previously, we created the JavaScript file necessary for syntax highlighting the html documentation whenever `npm` was found during `configure`.  We now make it opt-in with the `--enable-syntax-highlighting` option.
* Previously, we downloaded the necessary JavaScript prereqs (using `npm install`) regardless of whether or not the user passed `--enable-download` to `configure`.  It's now a requirement.
* Running `npm install` has been moved earlier in the build, alongside fetching the other libraries as part of `make -C libraries fetch`.