### PR TITLE
Add ForeignFunctions package

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Build Macaulay2 using Ninja
         if: matrix.build-system == 'cmake'
         run: |
-          cmake --build . --target M2-core M2-emacs install-packages
+          cmake --build . --target M2-core M2-emacs M2-highlightjs install-packages
           if [[ "${{ runner.os }}" == "Linux" ]] && [[ "${{ matrix.compiler }}" == "clang-11" ]]; then
               sudo apt-get install -y -q --no-install-recommends dpkg-dev
               echo "GIT_COMMIT=`git describe --dirty --always --match HEAD`" >> $GITHUB_ENV

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           brew config
           brew tap macaulay2/tap
-          brew install autoconf automake bison boost tbb ccache cmake ctags gnu-tar libtool make ninja pkg-config yasm
+          brew install autoconf automake bison boost tbb ccache cmake ctags gnu-tar libtool make ninja pkg-config yasm libffi
           brew install --only-dependencies macaulay2/tap/M2
 
 # ----------------------
@@ -132,7 +132,7 @@ jobs:
         run: |
           cmake -S../.. -B. -GNinja \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_NATIVE=OFF \
-            -DCMAKE_PREFIX_PATH="`brew --prefix`" \
+            -DCMAKE_PREFIX_PATH="`brew --prefix`;`brew --prefix libffi`" \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DWITH_PYTHON=ON \
             --debug-trycompile

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -280,6 +280,7 @@ The main targets for building Macaulay2 are:
 - `M2-binary`: build the Macaulay2 executable
 - `M2-core`: generate and copy the Core package
 - `M2-emacs`: generate the M2-mode package for Emacs
+- `M2-highlightjs`: generate syntax highlighting library for javascript
 
 In addition, the following targets are available:
 - `scc1`: build the Safe C Compiler

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -23,9 +23,9 @@ There are various tools needed to compile Macaulay2 dependencies.
 - On Mac OS X, using Homebrew, install `autoconf automake bison libtool pkg-config yasm`.
 
 There are 10 libraries that must be found on the system.
-- On Debian/Ubuntu, install `libopenblas-dev libgmp3-dev libxml2-dev libreadline-dev libgdbm-dev libboost-regex-dev libboost-stacktrace-dev libatomic-ops-dev libomp-dev libtbb-dev`.
-- On Fedora/CentOS, install `openblas-devel gmp-devel libxml2-devel readline-devel gdbm-devel boost-devel libatomic_ops-devel libomp-devel tbb-devel`.
-- On Mac OS X, using Homebrew, install `gmp libxml2 readline gdbm boost libatomic_ops libomp tbb`.
+- On Debian/Ubuntu, install `libopenblas-dev libgmp3-dev libxml2-dev libreadline-dev libgdbm-dev libboost-regex-dev libboost-stacktrace-dev libatomic-ops-dev libomp-dev libtbb-dev libffi-dev`.
+- On Fedora/CentOS, install `openblas-devel gmp-devel libxml2-devel readline-devel gdbm-devel boost-devel libatomic_ops-devel libomp-devel tbb-devel libffi-devel`.
+- On Mac OS X, using Homebrew, install `gmp libxml2 readline gdbm boost libatomic_ops libomp tbb libffi`.
 
 **TIP**: x86_64 binary packages for all dependencies on Mac OS X 10.15+ and Linux distributions are available through the [Macaulay2 tap](https://github.com/Macaulay2/homebrew-tap/) for Homebrew. To download the dependencies this way run:
 ```
@@ -150,6 +150,7 @@ For a complete list, along with descriptions, try `cmake -LAH .` or see `cmake/c
 - `USING_MPIR:BOOL=OFF`: use MPIR instead of GMP
 - `WITH_OMP:BOOL=ON`: link with the OpenMP library
 - `WITH_TBB:BOOL=ON`: link with the TBB library
+- `WITH_FFI:BOOL=ON`: link with the FFI library
 - `WITH_PYTHON:BOOL=OFF`: link with the Python library (set to `ON` to use the `Python` package)
 - `WITH_SQL:BOOL=OFF`: link with the MySQL library
 - `WITH_XML:BOOL=ON`: link with the libxml2 library

--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -87,6 +87,7 @@ set(DLIST
   interface.dd interface2.d
   texmacs.d
   boostmath.dd
+  ffi.d
   interp.dd	# this one is last, because it contains the top level interpreter
   version.dd
   )
@@ -140,7 +141,7 @@ add_library(M2-interpreter OBJECT ${CLIST} ${CXXLIST} ${TAGS}
   $<$<BOOL:${WITH_XML}>:xml-c.c xml-c.h>
   $<$<BOOL:${WITH_PYTHON}>:python-c.c>)
 
-target_link_libraries(M2-interpreter PRIVATE M2-supervisor Boost::regex TBB::tbb)
+target_link_libraries(M2-interpreter PRIVATE M2-supervisor Boost::regex TBB::tbb FFI::ffi)
 
 target_include_directories(M2-interpreter
   PUBLIC

--- a/M2/Macaulay2/d/Makefile.files.in
+++ b/M2/Macaulay2/d/Makefile.files.in
@@ -97,6 +97,7 @@ endif
 M2_DFILES += interface.dd interface2.d
 M2_DFILES += texmacs.d
 M2_DFILES += boostmath.dd
+M2_DFILES += ffi.d
 # this one is last, because it contains the top level interpreter
 M2_DFILES += interp.dd
 

--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -89,6 +89,12 @@ export (lhs:Expr) + (rhs:Expr) : Expr := (
 	       )
 	  is Error do rhs
 	  else binarymethod(lhs,rhs,PlusS))
+     is x:pointerCell do (
+	  when rhs
+	  is y:ZZcell do Expr(pointerCell(Ccode(voidPointer, x.v, " + ",
+		      toLong(y))))
+	  is Error do rhs
+	  else binarymethod(lhs,rhs,PlusS))
      is Error do lhs
      else binarymethod(lhs,rhs,PlusS));
 plus(e:Expr):Expr := accumulate(plus0,plus1,op+,e);

--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -733,7 +733,7 @@ registerFinalizer(e:Expr):Expr := (
 	       toExpr(finalizerCount))
      	  else WrongArgString(2))
      else WrongNumArgs(2));
-setupfun("registerFinalizer",registerFinalizer);
+setupfun("registerFinalizer",registerFinalizer).Protected=false;
 
 header "extern \"C\" void do_nothing();";
 

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1037,6 +1037,11 @@ tostringfun(e:Expr):Expr := (
 	       + ">>"
 	       ))
     is x:fileOutputSyncState do toExpr("File Output Sync State")
+    is x:pointerCell do (
+	buf := newstring(20);
+	Ccode(void, "sprintf((char *)", buf, "->array, \"%p\", ", x.v, ")");
+	Ccode(void, buf, "->len = strlen((char *)", buf, "->array)");
+	toExpr(buf))
 );
 setupfun("simpleToString",tostringfun);
 

--- a/M2/Macaulay2/d/basic.d
+++ b/M2/Macaulay2/d/basic.d
@@ -80,6 +80,8 @@ export hash(e:Expr):int := (
      is xmlAttrCell do int(123457)
      is t:TaskCell do t.body.hash
      is foss:fileOutputSyncState do int(123458)
+     -- cast to long first to avoid "different size" compiler warning
+     is x:pointerCell do int(long(Ccode(long, x.v)))
      );
 
 export hash(x:List):int := (

--- a/M2/Macaulay2/d/classes.dd
+++ b/M2/Macaulay2/d/classes.dd
@@ -79,6 +79,7 @@ setupconst("Ring",Expr(ringClass));
 setupconst("Nothing",Expr(nothingClass));
 setupconst("Task",Expr(taskClass));
 setupconst("FileOutputSyncState",Expr(fileOutputSyncStateClass));
+setupconst("Pointer",Expr(pointerClass));
 
 export ancestor(o:HashTable,p:HashTable):bool := (
      while true do (
@@ -168,6 +169,7 @@ export Class(e:Expr):HashTable := (
      is RawPointArrayCell do rawPointArrayClass
      -- NAG end
      is fileOutputSyncState do fileOutputSyncStateClass
+     is pointerCell do pointerClass
      );
 classfun(e:Expr):Expr := Expr(Class(e));
 setupfun("class",classfun);

--- a/M2/Macaulay2/d/equality.dd
+++ b/M2/Macaulay2/d/equality.dd
@@ -244,6 +244,10 @@ export equal(lhs:Expr,rhs:Expr):Expr := (
      is xmlAttrCell do False				    -- unimplemented
      is TaskCell do False
      is fileOutputSyncState do False
+     is x:pointerCell do
+	 when rhs
+	 is y:pointerCell do if x.v == y.v then True else False
+	 else False
      );
 
 -- Local Variables:

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -323,6 +323,7 @@ export rawPointArrayClass := newtypeof(rawObjectClass);    -- RawPointArray
 export rawMutableComplexClass := newtypeof(rawObjectClass);	    -- RawMutableComplex
 export angleBarListClass := newtypeof(visibleListClass);
 export RRiClass := newbignumbertype();
+export pointerClass := newbasictype();
 -- all new types, dictionaries, and classes go just above this line, if possible, so hash codes don't change gratuitously!
 
 

--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -1,0 +1,525 @@
+use system;
+use common;
+use hashtables;
+use evaluate;
+
+header "#include <dlfcn.h>
+	#include <ffi.h>
+	/* FFI_BAD_ARGTYPE not introduced until libffi 3.4 in 2021 */
+	#ifndef FFI_BAD_ARGTYPE
+	  #define FFI_BAD_ARGTYPE 3
+	#endif
+	#include <M2mem.h>";
+
+voidPointerOrNull := voidPointer or null;
+toExpr(x:voidPointer):Expr := Expr(pointerCell(x));
+WrongArgPointer():Expr := WrongArg("a pointer");
+WrongArgPointer(n:int):Expr := WrongArg(n, "a pointer");
+getMem(n:int):voidPointer := Ccode(voidPointer, "getmem(", n, ")");
+getMemAtomic(n:int):voidPointer := Ccode(voidPointer, "getmem_atomic(", n, ")");
+
+dlerror0():Expr:= buildErrorPacket(tostring(Ccode(charstar, "dlerror()")));
+
+dlopen0(e:Expr):Expr:=
+    when e
+    is s:stringCell do (
+	r := Ccode(voidPointerOrNull,
+	    "dlopen(", tocharstar(s.v), ", RTLD_LAZY)");
+	when r
+	is null do dlerror0()
+	is handle:voidPointer do toExpr(handle))
+    else WrongArgString();
+setupfun("dlopen", dlopen0);
+
+dlsym0(e:Expr):Expr :=
+    when e
+    is y:stringCell do (
+	r := Ccode(voidPointerOrNull,
+	    "dlsym(RTLD_DEFAULT, ", tocharstar(y.v), ")");
+	when r
+	is null do dlerror0()
+	is addr:voidPointer do toExpr(addr))
+    is a:Sequence do
+	if length(a) != 2 then WrongNumArgs(1,2)
+	else when a.0
+	    is x:pointerCell do when a.1
+		is y:stringCell do (
+		    r := Ccode(voidPointerOrNull,
+			"dlsym(", x.v, ", ", tocharstar(y.v), ")");
+		    when r
+		    is null do dlerror0()
+		    is addr:voidPointer do toExpr(addr))
+		else WrongArgString(2)
+	    else WrongArgPointer(1)
+    else WrongArg("a string or a pointer and a string");
+setupfun("dlsym", dlsym0);
+
+ffiTypeVoid := Ccode(voidPointer, "&ffi_type_void");
+ffiOk := Ccode(int, "FFI_OK");
+
+ffiTypeSize(e:Expr):Expr := (
+    when e
+    is x:pointerCell do toExpr(Ccode(int, "((ffi_type *)", x.v, ")->size"))
+    else WrongArgPointer());
+setupfun("ffiTypeSize", ffiTypeSize);
+
+ffiError(r:int):Expr:=
+    if r == Ccode(int, "FFI_BAD_TYPEDEF")
+    then buildErrorPacket("libffi: bad typedef")
+    else if r == Ccode(int, "FFI_BAD_ABI")
+    then buildErrorPacket("libffi: bad ABI")
+    else if r == Ccode(int, "FFI_BAD_ARGTYPE")
+    then buildErrorPacket("libffi: bad argtype")
+    else buildErrorPacket("libffi: unknown");
+
+ffiPrepCif(e:Expr):Expr :=
+    when e
+    is a:Sequence do
+	if length(a) != 2 then WrongNumArgs(2)
+	else when a.0
+	    is x:pointerCell do when a.1
+		is y:List do (
+		    argtypes := new array(voidPointer) len length(y.v) at i
+			do provide when y.v.i is z:pointerCell do z.v
+			    else ffiTypeVoid;
+		    cif := Ccode(voidPointer, "getmem(sizeof(ffi_cif))");
+		    r := Ccode(int, "ffi_prep_cif((ffi_cif *)", cif,
+			", FFI_DEFAULT_ABI, ",
+			argtypes, "->len, ",
+			"(ffi_type *) ", x.v, ", ",
+			"(ffi_type **) ", argtypes, "->array)");
+		    if r != ffiOk then ffiError(r)
+		    else toExpr(cif))
+		else WrongArg(2, "a list")
+	    else WrongArgPointer(1)
+    else WrongNumArgs(2);
+setupfun("ffiPrepCif", ffiPrepCif);
+
+ffiPrepCifVar(e:Expr):Expr :=
+    when e
+    is a:Sequence do
+	if length(a) != 3 then WrongNumArgs(3)
+	else when a.0
+	    is n:ZZcell do when a.1
+		is x:pointerCell do when a.2
+		    is y:List do (
+			argtypes := new array(voidPointer) len length(y.v) at i
+				do provide when y.v.i is z:pointerCell do z.v
+				else ffiTypeVoid;
+			cif := Ccode(voidPointer, "getmem(sizeof(ffi_cif))");
+			r := Ccode(int, "ffi_prep_cif_var((ffi_cif *)", cif,
+			    ", FFI_DEFAULT_ABI, ",
+			    toInt(n), ", ",
+			    argtypes, "->len, ",
+			    "(ffi_type *) ", x.v, ", ",
+			    "(ffi_type **) ", argtypes, "->array)");
+			if r != ffiOk then ffiError(r)
+			else toExpr(cif))
+		    else WrongArg(3, "a list")
+		else WrongArgPointer(2)
+	    else WrongArgZZ(1)
+	else WrongNumArgs(3);
+setupfun("ffiPrepCifVar", ffiPrepCifVar);
+
+ffiCall(e:Expr):Expr :=
+    when e
+    is a:Sequence do
+	if length(a) != 4 then WrongNumArgs(4)
+	else when a.0
+	    is cif:pointerCell do when a.1
+		is fn:pointerCell do when a.2
+		    is n:ZZcell do when a.3
+			is z:List do (
+			    rvalue := Ccode(voidPointer,
+				"getmem(", toInt(n), ")");
+			    avalues := new array(voidPointer)
+				len length(z.v) at i
+				    do provide when z.v.i is p:pointerCell
+					do p.v
+					else nullPointer();
+			    Ccode(void, "ffi_call((ffi_cif *)", cif.v, ", ",
+				fn.v, ", ",
+				rvalue, ", ",
+				avalues, "->array)");
+			    toExpr(rvalue))
+			else WrongArg(4, "a list")
+		    else WrongArgZZ(3)
+		else WrongArgPointer(2)
+	    else WrongArgPointer(1)
+    else WrongNumArgs(4);
+setupfun("ffiCall", ffiCall);
+
+---------------
+-- void type --
+---------------
+setupconst("ffiVoidType", toExpr(Ccode(voidPointer, "&ffi_type_void")));
+
+-------------------
+-- integer types --
+-------------------
+
+ffiIntegerType(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is n:ZZcell do (
+		when a.1
+		is signed:Boolean do (
+		    bits := toInt(n);
+		    if signed.v then (
+			if bits == 8
+			then toExpr(Ccode(voidPointer, "&ffi_type_sint8"))
+			else if bits == 16
+			then toExpr(Ccode(voidPointer, "&ffi_type_sint16"))
+			else if bits == 32
+			then toExpr(Ccode(voidPointer, "&ffi_type_sint32"))
+			else if bits == 64
+			then toExpr(Ccode(voidPointer, "&ffi_type_sint64"))
+			else buildErrorPacket("expected 8, 16, 32, or 64 bits"))
+		    else (
+			if bits == 8
+			then toExpr(Ccode(voidPointer, "&ffi_type_uint8"))
+			else if bits == 16
+			then toExpr(Ccode(voidPointer, "&ffi_type_uint16"))
+			else if bits == 32
+			then toExpr(Ccode(voidPointer, "&ffi_type_uint32"))
+			else if bits == 64
+			then toExpr(Ccode(voidPointer, "&ffi_type_uint64"))
+			else buildErrorPacket("expected 8, 16, 32, or 64 bits"))
+		    )
+		else WrongArgBoolean(2))
+	    else WrongArgZZ(1))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+setupfun("ffiIntegerType", ffiIntegerType);
+
+ffiIntegerAddress(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 3 then (
+	    when a.0
+	    is x:ZZcell do (
+		when a.1
+		is y:ZZcell do (
+		    when a.2
+		    is signed:Boolean do (
+			bits := toInt(y);
+			ptr := getMemAtomic(bits / 8);
+			if signed.v then (
+			    n := toLong(x);
+			    if bits == 8
+			    then Ccode(void, "*(int8_t *)", ptr, " = ", n)
+			    else if bits == 16
+			    then Ccode(void, "*(int16_t *)", ptr, " = ", n)
+			    else if bits == 32
+			    then Ccode(void, "*(int32_t *)", ptr, " = ", n)
+			    else if bits == 64
+			    then Ccode(void, "*(int64_t *)", ptr, " = ", n)
+			    else return buildErrorPacket(
+				"expected 8, 16, 32, or 64 bits");
+			    toExpr(ptr))
+			else (
+			    n := toULong(x);
+			    if bits == 8
+			    then Ccode(void, "*(uint8_t *)", ptr, " = ", n)
+			    else if bits == 16
+			    then Ccode(void, "*(uint16_t *)", ptr, " = ", n)
+			    else if bits == 32
+			    then Ccode(void, "*(uint32_t *)", ptr, " = ", n)
+			    else if bits == 64
+			    then Ccode(void, "*(uint64_t *)", ptr, " = ", n)
+			    else return buildErrorPacket(
+				"expected 8, 16, 32, or 64 bits");
+			    toExpr(ptr)))
+		    else WrongArgBoolean(3))
+		else WrongArgZZ(2))
+	    else WrongArgZZ(1))
+	else WrongNumArgs(3))
+    else WrongNumArgs(3));
+setupfun("ffiIntegerAddress", ffiIntegerAddress);
+
+ffiIntegerValue(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 3 then (
+	    when a.0
+	    is x:pointerCell do (
+		when a.1
+		is y:ZZcell do (
+		    when a.2
+		    is signed:Boolean do (
+			bits := toInt(y);
+			if signed.v then (
+			    n := Ccode(long, "*(long *)", x.v);
+			    if bits == 8
+			    then toExpr(long(int8_t(n)))
+			    else if bits == 16
+			    then toExpr(long(int16_t(n)))
+			    else if bits == 32
+			    then toExpr(long(int32_t(n)))
+			    else if bits == 64
+			    then toExpr(long(int64_t(n)))
+			    else buildErrorPacket(
+				"expected 8, 16, 32, or 64 bits"))
+			else (
+			    n := Ccode(long, "*(unsigned long *)", x.v);
+			    if bits == 8
+			    then toExpr(ulong(uint8_t(n)))
+			    else if bits == 16
+			    then toExpr(ulong(uint16_t(n)))
+			    else if bits == 32
+			    then toExpr(ulong(uint32_t(n)))
+			    else if bits == 64
+			    then toExpr(ulong(uint64_t(n)))
+			    else buildErrorPacket(
+				"expected 8, 16, 32, or 64 bits")))
+		    else WrongArgBoolean(3))
+		else WrongArgZZ(2))
+	    else WrongArgPointer(1))
+	else WrongNumArgs(3))
+    else WrongNumArgs(3));
+setupfun("ffiIntegerValue", ffiIntegerValue);
+
+----------------
+-- real types --
+----------------
+
+ffiRealType(e:Expr):Expr := (
+    when e
+    is n:ZZcell do (
+	bits := toInt(n);
+	if bits == 32 then toExpr(Ccode(voidPointer, "&ffi_type_float"))
+	else if bits == 64 then toExpr(Ccode(voidPointer, "&ffi_type_double"))
+	else buildErrorPacket("expected 32 or 64 bits"))
+    else WrongArgZZ());
+setupfun("ffiRealType", ffiRealType);
+
+ffiRealAddress(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is x:RRcell do (
+		when a.1
+		is y:ZZcell do (
+		    bits := toInt(y);
+		    ptr := getMemAtomic(bits / 8);
+		    if bits == 32
+		    then (
+			z := toFloat(x);
+			Ccode(void, "*(float *)", ptr, " = ", z))
+		    else if bits == 64
+		    then (
+			z := toDouble(x);
+			Ccode(void, "*(double *)", ptr, " = ", z))
+		    else return buildErrorPacket("expected 32 or 64 bits");
+		    toExpr(ptr))
+		else WrongArgZZ(2))
+	    else WrongArgRR(1))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+setupfun("ffiRealAddress", ffiRealAddress);
+
+ffiRealValue(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is x:pointerCell do (
+		when a.1
+		is y:ZZcell do (
+		    bits := toInt(y);
+		    if bits == 32
+		    then toExpr(Ccode(float, "*(float *)", x.v))
+		    else if bits == 64
+		    then toExpr(Ccode(double, "*(double *)", x.v))
+		    else buildErrorPacket("expected 32 or 64 bits"))
+		else WrongArgZZ(2))
+	    else WrongArgPointer(1))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+setupfun("ffiRealValue", ffiRealValue);
+
+-------------------
+-- pointer types --
+-------------------
+
+pointerSize := Ccode(int, "sizeof(void *)");
+
+setupconst("ffiPointerType", toExpr(Ccode(voidPointer, "&ffi_type_pointer")));
+
+ffiPointerAddress(e:Expr):Expr := (
+    when e
+    is x:pointerCell do (
+	y := getMem(pointerSize);
+	Ccode(void, "*(void **)", y, " = ", x.v);
+	toExpr(y))
+    is x:stringCell do (
+	y := getMem(pointerSize);
+	Ccode(void, "*(void **)", y, " = ", tocharstar(x.v));
+	toExpr(y))
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is x:pointerCell do (
+		when a.1
+		is y:List do (
+		    n := length(y.v);
+		    bytes := Ccode(int, "((ffi_type *)", x.v, ")->size");
+		    arr := getMem(n * bytes);
+		    for i from 0 to n - 1 do (
+			when y.v.i
+			is z:pointerCell do Ccode(void,
+			    "memcpy(", arr, " + ", i * bytes, ", ",
+			    z.v, ", ", bytes, ")")
+			else return buildErrorPacket(
+			    "expected a list of pointers"));
+		    ptr := getMem(pointerSize);
+		    Ccode(void, "*(void **)", ptr, " = ", arr);
+		    toExpr(ptr))
+		else WrongArg(2, "a list"))
+	    else WrongArgPointer(1))
+	else WrongNumArgs(1, 2))
+    else WrongArg("a pointer, string, or a pointer and a list"));
+setupfun("ffiPointerAddress", ffiPointerAddress);
+
+ffiPointerValue(e:Expr):Expr := (
+    when e
+    is x:pointerCell do toExpr(Ccode(voidPointer, "*(void **)", x.v))
+    else WrongArgPointer());
+setupfun("ffiPointerValue", ffiPointerValue);
+
+ffiStringValue(e:Expr):Expr := (
+    when e
+    is x:pointerCell do toExpr(tostring(Ccode(charstar, "*(char **)", x.v)))
+    else WrongArgPointer());
+setupfun("ffiStringValue", ffiStringValue);
+
+ptrfinalizer(x:voidPointer, a:Sequence):void := (
+    if length(a) == 2 then (
+	applyEE(a.0, a.1);
+	nothing)
+    else nothing);
+
+registerFinalizerForPointer(e:Expr):Expr := (
+    when e is s:Sequence do (
+	if length(s) == 3 then (
+	    when s.0
+	    is x:pointerCell do (
+		a := new Sequence len 2 at i do provide s.(i + 1);
+		Ccode(void, "GC_REGISTER_FINALIZER(", x.v, ", ",
+		    "(GC_finalization_proc)", ptrfinalizer, ", ", a, ", 0, 0)");
+		nullE)
+	    else WrongArgPointer(1))
+	else WrongNumArgs(3))
+    else WrongNumArgs(3));
+setupfun("registerFinalizerForPointer", registerFinalizerForPointer);
+
+------------------
+-- struct types --
+------------------
+
+ffiStructType(e:Expr):Expr := (
+    when e
+    is a:List do (
+	x := getMem(Ccode(int, "sizeof(ffi_type)"));
+	Ccode(void, "((ffi_type *)", x, ")->size = 0");
+	Ccode(void, "((ffi_type *)", x, ")->alignment = 0");
+	Ccode(void, "((ffi_type *)", x, ")->type = FFI_TYPE_STRUCT");
+	n := length(a.v);
+	elmnts := new array(voidPointer) len n + 1 at i do provide (
+	    if i < n then (
+		when a.v.i
+		is p:pointerCell do p.v
+		else nullPointer())
+	    else nullPointer());
+	Ccode(void, "((ffi_type *)", x, ")->elements = (ffi_type **)",
+	    elmnts, "->array");
+	toExpr(x))
+    else WrongArg("a list"));
+setupfun("ffiStructType", ffiStructType);
+
+ffiGetStructOffsets(e:Expr):Expr :=
+    when e
+    is x:pointerCell do (
+	n := 0;
+	while Ccode(voidPointer, "(((ffi_type *)", x.v, ")->elements)[", n,
+	    "]") != nullPointer() do n = n + 1;
+	offsets := Ccode(voidPointer, "getmem((", n , ") * sizeof(size_t))");
+	r := Ccode(int, "ffi_get_struct_offsets(FFI_DEFAULT_ABI, ",
+	    "(ffi_type *)", x.v, ", (size_t *)", offsets, ")");
+	if r != ffiOk then return ffiError(r);
+	Expr(list(new Sequence len n at i do provide
+	    toExpr(Ccode(int, "((size_t *)", offsets, ")[", i, "]")))))
+    else WrongArgPointer();
+setupfun("ffiGetStructOffsets", ffiGetStructOffsets);
+
+ffiStructAddress(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is x:pointerCell do (
+		when a.1 is y:List do (
+		    n := 0;
+		    while Ccode(voidPointer, "(((ffi_type *)", x.v,
+			")->elements)[", n, "]") != nullPointer() do n = n + 1;
+		    offsets := Ccode(voidPointer, "getmem((", n ,
+			") * sizeof(size_t))");
+		    r := Ccode(int, "ffi_get_struct_offsets(FFI_DEFAULT_ABI, ",
+			"(ffi_type *)", x.v, ", (size_t *)", offsets, ")");
+		    if r != ffiOk then return ffiError(r);
+		    result := getMem(Ccode(int, "((ffi_type *)", x.v,
+			    ")->size"));
+		    for i from 0 to n - 1 do (
+			when y.v.i
+			is elmnt:pointerCell do (
+			    tocopy := Ccode(int, "(((ffi_type *)", x.v,
+				")->elements)[", i, "]->size");
+			    Ccode(void, "memcpy(", result, " + ((size_t *)",
+				offsets, ")[", i, "],", elmnt.v, ", ",
+				tocopy, ")"))
+			else nothing);
+		    toExpr(result))
+		else WrongArg(2, "a list"))
+	    else WrongArgPointer(1))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+setupfun("ffiStructAddress", ffiStructAddress);
+
+-----------------
+-- union types --
+-----------------
+
+-- ffi_prep_cif trick from libffi manual
+ffiUnionType(e:Expr):Expr := (
+    when e
+    -- expects a list of pointers to ffi_type's
+    is a:List do (
+	x := getMem(Ccode(int, "sizeof(ffi_type)"));
+	Ccode(void, "((ffi_type *)", x, ")->size = 0");
+	Ccode(void, "((ffi_type *)", x, ")->alignment = 0");
+	Ccode(void, "((ffi_type *)", x, ")->type = FFI_TYPE_STRUCT");
+	elmnts := new array(voidPointer) len 2 do provide nullPointer();
+	Ccode(void, "((ffi_type *)", x, ")->elements = (ffi_type **)",
+	    elmnts, "->array");
+	cif := getMem(Ccode(int, "sizeof(ffi_cif)"));
+	for i from 0 to length(a.v) - 1 do (
+	    when a.v.i
+	    is p:pointerCell do (
+		if Ccode(int, "ffi_prep_cif((ffi_cif *)", cif,
+		    ", FFI_DEFAULT_ABI, 0, ", p.v, ", NULL)") == ffiOk then (
+		    if Ccode(int, "((ffi_type *)", p.v , ")->size"
+			) > Ccode(int, "((ffi_type *)", x, ")->size"
+			) then (Ccode(void, "((ffi_type *)", x,
+			    ")->size = ((ffi_type *)", p.v, ")->size"));
+		    if Ccode(int, "((ffi_type *)", p.v, ")->alignment"
+			) > Ccode(int, "((ffi_type *)", x, ")->alignment"
+			) then (Ccode(void, "((ffi_type *)", x,
+			    ")->alignment = ((ffi_type *)", p.v,
+			    ")->alignment"))))
+	    else return WrongArgPointer(i + 1));
+	toExpr(x))
+    else WrongArg("a list"));
+setupfun("ffiUnionType", ffiUnionType);

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -918,6 +918,11 @@ export toRRi(n:ulong,prec:ulong):RRi := (
     Ccode( void, "mpfi_set_ui(",  x, ",(unsigned long)", n, ")" );
     moveToRRiandclear(x));
 
+export toRR(n:float, prec:ulong):RR := (
+     x := newRRmutable(prec);
+     Ccode(void, "mpfr_set_flt(",  x, ", ", n, ", MPFR_RNDN)");
+     moveToRRandclear(x));
+
 export toRR(n:double,prec:ulong):RR := (
      x := newRRmutable(prec);
      Ccode( void, "mpfr_set_d(",  x, ",", n, ", MPFR_RNDN)" );
@@ -1084,6 +1089,11 @@ export toCC(x:ulong,prec:ulong):CC := CC(toRR(x,prec),toRR(0,prec));
 export toCC(x:double,prec:ulong):CC := CC(toRR(x,prec),toRR(0,prec));
 
 export toCC(x:double,y:double,prec:ulong):CC := CC(toRR(x,prec),toRR(y,prec));
+
+export toFloat(x:RR):float := Ccode(float, "mpfr_get_flt(", x, ", MPFR_RNDN)");
+export toFloat(x:RRi):float := toFloat(midpointRR(x));
+export toFloat(x:RRcell):float := toFloat(x.v);
+export toFloat(x:RRicell):float := toFloat(x.v);
 
 export toDouble(x:RR):double := Ccode( double, "mpfr_get_d(",  x, ", MPFR_RNDN)" );
                                     

--- a/M2/Macaulay2/d/parse.d
+++ b/M2/Macaulay2/d/parse.d
@@ -361,6 +361,7 @@ export TaskCellBody := {+
      fun:Expr, arg:Expr, returnValue:Expr  };
 export TaskCell := {+ body:TaskCellBody };
 
+export pointerCell := {+ v:voidPointer };
 
 export Expr := (
      CCcell or
@@ -415,7 +416,8 @@ export Expr := (
      pythonObjectCell or
      xmlNodeCell or xmlAttrCell or
      TaskCell or 
-     fileOutputSyncState
+     fileOutputSyncState or
+     pointerCell
      );
 export fun := function(Expr):Expr;
 

--- a/M2/Macaulay2/d/util.d
+++ b/M2/Macaulay2/d/util.d
@@ -206,6 +206,7 @@ export toExpr(x:QQ):Expr := Expr(QQcell(x));
 export toExpr(x:RR):Expr := Expr(RRcell(x));
 export toExpr(x:RRi):Expr := Expr(RRicell(x));
 export toExpr(x:CC):Expr := Expr(CCcell(x));
+export toExpr(x:float):Expr := Expr(RRcell(toRR(x,ulong(24))));
 export toExpr(x:double):Expr := Expr(RRcell(toRR(x,ulong(53))));
 export toExpr(x:RawComputation):Expr := Expr(RawComputationCell(x));
 export toExpr(x:RawFreeModule):Expr := Expr(RawFreeModuleCell(x));

--- a/M2/Macaulay2/editors/CMakeLists.txt
+++ b/M2/Macaulay2/editors/CMakeLists.txt
@@ -3,6 +3,7 @@
 ## and syntax highlighting engines as well as the M2-mode package for Emacs.
 ## - M2-editors generates grammar files
 ## - M2-emacs   generates the M2-mode package for Emacs
+## - M2-highlightjs   generates syntax highlighting library for javascript
 
 # TODO: generate vim grammar
 # TODO: generate textmate grammar
@@ -63,18 +64,20 @@ add_custom_command(OUTPUT ${EMACS_FILES}
 ################################################################################
 ## Generating highlight.js for syntax highlighting in the html documentation
 
-add_custom_target(M2-highlightjs ALL DEPENDS highlightjs/highlight.js)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/highlightjs)
-if(NOT NPM STREQUAL "NPM-NOTFOUND")
-  foreach(FILE IN ITEMS package.json webpack.config.js index.js
-      highlight-override.css)
-    configure_file(highlightjs/${FILE} highlightjs COPYONLY)
-  endforeach()
-  add_custom_command(OUTPUT highlightjs/highlight.js
-    COMMAND cd highlightjs && ${NPM} install && ${NPM} run build
-    DEPENDS highlightjs/macaulay2.js)
-else()
-  add_custom_command(OUTPUT highlightjs/highlight.js
-    COMMENT "warning: html docs will not have syntax highlighting"
-    COMMAND touch highlightjs/highlight.js)
+if(NOT NPM)
+  message(WARNING "npm is missing; html docs will not have syntax highlighting")
+  file(TOUCH highlightjs/highlight.js)
+  return()
 endif()
+
+set(HIGHLIGHTJS_DIR ${CMAKE_CURRENT_BINARY_DIR}/highlightjs)
+file(MAKE_DIRECTORY HIGHLIGHTJS_DIR)
+file(COPY highlightjs/ DESTINATION ${HIGHLIGHTJS_DIR}
+  FILES_MATCHING PATTERN "*.json" PATTERN "*.js" PATTERN "*.css")
+
+add_custom_target(M2-highlightjs ALL DEPENDS highlightjs/highlight.js)
+add_custom_command(OUTPUT highlightjs/highlight.js
+  COMMENT "Generating highlight.js syntax file"
+  COMMAND ${NPM} install && ${NPM} run build
+  WORKING_DIRECTORY ${HIGHLIGHTJS_DIR}
+  DEPENDS highlightjs/macaulay2.js)

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -711,6 +711,11 @@ locate Symbol     := Sequence => x -> locate' x
 locate List       := List     => x -> apply(x, locate)
 protect symbol locate
 
+-- registerFinalizer
+registerFinalizer' = registerFinalizer
+registerFinalizer = method()
+registerFinalizer(Thing, String) := registerFinalizer'
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -246,3 +246,4 @@ Isomorphism
 CodingTheory
 WhitneyStratifications
 JSON
+ForeignFunctions

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1,0 +1,1365 @@
+newPackage("ForeignFunctions",
+    Headline => "foreign function interface",
+    Version => "0.1",
+    Date => "September 11, 2022",
+    Authors => {{
+	    Name => "Doug Torrance",
+	    Email => "dtorrance@piedmont.edu",
+	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
+    Keywords => {"Interfaces"}
+    )
+
+-------------------------
+-- exports and imports --
+-------------------------
+
+export {
+-- classes
+    "SharedLibrary",
+    "ForeignFunction",
+    "ForeignType",
+    "ForeignVoidType",
+    "ForeignIntegerType",
+    "ForeignRealType",
+    "ForeignPointerType",
+    "ForeignStringType",
+    "ForeignArrayType",
+    "ForeignUnionType",
+    "ForeignStructType",
+    "ForeignObject",
+
+-- built-in foreign types
+    "void",
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "char'",
+    "uchar",
+    "short",
+    "ushort",
+    "int",
+    "uint",
+    "long",
+    "ulong",
+    "float",
+    "double",
+    "voidstar",
+    "charstar",
+
+-- methods
+    "openSharedLibrary",
+    "foreignFunction",
+    "foreignObject",
+    "address",
+    "foreignArrayType",
+    "foreignStructType",
+    "foreignUnionType",
+
+-- symbols
+    "Variadic"
+    }
+
+importFrom_Core {
+    "dlopen",
+    "dlsym",
+    "ffiPrepCif",
+    "ffiPrepCifVar",
+    "ffiCall",
+    "ffiTypeSize",
+    "ffiVoidType",
+    "ffiIntegerType",
+    "ffiIntegerAddress",
+    "ffiIntegerValue",
+    "ffiRealType",
+    "ffiRealAddress",
+    "ffiRealValue",
+    "ffiPointerType",
+    "ffiPointerAddress",
+    "ffiPointerValue",
+    "ffiStringValue",
+    "ffiStructType",
+    "ffiGetStructOffsets",
+    "ffiStructAddress",
+    "ffiUnionType",
+    "registerFinalizerForPointer"
+    }
+
+
+-------------
+-- pointer --
+-------------
+
+exportFrom_Core {"Pointer"}
+Pointer.synonym = "pointer"
+Pointer + ZZ := (ptr, n) -> ptr + n -- defined in actors.d
+ZZ + Pointer := (n, ptr) -> ptr + n
+Pointer - ZZ := (ptr, n) -> ptr + -n
+
+--------------------
+-- foreign object --
+--------------------
+
+ForeignObject = new SelfInitializingType of BasicList
+ForeignObject.synonym = "foreign object"
+net ForeignObject := x -> net value x
+ForeignObject#{Standard, AfterPrint} = x -> (
+    << endl
+    << concatenate(interpreterDepth:"o") << lineNumber
+    << " : ForeignObject of type " << class x << endl)
+
+value ForeignObject := x -> error("no value function exists for ", class x)
+
+address = method(TypicalValue => Pointer)
+address ForeignObject := first
+
+foreignObject = method(TypicalValue => ForeignObject)
+foreignObject ForeignObject := identity
+foreignObject ZZ := n -> int n
+foreignObject Number := foreignObject Constant := x -> double x
+foreignObject String := x -> charstar x
+foreignObject VisibleList := x -> (
+    types := unique(class \ foreignObject \ x);
+    if #types == 1 then (foreignArrayType(first types, #x)) x
+    else error("expected all elements to have the same type"))
+
+-----------------------------------
+-- foreign type (abstract class) --
+-----------------------------------
+
+ForeignType = new Type of Type
+ForeignType.synonym = "foreign type"
+
+new ForeignType := T -> new ForeignType of ForeignObject
+
+net ForeignType := T -> if T.?Name then T.Name else "<<a foreign type>>"
+
+protect Address
+address ForeignType := T -> if T.?Address then T.Address else error(
+    toString T, " has no address")
+
+size ForeignType := ffiTypeSize @@ address
+
+-- for most cases, when T is a ForeignType and ptr is a Pointer, we want
+-- "T ptr" to dereference the pointer and return the corresponding M2 thing,
+-- but this is ambiguous when T is a ForeignPointerType -- do we want the
+-- address to be a new Pointer that points to ptr (for inputs of foreign
+-- functions) or just ptr itself (for outputs)?
+-- so we add the unexported "dereference" method for the latter case
+
+dereference = method()
+dereference(ForeignType, Pointer) := (T, ptr) -> new T from ForeignObject {ptr}
+ForeignType Pointer := dereference
+ForeignType ForeignObject := (T, x) -> dereference_T address x
+
+-----------------------
+-- foreign void type --
+-----------------------
+
+ForeignVoidType = new Type of ForeignType
+ForeignVoidType.synonym = "foreign void type"
+
+dereference(ForeignVoidType, Pointer) := (T, x) -> null
+
+void = new ForeignVoidType
+void.Name = "void"
+void.Address = ffiVoidType
+
+--------------------------
+-- foreign integer type --
+--------------------------
+
+ForeignIntegerType = new Type of ForeignType
+ForeignIntegerType.synonym = "foreign integer type"
+
+foreignIntegerType = method()
+foreignIntegerType(String, ZZ, Boolean) := (name, bits, signed) -> (
+    T := new ForeignIntegerType;
+    T.Name = name;
+    T.Address = ffiIntegerType(bits, signed);
+    new T from ZZ := (T, n) -> new T from {ffiIntegerAddress(n, bits, signed)};
+    value T := x -> ffiIntegerValue(address x, bits, signed);
+    T)
+
+int8 = foreignIntegerType("int8", 8, true)
+uint8 = foreignIntegerType("uint8", 8, false)
+char' = int8  -- char is taken by ring characteristic
+uchar = uint8
+int16 = foreignIntegerType("int16", 16, true)
+uint16 = foreignIntegerType("uint16", 16, false)
+short = int16
+ushort = uint16
+int32 = foreignIntegerType("int32", 32, true)
+uint32 = foreignIntegerType("uint32", 32, false)
+int = int32
+uint = uint32
+int64 = foreignIntegerType("int64", 64, true);
+uint64 = foreignIntegerType("uint64", 64, false);
+if version#"pointer size" == 4 then (
+    long = int32;
+    ulong = uint32
+    ) else (
+    long = int64;
+    ulong = uint64)
+
+ForeignIntegerType Number :=
+ForeignIntegerType Constant := (T, x) -> new T from truncate x
+
+-----------------------
+-- foreign real type --
+-----------------------
+
+ForeignRealType = new Type of ForeignType
+ForeignRealType.synonym = "foreign real type"
+
+foreignRealType = method()
+foreignRealType(String, ZZ) := (name, bits) -> (
+    T := new ForeignRealType;
+    T.Name = name;
+    T.Address = ffiRealType(bits);
+    new T from RR := (T, x) -> new T from {ffiRealAddress(x, bits)};
+    value T := x -> ffiRealValue(address x, bits);
+    T)
+
+float = foreignRealType("float", 32)
+double = foreignRealType("double", 64)
+
+ForeignRealType Number :=
+ForeignRealType Constant := (T, x) -> new T from realPart numeric x
+ForeignRealType RRi := (T, x) -> T toRR x
+
+--------------------------
+-- foreign pointer type --
+--------------------------
+
+ForeignPointerType = new Type of ForeignType
+ForeignPointerType.synonym = "foreign pointer type"
+
+voidstar = new ForeignPointerType
+voidstar.Name = "void*"
+voidstar.Address = ffiPointerType
+value voidstar := ffiPointerValue @@ address
+ForeignPointerType Pointer := (T, x) -> new T from {ffiPointerAddress x}
+
+registerFinalizer(voidstar, Function) := (
+    x, f) -> registerFinalizerForPointer(address x, f, value x)
+
+-------------------------
+-- foreign string type --
+-------------------------
+
+ForeignStringType = new Type of ForeignType
+ForeignStringType.synonym = "foreign string type"
+
+charstar = new ForeignStringType
+charstar.Name = "char*"
+charstar.Address = ffiPointerType
+value charstar := ffiStringValue @@ address
+ForeignStringType String := (T, x) -> new T from {ffiPointerAddress x}
+
+------------------------
+-- foreign array type --
+------------------------
+
+ForeignArrayType = new Type of ForeignType
+ForeignArrayType.synonym = "foreign array type"
+
+checkarraybounds = (n, i) -> (
+    if i < -n or i >= n
+    then error("array index ", i, " out of bounds 0 .. ", n - 1)
+    else if i < 0
+    then n + i
+    else i)
+
+foreignArrayType = method(TypicalValue => ForeignArrayType)
+foreignArrayType(ForeignType, ZZ) := (T, n) -> foreignArrayType(
+    concatenate(net T, "[", toString n, "]"), T, n)
+foreignArrayType(String, ForeignType, ZZ) := (name, T, n) -> (
+    -- S will be the type for n-element arrays containing instances of T
+    S := new ForeignArrayType;
+    S.Name = name;
+    S.Address = ffiPointerType;
+    length S := x -> n;
+    new S from VisibleList := (S, x) -> (
+	if #x != n then error("expected a list of length ", n);
+	new S from ForeignObject {
+	    ffiPointerAddress(address T, address \ apply(x, y -> T y))});
+    value S := x -> (
+	ptr := ffiPointerValue address x;
+	sz := size T;
+	apply(n, i -> dereference_T(ptr + i * sz)));
+    S_ZZ := (x, i) -> dereference_T(
+	ffiPointerValue address x + size T * checkarraybounds(n, i));
+    S)
+
+ForeignArrayType VisibleList := (T, x) -> new T from x
+
+-- syntactic sugar based on Python's ctypes
+ZZ * ForeignType := (n, T) -> foreignArrayType(T, n)
+ForeignType * ZZ := (T, n) -> n * T
+
+-------------------------
+-- foreign struct type --
+-------------------------
+
+ForeignStructType = new Type of ForeignType
+ForeignStructType.synonym = "foreign struct type"
+
+foreignStructType = method(TypicalValue => ForeignStructType)
+foreignStructType(String, Option) := (name, x) -> foreignStructType(name, {x})
+-- the order matters, which is why we insist on a list and not a hash table
+foreignStructType(String, VisibleList) := (name, x) -> (
+    if not (all(x, y -> instance(y, Option)) and all(x, y ->
+	instance(first y, String) and instance(last y, ForeignType)))
+    then error("expected options of the form string => foreign type");
+    T := new ForeignStructType;
+    T.Name = name;
+    ptr := T.Address = ffiStructType \\ address \ last \ x;
+    types := hashTable x;
+    offsets := hashTable transpose {first \ x, ffiGetStructOffsets ptr};
+    new T from HashTable := (T, H) -> new T from {ffiStructAddress(ptr,
+	    apply(first \ x, mbr -> address types#mbr H#mbr))};
+    value T := y -> (
+	ptr' := address y;
+	applyPairs(types, (mbr, type) ->
+	    (mbr, dereference_type(ptr' + offsets#mbr))));
+    T_String := (y, mbr) -> dereference_(types#mbr)(address y + offsets#mbr);
+    T)
+
+ForeignStructType VisibleList := (T, x) -> new T from hashTable x
+
+------------------------
+-- foreign union type --
+------------------------
+
+ForeignUnionType = new Type of ForeignType
+ForeignUnionType.synonym = "foreign union type"
+
+foreignUnionType = method(TypicalValue => ForeignUnionType)
+foreignUnionType(String, Option) := (name, x) -> foreignUnionType(name, {x})
+foreignUnionType(String, VisibleList) := (name, x) -> (
+    if not (all(x, y -> instance(y, Option)) and all(x, y ->
+	    instance(first y, String) and instance(last y, ForeignType)))
+    then error("expected options of the form string => foreign type");
+    T := new ForeignUnionType;
+    T.Name = name;
+    T.Address = ffiUnionType \\ address \ last \ x;
+    types := hashTable x;
+    value T := y -> (
+	ptr := address y;
+	applyPairs(types, (mbr, type) -> (mbr, dereference_type ptr)));
+    T_String := (y, mbr) -> dereference_(types#mbr) address y;
+    T)
+
+ForeignUnionType Thing := (T, x) -> new T from {address foreignObject x}
+
+--------------------
+-- shared library --
+--------------------
+
+SharedLibrary = new SelfInitializingType of BasicList
+SharedLibrary.synonym = "shared library"
+net SharedLibrary := lib -> lib#1
+
+openSharedLibrary = method(TypicalValue => SharedLibrary,
+    Options => {FileName => null})
+openSharedLibrary String := o -> name -> (
+    filename := if o.FileName =!= null then o.FileName else (
+	"lib" | name |
+	if version#"operating system" == "Darwin" then ".dylib"
+	else ".so");
+    SharedLibrary {dlopen filename, name})
+
+----------------------
+-- foreign function --
+----------------------
+
+ForeignFunction = new SelfInitializingType of FunctionClosure
+ForeignFunction.synonym = "foreign function"
+net ForeignFunction := f -> (frames f)#0#1
+
+foreignFunction = method(TypicalValue => ForeignFunction,
+    Options => {Variadic => false})
+foreignFunction(String, ForeignType, ForeignType) := o -> (
+    symb, rtype, argtype) -> foreignFunction(symb, rtype, {argtype}, o)
+foreignFunction(String, ForeignType, VisibleList) := o -> (
+    symb, rtype, argtypes) -> foreignFunction(
+	dlsym symb, symb, rtype, argtypes, o)
+foreignFunction(SharedLibrary, String, ForeignType, ForeignType) := o -> (
+    lib, symb, rtype, argtype) -> foreignFunction(
+    lib, symb, rtype, {argtype}, o)
+foreignFunction(SharedLibrary, String, ForeignType, VisibleList) := o -> (
+    lib, symb, rtype, argtypes) -> foreignFunction(
+	dlsym(lib#0, symb), lib#1 | "::" | symb, rtype, argtypes, o)
+foreignFunction(Pointer, String, ForeignType, VisibleList) :=  o -> (
+    funcptr, name, rtype, argtypes) -> (
+	if any(argtypes, argtype -> not instance(argtype, ForeignType))
+	then error("expected argument types to be foreign types");
+	if any(argtypes, argtype -> instance(argtype, ForeignVoidType))
+	then (
+	    if not o.Variadic and #argtypes == 1 then argtypes = {}
+	    else error("void must be the only parameter"));
+	argtypePointers := address \ argtypes;
+	if o.Variadic then (
+	    nfixedargs := #argtypes;
+	    ForeignFunction(args -> (
+		    if not instance(args, Sequence) then args = 1:args;
+		    varargs := for i from nfixedargs to #args - 1 list (
+			foreignObject args#i);
+		    varargtypePointers := address \ class \ varargs;
+		    cif := ffiPrepCifVar(nfixedargs, address rtype,
+			argtypePointers | varargtypePointers);
+		    avalues := apply(nfixedargs, i ->
+			address (argtypes#i args#i)) | address \ varargs;
+		    dereference_rtype ffiCall(cif, funcptr, 100, avalues))))
+	else (
+	    cif := ffiPrepCif(address rtype, argtypePointers);
+	    ForeignFunction(args -> (
+		    if not instance(args, Sequence) then args = 1:args;
+		    if #argtypes != #args
+		    then error("expected ", #argtypes, " arguments");
+		    avalues := apply(#args, i -> address (argtypes#i args#i));
+		    dereference_rtype ffiCall(cif, funcptr, 100, avalues)))))
+
+beginDocumentation()
+
+doc ///
+  Key
+    ForeignFunctions
+  Headline
+    foreign function interface
+  Description
+    Text
+      This package provides the ability to load and call "foreign" functions
+      from shared libraries and to convert back and forth between Macaulay2
+      things and the foreign objects used by these functions.
+    Example
+      mycos = foreignFunction("cos", double, double)
+      mycos pi
+      value oo
+    Text
+      It is powered by @HREF{"https://sourceware.org/libffi/", "libffi"}@.
+///
+
+doc ///
+  Key
+    Pointer
+    (symbol +, Pointer, ZZ)
+    (symbol +, ZZ, Pointer)
+    (symbol -, Pointer, ZZ)
+  Headline
+    pointer to memory address
+  Description
+    Text
+      @TT "Pointer"@ objects are pointers to memory addresses.  These make up
+      each @TO ForeignObject@.
+    Example
+      x = int 20
+      peek x
+    Text
+      These pointers can be accessed using @TO address@.
+    Example
+      ptr = address x
+    Text
+      Simple arithmetic can be performed on pointers.
+    Example
+      ptr + 5
+      ptr - 3
+///
+
+doc ///
+  Key
+    ForeignType
+    (net, ForeignType)
+  Headline
+    abstract foreign type
+  Description
+    Text
+      This is the abstract class from which all other foreign type classes
+      should inherit.  All @TT "ForeignType"@ objects should have, at minimum,
+      three key-value pairs:
+
+      @UL {
+	  LI {TT "name", ", ", ofClass String, ", a human-readable name of ",
+	      "the class for display purposes, used by ",
+	      TT "net(ForeignType)", "."},
+	  LI {TT "address", ", ", ofClass Pointer, ", a pointer to the ",
+	      "corresponding ", TT "ffi_type", " object, used by ",
+	      TO (address, ForeignType), "."},
+	  LI {TT "value", ", ", ofClass Function, ", a function that sends ",
+	      "objects of this type to corresponding Macaulay2 values, ",
+	      "used by ", TO (value, ForeignObject), "."}}@
+
+      Subclasses may add additional key-value pairs as needed.
+///
+
+doc ///
+  Key
+    address
+    (address, ForeignType)
+    (address, ForeignObject)
+  Headline
+    pointer to type or object
+  Usage
+    address x
+  Inputs
+    x:{ForeignType,ForeignObject}
+  Outputs
+    :Pointer
+  Description
+    Text
+      If @TT "x"@ is a foreign type, then this returns the address to the
+      @TT "ffi_type"@ struct used by @TT "libffi"@ to identify the type.
+    Example
+      address int
+    Text
+      If @TT "x"@ is a foreign object, then this returns the address to the
+      object.  It behaves like the @TT "&"@ "address-of" operator in C.
+    Example
+      address int 5
+///
+
+doc ///
+  Key
+    (size, ForeignType)
+  Headline
+    size of a foreign type
+  Usage
+    size T
+  Inputs
+    T:ForeignType
+  Outputs
+    :ZZ
+  Description
+    Text
+      Return the number of bytes needed by the given foreign type, just like
+      the @TT "sizeof"@ operator in C.
+    Example
+      size char'
+      size voidstar
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignType, Pointer)
+  Headline
+    dereference a pointer
+  Usage
+    T ptr
+  Inputs
+    T:ForeignType
+    ptr:Pointer
+  Outputs
+    :ForeignObject -- of type @TT "T"@
+  Description
+    Text
+      Dereference the given pointer into the corresponding foreign object,
+      much like the dereference operator (@TT "*"@) in C.
+    Example
+      x = int 5
+      ptr = address x
+      int ptr
+///
+
+doc ///
+ Key
+   ForeignVoidType
+   "void"
+ Headline
+   foreign void type
+ Description
+   Text
+     The @wikipedia "void type"@.  There is one built-in type of this class,
+     @TT "void"@.
+
+     Note that there are no foreign objects of this type.  It is, however, used
+     as a return type for @TO foreignFunction@.  Such functions will return
+     @TO null@.  It may also be used by itself as an argument type to indicate
+     functions that take no arguments.
+   Example
+     void
+///
+
+doc ///
+  Key
+    ForeignIntegerType
+    "int8"
+    "uint8"
+    "int16"
+    "uint16"
+    "int32"
+    "uint32"
+    "int64"
+    "uint64"
+    "char'"
+    "uchar"
+    "short"
+    "ushort"
+    "int"
+    "uint"
+    "long"
+    "ulong"
+    (symbol SPACE, ForeignIntegerType, Number)
+    (symbol SPACE, ForeignIntegerType, Constant)
+  Headline
+    foreign integer type
+  Description
+    Text
+      This is the class of the various C integer types.  There are built-in
+      types for signed and unsigned integers of 8, 16, 32, and 64 bits.  Signed
+      types begin with @TT "int"@ and unsigned types with @TT "uint"@, and the
+      number of bits is indicated by a numeric suffix.
+    Example
+      int8
+      uint32
+    Text
+      There are also a number of aliases to these types without the numeric
+      suffixes.  Note the single quote on @TT "char'"@ to avoid conflicting
+      with @TO char@.  Also note that the number of bits for @TT "long"@ and
+      @TT "ulong"@ is system-dependent (32 on 32-bit systems and 64 on 64-bit
+      systems).
+    Example
+      char'
+      uchar
+      short
+      ushort
+      int
+      uint
+      long
+      ulong
+    Text
+      To cast a Macaulay2 number to a foreign object with an integer type,
+      give the type followed by the number.  Non-integers will be truncated.
+    Example
+      int 12
+      ulong pi
+      short(-2.71828)
+  Caveat
+    On 32-bit systems, @TT "int64"@ and @TT "uint64"@ objects may exhibit
+    unexpected behavior when converting to and from Macaulay2 integers.
+///
+
+doc ///
+  Key
+    ForeignRealType
+    "float"
+    "double"
+    (symbol SPACE, ForeignRealType, Constant)
+    (symbol SPACE, ForeignRealType, Number)
+    (symbol SPACE, ForeignRealType, RRi)
+  Headline
+    foreign real type
+  Description
+    Text
+      This is the class for C real types.  There are two built-in types,
+      @TT "float"@ for reals using the
+      @wikipedia "single-precision floating-point format"@ and @TT "double"@
+      for reals using the @wikipedia "double-precision floating-point format"@.
+    Example
+      float
+      double
+    Text
+      To cast a Macaulay2 number to a foreign object with a real type, give
+      the type followed by the number.
+    Example
+      float 3
+      double pi
+    Text
+      The imaginary parts of complex numbers are discarded.
+    Example
+      double(2 + 3*ii)
+///
+
+doc ///
+  Key
+    ForeignPointerType
+    "voidstar"
+  Headline
+    foreign pointer type
+  Description
+    Text
+      This is the class for C pointer types.  There is one built-in type,
+      @TT "voidstar"@.
+    Example
+      voidstar
+    Text
+      If a foreign pointer object corresponds to memory that was not allocated
+      by the @TO "GC garbage collector"@, then a function to properly
+      deallocate this memory when the @TO "Pointer"@ object that stores this
+      pointer is garbage collected should be called.  The function should
+      take a single argument, a foreign object of type @TO "voidstar"@,
+      which corresponds to the memory to deallocate.
+    Example
+      malloc = foreignFunction("malloc", voidstar, ulong)
+      free = foreignFunction("free", void, voidstar)
+      finalizer = x -> (print("freeing memory at " | net x); free x)
+      for i to 9 do (x := malloc 8; registerFinalizer(x, finalizer))
+      collectGarbage()
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignPointerType, Pointer)
+  Headline
+    cast a Macaulay2 pointer to a foreign pointer
+  Usage
+    T x
+  Inputs
+    T:ForeignPointerType
+    x:Pointer
+  Outputs
+    :ForeignObject
+  Description
+    Text
+      To cast a Macaulay2 pointer to a foreign object with a pointer type,
+      give the type followed by the pointer.
+    Example
+      ptr = address int 0
+      voidstar ptr
+///
+
+doc ///
+  Key
+    ForeignStringType
+    "charstar"
+  Headline
+    foreign string type
+  Description
+    Text
+      This is the class for C strings types, i.e., null-terminated character
+      arrays.  There is one built-in type, @TT "charstar"@.
+    Example
+      charstar
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignStringType, String)
+  Headline
+    cast a Macaulay2 string to a foreign string
+  Usage
+    T x
+  Inputs
+    T:ForeignStringType
+    x:String
+  Outputs
+    :ForeignObject
+  Description
+    Text
+      To cast a Macaulay2 string to a foreign object with a string type, give
+      the type followed by the string.
+    Example
+      charstar "Hello, world!"
+///
+
+doc ///
+  Key
+    ForeignArrayType
+  Headline
+    foreign array type
+  Description
+    Text
+      This is the class for array types.  There are no built-in types.  They
+      must be constructed using @TO "foreignArrayType"@.
+///
+
+doc ///
+  Key
+    foreignArrayType
+    (foreignArrayType, ForeignType, ZZ)
+    (foreignArrayType, String, ForeignType, ZZ)
+    (symbol *, ZZ, ForeignType)
+    (symbol *, ForeignType, ZZ)
+  Headline
+    construct a foreign array type
+  Usage
+    foreignArrayType(name, T, n)
+    foreignArrayType(T, n)
+    n * T
+  Inputs
+    name:String
+    T:ForeignType
+    n:ZZ
+  Outputs
+    :ForeignArrayType
+  Description
+    Text
+      To construct a foreign array type, specify a name, the type of the
+      elements of each array, and the number of elements in each array.
+    Example
+      foreignArrayType("myArrayType", int, 5)
+    Text
+      If the name is omitted, then a default one is chosen by taking the name of
+      the type of the elements and appending the number of elements enclosed in
+      brackets.
+    Example
+      foreignArrayType(int, 5)
+    Text
+      Alternatively, you may "multiply" the number of elements by the type to
+      accomplish the same.
+    Example
+      5 * int
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignArrayType, VisibleList)
+  Usage
+    T x
+  Inputs
+    T:ForeignArrayType
+    x:VisibleList
+  Outputs
+    :ForeignObject -- of type @TT "T"@
+  Description
+    Text
+      To cast a Macaulay2 list to a foreign object with array type, give the
+      type followed by the list.
+    Example
+      intarray5 = 5 * int
+      x = intarray5 {2, 4, 6, 8, 10}
+    Text
+      Use @TT "_"@ to return a single element of a foreign array.
+    Example
+      x_2
+      x_(-1)
+ Caveat
+   The number of elements of @TT "x"@ must match the number of elements
+   that were specified when @TT "T"@ was constructed.
+///
+
+doc ///
+  Key
+    ForeignStructType
+  Headline
+    foreign struct type
+  Description
+    Text
+      This is the class for @wikipedia("Struct_(C_programming_language)",
+      "C struct")@ types.  There are no built-in types.  They must be
+      constructed using @TO "foreignStructType"@.
+///
+
+doc ///
+  Key
+    foreignStructType
+    (foreignStructType, String, VisibleList)
+    (foreignStructType, String, Option)
+  Headline
+    construct a foreign struct type
+  Usage
+    foreignStructType(name, x)
+  Inputs
+    name:String
+    x:List -- of options
+  Outputs
+    :ForeignStructType
+  Description
+    Text
+      To construct a foreign struct type, specify a name and a list of the
+      members.  Each member should be an @TO Option@ of the form
+      @TT "memberName => memberType"@, where @TT "memberName"@ is a
+      @TO String@ and @TT "memberType"@ is a @TO ForeignType@.
+    Example
+      foreignStructType("mystruct", {"foo" => int, "bar" => double})
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignStructType, VisibleList)
+  Headline
+    cast a hash table to a foreign struct
+  Usage
+    T x
+  Inputs
+    T:ForeignStructType
+    x:VisibleList -- whose elements are options
+  Outputs
+    :ForeignObject
+  Description
+    Text
+      To cast a Macaulay2 hash table to a foreign object with a struct type,
+      give the type followed by the hash table, or a list that could be passed
+      to @TO hashTable@ to create one.  The keys should correspond to the
+      keys of the hash table passed to @TO foreignStructType@ when constructing
+      @TT "T"@.
+    Example
+      mystruct = foreignStructType("mystruct", {"foo" => int, "bar" => double})
+      x = mystruct {"foo" => 5, "bar" => pi}
+    Text
+      Use @TT "_"@ to return a single member of a foreign struct.
+    Example
+      x_"foo"
+      x_"bar"
+///
+
+doc ///
+  Key
+    ForeignUnionType
+  Headline
+    foreign union type
+  Description
+    Text
+      This is the class for @wikipedia("Union_type", "C union")@ types.  There
+      are no built-in types.  They must be  constructed using
+      @TO "foreignUnionType"@.
+///
+
+doc ///
+  Key
+    foreignUnionType
+    (foreignUnionType, String, VisibleList)
+    (foreignUnionType, String, Option)
+  Headline
+    construct a foreign union type
+  Usage
+    foreignUnionType(name, x)
+  Inputs
+    name:String
+    x:List -- of options
+  Outputs
+    :ForeignUnionType
+  Description
+    Text
+      To construct a foreign union type, specify a name and a list of the
+      members.  Each member should be an @TO Option@ of the form
+      @TT "memberName => memberType"@, where @TT "memberName"@ is a
+      @TO String@ and @TT "memberType"@ is a @TO ForeignType@.
+    Example
+      myunion = foreignUnionType("myunion",
+	  {"foo" => 4 * char', "bar" => charstar})
+    Text
+      Use @TT "_"@ to return a single member of a foreign union.
+    Example
+      x = myunion (4 * char') append(ascii "hi!", 0)
+      x_"foo"
+      x_"bar"
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignUnionType, Thing)
+  Headline
+    cast a thing to a foreign union
+  Usage
+    T x
+  Inputs
+    T:ForeignUnionType
+    x:Thing
+  Outputs
+    :ForeignObject
+  Description
+    Text
+      To cast a Macaulay2 thing to a foreign object with a union type,
+      give the type followed by the thing.  The appropriate member is
+      determined automatically by @TO "foreignObject"@.
+    Example
+      myunion = foreignUnionType("myunion", {"foo" => int, "bar" => double})
+      myunion 27
+      myunion pi
+    Text
+      To avoid ambiguity, it may be helpful to first cast the thing to the
+      appropriate foreign type.
+    Example
+      myunion double 5
+///
+
+doc ///
+  Key
+    ForeignObject
+  Headline
+    foreign object
+  Description
+    Text
+      A @TT "ForeignObject"@ represents some C object.  It consists of a
+      @TO "Pointer"@ with its address in memory.
+    Example
+      x = int 5
+      peek x
+    Text
+      To get this, use @TO address@.
+    Example
+      address x
+    Text
+      Use @TO class@ to determine the type of the object.
+    Example
+      class x
+///
+
+doc ///
+  Key
+    (value, ForeignObject)
+    (net, ForeignObject)
+  Headline
+    get the value of a foreign object as a Macaulay2 thing
+  Usage
+    value x
+  Inputs
+    x:ForeignObject
+  Outputs
+    :Thing
+  Description
+    Text
+      Convert the given foreign object to the corresponding Macaulay2 thing.
+      The type of the output is determined by the type of the foreign object.
+      Foreign integer objects are converted to @TO ZZ@ objects.
+    Example
+      x = int 5
+      value x
+    Text
+      Foreign real objects are converted to @TO RR@ objects.
+    Example
+      x = double 5
+      value x
+    Text
+      Foreign pointer objects are converted to @TO Pointer@ objects.
+    Example
+      x = voidstar address int 5
+      value x
+    Text
+      Foreign string objects are converted to strings.
+    Example
+      x = charstar "Hello, world!"
+      value x
+    Text
+      Foreign array objects are converted to lists.
+    Example
+      x = (4 * int) {2, 4, 6, 8}
+      value x
+    Text
+      Foreign struct and union objects are converted to hash tables.
+    Example
+      mystruct = foreignStructType("mystruct", {"a" => int, "b" => float})
+      x = mystruct {"a" => 2, "b" => sqrt 2}
+      value x
+    Text
+      Note that this function is also used by @TT "net(ForeignObject)"@ for
+      representing foreign objects.
+///
+
+doc ///
+  Key
+    foreignObject
+    (foreignObject, Constant)
+    (foreignObject, ForeignObject)
+    (foreignObject, VisibleList)
+    (foreignObject, Number)
+    (foreignObject, String)
+    (foreignObject, ZZ)
+  Headline
+    construct a foreign object
+  Usage
+    foreignObject x
+  Inputs
+    x:Thing
+  Outputs
+    :ForeignObject
+  Description
+    Text
+      This function constructs a @TO "ForeignObject"@.  The type is determined
+      automatically based on type of the input.
+      Integers are converted to @TO "int32"@ objects.
+    Example
+      foreignObject 5
+    Text
+      Non-integers are converted to @TO "double"@ objects.
+    Example
+      foreignObject pi
+    Text
+      Strings are converted to @TO "charstar"@ objects.
+    Example
+      foreignObject "Hello, world!"
+    Text
+      Lists are converted to foreign objects with the appropriate
+      @TO "ForeignArrayType"@.
+    Example
+      foreignObject {1, 3, 5, 7, 9}
+    Text
+      No conversion is done when the input is already a foreign object.
+    Example
+      foreignObject oo
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignType, ForeignObject)
+  Headline
+    cast a foreign object to the given foreign type
+  Usage
+    T x
+  Inputs
+    T:ForeignType
+    x:ForeignObject
+  Outputs
+    :ForeignObject
+  Description
+    Text
+      Cast the given foreign object to the given foreign type.  Note that the
+      addresses will remain the same.
+    Example
+      chararray4 = 4 * char'
+      x = chararray4 append(ascii "foo", 0)
+      y = charstar x
+      address x === address y
+///
+
+doc ///
+  Key
+    SharedLibrary
+    (net, SharedLibrary)
+  Headline
+    a shared library
+  Description
+    Text
+      A shared library that could be used to load foreign functions.  Each
+      shared library object consists of a pointer to a handle for the library
+      and a string that is used by @TT "net(SharedLibrary)"@.
+    Example
+      mpfr = openSharedLibrary "mpfr"
+      peek mpfr
+///
+
+doc ///
+  Key
+    openSharedLibrary
+    (openSharedLibrary, String)
+    [openSharedLibrary, FileName]
+  Headline
+    open a shared library
+  Usage
+    openSharedLibrary name
+  Inputs
+    name:String
+    FileName => String -- the filename of the library to open
+  Outputs
+    :SharedLibrary
+  Description
+    Text
+      Open a shared library with the given name.  In particular, this is a
+      wrapper around the C @TT "dlopen"@ function.  A library is searched for
+      with the filename @TT "\"lib\" | name | \".so\""@ (in Linux) or
+      @TT "\"lib\" | name | \".dylib\""@ (in macOS).  Alternatively, a
+      specific filename can be specified using the @TT "FileName"@ option.
+      A corresponding @TO "SharedLibrary"@ object, which can be later used by
+      @TO "foreignFunction"@, is returned.
+    Example
+      openSharedLibrary "mpfr"
+///
+
+doc ///
+  Key
+    foreignFunction
+    (foreignFunction, SharedLibrary, String, ForeignType, VisibleList)
+    (foreignFunction, SharedLibrary, String, ForeignType, ForeignType)
+    (foreignFunction, String, ForeignType, VisibleList)
+    (foreignFunction, String, ForeignType, ForeignType)
+    (foreignFunction, Pointer, String, ForeignType, VisibleList)
+    [foreignFunction, Variadic]
+    Variadic
+    ForeignFunction
+  Headline
+    construct a foreign function
+  Usage
+    foreignFunction(lib, symb, rtype, argtypes)
+    foreignFunction(symb, rtype, argtypes)
+  Inputs
+    lib:SharedLibrary -- containing the function
+    symb:String -- the symbol of the function
+    rtype:ForeignType -- the return type
+    argtypes:List -- the types of the arguments
+    Variadic => Boolean -- whether the function is variadic
+  Outputs
+    :ForeignFunction
+  Description
+    Text
+      Load a function contained in a shared library using the C function
+      @TT "dlsym"@ and declare its signature.
+    Example
+      mpfr = openSharedLibrary "mpfr"
+      mpfrVersion = foreignFunction(mpfr, "mpfr_get_version", charstar, void)
+      mpfrVersion()
+    Text
+      The library may be omitted if it is already loaded, e.g., for functions
+      in the C standard library or libraries that Macaulay2 is already linked
+      against.  For example, since Macaulay2 uses @TT "mpfr"@ for its
+      arbitrary precision real numbers, the above example may be simplified.
+    Example
+      mpfrVersion = foreignFunction("mpfr_get_version", charstar, void)
+      mpfrVersion()
+    Text
+      If a function takes multiple arguments, then provide these argument
+      types using a list.
+    Example
+      myatan2 = foreignFunction("atan2", double, {double, double})
+      myatan2(1, sqrt 3)
+    Text
+      For variadic functions, set the @TT "Variadic"@ option to @TT "true"@.
+    Example
+      sprintf = foreignFunction("sprintf", void, {charstar, charstar},
+	  Variadic => true)
+      buf = charstar "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      sprintf(buf, "%s %d", "foo", 3)
+      buf
+    Text
+      The variadic arguments are processed using @TO "foreignObject"@, which
+      may lead to unexpected behavior.  It may be useful to cast them to
+      foreign objects to avoid ambiguity.
+    Example
+      sprintf(buf, "%s %.1f", "foo", 3)
+      buf
+      sprintf(buf, "%s %.1f", "foo", double 3)
+      buf
+    Text
+      Note that variadic functions cannot be passed arguments that have a
+      size of fewer than 4 bytes.
+    Example
+      stopIfError = false
+      sprintf(buf, "%c", char' 77)
+    Text
+      If the foreign function allocates any memory, then register a finalizer
+      for its outputs to deallocate the memory during garbage collection using
+      @TT "registerFinalizer"@.
+    Example
+      malloc = foreignFunction("malloc", voidstar, ulong)
+      free = foreignFunction("free", void, voidstar)
+      x = malloc 8
+      registerFinalizer(x, free)
+///
+
+
+TEST ///
+-----------
+-- value --
+-----------
+
+-- integer types
+assert Equation(value uint8(2^8 - 1), 2^8 - 1)
+assert Equation(value int8(2^7 - 1), 2^7 - 1)
+assert Equation(value int8(-2^7), -2^7)
+assert Equation(value uint16(2^16 - 1), 2^16 - 1)
+assert Equation(value int16(2^15 - 1), 2^15 - 1)
+assert Equation(value int16(-2^15), -2^15)
+assert Equation(value uint32(2^32 - 1), 2^32 - 1)
+assert Equation(value int32(2^31 - 1), 2^31 - 1)
+assert Equation(value int32(-2^31), -2^31)
+if version#"pointer size" == 8 then (
+    assert Equation(value uint64(2^64 - 1), 2^64 - 1);
+    assert Equation(value int64(2^63 - 1), 2^63 - 1);
+    assert Equation(value int64(-2^63), -2^63))
+assert Equation(value uchar(2^8 - 1), 2^8 - 1)
+assert Equation(value char'(2^7 - 1), 2^7 - 1)
+assert Equation(value char'(-2^7), -2^7)
+assert Equation(value ushort(2^16 - 1), 2^16 - 1)
+assert Equation(value short(2^15 - 1), 2^15 - 1)
+assert Equation(value short(-2^15), -2^15)
+assert Equation(value uint(2^32 - 1), 2^32 - 1)
+assert Equation(value int(2^31 - 1), 2^31 - 1)
+assert Equation(value int(-2^31), -2^31)
+longexp = 8 * version#"pointer size"
+assert Equation(value ulong(2^longexp - 1), 2^longexp - 1)
+assert Equation(value long(2^(longexp - 1) - 1), 2^(longexp - 1) - 1)
+assert Equation(value long(-2^(longexp - 1)), -2^(longexp - 1))
+
+-- real types
+assert Equation(value float 3.14159, 3.14159p24)
+assert Equation(value double 3.14159, 3.14159p53)
+
+-- pointer types
+ptr = address int 3
+assert(value voidstar ptr === ptr)
+assert(value voidstar voidstar voidstar voidstar ptr === ptr)
+assert Equation(value int ptr, 3)
+
+-- string types
+assert Equation(value charstar "Hello, world!", "Hello, world!")
+
+-- array types
+intarray3 = 3 * int
+x = intarray3 {1, 2, 3}
+assert Equation(value \ value x, {1, 2, 3})
+ptr = address x
+assert Equation(value \ value intarray3 ptr, {1, 2, 3})
+assert Equation(value x_0, 1)
+assert Equation(value x_(-1), 3)
+ptrarray = 3 * voidstar
+assert Equation(
+    apply(value ptrarray {address int 1, address int 2, address int 3},
+    x -> value int value x), {1, 2, 3})
+
+-- struct types
+teststructtype = foreignStructType("foo",
+    {"a" => int, "b" => double, "c" => charstar, "d" => voidstar})
+x = teststructtype {"a" => 1, "b" => 2, "c" => "foo", "d" => address int 4}
+assert instance(value x, HashTable)
+assert Equation(value x_"a", 1)
+assert Equation(value x_"b", 2.0)
+assert Equation(value x_"c", "foo")
+assert Equation(value int value x_"d", 4)
+
+-- union types
+testuniontype = foreignUnionType("bar", {"a" => float, "b" => uint32})
+x = testuniontype float 1
+assert instance(value x, HashTable)
+assert Equation(value x_"a", 1)
+assert Equation(value x_"b", 0x3f800000)
+y = testuniontype uint32 0xc0000000
+assert Equation(value y_"a", -2)
+assert Equation(value y_"b", 0xc0000000)
+///
+
+TEST ///
+-------------------
+-- foreignObject --
+-------------------
+assert Equation(value foreignObject 3, 3)
+assert Equation(value foreignObject 3.14159, 3.14159)
+assert Equation(value foreignObject "foo", "foo")
+assert Equation(value \ value foreignObject {1, 2, 3}, {1, 2, 3})
+assert Equation(value \ value foreignObject {1.0, 2.0, 3.0}, {1.0, 2.0, 3.0})
+assert Equation(value \ value foreignObject {"foo", "bar"}, {"foo", "bar"})
+///
+
+TEST ///
+---------------------
+-- foreignFunction --
+---------------------
+cCos = foreignFunction("cos", double, double)
+assert Equation(value cCos pi, -1)
+///
+
+TEST ///
+--------------------------------
+-- foreignFunction (variadic) --
+--------------------------------
+sprintf = foreignFunction("sprintf", void, {charstar, charstar},
+    Variadic => true)
+foo = charstar "foo"
+sprintf(foo, "%s", "bar")
+assert Equation(value foo, "bar")
+///
+
+TEST ///
+---------------------------------
+-- foreignFunction (w/ struct) --
+---------------------------------
+tm = foreignStructType("tm", {
+	"tm_sec" => int,
+	"tm_min" => int,
+	"tm_hour" => int,
+	"tm_mday" => int,
+	"tm_mon" => int,
+	"tm_year" => int,
+	"tm_wday" => int,
+	"tm_yday" => int,
+	"tm_isdst" => int,
+	"tm_gmtoff" => long,
+	"tm_zone" => charstar})
+gmtime = foreignFunction("gmtime", voidstar, voidstar)
+asctime = foreignFunction("asctime", charstar, voidstar)
+epoch = tm value gmtime address long 0
+assert Equation(value asctime address epoch,"Thu Jan  1 00:00:00 1970\n")
+///

--- a/M2/cmake/FindFFI.cmake
+++ b/M2/cmake/FindFFI.cmake
@@ -1,0 +1,81 @@
+# Attempts to discover ffi library with a linkable ffi_call function.
+#
+# Example usage:
+#
+# find_package(FFI)
+#
+# FFI_REQUIRE_INCLUDE may be set to consider ffi found if the includes
+# are present in addition to the library. This is useful to keep off
+# for the imported package on platforms that install the library but
+# not the headers.
+#
+# FFI_LIBRARY_DIR may be set to define search paths for the ffi library.
+#
+# If successful, the following variables will be defined:
+# FFI_FOUND
+# FFI_INCLUDE_DIRS
+# FFI_LIBRARIES
+# HAVE_FFI_CALL
+#
+# HAVE_FFI_H or HAVE_FFI_FFI_H is defined depending on the ffi.h include path.
+#
+# Additionally, the following import target will be defined:
+# FFI::ffi
+
+find_path(FFI_INCLUDE_DIRS ffi.h PATHS ${FFI_INCLUDE_DIR})
+if( EXISTS "${FFI_INCLUDE_DIRS}/ffi.h" )
+  set(FFI_HEADER ffi.h CACHE INTERNAL "")
+  set(HAVE_FFI_H 1 CACHE INTERNAL "")
+else()
+  find_path(FFI_INCLUDE_DIRS ffi/ffi.h PATHS ${FFI_INCLUDE_DIR})
+  if( EXISTS "${FFI_INCLUDE_DIRS}/ffi/ffi.h" )
+    set(FFI_HEADER ffi/ffi.h CACHE INTERNAL "")
+    set(HAVE_FFI_FFI_H 1 CACHE INTERNAL "")
+  endif()
+endif()
+
+find_library(FFI_LIBRARIES ffi PATHS ${FFI_LIBRARY_DIR})
+
+if(FFI_LIBRARIES)
+  include(CMakePushCheckState)
+  include(CheckCSourceCompiles)
+  cmake_push_check_state()
+  list(APPEND CMAKE_REQUIRED_LIBRARIES ${FFI_LIBRARIES})
+  check_c_source_compiles("
+    struct ffi_cif;
+    typedef struct ffi_cif ffi_cif;
+    void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue);
+    int main() { ffi_call(0, 0, 0, 0); }"
+    HAVE_FFI_CALL)
+  cmake_pop_check_state()
+endif()
+
+unset(required_includes)
+if(FFI_REQUIRE_INCLUDE)
+  set(required_includes FFI_INCLUDE_DIRS)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FFI
+                                  FOUND_VAR
+                                    FFI_FOUND
+                                  REQUIRED_VARS
+                                    FFI_LIBRARIES
+                                    ${required_includes}
+                                    HAVE_FFI_CALL)
+mark_as_advanced(FFI_LIBRARIES
+                 FFI_INCLUDE_DIRS
+                 HAVE_FFI_CALL
+                 FFI_HEADER
+                 HAVE_FFI_H
+                 HAVE_FFI_FFI_H)
+
+if(FFI_FOUND)
+  if(NOT TARGET FFI::ffi)
+    add_library(FFI::ffi UNKNOWN IMPORTED)
+    set_target_properties(FFI::ffi PROPERTIES IMPORTED_LOCATION "${FFI_LIBRARIES}")
+    if(FFI_INCLUDE_DIRS)
+      set_target_properties(FFI::ffi PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFI_INCLUDE_DIRS}")
+    endif()
+  endif()
+endif()

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -7,7 +7,7 @@
 ##    reconfigure NTL variables: cmake -U*NTL* .
 
 # These are some of the libraries linked with Macaulay2 in Macaulay2/{d,e,bin}/CMakeLists.txt
-# Others, like TBB::tbb and Boost::regex, are linked as imported libraries in those files.
+# Others, like TBB::tbb, FFI::ffi, and Boost::regex, are linked as imported libraries in those files.
 # TODO: turn all these libraries into imported libraries and find incompatibilities another way.
 set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
 set(LIBRARIES_LIST MPSOLVE FROBBY FACTORY FLINT NTL MPFI MPFR MP BDWGC LAPACK)
@@ -77,6 +77,10 @@ endforeach()
 
 if(WITH_TBB)
   find_package(TBB REQUIRED)
+endif()
+
+if(WITH_FFI)
+  find_package(FFI REQUIRED QUIET)
 endif()
 
 ###############################################################################

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -28,6 +28,7 @@ option(BUILD_DOCS	"Build internal documentation"		OFF)
 option(AUTOTUNE		"Autotune library parameters"		OFF)
 option(WITH_OMP		"Link with the OpenMP library"		ON)
 option(WITH_TBB		"Link with the TBB library"		ON)
+option(WITH_FFI		"Link with the FFI library"		ON)
 # TODO: parse.d expr.d tokens.d actors4.d actors5.d still need xml
 option(WITH_XML		"Link with the libxml2 library"		ON)
 # TODO: still not operational

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1679,6 +1679,16 @@ AC_SEARCH_LIBS(gzopen,z,,AC_MSG_ERROR(libz not found or not linkable))
 AC_SEARCH_LIBS(lzma_end,lzma,,AC_MSG_ERROR(library lzma not found or not linkable))
 AC_SEARCH_LIBS(xmlNewNode,xml2,,AC_MSG_ERROR(library xml2 not found or not linkable))
 
+AC_MSG_CHECKING([whether package libffi is provided])
+AS_IF([pkg-config --exists libffi],
+      [AC_MSG_RESULT([yes])
+       CPPFLAGS="$(pkg-config --cflags-only-I libffi) $CPPFLAGS"
+       AC_CHECK_HEADER([ffi.h], [], [AC_MSG_ERROR([ffi.h not found])])
+       AC_SEARCH_LIBS([ffi_call], [ffi], [],
+	   [AC_MSG_ERROR([libffi not found or not linkable])])],
+      [AC_MSG_RESULT([no])
+       AC_MSG_ERROR([libffi is required])])
+
 # after this point we add no more libraries to $LIBS, e.g., with AC_SEARCH_LIBS()
 SAVELIBS=$LIBS
 


### PR DESCRIPTION
I've been working on a package that uses [libffi](https://sourceware.org/libffi/) to allow calling C functions from top level (see #1310).  It's still pretty rough, but basically works, so I figured I'd open up a draft PR for comments.  I still need to implement support for some libffi features like structs and variadic functions.

There's one new class, `Pointer`, in the interpreter that is exported by the package, and lots of D language functions for converting Macaulay2 objects into corresponding C objects (e.g., `ZZ` -> `int`) to get a `Pointer` object with their address, and then going back again.

No clue if this works in macOS, and I haven't messed with the CMake build yet, either.

```m2
i1 : loadPackage "ForeignFunctions"

o1 = ForeignFunctions

o1 : Package

i2 : libm = openSharedLibrary "libm.so.6"

o2 = libm.so.6

o2 : SharedLibrary

i3 : cCos = foreignFunction(libm, "cos", "double", "double")

o3 = libm.so.6::cos

o3 : ForeignFunction

i4 : cCos numeric pi

o4 = -1

o4 : RR (of precision 53)

i5 : libc = openSharedLibrary "libc.so.6"

o5 = libc.so.6

o5 : SharedLibrary

i6 : puts = foreignFunction(libc, "puts", "void", "pointer")

o6 = libc.so.6::puts

o6 : ForeignFunction

i7 : puts "Hello, world!"
Hello, world!
```