### PR TITLE
Fix Python bug

### DIFF
--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -169,7 +169,7 @@ toFunction = method()
 toFunction PythonObject := x -> y -> (
     p := partition(a -> instance(a, Option),
 	if instance(y, Sequence) then y else 1:y);
-    args := toPython if p#?false then toSequence p#false else ();
+    args := toPython if p#?false then p#false else ();
     kwargs := toPython hashTable if p#?true then toList p#true else {};
     if debugLevel > 0 then printerr(
 	"callable: " | toString x    ||

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -476,6 +476,14 @@ assert Equation(foo@@replace("f", "F"), pythonValue "'Foo'")
 assert Equation(foo@@upper(), pythonValue "'FOO'")
 ///
 
+TEST ///
+-- issue #2315
+rand = import "random"
+L = toPython {1, 2, 3}
+assert member(value rand@@choice L, {1, 2, 3})
+assert Equation(L + L, toPython {1, 2, 3, 1, 2, 3})
+///
+
 end --------------------------------------------------------
 
 


### PR DESCRIPTION
I finally figured out what was causing #2315.  Macaulay2's `hash` function was using Python's `hash` function, but not every Python object is hashable (e.g., lists).  This was causing an error, but it wasn't being raised at top level.  And the next time we ran any Python code, that error would appear:

```m2
i1 : needsPackage "Python"

o1 = Python

o1 : Package

i2 : hash toPython {1, 2, 3}

o2 = -1

i3 : (pythonValue "print") "Hello, world!"
TypeError: unhashable type: 'list'
stdio:3:2:(3): error: python error
```
We switch it so that if Python's `hash` function raises that error, then we clear the error flag and use a dummy hash value instead:

```m2
i1 : needsPackage "Python"

o1 = Python

o1 : Package

i2 : hash toPython {1, 2, 3}

o2 = 123455

i3 : (pythonValue "print") "Hello, world!"
Hello, world!

o3 = None

o3 : PythonObject of class NoneType
```