### PR TITLE
Relax a Probability test

### DIFF
--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -1394,7 +1394,7 @@ assert Equation(density_X 0.3, 0.756) -- R: dbeta(0.3, 3, 2)
 assert Equation(density_X 2 , 0)
 
 assert Equation(probability_X(-1), 0)
-assert Equation(probability_X 0.3, 0.0837) -- R: pbeta(0.3., 3, 2)
+assert (abs(probability_X 0.3 - 0.0837) < 1e-15) -- R: pbeta(0.3., 3, 2)
 assert Equation(probability_X 2, 1)
 
 assert Equation(quantile_X 0, 0)


### PR DESCRIPTION
Was [failing on Ubuntu 18.04](https://launchpadlibrarian.net/605883082/buildlog_ubuntu-bionic-amd64.macaulay2_1.20.0.1+git202206061811-0ppa202206061818~ubuntu18.04.1_BUILDING.txt.gz) after the recent change adding MPFR support for Boost Math Library functions (#2521).

Not sure if it's because of updates in Boost or MPFR since Ubuntu 18.04 was released, but we get slightly different results:

### Ubuntu 18.04
```m2
1 : toExternalString regularizedBeta(0.3, 3, 2)

o1 = .83700000000000052p53e-1
```

### Ubuntu 21.10
```m2
i1 : toExternalString regularizedBeta(0.3, 3, 2)

o1 = .83699999999999997p53e-1
```
So we relax the test so that this only needs to be within 10<sup>-15</sup> of 0.0837 to pass.
