### PR TITLE
Build and deploy engine documentation to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-doxygen.yml
+++ b/.github/workflows/deploy-doxygen.yml
@@ -1,0 +1,34 @@
+name: Build and deploy engine documentation
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo add-apt-repository -y -n ppa:macaulay2/macaulay2
+          sudo apt-get update
+          sudo apt-get install -y doxygen libtool-bin libtbb-dev \
+               libeigen3-dev libboost-dev libboost-regex-dev \
+               libflint-dev libmathicgb-dev libmemtailor-dev libgc-dev \
+               libgdbm-dev
+      - name: Configure
+        run: |
+          make -C M2
+          cd M2/BUILD && ../configure
+      - name: Build engine documentation
+        run: |
+          make -C M2/BUILD/Macaulay2/util echoout
+          make -C M2/BUILD/Macaulay2/c scc1
+          make -C M2/BUILD/Macaulay2/d engine-exports.h.tmp
+          make -C M2/BUILD/Macaulay2/e tinydoc
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: M2/BUILD/Macaulay2/e/doc/tinydoc


### PR DESCRIPTION
After bringing this up in M2internals this afternoon, I figured I'd mess around with it.  This workflow builds the doxygen documentation for the engine every Sunday at midnight UTC (or at least it should -- I haven't tested the cron part...), and then publishes it to GitHub pages.  See for example [this copy](https://www.friedcheese.org/M2) that was built and deployed from my fork.

There would need to be some setup from someone with the proper privileges to set up `gh-pages` as the branch that gets published (see https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch).  The URL should end up being something like "https://Macaulay2.github.io/M2".

Note that I used `make tinydoc` since `fulldoc` and `smalldoc` take a lot longer (graphviz is run thousands of times).