### PR TITLE
Add -latomic flag for autotools TBB check

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -398,26 +398,6 @@ AC_SEARCH_LIBS(hstrerror,resolv)
 AC_SEARCH_LIBS(dlopen,dl)
 AC_SEARCH_LIBS(gethostbyname,nsl)
 
-AC_SUBST(ENABLE_TBB,yes)  AC_ARG_ENABLE(tbb, AS_HELP_STRING(--disable-tbb,disable use of the tbb (threaded building blocks) library), ENABLE_TBB=$enableval)
-if test $ENABLE_TBB = yes
-then AC_DEFINE(WITH_TBB,1,[whether the tbb library has been enabled by the builder])
-     AC_LANG(C++)
-     AC_CHECK_HEADER(tbb/tbb.h,
-	[AC_SEARCH_LIBS(TBB_runtime_interface_version,"tbb",
-	   ,
-	   [AC_MSG_ERROR([tbb library not found])])],
-	 [AC_MSG_ERROR([tbb include file (tbb.h) not found])])
-     AC_RUN_IFELSE([AC_LANG_SOURCE([[
-		#include <stdio.h>
-		#define TBB_SUPPRESS_DEPRECATED_MESSAGES 1
-		#include <tbb/tbb.h>
-		int main () {
-		  printf("tbb version %d.%d found\n", TBB_VERSION_MAJOR, TBB_VERSION_MINOR);
-		  return 0;
-		}
- 	     ]])])
-fi
-
 AC_CHECK_FUNCS([herror error clock_gettime getaddrinfo hstrerror sync getpgrp setpgid fchmod pipe waitpid setrlimit alarm fork sigprocmask kill longjmp siglongjmp sigaction wait4 readlink lstat realpath mkdir link symlink socket accept fcntl personality ioctl])
 
 AC_SUBST(HAVE_PERSONALITY,$ac_cv_func_personality)
@@ -780,6 +760,26 @@ dnl We disable something temporarily that didn't work out, because if we put a s
 dnl as libflint.a, into LIBS, then mathicgb, mathic, and memtailor get confused and include a copy
 dnl of the file in their *.a file.
 TRY_STATIC=no
+
+AC_SUBST(ENABLE_TBB,yes)  AC_ARG_ENABLE(tbb, AS_HELP_STRING(--disable-tbb,disable use of the tbb (threaded building blocks) library), ENABLE_TBB=$enableval)
+if test $ENABLE_TBB = yes
+then AC_DEFINE(WITH_TBB,1,[whether the tbb library has been enabled by the builder])
+     AC_LANG(C++)
+     AC_CHECK_HEADER(tbb/tbb.h,
+	[AC_SEARCH_LIBS(TBB_runtime_interface_version,"tbb",
+	   ,
+	   [AC_MSG_ERROR([tbb library not found])])],
+	 [AC_MSG_ERROR([tbb include file (tbb.h) not found])])
+     AC_RUN_IFELSE([AC_LANG_SOURCE([[
+		#include <stdio.h>
+		#define TBB_SUPPRESS_DEPRECATED_MESSAGES 1
+		#include <tbb/tbb.h>
+		int main () {
+		  printf("tbb version %d.%d found\n", TBB_VERSION_MAJOR, TBB_VERSION_MINOR);
+		  return 0;
+		}
+ 	     ]])])
+fi
 
 AC_SUBST(LIBS_GDBM)
 AC_LANG(C)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -401,11 +401,10 @@ AC_SEARCH_LIBS(gethostbyname,nsl)
 AC_SUBST(ENABLE_TBB,yes)  AC_ARG_ENABLE(tbb, AS_HELP_STRING(--disable-tbb,disable use of the tbb (threaded building blocks) library), ENABLE_TBB=$enableval)
 if test $ENABLE_TBB = yes
 then AC_DEFINE(WITH_TBB,1,[whether the tbb library has been enabled by the builder])
-     AC_SUBST(LIBTBB)		dnl LIBTBB is usually set to -ltbb
      AC_LANG(C++)
      AC_CHECK_HEADER(tbb/tbb.h,
 	[AC_SEARCH_LIBS(TBB_runtime_interface_version,"tbb",
-	   LIBTBB=$ac_cv_search_TBB_runtime_interface_version,
+	   ,
 	   [AC_MSG_ERROR([tbb library not found])])],
 	 [AC_MSG_ERROR([tbb include file (tbb.h) not found])])
      AC_RUN_IFELSE([AC_LANG_SOURCE([[

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -767,7 +767,7 @@ then AC_DEFINE(WITH_TBB,1,[whether the tbb library has been enabled by the build
      AC_LANG(C++)
      AC_CHECK_HEADER(tbb/tbb.h,
 	[AC_SEARCH_LIBS(TBB_runtime_interface_version,"tbb",
-	   ,
+	   [LIBS="$LIBS -latomic"],
 	   [AC_MSG_ERROR([tbb library not found])])],
 	 [AC_MSG_ERROR([tbb include file (tbb.h) not found])])
      AC_RUN_IFELSE([AC_LANG_SOURCE([[


### PR DESCRIPTION
TBB 2021 finally was uploaded to Debian unstable, and the [armel rebuild of Macaulay2 against it failed](https://buildd.debian.org/status/fetch.php?pkg=macaulay2&arch=armel&ver=1.20%2Bds-4%2Bb1&stamp=1655196258&raw=0):

```
checking for library containing TBB_runtime_interface_version... no
configure: error: tbb library not found
```
Here's the relevant lines in `config.log`:

```
configure:7795: g++ -o conftest -std=gnu++14 -g -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -g3 -O2 -Wdate-time -D_FORTIFY_SOURCE=2 -DNDEBUG -Wl,-z,relro -Wl,-z,now -g3 conftest.cpp -ltbb  -ldl  >&5
/usr/bin/ld: /usr/lib/gcc/arm-linux-gnueabi/11/../../../arm-linux-gnueabi/libtbb.so: undefined reference to `__atomic_fetch_sub_8'
/usr/bin/ld: /usr/lib/gcc/arm-linux-gnueabi/11/../../../arm-linux-gnueabi/libtbb.so: undefined reference to `__atomic_load_8'
/usr/bin/ld: /usr/lib/gcc/arm-linux-gnueabi/11/../../../arm-linux-gnueabi/libtbb.so: undefined reference to `__atomic_fetch_add_8'
collect2: error: ld returned 1 exit status
```
I think this is due to [GCC bug #104248](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104248).  An easy fix is to add `-latomic` to `LIBS`.  See also https://github.com/Macaulay2/mathicgb/pull/41.

I also cleaned up a couple other things I noticed in the TBB check (removing an unused variable and moving the check later so `-ltbb` doesn't end up in the Fortran flags).