### PR TITLE
Fix typo in regex docs

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/regex-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/regex-doc.m2
@@ -13,7 +13,7 @@ doc ///
   Headline
     evaluate a regular expression search
   Usage
-    regex(re, start)
+    regex(re, str)
     regex(re, start, str)
     regex(re, start, range, str)
   Inputs


### PR DESCRIPTION
When two arguments are given, the second is the string to be searched.

[ci skip]