### PR TITLE
Fix typo in alphaCertified documentation

### DIFF
--- a/M2/Macaulay2/packages/NumericalCertification/Documents/DocNumericalCertification.m2
+++ b/M2/Macaulay2/packages/NumericalCertification/Documents/DocNumericalCertification.m2
@@ -678,7 +678,7 @@ doc ///
 
 		In order to use alphaCertified, users need to let the package knows a directory for alphaCertified when it is loaded.
 	    Example
-	    	needsPackage("NumericalCertification", Configuration => {"some/path/to/alphaCertified"})
+	    	needsPackage("NumericalCertification", Configuration => {"ALPHACERTIFIEDexec" => "some/path/to/alphaCertified"})
 	    Text
 		Function only takes elements over @TO "RR"@ or @TO "CC"@ as an input.
     	    Example


### PR DESCRIPTION
`Configuration` key to `needsPackage` should be a list of options.  This would ordinarily result in an error, but it didn't since the package was already loaded when generating the example.

---

I noticed this after playing around with the package after Kisun's talk earlier today in Cleveland.