### PR TITLE
Allow option to set argumentMode for package tests (autotools)

### DIFF
--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -44,11 +44,17 @@ ARGS := $(ARGS), $(IARGS)
 endif
 
 STOP = --stop --silent
+ArgumentMode = defaultMode
+m2-need-template = "needsPackage(\"$(1)\",LoadDocumentation=>true,DebuggingMode=>true)"
+m2-check-template = "check($(1),UserMode=>false,Verbose=>$(Verbose)); exit 0"
 $(foreach i,\
 	$(sort $(ALL_PACKAGES) $(DEVEL)),\
 	$(eval check::check-$i)\
 	$(eval check-$i:; \
-		@pre_bindir@/M2 -q --no-preload $(STOP) -e "needsPackage(\"$i\",LoadDocumentation=>true,DebuggingMode=>true); check($i,UserMode=>false,Verbose=>$(Verbose)); exit 0" ))
+		@pre_bindir@/M2 -q --no-preload $(STOP)                 \
+			-e $(call m2-need-template,$i)                  \
+			-e "debug Core; argumentMode = $(ArgumentMode)" \
+			-e $(call m2-check-template,$i)))
 info-dir: @pre_infodir@/dir
 @pre_infodir@/dir:|@pre_infodir@
 	@INSTALL_DATA@ @abs_top_srcdir@/files/info-dir-template $@


### PR DESCRIPTION
This brings the package tests in the autotools build more in line with the cmake build, which already has this feature.  For example, let's say we don't want to use `capture` to run a package's tests:

```m2
dtorrance@mixtuppa:~/src/macaulay2/M2/M2/BUILD/doug$ make -C Macaulay2/packages/ check-Probability ArgumentMode="defaultMode + NoCapture"
make: Entering directory '/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/Macaulay2/packages'
cd ../..; ./config.status Macaulay2/packages/Makefile
config.status: creating Macaulay2/packages/Makefile
/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/usr-dist/x86_64-Linux-Ubuntu-21.10/bin/M2 -q --no-preload --stop --silent -e "needsPackage(\"Probability\",LoadDocumentation=>true,DebuggingMode=>true)" -e "debug Core; argumentMode = defaultMode + NoCapture" -e "check(Probability,UserMode=>false,Verbose=>false); exit 0"
 -- running   check(0, "Probability")                                        -- 0.888558 seconds elapsed
 -- running   check(1, "Probability")                                        -- 0.889023 seconds elapsed
 -- running   check(2, "Probability")                                        -- 0.888267 seconds elapsed
 -- running   check(3, "Probability")                                        -- 0.854109 seconds elapsed
 -- running   check(4, "Probability")                                        -- 0.864179 seconds elapsed
 -- running   check(5, "Probability")                                        -- 0.856605 seconds elapsed
 -- running   check(6, "Probability")                                        -- 0.86081 seconds elapsed
 -- running   check(7, "Probability")                                        -- 0.869786 seconds elapsed
 -- running   check(8, "Probability")                                        -- 0.854625 seconds elapsed
 -- running   check(9, "Probability")                                        -- 0.850131 seconds elapsed
 -- running   check(10, "Probability")                                       -- 0.881283 seconds elapsed
 -- running   check(11, "Probability")                                       -- 0.881599 seconds elapsed
 -- running   check(12, "Probability")                                       -- 0.884411 seconds elapsed
 -- running   check(13, "Probability")                                       -- 0.907521 seconds elapsed
 -- running   check(14, "Probability")                                       -- 0.908517 seconds elapsed
make: Leaving directory '/home/dtorrance/src/macaulay2/M2/M2/BUILD/doug/Macaulay2/packages'
```