### PR TITLE
Add bitwise not operator

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -698,6 +698,13 @@ bitxorfun(e:Expr):Expr := (
      else WrongNumArgs(2)
      else WrongNumArgs(2));
 setupfun("bitxorfun",bitxorfun);
+
+bitnotfun(e:Expr):Expr := (
+    when e
+    is x:ZZcell do toExpr(not(x.v))
+    else WrongArgZZ());
+setupfun("bitnotfun", bitnotfun);
+
 semicolonfun(lhs:Code,rhs:Code):Expr := when eval(lhs) is err:Error do Expr(err) else eval(rhs);
 setup(SemicolonS,semicolonfun);
 starfun(rhs:Code):Expr := unarymethod(rhs,StarS);

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -453,6 +453,13 @@ export (x:ZZ) ^^ (y:ZZ) : ZZ := (
      xor(w,x,y);
      moveToZZandclear(w));
 
+not(x:ZZmutable, y:ZZ) ::= Ccode(void, "mpz_com(", x, ",", y, ")");
+
+export not(y:ZZ) : ZZ := (
+    x := newZZmutable();
+    not(x, y);
+    moveToZZandclear(x));
+
 base := 10;
 toCstring(x:ZZ) ::= getstr(charstarOrNull(null()), base, x);
 

--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -80,6 +80,8 @@ ZZ & ZZ := ZZ => lookup(symbol &, ZZ, ZZ)
 ZZ ^^ ZZ := bitxorfun
 Boolean xor Boolean := (x, y) -> x and not y or not x and y
 
+ZZ~ := bitnotfun
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -214,7 +214,7 @@ document {
      	       integers ", TT "m", " and ", TT "n", " by logical 'and'."}
 	  },
      EXAMPLE "(2^15 + 2^13 + 2^42) & (2^15 + 2^23 + 2^42) == 2^15 + 2^42",
-     SeeAlso => {(symbol |,ZZ,ZZ),(symbol ^^,ZZ,ZZ)}
+     SeeAlso => {(symbol |,ZZ,ZZ),(symbol ^^,ZZ,ZZ), (symbol ~, ZZ)}
      }
 
 undocumented {
@@ -604,6 +604,32 @@ document {
      SeeAlso =>{ "and", "or" }
      }
 
+doc ///
+  Key
+    (symbol ~, ZZ)
+  Headline
+    logical not
+  Usage
+    n~
+  Inputs
+    n:ZZ
+  Outputs
+    :ZZ -- the bitwise complement of @TT "n"@
+  Description
+    Example
+      7~
+    Text
+      Note that @TT "~"@ has @TO2 {"precedence of operators",
+      "higher precedence"}@ than @TT "-"@, so enclose negative integers in
+      parentheses.
+    Example
+      (-12)~
+  SeeAlso
+    (symbol &, ZZ, ZZ)
+    (symbol |, ZZ, ZZ)
+    (symbol ^^, ZZ, ZZ)
+///
+
 document {
      Key => symbol |, 
      Headline => "a binary operator, often used for horizontal concatenation",
@@ -656,7 +682,7 @@ document {
      	       integers ", TT "m", " and ", TT "n", " by logical 'or'."}
 	  },
      EXAMPLE "2^42 | 2^15 == 2^42 + 2^15",
-     SeeAlso => {(symbol &,ZZ,ZZ),(symbol ^^,ZZ,ZZ)}
+     SeeAlso => {(symbol &,ZZ,ZZ),(symbol ^^,ZZ,ZZ), (symbol ~, ZZ)}
      }
 
 document {

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
@@ -206,7 +206,7 @@ document {
 	       the integers ", TT "m", " and ", TT "n"}
 	  },
      EXAMPLE "10 ^^ 12",
-     SeeAlso => { (symbol|,ZZ,ZZ), (symbol&,ZZ,ZZ) }
+     SeeAlso => { (symbol|,ZZ,ZZ), (symbol&,ZZ,ZZ), (symbol ~, ZZ) }
      }
 
 document {

--- a/M2/Macaulay2/tests/normal/boolean.m2
+++ b/M2/Macaulay2/tests/normal/boolean.m2
@@ -36,6 +36,13 @@ assert Equation(1 | 1 ^^ 1, 1)
 assert Equation(1 ^^ 0 | 1, 1)
 assert Equation(1 | 0 ^^ 1, 1)
 
+
+-----------------
+-- bitwise not --
+-----------------
+assert Equation(1138~, -1139)
+assert Equation((-1139)~, 1138)
+
 -----------------
 -- expressions --
 -----------------


### PR DESCRIPTION
I noticed that despite having the other big bitwise operators (`&`, `|`, and `^^`), we were missing bitwise not.  Most other languages use `~` for this, which is a postfix operator in Macaulay2.  It may look a little strange, but it works.

So for example:

## Python

```python
>>> ~1234
-1235
>>> ~-1234
1233
```
## Macaulay2

```m2
i1 : 1234~

o1 = -1235

i2 : (-1234)~

o2 = 1233
```

