### PR TITLE
fix_some_warnings_in_doc

### DIFF
--- a/M2/Macaulay2/packages/CharacteristicClasses.m2
+++ b/M2/Macaulay2/packages/CharacteristicClasses.m2
@@ -2058,7 +2058,12 @@ doc ///
 	  (CSM, QuotientRing, NormalToricVariety,Ideal,MutableHashTable)
 	  (CSM, Ideal, Symbol)
 	  (CSM,NormalToricVariety)
-          (CSM,QuotientRing,NormalToricVariety)	  
+	  (CSM,QuotientRing,NormalToricVariety)
+	  [CSM, CompMethod]
+	  [CSM, Method]
+	  [CSM, CheckSmooth]
+	  [CSM, InputIsSmooth]
+	  [CSM, IndsOfSmooth]
      Headline
      	  The Chern-Schwartz-MacPherson class
      Usage

--- a/M2/Macaulay2/packages/CohomCalg.m2
+++ b/M2/Macaulay2/packages/CohomCalg.m2
@@ -286,7 +286,7 @@ Key
   (cohomCalg, NormalToricVariety, List)
   (cohomCalg, ToricDivisor)
   (cohomCalg, NormalToricVariety, ToricDivisor)
-  Silent
+  [cohomCalg, Silent]
 Headline
   compute cohomology vectors using the CohomCalg software
 Usage

--- a/M2/Macaulay2/packages/RandomComplexes.m2
+++ b/M2/Macaulay2/packages/RandomComplexes.m2
@@ -387,6 +387,7 @@ doc ///
    Key
      disturb
      (disturb,ChainComplex,RR)
+     [disturb, Strategy]
    Headline
      disturb the matrices of a chain complex over RR
    Usage
@@ -458,6 +459,7 @@ doc ///
    Key
      testTimeForLLLonSyzygies
      (testTimeForLLLonSyzygies,ZZ,ZZ)
+     [testTimeForLLLonSyzygies, Height]
    Headline
      test timing for LLL on syzygies 
    Usage


### PR DESCRIPTION
it seems that optional arguments should also appear in the `key` field