### PR TITLE
Bump Python package to version 0.3

### DIFF
--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -5,8 +5,8 @@ this does not work unless M2 is compiled --with-python
 pythonPresent := Core#"private dictionary"#?"pythonRunString"
 
 newPackage("Python",
-    Version => "0.2",
-    Date => "November 6, 2021",
+    Version => "0.3",
+    Date => "May 4, 2022",
     Headline => "interface to Python",
     Authors => {
 	{Name => "Daniel R. Grayson",


### PR DESCRIPTION
There have been a few changes since version 0.2 was released with Macaulay2 1.19 (#2316, #2332).