### PR TITLE
Replace deprecated GMP_RNDN with MPFR_RNDN

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -857,7 +857,7 @@ setupfun("Digamma",Digamma).Protected=false;
 export lgamma(x:RR):Expr := (
      z := newRRmutable(precision(x));
      i := 0;
-     Ccode( void, "mpfr_lgamma((mpfr_ptr)", z, ",&",i,",(mpfr_srcptr)", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_lgamma((mpfr_ptr)", z, ",&",i,",(mpfr_srcptr)", x, ", MPFR_RNDN)" );
      Expr(Sequence(toExpr(moveToRR(z)),toExpr(i))));
 lgamma(e:Expr):Expr := (
      when e

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -844,7 +844,7 @@ export precision(x:CC):ulong := precision0(x.re);
 export toRR(x:RR,prec:ulong):RR := (
      if precision0(x) == prec then return x;
      z := newRRmutable(prec);
-     Ccode( void, "mpfr_set(",  z, ",",  x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_set(",  z, ",",  x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export toRRi(x:RRi,prec:ulong):RRi := (
@@ -855,7 +855,7 @@ export toRRi(x:RRi,prec:ulong):RRi := (
 
 export toRR(s:string,prec:ulong):RR := (
      z := newRRmutable(prec);
-     Ccode( void,  "mpfr_set_str(",  z,", (char *)",  s, "->array,", "10,", "GMP_RNDN", ")" );
+     Ccode( void,  "mpfr_set_str(",  z,", (char *)",  s, "->array,", "10,", "MPFR_RNDN", ")" );
      moveToRRandclear(z));
 
 export toRRi(s:string,prec:ulong):RRi := (
@@ -865,7 +865,7 @@ export toRRi(s:string,prec:ulong):RRi := (
 
 export toRR(x:QQ,prec:ulong):RR := (
      z := newRRmutable(prec);
-     Ccode( void, "mpfr_set_q(",  z, ",",  x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_set_q(",  z, ",",  x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export toRRi(x:QQ,prec:ulong):RRi := (
@@ -879,7 +879,7 @@ export toRRi(x:QQ):RRi := toRRi(x,defaultPrecision);
 
 export toRR(x:ZZ,prec:ulong):RR := (
      z := newRRmutable(prec);
-     Ccode( void, "mpfr_set_z(",  z, ",",  x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_set_z(",  z, ",",  x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export toRRi(x:ZZ,prec:ulong):RRi := (
@@ -893,7 +893,7 @@ export toRRi(x:ZZ):RRi := toRRi(x,defaultPrecision);
 
 export toRR(n:int,prec:ulong):RR := (
      x := newRRmutable(prec);
-     Ccode( void, "mpfr_set_si(",  x, ",(long)", n, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_set_si(",  x, ",(long)", n, ", MPFR_RNDN)" );
      moveToRRandclear(x));
 
 export toRRi(n:int,prec:ulong):RRi := (
@@ -903,7 +903,7 @@ export toRRi(n:int,prec:ulong):RRi := (
 
 export toRR(n:ulong,prec:ulong):RR := (
      x := newRRmutable(prec);
-     Ccode( void, "mpfr_set_ui(",  x, ",(unsigned long)", n, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_set_ui(",  x, ",(unsigned long)", n, ", MPFR_RNDN)" );
      moveToRRandclear(x));
 
 export toRRi(n:ulong,prec:ulong):RRi := (
@@ -913,7 +913,7 @@ export toRRi(n:ulong,prec:ulong):RRi := (
 
 export toRR(n:double,prec:ulong):RR := (
      x := newRRmutable(prec);
-     Ccode( void, "mpfr_set_d(",  x, ",", n, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_set_d(",  x, ",", n, ", MPFR_RNDN)" );
      moveToRRandclear(x));
 
 export toRRi(n:double,prec:ulong):RRi := (
@@ -934,72 +934,72 @@ export toRRi(n:RR):RRi := toRRi(n,precision(n));
                                     
 export toRRi(a:ZZ,b:ZZ,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
                                   
 export toRRi(a:ZZ,b:ZZ):RRi := toRRi(a,b,defaultPrecision);
 
 export toRRi(a:ZZ,b:QQ,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
 
 export toRRi(a:ZZ, b:QQ):RRi := toRRi(a,b,defaultPrecision);
 
 export toRRi(a:ZZ,b:RR,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set_z( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
 
 export toRRi(a:ZZ, b:RR):RRi := toRRi(a,b,precision(b));
 
 export toRRi(a:QQ,b:ZZ,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
                                   
 export toRRi(a:QQ,b:ZZ):RRi := toRRi(a,b,defaultPrecision);
 
 export toRRi(a:QQ,b:QQ,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
 
 export toRRi(a:QQ, b:QQ):RRi := toRRi(a,b,defaultPrecision);
 
 export toRRi(a:QQ,b:RR,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set_q( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
 
 export toRRi(a:QQ, b:RR):RRi := toRRi(a,b,precision(b));
 
 export toRRi(a:RR,b:ZZ,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set_z( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
                                   
 export toRRi(a:RR,b:ZZ):RRi := toRRi(a,b,precision(a));
 
 export toRRi(a:RR,b:QQ,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set_q( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
 
 export toRRi(a:RR, b:QQ):RRi := toRRi(a,b,precision(a));
 
 export toRRi(a:RR,b:RR,prec:ulong):RRi := (
      x := newRRimutable(prec);
-     Ccode( void, "mpfr_set( &", x, "->left," , a, ",GMP_RNDD)");
-     Ccode( void, "mpfr_set( &", x, "->right," , b, ",GMP_RNDU)");
+     Ccode( void, "mpfr_set( &", x, "->left," , a, ",MPFR_RNDD)");
+     Ccode( void, "mpfr_set( &", x, "->right," , b, ",MPFR_RNDU)");
      moveToRRiandclear(x));
 
 export toRRi(a:RR, b:RR):RRi := toRRi(a,b,min(precision(a),precision(b)));
@@ -1078,11 +1078,11 @@ export toCC(x:double,prec:ulong):CC := CC(toRR(x,prec),toRR(0,prec));
 
 export toCC(x:double,y:double,prec:ulong):CC := CC(toRR(x,prec),toRR(y,prec));
 
-export toDouble(x:RR):double := Ccode( double, "mpfr_get_d(",  x, ", GMP_RNDN)" );
+export toDouble(x:RR):double := Ccode( double, "mpfr_get_d(",  x, ", MPFR_RNDN)" );
                                     
 export toDouble(x:RRi):double := toDouble(midpointRR(x));
 
-export toDouble(x:RRcell):double := Ccode( double, "mpfr_get_d(",  x.v, ", GMP_RNDN)" );
+export toDouble(x:RRcell):double := Ccode( double, "mpfr_get_d(",  x.v, ", MPFR_RNDN)" );
                                     
 export toDouble(x:RRicell):double := toDouble(midpointRR(x.v));
 
@@ -1336,7 +1336,7 @@ export hash(x:CC):int := 123 + hash(x.re) + 111 * hash(x.im);
      
 export (x:RR) + (y:RR) : RR := (
      z := newRRmutable(min(precision0(x),precision0(y)));
-     Ccode( void, "mpfr_add(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_add(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) + (y:RRi) : RRi := (
@@ -1346,7 +1346,7 @@ export (x:RRi) + (y:RRi) : RRi := (
 
 export (x:RR) + (y:int) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_add_si(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_add_si(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export (x:RRi) + (y:int) : RRi := (
@@ -1356,7 +1356,7 @@ export (x:RRi) + (y:int) : RRi := (
      
 export (x:RR) + (y:ZZ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_add_z(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_add_z(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export (x:RRi) + (y:ZZ) : RRi := (
@@ -1366,7 +1366,7 @@ export (x:RRi) + (y:ZZ) : RRi := (
      
 export (x:RR) + (y:QQ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_add_q(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_add_q(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export (x:RRi) + (y:QQ) : RRi := (
@@ -1381,7 +1381,7 @@ export (x:RRi) + (y:RR) : RRi := (
 
 export - (y:RR) : RR := (
      z := newRRmutable(precision0(y));
-     Ccode( void, "mpfr_neg(", z, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_neg(", z, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export - (y:RRi) : RRi := (
@@ -1391,7 +1391,7 @@ export - (y:RRi) : RRi := (
 
 export (x:RR) - (y:RR) : RR := (
      z := newRRmutable(min(precision0(x),precision0(y)));
-     Ccode( void, "mpfr_sub(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sub(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) - (y:RRi) : RRi := (
@@ -1401,7 +1401,7 @@ export (x:RRi) - (y:RRi) : RRi := (
 
 export (x:RR) - (y:int) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_sub_si(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sub_si(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export (y:int) - (x:RR) : RR := -(x-y);
@@ -1415,7 +1415,7 @@ export (y:int) - (x:RRi) : RRi := -(x-y);
                                     
 export (x:RR) - (y:ZZ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_sub_z(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sub_z(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) - (y:ZZ) : RRi := (
@@ -1425,7 +1425,7 @@ export (x:RRi) - (y:ZZ) : RRi := (
      
 export (x:RR) - (y:QQ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_sub_q(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sub_q(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) - (y:QQ) : RRi := (
@@ -1447,7 +1447,7 @@ export abs(x:RRi) : RRi := (
 
 export (x:RR) * (y:RR) : RR := (
      z := newRRmutable(min(precision0(x),precision0(y)));
-     Ccode( void, "mpfr_mul(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_mul(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
  
 export (x:RRi) * (y:RRi) : RRi := (
@@ -1457,7 +1457,7 @@ export (x:RRi) * (y:RRi) : RRi := (
 
 export (x:RR) * (y:ZZ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_mul_z(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_mul_z(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) * (y:ZZ) : RRi := (
@@ -1467,7 +1467,7 @@ export (x:RRi) * (y:ZZ) : RRi := (
 
 export (y:ZZ) * (x:RR) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_mul_z(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_mul_z(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (y:ZZ) * (x:RRi) : RRi := (
@@ -1477,7 +1477,7 @@ export (y:ZZ) * (x:RRi) : RRi := (
 
 export (x:RR) * (y:int) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_mul_si(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_mul_si(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) * (y:int) : RRi := (
@@ -1487,14 +1487,14 @@ export (x:RRi) * (y:int) : RRi := (
 
 export (y:int) * (x:RR) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_mul_si(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_mul_si(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (y:int) * (x:RRi) : RRi := x*y;
      
 export (x:RR) * (y:QQ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_mul_q(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_mul_q(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) * (y:QQ) : RRi := (
@@ -1509,7 +1509,7 @@ export (x:RRi) * (y:RR) : RRi := (
 
 export (x:RR) / (y:RR) : RR := (
      z := newRRmutable(min(precision0(x),precision0(y)));
-     Ccode( void, "mpfr_div(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_div(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) / (y:RRi) : RRi := (
@@ -1519,7 +1519,7 @@ export (x:RRi) / (y:RRi) : RRi := (
 
 export (x:RR) / (y:long) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_div_si(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_div_si(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RR) / (y:int) : RR := x / long(y);
@@ -1540,7 +1540,7 @@ export (y:int) / (x:RRi) : RRi := long(y) / x;
      
 export (x:RR) / (y:ZZ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_div_z(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_div_z(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) / (y:ZZ) : RRi := (
@@ -1555,7 +1555,7 @@ export (y:ZZ) / (x:RRi) : RRi := (
      
 export (x:RR) / (y:QQ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_div_q(", z, ",",  x, ",",  y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_div_q(", z, ",",  x, ",",  y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) / (y:QQ) : RRi := (
@@ -1580,7 +1580,7 @@ export (y:RR) / (x:RRi) : RRi := (
 
 export sqrt(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_sqrt(",  z, ",",  x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sqrt(",  z, ",",  x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export sqrt(x:RRi):RRi := (
@@ -1590,7 +1590,7 @@ export sqrt(x:RRi):RRi := (
 
 export (x:RR) ^ (n:long) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_pow_si(",  z, ",",  x, ",", n, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_pow_si(",  z, ",",  x, ",", n, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) ^ (n:long) : RRi := (
@@ -1603,32 +1603,32 @@ export (x:RRi) ^ (n:long) : RRi := (
     upper := newRRmutable(precision0(x));
     lower := newRRmutable(precision0(x));
           
-    if contains0(x) then Ccode(void, "mpfr_set_si(", extra, ",0, GMP_RNDN)")
+    if contains0(x) then Ccode(void, "mpfr_set_si(", extra, ",0, MPFR_RNDN)")
     else Ccode( void, "mpfr_set_inf(", extra, ",-1)" );
                                     
-    Ccode( void, "mpfr_pow_si(",  left, ",",  leftRR(x), ",", n, ", GMP_RNDU)" );
-    Ccode( void, "mpfr_pow_si(",  right, ",",  rightRR(x), ",", n, ", GMP_RNDU)" );
+    Ccode( void, "mpfr_pow_si(",  left, ",",  leftRR(x), ",", n, ", MPFR_RNDU)" );
+    Ccode( void, "mpfr_pow_si(",  right, ",",  rightRR(x), ",", n, ", MPFR_RNDU)" );
           
     if (Ccode(int, "mpfr_cmp(", left, ",", right, ")") > 0)
     then (if (Ccode(int, "mpfr_cmp(", left, ",", extra, ")") > 0)
-        then Ccode(void, "mpfr_set(", upper, ",", left, ", GMP_RNDU)")
-        else Ccode(void, "mpfr_set(", upper, ",", extra, ", GMP_RNDU)"))
+        then Ccode(void, "mpfr_set(", upper, ",", left, ", MPFR_RNDU)")
+        else Ccode(void, "mpfr_set(", upper, ",", extra, ", MPFR_RNDU)"))
     else (if (Ccode(int, "mpfr_cmp(", right, ",", extra, ")") > 0)
-        then Ccode(void, "mpfr_set(", upper, ",", right, ", GMP_RNDU)")
-        else Ccode(void, "mpfr_set(", upper, ",", extra, ", GMP_RNDU)"));
+        then Ccode(void, "mpfr_set(", upper, ",", right, ", MPFR_RNDU)")
+        else Ccode(void, "mpfr_set(", upper, ",", extra, ", MPFR_RNDU)"));
           
     if !contains0(x) then Ccode( void, "mpfr_set_inf(", extra, ",1)" );
                                     
-    Ccode( void, "mpfr_pow_si(",  left, ",",  leftRR(x), ",", n, ", GMP_RNDD)" );
-    Ccode( void, "mpfr_pow_si(",  right, ",",  rightRR(x), ",", n, ", GMP_RNDD)" );
+    Ccode( void, "mpfr_pow_si(",  left, ",",  leftRR(x), ",", n, ", MPFR_RNDD)" );
+    Ccode( void, "mpfr_pow_si(",  right, ",",  rightRR(x), ",", n, ", MPFR_RNDD)" );
           
     if (Ccode(int, "mpfr_cmp(", left, ",", right, ")") < 0)
     then (if (Ccode(int, "mpfr_cmp(", left, ",", extra, ")") < 0)
-        then Ccode(void, "mpfr_set(", lower, ",", left, ", GMP_RNDD)")
-        else Ccode(void, "mpfr_set(", lower, ",", extra, ", GMP_RNDD)"))
+        then Ccode(void, "mpfr_set(", lower, ",", left, ", MPFR_RNDD)")
+        else Ccode(void, "mpfr_set(", lower, ",", extra, ", MPFR_RNDD)"))
     else (if (Ccode(int, "mpfr_cmp(", right, ",", extra, ")") < 0)
-        then Ccode(void, "mpfr_set(", lower, ",", right, ", GMP_RNDD)")
-        else Ccode(void, "mpfr_set(", lower, ",", extra, ", GMP_RNDD)"));
+        then Ccode(void, "mpfr_set(", lower, ",", right, ", MPFR_RNDD)")
+        else Ccode(void, "mpfr_set(", lower, ",", extra, ", MPFR_RNDD)"));
                  
     clear(left);
     clear(right);
@@ -1638,7 +1638,7 @@ export (x:RRi) ^ (n:long) : RRi := (
                                     
 export (x:RR) ^ (n:ulong) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_pow_ui(",  z, ",",  x, ",", n, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_pow_ui(",  z, ",",  x, ",", n, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) ^ (n:ulong) : RRi := (
@@ -1651,32 +1651,32 @@ export (x:RRi) ^ (n:ulong) : RRi := (
     upper := newRRmutable(precision0(x));
     lower := newRRmutable(precision0(x));
           
-    if contains0(x) then Ccode(void, "mpfr_set_ui(", extra, ",0, GMP_RNDN)")
+    if contains0(x) then Ccode(void, "mpfr_set_ui(", extra, ",0, MPFR_RNDN)")
     else Ccode( void, "mpfr_set_inf(", extra, ",-1)" );
                                     
-    Ccode( void, "mpfr_pow_ui(",  left, ",",  leftRR(x), ",", n, ", GMP_RNDU)" );
-    Ccode( void, "mpfr_pow_ui(",  right, ",",  rightRR(x), ",", n, ", GMP_RNDU)" );
+    Ccode( void, "mpfr_pow_ui(",  left, ",",  leftRR(x), ",", n, ", MPFR_RNDU)" );
+    Ccode( void, "mpfr_pow_ui(",  right, ",",  rightRR(x), ",", n, ", MPFR_RNDU)" );
           
     if (Ccode(int, "mpfr_cmp(", left, ",", right, ")") > 0)
     then (if (Ccode(int, "mpfr_cmp(", left, ",", extra, ")") > 0)
-        then Ccode(void, "mpfr_set(", upper, ",", left, ", GMP_RNDU)")
-        else Ccode(void, "mpfr_set(", upper, ",", extra, ", GMP_RNDU)"))
+        then Ccode(void, "mpfr_set(", upper, ",", left, ", MPFR_RNDU)")
+        else Ccode(void, "mpfr_set(", upper, ",", extra, ", MPFR_RNDU)"))
     else (if (Ccode(int, "mpfr_cmp(", right, ",", extra, ")") > 0)
-        then Ccode(void, "mpfr_set(", upper, ",", right, ", GMP_RNDU)")
-        else Ccode(void, "mpfr_set(", upper, ",", extra, ", GMP_RNDU)"));
+        then Ccode(void, "mpfr_set(", upper, ",", right, ", MPFR_RNDU)")
+        else Ccode(void, "mpfr_set(", upper, ",", extra, ", MPFR_RNDU)"));
           
     if !contains0(x) then Ccode( void, "mpfr_set_inf(", extra, ",1)" );
                                     
-    Ccode( void, "mpfr_pow_ui(",  left, ",",  leftRR(x), ",", n, ", GMP_RNDD)" );
-    Ccode( void, "mpfr_pow_ui(",  right, ",",  rightRR(x), ",", n, ", GMP_RNDD)" );
+    Ccode( void, "mpfr_pow_ui(",  left, ",",  leftRR(x), ",", n, ", MPFR_RNDD)" );
+    Ccode( void, "mpfr_pow_ui(",  right, ",",  rightRR(x), ",", n, ", MPFR_RNDD)" );
           
     if (Ccode(int, "mpfr_cmp(", left, ",", right, ")") < 0)
     then (if (Ccode(int, "mpfr_cmp(", left, ",", extra, ")") < 0)
-        then Ccode(void, "mpfr_set(", lower, ",", left, ", GMP_RNDD)")
-        else Ccode(void, "mpfr_set(", lower, ",", extra, ", GMP_RNDD)"))
+        then Ccode(void, "mpfr_set(", lower, ",", left, ", MPFR_RNDD)")
+        else Ccode(void, "mpfr_set(", lower, ",", extra, ", MPFR_RNDD)"))
     else (if (Ccode(int, "mpfr_cmp(", right, ",", extra, ")") < 0)
-        then Ccode(void, "mpfr_set(", lower, ",", right, ", GMP_RNDD)")
-        else Ccode(void, "mpfr_set(", lower, ",", extra, ", GMP_RNDD)"));
+        then Ccode(void, "mpfr_set(", lower, ",", right, ", MPFR_RNDD)")
+        else Ccode(void, "mpfr_set(", lower, ",", extra, ", MPFR_RNDD)"));
                  
     clear(left);
     clear(right);
@@ -1686,14 +1686,14 @@ export (x:RRi) ^ (n:ulong) : RRi := (
 
 export pow10(n:ulong,prec:ulong):RR := (
      z := newRRmutable(prec);
-     Ccode( void, "mpfr_ui_pow_ui(",  z, ",", ulong(10), ",", n, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_ui_pow_ui(",  z, ",", ulong(10), ",", n, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export pow10RRi(n:ulong,prec:ulong):RRi := (
      left := newRRmutable(prec);
      right := newRRmutable(prec);
-     Ccode( void, "mpfr_ui_pow_ui(",  left, ",", ulong(10), ",", n, ", GMP_RNDD)" );
-     Ccode( void, "mpfr_ui_pow_ui(",  right, ",", ulong(10), ",", n, ", GMP_RNDU)" );
+     Ccode( void, "mpfr_ui_pow_ui(",  left, ",", ulong(10), ",", n, ", MPFR_RNDD)" );
+     Ccode( void, "mpfr_ui_pow_ui(",  right, ",", ulong(10), ",", n, ", MPFR_RNDU)" );
      toRRi(moveToRRandclear(left),moveToRRandclear(right)));
 
 export pow10(n:long,prec:ulong):RR := (
@@ -1712,7 +1712,7 @@ export pow10RRi(n:int,prec:ulong):RRi := pow10RRi(long(n),prec);
 
 export (n:ulong) ^ (x:RR) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_ui_pow(",  z, ",", n, ",",  x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_ui_pow(",  z, ",", n, ",",  x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (n:ulong) ^ (x:RRi) : RRi := (
@@ -1722,17 +1722,17 @@ export (n:ulong) ^ (x:RRi) : RRi := (
      right := newRRmutable(precision0(x));
                                      
      if (n > ulong(1)) then (
-        Ccode( void, "mpfr_ui_pow(",  left, ",", n, ",", leftRR(x), ", GMP_RNDD)" );
-        Ccode( void, "mpfr_ui_pow(",  right, ",", n, ",", rightRR(x), ", GMP_RNDU)" ))
+        Ccode( void, "mpfr_ui_pow(",  left, ",", n, ",", leftRR(x), ", MPFR_RNDD)" );
+        Ccode( void, "mpfr_ui_pow(",  right, ",", n, ",", rightRR(x), ", MPFR_RNDU)" ))
      else (
-        Ccode( void, "mpfr_ui_pow(",  left, ",", n, ",", rightRR(x), ", GMP_RNDD)" );
-        Ccode( void, "mpfr_ui_pow(",  right, ",", n, ",", leftRR(x), ", GMP_RNDU)" ));
+        Ccode( void, "mpfr_ui_pow(",  left, ",", n, ",", rightRR(x), ", MPFR_RNDD)" );
+        Ccode( void, "mpfr_ui_pow(",  right, ",", n, ",", leftRR(x), ", MPFR_RNDU)" ));
                                      
      toRRi(moveToRRandclear(left),moveToRRandclear(right)));
 
 export (x:RR) ^ (y:ZZ) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_pow_z(",  z, ",",  x, ",", y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_pow_z(",  z, ",",  x, ",", y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (x:RRi) ^ (y:ZZ) : RRi := (
@@ -1745,32 +1745,32 @@ export (x:RRi) ^ (y:ZZ) : RRi := (
     upper := newRRmutable(precision0(x));
     lower := newRRmutable(precision0(x));
 
-    if contains0(x) then Ccode(void, "mpfr_set_ui(", extra, ",0, GMP_RNDN)")
+    if contains0(x) then Ccode(void, "mpfr_set_ui(", extra, ",0, MPFR_RNDN)")
     else Ccode( void, "mpfr_set_inf(", extra, ",-1)" );
 
-    Ccode( void, "mpfr_pow_z(",  left, ",",  leftRR(x), ",", y, ", GMP_RNDU)" );
-    Ccode( void, "mpfr_pow_z(",  right, ",",  rightRR(x), ",", y, ", GMP_RNDU)" );
+    Ccode( void, "mpfr_pow_z(",  left, ",",  leftRR(x), ",", y, ", MPFR_RNDU)" );
+    Ccode( void, "mpfr_pow_z(",  right, ",",  rightRR(x), ",", y, ", MPFR_RNDU)" );
 
     if (Ccode(int, "mpfr_cmp(", left, ",", right, ")") > 0)
     then (if (Ccode(int, "mpfr_cmp(", left, ",", extra, ")") > 0)
-        then Ccode(void, "mpfr_set(", upper, ",", left, ", GMP_RNDU)")
-        else Ccode(void, "mpfr_set(", upper, ",", extra, ", GMP_RNDU)"))
+        then Ccode(void, "mpfr_set(", upper, ",", left, ", MPFR_RNDU)")
+        else Ccode(void, "mpfr_set(", upper, ",", extra, ", MPFR_RNDU)"))
     else (if (Ccode(int, "mpfr_cmp(", right, ",", extra, ")") > 0)
-        then Ccode(void, "mpfr_set(", upper, ",", right, ", GMP_RNDU)")
-        else Ccode(void, "mpfr_set(", upper, ",", extra, ", GMP_RNDU)"));
+        then Ccode(void, "mpfr_set(", upper, ",", right, ", MPFR_RNDU)")
+        else Ccode(void, "mpfr_set(", upper, ",", extra, ", MPFR_RNDU)"));
 
     if !contains0(x) then Ccode( void, "mpfr_set_inf(", extra, ",1)" );
 
-    Ccode( void, "mpfr_pow_z(",  left, ",",  leftRR(x), ",", y, ", GMP_RNDD)" );
-    Ccode( void, "mpfr_pow_z(",  right, ",",  rightRR(x), ",", y, ", GMP_RNDD)" );
+    Ccode( void, "mpfr_pow_z(",  left, ",",  leftRR(x), ",", y, ", MPFR_RNDD)" );
+    Ccode( void, "mpfr_pow_z(",  right, ",",  rightRR(x), ",", y, ", MPFR_RNDD)" );
 
     if (Ccode(int, "mpfr_cmp(", left, ",", right, ")") < 0)
     then (if (Ccode(int, "mpfr_cmp(", left, ",", extra, ")") < 0)
-        then Ccode(void, "mpfr_set(", lower, ",", left, ", GMP_RNDD)")
-        else Ccode(void, "mpfr_set(", lower, ",", extra, ", GMP_RNDD)"))
+        then Ccode(void, "mpfr_set(", lower, ",", left, ", MPFR_RNDD)")
+        else Ccode(void, "mpfr_set(", lower, ",", extra, ", MPFR_RNDD)"))
     else (if (Ccode(int, "mpfr_cmp(", right, ",", extra, ")") < 0)
-        then Ccode(void, "mpfr_set(", lower, ",", right, ", GMP_RNDD)")
-        else Ccode(void, "mpfr_set(", lower, ",", extra, ", GMP_RNDD)"));
+        then Ccode(void, "mpfr_set(", lower, ",", right, ", MPFR_RNDD)")
+        else Ccode(void, "mpfr_set(", lower, ",", extra, ", MPFR_RNDD)"));
 
     clear(left);
     clear(right);
@@ -1780,7 +1780,7 @@ export (x:RRi) ^ (y:ZZ) : RRi := (
 
 export (x:RR) ^ (y:RR) : RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_pow(",  z, ",",  x, ",", y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_pow(",  z, ",",  x, ",", y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                     
 export (y:RR) ^ (x:RRi) : RRi := (
@@ -1791,11 +1791,11 @@ export (y:RR) ^ (x:RRi) : RRi := (
      right := newRRmutable(min(precision0(x),precision0(y)));
                                      
      if (y > toRR(1,precision0(y))) then (
-        Ccode( void, "mpfr_pow(",  left, ",", y, ",", leftRR(x), ", GMP_RNDD)" );
-        Ccode( void, "mpfr_pow(",  right, ",", y, ",", rightRR(x), ", GMP_RNDU)" ))
+        Ccode( void, "mpfr_pow(",  left, ",", y, ",", leftRR(x), ", MPFR_RNDD)" );
+        Ccode( void, "mpfr_pow(",  right, ",", y, ",", rightRR(x), ", MPFR_RNDU)" ))
      else (
-        Ccode( void, "mpfr_pow(",  left, ",", y, ",", rightRR(x), ", GMP_RNDD)" );
-        Ccode( void, "mpfr_pow(",  right, ",", y, ",", leftRR(x), ", GMP_RNDU)" ));
+        Ccode( void, "mpfr_pow(",  left, ",", y, ",", rightRR(x), ", MPFR_RNDD)" );
+        Ccode( void, "mpfr_pow(",  right, ",", y, ",", leftRR(x), ", MPFR_RNDU)" ));
                                      
      toRRi(moveToRRandclear(left),moveToRRandclear(right)));
                                     
@@ -1809,32 +1809,32 @@ export (x:RRi) ^ (y:RR) : RRi := (
     upper := newRRmutable(min(precision0(x),precision0(y)));
     lower := newRRmutable(min(precision0(x),precision0(y)));
 
-    if contains0(x) then Ccode(void, "mpfr_set_ui(", extra, ",0, GMP_RNDN)")
+    if contains0(x) then Ccode(void, "mpfr_set_ui(", extra, ",0, MPFR_RNDN)")
     else Ccode( void, "mpfr_set_inf(", extra, ",-1)" );
 
-    Ccode( void, "mpfr_pow(",  left, ",",  leftRR(x), ",", y, ", GMP_RNDU)" );
-    Ccode( void, "mpfr_pow(",  right, ",",  rightRR(x), ",", y, ", GMP_RNDU)" );
+    Ccode( void, "mpfr_pow(",  left, ",",  leftRR(x), ",", y, ", MPFR_RNDU)" );
+    Ccode( void, "mpfr_pow(",  right, ",",  rightRR(x), ",", y, ", MPFR_RNDU)" );
 
     if (Ccode(int, "mpfr_cmp(", left, ",", right, ")") > 0)
     then (if (Ccode(int, "mpfr_cmp(", left, ",", extra, ")") > 0)
-        then Ccode(void, "mpfr_set(", upper, ",", left, ", GMP_RNDU)")
-        else Ccode(void, "mpfr_set(", upper, ",", extra, ", GMP_RNDU)"))
+        then Ccode(void, "mpfr_set(", upper, ",", left, ", MPFR_RNDU)")
+        else Ccode(void, "mpfr_set(", upper, ",", extra, ", MPFR_RNDU)"))
     else (if (Ccode(int, "mpfr_cmp(", right, ",", extra, ")") > 0)
-        then Ccode(void, "mpfr_set(", upper, ",", right, ", GMP_RNDU)")
-        else Ccode(void, "mpfr_set(", upper, ",", extra, ", GMP_RNDU)"));
+        then Ccode(void, "mpfr_set(", upper, ",", right, ", MPFR_RNDU)")
+        else Ccode(void, "mpfr_set(", upper, ",", extra, ", MPFR_RNDU)"));
 
     if !contains0(x) then Ccode( void, "mpfr_set_inf(", extra, ",1)" );
 
-    Ccode( void, "mpfr_pow(",  left, ",",  leftRR(x), ",", y, ", GMP_RNDD)" );
-    Ccode( void, "mpfr_pow(",  right, ",",  rightRR(x), ",", y, ", GMP_RNDD)" );
+    Ccode( void, "mpfr_pow(",  left, ",",  leftRR(x), ",", y, ", MPFR_RNDD)" );
+    Ccode( void, "mpfr_pow(",  right, ",",  rightRR(x), ",", y, ", MPFR_RNDD)" );
 
     if (Ccode(int, "mpfr_cmp(", left, ",", right, ")") < 0)
     then (if (Ccode(int, "mpfr_cmp(", left, ",", extra, ")") < 0)
-        then Ccode(void, "mpfr_set(", lower, ",", left, ", GMP_RNDD)")
-        else Ccode(void, "mpfr_set(", lower, ",", extra, ", GMP_RNDD)"))
+        then Ccode(void, "mpfr_set(", lower, ",", left, ", MPFR_RNDD)")
+        else Ccode(void, "mpfr_set(", lower, ",", extra, ", MPFR_RNDD)"))
     else (if (Ccode(int, "mpfr_cmp(", right, ",", extra, ")") < 0)
-        then Ccode(void, "mpfr_set(", lower, ",", right, ", GMP_RNDD)")
-        else Ccode(void, "mpfr_set(", lower, ",", extra, ", GMP_RNDD)"));
+        then Ccode(void, "mpfr_set(", lower, ",", right, ", MPFR_RNDD)")
+        else Ccode(void, "mpfr_set(", lower, ",", extra, ", MPFR_RNDD)"));
 
     clear(left);
     clear(right);
@@ -1854,53 +1854,53 @@ export (y:RRi) ^ (x:RRi) : RRi := (
      lowerright := newRRmutable(min(precision0(x),precision0(y)));
      lowerleft := newRRmutable(min(precision0(x),precision0(y)));
 
-     Ccode( void, "mpfr_pow(",  upperleft, ",",  leftRR(y), ",", rightRR(x), ", GMP_RNDU)" );
-     Ccode( void, "mpfr_pow(",  upperright, ",",  rightRR(y), ",", rightRR(x), ", GMP_RNDU)" );
-     Ccode( void, "mpfr_pow(",  lowerleft, ",",  leftRR(y), ",", leftRR(x), ", GMP_RNDU)" );
-     Ccode( void, "mpfr_pow(",  lowerright, ",",  rightRR(y), ",", leftRR(x), ", GMP_RNDU)" );
+     Ccode( void, "mpfr_pow(",  upperleft, ",",  leftRR(y), ",", rightRR(x), ", MPFR_RNDU)" );
+     Ccode( void, "mpfr_pow(",  upperright, ",",  rightRR(y), ",", rightRR(x), ", MPFR_RNDU)" );
+     Ccode( void, "mpfr_pow(",  lowerleft, ",",  leftRR(y), ",", leftRR(x), ", MPFR_RNDU)" );
+     Ccode( void, "mpfr_pow(",  lowerright, ",",  rightRR(y), ",", leftRR(x), ", MPFR_RNDU)" );
                                    
      if (Ccode(int, "mpfr_cmp(", upperleft, ",", upperright, ")") > 0) then (
          if (Ccode(int, "mpfr_cmp(", lowerleft, ",", lowerright, ")") > 0) then (
              if (Ccode(int, "mpfr_cmp(", upperleft, ",", lowerleft, ")") > 0)
-             then Ccode(void, "mpfr_set(", right, ",", upperleft, ", GMP_RNDU)")
-             else Ccode(void, "mpfr_set(", right, ",", lowerleft, ", GMP_RNDU)"))
+             then Ccode(void, "mpfr_set(", right, ",", upperleft, ", MPFR_RNDU)")
+             else Ccode(void, "mpfr_set(", right, ",", lowerleft, ", MPFR_RNDU)"))
          else (
              if (Ccode(int, "mpfr_cmp(", upperleft, ",", lowerright, ")") > 0)
-             then Ccode(void, "mpfr_set(", right, ",", upperleft, ", GMP_RNDU)")
-             else Ccode(void, "mpfr_set(", right, ",", lowerright, ", GMP_RNDU)")))
+             then Ccode(void, "mpfr_set(", right, ",", upperleft, ", MPFR_RNDU)")
+             else Ccode(void, "mpfr_set(", right, ",", lowerright, ", MPFR_RNDU)")))
       else (
          if (Ccode(int, "mpfr_cmp(", lowerleft, ",", lowerright, ")") > 0) then (
              if (Ccode(int, "mpfr_cmp(", upperright, ",", lowerleft, ")") > 0)
-             then Ccode(void, "mpfr_set(", right, ",", upperright, ", GMP_RNDU)")
-             else Ccode(void, "mpfr_set(", right, ",", lowerleft, ", GMP_RNDU)"))
+             then Ccode(void, "mpfr_set(", right, ",", upperright, ", MPFR_RNDU)")
+             else Ccode(void, "mpfr_set(", right, ",", lowerleft, ", MPFR_RNDU)"))
          else (
              if (Ccode(int, "mpfr_cmp(", upperright, ",", lowerright, ")") > 0)
-             then Ccode(void, "mpfr_set(", right, ",", upperright, ", GMP_RNDU)")
-             else Ccode(void, "mpfr_set(", right, ",", lowerright, ", GMP_RNDU)")));
+             then Ccode(void, "mpfr_set(", right, ",", upperright, ", MPFR_RNDU)")
+             else Ccode(void, "mpfr_set(", right, ",", lowerright, ", MPFR_RNDU)")));
 
-     Ccode( void, "mpfr_pow(",  upperleft, ",",  leftRR(y), ",", rightRR(x), ", GMP_RNDD)" );
-     Ccode( void, "mpfr_pow(",  upperright, ",",  rightRR(y), ",", rightRR(x), ", GMP_RNDD)" );
-     Ccode( void, "mpfr_pow(",  lowerleft, ",",  leftRR(y), ",", leftRR(x), ", GMP_RNDD)" );
-     Ccode( void, "mpfr_pow(",  lowerright, ",",  rightRR(y), ",", leftRR(x), ", GMP_RNDD)" );
+     Ccode( void, "mpfr_pow(",  upperleft, ",",  leftRR(y), ",", rightRR(x), ", MPFR_RNDD)" );
+     Ccode( void, "mpfr_pow(",  upperright, ",",  rightRR(y), ",", rightRR(x), ", MPFR_RNDD)" );
+     Ccode( void, "mpfr_pow(",  lowerleft, ",",  leftRR(y), ",", leftRR(x), ", MPFR_RNDD)" );
+     Ccode( void, "mpfr_pow(",  lowerright, ",",  rightRR(y), ",", leftRR(x), ", MPFR_RNDD)" );
                                    
      if (Ccode(int, "mpfr_cmp(", upperleft, ",", upperright, ")") < 0) then (
          if (Ccode(int, "mpfr_cmp(", lowerleft, ",", lowerright, ")") < 0) then (
              if (Ccode(int, "mpfr_cmp(", upperleft, ",", lowerleft, ")") < 0)
-             then Ccode(void, "mpfr_set(", left, ",", upperleft, ", GMP_RNDD)")
-             else Ccode(void, "mpfr_set(", left, ",", lowerleft, ", GMP_RNDD)"))
+             then Ccode(void, "mpfr_set(", left, ",", upperleft, ", MPFR_RNDD)")
+             else Ccode(void, "mpfr_set(", left, ",", lowerleft, ", MPFR_RNDD)"))
          else (
              if (Ccode(int, "mpfr_cmp(", upperleft, ",", lowerright, ")") < 0)
-             then Ccode(void, "mpfr_set(", left, ",", upperleft, ", GMP_RNDD)")
-             else Ccode(void, "mpfr_set(", left, ",", lowerright, ", GMP_RNDD)")))
+             then Ccode(void, "mpfr_set(", left, ",", upperleft, ", MPFR_RNDD)")
+             else Ccode(void, "mpfr_set(", left, ",", lowerright, ", MPFR_RNDD)")))
       else (
          if (Ccode(int, "mpfr_cmp(", lowerleft, ",", lowerright, ")") < 0) then (
              if (Ccode(int, "mpfr_cmp(", upperright, ",", lowerleft, ")") < 0)
-             then Ccode(void, "mpfr_set(", left, ",", upperright, ", GMP_RNDD)")
-             else Ccode(void, "mpfr_set(", left, ",", lowerleft, ", GMP_RNDD)"))
+             then Ccode(void, "mpfr_set(", left, ",", upperright, ", MPFR_RNDD)")
+             else Ccode(void, "mpfr_set(", left, ",", lowerleft, ", MPFR_RNDD)"))
          else (
              if (Ccode(int, "mpfr_cmp(", upperright, ",", lowerright, ")") < 0)
-             then Ccode(void, "mpfr_set(", left, ",", upperright, ", GMP_RNDD)")
-             else Ccode(void, "mpfr_set(", left, ",", lowerright, ", GMP_RNDD)")));
+             then Ccode(void, "mpfr_set(", left, ",", upperright, ", MPFR_RNDD)")
+             else Ccode(void, "mpfr_set(", left, ",", lowerright, ", MPFR_RNDD)")));
 
      clear(upperleft);
      clear(lowerleft);
@@ -1912,7 +1912,7 @@ export (y:RRi) ^ (x:RRi) : RRi := (
 export floor(x:RR) : ZZ := (
      if !isfinite0(x) then return zeroZZ;			    -- nothing else to do!
      w := newZZmutable();
-     Ccode( void, "mpfr_get_z(", w, ",", x, ", GMP_RNDD)" );
+     Ccode( void, "mpfr_get_z(", w, ",", x, ", MPFR_RNDD)" );
      moveToZZandclear(w));
                                      
 export floor(x:RRi) : ZZ := floor(leftRR(x));
@@ -1920,7 +1920,7 @@ export floor(x:RRi) : ZZ := floor(leftRR(x));
 export ceil(x:RR) : ZZ := (
      if !isfinite0(x) then return zeroZZ;			    -- nothing else to do!
      w := newZZmutable();
-     Ccode( void, "mpfr_get_z(", w, ",", x, ", GMP_RNDU)" );
+     Ccode( void, "mpfr_get_z(", w, ",", x, ", MPFR_RNDU)" );
      moveToZZandclear(w));
                                      
 export ceil(x:RRi) : ZZ := ceil(rightRR(x));
@@ -1928,7 +1928,7 @@ export ceil(x:RRi) : ZZ := ceil(rightRR(x));
 export round(x:RR) : ZZ := (
      if !isfinite0(x) then return zeroZZ;			    -- nothing else to do!
      w := newZZmutable();
-     Ccode( void, "mpfr_get_z(", w, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_get_z(", w, ",", x, ", MPFR_RNDN)" );
      moveToZZandclear(w));
                                     
 export round(x:RRi) : ZZ := (
@@ -1937,14 +1937,14 @@ export round(x:RRi) : ZZ := (
      Ccode( void, "mpfi_get_fr(", w, ",", x, ")" );
      if !isfinite0(w) then return zeroZZ;			    -- nothing else to do!
      y := newZZmutable();
-     Ccode( void, "mpfr_get_z(", y, ",", w, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_get_z(", y, ",", w, ", MPFR_RNDN)" );
      clear(w);
      moveToZZandclear(y));
 
 export (x:RR) << (n:long) : RR := (
      if n == long(0) then return x;
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_mul_2si(", z, ",", x, ",", n, ",GMP_RNDN)" );
+     Ccode( void, "mpfr_mul_2si(", z, ",", x, ",", n, ",MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export (x:RRi) << (n:long) : RRi := (
@@ -2137,7 +2137,7 @@ export compare(x:QQ,y:CC):int := (
 
 export abs(x:CC):RR := (
      z := newRRmutable(precision(x));
-     Ccode( void, "mpfr_hypot(", z, ",", x.re, ",", x.im, ",GMP_RNDN)" );
+     Ccode( void, "mpfr_hypot(", z, ",", x.re, ",", x.im, ",MPFR_RNDN)" );
      moveToRRandclear(z));
 
 header "#include <complex.h> ";
@@ -2151,7 +2151,7 @@ export sqrt(x:CC):CC := (
 
 export pi(prec:ulong):RR := (
      z := newRRmutable(prec);
-     Ccode( void, "mpfr_const_pi(",  z, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_const_pi(",  z, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export piRRi(prec:ulong):RRi := (
@@ -2171,7 +2171,7 @@ export cRRi(prec:ulong):RRi := (
 
 export exp(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_exp(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_exp(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export exp(x:RRi):RRi := (
@@ -2181,7 +2181,7 @@ export exp(x:RRi):RRi := (
 
 export log(x:RR):RR := (				    -- works only if x>0
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_log(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_log(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export log(x:RRi):RRi := (				    -- works only if x>0
@@ -2201,7 +2201,7 @@ export log(b:RRi,x:RRi):RRi := (				    -- works only if x>0 and b>0
 
 export sin(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_sin(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sin(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export sin(x:RRi):RRi := (
@@ -2211,7 +2211,7 @@ export sin(x:RRi):RRi := (
 
 export cos(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_cos(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_cos(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export cos(x:RRi):RRi := (
@@ -2221,7 +2221,7 @@ export cos(x:RRi):RRi := (
 
 export tan(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_tan(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_tan(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export tan(x:RRi):RRi := (
@@ -2231,7 +2231,7 @@ export tan(x:RRi):RRi := (
 
 export asin(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_asin(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_asin(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export asin(x:RRi):RRi := (
@@ -2241,7 +2241,7 @@ export asin(x:RRi):RRi := (
 
 export acos(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_acos(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_acos(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export acos(x:RRi):RRi := (
@@ -2251,7 +2251,7 @@ export acos(x:RRi):RRi := (
 
 export atan(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_atan(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_atan(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export atan(x:RRi):RRi := (
@@ -2262,7 +2262,7 @@ export atan(x:RRi):RRi := (
 export atan2(y:RR,x:RR):RR := (
      -- if isZero0(x) && isZero0(y) && isfinite0(x) && isfinite0(y) then return nanRR(min(precision0(x),precision0(y)));
      z := newRRmutable(min(precision0(x),precision0(y)));
-     Ccode( void, "mpfr_atan2(", z, ",", y, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_atan2(", z, ",", y, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export atan2(y:RRi,x:RRi):RRi := (
@@ -2272,17 +2272,17 @@ export atan2(y:RRi,x:RRi):RRi := (
 
 export Beta(x:RR,y:RR):RR := (
      z := newRRmutable(min(precision0(x),precision0(y)));
-     Ccode( void, "mpfr_beta(", z, ",", y, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_beta(", z, ",", y, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export agm(x:RR,y:RR):RR := (
      z := newRRmutable(min(precision0(x),precision0(y)));
-     Ccode( void, "mpfr_agm(", z, ",", x, ",", y, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_agm(", z, ",", x, ",", y, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export sinh(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_sinh(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sinh(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export sinh(x:RRi):RRi := (
@@ -2292,7 +2292,7 @@ export sinh(x:RRi):RRi := (
 
 export cosh(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_cosh(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_cosh(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export cosh(x:RRi):RRi := (
@@ -2302,7 +2302,7 @@ export cosh(x:RRi):RRi := (
 
 export tanh(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_tanh(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_tanh(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export tanh(x:RRi):RRi := (
@@ -2312,7 +2312,7 @@ export tanh(x:RRi):RRi := (
 
 export sec(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_sec(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sec(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export sec(x:RRi):RRi := (
@@ -2322,7 +2322,7 @@ export sec(x:RRi):RRi := (
 
 export csc(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_csc(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_csc(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export csc(x:RRi):RRi := (
@@ -2332,7 +2332,7 @@ export csc(x:RRi):RRi := (
 
 export cot(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_cot(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_cot(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export cot(x:RRi):RRi := (
@@ -2342,7 +2342,7 @@ export cot(x:RRi):RRi := (
 
 export sech(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_sech(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_sech(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export sech(x:RRi):RRi := (
@@ -2352,7 +2352,7 @@ export sech(x:RRi):RRi := (
 
 export csch(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_csch(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_csch(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export csch(x:RRi):RRi := (
@@ -2362,7 +2362,7 @@ export csch(x:RRi):RRi := (
 
 export coth(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_coth(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_coth(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export coth(x:RRi):RRi := (
@@ -2377,7 +2377,7 @@ export factorial(x:ulong):ZZ := (
 
 export log1p(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_log1p(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_log1p(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export log1p(x:RRi):RRi := (
@@ -2387,7 +2387,7 @@ export log1p(x:RRi):RRi := (
 
 export expm1(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_expm1(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_expm1(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
                                      
 export expm1(x:RRi):RRi := (
@@ -2397,78 +2397,78 @@ export expm1(x:RRi):RRi := (
 
 export Gamma(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_gamma(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_gamma(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export Gamma(s:RR,x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_gamma_inc(", z, ",", s, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_gamma_inc(", z, ",", s, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export Digamma(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_digamma(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_digamma(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export factorial(x:RR):RR := Gamma(x+1);
 
 export eint(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_eint(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_eint(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 --export lngamma(x:RR):RR := (
 --     z := newRRmutable(precision0(x));
---     Ccode( void, "mpfr_lngamma(", z, ",", x, ", GMP_RNDN)" );
+--     Ccode( void, "mpfr_lngamma(", z, ",", x, ", MPFR_RNDN)" );
 --     moveToRRandclear(z));
 
 export zeta(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_zeta(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_zeta(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export zeta(x:ulong,prec:ulong):RR := (
      z := newRRmutable(prec);
-     Ccode( void, "mpfr_zeta_ui(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_zeta_ui(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export erf(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_erf(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_erf(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export erfc(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_erfc(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_erfc(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export j0(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_j0(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_j0(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export j1(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_j1(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_j1(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export jn(n:long,x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_jn(", z, ",",n,",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_jn(", z, ",",n,",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export y0(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_y0(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_y0(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export y1(x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_y1(", z, ",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_y1(", z, ",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export yn(n:long,x:RR):RR := (
      z := newRRmutable(precision0(x));
-     Ccode( void, "mpfr_yn(", z, ",",n,",", x, ", GMP_RNDN)" );
+     Ccode( void, "mpfr_yn(", z, ",",n,",", x, ", MPFR_RNDN)" );
      moveToRRandclear(z));
 
 export sign(x:RR):bool := 0 != Ccode(int,"mpfr_signbit(",x,")");

--- a/M2/Macaulay2/d/gmp1.d
+++ b/M2/Macaulay2/d/gmp1.d
@@ -50,14 +50,14 @@ base := 10;
 
 getstr(returnexponent:long, base:int, sigdigs:int, x:RR) ::= (
      strptr := Ccode(charstarOrNull, "(M2_charstarOrNull) mpfr_get_str((char *)0,&", returnexponent, ",",
-	  base, ",(size_t)", sigdigs, ",", x, ",GMP_RNDN)");
+	  base, ",(size_t)", sigdigs, ",", x, ",MPFR_RNDN)");
      ret := tostring(strptr);
      Ccode(void, "mpfr_free_str(", strptr, ")");
      ret);
 
 getstr(returnexponent:long, base:int, sigdigs:int, x:RRi) ::= (
      strptr := Ccode(charstarOrNull, "(M2_charstarOrNull) mpfr_get_str((char *)0,&", returnexponent, ",",
-	  base, ",(size_t)", sigdigs, ",", x, ",GMP_RNDN)");
+	  base, ",(size_t)", sigdigs, ",", x, ",MPFR_RNDN)");
      ret := tostring(strptr);
      Ccode(void, "mpfr_free_str(", strptr, ")");
      ret);

--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -4473,7 +4473,7 @@ setupfun("cRRi0",cRRi0);
 mpfrConstantEuler(e:Expr):Expr := (
      when e is prec:ZZcell do if !isULong(prec) then WrongArgSmallUInteger(1) else (
 	  z := newRRmutable(toULong(prec));
-	  Ccode( void, "mpfr_const_euler(", z, ", GMP_RNDN)" );
+	  Ccode( void, "mpfr_const_euler(", z, ", MPFR_RNDN)" );
 	  toExpr(moveToRRandclear(z)))
      else WrongArgZZ(1));
 setupfun("mpfrConstantEuler",mpfrConstantEuler);
@@ -4481,7 +4481,7 @@ setupfun("mpfrConstantEuler",mpfrConstantEuler);
 mpfrConstantCatalan(e:Expr):Expr := (
      when e is prec:ZZcell do if !isULong(prec) then WrongArgSmallUInteger(1) else (
 	  z := newRRmutable(toULong(prec));
-	  Ccode( void, "mpfr_const_catalan(", z, ", GMP_RNDN)" );
+	  Ccode( void, "mpfr_const_catalan(", z, ", MPFR_RNDN)" );
 	  toExpr(moveToRRandclear(z)))
      else WrongArgZZ(1));
 setupfun("mpfrConstantCatalan",mpfrConstantCatalan);

--- a/M2/Macaulay2/e/NAG.cpp
+++ b/M2/Macaulay2/e/NAG.cpp
@@ -1454,7 +1454,7 @@ PathTracker /* or null */* PathTracker::make(const Matrix* S,
       ERROR("complex coefficients expected");
       return NULL;
     }
-  p->productST = mpfr_get_d(productST, GMP_RNDN);
+  p->productST = mpfr_get_d(productST, MPFR_RNDN);
   // p->bigT = asin(sqrt(1-p->productST*p->productST));
   // const double pi = 3.141592653589793238462643383279502;
   // if (p->productST < 0)
@@ -1637,15 +1637,15 @@ const Matrix /* or null */* rawRefinePT(PathTracker* PT,
 int PathTracker::track(const Matrix* start_sols)
 {
   double the_smallest_number = 1e-13;
-  double epsilon2 = mpfr_get_d(epsilon, GMP_RNDN);
+  double epsilon2 = mpfr_get_d(epsilon, MPFR_RNDN);
   epsilon2 *= epsilon2;                           // epsilon^2
-  double t_step = mpfr_get_d(init_dt, GMP_RNDN);  // initial step
-  double dt_min_dbl = mpfr_get_d(min_dt, GMP_RNDN);
-  double dt_increase_factor_dbl = mpfr_get_d(dt_increase_factor, GMP_RNDN);
-  double dt_decrease_factor_dbl = mpfr_get_d(dt_decrease_factor, GMP_RNDN);
-  double infinity_threshold2 = mpfr_get_d(infinity_threshold, GMP_RNDN);
+  double t_step = mpfr_get_d(init_dt, MPFR_RNDN);  // initial step
+  double dt_min_dbl = mpfr_get_d(min_dt, MPFR_RNDN);
+  double dt_increase_factor_dbl = mpfr_get_d(dt_increase_factor, MPFR_RNDN);
+  double dt_decrease_factor_dbl = mpfr_get_d(dt_decrease_factor, MPFR_RNDN);
+  double infinity_threshold2 = mpfr_get_d(infinity_threshold, MPFR_RNDN);
   infinity_threshold2 *= infinity_threshold2;
-  double end_zone_factor_dbl = mpfr_get_d(end_zone_factor, GMP_RNDN);
+  double end_zone_factor_dbl = mpfr_get_d(end_zone_factor, MPFR_RNDN);
 
   if (C == NULL)
     C = cast_to_CCC(
@@ -1976,7 +1976,7 @@ Matrix /* or null */* PathTracker::refine(const Matrix* sols,
                                           gmp_RR tolerance,
                                           int max_corr_steps_refine)
 {
-  double epsilon2 = mpfr_get_d(tolerance, GMP_RNDN);
+  double epsilon2 = mpfr_get_d(tolerance, MPFR_RNDN);
   epsilon2 *= epsilon2;
   int n = n_coords;
   if (!cast_to_CCC(sols->get_ring()))
@@ -2049,8 +2049,8 @@ Matrix /* or null */* PathTracker::refine(const Matrix* sols,
   for (i = 0; i < n_sols; i++)
     for (j = 0; j < n; j++, c++)
       {
-        // mpfr_set_d(re, c->getreal(), GMP_RNDN);
-        // mpfr_set_d(im, c->getimaginary(), GMP_RNDN);
+        // mpfr_set_d(re, c->getreal(), MPFR_RNDN);
+        // mpfr_set_d(im, c->getimaginary(), MPFR_RNDN);
         // ring_elem e = from_BigReals(C,re,im);
         ring_elem e = from_doubles(C, c->getreal(), c->getimaginary());
 
@@ -2082,8 +2082,8 @@ Matrix /* or null */* PathTracker::getSolution(int solN)
   complex* c = s->x;
   for (int j = 0; j < n_coords; j++, c++)
     {
-      // mpfr_set_d(re, c->getreal(), GMP_RNDN);
-      // mpfr_set_d(im, c->getimaginary(), GMP_RNDN);
+      // mpfr_set_d(re, c->getreal(), MPFR_RNDN);
+      // mpfr_set_d(im, c->getimaginary(), MPFR_RNDN);
       // ring_elem e = from_BigReals(C,re,im);
       ring_elem e = from_doubles(C, c->getreal(), c->getimaginary());
 
@@ -2109,8 +2109,8 @@ Matrix /* or null */* PathTracker::getAllSolutions()
       complex* c = s->x;
       for (int j = 0; j < n_coords; j++, c++)
         {
-          // mpfr_set_d(re, c->getreal(), GMP_RNDN);
-          // mpfr_set_d(im, c->getimaginary(), GMP_RNDN);
+          // mpfr_set_d(re, c->getreal(), MPFR_RNDN);
+          // mpfr_set_d(im, c->getimaginary(), MPFR_RNDN);
           // ring_elem e = from_BigReals(C,re,im);
           ring_elem e = from_doubles(C, c->getreal(), c->getimaginary());
 
@@ -2139,7 +2139,7 @@ gmp_RRorNull PathTracker::getSolutionLastT(int solN)
   if (solN < 0 || solN >= n_sols) return NULL;
   gmp_RRmutable result = getmemstructtype(gmp_RRmutable);
   mpfr_init2(result, C->get_precision());
-  mpfr_set_d(result, raw_solutions[solN].t, GMP_RNDN);
+  mpfr_set_d(result, raw_solutions[solN].t, MPFR_RNDN);
   return moveTo_gmpRR(result);
 }
 
@@ -2148,7 +2148,7 @@ gmp_RRorNull PathTracker::getSolutionRcond(int solN)
   if (solN < 0 || solN >= n_sols) return NULL;
   gmp_RRmutable result = getmemstructtype(gmp_RRmutable);
   mpfr_init2(result, C->get_precision());
-  mpfr_set_d(result, raw_solutions[solN].cond, GMP_RNDN);
+  mpfr_set_d(result, raw_solutions[solN].cond, MPFR_RNDN);
   return moveTo_gmpRR(result);
 }
 

--- a/M2/Macaulay2/e/NAG.hpp
+++ b/M2/Macaulay2/e/NAG.hpp
@@ -211,8 +211,8 @@ inline complex::complex(const complex& c)
 
 inline complex::complex(gmp_CC mpfrCC)
 {
-  real = mpfr_get_d(mpfrCC->re, GMP_RNDN);
-  imag = mpfr_get_d(mpfrCC->im, GMP_RNDN);
+  real = mpfr_get_d(mpfrCC->re, MPFR_RNDN);
+  imag = mpfr_get_d(mpfrCC->im, MPFR_RNDN);
 }
 
 inline void complex::operator=(complex c)

--- a/M2/Macaulay2/e/aring-CC.hpp
+++ b/M2/Macaulay2/e/aring-CC.hpp
@@ -133,20 +133,20 @@ class ARingCC : public RingInterface
 
   bool set_from_BigReal(ElementType& result, gmp_RR a) const
   {
-    result.re = mpfr_get_d(a, GMP_RNDN);
+    result.re = mpfr_get_d(a, MPFR_RNDN);
     result.im = 0.0;
     return true;
   }
   bool set_from_BigReals(ElementType& result, gmp_RR re, gmp_RR im) const
   {
-    result.re = mpfr_get_d(re, GMP_RNDN);
-    result.im = mpfr_get_d(im, GMP_RNDN);
+    result.re = mpfr_get_d(re, MPFR_RNDN);
+    result.im = mpfr_get_d(im, MPFR_RNDN);
     return true;
   }
   bool set_from_BigComplex(ElementType& result, gmp_CC a) const
   {
-    result.re = mpfr_get_d(a->re, GMP_RNDN);
-    result.im = mpfr_get_d(a->im, GMP_RNDN);
+    result.re = mpfr_get_d(a->re, MPFR_RNDN);
+    result.im = mpfr_get_d(a->im, MPFR_RNDN);
     return true;
   }
   bool set_from_double(ElementType& result, double a) const
@@ -384,8 +384,8 @@ class ARingCC : public RingInterface
     result->im = getmemstructtype(mpfr_ptr);
     mpfr_init2(result->re, get_precision());
     mpfr_init2(result->im, get_precision());
-    mpfr_set_d(result->re, a.re, GMP_RNDN);
-    mpfr_set_d(result->im, a.im, GMP_RNDN);
+    mpfr_set_d(result->re, a.re, MPFR_RNDN);
+    mpfr_set_d(result->im, a.im, MPFR_RNDN);
     return moveTo_gmpCC(result);
   }
 
@@ -405,7 +405,7 @@ class ARingCC : public RingInterface
   {
     double d;
     abs(d, a);
-    if (mpfr_cmp_d(norm, d) < 0) mpfr_set_d(norm, d, GMP_RNDN);
+    if (mpfr_cmp_d(norm, d) < 0) mpfr_set_d(norm, d, MPFR_RNDN);
   }
 };
 

--- a/M2/Macaulay2/e/aring-CCC.hpp
+++ b/M2/Macaulay2/e/aring-CCC.hpp
@@ -41,8 +41,8 @@ class ARingCCC : public RingInterface
   const RealRingType& real_ring() const { return mRRR; }
   unsigned int computeHashValue(const ElementType& a) const
   {
-    double a1 = mpfr_get_d(&a.re, GMP_RNDN);
-    double b1 = mpfr_get_d(&a.im, GMP_RNDN);
+    double a1 = mpfr_get_d(&a.re, MPFR_RNDN);
+    double b1 = mpfr_get_d(&a.im, MPFR_RNDN);
     return static_cast<unsigned int>(12347. * a1 + 865800. * b1);
   }
 
@@ -101,20 +101,20 @@ class ARingCCC : public RingInterface
   void init_set(ElementType& result, const ElementType& a) const
   {
     init(result);
-    mpfr_set(&result.re, &a.re, GMP_RNDN);
-    mpfr_set(&result.im, &a.im, GMP_RNDN);
+    mpfr_set(&result.re, &a.re, MPFR_RNDN);
+    mpfr_set(&result.im, &a.im, MPFR_RNDN);
   }
 
   void set(ElementType& result, const ElementType& a) const
   {
-    mpfr_set(&result.re, &a.re, GMP_RNDN);
-    mpfr_set(&result.im, &a.im, GMP_RNDN);
+    mpfr_set(&result.re, &a.re, MPFR_RNDN);
+    mpfr_set(&result.im, &a.im, MPFR_RNDN);
   }
 
   void set_zero(ElementType& result) const
   {
-    mpfr_set_si(&result.re, 0, GMP_RNDN);
-    mpfr_set_si(&result.im, 0, GMP_RNDN);
+    mpfr_set_si(&result.re, 0, MPFR_RNDN);
+    mpfr_set_si(&result.im, 0, MPFR_RNDN);
   }
 
   void clear(ElementType& result) const
@@ -126,60 +126,60 @@ class ARingCCC : public RingInterface
   void copy(ElementType& result, const ElementType& a) const { set(result, a); }
   void set_from_long(ElementType& result, long a) const
   {
-    mpfr_set_si(&result.re, a, GMP_RNDN);
-    mpfr_set_si(&result.im, 0, GMP_RNDN);
+    mpfr_set_si(&result.re, a, MPFR_RNDN);
+    mpfr_set_si(&result.im, 0, MPFR_RNDN);
   }
 
   void set_var(ElementType& result, int v) const { set_from_long(result, 1); }
   void set_from_mpz(ElementType& result, mpz_srcptr a) const
   {
-    mpfr_set_z(&result.re, a, GMP_RNDN);
-    mpfr_set_si(&result.im, 0, GMP_RNDN);
+    mpfr_set_z(&result.re, a, MPFR_RNDN);
+    mpfr_set_si(&result.im, 0, MPFR_RNDN);
   }
 
   bool set_from_mpq(ElementType& result, mpq_srcptr a) const
   {
-    mpfr_set_q(&result.re, a, GMP_RNDN);
-    mpfr_set_si(&result.im, 0, GMP_RNDN);
+    mpfr_set_q(&result.re, a, MPFR_RNDN);
+    mpfr_set_si(&result.im, 0, MPFR_RNDN);
     return true;
   }
 
   bool set_from_BigReal(ElementType& result, gmp_RR a) const
   {
-    mpfr_set(&result.re, a, GMP_RNDN);
-    mpfr_set_si(&result.im, 0, GMP_RNDN);
+    mpfr_set(&result.re, a, MPFR_RNDN);
+    mpfr_set_si(&result.im, 0, MPFR_RNDN);
     return true;
   }
   bool set_from_BigComplex(ElementType& result, gmp_CC a) const
   {  //???
-    mpfr_set(&result.re, a->re, GMP_RNDN);
-    mpfr_set(&result.im, a->im, GMP_RNDN);
+    mpfr_set(&result.re, a->re, MPFR_RNDN);
+    mpfr_set(&result.im, a->im, MPFR_RNDN);
     return true;
   }
   bool set_from_double(ElementType& result, double a) const
   {
-    mpfr_set_d(&result.re, a, GMP_RNDN);
-    mpfr_set_si(&result.im, 0, GMP_RNDN);
+    mpfr_set_d(&result.re, a, MPFR_RNDN);
+    mpfr_set_si(&result.im, 0, MPFR_RNDN);
     return true;
   }
   bool set_from_complex_double(ElementType& result, double re, double im) const
   {
-    mpfr_set_d(&result.re, re, GMP_RNDN);
-    mpfr_set_d(&result.im, im, GMP_RNDN);
+    mpfr_set_d(&result.re, re, MPFR_RNDN);
+    mpfr_set_d(&result.im, im, MPFR_RNDN);
     return true;
   }
   bool set_from_complex_mpfr(ElementType& result, mpfr_srcptr re, const mpfr_srcptr im) const
   {
-    mpfr_set(&result.re, re, GMP_RNDN);
-    mpfr_set(&result.im, im, GMP_RNDN);
+    mpfr_set(&result.re, re, MPFR_RNDN);
+    mpfr_set(&result.im, im, MPFR_RNDN);
     return true;
   }
 
   // arithmetic
   void negate(ElementType& result, const ElementType& a) const
   {
-    mpfr_neg(&result.re, &a.re, GMP_RNDN);
-    mpfr_neg(&result.im, &a.im, GMP_RNDN);
+    mpfr_neg(&result.re, &a.re, MPFR_RNDN);
+    mpfr_neg(&result.im, &a.im, MPFR_RNDN);
   }
 
   void invert(ElementType& result, const ElementType& a) const
@@ -196,12 +196,12 @@ class ARingCCC : public RingInterface
         // &result.re = 1.0/denom;
         // &result.im = - p/denom;
 
-        mpfr_div(p, &a.im, &a.re, GMP_RNDN);
-        mpfr_mul(denom, p, &a.im, GMP_RNDN);
-        mpfr_add(denom, denom, &a.re, GMP_RNDN);
-        mpfr_si_div(&result.re, 1, denom, GMP_RNDN);
-        mpfr_div(&result.im, p, denom, GMP_RNDN);
-        mpfr_neg(&result.im, &result.im, GMP_RNDN);
+        mpfr_div(p, &a.im, &a.re, MPFR_RNDN);
+        mpfr_mul(denom, p, &a.im, MPFR_RNDN);
+        mpfr_add(denom, denom, &a.re, MPFR_RNDN);
+        mpfr_si_div(&result.re, 1, denom, MPFR_RNDN);
+        mpfr_div(&result.im, p, denom, MPFR_RNDN);
+        mpfr_neg(&result.im, &result.im, MPFR_RNDN);
       }
     else
       {
@@ -210,12 +210,12 @@ class ARingCCC : public RingInterface
         // &result.re = p/denom;
         // &result.im = -1.0/denom;
 
-        mpfr_div(p, &a.re, &a.im, GMP_RNDN);
-        mpfr_mul(denom, p, &a.re, GMP_RNDN);
-        mpfr_add(denom, denom, &a.im, GMP_RNDN);
-        mpfr_si_div(&result.im, 1, denom, GMP_RNDN);
-        mpfr_neg(&result.im, &result.im, GMP_RNDN);
-        mpfr_div(&result.re, p, denom, GMP_RNDN);
+        mpfr_div(p, &a.re, &a.im, MPFR_RNDN);
+        mpfr_mul(denom, p, &a.re, MPFR_RNDN);
+        mpfr_add(denom, denom, &a.im, MPFR_RNDN);
+        mpfr_si_div(&result.im, 1, denom, MPFR_RNDN);
+        mpfr_neg(&result.im, &result.im, MPFR_RNDN);
+        mpfr_div(&result.re, p, denom, MPFR_RNDN);
       }
 
     mpfr_clear(p);
@@ -226,8 +226,8 @@ class ARingCCC : public RingInterface
            const ElementType& a,
            const ElementType& b) const
   {
-    mpfr_add(&result.re, &a.re, &b.re, GMP_RNDN);
-    mpfr_add(&result.im, &a.im, &b.im, GMP_RNDN);
+    mpfr_add(&result.re, &a.re, &b.re, MPFR_RNDN);
+    mpfr_add(&result.im, &a.im, &b.im, MPFR_RNDN);
   }
 
   void addMultipleTo(ElementType& result,
@@ -253,8 +253,8 @@ class ARingCCC : public RingInterface
                 const ElementType& a,
                 const ElementType& b) const
   {
-    mpfr_sub(&result.re, &a.re, &b.re, GMP_RNDN);
-    mpfr_sub(&result.im, &a.im, &b.im, GMP_RNDN);
+    mpfr_sub(&result.re, &a.re, &b.re, MPFR_RNDN);
+    mpfr_sub(&result.im, &a.im, &b.im, MPFR_RNDN);
   }
 
   void subtract_multiple(ElementType& result,
@@ -279,12 +279,12 @@ class ARingCCC : public RingInterface
     mpfr_init2(tmp, get_precision());
 
     // &result.re = &a.re*&b;
-    mpfr_mul(tmp, &a.re, &b, GMP_RNDN);
-    mpfr_set(&result.re, tmp, GMP_RNDN);
+    mpfr_mul(tmp, &a.re, &b, MPFR_RNDN);
+    mpfr_set(&result.re, tmp, MPFR_RNDN);
 
     // &result.im = &a.im*&b;
-    mpfr_mul(tmp, &a.im, &b, GMP_RNDN);
-    mpfr_set(&result.im, tmp, GMP_RNDN);
+    mpfr_mul(tmp, &a.im, &b, MPFR_RNDN);
+    mpfr_set(&result.im, tmp, MPFR_RNDN);
 
     set(res, result);
     clear(result);
@@ -299,16 +299,16 @@ class ARingCCC : public RingInterface
     mpfr_init2(tmp, get_precision());
 
     // &result.re = &a.re*&b.re - &a.im*&b.im;
-    mpfr_mul(tmp, &a.re, &b.re, GMP_RNDN);
-    mpfr_set(&result.re, tmp, GMP_RNDN);
-    mpfr_mul(tmp, &a.im, &b.im, GMP_RNDN);
-    mpfr_sub(&result.re, &result.re, tmp, GMP_RNDN);
+    mpfr_mul(tmp, &a.re, &b.re, MPFR_RNDN);
+    mpfr_set(&result.re, tmp, MPFR_RNDN);
+    mpfr_mul(tmp, &a.im, &b.im, MPFR_RNDN);
+    mpfr_sub(&result.re, &result.re, tmp, MPFR_RNDN);
 
     // &result.im = &a.re*&b.im + &a.im*&b.re;
-    mpfr_mul(tmp, &a.re, &b.im, GMP_RNDN);
-    mpfr_set(&result.im, tmp, GMP_RNDN);
-    mpfr_mul(tmp, &a.im, &b.re, GMP_RNDN);
-    mpfr_add(&result.im, &result.im, tmp, GMP_RNDN);
+    mpfr_mul(tmp, &a.re, &b.im, MPFR_RNDN);
+    mpfr_set(&result.im, tmp, MPFR_RNDN);
+    mpfr_mul(tmp, &a.im, &b.re, MPFR_RNDN);
+    mpfr_add(&result.im, &result.im, tmp, MPFR_RNDN);
 
     set(res, result);
     clear(result);
@@ -324,11 +324,11 @@ class ARingCCC : public RingInterface
     init(result);
     mpfr_init2(tmp, get_precision());
 
-    mpfr_div(tmp, &a.re, &b, GMP_RNDN);
-    mpfr_set(&result.re, tmp, GMP_RNDN);
+    mpfr_div(tmp, &a.re, &b, MPFR_RNDN);
+    mpfr_set(&result.re, tmp, MPFR_RNDN);
 
-    mpfr_div(tmp, &a.im, &b, GMP_RNDN);
-    mpfr_set(&result.im, tmp, GMP_RNDN);
+    mpfr_div(tmp, &a.im, &b, MPFR_RNDN);
+    mpfr_set(&result.im, tmp, MPFR_RNDN);
 
     set(res, result);
     clear(result);
@@ -357,18 +357,18 @@ class ARingCCC : public RingInterface
         // result.re = (u.re + p*u.im)/denom;
         // result.im = (u.im - p*u.re)/denom;
 
-        mpfr_div(p, &b.im, &b.re, GMP_RNDN);
-        mpfr_mul(denom, p, &b.im, GMP_RNDN);
-        mpfr_add(denom, denom, &b.re, GMP_RNDN);
+        mpfr_div(p, &b.im, &b.re, MPFR_RNDN);
+        mpfr_mul(denom, p, &b.im, MPFR_RNDN);
+        mpfr_add(denom, denom, &b.re, MPFR_RNDN);
 
-        mpfr_mul(&result.re, p, &a.im, GMP_RNDN);
-        mpfr_add(&result.re, &result.re, &a.re, GMP_RNDN);
-        mpfr_div(&result.re, &result.re, denom, GMP_RNDN);
+        mpfr_mul(&result.re, p, &a.im, MPFR_RNDN);
+        mpfr_add(&result.re, &result.re, &a.re, MPFR_RNDN);
+        mpfr_div(&result.re, &result.re, denom, MPFR_RNDN);
 
-        mpfr_mul(&result.im, p, &a.re, GMP_RNDN);
-        mpfr_neg(&result.im, &result.im, GMP_RNDN);
-        mpfr_add(&result.im, &result.im, &a.im, GMP_RNDN);
-        mpfr_div(&result.im, &result.im, denom, GMP_RNDN);
+        mpfr_mul(&result.im, p, &a.re, MPFR_RNDN);
+        mpfr_neg(&result.im, &result.im, MPFR_RNDN);
+        mpfr_add(&result.im, &result.im, &a.im, MPFR_RNDN);
+        mpfr_div(&result.im, &result.im, denom, MPFR_RNDN);
       }
     else
       {
@@ -377,17 +377,17 @@ class ARingCCC : public RingInterface
         // result.re = (u.re * p + u.im)/denom;
         // result.im = (-u.re + p * u.im)/denom;
 
-        mpfr_div(p, &b.re, &b.im, GMP_RNDN);
-        mpfr_mul(denom, p, &b.re, GMP_RNDN);
-        mpfr_add(denom, denom, &b.im, GMP_RNDN);
+        mpfr_div(p, &b.re, &b.im, MPFR_RNDN);
+        mpfr_mul(denom, p, &b.re, MPFR_RNDN);
+        mpfr_add(denom, denom, &b.im, MPFR_RNDN);
 
-        mpfr_mul(&result.re, p, &a.re, GMP_RNDN);
-        mpfr_add(&result.re, &result.re, &a.im, GMP_RNDN);
-        mpfr_div(&result.re, &result.re, denom, GMP_RNDN);
+        mpfr_mul(&result.re, p, &a.re, MPFR_RNDN);
+        mpfr_add(&result.re, &result.re, &a.im, MPFR_RNDN);
+        mpfr_div(&result.re, &result.re, denom, MPFR_RNDN);
 
-        mpfr_mul(&result.im, p, &a.im, GMP_RNDN);
-        mpfr_sub(&result.im, &result.im, &a.re, GMP_RNDN);
-        mpfr_div(&result.im, &result.im, denom, GMP_RNDN);
+        mpfr_mul(&result.im, p, &a.im, MPFR_RNDN);
+        mpfr_sub(&result.im, &result.im, &a.re, MPFR_RNDN);
+        mpfr_div(&result.im, &result.im, denom, MPFR_RNDN);
       }
     mpfr_clear(p);
     mpfr_clear(denom);
@@ -408,7 +408,7 @@ class ARingCCC : public RingInterface
   void abs(ARingRRR::ElementType& result, const ElementType& a) const
   {
     abs_squared(result, a);
-    mpfr_sqrt(&result, &result, GMP_RNDN);  // should we have ARingRRR::sqrt ???
+    mpfr_sqrt(&result, &result, MPFR_RNDN);  // should we have ARingRRR::sqrt ???
   }
 
   void power(ElementType& result, const ElementType& a, int n) const
@@ -506,15 +506,15 @@ class ARingCCC : public RingInterface
     result->im = getmemstructtype(gmp_RRmutable);
     mpfr_init2(result->re, get_precision());
     mpfr_init2(result->im, get_precision());
-    mpfr_set(result->re, &a.re, GMP_RNDN);
-    mpfr_set(result->im, &a.im, GMP_RNDN);
+    mpfr_set(result->re, &a.re, MPFR_RNDN);
+    mpfr_set(result->im, &a.im, MPFR_RNDN);
     return moveTo_gmpCC(result);
   }
 
   bool set_from_RRR(ElementType& result, const ARingRRR::ElementType& a) const
   {
-    mpfr_set(&result.re, &a, GMP_RNDN);
-    mpfr_set_si(&result.im, 0, GMP_RNDN);
+    mpfr_set(&result.re, &a, MPFR_RNDN);
+    mpfr_set_si(&result.im, 0, MPFR_RNDN);
     return true;
   }
 
@@ -529,16 +529,16 @@ class ARingCCC : public RingInterface
   }
   void set_real_part(ElementType& c, ARingRRR::ElementType& a) const
   {
-    mpfr_set(&c.re, &a, GMP_RNDN);
+    mpfr_set(&c.re, &a, MPFR_RNDN);
   }
   void set_imaginary_part(ElementType& c, ARingRRR::ElementType& a) const
   {
-    mpfr_set(&c.im, &a, GMP_RNDN);
+    mpfr_set(&c.im, &a, MPFR_RNDN);
   }
   void set_from_BigReals(ElementType& result, gmp_RR re, gmp_RR im) const
   {
-    mpfr_set(&result.re, re, GMP_RNDN);
-    mpfr_set(&result.im, im, GMP_RNDN);
+    mpfr_set(&result.re, re, MPFR_RNDN);
+    mpfr_set(&result.im, im, MPFR_RNDN);
   }
   void set_from_doubles(ElementType& result, double re, double im) const
   {

--- a/M2/Macaulay2/e/aring-RR.cpp
+++ b/M2/Macaulay2/e/aring-RR.cpp
@@ -12,7 +12,7 @@ void ARingRR::elem_text_out(buffer &o,
   ElementType &ap1 = const_cast<ElementType &>(ap);
   mpfr_t a;
   mpfr_init(a);
-  mpfr_set_d(a, ap1, GMP_RNDN);
+  mpfr_set_d(a, ap1, MPFR_RNDN);
   M2_string s = (*gmp_tostringRRpointer)(a);
   mpfr_clear(a);
   bool prepend_plus = p_plus && (s->array[0] != '-');

--- a/M2/Macaulay2/e/aring-RR.hpp
+++ b/M2/Macaulay2/e/aring-RR.hpp
@@ -103,7 +103,7 @@ class ARingRR : public RingInterface
 
   bool set_from_BigReal(ElementType &result, gmp_RR a) const
   {
-    result = mpfr_get_d(a, GMP_RNDN);
+    result = mpfr_get_d(a, MPFR_RNDN);
     return true;
   }
   bool set_from_double(ElementType &result, double a) const
@@ -236,7 +236,7 @@ class ARingRR : public RingInterface
   void increase_norm(mpfr_ptr norm, const ElementType &a) const
   {
     double d = fabs(a);
-    if (mpfr_cmp_d(norm, d) < 0) mpfr_set_d(norm, d, GMP_RNDN);
+    if (mpfr_cmp_d(norm, d) < 0) mpfr_set_d(norm, d, MPFR_RNDN);
   }
 
   double coerceToDouble(const ElementType &a) const { return a; }

--- a/M2/Macaulay2/e/aring-RRR.hpp
+++ b/M2/Macaulay2/e/aring-RRR.hpp
@@ -34,7 +34,7 @@ class ARingRRR : public RingInterface
 
   unsigned int computeHashValue(const elem &a) const
   {
-    double d = mpfr_get_d(&a, GMP_RNDN);
+    double d = mpfr_get_d(&a, MPFR_RNDN);
     return static_cast<unsigned int>(d);
   }
 
@@ -68,13 +68,13 @@ class ARingRRR : public RingInterface
   {
     mpfr_ptr res = getmemstructtype(mpfr_ptr);
     mpfr_init2(res, mPrecision);
-    mpfr_set(res, &a, GMP_RNDN);
+    mpfr_set(res, &a, MPFR_RNDN);
     result = ring_elem(moveTo_gmpRR(res));
   }
 
   void from_ring_elem(ElementType &result, const ring_elem &a) const
   {
-    mpfr_set(&result, a.get_mpfr(), GMP_RNDN);
+    mpfr_set(&result, a.get_mpfr(), MPFR_RNDN);
   }
 
   // 'init', 'init_set' functions
@@ -83,88 +83,88 @@ class ARingRRR : public RingInterface
   void init_set(ElementType &result, const ElementType &a) const
   {
     init(result);
-    mpfr_set(&result, &a, GMP_RNDN);
+    mpfr_set(&result, &a, MPFR_RNDN);
   }
 
   void set(ElementType &result, const ElementType &a) const
   {
-    mpfr_set(&result, &a, GMP_RNDN);
+    mpfr_set(&result, &a, MPFR_RNDN);
   }
 
   void set_zero(ElementType &result) const
   {
-    mpfr_set_si(&result, 0, GMP_RNDN);
+    mpfr_set_si(&result, 0, MPFR_RNDN);
   }
 
   void clear(ElementType &result) const { mpfr_clear(&result); }
   void copy(ElementType &result, const ElementType &a) const
   {
-    mpfr_set(&result, &a, GMP_RNDN);
+    mpfr_set(&result, &a, MPFR_RNDN);
   }
 
   void set_from_long(ElementType &result, long a) const
   {
-    mpfr_set_si(&result, a, GMP_RNDN);
+    mpfr_set_si(&result, a, MPFR_RNDN);
   }
 
   void set_var(ElementType &result, int v) const
   {
-    mpfr_set_si(&result, 1, GMP_RNDN);
+    mpfr_set_si(&result, 1, MPFR_RNDN);
   }
 
   void set_from_mpz(ElementType &result, mpz_srcptr a) const
   {
-    mpfr_set_z(&result, a, GMP_RNDN);
+    mpfr_set_z(&result, a, MPFR_RNDN);
   }
 
   bool set_from_mpq(ElementType &result, mpq_srcptr a) const
   {
-    mpfr_set_q(&result, a, GMP_RNDN);
+    mpfr_set_q(&result, a, MPFR_RNDN);
     return true;
   }
 
   bool set_from_double(ElementType &result, double a) const
   {
-    mpfr_set_d(&result, a, GMP_RNDN);
+    mpfr_set_d(&result, a, MPFR_RNDN);
     return true;
   }
   bool set_from_BigReal(ElementType &result, gmp_RR a) const
   {
-    mpfr_set(&result, a, GMP_RNDN);
+    mpfr_set(&result, a, MPFR_RNDN);
     return true;
   }
 
   // arithmetic
   void negate(ElementType &result, const ElementType &a) const
   {
-    mpfr_neg(&result, &a, GMP_RNDN);
+    mpfr_neg(&result, &a, MPFR_RNDN);
   }
 
   void invert(ElementType &result, const ElementType &a) const
   // we silently assume that a != 0.  If it is, result is set to a^0, i.e. 1
   {
-    mpfr_si_div(&result, 1, &a, GMP_RNDN);
+    mpfr_si_div(&result, 1, &a, MPFR_RNDN);
   }
 
   void add(ElementType &result,
            const ElementType &a,
            const ElementType &b) const
   {
-    mpfr_add(&result, &a, &b, GMP_RNDN);
+    mpfr_add(&result, &a, &b, MPFR_RNDN);
   }
 
   void addMultipleTo(ElementType &result,
                      const ElementType &a,
                      const ElementType &b) const
   {
-    mpfr_fma(&result, &a, &b, &result, GMP_RNDN);
+    mpfr_fma(&result, &a, &b, &result, MPFR_RNDN);
   }
 
   void subtract(ElementType &result,
                 const ElementType &a,
                 const ElementType &b) const
   {
-    mpfr_sub(&result, &a, &b, GMP_RNDN);
+    mpfr_sub(&result, &a, &b, MPFR_RNDN);
   }
 
   void subtract_multiple(ElementType &result,
@@ -183,24 +183,24 @@ class ARingRRR : public RingInterface
             const ElementType &a,
             const ElementType &b) const
   {
-    mpfr_mul(&result, &a, &b, GMP_RNDN);
+    mpfr_mul(&result, &a, &b, MPFR_RNDN);
   }
 
   void divide(ElementType &result,
               const ElementType &a,
               const ElementType &b) const
   {
-    mpfr_div(&result, &a, &b, GMP_RNDN);
+    mpfr_div(&result, &a, &b, MPFR_RNDN);
   }
 
   void power(ElementType &result, const ElementType &a, int n) const
   {
-    mpfr_pow_si(&result, &a, n, GMP_RNDN);
+    mpfr_pow_si(&result, &a, n, MPFR_RNDN);
   }
 
   void power_mpz(ElementType &result, const ElementType &a, mpz_srcptr n) const
   {
-    mpfr_pow_z(&result, &a, n, GMP_RNDN);
+    mpfr_pow_z(&result, &a, n, MPFR_RNDN);
   }
 
   void swap(ElementType &a, ElementType &b) const { mpfr_swap(&a, &b); }
@@ -272,7 +272,7 @@ class ARingRRR : public RingInterface
 
   double coerceToDouble(const ElementType &a) const
   {
-    return mpfr_get_d(&a, GMP_RNDN);
+    return mpfr_get_d(&a, MPFR_RNDN);
   }
 
  private:

--- a/M2/Macaulay2/e/aring-RRi.hpp
+++ b/M2/Macaulay2/e/aring-RRi.hpp
@@ -38,7 +38,7 @@ class ARingRRi : public RingInterface
 
   unsigned int computeHashValue(const elem &a) const
   {
-    double d = 12347. * mpfr_get_d(&(a.left), GMP_RNDN) + 865800. * mpfr_get_d(&(a.right), GMP_RNDN);
+    double d = 12347. * mpfr_get_d(&(a.left), MPFR_RNDN) + 865800. * mpfr_get_d(&(a.right), MPFR_RNDN);
     return static_cast<unsigned int>(d);
   }
 

--- a/M2/Macaulay2/e/aring-glue.hpp
+++ b/M2/Macaulay2/e/aring-glue.hpp
@@ -1201,7 +1201,7 @@ inline void ConcreteRing<ARingRR>::increase_maxnorm(gmp_RRmutable norm,
   R->init(b);
   R->from_ring_elem(b, f);
   R->abs(a, b);
-  if (mpfr_cmp_d(norm, a) < 0) mpfr_set_d(norm, a, GMP_RNDN);
+  if (mpfr_cmp_d(norm, a) < 0) mpfr_set_d(norm, a, MPFR_RNDN);
   R->clear(b);
   R->clear(a);
 }
@@ -1217,7 +1217,7 @@ inline void ConcreteRing<ARingCC>::increase_maxnorm(gmp_RRmutable norm,
   R->init(b);
   R->from_ring_elem(b, f);
   R->abs(a, b);
-  if (mpfr_cmp_d(norm, a) < 0) mpfr_set_d(norm, a, GMP_RNDN);
+  if (mpfr_cmp_d(norm, a) < 0) mpfr_set_d(norm, a, MPFR_RNDN);
   R->clear(b);
   realR.clear(a);
 }
@@ -1232,7 +1232,7 @@ inline void ConcreteRing<ARingRRR>::increase_maxnorm(gmp_RRmutable norm,
   R->init(b);
   R->from_ring_elem(b, f);
   R->abs(a, b);
-  if (mpfr_cmp(&a, norm) > 0) mpfr_set(norm, &a, GMP_RNDN);
+  if (mpfr_cmp(&a, norm) > 0) mpfr_set(norm, &a, MPFR_RNDN);
   R->clear(b);
   R->clear(a);
 }
@@ -1248,7 +1248,7 @@ inline void ConcreteRing<ARingCCC>::increase_maxnorm(gmp_RRmutable norm,
   R->init(b);
   R->from_ring_elem(b, f);
   R->abs(a, b);
-  if (mpfr_cmp(&a, norm) > 0) mpfr_set(norm, &a, GMP_RNDN);
+  if (mpfr_cmp(&a, norm) > 0) mpfr_set(norm, &a, MPFR_RNDN);
   R->clear(b);
   realR.clear(a);
 }

--- a/M2/Macaulay2/e/complex.c
+++ b/M2/Macaulay2/e/complex.c
@@ -8,8 +8,8 @@ void mpfc_init_set(gmp_CCmutable result, gmp_CCmutable a)
 {
   result->re = getmemstructtype(gmp_RRmutable);
   result->im = getmemstructtype(gmp_RRmutable);
-  mpfr_init_set(result->re, a->re, GMP_RNDN);
-  mpfr_init_set(result->im, a->im, GMP_RNDN);
+  mpfr_init_set(result->re, a->re, MPFR_RNDN);
+  mpfr_init_set(result->im, a->im, MPFR_RNDN);
 }
 
 void mpfc_init(gmp_CCmutable result, long precision)
@@ -21,8 +21,8 @@ void mpfc_init(gmp_CCmutable result, long precision)
 }
 void mpfc_set(gmp_CCmutable result, gmp_CCmutable a)
 {
-  mpfr_set(result->re, a->re, GMP_RNDN);
-  mpfr_set(result->im, a->im, GMP_RNDN);
+  mpfr_set(result->re, a->re, MPFR_RNDN);
+  mpfr_set(result->im, a->im, MPFR_RNDN);
 }
 
 void mpfc_clear(gmp_CCmutable result)
@@ -36,8 +36,8 @@ void mpfc_clear(gmp_CCmutable result)
 }
 void mpfc_set_si(gmp_CCmutable result, long re)
 {
-  mpfr_set_si(result->re, re, GMP_RNDN);
-  mpfr_set_si(result->im, 0, GMP_RNDN);
+  mpfr_set_si(result->re, re, MPFR_RNDN);
+  mpfr_set_si(result->im, 0, MPFR_RNDN);
 }
 int mpfc_is_zero(gmp_CCmutable a)
 {
@@ -50,18 +50,18 @@ int mpfc_is_equal(gmp_CCmutable a, gmp_CCmutable b)
 }
 void mpfc_add(gmp_CCmutable result, gmp_CCmutable a, gmp_CCmutable b)
 {
-  mpfr_add(result->re, a->re, b->re, GMP_RNDN);
-  mpfr_add(result->im, a->im, b->im, GMP_RNDN);
+  mpfr_add(result->re, a->re, b->re, MPFR_RNDN);
+  mpfr_add(result->im, a->im, b->im, MPFR_RNDN);
 }
 void mpfc_neg(gmp_CCmutable result, gmp_CCmutable a)
 {
-  mpfr_neg(result->re, a->re, GMP_RNDN);
-  mpfr_neg(result->im, a->im, GMP_RNDN);
+  mpfr_neg(result->re, a->re, MPFR_RNDN);
+  mpfr_neg(result->im, a->im, MPFR_RNDN);
 }
 void mpfc_sub(gmp_CCmutable result, gmp_CCmutable a, gmp_CCmutable b)
 {
-  mpfr_sub(result->re, a->re, b->re, GMP_RNDN);
-  mpfr_sub(result->im, a->im, b->im, GMP_RNDN);
+  mpfr_sub(result->re, a->re, b->re, MPFR_RNDN);
+  mpfr_sub(result->im, a->im, b->im, MPFR_RNDN);
 }
 void mpfc_mul(gmp_CCmutable result, gmp_CCmutable a, gmp_CCmutable b)
 {
@@ -69,16 +69,16 @@ void mpfc_mul(gmp_CCmutable result, gmp_CCmutable a, gmp_CCmutable b)
   mpfr_init2(tmp, mpfr_get_prec(a->re));
 
   // result->re = a->re*b->re - a->im*b->im;
-  mpfr_mul(tmp, a->re, b->re, GMP_RNDN);
-  mpfr_set(result->re, tmp, GMP_RNDN);
-  mpfr_mul(tmp, a->im, b->im, GMP_RNDN);
-  mpfr_sub(result->re, result->re, tmp, GMP_RNDN);
+  mpfr_mul(tmp, a->re, b->re, MPFR_RNDN);
+  mpfr_set(result->re, tmp, MPFR_RNDN);
+  mpfr_mul(tmp, a->im, b->im, MPFR_RNDN);
+  mpfr_sub(result->re, result->re, tmp, MPFR_RNDN);
 
   // result->im = a->re*b->im + a->im*b->re;
-  mpfr_mul(tmp, a->re, b->im, GMP_RNDN);
-  mpfr_set(result->im, tmp, GMP_RNDN);
-  mpfr_mul(tmp, a->im, b->re, GMP_RNDN);
-  mpfr_add(result->im, result->im, tmp, GMP_RNDN);
+  mpfr_mul(tmp, a->re, b->im, MPFR_RNDN);
+  mpfr_set(result->im, tmp, MPFR_RNDN);
+  mpfr_mul(tmp, a->im, b->re, MPFR_RNDN);
+  mpfr_add(result->im, result->im, tmp, MPFR_RNDN);
 
   mpfr_clear(tmp);
 }
@@ -95,12 +95,12 @@ void mpfc_invert(gmp_CCmutable result, gmp_CCmutable v)
       // result->re = 1.0/denom;
       // result->im = - p/denom;
 
-      mpfr_div(p, v->im, v->re, GMP_RNDN);
-      mpfr_mul(denom, p, v->im, GMP_RNDN);
-      mpfr_add(denom, denom, v->re, GMP_RNDN);
-      mpfr_si_div(result->re, 1, denom, GMP_RNDN);
-      mpfr_div(result->im, p, denom, GMP_RNDN);
-      mpfr_neg(result->im, result->im, GMP_RNDN);
+      mpfr_div(p, v->im, v->re, MPFR_RNDN);
+      mpfr_mul(denom, p, v->im, MPFR_RNDN);
+      mpfr_add(denom, denom, v->re, MPFR_RNDN);
+      mpfr_si_div(result->re, 1, denom, MPFR_RNDN);
+      mpfr_div(result->im, p, denom, MPFR_RNDN);
+      mpfr_neg(result->im, result->im, MPFR_RNDN);
     }
   else
     {
@@ -109,12 +109,12 @@ void mpfc_invert(gmp_CCmutable result, gmp_CCmutable v)
       // result->re = p/denom;
       // result->im = -1.0/denom;
 
-      mpfr_div(p, v->re, v->im, GMP_RNDN);
-      mpfr_mul(denom, p, v->re, GMP_RNDN);
-      mpfr_add(denom, denom, v->im, GMP_RNDN);
-      mpfr_si_div(result->im, 1, denom, GMP_RNDN);
-      mpfr_neg(result->im, result->im, GMP_RNDN);
-      mpfr_div(result->re, p, denom, GMP_RNDN);
+      mpfr_div(p, v->re, v->im, MPFR_RNDN);
+      mpfr_mul(denom, p, v->re, MPFR_RNDN);
+      mpfr_add(denom, denom, v->im, MPFR_RNDN);
+      mpfr_si_div(result->im, 1, denom, MPFR_RNDN);
+      mpfr_neg(result->im, result->im, MPFR_RNDN);
+      mpfr_div(result->re, p, denom, MPFR_RNDN);
     }
 
   mpfr_clear(p);
@@ -140,18 +140,18 @@ void mpfc_div(gmp_CCmutable result, gmp_CCmutable u, gmp_CCmutable v)
       // result.re = (u.re + p*u.im)/denom;
       // result.im = (u.im - p*u.re)/denom;
 
-      mpfr_div(p, v->im, v->re, GMP_RNDN);
-      mpfr_mul(denom, p, v->im, GMP_RNDN);
-      mpfr_add(denom, denom, v->re, GMP_RNDN);
+      mpfr_div(p, v->im, v->re, MPFR_RNDN);
+      mpfr_mul(denom, p, v->im, MPFR_RNDN);
+      mpfr_add(denom, denom, v->re, MPFR_RNDN);
 
-      mpfr_mul(result->re, p, u->im, GMP_RNDN);
-      mpfr_add(result->re, result->re, u->re, GMP_RNDN);
-      mpfr_div(result->re, result->re, denom, GMP_RNDN);
+      mpfr_mul(result->re, p, u->im, MPFR_RNDN);
+      mpfr_add(result->re, result->re, u->re, MPFR_RNDN);
+      mpfr_div(result->re, result->re, denom, MPFR_RNDN);
 
-      mpfr_mul(result->im, p, u->re, GMP_RNDN);
-      mpfr_neg(result->im, result->re, GMP_RNDN);
-      mpfr_add(result->im, result->re, u->im, GMP_RNDN);
-      mpfr_div(result->im, result->re, denom, GMP_RNDN);
+      mpfr_mul(result->im, p, u->re, MPFR_RNDN);
+      mpfr_neg(result->im, result->re, MPFR_RNDN);
+      mpfr_add(result->im, result->re, u->im, MPFR_RNDN);
+      mpfr_div(result->im, result->re, denom, MPFR_RNDN);
     }
   else
     {
@@ -160,17 +160,17 @@ void mpfc_div(gmp_CCmutable result, gmp_CCmutable u, gmp_CCmutable v)
       // result.re = (u.re * p + u.im)/denom;
       // result.im = (-u.re + p * u.im)/denom;
 
-      mpfr_div(p, v->re, v->im, GMP_RNDN);
-      mpfr_mul(denom, p, v->re, GMP_RNDN);
-      mpfr_add(denom, denom, v->im, GMP_RNDN);
+      mpfr_div(p, v->re, v->im, MPFR_RNDN);
+      mpfr_mul(denom, p, v->re, MPFR_RNDN);
+      mpfr_add(denom, denom, v->im, MPFR_RNDN);
 
-      mpfr_mul(result->re, p, u->re, GMP_RNDN);
-      mpfr_add(result->re, result->re, u->im, GMP_RNDN);
-      mpfr_div(result->re, result->re, denom, GMP_RNDN);
+      mpfr_mul(result->re, p, u->re, MPFR_RNDN);
+      mpfr_add(result->re, result->re, u->im, MPFR_RNDN);
+      mpfr_div(result->re, result->re, denom, MPFR_RNDN);
 
-      mpfr_mul(result->im, p, u->im, GMP_RNDN);
-      mpfr_sub(result->im, result->re, u->re, GMP_RNDN);
-      mpfr_div(result->im, result->re, denom, GMP_RNDN);
+      mpfr_mul(result->im, p, u->im, MPFR_RNDN);
+      mpfr_sub(result->im, result->re, u->re, MPFR_RNDN);
+      mpfr_div(result->im, result->re, denom, MPFR_RNDN);
     }
 
   mpfr_clear(p);
@@ -204,22 +204,22 @@ void mpfc_sub_mult(gmp_CCmutable result, gmp_CCmutable a, gmp_CCmutable b)
   mpfr_t tmp;
   mpfr_init2(tmp, mpfr_get_prec(a->re));
 
-  mpfr_mul(tmp, a->re, b->re, GMP_RNDN);
-  mpfr_add(result->re, result->re, tmp, GMP_RNDN);
-  mpfr_mul(tmp, a->im, b->im, GMP_RNDN);
-  mpfr_sub(result->re, result->re, tmp, GMP_RNDN);
+  mpfr_mul(tmp, a->re, b->re, MPFR_RNDN);
+  mpfr_add(result->re, result->re, tmp, MPFR_RNDN);
+  mpfr_mul(tmp, a->im, b->im, MPFR_RNDN);
+  mpfr_sub(result->re, result->re, tmp, MPFR_RNDN);
 
-  mpfr_mul(tmp, a->re, b->im, GMP_RNDN);
-  mpfr_add(result->im, result->im, tmp, GMP_RNDN);
-  mpfr_mul(tmp, a->im, b->re, GMP_RNDN);
-  mpfr_add(result->im, result->im, tmp, GMP_RNDN);
+  mpfr_mul(tmp, a->re, b->im, MPFR_RNDN);
+  mpfr_add(result->im, result->im, tmp, MPFR_RNDN);
+  mpfr_mul(tmp, a->im, b->re, MPFR_RNDN);
+  mpfr_add(result->im, result->im, tmp, MPFR_RNDN);
 
   mpfr_clear(tmp);
 }
 void mpfc_conj(gmp_CCmutable result, gmp_CCmutable a)
 {
-  mpfr_set(result->re, a->re, GMP_RNDN);
-  mpfr_neg(result->im, a->im, GMP_RNDN);
+  mpfr_set(result->re, a->re, MPFR_RNDN);
+  mpfr_neg(result->im, a->im, MPFR_RNDN);
 }
 void mpfc_abs(gmp_RRmutable result, gmp_CCmutable c)
 {
@@ -227,33 +227,33 @@ void mpfc_abs(gmp_RRmutable result, gmp_CCmutable c)
 
   mpfr_init2(a, mpfr_get_prec(c->re));
   mpfr_init2(b, mpfr_get_prec(c->re));
-  mpfr_abs(a, c->re, GMP_RNDN);
-  mpfr_abs(b, c->im, GMP_RNDN);
+  mpfr_abs(a, c->re, MPFR_RNDN);
+  mpfr_abs(b, c->im, MPFR_RNDN);
   if (mpfr_zero_p(a))
-    mpfr_set(result, b, GMP_RNDN);
+    mpfr_set(result, b, MPFR_RNDN);
   else if (mpfr_zero_p(b))
-    mpfr_set(result, a, GMP_RNDN);
+    mpfr_set(result, a, MPFR_RNDN);
   else if (mpfr_greater_p(a, b))
     {
       // double d = b/a;
       // But use b for d, as it is not needed later.
       // result = a * ::sqrt(1.0 + d*d);
-      mpfr_div(b, b, a, GMP_RNDN);
-      mpfr_sqr(b, b, GMP_RNDN);
-      mpfr_add_si(b, b, 1, GMP_RNDN);
-      mpfr_sqrt(b, b, GMP_RNDN);
-      mpfr_mul(result, a, b, GMP_RNDN);
+      mpfr_div(b, b, a, MPFR_RNDN);
+      mpfr_sqr(b, b, MPFR_RNDN);
+      mpfr_add_si(b, b, 1, MPFR_RNDN);
+      mpfr_sqrt(b, b, MPFR_RNDN);
+      mpfr_mul(result, a, b, MPFR_RNDN);
     }
   else
     {
       // double d = a/b;
       // But use a for d, as it is not needed later.
       // result = b * ::sqrt(1.0 + d*d);
-      mpfr_div(a, a, b, GMP_RNDN);
-      mpfr_sqr(a, a, GMP_RNDN);
-      mpfr_add_si(a, a, 1, GMP_RNDN);
-      mpfr_sqrt(a, a, GMP_RNDN);
-      mpfr_mul(result, b, a, GMP_RNDN);
+      mpfr_div(a, a, b, MPFR_RNDN);
+      mpfr_sqr(a, a, MPFR_RNDN);
+      mpfr_add_si(a, a, 1, MPFR_RNDN);
+      mpfr_sqrt(a, a, MPFR_RNDN);
+      mpfr_mul(result, b, a, MPFR_RNDN);
     }
   mpfr_clear(a);
   mpfr_clear(b);
@@ -289,8 +289,8 @@ void mpfc_sqrt(gmp_CCmutable result, gmp_CC a)
 
   if (mpfr_zero_p(a->re) && mpfr_zero_p(a->im))
     {
-      mpfr_set_si(result->re, 0, GMP_RNDN);
-      mpfr_set_si(result->im, 0, GMP_RNDN);
+      mpfr_set_si(result->re, 0, MPFR_RNDN);
+      mpfr_set_si(result->im, 0, MPFR_RNDN);
       return;
     }
 
@@ -304,53 +304,53 @@ void mpfc_sqrt(gmp_CCmutable result, gmp_CC a)
 
   // b = fabs(a.re);
   // c = fabs(a.im);
-  mpfr_abs(b, a->re, GMP_RNDN);
-  mpfr_abs(c, a->im, GMP_RNDN);
+  mpfr_abs(b, a->re, MPFR_RNDN);
+  mpfr_abs(c, a->im, MPFR_RNDN);
   if (mpfr_greater_p(b, c))
     {
       // d = c/b;
       // e = ::sqrt(b) * ::sqrt(0.5 * (1.0 + ::sqrt(1.0 + d*d)));
       // but use c as d, and also as e
-      mpfr_div(d, c, b, GMP_RNDN);
-      mpfr_sqr(d, d, GMP_RNDN);
-      mpfr_add_si(d, d, 1, GMP_RNDN);
-      mpfr_sqrt(d, d, GMP_RNDN);
-      mpfr_add_si(d, d, 1, GMP_RNDN);
-      mpfr_div_2ui(d, d, 1, GMP_RNDN);
-      mpfr_sqrt(d, d, GMP_RNDN);
-      mpfr_sqrt(b, b, GMP_RNDN);
-      mpfr_mul(d, d, b, GMP_RNDN); /* this is now e ! */
+      mpfr_div(d, c, b, MPFR_RNDN);
+      mpfr_sqr(d, d, MPFR_RNDN);
+      mpfr_add_si(d, d, 1, MPFR_RNDN);
+      mpfr_sqrt(d, d, MPFR_RNDN);
+      mpfr_add_si(d, d, 1, MPFR_RNDN);
+      mpfr_div_2ui(d, d, 1, MPFR_RNDN);
+      mpfr_sqrt(d, d, MPFR_RNDN);
+      mpfr_sqrt(b, b, MPFR_RNDN);
+      mpfr_mul(d, d, b, MPFR_RNDN); /* this is now e ! */
     }
   else
     {
       // d = b/c;
       // e = ::sqrt(c) * ::sqrt(0.5 * (d + ::sqrt(1.0 + d*d)));
-      mpfr_div(d, b, c, GMP_RNDN);
-      mpfr_sqr(d2, d, GMP_RNDN);
-      mpfr_add_si(d2, d2, 1, GMP_RNDN);
-      mpfr_sqrt(d2, d2, GMP_RNDN);
-      mpfr_add(d, d2, d, GMP_RNDN);
-      mpfr_div_2ui(d, d, 1, GMP_RNDN);
-      mpfr_sqrt(d, d, GMP_RNDN);
-      mpfr_sqrt(c, c, GMP_RNDN);
-      mpfr_mul(d, d, c, GMP_RNDN); /* this is now e ! */
+      mpfr_div(d, b, c, MPFR_RNDN);
+      mpfr_sqr(d2, d, MPFR_RNDN);
+      mpfr_add_si(d2, d2, 1, MPFR_RNDN);
+      mpfr_sqrt(d2, d2, MPFR_RNDN);
+      mpfr_add(d, d2, d, MPFR_RNDN);
+      mpfr_div_2ui(d, d, 1, MPFR_RNDN);
+      mpfr_sqrt(d, d, MPFR_RNDN);
+      mpfr_sqrt(c, c, MPFR_RNDN);
+      mpfr_mul(d, d, c, MPFR_RNDN); /* this is now e ! */
     }
   if (mpfr_sgn(a->re) >= 0)
     {
       // result.re = e;
       // result.im = a.im/(2.0 * e);
-      mpfr_set(result->re, d, GMP_RNDN);
-      mpfr_mul_2ui(d, d, 1, GMP_RNDN);
-      mpfr_div(result->im, a->im, d, GMP_RNDN);
+      mpfr_set(result->re, d, MPFR_RNDN);
+      mpfr_mul_2ui(d, d, 1, MPFR_RNDN);
+      mpfr_div(result->im, a->im, d, MPFR_RNDN);
     }
   else
     {
       // result.im = (a.im >= 0.0 ? e : -e);
       // result.re = a.re/(2.0*result.im);
-      mpfr_set(result->im, d, GMP_RNDN);
-      if (mpfr_sgn(a->im) < 0) mpfr_neg(result->im, result->im, GMP_RNDN);
-      mpfr_mul_2ui(d, result->im, 1, GMP_RNDN);
-      mpfr_div(result->re, a->im, d, GMP_RNDN);
+      mpfr_set(result->im, d, MPFR_RNDN);
+      if (mpfr_sgn(a->im) < 0) mpfr_neg(result->im, result->im, MPFR_RNDN);
+      mpfr_mul_2ui(d, result->im, 1, MPFR_RNDN);
+      mpfr_div(result->re, a->im, d, MPFR_RNDN);
     }
 
   mpfr_clear(b);

--- a/M2/Macaulay2/e/complex.h
+++ b/M2/Macaulay2/e/complex.h
@@ -5,7 +5,7 @@
 
 /* The interface is similar to mpfr:
    Every gmp_CC struct needs to be initialized with init or init_set.
-   All rounding is GMP_RNDN.
+   All rounding is MPFR_RNDN.
    Resulting values are the first argument
 */
 

--- a/M2/Macaulay2/e/interface/mutable-matrix.cpp
+++ b/M2/Macaulay2/e/interface/mutable-matrix.cpp
@@ -1079,7 +1079,7 @@ static gmp_RRmutable get_norm_start(gmp_RR p, const Ring *R)
     }
   gmp_RRmutable norm = getmemstructtype(gmp_RRmutable);
   mpfr_init2(norm, mpfr_get_prec(p));
-  mpfr_ui_div(norm, 1, p, GMP_RNDN);
+  mpfr_ui_div(norm, 1, p, MPFR_RNDN);
   if (!mpfr_zero_p(norm))
     {
       ERROR("Lp norm only implemented for p = infinity");

--- a/M2/Macaulay2/e/interface/polyroots.cpp
+++ b/M2/Macaulay2/e/interface/polyroots.cpp
@@ -64,10 +64,10 @@ engine_RawRingElementArrayOrNull rawRoots(const RingElement *p,
       mpc_t mpc_cc;
       mpc_init2(mpc_cc,K->get_precision());
       if (ID==M2::ring_RRR) {
-          mpfr_get_f(mpc_cc->r,t->coeff.get_mpfr(),GMP_RNDN);
+          mpfr_get_f(mpc_cc->r,t->coeff.get_mpfr(),MPFR_RNDN);
       } else {
-        mpfr_get_f(mpc_cc->r,&t->coeff.get_cc()->re,GMP_RNDN);
-        mpfr_get_f(mpc_cc->i,&t->coeff.get_cc()->im,GMP_RNDN);
+        mpfr_get_f(mpc_cc->r,&t->coeff.get_cc()->re,MPFR_RNDN);
+        mpfr_get_f(mpc_cc->i,&t->coeff.get_cc()->im,MPFR_RNDN);
       }
       mps_monomial_poly_set_coefficient_f (s, mps_p, deg, mpc_cc); 
       mpc_clear(mpc_cc);
@@ -146,8 +146,8 @@ engine_RawRingElementArrayOrNull rawRoots(const RingElement *p,
     C0.init(cc);
     for (int i = 0; i < hideg; i++) {
       auto& mps_root = roots[i];
-      mpfr_set_f(&cc.re,mpc_Re(mps_root),GMP_RNDN);
-      mpfr_set_f(&cc.im,mpc_Im(mps_root),GMP_RNDN);
+      mpfr_set_f(&cc.re,mpc_Re(mps_root),MPFR_RNDN);
+      mpfr_set_f(&cc.im,mpc_Im(mps_root),MPFR_RNDN);
       ring_elem m2_root;
       C0.to_ring_elem(m2_root, cc);
       result->array[i] = RingElement::make_raw(C, m2_root);

--- a/M2/Macaulay2/e/interface/random.cpp
+++ b/M2/Macaulay2/e/interface/random.cpp
@@ -127,7 +127,7 @@ double randomDouble()
   mpfr_t val;
   mpfr_init2(val, 53);
   randomMpfr(val);
-  double result = mpfr_get_d(val, GMP_RNDN);
+  double result = mpfr_get_d(val, MPFR_RNDN);
   mpfr_clear(val);
   return result;
 }

--- a/M2/Macaulay2/e/interface/ringelement.cpp
+++ b/M2/Macaulay2/e/interface/ringelement.cpp
@@ -129,14 +129,14 @@ gmp_RRorNull IM2_RingElement_to_BigReal(const RingElement *a)
       case M2::ring_RR:
         result = getmemstructtype(gmp_RRmutable);
         mpfr_init2(result, 53);
-        mpfr_set_d(result, a->get_value().get_double(), GMP_RNDN);
+        mpfr_set_d(result, a->get_value().get_double(), MPFR_RNDN);
         return moveTo_gmpRR(result);
       case M2::ring_RRR:
         R1 =
             dynamic_cast<const M2::ConcreteRing<M2::ARingRRR> *>(a->get_ring());
         result = getmemstructtype(gmp_RRmutable);
         mpfr_init2(result, R1->get_precision());
-        mpfr_set(result, a->get_value().get_mpfr(), GMP_RNDN);
+        mpfr_set(result, a->get_value().get_mpfr(), MPFR_RNDN);
         return moveTo_gmpRR(result);
       default:
         ERROR("expected an element of RRR");

--- a/M2/Macaulay2/e/lapack.cpp
+++ b/M2/Macaulay2/e/lapack.cpp
@@ -25,7 +25,7 @@ double *make_lapack_array(const DMat<M2::ARingRRR> &mat)
     {
       auto end = mat.columnEnd(c);
       for (auto a = mat.columnBegin(c); a != end; ++a)
-        *p++ = mpfr_get_d(&(*a), GMP_RNDN);
+        *p++ = mpfr_get_d(&(*a), MPFR_RNDN);
     }
   return result;
 }
@@ -41,8 +41,8 @@ double *make_lapack_array(const DMat<M2::ARingCCC> &mat)
       auto end = mat.columnEnd(c);
       for (auto a = mat.columnBegin(c); a != end; ++a)
         {
-          *p++ = mpfr_get_d(&(*a).re, GMP_RNDN);
-          *p++ = mpfr_get_d(&(*a).im, GMP_RNDN);
+          *p++ = mpfr_get_d(&(*a).re, MPFR_RNDN);
+          *p++ = mpfr_get_d(&(*a).im, MPFR_RNDN);
         }
     }
   return result;
@@ -503,7 +503,7 @@ bool Lapack::eigenvectors(const LMatrixRRR *A,
           eigvals->ring().set_from_doubles(elems[j], real[j], imag[j]);
           auto end = eigvecs->columnEnd(j);
 
-          // mpfr_get_d(&(*a), GMP_RNDN);
+          // mpfr_get_d(&(*a), MPFR_RNDN);
           int loc = j * size;
           if (imag[j] == 0)
             {
@@ -2160,7 +2160,7 @@ bool Lapack::eigenvectors(const LMatrixRR *A,
           eigvals->ring().set_from_doubles(elems[j], real[j], imag[j]);
           auto end = eigvecs->columnEnd(j);
 
-          // mpfr_get_d(&(*a), GMP_RNDN);
+          // mpfr_get_d(&(*a), MPFR_RNDN);
           int loc = j * size;
           if (imag[j] == 0)
             {

--- a/M2/Macaulay2/e/matrix.cpp
+++ b/M2/Macaulay2/e/matrix.cpp
@@ -2038,7 +2038,7 @@ gmp_RRorNull Matrix::norm(gmp_RR p) const
     }
   gmp_RRmutable nm = getmemstructtype(gmp_RRmutable);
   mpfr_init2(nm, mpfr_get_prec(p));
-  mpfr_ui_div(nm, 1, p, GMP_RNDN);
+  mpfr_ui_div(nm, 1, p, MPFR_RNDN);
   if (!mpfr_zero_p(nm))
     {
       ERROR("Lp norm only implemented for p = infinity");

--- a/M2/Macaulay2/e/mutablemat-imp.hpp
+++ b/M2/Macaulay2/e/mutablemat-imp.hpp
@@ -327,7 +327,7 @@ gmp_RRorNull MutableMat<T>::norm() const
 
   gmp_RRmutable nm = getmemstructtype(gmp_RRmutable);
   mpfr_init2(nm, get_ring()->get_precision());
-  mpfr_set_si(nm, 0, GMP_RNDN);
+  mpfr_set_si(nm, 0, MPFR_RNDN);
 
   MatrixOps::increase_norm(nm, mat);
   return moveTo_gmpRR(nm);

--- a/M2/Macaulay2/e/unit-tests/ARingCCCTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingCCCTest.cpp
@@ -19,7 +19,7 @@ bool almostEqual(const M2::ARingCCC& C,
 {
   mpfr_t epsilon;
   mpfr_init2(epsilon, C.get_precision());
-  mpfr_set_ui_2exp(epsilon, 1, -nbits, GMP_RNDN);  // should there be exp() ???
+  mpfr_set_ui_2exp(epsilon, 1, -nbits, MPFR_RNDN);  // should there be exp() ???
 
   M2::ARingCCC::ElementType c;
   C.init(c);

--- a/M2/Macaulay2/e/unit-tests/ARingRRRTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingRRRTest.cpp
@@ -18,7 +18,7 @@ bool almostEqual(const M2::ARingRRR& R,
 {
   mpfr_t epsilon;
   mpfr_init2(epsilon, R.get_precision());
-  mpfr_set_ui_2exp(epsilon, 1, -nbits, GMP_RNDN);
+  mpfr_set_ui_2exp(epsilon, 1, -nbits, MPFR_RNDN);
 
   M2::ARingRRR::ElementType c;
   R.init(c);

--- a/M2/Macaulay2/e/unit-tests/ARingRRiTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingRRiTest.cpp
@@ -21,14 +21,14 @@ bool almostEqual(const M2::ARingRRi& R,
 {
     mpfr_t epsilon;
     mpfr_init2(epsilon, R.get_precision());
-    mpfr_set_ui_2exp(epsilon, 1, -nbits, GMP_RNDN);
+    mpfr_set_ui_2exp(epsilon, 1, -nbits, MPFR_RNDN);
     
     mpfr_t c,d;
     mpfr_init2(c, R.get_precision());
     mpfr_init2(d, R.get_precision());
     
-    mpfr_sub(c,&(a.left),&(b.left),GMP_RNDN);
-    mpfr_sub(d,&(a.right),&(b.right),GMP_RNDN);
+    mpfr_sub(c,&(a.left),&(b.left),MPFR_RNDN);
+    mpfr_sub(d,&(a.right),&(b.right),MPFR_RNDN);
     
     bool retL = mpfr_cmpabs(c, epsilon) < 0,
          retR = mpfr_cmpabs(d, epsilon) < 0;

--- a/M2/Macaulay2/e/unit-tests/RingCCCTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/RingCCCTest.cpp
@@ -11,7 +11,7 @@ bool almostEqual(const RingCCC *R, int nbits, ring_elem a, ring_elem b)
 {
   mpfr_t epsilon;
   mpfr_init2(epsilon, 100);
-  mpfr_set_ui_2exp(epsilon, 1, -nbits, GMP_RNDN);
+  mpfr_set_ui_2exp(epsilon, 1, -nbits, MPFR_RNDN);
 
   ring_elem f = R->subtract(a, b);
   auto f1 = BIGCC_RE(f);

--- a/M2/Macaulay2/e/unit-tests/RingRRRTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/RingRRRTest.cpp
@@ -10,7 +10,7 @@ bool almostEqual(const RingRRR *R, int nbits, ring_elem a, ring_elem b)
 {
   mpfr_t epsilon;
   mpfr_init2(epsilon, 100);
-  mpfr_set_ui_2exp(epsilon, 1, -nbits, GMP_RNDN);
+  mpfr_set_ui_2exp(epsilon, 1, -nbits, MPFR_RNDN);
 
   ring_elem c = R->subtract(a, b);
   bool ret = mpfr_cmpabs(c.get_mpfr(), epsilon) < 0;


### PR DESCRIPTION
According the [MPFR manual](https://www.mpfr.org/mpfr-current/mpfr.html), section 6.1:

> The rounding modes GMP_RNDx were renamed to MPFR_RNDx in MPFR 3.0. However the old names GMP_RNDx have been kept for compatibility (this might change in future versions) ..."
