### PR TITLE
Remove inefficiency in computation of minimalBetti

### DIFF
--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
@@ -849,28 +849,16 @@ int SchreyerFrame::rank(int slanted_degree, int lev)
     }
   int rkSparse = -1;
   int rkDense = -1;
-  if (frac_nonzero <= .02)
-    rkSparse = rankUsingSparseMatrix(D);
-  if (frac_nonzero >= .01)
+  if (frac_nonzero <= .007)
+    {
+      rkSparse = rankUsingSparseMatrix(D);
+      return rkSparse;
+    }
+  else
     {
       rkDense = rankUsingDenseMatrix(D);
-      int rkDense1B = rankUsingDenseMatrix(D, true);
-      int rkDense2 = rankUsingDenseMatrixFlint(D);
-      int rkDense3 = rankUsingDenseMatrixFlint(D, true);
-      if (rkDense != rkDense2 or rkDense != rkDense3 or rkDense != rkDense1B)
-        {
-          std::cout << "ERROR!! dense ranks(" << slanted_degree << "," << lev << ") = " << rkDense
-                    << " and " << rkDense2 << " and " << rkDense3 << " and " << rkDense1B << std::endl;
-        }
+      return rkDense;
     }
-      
-  if (rkSparse >= 0 and rkDense >= 0 and rkSparse != rkDense)
-    {
-      std::cout << "ERROR!! ranks(" << slanted_degree << "," << lev << ") = " << rkSparse
-                << " and " << rkDense << std::endl;
-    }
-
-  return (rkSparse >= 0 ? rkSparse : rkDense);
 }
 
 M2_arrayint rawMinimalBetti(Computation* C,


### PR DESCRIPTION
This pull request fixes two issues with minimalBetti.

First, @mahrud had noted that there were debugging statements that mistakenly got pushed into the release code (it was computing the rank of a matrix using different methods, where only one is needed).  This removes the unneeded calls.  Thanks Mahrud!

Second, the caching of resolutions was not quite working as intended: suppose a nonminimal resolution to length infinity was computed.  When minimalBetti was then called, it was recomputing a nonminimal resolution to a length limit one higher than the actual computed value.  Since it didn't realize that the first resolution was run to completion, it was redoing the computation.  A better fix would be to add infinity length limits.  This is what we are doing in Complexes, with @ggsmith .  Since the code here will be superceded by that code in the near future (hopefully), I chose a simpler approach here.