### PR TITLE
Updates to RR exponent syntax

### DIFF
--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -379,7 +379,9 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 	       	    c = peek(file);
 		    if c == int('e') then (
 			 tokenbuf << char(getc(file));
-			 if ( peek(file) == int('-') && isdigit(peek(file,1)) || isdigit(peek(file)) )
+			 if ( peek(file) == int('-') && isdigit(peek(file,1)) ||
+			      peek(file) == int('+') && isdigit(peek(file,1)) ||
+			      isdigit(peek(file)) )
 			 then (
 			      tokenbuf << char(getc(file));
 			      while isdigit(peek(file)) do tokenbuf << char(getc(file));

--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -356,7 +356,7 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 	       else while isdigit(peek(file)) do
 		    tokenbuf << char(getc(file));
 	       c := peek(file);
-	       if decimal && (c == int('.') && peek(file,1) != int('.') || c == int('p') || c == int('e'))
+	       if decimal && (c == int('.') && peek(file,1) != int('.') || c == int('p') || c == int('e')) || c == int('E')
 	       then (
 		    typecode = TCRR;
 		    if c == int('.') then (
@@ -377,7 +377,7 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 			      )
 			 );
 	       	    c = peek(file);
-		    if c == int('e') then (
+		    if c == int('e') || c == int('E') then (
 			 tokenbuf << char(getc(file));
 			 if ( peek(file) == int('-') && isdigit(peek(file,1)) ||
 			      peek(file) == int('+') && isdigit(peek(file,1)) ||

--- a/M2/Macaulay2/m2/basictests/bigreal.m2
+++ b/M2/Macaulay2/m2/basictests/bigreal.m2
@@ -11,3 +11,8 @@ assert( x < y )
 assert( -x < y )
 assert( x > -y )
 assert( -x > -y )
+
+assert( 1e2  === 100. )
+assert( 1E2  === 100. )
+assert( 1e+2 === 100. )
+assert( 1E+2 === 100. )


### PR DESCRIPTION
It's standard in other languages to allow `E` and `+` when specifying exponents for floating point numbers.  For example, in Python:

```python
>>> 1e2
100.0
>>> 1E2
100.0
>>> 1e+2
100.0
>>> 1E+2
100.0
```

We introduce this syntax to Macaulay2.

### Before

```m2
i1 : 1e2

o1 = 100

o1 : RR (of precision 53)

i2 : 1E2
stdio:2:2:(3): warning: character 'E' immediately following number
stdio:2:1:(3): error: no method for adjacent objects:
--            1 (of class ZZ)
--    SPACE   E2 (of class Symbol)

i3 : 1e+2
stdio:3:3:(3): error: exponent missing in floating point constant

i3 : 1E+2
stdio:3:4:(3): warning: character 'E' immediately following number
stdio:3:3:(3): error: no method for adjacent objects:
--            1 (of class ZZ)
--    SPACE   E (of class Symbol)
```

### After

```m2
i1 : 1e2

o1 = 100

o1 : RR (of precision 53)

i2 : 1E2

o2 = 100

o2 : RR (of precision 53)

i3 : 1e+2

o3 = 100

o3 : RR (of precision 53)

i4 : 1E+2

o4 = 100

o4 : RR (of precision 53)
```