### PR TITLE
Fix a crash in basis for degrees of length 0

### DIFF
--- a/M2/Macaulay2/e/monoid.cpp
+++ b/M2/Macaulay2/e/monoid.cpp
@@ -225,7 +225,13 @@ void Monoid::set_degrees()
       }
   else
     {
-      for (int i = 0; i < nvars_; i++) heft_degree_of_var_->array[i] = 1;
+      for (int i = 0; i < nvars_; i++)
+        {
+          monomial m = degree_monoid_->make_one();
+          degree_monoid_->from_expvector(t, m);
+          degree_of_var_.push_back(m);
+          heft_degree_of_var_->array[i] = 1;
+        }
     }
   degree_of_var_.push_back(degree_monoid_->make_one());
 }


### PR DESCRIPTION
I changed Monoid::set_degrees to add the right number of entries to the degree_of_var_ list even if degvars is zero. This should fix the crash in #2513.
