### PR TITLE
Use multiple precision for Boost math functions

### DIFF
--- a/M2/Macaulay2/d/boostmath.dd
+++ b/M2/Macaulay2/d/boostmath.dd
@@ -2,68 +2,78 @@ use util;
 use common;
 
 header "#include <iostream>
+  #include <boost/multiprecision/mpfr.hpp>
   #include <boost/math/special_functions/beta.hpp>
   #include <boost/math/special_functions/erf.hpp>
   #include <boost/math/special_functions/gamma.hpp>
 
-  #define BOOST_MATH_CALL(f, ...)       \\
-  try {                                 \\
-    return boost::math::f(__VA_ARGS__); \\
-  } catch (const std::exception& e) {   \\
-    std::cout << e.what() << std::endl; \\
-    return NAN;                         \\
+  #define RR_TO_BOOST(x) boost::multiprecision::mpfr_float(x)
+
+  #define BOOST_MATH_CALL(f, prec, ...)                                  \\
+  try {                                                                  \\
+    boost::multiprecision::mpfr_float::default_precision(                \\
+	boost::multiprecision::detail::digits2_2_10(prec));              \\
+    return gmp_toRR(boost::math::f(__VA_ARGS__).backend().data(), prec); \\
+  } catch (const std::exception& e) {                                    \\
+    std::cout << e.what() << std::endl;                                  \\
+    return nullptr;                                                      \\
   }";
 
-handleBoostError(x:double):Expr:=
-    if isnan(x) then buildErrorPacket("Boost Math Toolkit error")
-    else toExpr(x);
+handleBoostError(x:RRorNull):Expr:=
+    when x
+    is null do buildErrorPacket("Boost Math Toolkit error")
+    is y:RR do toExpr(y);
 
 -- # typical value: inverseErf, RR, RR
-inverseErf(p:double):double:=
-    Ccode(returns, "BOOST_MATH_CALL(erf_inv, ", p, ")");
+inverseErf(p:RR):RRorNull:= (
+    prec := precision(p);
+    Ccode(returns, "BOOST_MATH_CALL(erf_inv, ", prec,
+	", RR_TO_BOOST(", p,"))"));
 inverseErf(e:Expr):Expr :=
-    when e is p:RRcell do handleBoostError(inverseErf(toDouble(p)))
+    when e is p:RRcell do handleBoostError(inverseErf(p.v))
     else WrongArgRR();
 setupfun("inverseErf",inverseErf).Protected=false;
 
 -- # typical value: regularizedGamma, RR, RR, RR
-regularizedGamma(a:double,z:double):double:=
-    Ccode(returns, "BOOST_MATH_CALL(gamma_q, ", a, ", ", z, ")");
+regularizedGamma(a:RR,z:RR):RRorNull:= (
+    prec := min(precision(a), precision(z));
+    Ccode(returns, "BOOST_MATH_CALL(gamma_q, ", prec, ", RR_TO_BOOST(", a,
+	"), RR_TO_BOOST(", z, "))"));
 regularizedGamma(e:Expr):Expr :=
     when e is s:Sequence do
 	when s.0 is a:RRcell do
-	    when s.1 is z:RRcell do
-		handleBoostError(regularizedGamma(toDouble(a),
-		    toDouble(z)))
+	    when s.1 is z:RRcell do handleBoostError(regularizedGamma(a.v, z.v))
 	    else WrongArgRR(2)
 	else WrongArgRR(1)
     else WrongNumArgs(2);
 setupfun("regularizedGamma",regularizedGamma).Protected=false;
 
 -- # typical value: inverseRegularizedGamma, RR, RR, RR
-inverseRegularizedGamma(a:double,q:double):double:=
-    Ccode(returns, "BOOST_MATH_CALL(gamma_q_inv, ", a, ", ", q, ")");
+inverseRegularizedGamma(a:RR,q:RR):RRorNull:= (
+    prec := min(precision(a), precision(q));
+    Ccode(returns, "BOOST_MATH_CALL(gamma_q_inv, ", prec, ", RR_TO_BOOST(", a,
+	"), RR_TO_BOOST(", q, "))"));
 inverseRegularizedGamma(e:Expr):Expr :=
     when e is s:Sequence do
 	when s.0 is a:RRcell do
 	    when s.1 is q:RRcell do
-		handleBoostError(inverseRegularizedGamma(toDouble(a),
-		    toDouble(q)))
+		handleBoostError(inverseRegularizedGamma(a.v, q.v))
 	    else WrongArgRR(2)
 	else WrongArgRR(1)
     else WrongNumArgs(2);
 setupfun("inverseRegularizedGamma",inverseRegularizedGamma).Protected=false;
 
 -- # typical value: regularizedBeta, RR, RR, RR, RR
-regularizedBeta(x:double,a:double,b:double):double:=
-   Ccode(returns, "BOOST_MATH_CALL(ibeta, ", a, ", ", b, ", ", x, ")");
+regularizedBeta(x:RR,a:RR,b:RR):RRorNull:= (
+    prec := min(precision(x), min(precision(a), precision(b)));
+    Ccode(returns, "BOOST_MATH_CALL(ibeta, ", prec, ", RR_TO_BOOST(", a,
+	"), RR_TO_BOOST(", b, "), RR_TO_BOOST(", x, "))"));
 regularizedBeta(e:Expr):Expr :=
     when e is s:Sequence do
 	when s.0 is x:RRcell do
 	    when s.1 is a:RRcell do
 		when s.2 is b:RRcell do
-		    handleBoostError(regularizedBeta(toDouble(x),
-			    toDouble(a), toDouble(b)))
+		    handleBoostError(regularizedBeta(x.v, a.v, b.v))
 		else WrongArgRR(3)
 	    else WrongArgRR(2)
 	else WrongArgRR(1)
@@ -71,15 +81,16 @@ regularizedBeta(e:Expr):Expr :=
 setupfun("regularizedBeta",regularizedBeta).Protected=false;
 
 -- # typical value: inverseRegularizedBeta, RR, RR, RR, RR
-inverseRegularizedBeta(p:double,a:double,b:double):double:=
-   Ccode(returns, "BOOST_MATH_CALL(ibeta_inv, ", a, ", ", b, ", ", p, ")");
+inverseRegularizedBeta(p:RR,a:RR,b:RR):RRorNull:= (
+    prec := min(precision(p), min(precision(a), precision(b)));
+    Ccode(returns, "BOOST_MATH_CALL(ibeta_inv, ", prec, ", RR_TO_BOOST(", a,
+       "), RR_TO_BOOST(", b, "), RR_TO_BOOST(", p, "))"));
 inverseRegularizedBeta(e:Expr):Expr :=
     when e is s:Sequence do
 	when s.0 is p:RRcell do
 	    when s.1 is a:RRcell do
 		when s.2 is b:RRcell do
-		    handleBoostError(inverseRegularizedBeta(toDouble(p),
-			    toDouble(a), toDouble(b)))
+		    handleBoostError(inverseRegularizedBeta(p.v, a.v, b.v))
 		else WrongArgRR(3)
 	    else WrongArgRR(2)
 	else WrongArgRR(1)

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/Beta-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/Beta-doc.m2
@@ -41,9 +41,6 @@ doc ///
     Example
       regularizedBeta(1/2, 3, 4)
       1/Beta(3,4) * integrate(t -> t^2 * (1 - t)^3, 0, 1/2)
-  Caveat
-    This function always returns a double precision real number (53 bits)
-    regardless of the precision of its arguments.
   SeeAlso
     Beta
     inverseRegularizedBeta
@@ -69,9 +66,6 @@ doc ///
     Example
       regularizedBeta(1/2, 3, 4)
       inverseRegularizedBeta(oo, 3, 4)
-  Caveat
-    This function always returns a double precision real number (53 bits)
-    regardless of the precision of its arguments.
   SeeAlso
     Beta
     regularizedBeta

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/Gamma-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/Gamma-doc.m2
@@ -47,9 +47,6 @@ doc ///
     Example
       regularizedGamma(3, 7)
       Gamma(3, 7) / Gamma 3
-  Caveat
-    This function always returns a double precision real number (53 bits)
-    regardless of the precision of its arguments.
   SeeAlso
     Gamma
     inverseRegularizedGamma
@@ -74,12 +71,9 @@ doc ///
     Example
       regularizedGamma(3, 7)
       inverseRegularizedGamma(3, oo)
-  Caveat
-    This function always returns a double precision real number (53 bits)
-    regardless of the precision of its arguments.
   SeeAlso
     Gamma
-    inverseRegularizedGamma
+    regularizedGamma
 ///
 
 doc ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/erf-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/erf-doc.m2
@@ -59,9 +59,6 @@ doc ///
     Example
       erf 2
       inverseErf oo
-  Caveat
-    This function always returns a double precision real number (53 bits)
-    regardless of the precision of its arguments.
   SeeAlso
     erf
     erfc

--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -1241,8 +1241,8 @@ assert Equation(density_X 3, 3^3/3! * exp(-3))
 assert Equation(density_X 3.5, 0)
 
 assert Equation(probability_X(-1), 0)
-assert Equation(probability_X 3, sum(0..3, x -> 3^x / x! * exp(-3)))
-assert Equation(probability_X 3.5, sum(0..3, x -> 3^x / x! * exp(-3)))
+assert (abs(probability_X 3 - sum(0..3, x -> 3^x / x! * exp(-3))) < 1e-15)
+assert (abs(probability_X 3.5 - sum(0..3, x -> 3^x / x! * exp(-3))) < 1e-15)
 
 assert Equation(quantile_X 0, 0)
 assert Equation(quantile_X 0.3, 2)
@@ -1398,7 +1398,7 @@ assert Equation(probability_X 0.3, 0.0837) -- R: pbeta(0.3., 3, 2)
 assert Equation(probability_X 2, 1)
 
 assert Equation(quantile_X 0, 0)
-assert Equation(quantile_X 0.0837, 0.3)
+assert (abs(quantile_X 0.0837 - 0.3) < 1e-15)
 assert Equation(quantile_X 1, 1)
 ///
 


### PR DESCRIPTION
This is a followup to #2436, using [Boost's MPFR support](https://www.boost.org/doc/libs/1_79_0/libs/multiprecision/doc/html/boost_multiprecision/tut/floats/mpfr_float.html) so that the functions we use from Boost behave like the ones we use from MPFR.

Note that Boost makes heavy use of templates for this feature, so it takes a while to compile `boostmath-tmp.cc` after these changes.

### Before
```m2
i1 : inverseErf 0.5p100

o1 = .47693627620447

o1 : RR (of precision 53)
```

### After
```m2
i1 : inverseErf 0.5p100

o1 = .476936276204469873381191844309

o1 : RR (of precision 100)
```



