### PR TITLE
Make "abs" overloadable

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -96,13 +96,13 @@ setupfun("setGroupID",setpgidfun);
 
 absfun(e:Expr):Expr := (
      when e
-     is i:ZZcell do toExpr(abs(i.v))				    -- # typical value: abs, ZZ, ZZ
-     is x:RRcell do toExpr(if sign(x.v) then -x.v else x.v)		    -- # typical value: abs, RR, RR
-     is x:RRicell do toExpr(abs(x.v))            -- # typical value: abs, RRi, RRi
-     is x:CCcell do toExpr(abs(x.v))				    -- # typical value: abs, CC, RR
-     is r:QQcell do toExpr(abs(r.v))				    -- # typical value: abs, QQ, RR
+     is i:ZZcell do toExpr(abs(i.v))
+     is x:RRcell do toExpr(if sign(x.v) then -x.v else x.v)
+     is x:RRicell do toExpr(abs(x.v))
+     is x:CCcell do toExpr(abs(x.v))
+     is r:QQcell do toExpr(abs(r.v))
      else WrongArg("a number, real or complex"));
-setupfun("abs",absfun);
+setupfun("abs0",absfun);
 
 select(a:Sequence,f:Expr):Expr := (
      b := new array(bool) len length(a) do provide false;

--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -53,6 +53,9 @@ gcd(QQ,QQ) := QQ => (x,y) -> (
      d := denominator x * (denominator y // gcd(denominator x, denominator y));
      gcd(numerator (x * d), numerator (y * d)) / d)
 
+abs = method()
+abs ZZ := abs RR := abs RRi := abs CC := abs QQ := abs0
+
 lcm = method(Binary => true)
 lcm(ZZ,ZZ) := (f,g) -> abs f * (abs g // gcd(f,g))
 lcm(ZZ,QQ) := (f,g) -> abs f * (abs g / gcd(f,g))

--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -55,6 +55,7 @@ gcd(QQ,QQ) := QQ => (x,y) -> (
 
 abs = method()
 abs ZZ := abs RR := abs RRi := abs CC := abs QQ := abs0
+abs Constant := abs @@ numeric
 
 lcm = method(Binary => true)
 lcm(ZZ,ZZ) := (f,g) -> abs f * (abs g // gcd(f,g))

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -261,8 +261,6 @@ scanPairs(new HashTable from variants, (args,f) -> (
 	undocumented args;
 	))
 
--- TODO abs Constant
-
 nilp := x -> (  -- degree of nilpotency
     R := ring x;
     k := R; while not isField k do k = baseRing k;

--- a/M2/Macaulay2/tests/normal/000-core.m2
+++ b/M2/Macaulay2/tests/normal/000-core.m2
@@ -449,7 +449,7 @@ assert (not isPrimitive 0_R)
 
 --
 assert ( class (x->x) === FunctionClosure )
-assert ( class abs === CompiledFunction )
+assert ( class any === CompiledFunction )
 assert ( class depth === MethodFunction )
 
 


### PR DESCRIPTION
We make `abs` overloadable and take the opportunity to implement `abs(Constant)`.

## Before
```m2
i1 : abs Constant := abs @@ numeric

o1 = -*Function[/usr/share/Macaulay2/Core/classes.m2:90:48-90:55]*-

o1 : FunctionClosure

i2 : abs pi
stdio:2:1:(3): error: expected a number, real or complex
```

## After

```m2
i1 : abs pi

o1 = 3.14159265358979
```