### PR TITLE
Add JSON package

### DIFF
--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -245,3 +245,4 @@ Probability
 Isomorphism
 CodingTheory
 WhitneyStratifications
+JSON

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -1,13 +1,15 @@
 newPackage(
     "JSON",
     Headline => "JSON encoding and decoding",
+    Version => "0.1",
+    Date => "August 31, 2022",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
+    Keywords => {"System"},
     PackageImports => {"Parsing"},
-    AuxiliaryFiles => true,
-    Version => "0.1")
+    AuxiliaryFiles => true)
 
 export {
     "toJSON",

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -5,7 +5,7 @@ newPackage(
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
-    PackageExports => {"Parsing"},
+    PackageImports => {"Parsing"},
     AuxiliaryFiles => true,
     Version => "0.1")
 
@@ -16,6 +16,8 @@ export {
     "NameSeparator",
     "ValueSeparator"
     }
+
+exportFrom_Parsing {"nil"}
 
 ----------------------------------------------------------------
 -- parser based on https://datatracker.ietf.org/doc/html/rfc8259

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -1,0 +1,345 @@
+newPackage(
+    "JSON",
+    Headline => "JSON encoding and decoding",
+    Authors => {{
+	    Name => "Doug Torrance",
+	    Email => "dtorrance@piedmont.edu",
+	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
+    PackageExports => {"Parsing"},
+    AuxiliaryFiles => true,
+    Version => "0.1")
+
+export {
+    "toJSON",
+    "fromJSON",
+    "Indent",
+    "NameSeparator",
+    "ValueSeparator"
+    }
+
+----------------------------------------------------------------
+-- parser based on https://datatracker.ietf.org/doc/html/rfc8259
+----------------------------------------------------------------
+
+-- whitespace
+wsP   = *orP(" ", "\t", "\n", "\r")
+strip = p -> first % (p @ wsP)
+
+-- structural characters
+beginArrayP     = strip "["
+beginObjectP    = strip "{"
+endArrayP       = strip "]"
+endObjectP      = strip "}"
+nameSeparatorP  = strip ":"
+valueSeparatorP = strip ","
+
+-- literals
+falseP = (x -> false) % constParser "false"
+nullP  = (x -> nil)   % constParser "null" -- using null would break parsing
+trueP  = (x -> true)  % constParser "true"
+
+-- numbers
+digit19P = orP("1", "2", "3", "4", "5", "6", "7", "8", "9")
+digitP   = "0" | digit19P
+expP     = andP(orP("e", "E"), optP(orP("-", "+")), +digitP)
+fracP    = andP(".", +digitP)
+intP     = orP("0", digit19P @ *digitP)
+numberP  = (x -> value concatenate delete(nil, deepSplice x)
+    ) % andP(optP("-"), intP, optP(fracP), optP(expP))
+
+-- strings
+hexDigitP = digitP | orP("a", "b", "c", "d", "e", "f",
+    "A", "B", "C", "D", "E", "F");
+unescapedP = Parser(c -> if c === null then null else (
+	x := first utf8 c;
+	if x < 0x20 or x == 0x22 or x == 0x5c or x > 0x10ffff
+	then null
+	else terminalParser c))
+charP = unescapedP | ("\\" @
+    orP("\"", "\\", "/", "b", "f", "n", "r", "t",
+	andP("u", hexDigitP, hexDigitP, hexDigitP, hexDigitP)))
+stringP = ((l, x, r) -> concatenate x) % andP("\"", *charP, "\"")
+
+-- objects
+memberP = ((k, gets, v) -> k => v) % andP(
+    stringP, nameSeparatorP, futureParser valueP)
+objectP = ((l, x, r) ->  hashTable (
+	if x === nil then {}
+	else toList deepSplice x)) % andP(
+    beginObjectP,
+    optP(memberP @ * (last % valueSeparatorP @ memberP)),
+    endObjectP)
+
+-- arrays
+arrayP = ((l, x, r) -> (
+	if x === nil then {}
+	else toList deepSplice x)) % andP(
+    beginArrayP,
+    optP(futureParser valueP @
+	*(last % valueSeparatorP @ futureParser valueP)),
+    endArrayP)
+
+-- values
+valueP = strip orP(falseP, nullP, trueP, objectP, arrayP, numberP, stringP)
+jsonTextP = (last @@ last) % (*wsP @ valueP)
+
+utf8Analyzer = Analyzer(s -> (
+	if not instance(s, String) then error "analyzer expected a string";
+	chars := characters s;
+	i := 0;
+	() -> if chars#?i then (
+	    r := (i, chars#i);
+	    i = i + 1;
+	    r)))
+
+fromJSON = method()
+fromJSON String := jsonTextP : utf8Analyzer
+fromJSON File   := fromJSON @@ get
+
+--------------
+-- encoding --
+--------------
+
+JSONEncoder = new SelfInitializingType of MutableHashTable
+
+protect IndentLevel
+
+jsonEncoder = method()
+jsonEncoder OptionTable := o -> (
+    e := JSONEncoder o;
+    e.IndentLevel = 0;
+    if e.ValueSeparator === null then e.ValueSeparator = (
+	if e.Indent === null then ", " else ",");
+    e)
+
+toJSON = method(Options => {
+	Indent         => null,
+	NameSeparator  => ": ",
+	ValueSeparator => null,
+	Sort           => false
+	})
+
+toJSON Thing := o -> x -> toJSON(jsonEncoder o, x)
+
+toJSON(JSONEncoder, String)  := o -> (e, x) -> format x
+toJSON(JSONEncoder, RR)      := o -> (e, x) -> format(0, x)
+toJSON(JSONEncoder, ZZ)      :=
+toJSON(JSONEncoder, Boolean) :=
+toJSON(JSONEncoder, Nothing) := o -> (e, x) -> toString x
+toJSON(JSONEncoder, QQ)       :=
+toJSON(JSONEncoder, Constant) :=  o -> (e, x) -> toJSON(e, numeric x)
+toJSON(JSONEncoder, Symbol) := o -> (e, x) -> (
+    if x === nil then "null" else error("unknown symbol"))
+
+maybeNewline = method()
+maybeNewline JSONEncoder := e -> if e.Indent === null then "" else newline
+
+indent = method()
+indent JSONEncoder := e -> (
+    if e.Indent === null then ""
+    else if instance(e.Indent, ZZ) then concatenate(e.IndentLevel * e.Indent)
+    else if instance(e.Indent, String) then concatenate(
+	e.IndentLevel : e.Indent)
+    else error("expected indent level to be null, an integer, or a string"))
+
+incIndentLevel = method()
+incIndentLevel JSONEncoder := e -> e.IndentLevel = e.IndentLevel + 1
+
+decIndentLevel = method()
+decIndentLevel JSONEncoder := e -> e.IndentLevel = e.IndentLevel - 1
+
+toJSON(JSONEncoder, VisibleList):= o -> (e, L) -> (
+    concatenate("[",
+	maybeNewline e,
+	(incIndentLevel e; indent e),
+	demark(e.ValueSeparator | maybeNewline e | indent e,
+	    apply(L, x -> toJSON(e, x))),
+	maybeNewline e,
+	(decIndentLevel e; indent e),
+	"]"))
+
+toJSON(JSONEncoder, HashTable) := o -> (e, H) -> (
+    concatenate("{",
+	maybeNewline e,
+	(incIndentLevel e; indent e),
+	demark(e.ValueSeparator | maybeNewline e | indent e,
+	    (if e.Sort then sort else identity) apply(keys H, k -> concatenate(
+		    toJSON(e, toString k),
+		    e.NameSeparator,
+		    toJSON(e, H#k)))),
+	maybeNewline e,
+	(decIndentLevel e; indent e),
+	"}"))
+
+beginDocumentation()
+
+doc ///
+  Key
+    JSON
+  Headline
+    JSON encoding and decoding
+  Description
+    Text
+      @HREF{"https://www.json.org/", "JSON"}@ (JavaScript Object Notation)
+      is a common data interchange format.  This package provides two methods,
+      @TO toJSON@ and @TO fromJSON@, for converting Macaulay2 things to
+      valid JSON data and vice versa.
+    Example
+      toJSON {hashTable{"foo" => "bar"}, 1, 3.14159, true, false, nil}
+      fromJSON oo
+///
+
+doc ///
+  Key
+    toJSON
+    (toJSON,Thing)
+    [toJSON,Indent]
+    [toJSON,ValueSeparator]
+    [toJSON,NameSeparator]
+    [toJSON,Sort]
+    Indent
+    ValueSeparator
+    NameSeparator
+  Headline
+    encode Macaulay2 things as JSON data
+  Usage
+    toJSON x
+  Inputs
+    x:Thing
+    Indent => {Nothing, ZZ, String} -- how much to indent
+    ValueSeparator => {Nothing, String} -- the string between values
+    NameSeparator => String -- the string after names in object members
+    Sort => Boolean -- whether to sort object members
+  Outputs
+    :String -- containing JSON data
+  Description
+    Text
+      This method returns a string containing JSON data corresponding to the
+      given Macaulay2 thing.  If the @TT "Indent"@ option is @TT "null"@
+      (the default), then there are no newlines or indentation.
+    Example
+      x = hashTable {"foo" => {1, 2, {pi, true, false, nil}}}
+      toJSON x
+    Text
+      If the @TT "Indent"@ option is an integer, then newlines are added between
+      values of arrays and members of lists and the given integer determines the
+      number of spaces to indent for each level of indentation.
+    Example
+      toJSON(x, Indent => 2)
+    Text
+      Alternatively, the @TT "Indent"@ option can be a string corresponding to
+      the indentation used for each level.
+    Example
+      toJSON(x, Indent => "\t")
+    Text
+      The @TT "ValueSeparator"@ option determines the string to use between
+      values in an array and members in an object.  If it is @TT "null"@ (the
+      default), then the string will either be @TT "\", \""@ or @TT "\",\""@,
+      depending on whether @TT "Indent"@ is @TT "null"@ or not, respectively.
+      Otherwise, the given string is used.
+    Example
+      toJSON(x, ValueSeparator => " , ")
+    Text
+      The @TT "NameSeparator"@ option determines the string to use after
+      the name of an object member.  By default, it is @TT "\": \""@.
+    Example
+      toJSON(x, NameSeparator => " : ")
+    Text
+      By default, the members of objects are given in arbitrary order.  To
+      sort them by name in lexicographic order as strings, use the @TT "Sort"@
+      option.
+    Example
+      toJSON(hashTable{"foo" => 1, "bar" => 2, "baz" => 3}, Sort => true)
+///
+
+doc ///
+  Key
+    fromJSON
+    (fromJSON, String)
+    (fromJSON, File)
+  Headline
+    decode JSON data into Macaulay2 things
+  Usage
+    fromJSON s
+  Inputs
+    s:{String,File}
+  Outputs
+    :Thing -- the Macaulay2 equivalent of the given data
+  Description
+    Text
+      The JSON data provided in the given string or file is parsed using the
+      @TO "Parsing"@ package with the context-free grammar specified by
+      @HREF{"https://datatracker.ietf.org/doc/html/rfc8259", "RFC 8259"}@.
+      The type of the return value will vary depending on the data.
+
+      Numbers will result in @TT "ZZ"@ or @TT "RR"@ objects, as appropriate.
+    Example
+      fromJSON "2"
+      fromJSON "2.71828"
+    Text
+      Strings will result in strings.
+    Example
+      fromJSON "\"Hello, world!\""
+    Text
+      JSON's @TT "true"@ and @TT "false"@ will result in the corresponding
+      Macaulay2 booleans.
+    Example
+      fromJSON "true"
+      fromJSON "false"
+    Text
+      Due to the implementation of the @TT "Parsing"@ package, @TO "null"@
+      cannot be a return value, and so the symbol @TO "nil"@ is returned
+      when JSON's @TT "null"@ is given.
+    Example
+      fromJSON "null"
+    Text
+      Objects will result in hash tables.
+    Example
+      fromJSON "{\"foo\": 1, \"bar\": 2}"
+    Text
+      Arrays will result in lists.
+    Example
+      fromJSON "[1, 2, 3]"
+    Text
+      The input may also be a file containing JSON data.
+    Example
+      jsonFile = temporaryFileName() | ".json"
+      jsonFile << "[1, 2, 3]" << endl << close
+      fromJSON openIn jsonFile
+///
+
+-- generate parsing test file
+///
+tmpdir = temporaryFileName()
+makeDirectory tmpdir
+run("cd " | tmpdir |" && git clone https://github.com/nst/JSONTestSuite")
+testdir = tmpdir | "/JSONTestSuite/test_parsing"
+tsts = select(readDirectory(testdir), f ->
+    match("\\.json$", f))
+
+needsPackage "Parsing" -- for nil
+debug Core -- for commentize
+
+outdir = (needsPackage "JSON")#"source directory" | "JSON"
+makeDirectory outdir
+
+copyrightBanner = "tests from JSON Parsing Test Suite
+Copyright 2016 Nicolas Seriot
+MIT License
+https://github.com/nst/JSONTestSuite"
+
+outfile = openOut(outdir | "/test-parse.m2")
+outfile << commentize  copyrightBanner << endl
+for tst in sort select(tsts, f -> match("^y_", f)) do (
+    outfile << endl << commentize tst << endl;
+    json = get(testdir | "/" | tst);
+    outfile << "assert BinaryOperation(symbol ===, fromJSON " <<
+    format json << ", " << toExternalString fromJSON json << ")" << endl)
+close outfile
+///
+
+TEST(currentPackage#"source directory" | "JSON/test-parse.m2",
+    FileName => true)
+
+TEST(currentPackage#"source directory" | "JSON/test-encode.m2",
+    FileName => true)

--- a/M2/Macaulay2/packages/JSON/test-encode.m2
+++ b/M2/Macaulay2/packages/JSON/test-encode.m2
@@ -1,0 +1,56 @@
+-- numbers
+assert Equation(toJSON 1, "1")
+assert Equation(toJSON 3.14159, "3.14159")
+assert Equation(toJSON pi, "3.14159265358979")
+assert Equation(toJSON(1/2), ".5")
+
+-- strings
+assert Equation(toJSON "Hello, world!", "\"Hello, world!\"")
+assert Equation(toJSON "¡pʃɹoʍ 'oʃʃǝH", "\"¡pʃɹoʍ 'oʃʃǝH\"")
+
+-- true/false/null
+assert Equation(toJSON true, "true")
+assert Equation(toJSON false, "false")
+assert Equation(toJSON null, "null")
+assert Equation(toJSON nil, "null")
+
+-- arrays
+assert Equation(toJSON {1, 2, 3}, "[1, 2, 3]")
+assert Equation(toJSON [1, 2, 3], "[1, 2, 3]")
+assert Equation(toJSON <|1, 2, 3|>, "[1, 2, 3]")
+assert Equation(toJSON({1, 2, 3}, ValueSeparator => " , "), "[1 , 2 , 3]")
+assert Equation(toJSON({1, 2, 3, {4, 5}}, Indent => 0), ///[
+1,
+2,
+3,
+[
+4,
+5
+]
+]///)
+assert Equation(toJSON({1, 2, 3, {4, 5}}, Indent => 2), ///[
+  1,
+  2,
+  3,
+  [
+    4,
+    5
+  ]
+]///)
+assert Equation(toJSON({1, 2, 3, {4, 5}}, Indent => "  "), ///[
+  1,
+  2,
+  3,
+  [
+    4,
+    5
+  ]
+]///)
+
+-- objects
+assert Equation(toJSON(hashTable{"a" => 1, "b" => 2, "c" => 3}, Sort => true),
+    "{\"a\": 1, \"b\": 2, \"c\": 3}")
+assert Equation(toJSON(hashTable{"a" => 1, "b" => 2, "c" => 3}, Sort => true,
+	ValueSeparator => " , "), "{\"a\": 1 , \"b\": 2 , \"c\": 3}")
+assert Equation(toJSON(hashTable{"a" => 1, "b" => 2, "c" => 3}, Sort => true,
+	NameSeparator => " : "), "{\"a\" : 1, \"b\" : 2, \"c\" : 3}")

--- a/M2/Macaulay2/packages/JSON/test-parse.m2
+++ b/M2/Macaulay2/packages/JSON/test-parse.m2
@@ -1,0 +1,294 @@
+ -- tests from JSON Parsing Test Suite
+ -- Copyright 2016 Nicolas Seriot
+ -- MIT License
+ -- https://github.com/nst/JSONTestSuite
+
+ -- y_array_arraysWithSpaces.json
+assert BinaryOperation(symbol ===, fromJSON "[[]   ]", {{}})
+
+ -- y_array_empty-string.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\"]", {""})
+
+ -- y_array_empty.json
+assert BinaryOperation(symbol ===, fromJSON "[]", {})
+
+ -- y_array_ending_with_newline.json
+assert BinaryOperation(symbol ===, fromJSON "[\"a\"]", {"a"})
+
+ -- y_array_false.json
+assert BinaryOperation(symbol ===, fromJSON "[false]", {false})
+
+ -- y_array_heterogeneous.json
+assert BinaryOperation(symbol ===, fromJSON "[null, 1, \"1\", {}]", {nil,1,"1",new HashTable from {}})
+
+ -- y_array_null.json
+assert BinaryOperation(symbol ===, fromJSON "[null]", {nil})
+
+ -- y_array_with_1_and_newline.json
+assert BinaryOperation(symbol ===, fromJSON "[1
+]", {1})
+
+ -- y_array_with_leading_space.json
+assert BinaryOperation(symbol ===, fromJSON " [1]", {1})
+
+ -- y_array_with_several_null.json
+assert BinaryOperation(symbol ===, fromJSON "[1,null,null,null,2]", {1,nil,nil,nil,2})
+
+ -- y_array_with_trailing_space.json
+assert BinaryOperation(symbol ===, fromJSON "[2] ", {2})
+
+ -- y_number.json
+assert BinaryOperation(symbol ===, fromJSON "[123e65]", {.12300000000000001p53e68})
+
+ -- y_number_0e+1.json
+assert BinaryOperation(symbol ===, fromJSON "[0e+1]", {.0p53})
+
+ -- y_number_0e1.json
+assert BinaryOperation(symbol ===, fromJSON "[0e1]", {.0p53})
+
+ -- y_number_after_space.json
+assert BinaryOperation(symbol ===, fromJSON "[ 4]", {4})
+
+ -- y_number_double_close_to_zero.json
+assert BinaryOperation(symbol ===, fromJSON "[-0.000000000000000000000000000000000000000000000000000000000000000000000000000001]
+", {-.1p53e-77})
+
+ -- y_number_int_with_exp.json
+assert BinaryOperation(symbol ===, fromJSON "[20e1]", {.2p53e3})
+
+ -- y_number_minus_zero.json
+assert BinaryOperation(symbol ===, fromJSON "[-0]", {0})
+
+ -- y_number_negative_int.json
+assert BinaryOperation(symbol ===, fromJSON "[-123]", {-123})
+
+ -- y_number_negative_one.json
+assert BinaryOperation(symbol ===, fromJSON "[-1]", {-1})
+
+ -- y_number_negative_zero.json
+assert BinaryOperation(symbol ===, fromJSON "[-0]", {0})
+
+ -- y_number_real_capital_e.json
+assert BinaryOperation(symbol ===, fromJSON "[1E22]", {.1p53e23})
+
+ -- y_number_real_capital_e_neg_exp.json
+assert BinaryOperation(symbol ===, fromJSON "[1E-2]", {.1p53e-1})
+
+ -- y_number_real_capital_e_pos_exp.json
+assert BinaryOperation(symbol ===, fromJSON "[1E+2]", {.1p53e3})
+
+ -- y_number_real_exponent.json
+assert BinaryOperation(symbol ===, fromJSON "[123e45]", {.12299999999999999p53e48})
+
+ -- y_number_real_fraction_exponent.json
+assert BinaryOperation(symbol ===, fromJSON "[123.456e78]", {.123456p53e81})
+
+ -- y_number_real_neg_exp.json
+assert BinaryOperation(symbol ===, fromJSON "[1e-2]", {.1p53e-1})
+
+ -- y_number_real_pos_exponent.json
+assert BinaryOperation(symbol ===, fromJSON "[1e+2]", {.1p53e3})
+
+ -- y_number_simple_int.json
+assert BinaryOperation(symbol ===, fromJSON "[123]", {123})
+
+ -- y_number_simple_real.json
+assert BinaryOperation(symbol ===, fromJSON "[123.456789]", {.123456789p53e3})
+
+ -- y_object.json
+assert BinaryOperation(symbol ===, fromJSON "{\"asd\":\"sdf\", \"dfg\":\"fgh\"}", new HashTable from {"dfg" => "fgh", "asd" => "sdf"})
+
+ -- y_object_basic.json
+assert BinaryOperation(symbol ===, fromJSON "{\"asd\":\"sdf\"}", new HashTable from {"asd" => "sdf"})
+
+ -- y_object_duplicated_key.json
+assert BinaryOperation(symbol ===, fromJSON "{\"a\":\"b\",\"a\":\"c\"}", new HashTable from {"a" => "c"})
+
+ -- y_object_duplicated_key_and_value.json
+assert BinaryOperation(symbol ===, fromJSON "{\"a\":\"b\",\"a\":\"b\"}", new HashTable from {"a" => "b"})
+
+ -- y_object_empty.json
+assert BinaryOperation(symbol ===, fromJSON "{}", new HashTable from {})
+
+ -- y_object_empty_key.json
+assert BinaryOperation(symbol ===, fromJSON "{\"\":0}", new HashTable from {"" => 0})
+
+ -- y_object_escaped_null_in_key.json
+assert BinaryOperation(symbol ===, fromJSON "{\"foo\\u0000bar\": 42}", new HashTable from {"foo\\u0000bar" => 42})
+
+ -- y_object_extreme_numbers.json
+assert BinaryOperation(symbol ===, fromJSON "{ \"min\": -1.0e+28, \"max\": 1.0e+28 }", new HashTable from {"max" => .99999999999999996p53e28, "min" => -.99999999999999996p53e28})
+
+ -- y_object_long_strings.json
+assert BinaryOperation(symbol ===, fromJSON "{\"x\":[{\"id\": \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}], \"id\": \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}", new HashTable from {"x" => {new HashTable from {"id" => "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}, "id" => "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"})
+
+ -- y_object_simple.json
+assert BinaryOperation(symbol ===, fromJSON "{\"a\":[]}", new HashTable from {"a" => {}})
+
+ -- y_object_string_unicode.json
+assert BinaryOperation(symbol ===, fromJSON "{\"title\":\"\\u041f\\u043e\\u043b\\u0442\\u043e\\u0440\\u0430 \\u0417\\u0435\\u043c\\u043b\\u0435\\u043a\\u043e\\u043f\\u0430\" }", new HashTable from {"title" => "\\u041f\\u043e\\u043b\\u0442\\u043e\\u0440\\u0430 \\u0417\\u0435\\u043c\\u043b\\u0435\\u043a\\u043e\\u043f\\u0430"})
+
+ -- y_object_with_newlines.json
+assert BinaryOperation(symbol ===, fromJSON "{
+\"a\": \"b\"
+}", new HashTable from {"a" => "b"})
+
+ -- y_string_1_2_3_bytes_UTF-8_sequences.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0060\\u012a\\u12AB\"]", {"\\u0060\\u012a\\u12AB"})
+
+ -- y_string_accepted_surrogate_pair.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD801\\udc37\"]", {"\\uD801\\udc37"})
+
+ -- y_string_accepted_surrogate_pairs.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\ud83d\\ude39\\ud83d\\udc8d\"]", {"\\ud83d\\ude39\\ud83d\\udc8d"})
+
+ -- y_string_allowed_escapes.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"]", {"\\\"\\\\\\/\\b\\f\\n\\r\\t"})
+
+ -- y_string_backslash_and_u_escaped_zero.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\\u0000\"]", {"\\\\u0000"})
+
+ -- y_string_backslash_doublequotes.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\"\"]", {"\\\""})
+
+ -- y_string_comments.json
+assert BinaryOperation(symbol ===, fromJSON "[\"a/*b*/c/*d//e\"]", {"a/*b*/c/*d//e"})
+
+ -- y_string_double_escape_a.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\\a\"]", {"\\\\a"})
+
+ -- y_string_double_escape_n.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\\n\"]", {"\\\\n"})
+
+ -- y_string_escaped_control_character.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0012\"]", {"\\u0012"})
+
+ -- y_string_escaped_noncharacter.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uFFFF\"]", {"\\uFFFF"})
+
+ -- y_string_in_array.json
+assert BinaryOperation(symbol ===, fromJSON "[\"asd\"]", {"asd"})
+
+ -- y_string_in_array_with_leading_space.json
+assert BinaryOperation(symbol ===, fromJSON "[ \"asd\"]", {"asd"})
+
+ -- y_string_last_surrogates_1_and_2.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFF\"]", {"\\uDBFF\\uDFFF"})
+
+ -- y_string_nbsp_uescaped.json
+assert BinaryOperation(symbol ===, fromJSON "[\"new\\u00A0line\"]", {"new\\u00A0line"})
+
+ -- y_string_nonCharacterInUTF-8_U+10FFFF.json
+assert BinaryOperation(symbol ===, fromJSON "[\"􏿿\"]", {"􏿿"})
+
+ -- y_string_nonCharacterInUTF-8_U+FFFF.json
+assert BinaryOperation(symbol ===, fromJSON "[\"￿\"]", {"￿"})
+
+ -- y_string_null_escape.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0000\"]", {"\\u0000"})
+
+ -- y_string_one-byte-utf-8.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u002c\"]", {"\\u002c"})
+
+ -- y_string_pi.json
+assert BinaryOperation(symbol ===, fromJSON "[\"π\"]", {"π"})
+
+ -- y_string_reservedCharacterInUTF-8_U+1BFFF.json
+assert BinaryOperation(symbol ===, fromJSON "[\"𛿿\"]", {"𛿿"})
+
+ -- y_string_simple_ascii.json
+assert BinaryOperation(symbol ===, fromJSON "[\"asd \"]", {"asd "})
+
+ -- y_string_space.json
+assert BinaryOperation(symbol ===, fromJSON "\" \"", " ")
+
+ -- y_string_surrogates_U+1D11E_MUSICAL_SYMBOL_G_CLEF.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD834\\uDd1e\"]", {"\\uD834\\uDd1e"})
+
+ -- y_string_three-byte-utf-8.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0821\"]", {"\\u0821"})
+
+ -- y_string_two-byte-utf-8.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0123\"]", {"\\u0123"})
+
+ -- y_string_u+2028_line_sep.json
+assert BinaryOperation(symbol ===, fromJSON "[\" \"]", {" "})
+
+ -- y_string_u+2029_par_sep.json
+assert BinaryOperation(symbol ===, fromJSON "[\" \"]", {" "})
+
+ -- y_string_uEscape.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0061\\u30af\\u30EA\\u30b9\"]", {"\\u0061\\u30af\\u30EA\\u30b9"})
+
+ -- y_string_uescaped_newline.json
+assert BinaryOperation(symbol ===, fromJSON "[\"new\\u000Aline\"]", {"new\\u000Aline"})
+
+ -- y_string_unescaped_char_delete.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\"]", {""})
+
+ -- y_string_unicode.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uA66D\"]", {"\\uA66D"})
+
+ -- y_string_unicode_2.json
+assert BinaryOperation(symbol ===, fromJSON "[\"⍂㈴⍂\"]", {"⍂㈴⍂"})
+
+ -- y_string_unicode_escaped_double_quote.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0022\"]", {"\\u0022"})
+
+ -- y_string_unicode_U+1FFFE_nonchar.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD83F\\uDFFE\"]", {"\\uD83F\\uDFFE"})
+
+ -- y_string_unicode_U+10FFFE_nonchar.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFE\"]", {"\\uDBFF\\uDFFE"})
+
+ -- y_string_unicode_U+200B_ZERO_WIDTH_SPACE.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u200B\"]", {"\\u200B"})
+
+ -- y_string_unicode_U+2064_invisible_plus.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u2064\"]", {"\\u2064"})
+
+ -- y_string_unicode_U+FDD0_nonchar.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uFDD0\"]", {"\\uFDD0"})
+
+ -- y_string_unicode_U+FFFE_nonchar.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uFFFE\"]", {"\\uFFFE"})
+
+ -- y_string_unicodeEscapedBackslash.json
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u005C\"]", {"\\u005C"})
+
+ -- y_string_utf8.json
+assert BinaryOperation(symbol ===, fromJSON "[\"€𝄞\"]", {"€𝄞"})
+
+ -- y_string_with_del_character.json
+assert BinaryOperation(symbol ===, fromJSON "[\"aa\"]", {"aa"})
+
+ -- y_structure_lonely_false.json
+assert BinaryOperation(symbol ===, fromJSON "false", false)
+
+ -- y_structure_lonely_int.json
+assert BinaryOperation(symbol ===, fromJSON "42", 42)
+
+ -- y_structure_lonely_negative_real.json
+assert BinaryOperation(symbol ===, fromJSON "-0.1", -.10000000000000001p53)
+
+ -- y_structure_lonely_null.json
+assert BinaryOperation(symbol ===, fromJSON "null", nil)
+
+ -- y_structure_lonely_string.json
+assert BinaryOperation(symbol ===, fromJSON "\"asd\"", "asd")
+
+ -- y_structure_lonely_true.json
+assert BinaryOperation(symbol ===, fromJSON "true", true)
+
+ -- y_structure_string_empty.json
+assert BinaryOperation(symbol ===, fromJSON "\"\"", "")
+
+ -- y_structure_trailing_newline.json
+assert BinaryOperation(symbol ===, fromJSON "[\"a\"]
+", {"a"})
+
+ -- y_structure_true_in_array.json
+assert BinaryOperation(symbol ===, fromJSON "[true]", {true})
+
+ -- y_structure_whitespace_array.json
+assert BinaryOperation(symbol ===, fromJSON " [] ", {})


### PR DESCRIPTION
This package translates back and forth between JSON data (given in strings or files) and Macaulay2 things.  For example:

```m2
i2 : fromJSON "{\"foo\": [1, 2, 3], \"bar\": true}"

o2 = HashTable{bar => true     }
               foo => {1, 2, 3}

o2 : HashTable

i3 : toJSON oo

o3 = {"foo": [1, 2, 3], "bar": true}
```
It looks like this package might be useful for the the polymake interface (see the [corresponding project](https://github.com/Macaulay2/M2/wiki/Project%3A-Improve-polyhedral-functionality-%28Polyhedra.m2%2C-Polymake.m2%29)).  In the longer term, I'm planning on using it to develop a Macaulay2 [language server](https://microsoft.github.io/language-server-protocol/).