### PR TITLE
Add quotientRemainder(ZZ, ZZ)

### DIFF
--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -1399,7 +1399,19 @@ export rawDivMod(e:Expr):Expr := (
 	       )
 	  )
      else WrongArg(2,"a raw ring element")
-     else WrongArg(1,"a raw ring element")
+     is x:ZZcell do
+     when a.1 is y:ZZcell do (
+	 if isZero(y.v) then return seq(zeroE, Expr(x));
+	 q := newZZmutable();
+	 r := newZZmutable();
+	 if isPositive(y.v)
+	 then Ccode(void,
+	     "mpz_fdiv_qr(", q, ", ", r, ", ", x.v, ", ", y.v, ")")
+	 else Ccode(void,
+	     "mpz_cdiv_qr(", q, ", ", r, ", ", x.v, ", ", y.v, ")");
+	 seq(toExpr(moveToZZandclear(q)), toExpr(moveToZZandclear(r))))
+     else WrongArg(2, "an integer")
+     else WrongArg(1,"a raw ring element or integer")
      else WrongNumArgs(2)
      else WrongNumArgs(2));
 setupfun("rawDivMod",rawDivMod);

--- a/M2/Macaulay2/m2/engine.m2
+++ b/M2/Macaulay2/m2/engine.m2
@@ -264,7 +264,8 @@ compvals := hashTable { 0 => symbol == , 1 => symbol > , -1 => symbol < }
 comparison := n -> compvals#n
 RawRingElement ? RawRingElement := (f,g) -> comparison rawCompare(f,g)
 
-quotientRemainder(RawRingElement,RawRingElement) := rawDivMod
+quotientRemainder(RawRingElement,RawRingElement) :=
+quotientRemainder(ZZ, ZZ) := rawDivMod
 
 -- monomial ideals
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc14.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc14.m2
@@ -533,7 +533,8 @@ document {
 document {
      Key => {(quotientRemainder,RingElement,RingElement),
 	  (quotientRemainder,InexactNumber,RingElement), (quotientRemainder,RingElement,InexactNumber),
-	  (quotientRemainder,Number,RingElement), (quotientRemainder,RingElement,Number)},
+	  (quotientRemainder,Number,RingElement), (quotientRemainder,RingElement,Number),
+	  (quotientRemainder,ZZ,ZZ)},
      Headline => "quotient and remainder",
      Usage => "(q,r) = quotientRemainder(f,g)",
      Inputs => {"f","g"},

--- a/M2/Macaulay2/tests/normal/division.m2
+++ b/M2/Macaulay2/tests/normal/division.m2
@@ -199,6 +199,11 @@ assert( (quotientRemainder(1-u^3,1-u)) === (1+u+u^2,0_R) )
   R = QQ[x]
   assert(try (0_R / 0_R; false) else true) -- should give an error
 
+-- quotientRemainder(ZZ, ZZ)
+  assert Equation(quotientRemainder(5710, 56), (101, 54))
+  assert Equation(quotientRemainder(5710, -56), (-101, 54))
+  assert Equation(quotientRemainder(5710, 0), (0, 5710))
+
 end--
 generateAssertions ///
 R = ZZ[t..u, Degrees => {2:1}, MonomialOrder => { MonomialSize => 32, GroupRevLex => 2, Position => Up}, Inverses => true]


### PR DESCRIPTION
I've wanted this feature for a long time.  It could have been implemented at top level using `(x // y, x % y)` or `quotientRemainder(raw x, raw y)`, but I decided to wrap the corresponding GMP functions (`mpz_fdiv_qr` and `mpz_cdiv_qr`) for improved performance.

### Before
```m2
i1 : quotientRemainder(100, 7)
stdio:1:1:(3): error: no method found for applying quotientRemainder to:
     argument 1 :  100 (of class ZZ)
     argument 2 :  7 (of class ZZ)
```

### After
```m2
i1 : quotientRemainder(100, 7)

o1 = (14, 2)

o1 : Sequence
```