### PR TITLE
Random collection of changes

### DIFF
--- a/M2/Macaulay2/m2/chaincomplexes.m2
+++ b/M2/Macaulay2/m2/chaincomplexes.m2
@@ -877,18 +877,6 @@ minimalPresentation ChainComplexMap := prune ChainComplexMap := ChainComplexMap 
      map(minimalPresentation target f, minimalPresentation source f, k -> minimalPresentation f#k)
      )
 ----------------------------------------
-compositions = method(TypicalValue => List);
-compositions(ZZ,ZZ) := (n,k) -> (
-     compositionn := (n,k) -> (
-	  if n===0 or k < 0 then {}
-	  else if k===0 then {toList(n:0)}
-	  else join(
-	       apply(compositionn(n-1,k), s -> s | {0}),
-	       apply(compositionn(n,k-1), s -> s + (toList(n-1:0) | {1}))));
-     compositionn = memoize compositionn;
-     result := compositionn(n,k);
-     compositionn = null;
-     result);
 
 eagonNorthcott = method(TypicalValue => ChainComplex)
 eagonNorthcott Matrix := f -> (

--- a/M2/Macaulay2/m2/combinatorics.m2
+++ b/M2/Macaulay2/m2/combinatorics.m2
@@ -2,7 +2,10 @@
 
 needs "remember.m2" -- for memoize
 
-subsets(ZZ,ZZ) := List => (n,j) -> (
+-----------------------------------------------------------------------------
+
+subsets = method(TypicalValue => List)
+subsets(ZZ, ZZ) := (n, j) -> (
      if n < 0 then error "expected a nonnegative number";
      if j < 0 then return {};
      if j == 0 then return {{}};
@@ -14,24 +17,27 @@ subsets(ZZ,ZZ) := List => (n,j) -> (
      scan(j-2, i -> x = join apply(x, s -> apply(0 .. s#0 - 1, i -> prepend(i,s))));
      toList apply(x,toList))
 
-subsets(List,ZZ) := List => (s,j) -> apply(subsets(#s,j),v->apply(v,i->s#i))
-subsets(Sequence,ZZ) := List => (s,j) -> subsets(toList s,j)
-subsets(Set,ZZ) := List => (s,j) -> apply(subsets(toList s, j), set)
-subsets Set := List => x -> apply(subsets toList x, set)
-subsets List := List => x -> (
+subsets(Set,      ZZ) := (s, j) -> apply(subsets(toList s, j), set)
+subsets(List,     ZZ) := (s, j) -> apply(subsets(#s, j), v -> s_v)
+subsets(Sequence, ZZ) := (s, j) -> subsets(toList s, j)
+
+subsets ZZ   := n -> subsets toList(0 ..< n)
+subsets Set  := x -> apply(subsets toList x, set)
+subsets List := x -> (
      if #x === 0 then {x}
      else (
 	  a := x#-1;
 	  x = drop(x,-1);
 	  s := subsets x;
 	  join(s,apply(s,y->append(y,a)))))
-subsets ZZ := List => n -> (
-    if n < 0 then error "expected a nonnegative number";
-    subsets toList (0 .. n-1))
+
+-----------------------------------------------------------------------------
 
 Partition = new Type of BasicList
 Partition _ ZZ := (p,i) -> p#i
-partitions(ZZ,ZZ) := List => memoize (
+
+partitions = method(TypicalValue => List)
+partitions(ZZ, ZZ) := memoize(
      (n,k) -> (
      	  if k > n then k=n;
 	  if n < 0 then {}
@@ -41,7 +47,20 @@ partitions(ZZ,ZZ) := List => memoize (
      	  else join( 
 	       apply(partitions(n-k,k),i -> prepend(k,i)), 
 	       partitions(n,k-1))))
-partitions ZZ := List => (n) -> partitions(n,n)
+partitions ZZ := n -> partitions(n, n)
+
+compositions = method(TypicalValue => List)
+compositions(ZZ, ZZ) := memoize(
+    (n, k) -> (
+	if k  < 0
+	or n == 0 then {} else
+	if k == 0 then { toList(n:0) }
+	else join(
+	    nz1 := toList(n-1:0) | {1};
+	    apply(compositions(n - 1, k), s -> s | {0}),
+	    apply(compositions(n, k - 1), s -> s + nz1))
+    ))
+compositions ZZ := n -> compositions(n, n)
 
 conjugate Partition := Partition => (lambda) -> (
      if #lambda === 0 then new Partition from {} else (

--- a/M2/Macaulay2/m2/gb.m2
+++ b/M2/Macaulay2/m2/gb.m2
@@ -190,7 +190,8 @@ status GroebnerBasis := o -> g -> (
     )
 net      GroebnerBasis :=
 toString GroebnerBasis := g -> "GroebnerBasis[" | status g | "]"
-texMath  GroebnerBasis := g -> texMath toString g
+texMath  GroebnerBasis := texMath @@ toString
+html     GroebnerBasis := html    @@ toString
 
 
 rawsort := m -> rawSubmatrix(m, rawSortColumns(m,1,1))

--- a/M2/Macaulay2/m2/hilbert.m2
+++ b/M2/Macaulay2/m2/hilbert.m2
@@ -70,8 +70,6 @@ heft Ring           :=
 heft Monoid         := R -> if (o := options R) =!= null and o.?Heft then o.Heft
 heft PolynomialRing := R -> heft R.FlatMonoid
 heft QuotientRing   := R -> heft ambient R
--- TODO: deprecate this in favor of just "heft ring M"
-heft Module         := M -> heft ring M
 
 -----------------------------------------------------------------------------
 -- poincare

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -5,7 +5,6 @@
 
 needs "debugging.m2" -- for Descent
 needs "format.m2"
-needs "gb.m2" -- for for GroebnerBasis
 needs "packages.m2" -- for Package
 needs "system.m2" -- for getViewer
 
@@ -185,8 +184,6 @@ html Time := x -> html x#1 | html DIV ("-- ", toString x#0, " seconds")
 html Command :=
 html File :=
 html IndeterminateNumber :=
-html GroebnerBasis :=
-html Package :=
 html Boolean :=
 html Function :=
 html FilePosition :=

--- a/M2/Macaulay2/m2/loadsequence
+++ b/M2/Macaulay2/m2/loadsequence
@@ -56,7 +56,6 @@ mutablemat.m2
 localring.m2
 quotring.m2
 freealgebras.m2
-multilin.m2
 flint.m2
 modules2.m2
 hilbert.m2
@@ -67,6 +66,7 @@ ringmap.m2
 newring.m2
 basis.m2
 genmat.m2
+multilin.m2
 pushforward.m2
 ext.m2
 tor.m2

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -265,7 +265,7 @@ setupMethods := (args, symbols) -> (
 
 setupMethods((), { 
 	  entries, baseName, borel, gcdCoefficients, singularLocus,
-	  Hom, diff, diff', contract, contract', subsets, partitions, member,
+	  Hom, diff, diff', contract, contract', member,
 	  koszul, target, source,
 	  getChangeMatrix, cover, coverMap, super, terms,
 	  cokernel, coimage, comodule, image, someTerms, scanKeys, scanValues,

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -269,13 +269,13 @@ setupMethods((), {
 	  koszul, symmetricPower, trace, target, source,
 	  getChangeMatrix, cover, coverMap, super, terms,
 	  cokernel, coimage, comodule, image, someTerms, scanKeys, scanValues,
-	  substitute, rank, complete, ambient, remainder, quotientRemainder, remainder', quotientRemainder', quotient',
+	  substitute, complete, ambient, remainder, quotientRemainder, remainder', quotientRemainder', quotient',
 	  coefficients, monomials, size, sum, product, exponents, nullhomotopy, module, raw,
 	  content, leadTerm, leadCoefficient, leadMonomial, components,
-	  leadComponent, degreesRing, degrees, assign, numgens, realPart, imaginaryPart, conjugate,
+	  leadComponent, degreesRing, assign, realPart, imaginaryPart, conjugate,
 	  relations, cone, standardForm, inverse, numeric, numericInterval, floor, ceiling, round, degree, multidegree,
 	  presentation, dismiss, precision, 
-	  norm, clean, numColumns, numRows, fraction, part, coefficient, preimage,
+	  norm, clean, fraction, part, coefficient, preimage,
 	  hasEngineLinearAlgebra, nullSpace,
       isBasicMatrix, basicDet, basicInverse, basicKernel, basicRank, basicSolve, basicRankProfile
 	  })
@@ -357,10 +357,11 @@ setupMethods(TypicalValue => Boolean,
      {isBorel, isWellDefined, isInjective, isSurjective, isUnit,
 	  isSubset,isHomogeneous, isIsomorphism, isField, isConstant
 	  })
-setupMethods(TypicalValue => ZZ,
-     {binomial,degreeLength,height,char,pdim,dim,depth,width,euler,genus})
-setupMethods(TypicalValue => List,
-     {eulers, genera})
+setupMethods(TypicalValue => ZZ, {
+	binomial, char, degreeLength, depth, dim, euler, genus, height,
+	numgens, numColumns, numRows, pdim, rank, width})
+setupMethods(TypicalValue => List, {
+	degrees, eulers, genera})
 
 length = method(TypicalValue => ZZ, Dispatch => Thing)
 codim = method( Options => true )

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -266,7 +266,7 @@ setupMethods := (args, symbols) -> (
 setupMethods((), { 
 	  entries, baseName, borel, gcdCoefficients, singularLocus,
 	  Hom, diff, diff', contract, contract', subsets, partitions, member,
-	  koszul, symmetricPower, trace, target, source,
+	  koszul, target, source,
 	  getChangeMatrix, cover, coverMap, super, terms,
 	  cokernel, coimage, comodule, image, someTerms, scanKeys, scanValues,
 	  substitute, complete, ambient, remainder, quotientRemainder, remainder', quotientRemainder', quotient',
@@ -293,8 +293,6 @@ default = method()
 --     m := lookup(X,symbol default);
 --     if m === null then error "no method found";
 --     m ())
-
-determinant = method(Options => { Strategy => null })
 
 random = method(Options => {
 	  MaximalRank => false,

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -264,7 +264,7 @@ setupMethods := (args, symbols) -> (
 	  )))
 
 setupMethods((), { 
-	  entries, borel, gcdCoefficients, singularLocus,
+	  entries, baseName, borel, gcdCoefficients, singularLocus,
 	  Hom, diff, diff', contract, contract', subsets, partitions, member,
 	  koszul, symmetricPower, trace, target, source,
 	  getChangeMatrix, cover, coverMap, super, terms,
@@ -712,16 +712,6 @@ locate Sequence   := Sequence => x -> locate' x
 locate Symbol     := Sequence => x -> locate' x
 locate List       := List     => x -> apply(x, locate)
 protect symbol locate
-
--- baseName
-baseName = method()
-baseName Thing := R -> (
-     if hasAttribute(R,ReverseDictionary) then (
-	  x := getAttribute(R,ReverseDictionary);
-	  if not mutable x then error("baseName: base name ",toString x," is not mutable, hence not available for use as a variable");
-	  x)
-     else error "baseName: no base name available"
-     )
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/m2/multilin.m2
+++ b/M2/Macaulay2/m2/multilin.m2
@@ -1,18 +1,22 @@
 --		Copyright 1995-2002,2010 by Daniel R. Grayson and Michael Stillman
+-- TODO: implement better caching here
 
 needs "matrix1.m2"
+needs "basis.m2"
 
-symmetricPower(ZZ, Matrix) := Matrix => (i,m) -> map(ring m, rawSymmetricPower(i, raw m))
+-----------------------------------------------------------------------------
+-- helper for exteriorPower and minors
+-----------------------------------------------------------------------------
 
 hasNoQuotients = method()
 hasNoQuotients QuotientRing := (R) -> isField R
 hasNoQuotients PolynomialRing := (R) -> hasNoQuotients coefficientRing R
 hasNoQuotients Ring := (R) -> true
 
-getMinorsStrategy := (R,options) -> (
+getMinorsStrategy := (R, opts) -> (
      bareiss := 0;  -- WARNING: these must match the engine!!
      cofactor := 1;
-     strat := if options.?Strategy then options.Strategy else null;
+     strat := if opts.?Strategy then opts.Strategy else null;
      if strat === global Bareiss then bareiss
      else if strat === global Cofactor then cofactor
      else if strat =!= null then (
@@ -29,11 +33,17 @@ getMinorsStrategy := (R,options) -> (
      	    cofactor
      ))
 
-minors = method(Options => { Limit => infinity, First => null, Strategy => null })
-exteriorPower = method(Options => { Strategy => null })
--- def of determinant moved to methods.m2
+-----------------------------------------------------------------------------
+-- symmetricPower, exteriorPower, and wedgeProduct
+-----------------------------------------------------------------------------
 
-exteriorPower(ZZ,Module) := Module => options -> (p,M) -> (
+symmetricPower = method()
+symmetricPower(ZZ, Module) := Module => (d, M) -> coimage basis(d, symmetricAlgebra M,
+    global SourceRing => ring M, Degree => {d, degreeLength M:0})
+symmetricPower(ZZ, Matrix) := Matrix => (i, m) -> map(ring m, rawSymmetricPower(i, raw m))
+
+exteriorPower = method(Options => { Strategy => null })
+exteriorPower(ZZ, Module) := Module => opts -> (p, M) -> (
      R := ring M;
      if p < 0 then R^0
      else if p === 0 then R^1
@@ -44,28 +54,42 @@ exteriorPower(ZZ,Module) := Module => options -> (p,M) -> (
 	       m := presentation M;
 	       F := target m;
 	       G := source m;
-	       Fp1 := exteriorPower(p-1,F,options);
-	       Fp := exteriorPower(p,F,options);
+	       Fp1 := exteriorPower(p-1, F, opts);
+	       Fp := exteriorPower(p, F, opts);
 	       h1 := m ** id_Fp1;
 	       h2 := wedgeProduct(1,p-1,F);
 	       cokernel (h2*h1))))
 
-exteriorPower(ZZ, Matrix) := Matrix => options -> (p,m) -> (
+exteriorPower(ZZ, Matrix) := Matrix => opts -> (p, m) -> (
      R := ring m;
      if p < 0 then map(R^0,R^0,0)
      else if p === 0 then map(R^1,R^1,1)
      else if p === 1 then m
      else map(
-	  exteriorPower(p, target m, options),
-	  exteriorPower(p, source m, options),
-	  rawExteriorPower(p,raw m,getMinorsStrategy(R,options))))
+	exteriorPower(p, target m, opts),
+	exteriorPower(p, source m, opts),
+	rawExteriorPower(p, raw m, getMinorsStrategy(R, opts)))
+    )
 
 wedgeProduct = method()
-wedgeProduct(ZZ,ZZ,Module) := Matrix => (p,q,M) -> (
+wedgeProduct(ZZ, ZZ, Module) := Matrix => (p, q, M) -> (
      if isFreeModule M then map(ring M, rawWedgeProduct(p,q,raw M))
      else map(exteriorPower(p+q,M),exteriorPower(p,M)**exteriorPower(q,M),wedgeProduct(p,q,cover M)))
 
-minors(ZZ,Matrix) := Ideal => opts -> (j,m) -> (
+-----------------------------------------------------------------------------
+-- ideals of minors, permanents, and pfaffians
+-----------------------------------------------------------------------------
+
+-- TODO: singularLocus uses minors, but it is defined in quotring.m2
+-- TODO: Minors with prescribed rows or columns, https://github.com/Macaulay2/M2/issues/1705
+minors = method(
+    Options => {
+	Limit    => infinity,
+	First    => null,
+	Strategy => null,
+	}
+    )
+minors(ZZ, Matrix) := Ideal => opts -> (j, m) -> (
      f := opts.First;
      if not (
 	  f === null or (
@@ -81,18 +105,23 @@ minors(ZZ,Matrix) := Ideal => opts -> (j,m) -> (
 	       if f =!= null then f#1)))
 
 pfaffians = method(TypicalValue => Ideal)
-pfaffians(ZZ,Matrix) := Ideal => (j,m) -> (
+pfaffians(ZZ, Matrix) := (j, m) -> (
      ideal(map(ring m, rawPfaffians(j,raw m))))
 
 -----------------------------------------------------------------------------
+-- trace and determinant
+-----------------------------------------------------------------------------
+
+trace = method()
 trace Matrix := RingElement => f -> (
      if rank source f != rank target f
      or not isFreeModule source f
      or not isFreeModule target f
      then error "expected a square matrix";
      sum(rank source f, i -> f_(i,i)))
------------------------------------------------------------------------------
-determinant Matrix := RingElement => options -> f -> (
+
+-- declared in mutablemat.m2
+determinant Matrix := RingElement => opts -> f -> (
      if rank source f != rank target f
      or not isFreeModule source f
      or not isFreeModule target f
@@ -100,17 +129,20 @@ determinant Matrix := RingElement => options -> f -> (
      if hasEngineLinearAlgebra ring f and isBasicMatrix f and numRows f === numColumns f then
        basicDet f
      else 
-       (exteriorPower(numgens source f, f, options))_(0,0))
+       (exteriorPower(numgens source f, f, opts))_(0,0))
+
+-- TODO: permanent
+-- TODO: immanant
+
+-----------------------------------------------------------------------------
 
 fittingIdeal = method(TypicalValue => Ideal)
-fittingIdeal(ZZ,Module) := Ideal => (i,M) -> (
+fittingIdeal(ZZ, Module) := (i, M) -> (
      p := presentation M;
      n := rank target p;
      if n <= i
      then ideal 1_(ring M)
      else trim minors(n-i,p))
-
-symmetricPower(ZZ,Module) := (d,M) -> coimage basis(d,symmetricAlgebra M,global SourceRing => ring M,Degree => {d,degreeLength M:0})
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/m2/multilin.m2
+++ b/M2/Macaulay2/m2/multilin.m2
@@ -177,12 +177,15 @@ determinant Matrix := RingElement => opts -> f -> (
 -----------------------------------------------------------------------------
 
 fittingIdeal = method(TypicalValue => Ideal)
-fittingIdeal(ZZ, Module) := (i, M) -> (
-     p := presentation M;
+-- TODO: document this
+fittingIdeal(ZZ, Matrix) := (i, p) -> (
      n := rank target p;
      if n <= i
-     then ideal 1_(ring M)
+     then ideal 1_(ring p)
      else trim minors(n-i,p))
+fittingIdeal(ZZ, Module) := (i, M) -> fittingIdeal(i, presentation M)
+
+-- TODO: fittingImage of a ring map
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/m2/multilin.m2
+++ b/M2/Macaulay2/m2/multilin.m2
@@ -44,28 +44,28 @@ symmetricPower(ZZ, Matrix) := Matrix => (i, m) -> map(ring m, rawSymmetricPower(
 
 exteriorPower = method(Options => { Strategy => null })
 exteriorPower(ZZ, Module) := Module => opts -> (p, M) -> (
-     R := ring M;
-     if p < 0 then R^0
-     else if p === 0 then R^1
-     else if p === 1 then M
-     else (
-	  if isFreeModule M then new Module from (R, rawExteriorPower(p,M.RawFreeModule))
-	  else (
-	       m := presentation M;
-	       F := target m;
-	       G := source m;
-	       Fp1 := exteriorPower(p-1, F, opts);
-	       Fp := exteriorPower(p, F, opts);
-	       h1 := m ** id_Fp1;
-	       h2 := wedgeProduct(1,p-1,F);
-	       cokernel (h2*h1))))
+    if M.cache#?(exteriorPower, p) then M.cache#(exteriorPower, p) else M.cache#(exteriorPower, p) = (
+	R := ring M;
+	if p   < 0 then R^0 else
+	if p === 0 then R^1 else
+	if p === 1 then M   else
+	if isFreeModule M   then new Module from (R, rawExteriorPower(p, M.RawFreeModule))
+	else (
+	    m := presentation M;
+	    F := target m;
+	    Fp1 := exteriorPower(p-1, F, opts);
+	    h1 := m ** id_Fp1;
+	    h2 := wedgeProduct(1,p-1,F);
+	    cokernel(h2 * h1))
+    ))
 
 exteriorPower(ZZ, Matrix) := Matrix => opts -> (p, m) -> (
-     R := ring m;
-     if p < 0 then map(R^0,R^0,0)
-     else if p === 0 then map(R^1,R^1,1)
-     else if p === 1 then m
-     else map(
+    R := ring m;
+    if p   < 0 then id_(R^0) else
+    if p === 0 then id_(R^1) else
+    if p === 1 then m
+    -- TODO: should this be cached, too?
+    else map(
 	exteriorPower(p, target m, opts),
 	exteriorPower(p, source m, opts),
 	rawExteriorPower(p, raw m, getMinorsStrategy(R, opts)))

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -303,6 +303,7 @@ rank MutableMatrix := (M) -> (
       rank matrix M
     )
 
+determinant = method(Options => { Strategy => null })
 determinant MutableMatrix := opts -> (M) -> (
     if numRows M =!= numColumns M then error "expected a square matrix";
     if isField ring M then

--- a/M2/Macaulay2/m2/newring.m2
+++ b/M2/Macaulay2/m2/newring.m2
@@ -112,36 +112,6 @@ graphIdeal RingMap := Ideal => opts -> (cacheValue (symbol graphIdeal => opts)) 
 
 graphRing RingMap := QuotientRing => opts -> (f) -> ( I := graphIdeal(f,opts); (ring I)/I )
 
------------------------
--- Symmetric Algebra --
------------------------
-
-rep := (meth,opts,args) -> prepend_opts nonnull apply(args, arg -> 
-     if instance(arg,Option) and #arg == 2 and instance(arg#1,Function) then (
-	  if (options meth)#(arg#0) === opts#(arg#0)
-     	  then arg#0 => arg#1()
-	  )
-     else arg)
-
-symmetricAlgebra = method( Options => monoidDefaults )
-symmetricAlgebra Module := Ring => opts -> (cacheValue (symmetricAlgebra => opts)) (M -> (
-	  k := ring M;
-	  N := monoid rep(symmetricAlgebra, opts, [Join => false, Variables => () -> numgens M, Degrees => () -> degrees M / prepend_1]);
-	  S := k N;
-	  S  = S / ideal(vars S * promote(presentation M,S));
-	  S.Module = M;
-	  S))
-symmetricAlgebra(Ring,Ring,Matrix) := RingMap => opts -> (T,S,f) -> (
-     key := (T,S,f) ;
-     if f.cache#?key then f.cache#key else f.cache#key = (
-     	  p := map(T,S,vars T * promote(cover f, T));
-	  if f.cache.?inverse then p.cache.inverse = map(S,T,vars S * promote(cover inverse f, S));
-	  p))
-symmetricAlgebra Matrix := RingMap => opts -> f -> symmetricAlgebra(symmetricAlgebra target f,symmetricAlgebra source f,f)
-symmetricAlgebra(Ring,Nothing,Matrix) := RingMap => opts -> (T,S,f) -> symmetricAlgebra(T,symmetricAlgebra source f,f)
-symmetricAlgebra(Nothing,Ring,Matrix) := RingMap => opts -> (T,S,f) -> symmetricAlgebra(symmetricAlgebra target f,S,f)
-symmetricAlgebra(Nothing,Nothing,Matrix) := RingMap => opts -> (T,S,f) -> symmetricAlgebra f
-
 -----------------------------------------------------------------------------
 -- flattenRing
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/orderedmonoidrings.m2
+++ b/M2/Macaulay2/m2/orderedmonoidrings.m2
@@ -14,8 +14,6 @@ use Monoid := x -> ( if x.?use then x.use x; x)
 
 options Monoid := x -> null
 
-baseName Symbol := identity
-
 OrderedMonoid = new Type of Monoid
 OrderedMonoid.synonym = "ordered monoid"
 degreeLength OrderedMonoid := M -> M.degreeLength

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -111,6 +111,7 @@ Package.GlobalReleaseHook = globalReleaseFunction
 
 net      Package :=
 toString Package := pkg -> if pkg#?"pkgname" then pkg#"pkgname" else "-*package*-"
+html     Package := pkg -> html    toString pkg
 texMath  Package := pkg -> texMath toString pkg
 options  Package := pkg -> pkg.Options
 methods  Package := memoize(pkg -> select(methods(), m -> package m === pkg))

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -268,7 +268,8 @@ newPackage String := opts -> pkgname -> (
 	if opts.Reload === null then warningMessage("package ", pkgname, " being reloaded")
 	else if opts.Reload === false then error("package ", pkgname, " not reloaded; try Reload => true"));
     -- load dependencies
-    scan(opts.PackageExports, needsPackage);
+    -- TODO: why is this called again later?
+    scan(nonnull opts.PackageExports, needsPackage);
     dismiss pkgname;
     -- the exit hook calls endPackage at the end of the file
     local hook;
@@ -381,8 +382,8 @@ newPackage String := opts -> pkgname -> (
     setAttribute(newpkg.Dictionary,           PrintNames, pkgname | ".Dictionary");
     setAttribute(newpkg#"private dictionary", PrintNames, pkgname | "#\"private dictionary\"");
     debuggingMode = opts.DebuggingMode;		    -- last step before turning control back to code of package
-    scan(opts.PackageImports, needsPackage);
-    scan(opts.PackageExports, needsPackage);
+    scan(nonnull opts.PackageImports, needsPackage);
+    scan(nonnull opts.PackageExports, needsPackage);
     newpkg.loadDepth = loadDepth;
     loadDepth = if pkgname === "Core" then 1 else if not debuggingMode then 2 else 3;
     newpkg)
@@ -399,7 +400,7 @@ export List   := v -> (
     d  := currentPackage.Dictionary;
     title := currentPackage#"pkgname";
     syms := new MutableHashTable;
-    scan(v, sym -> (
+    scan(nonnull v, sym -> (
 	    local nam;
 	    -- a synonym, e.g. "res" => "resolution"
 	    if instance(sym, Option) then (
@@ -535,7 +536,7 @@ package Dictionary := d -> (
 
 -- TODO: should this reset the values of exported mutable symbols?
 use Package := pkg -> (
-    scan(pkg.Options.PackageExports, needsPackage);
+    scan(nonnull pkg.Options.PackageExports, needsPackage);
     loadedPackages = prepend(pkg,            delete(pkg,            loadedPackages));
     dictionaryPath = prepend(pkg.Dictionary, delete(pkg.Dictionary, dictionaryPath));
     checkShadow();

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -428,9 +428,11 @@ exportMutable = method(Dispatch => Thing)
 exportMutable String := x -> exportMutable {x}
 exportMutable List   := v -> currentPackage#"exported mutable symbols" = join_(currentPackage#"exported mutable symbols") (export v)
 
+symbolFrom = (pkgname, name) -> value (getpkg pkgname)#"private dictionary"#name
+
 importFrom = method()
 importFrom(String,  List) := (P, x) -> importFrom(getpkg P, x)
-importFrom(Package, List) := (P, x) -> apply(nonnull x, s -> currentPackage#"private dictionary"#s = P#"private dictionary"#s)
+importFrom(Package, List) := (P, x) -> apply(nonnull x, s -> if not currentPackage#"private dictionary"#?s then currentPackage#"private dictionary"#s = P#"private dictionary"#s)
 
 exportFrom = method()
 exportFrom(Package, List) := (P, x) -> export \\ toString \ importFrom(P, x)

--- a/M2/Macaulay2/m2/variables.m2
+++ b/M2/Macaulay2/m2/variables.m2
@@ -70,6 +70,13 @@ installMethod(symbol <-, Sequence, (x,y) -> (
 IndexedVariable .. IndexedVariable := Sequence => (v,w) -> apply(toSequence v .. toSequence w, xi -> new IndexedVariable from xi)
 IndexedVariable ..< IndexedVariable := Sequence => (v,w) -> apply(toSequence v ..< toSequence w, xi -> new IndexedVariable from xi)
 
+-- baseName
+baseName Thing := R -> (
+    if not hasAttribute(R, ReverseDictionary) then error "baseName: no base name available";
+    x := getAttribute(R, ReverseDictionary);
+    if mutable x then x else error("baseName: base name ", toString x,
+	" is not mutable, hence not available for use as a variable"))
+baseName Symbol :=
 baseName IndexedVariable := identity
 baseName IndexedVariableTable := x -> if x#?symbol$ then x#symbol$ else error "indexed variable table not associated to a symbol"
 baseName Subscript := x -> new IndexedVariable from { baseName x#0 , x#1 }

--- a/M2/Macaulay2/packages/LinearTruncations.m2
+++ b/M2/Macaulay2/packages/LinearTruncations.m2
@@ -82,7 +82,7 @@ irrelevantIdeal Ring := S -> (
     )
 
 exponent = method()
---Redundant with unexported function dimVector in VirtualResolutions
+--redundant with unexported function dimVector in VirtualResolutions
 exponent Ring := S -> (
     alldegs := degrees S;
     degs := unique alldegs;
@@ -320,7 +320,10 @@ isQuasiLinear ChainComplex := opts -> F -> isQuasiLinear(betti F, opts)
 
 supportOfTor = method()
 supportOfTor ChainComplex := F -> (
-    for i from min F to max F-1 list unique degrees F_i
+    for i from min F to max F list (
+	degs := unique degrees F_i;
+	if degs == {} then continue else degs
+	)
     )
 supportOfTor Module := M -> supportOfTor res prune M
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/heft-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/heft-doc.m2
@@ -2,9 +2,6 @@
 --- author(s): 
 --- notes: heft is defined in hilbert.m2
 
--- This is to be deprecated
-undocumented (heft, Module)
-
 doc ///
 Node
   Key

--- a/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
@@ -126,6 +126,12 @@ cotangentSheaf NormalToricVariety := CoherentSheaf => opts -> (
 cotangentSheaf(ZZ,NormalToricVariety) := CoherentSheaf => opts -> (i,X) -> 
   exteriorPower (i, cotangentSheaf (X,opts)) 
 
+cotangentSheaf(List, NormalToricVariety) := CoherentSheaf => opts -> (a, X) -> (
+    assert(#a == #(Xs := components X));
+    if X#?(cotangentSheaf, a)
+    then X#(cotangentSheaf, a)
+    else X#(cotangentSheaf, a) = tensor apply(#a, i -> pullback(X^[i], cotangentSheaf(a#i, Xs#i))))
+
 
 -- THIS FUNCTION IS NOT EXPORTED.  Given a normal toric variety, this function
 -- creates a HashTable describing the cohomology of all twists of the

--- a/M2/Macaulay2/packages/NormalToricVarieties/SheavesDocumentation.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/SheavesDocumentation.m2
@@ -339,6 +339,7 @@ doc ///
     Key 
         (cotangentSheaf, NormalToricVariety)
 	(cotangentSheaf, ZZ, NormalToricVariety)
+	(cotangentSheaf, List, NormalToricVariety)
     Headline
         make the sheaf of Zariski 1-forms
     Usage 

--- a/M2/Macaulay2/tests/normal/000-core.m2
+++ b/M2/Macaulay2/tests/normal/000-core.m2
@@ -741,12 +741,6 @@ annihilator E
 
 
 --
-    R = ZZ/101[s,t]
-    J = image matrix {{s^4, s^3*t, s*t^3, t^4}}
-    S = symmetricAlgebra J  -- MES: make an assertion here...
-
-
---
 R = ZZ/101[a,b,c,d]
 f = matrix {{c^3-b*d^2, b*c-a*d, b^3-a^2*c, a*c^2-b^2*d}}
 M = cokernel f

--- a/M2/Macaulay2/tests/normal/000-core.m2
+++ b/M2/Macaulay2/tests/normal/000-core.m2
@@ -152,15 +152,6 @@ clearAll
 
 
 --
-R = ZZ/101[a..d]
-I = monomialCurveIdeal(R,{1,3,4})
-A = R/I
-jacobian A
-singA = minors(codim ideal presentation A, jacobian A)
-generators gb singA
-
-
---
 R=ZZ/101[a..d]
 f = matrix {{a}}
 assert( isHomogeneous f )
@@ -196,40 +187,6 @@ assert isSurjective R^2_{0,0,1}
 assert not isSurjective R^2_{1}
 
 
---
-    R = ZZ[x,y,z]
-    modules = {
-	 image matrix {{x^2,x,y}},
-	 coker matrix {{x^2,y^2,0},{0,y,z}},
-	 R^{-1,-2,-3},
-	 image matrix {{x,y}} ++ coker matrix {{y,z}}
-	 }
-    scan(modules, M -> assert( cover exteriorPower(2,M) == exteriorPower(2,cover M) ))
-
---
-R = ZZ/101[x];
-k = coker vars R;
-M = R^3 ++ k^5;
-assert( fittingIdeal(0,M) == ideal 0_R )
-assert( fittingIdeal(1,M) == ideal 0_R )
-assert( fittingIdeal(2,M) == ideal 0_R )
-assert( fittingIdeal(3,M) == ideal x^5 )
-assert( fittingIdeal(4,M) == ideal x^4 )
-assert( fittingIdeal(5,M) == ideal x^3 )
-assert( fittingIdeal(6,M) == ideal x^2 )
-assert( fittingIdeal(7,M) == ideal x )
-assert( fittingIdeal(8,M) == ideal 1_R )
-assert( fittingIdeal(9,M) == ideal 1_R )
-
---
-    R = ZZ[x,y,z]
-    modules = {
-	 image matrix {{x^2,x,y}},
-	 coker matrix {{x^2,y^2,0},{0,y,z}},
-	 R^{-1,-2,-3},
-	 image matrix {{x,y}} ++ coker matrix {{y,z}}
-	 }
-    table(modules, modules, (P,Q) -> assert(cover P ** cover Q == cover (P ** Q)));
 
 --
 scan(3, n -> scan(-3 .. 3, d -> (
@@ -241,10 +198,6 @@ r = ZZ/101[a,b]
 assert ( 2 * degree (a * b^2) === {6} )
 M = cokernel matrix (r,{{1}})
 assert ( isFreeModule prune M )
-
---
-GF(8,Variable => x)
-assert ( det matrix{{x,1},{x^2,x^3}} == x^4 - x^2 )
 
 --
 clearAll
@@ -709,49 +662,6 @@ assert(size promote(f,S) == 4)
 
 --
 clearAll
-R = ZZ/101
-exteriorPower(3,R^5)
-R = ZZ/101[a..d]
-I = monomialCurveIdeal(R,{1,3,4})
-M = Ext^2(coker generators I, R)
-prune exteriorPower(3,M)
-exteriorPower(0,R^3)
-exteriorPower(0,M)
-prune exteriorPower(1,M)
-exteriorPower(2,M)
-exteriorPower(-1,M)
-exteriorPower(-2,M)
-
-M = subquotient(matrix{{a,b,c}}, matrix{{a^2,b^2,c^2,d^2}})
-N = subquotient(matrix{{a^2,b^2,c^2}}, matrix{{a^3,b^3,c^3,d^3}})
-m = map(N,M,matrix(R,{{1,0,0},{0,1,0},{0,0,1}}))
-source m
-target m
-trim ker m
-M1 = coker presentation M
-N1 = coker presentation N
-m1 = map(N1,M1,matrix m)
-M2 = trim exteriorPower(2,M)
-N2 = trim exteriorPower(2,N)
-
-
---
-R = ZZ/101[a .. i]
-m = genericMatrix(R,a,3,3)
-assert( exteriorPower(1,m) == m )
-assert( minors(1,m) == image vars R )
-assert( exteriorPower(2,m*m) == exteriorPower(2,m)*exteriorPower(2,m) )
-assert(
-     exteriorPower(2,m)
-     ==
-     matrix {
-	  {-b*d+a*e, -b*g+a*h, -e*g+d*h},
-	  {-c*d+a*f, -c*g+a*i, -f*g+d*i},
-	  {-c*e+b*f, -c*h+b*i, -f*h+e*i}} )
-assert( exteriorPower(3,m) == matrix {{-c*e*g+b*f*g+c*d*h-a*f*h-b*d*i+a*e*i}} )
-
-
---
 k = ZZ/101
 f = random(k^3,k^9)
 R = k[a,b,c]
@@ -1249,17 +1159,6 @@ assert ( rank HH_2 C == 1 )
 
 
 --
-    R = QQ[x,y,z]
-    modules = {
-	 image matrix {{x^2,x,y}},
-	 coker matrix {{x^2,y^2,0},{0,y,z}},
-	 R^{-1,-2,-3},
-	 image matrix {{x,y}} ++ coker matrix {{y,z}}
-	 }
-    scan(modules, M -> assert( cover cokernel M_{1} ==  cover M ) )
-
-
---
   R = ZZ[x]
   M = image map(R^2,,{{2},{0}})
   f = coverMap M
@@ -1383,19 +1282,6 @@ F 3
 	  lift(oo,QQ)
 
 
-
-
---
-    R = ZZ[x,y,z]
-    modules = {
-	 image matrix {{x^2,x,y}},
-	 coker matrix {{x^2,y^2,0},{0,y,z}},
-	 R^{-1,-2,-3},
-	 image matrix {{x,y}} ++ coker matrix {{y,z}}
-	 }
-    scan(modules, M -> assert( cover M == target presentation M ) )
-
-
 --
      assert( 3 === position({a,b,c,d,e,f},i->i===d ) )
 
@@ -1417,17 +1303,6 @@ F 3
 
 --
 clearAll
-R=ZZ/101[a..f]
-m=genericSkewMatrix(R,a,4)
-assert( pfaffians(-2,m) == ideal(0_R) )
-assert( pfaffians(0,m) == ideal(1_R) )
-assert( pfaffians(1,m) == ideal(0_R) )
-assert( pfaffians(2,m) == ideal(a,b,c,d,e,f) )
-assert( pfaffians(3,m) == ideal(0_R) )
-assert( pfaffians(4,m) == ideal(c*d-b*e+a*f) )
-
-
---
 numgens ZZ
 numgens GF(9)
 A = ZZ[a,b,c]
@@ -1851,13 +1726,3 @@ IL = substitute(I,Rlex);
 G = gb(IL, SubringLimit=>1, Hilbert=>hf, DegreeLimit=>2); -- SubringLimit now seems OK
 G = gb(IL, SubringLimit=>1, Hilbert=>hf, DegreeLimit=>4);
 assert(numgens source selectInSubring(1,gens G) == 1)
-
-
-
---
--- For more determinant tests, see Macaulay2/test/testdet.m2
-R = ZZ/103[a,b,c,d]
-h = matrix {{a,b},{c,d}}
-assert( det h == a * d - b * c )
-assert( minors(1,h) == image matrix {{a,b,c,d}} )
-assert( minors(2,h) == image matrix {{a * d - b * c}} )

--- a/M2/Macaulay2/tests/normal/multilin.m2
+++ b/M2/Macaulay2/tests/normal/multilin.m2
@@ -12,6 +12,14 @@ scan(modules, M -> assert( cover M == target presentation M ))
 table(modules, modules,
     (P, Q) -> assert( cover P ** cover Q == cover(P ** Q) ));
 
+-- see https://github.com/Macaulay2/M2/issues/2550
+(t, M) = toSequence timing symmetricPower(2, R^(splice{3:2, 16:1, 3:0}))
+assert(flatten degrees M == splice{3:-4, 16:-3, 3:-2, 2:-4, 16:-3, 3:-2, -4..-3,
+	15:-3, 19:-2, 3:-1, 15:-2, 3:-1, 14:-2, 3:-1, 13:-2, 3:-1, 12:-2, 3:-1,
+	11:-2, 3:-1, 10:-2, 3:-1, 9:-2, 3:-1, 8:-2, 3:-1, 7:-2, 3:-1, 6:-2, 3:-1,
+	5:-2, 3:-1, 4:-2, 3:-1, 3:-2, 3:-1, 2:-2, 3:-1, -2..-1, 2:-1, 6:0})
+assert(t < 1)
+
 --
 R = ZZ/101
 exteriorPower(3,R^5)

--- a/M2/Macaulay2/tests/normal/multilin.m2
+++ b/M2/Macaulay2/tests/normal/multilin.m2
@@ -1,0 +1,74 @@
+R = ZZ[x,y,z]
+modules = {
+    image matrix {{x^2,x,y}},
+    coker matrix {{x^2,y^2,0},{0,y,z}},
+    image matrix {{x,y}} ++ coker matrix {{y,z}},
+    R^{-1,-2,-3}
+    }
+
+scan(modules, M -> assert( cover exteriorPower(2, M) == exteriorPower(2, cover M) ))
+scan(modules, M -> assert( cover cokernel M_{1} == cover M ))
+scan(modules, M -> assert( cover M == target presentation M ))
+table(modules, modules,
+    (P, Q) -> assert( cover P ** cover Q == cover(P ** Q) ));
+
+--
+R = ZZ/101
+exteriorPower(3,R^5)
+R = ZZ/101[a..d]
+I = monomialCurveIdeal(R,{1,3,4})
+M = Ext^2(coker generators I, R)
+prune exteriorPower(3,M)
+exteriorPower(0,R^3)
+exteriorPower(0,M)
+prune exteriorPower(1,M)
+exteriorPower(2,M)
+exteriorPower(-1,M)
+exteriorPower(-2,M)
+
+M = subquotient(matrix{{a,b,c}}, matrix{{a^2,b^2,c^2,d^2}})
+N = subquotient(matrix{{a^2,b^2,c^2}}, matrix{{a^3,b^3,c^3,d^3}})
+m = map(N,M,matrix(R,{{1,0,0},{0,1,0},{0,0,1}}))
+source m
+target m
+trim ker m
+M1 = coker presentation M
+N1 = coker presentation N
+m1 = map(N1,M1,matrix m)
+M2 = trim exteriorPower(2,M)
+N2 = trim exteriorPower(2,N)
+
+--
+R = ZZ/101[a .. i]
+m = genericMatrix(R,a,3,3)
+assert( exteriorPower(1,m) == m )
+assert( minors(1,m) == image vars R )
+assert( exteriorPower(2,m*m) == exteriorPower(2,m)*exteriorPower(2,m) )
+assert( exteriorPower(2,m) == matrix {
+	{-b*d+a*e, -b*g+a*h, -e*g+d*h},
+	{-c*d+a*f, -c*g+a*i, -f*g+d*i},
+	{-c*e+b*f, -c*h+b*i, -f*h+e*i}} )
+assert( exteriorPower(3,m) == matrix {{-c*e*g+b*f*g+c*d*h-a*f*h-b*d*i+a*e*i}} )
+
+--
+R = ZZ/101[a..d]
+I = monomialCurveIdeal(R,{1,3,4})
+A = R/I
+jacobian A
+singA = minors(codim ideal presentation A, jacobian A)
+generators gb singA
+
+-- fitting ideal
+R = ZZ/101[x];
+k = coker vars R;
+M = R^3 ++ k^5;
+assert( fittingIdeal(0,M) == ideal 0_R )
+assert( fittingIdeal(1,M) == ideal 0_R )
+assert( fittingIdeal(2,M) == ideal 0_R )
+assert( fittingIdeal(3,M) == ideal x^5 )
+assert( fittingIdeal(4,M) == ideal x^4 )
+assert( fittingIdeal(5,M) == ideal x^3 )
+assert( fittingIdeal(6,M) == ideal x^2 )
+assert( fittingIdeal(7,M) == ideal x )
+assert( fittingIdeal(8,M) == ideal 1_R )
+assert( fittingIdeal(9,M) == ideal 1_R )

--- a/M2/Macaulay2/tests/normal/pfaffians.m2
+++ b/M2/Macaulay2/tests/normal/pfaffians.m2
@@ -1,3 +1,13 @@
+R = ZZ/101[a..f]
+m = genericSkewMatrix(R,a,4)
+assert( pfaffians(-2,m) == ideal(0_R) )
+assert( pfaffians(0,m) == ideal(1_R) )
+assert( pfaffians(1,m) == ideal(0_R) )
+assert( pfaffians(2,m) == ideal(a,b,c,d,e,f) )
+assert( pfaffians(3,m) == ideal(0_R) )
+assert( pfaffians(4,m) == ideal(c*d-b*e+a*f) )
+
+
 R = QQ[vars(0..9)]
 M = genericSkewMatrix(R,5)
 

--- a/M2/Macaulay2/tests/normal/symmetricAlgebra.m2
+++ b/M2/Macaulay2/tests/normal/symmetricAlgebra.m2
@@ -8,3 +8,11 @@ g = map(dual source f, M, transpose vars R)
 assert( source g === target f )
 assert( source symmetricAlgebra g === target symmetricAlgebra f )
 assert( symmetricAlgebra g * symmetricAlgebra f === symmetricAlgebra (g*f) )
+
+--
+R = ZZ/101[s,t]
+J = image matrix {{s^4, s^3*t, s*t^3, t^4}}
+S = symmetricAlgebra J
+assert( (ideal S)_* == {-t*p_0+s*p_1, -t*p_2+s*p_3, -t^2*p_1+s^2*p_2} )
+S = symmetricAlgebra(J, Variables => vars(0..3))
+assert( (ideal S)_* == {-t*a+s*b, -t*c+s*d, -t^2*b+s^2*c} )

--- a/M2/Macaulay2/tests/normal/testdet.m2
+++ b/M2/Macaulay2/tests/normal/testdet.m2
@@ -19,6 +19,7 @@ testsame2 = (p,m) -> (
 
 R = ZZ/101[a..d]
 m = matrix{{a,b},{c,d}}
+assert(det m == a*d - b*c)
 assert(minors(2,m) == ideal(a*d-b*c))
 assert(minors(1,m) == ideal(a,b,c,d))
 assert(minors(0,m) == ideal(1_R))
@@ -60,6 +61,10 @@ testsame1(1,m1)
 testsame1(2,m1)
 testsame1(3,m1)
 testsame1(4,m1)
+
+F = GF(8, Variable => x)
+m = matrix{{x,1},{x^2,x^3}}
+assert ( det m == x^4 - x^2 )
 
 R = QQ
 m = random(QQ^8,QQ^8)

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -6,6 +6,9 @@
 ## - test all:  cmake --build . --target check-components check-components-slow (very slow)
 ## - clean all: cmake --build . --target clean-stamps
 
+## Set the timestamp of the extracted content to the time of extraction
+cmake_policy(SET CMP0135 NEW)
+
 include(ExternalProject) # configure, patch, build, install, or test at build time
 set(M2_SOURCE_URL https://faculty.math.illinois.edu/Macaulay2/Downloads/OtherSourceCode)
 


### PR DESCRIPTION
List of commits in chronological order:

- updated emacs submodule hash
- set policy for CMake versions >= 3.24
- simplified printing methods for GroebnerBasis and Package
- added typical value to a few methods
- moved baseName to variables.m2
- deprecated heft Module
- permit a trailing comma in newPackage and export
- fixed bug in importFrom
- reorganized multilin.m2
- moved tests concerning multilin.m2
- cached exteriorPower(ZZ, Module)
- moved symmetricAlgebra and fixed #2550
- added fittingIdeal of Module
- moved and memoized compositions, allow trivial subsets
- LinearTruncations patch
- add cotangentSheaf(List, NormalToricVariety)