### PR TITLE
fix bug #1851 in rawGCD

### DIFF
--- a/M2/Macaulay2/e/interface/factory.cpp
+++ b/M2/Macaulay2/e/interface/factory.cpp
@@ -535,6 +535,7 @@ const RingElement /* or null */ *rawGCDRingElement(const RingElement *f,
         return NULL;
       }
   }
+  if (ret->is_zero()) return ret;
   ring_elem a = P->getNumeratorRing()->preferred_associate_divisor(
       ret->get_value());  // an element in the coeff ring
   ring_elem b = P->getCoefficients()->invert(a);

--- a/M2/Macaulay2/e/relem.cpp
+++ b/M2/Macaulay2/e/relem.cpp
@@ -421,6 +421,9 @@ RingElement *RingElement::denominator() const
 RingElement *RingElement::fraction(const Ring *K,
                                    const RingElement *bottom) const
 {
+  if (bottom->is_zero())
+    throw exc::division_by_zero_error();
+      
   if (K == globalQQ)
     return new RingElement(globalQQ,
                            globalQQ->fraction(val, bottom->get_value()));


### PR DESCRIPTION
The fix was to return the zero element before trying to divide by the lead coefficient (the attempt to divide was crashing, or returning an uncaught exception).