### PR TITLE
utf8 width for strings, nets

### DIFF
--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -482,6 +482,26 @@ numparms(e:Expr):Expr := (
      else WrongArg("a function"));
 setupfun("numparms",numparms);
 
+utf8substrfun(e:Expr):Expr := (
+     when e is args:Sequence do
+	  if length(args) != 3 then WrongNumArgs(3) else
+	       when args.0 is s:stringCell do
+		   when args.1 is start:ZZcell do
+		       when args.2 is width:ZZcell do
+		       toExpr(utf8substr(s.v,toInt(start),toInt(width)))
+		       else WrongArgSmallInteger(3)
+		   else WrongArgSmallInteger(2)
+	       else WrongArg(1,"a string")
+     else WrongNumArgs(3)
+);
+setupfun("utf8substring",utf8substrfun);
+
+stringWidth(e:Expr):Expr := (
+     when e
+     is s:stringCell do toExpr(utf8width(s.v))
+     else WrongArg("a string"));
+setupfun("stringWidth",stringWidth);
+
 netWidth(e:Expr):Expr := (
      when e
      is n:Net do toExpr(n.width)

--- a/M2/Macaulay2/d/strings.d
+++ b/M2/Macaulay2/d/strings.d
@@ -64,6 +64,41 @@ export index(s:string,offset:int,c:char,d:char):int := (
      while i+1 < length(s) do if c == s.i && d==s.(i+1) then return i else i=i+1;
      -1);     
 
+utf8charlength(c0:char):int := (
+    c := int(uchar(c0));
+    if (c & 0x80) == 0 then 1
+    else if (c & 0xe0) == 0xc0 then 2
+    else if (c & 0xf0) == 0xe0 then 3
+    -- else if (c & 0xf8) == 0xf0 then 4
+    else 4
+);
+
+export utf8width(s:string):int := (
+     n := length(s);
+     i := 0;
+     l := 0;
+     while i < n do (
+	  l = l + 1;
+	  i = i + utf8charlength(s.i);
+     );
+     l
+);
+
+export utf8substr(s:string,start:int,wid:int):string := ( -- compared to substr, start and wid are in utf8 characters, not bytes
+     i := 0;
+     for j from 0 to start-1 do (
+	  if i >= length(s) then break;
+	  i = i + utf8charlength(s.i);
+	  );
+     start1 := i;
+     for j from 0 to wid-1 do (
+	  if i >= length(s) then break;
+	  i = i + utf8charlength(s.i);
+	  );
+     substr(s,start1,i-start1)
+);
+
+
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d strings.o "

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1207,6 +1207,7 @@ export {
 	"userSymbols",
 	"utf8",
 	"utf8check",
+	"utf8substring",
 	"value",
 	"values",
 	"variety",

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -413,7 +413,7 @@ width Net := netWidth
 height Net := netHeight
 depth Net := netDepth
 
-width String := s -> #s
+width String := stringWidth
 height String := s -> 1
 depth String := s -> 0
 


### PR DESCRIPTION
This is an attempt to better handle strings with utf8 content; cf the discussion in #1069.
A priori, there are 3 distinct concepts associated to a `String`:
(1) its length -- its number of bytes
(2) its utf8 length -- its number of utf8 characters
(3) its (utf8) width -- its width in a monospace font
Most characters have width 1, so in the first approximation one can assume (2)=(3).
Right now M2 defines two methods for strings, `length` and `width`. Both point to `#` which computes its length (1).
- This PR implements (2) and assigns it to `width`. It *does not* distinguish between (2) and (3) (e.g. for wide chinese characters), this is left for future work.
- It also fixes various methods for nets, most notably `horizontalJoin`.
- It introduces (and exports) a new method `utf8substring`.
- The other thing it does not do is fix `wrap` since its current implementation is very much byte-based.
- Since redefining `width` is a potentially breaking change, one should carefully check its repercussions.

Example:
```
i1 : R=QQ[α,β]

o1 = R

o1 : PolynomialRing

i2 : 1/(α^2+1)

        1
o2 = ------
      2
     α  + 1

o2 : frac R

i3 : I=ideal(α^2+2*α*β,β^2+1)

             2          2
o3 = ideal (α  + 2α*β, β  + 1)

o3 : Ideal of R

i4 : netList I_*

     +---------+
     | 2       |
o4 = |α  + 2α*β|
     +---------+
     | 2       |
     |β  + 1   |
     +---------+

i5 : wrap(5,"abcdeαβγδϵ12345") -- still not right

o5 = abcde
     αβγδ
     ϵ123
     45
```