### PR TITLE
Minor parser issues

### DIFF
--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -107,6 +107,7 @@ readeval4(file:TokenFile,printout:bool,dictionary:Dictionary,returnLastvalue:boo
 		    promptWanted = true;
 	       	    if fileError(file) then return buildErrorPacket(fileErrorMessage(file));
 	       	    if stopIfError || returnIfError then return buildErrorPacket("--backtrace: token read error--");
+		    if isatty(file) || file.posFile.file.fulllines then flush(file);
 		    )
 	       )
 	  else (

--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -96,8 +96,9 @@ recognize(file:PosFile):(null or Word) := (
 	  );
      when last
      is null do (
-	  printErrorMessage(position(file),"invalid character" );
+	  p := position(file);
 	  getc(file);
+	  printErrorMessage(p,"invalid character" );
 	  (null or Word)(NULL))
      is word:Word do ( 
 	  for length(word.name) do getc(file); 

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -648,11 +648,11 @@ export present(x:string):string := (
 	       ))
      else x);
 
-export presentn(x:string):string := ( -- fix newlines, also
+export presentn(x:string):string := ( -- fix newlines and other special chars, also
      fixesneeded := 0;
      foreach cc in x do (
 	  c := cc; 
-	  if c == char(0) || c == '\t' || c == '\b' || c == '\r' || c == '\"' || c == '\\' || c == '\n' 
+	  if c < char(32) || c == '\"' || c == '\\'
 	  then fixesneeded = fixesneeded + 1 
 	  );
      if fixesneeded != 0 then (
@@ -663,6 +663,7 @@ export presentn(x:string):string := ( -- fix newlines, also
 	       else if c == '\n' then (provide '\\'; provide 'n';)
 	       else if c == '\b' then (provide '\\'; provide 'b';)
 	       else if c == '\t' then (provide '\\'; provide 't';)
+	       else if c < char(32) then (provide '\\'; provide '?';)
 	       else (
 		    if c == '\"' || c == '\\' then provide '\\';
 	       	    provide c;


### PR DESCRIPTION
This fixes some minor issues with parsing and certain errors it encounters.
When parsing encountered an invalid character or some other error like
```
i5 : 1p 8
stdio:7:3:(3): error: precision missing in floating point constant

o5 = 8
```
it would continue parsing anyway (notice the 8 in the output). I believe this is a bug and fixed it.

There was also a problem specific to invalid characters, hard to replicate in emacs, that the order in which the error message and the offending character were sent out was wrong (easy to see in the web app: just type \` then press return and you'll see).
I fixed that too.

Finally, I made debugLevel 123 WebApp-compatible by making `presentn` filter more special characters. This shouldn't affect anything. 