### PR TITLE
Add docstring for Pygments Macaulay2Lexer class

### DIFF
--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -31,6 +31,8 @@ M2CONSTANTS = (
     )
 
 class Macaulay2Lexer(RegexLexer):
+    """Lexer for Macaulay2, a software system for research in algebraic geometry."""
+
     name = 'Macaulay2'
     url = 'https://faculty.math.illinois.edu/Macaulay2/'
     aliases = ['macaulay2']


### PR DESCRIPTION
Apparently fixes a warning in a Sphinx build.  See https://github.com/pygments/pygments/pull/2124.

(Doesn't affect the build, so skipping Github workflow.)