### PR TITLE
Python updates

### DIFF
--- a/M2/Macaulay2/d/python-c.c
+++ b/M2/Macaulay2/d/python-c.c
@@ -162,10 +162,6 @@ PyObject *python_UnicodeFromString(char *u) {
 	return PyUnicode_FromString(u);
 }
 
-PyObject *python_UnicodeConcat(PyObject *o1, PyObject *o2) {
-	return PyUnicode_Concat(o1, o2);
-}
-
 /**********
  * tuples *
  **********/

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -231,24 +231,6 @@ PyUnicodeFromString(e:Expr):Expr :=
     else WrongArgString();
 setupfun("pythonUnicodeFromString",PyUnicodeFromString);
 
-import UnicodeConcat(o1:pythonObject,o2:pythonObject):pythonObjectOrNull;
-PyUnicodeConcat(lhs:Expr,rhs:Expr):Expr :=
-    when lhs
-    is x:pythonObjectCell do
-	when rhs
-	is y:pythonObjectCell do toExpr(UnicodeConcat(x.v, y.v))
-	is s:SpecialExpr do PyUnicodeConcat(lhs, s.e)
-	else WrongArgPythonObject(2)
-    is s:SpecialExpr do PyUnicodeConcat(s.e, rhs)
-    else WrongArgPythonObject(1);
-PyUnicodeConcat(e:Expr):Expr :=
-    when e
-    is a:Sequence do
-	if length(a) == 2 then PyUnicodeConcat(a.0, a.1)
-	else WrongNumArgs(2)
-    else WrongNumArgs(2);
-setupfun("pythonUnicodeConcat",PyUnicodeConcat);
-
 ------------
 -- tuples --
 ------------

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -36,7 +36,11 @@ setupfun("pythonMain",PyMain);
 -------------
 
 import ObjectType(o:pythonObject):pythonObjectOrNull;
-PyObjectType(e:Expr):Expr := when e is o:pythonObjectCell do toExpr(ObjectType(o.v)) else WrongArgPythonObject();
+PyObjectType(e:Expr):Expr := (
+    when e
+    is o:pythonObjectCell do toExpr(ObjectType(o.v))
+    is s:SpecialExpr do PyObjectType(s.e)
+    else WrongArgPythonObject());
 setupfun("objectType",PyObjectType);
 
 import ObjectRichCompareBool(o1:pythonObject,o2:pythonObject,opid:int):int;
@@ -51,7 +55,9 @@ PyObjectRichCompareBool(e1:Expr,e2:Expr,e3:Expr):Expr :=
 		if r == -1 then buildPythonErrorPacket()
 		else toExpr(r == 1))
 	    else WrongArgZZ(3)
+	is s:SpecialExpr do PyObjectRichCompareBool(e1, s.e, e3)
 	else WrongArgPythonObject(2)
+    is s:SpecialExpr do PyObjectRichCompareBool(s.e, e2, e3)
     else WrongArgPythonObject(1);
 PyObjectRichCompareBool(e:Expr):Expr :=
     when e
@@ -69,6 +75,7 @@ PyObjectHasAttrString(lhs:Expr,rhs:Expr):Expr :=
 	is y:stringCell do
 	    toExpr(ObjectHasAttrString(x.v, tocharstar(y.v)) == 1)
 	else WrongArgString(2)
+    is s:SpecialExpr do PyObjectHasAttrString(s.e, rhs)
     else WrongArgPythonObject(1);
 PyObjectHasAttrString(e:Expr):Expr :=
     when e
@@ -85,6 +92,7 @@ PyObjectGetAttrString(lhs:Expr,rhs:Expr):Expr :=
 	when rhs
 	is y:stringCell do toExpr(ObjectGetAttrString(x.v, tocharstar(y.v)))
 	else WrongArgString(2)
+    is s:SpecialExpr do PyObjectGetAttrString(s.e, rhs)
     else WrongArgPythonObject(1);
 PyObjectGetAttrString(e:Expr):Expr :=
     when e
@@ -105,8 +113,10 @@ PyObjectSetAttrString(e1:Expr,e2:Expr,e3:Expr):Expr :=
 		if ObjectSetAttrString(x.v, tocharstar(y.v), z.v) == -1 then
 		    buildPythonErrorPacket()
 		else nullE)
+	    is s:SpecialExpr do PyObjectSetAttrString(e1, e2, s.e)
 	    else WrongArgPythonObject(3)
 	else WrongArgString(2)
+    is s:SpecialExpr do PyObjectSetAttrString(s.e, e2, e3)
     else WrongArgPythonObject(1);
 PyObjectSetAttrString(e:Expr):Expr :=
     when e
@@ -120,6 +130,7 @@ import ObjectStr(o:pythonObject):pythonObjectOrNull;
 PyObjectStr(e:Expr):Expr :=
     when e
     is x:pythonObjectCell do toExpr(ObjectStr(x.v))
+    is s:SpecialExpr do PyObjectStr(s.e)
     else WrongArgPythonObject();
 setupfun("pythonObjectStr",PyObjectStr);
 
@@ -148,6 +159,7 @@ PyLongAsLong(e:Expr):Expr :=
 	y := LongAsLong(x.v);
 	if ErrOccurred() == 1 then buildPythonErrorPacket()
 	else toExpr(y))
+    is s:SpecialExpr do PyLongAsLong(s.e)
     else WrongArgPythonObject();
 setupfun("pythonLongAsLong",PyLongAsLong);
 
@@ -169,6 +181,7 @@ PyFloatAsDouble(e:Expr):Expr :=
 	y := FloatAsDouble(x.v);
 	if ErrOccurred() == 1 then buildPythonErrorPacket()
 	else toExpr(y))
+    is s:SpecialExpr do PyFloatAsDouble(s.e)
     else WrongArgPythonObject();
 setupfun("pythonFloatAsDouble",PyFloatAsDouble);
 
@@ -207,6 +220,7 @@ import UnicodeAsUTF8(o:pythonObject):constcharstar;
 PyUnicodeAsUTF8(e:Expr):Expr :=
     when e
     is x:pythonObjectCell do toExpr(UnicodeAsUTF8(x.v))
+    is s:SpecialExpr do PyUnicodeAsUTF8(s.e)
     else WrongArgPythonObject();
 setupfun("pythonUnicodeAsUTF8",PyUnicodeAsUTF8);
 
@@ -223,7 +237,9 @@ PyUnicodeConcat(lhs:Expr,rhs:Expr):Expr :=
     is x:pythonObjectCell do
 	when rhs
 	is y:pythonObjectCell do toExpr(UnicodeConcat(x.v, y.v))
+	is s:SpecialExpr do PyUnicodeConcat(lhs, s.e)
 	else WrongArgPythonObject(2)
+    is s:SpecialExpr do PyUnicodeConcat(s.e, rhs)
     else WrongArgPythonObject(1);
 PyUnicodeConcat(e:Expr):Expr :=
     when e
@@ -255,6 +271,7 @@ PyTupleSetItem(e1:Expr,e2:Expr,e3:Expr):Expr :=
 		if TupleSetItem(x.v, toInt(y), z.v) == -1 then
 		    buildPythonErrorPacket()
 		else nullE)
+	    is s:SpecialExpr do PyTupleSetItem(e1, e2, s.e)
 	    else WrongArgPythonObject(3)
 	else WrongArgZZ(2)
     else WrongArgPythonObject(1);
@@ -288,6 +305,7 @@ PyListSetItem(e1:Expr,e2:Expr,e3:Expr):Expr :=
 		if ListSetItem(x.v, toInt(y), z.v) == -1 then
 		    buildPythonErrorPacket()
 		else nullE)
+	    is s:SpecialExpr do PyListSetItem(e1, e2, s.e)
 	    else WrongArgPythonObject(3)
 	else WrongArgZZ(2)
     else WrongArgPythonObject(1);
@@ -323,7 +341,9 @@ PyDictSetItem(e1:Expr,e2:Expr,e3:Expr):Expr :=
 		if DictSetItem(x.v, y.v, z.v) == -1 then
 		    buildPythonErrorPacket()
 		else nullE)
+	    is s:SpecialExpr do PyDictSetItem(e1, e2, s.e)
 	    else WrongArgPythonObject(3)
+	is s:SpecialExpr do PyDictSetItem(e1, s.e, e3)
 	else WrongArgPythonObject(2)
     else WrongArgPythonObject(1);
 PyDictSetItem(e:Expr):Expr :=
@@ -360,6 +380,7 @@ PyObjectCall(e1:Expr,e2:Expr,e3:Expr):Expr :=
 	    is z:pythonObjectCell do toExpr(ObjectCall(x.v, y.v, z.v))
 	    else WrongArgPythonObject(3)
 	else WrongArgPythonObject(2)
+    is s:SpecialExpr do PyObjectCall(s.e, e2, e3)
     else WrongArgPythonObject(1);
 PyObjectCall(e:Expr):Expr :=
     when e

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -225,6 +225,7 @@ scan({
 	(symbol +, "add"),
 	(symbol -, "sub"),
 	(symbol *, "mul"),
+	(symbol @, "matmul"),
 	(symbol /, "truediv"),
 	(symbol //, "floordiv"),
 	(symbol %, "mod"),

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -303,6 +303,8 @@ truncate PythonObject := {} >> o -> x -> x@@"__trunc__"()
 floor PythonObject := x -> x@@"__floor__"()
 ceiling PythonObject := x -> x@@"__ceil__"()
 
+help#0 PythonObject := x -> toString x@@"__doc__"
+
 toPython = method(Dispatch => Thing)
 toPython RR := pythonFloatFromDouble
 toPython QQ := toPython @@ toRR

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -553,6 +553,14 @@ assert Equation(round toPython 3.5, 4)
 -- math.trunc
 assert Equation(truncate e, 2)
 assert Equation(truncate(-e), -2)
+
+-- math.floor
+assert Equation(floor e, 2)
+assert Equation(floor(-e), -3)
+
+-- mail.ceil
+assert Equation(ceiling e, 3)
+assert Equation(ceiling(-e), -2)
 ///
 
 end --------------------------------------------------------

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -304,8 +304,17 @@ round(PythonObject, PythonObject) := (n, x) -> x@@"__round__" n
 round(ZZ, PythonObject) := (n, x) -> round(toPython n, x)
 round PythonObject := x -> round(pythonNone, x)
 truncate PythonObject := {} >> o -> x -> x@@"__trunc__"()
-floor PythonObject := x -> x@@"__floor__"()
-ceiling PythonObject := x -> x@@"__ceil__"()
+
+-- __floor__ and __ceil__ were added for floats in Python 3.9
+-- (https://bugs.python.org/issue38629), so we include backup definitions
+-- for older versions
+if hasattr(pythonFloatFromDouble 1.0, "__floor__") then (
+    floor PythonObject := x -> x@@"__floor__"();
+    ceiling PythonObject := x -> x@@"__ceil__"()
+    ) else (
+    math := import "math";
+    floor PythonObject := toFunction math@@"floor";
+    ceiling PythonObject := toFunction math@@"ceil")
 
 help#0 PythonObject := x -> toString x@@"__doc__"
 

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -298,7 +298,9 @@ quotientRemainder(PythonObject, Thing) := (x, y
 quotientRemainder(Thing, PythonObject) := (x, y
     ) -> quotientRemainder(toPython x, y)
 
-round PythonObject := x -> x@@"__round__"()
+round(PythonObject, PythonObject) := (n, x) -> x@@"__round__" n
+round(ZZ, PythonObject) := (n, x) -> round(toPython n, x)
+round PythonObject := x -> round(pythonNone, x)
 truncate PythonObject := {} >> o -> x -> x@@"__trunc__"()
 floor PythonObject := x -> x@@"__floor__"()
 ceiling PythonObject := x -> x@@"__ceil__"()

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -254,6 +254,8 @@ scan({
 
 -PythonObject := o -> o@@"__neg__"()
 +PythonObject := o -> o@@"__pos__"()
+abs PythonObject := o -> o@@"__abs__"()
+PythonObject~ := o -> o@@"__invert__"()
 
 PythonObject Thing := (o, x) -> (toFunction o) x
 

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -501,6 +501,28 @@ assert member(value rand@@choice L, {1, 2, 3})
 assert Equation(L + L, toPython {1, 2, 3, 1, 2, 3})
 ///
 
+TEST ///
+-- issue #2590
+ChildPythonObject = new Type of PythonObject
+x = new ChildPythonObject from toPython 5
+y = new ChildPythonObject from toPython 10
+assert BinaryOperation(symbol <, x, y)
+assert hasattr(x, "__abs__")
+assert Equation(x@@"__abs__"(), 5)
+assert Equation(toString x, "5")
+assert Equation(value x, 5)
+math = new ChildPythonObject from import "math"
+math@@pi = 3.14159
+assert Equation(math@@pi, 3.14159)
+z = new ChildPythonObject from math@@pi
+assert Equation(value z, 3.14159)
+hello = new ChildPythonObject from toPython "Hello, world!"
+assert Equation(value hello, "Hello, world!")
+assert Equation(toPython (x, y, z), (5, 10, 3.14159))
+assert Equation(toPython {x, y, z}, {5, 10, 3.14159})
+assert Equation(toPython hashTable {x => y}, hashTable {x => y})
+///
+
 end --------------------------------------------------------
 
 

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -532,6 +532,16 @@ assert Equation(toPython {x, y, z}, {5, 10, 3.14159})
 assert Equation(toPython hashTable {x => y}, hashTable {x => y})
 ///
 
+
+TEST ///
+-- built-in functions
+
+-- divmod
+assert Equation(quotientRemainder(toPython 1234, toPython 456), (2, 322))
+assert Equation(quotientRemainder(toPython 1234, 456), (2, 322))
+assert Equation(quotientRemainder(1234, toPython 456), (2, 322))
+///
+
 end --------------------------------------------------------
 
 

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -299,6 +299,11 @@ quotientRemainder(PythonObject, Thing) := (x, y
 quotientRemainder(Thing, PythonObject) := (x, y
     ) -> quotientRemainder(toPython x, y)
 
+round PythonObject := x -> x@@"__round__"()
+truncate PythonObject := {} >> o -> x -> x@@"__trunc__"()
+floor PythonObject := x -> x@@"__floor__"()
+ceiling PythonObject := x -> x@@"__ceil__"()
+
 toPython = method(Dispatch => Thing)
 toPython RR := pythonFloatFromDouble
 toPython QQ := toPython @@ toRR

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -549,6 +549,10 @@ assert Equation(round e, 3)
 assert Equation(round(3, e), 2.718)
 assert Equation(round toPython 2.5, 2)
 assert Equation(round toPython 3.5, 4)
+
+-- math.trunc
+assert Equation(truncate e, 2)
+assert Equation(truncate(-e), -2)
 ///
 
 end --------------------------------------------------------

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -538,6 +538,11 @@ assert Equation(toPython hashTable {x => y}, hashTable {x => y})
 TEST ///
 -- built-in functions
 
+-- __contains__
+assert member(toPython 3, toPython {1, 2, 3})
+assert not member(toPython 4, toPython {1, 2, 3})
+assert not member(3, toPython {1, 2, 3})
+
 -- divmod
 assert Equation(quotientRemainder(toPython 1234, toPython 456), (2, 322))
 assert Equation(quotientRemainder(toPython 1234, 456), (2, 322))

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -542,6 +542,13 @@ TEST ///
 assert Equation(quotientRemainder(toPython 1234, toPython 456), (2, 322))
 assert Equation(quotientRemainder(toPython 1234, 456), (2, 322))
 assert Equation(quotientRemainder(1234, toPython 456), (2, 322))
+
+-- round
+e = (import "math")@@e
+assert Equation(round e, 3)
+assert Equation(round(3, e), 2.718)
+assert Equation(round toPython 2.5, 2)
+assert Equation(round toPython 3.5, 4)
 ///
 
 end --------------------------------------------------------

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -561,6 +561,11 @@ assert Equation(floor(-e), -3)
 -- mail.ceil
 assert Equation(ceiling e, 3)
 assert Equation(ceiling(-e), -2)
+
+-- help
+x = help (import "math")@@cos
+assert instance(x, String)
+assert match("cosine", x)
 ///
 
 end --------------------------------------------------------

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -287,6 +287,9 @@ setattr(PythonObject, String, Thing) := (x, y, e) ->
     pythonObjectSetAttrString(x, y, toPython e)
 PythonObject @@ Thing = (x, y, e) -> setattr(x, toString y, e)
 
+member(Thing,        PythonObject) := (x, y) -> false
+member(PythonObject, PythonObject) := (x, y) -> value y@@"__contains__" x
+
 toPython = method(Dispatch => Thing)
 toPython RR := pythonFloatFromDouble
 toPython QQ := toPython @@ toRR

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -540,6 +540,12 @@ assert Equation(toPython hashTable {x => y}, hashTable {x => y})
 TEST ///
 -- built-in functions
 
+-- abs
+assert Equation(abs toPython(-3), 3)
+
+-- ~ (bitwise not)
+assert Equation((toPython 5)~, -6)
+
 -- __contains__
 assert member(toPython 3, toPython {1, 2, 3})
 assert not member(toPython 4, toPython {1, 2, 3})

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -465,6 +465,14 @@ assert Equation(-x, -5)
 assert Equation(+x, 5)
 ///
 
+-- test @ (not part of default testsuite since it requires numpy)
+///
+np = import "numpy"
+v = np@@array {1, 2, 3}
+w = np@@array {4, 5, 6}
+assert Equation(v @ w, 32)
+///
+
 TEST ///
 -----------------------
 -- string operations --

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -291,6 +291,14 @@ PythonObject @@ Thing = (x, y, e) -> setattr(x, toString y, e)
 member(Thing,        PythonObject) := (x, y) -> false
 member(PythonObject, PythonObject) := (x, y) -> value y@@"__contains__" x
 
+quotientRemainder(PythonObject, PythonObject) := (x, y) -> (
+    qr := x@@"__divmod__" y;
+    (qr_0, qr_1))
+quotientRemainder(PythonObject, Thing) := (x, y
+    ) -> quotientRemainder(x, toPython y)
+quotientRemainder(Thing, PythonObject) := (x, y
+    ) -> quotientRemainder(toPython x, y)
+
 toPython = method(Dispatch => Thing)
 toPython RR := pythonFloatFromDouble
 toPython QQ := toPython @@ toRR

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -59,7 +59,6 @@ importFrom_Core {
     "pythonTupleNew",
     "pythonTupleSetItem",
     "pythonUnicodeAsUTF8",
-    "pythonUnicodeConcat",
     "pythonUnicodeFromString"
 }
 

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -749,3 +749,24 @@ doc ///
       ceiling toPython 5.8
       ceiling toPython(-5.8)
 ///
+
+doc ///
+  Key
+    (help#0, PythonObject)
+  Headline
+    documentation for python object
+  Usage
+    help x
+  Inputs
+    x:PythonObject
+  Outputs
+    :String
+  Description
+    Text
+      This calls Python's built-in @TT "help"@ function, which provides
+      documentation for Python objects.
+    Example
+      math = import "math"
+      help math
+      help math@@sin
+///

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -659,3 +659,34 @@ doc ///
       quotientRemainder(toPython 37, 5)
       class \ oo
 ///
+
+doc ///
+  Key
+    (round, ZZ, PythonObject)
+    (round, PythonObject, PythonObject)
+    (round, PythonObject)
+  Headline
+    round a python object
+  Usage
+    round(n, x)
+    round x
+  Inputs
+    n:ZZ
+    x:PythonObject
+  Outputs
+    :PythonObject
+  Description
+    Text
+      This calls Python's built-in @TT "round"@ function, which round @TT "x"@
+      to @TT "n"@ decimal places, or to the nearest integer if @TT "n"@ is not
+      given.
+    Example
+      x = (import "math")@@pi
+      round x
+      round(3, x)
+    Text
+      Ties are broken by @EM "round half to even"@.
+    Example
+      round toPython 2.5
+      round toPython 3.5
+///

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -630,3 +630,32 @@ doc ///
       objectType pythonValue "2"
       objectType pythonValue "'Hello, world!'"
 ///
+
+doc ///
+  Key
+    (quotientRemainder, PythonObject, PythonObject)
+    (quotientRemainder, PythonObject, Thing)
+    (quotientRemainder, Thing, PythonObject)
+  Headline
+    quotient and remainder of python objects
+  Usage
+    quotientRemainder(x, y)
+  Inputs
+    x:PythonObject
+    y:PythonObject
+  Outputs
+    :Sequence -- a pair of two python objects
+  Description
+    Text
+      The quotient and remainder when @TT "x"@ is divided by @TT "y"@.  This
+      calls Python's built-in @TT "divmod"@ function.
+    Example
+      quotientRemainder(toPython 37, toPython 5)
+      class \ oo
+    Text
+      If just one of the arguments is a python object, then the other is
+      converted to a python object using @TO "toPython"@.
+    Example
+      quotientRemainder(toPython 37, 5)
+      class \ oo
+///

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -364,6 +364,43 @@ doc ///
 
 doc ///
   Key
+    (abs, PythonObject)
+  Headline
+    absolute value of a python object
+  Usage
+    abs x
+  Inputs
+    x:PythonObject
+  Outputs
+    :PythonObject -- the absolute value of @TT "x"@
+  Description
+    Text
+      This is equivalent to the Python @HREF {
+      "https://docs.python.org/3/library/functions.html#abs", "abs"}@ function.
+    Example
+      abs toPython(-12)
+///
+
+doc ///
+  Key
+    (symbol ~, PythonObject)
+  Headline
+    bitwise not of a python object
+  Usage
+    x~
+  Inputs
+    x:PythonObject
+  Outputs
+    :PythonObject -- the bitwise not of @TT "x"@
+  Description
+    Text
+      This calls Python's special @TT "__invert__"@ method.
+    Example
+      (toPython 5)~
+///
+
+doc ///
+  Key
     (length,PythonObject)
   Headline
     returns the length of a python object

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -710,3 +710,42 @@ doc ///
       truncate toPython 5.8
       truncate toPython(-5.8)
 ///
+doc ///
+  Key
+    (floor, PythonObject)
+  Headline
+    floor of a python object
+  Usage
+    floor x
+  Inputs
+    x:PythonObject
+  Outputs
+    :PythonObject
+  Description
+    Text
+      This calls Python's built-in @TT "math.floor"@ function, which rounds
+      toward negative infinity.
+    Example
+      floor toPython 5.8
+      floor toPython(-5.8)
+///
+
+doc ///
+  Key
+    (ceiling, PythonObject)
+  Headline
+    ceiling of a python object
+  Usage
+    ceiling x
+  Inputs
+    x:PythonObject
+  Outputs
+    :PythonObject
+  Description
+    Text
+      This calls Python's built-in @TT "math.ceil"@ function, which rounds
+      toward positive infinity.
+    Example
+      ceiling toPython 5.8
+      ceiling toPython(-5.8)
+///

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -690,3 +690,23 @@ doc ///
       round toPython 2.5
       round toPython 3.5
 ///
+
+doc ///
+  Key
+    (truncate, PythonObject)
+  Headline
+    truncate a python object
+  Usage
+    truncate x
+  Inputs
+    x:PythonObject
+  Outputs
+    :PythonObject
+  Description
+    Text
+      This calls Python's built-in @TT "math.trunc"@ function, which rounds
+      toward zero.
+    Example
+      truncate toPython 5.8
+      truncate toPython(-5.8)
+///

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -633,6 +633,33 @@ doc ///
 
 doc ///
   Key
+    (member, Thing, PythonObject)
+    (member, PythonObject, PythonObject)
+  Headline
+    test membership in a python object
+  Usage
+    member(e, x)
+  Inputs
+    e:Thing
+    x:PythonObject
+  Outputs
+    :Boolean -- whether @TT "e"@ is in @TT "x"@
+  Description
+    Text
+      This calls Python's @TT "__contains__"@ method, which is equivalent
+      to using the Python @TT "in"@ keyword.
+    Example
+      member(toPython 3, toPython {1, 2, 3})
+      member(toPython 4, toPython {1, 2, 3})
+    Text
+      Note that testing a non-Python object for membership will always return
+      @TT "false"@.
+    Example
+      member(3, toPython {1, 2, 3})
+///
+
+doc ///
+  Key
     (quotientRemainder, PythonObject, PythonObject)
     (quotientRemainder, PythonObject, Thing)
     (quotientRemainder, Thing, PythonObject)

--- a/M2/Macaulay2/packages/Python/doc.m2
+++ b/M2/Macaulay2/packages/Python/doc.m2
@@ -29,6 +29,9 @@ doc ///
     (symbol *, PythonObject, PythonObject)
     (symbol *, PythonObject, Thing)
     (symbol *, Thing, PythonObject)
+    (symbol @, PythonObject, PythonObject)
+    (symbol @, PythonObject, Thing)
+    (symbol @, Thing, PythonObject)
     (symbol /, PythonObject, PythonObject)
     (symbol /, PythonObject, Thing)
     (symbol /, Thing, PythonObject)
@@ -110,6 +113,7 @@ doc ///
         LI {TT "-", " → ", TT "__sub__", " (binary), ",
 	    TT "__neg__", " (unary)"},
         LI {TT "*", " → ", TT "__mul__"},
+	LI {TT "@", " → ", TT "__matmul__"},
         LI {TT "/", " → ", TT "__truediv__"},
         LI {TT "//", " → ", TT "__floordiv__"},
         LI {TT "%", " → ", TT "__mod__"},

--- a/M2/Macaulay2/packages/Python/examples/___Python__Object_sp~.out
+++ b/M2/Macaulay2/packages/Python/examples/___Python__Object_sp~.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: -884777151
+
+i1 : (toPython 5)~
+
+o1 = -6
+
+o1 : PythonObject of class int
+
+i2 : 

--- a/M2/Macaulay2/packages/Python/examples/_abs_lp__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_abs_lp__Python__Object_rp.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: 941520406
+
+i1 : abs toPython(-12)
+
+o1 = 12
+
+o1 : PythonObject of class int
+
+i2 : 

--- a/M2/Macaulay2/packages/Python/examples/_ceiling_lp__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_ceiling_lp__Python__Object_rp.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: -1024785038
+
+i1 : ceiling toPython 5.8
+
+o1 = 6
+
+o1 : PythonObject of class int
+
+i2 : ceiling toPython(-5.8)
+
+o2 = -5
+
+o2 : PythonObject of class int
+
+i3 : 

--- a/M2/Macaulay2/packages/Python/examples/_floor_lp__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_floor_lp__Python__Object_rp.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: 1355463756
+
+i1 : floor toPython 5.8
+
+o1 = 5
+
+o1 : PythonObject of class int
+
+i2 : floor toPython(-5.8)
+
+o2 = -6
+
+o2 : PythonObject of class int
+
+i3 : 

--- a/M2/Macaulay2/packages/Python/examples/_help_lp__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_help_lp__Python__Object_rp.out
@@ -1,0 +1,18 @@
+-- -*- M2-comint -*- hash: 538010608
+
+i1 : math = import "math"
+
+o1 = <module 'math' (built-in)>
+
+o1 : PythonObject of class module
+
+i2 : help math
+
+o2 = This module provides access to the mathematical functions
+     defined by the C standard.
+
+i3 : help math@@sin
+
+o3 = Return the sine of x (measured in radians).
+
+i4 : 

--- a/M2/Macaulay2/packages/Python/examples/_member_lp__Thing_cm__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_member_lp__Thing_cm__Python__Object_rp.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: 392422130
+
+i1 : member(toPython 3, toPython {1, 2, 3})
+
+o1 = true
+
+i2 : member(toPython 4, toPython {1, 2, 3})
+
+o2 = false
+
+i3 : member(3, toPython {1, 2, 3})
+
+o3 = false
+
+i4 : 

--- a/M2/Macaulay2/packages/Python/examples/_quotient__Remainder_lp__Python__Object_cm__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_quotient__Remainder_lp__Python__Object_cm__Python__Object_rp.out
@@ -1,0 +1,27 @@
+-- -*- M2-comint -*- hash: 1175896729
+
+i1 : quotientRemainder(toPython 37, toPython 5)
+
+o1 = (7, 2)
+
+o1 : Sequence
+
+i2 : class \ oo
+
+o2 = (PythonObject, PythonObject)
+
+o2 : Sequence
+
+i3 : quotientRemainder(toPython 37, 5)
+
+o3 = (7, 2)
+
+o3 : Sequence
+
+i4 : class \ oo
+
+o4 = (PythonObject, PythonObject)
+
+o4 : Sequence
+
+i5 : 

--- a/M2/Macaulay2/packages/Python/examples/_round_lp__Z__Z_cm__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_round_lp__Z__Z_cm__Python__Object_rp.out
@@ -1,0 +1,33 @@
+-- -*- M2-comint -*- hash: 259384909
+
+i1 : x = (import "math")@@pi
+
+o1 = 3.141592653589793
+
+o1 : PythonObject of class float
+
+i2 : round x
+
+o2 = 3
+
+o2 : PythonObject of class int
+
+i3 : round(3, x)
+
+o3 = 3.142
+
+o3 : PythonObject of class float
+
+i4 : round toPython 2.5
+
+o4 = 2
+
+o4 : PythonObject of class int
+
+i5 : round toPython 3.5
+
+o5 = 4
+
+o5 : PythonObject of class int
+
+i6 : 

--- a/M2/Macaulay2/packages/Python/examples/_truncate_lp__Python__Object_rp.out
+++ b/M2/Macaulay2/packages/Python/examples/_truncate_lp__Python__Object_rp.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: 1061541480
+
+i1 : truncate toPython 5.8
+
+o1 = 5
+
+o1 : PythonObject of class int
+
+i2 : truncate toPython(-5.8)
+
+o2 = -5
+
+o2 : PythonObject of class int
+
+i3 : 

--- a/M2/Macaulay2/packages/Python/no-python.m2
+++ b/M2/Macaulay2/packages/Python/no-python.m2
@@ -78,18 +78,41 @@ for type in {
 
 for op in {symbol +, symbol -, symbol *, symbol /, symbol //, symbol %,
     symbol ^, symbol <<, symbol >>, symbol &, symbol |, symbol ^^, symbol and,
-    symbol or, symbol xor, symbol ==, symbol ?} do (
+    symbol or, symbol xor, symbol ==, symbol ?, symbol @} do (
     installMethod(op, PythonObject, PythonObject, err);
     installMethod(op, PythonObject, Thing, err);
     installMethod(op, Thing, PythonObject, err))
 
-PythonObject Thing :=
-length PythonObject :=
-value PythonObject :=
-PythonObject @@ Thing :=
-PythonObject_Thing :=
-+PythonObject :=
--PythonObject := err
+-- unary methods
+for m in {
+    length,
+    value,
+    symbol +,
+    symbol -,
+    abs,
+    symbol ~,
+    round,
+    truncate,
+    floor,
+    ceiling,
+    help#0
+    } do installMethod(m, PythonObject, err)
+
+-- binary methods (PythonObject, Thing)
+for m in {
+    symbol SPACE,
+    symbol @@,
+    symbol_,
+    quotientRemainder
+    } do installMethod(m, PythonObject, Thing, err)
+
+-- others
+member(Thing, PythonObject) :=
+member(PythonObject, PythonObject) :=
+quotientRemainder(PythonObject, PythonObject) :=
+quotientRemainder(Thing, PythonObject) :=
+round(ZZ, PythonObject) :=
+round(PythonObject, PythonObject) := err
 
 objectType = x -> error errmsg
 runSimpleString = x -> error errmsg


### PR DESCRIPTION
A number of updates to the `Python` package.  Many of these prompted some of my more recent pull requests.

* Remove the unused `pythonUnicodeConcat` function from the interpreter.
* Add a bunch of `SpecialExpr` cases to `when` clauses in `python.d` to allow subclasses of `PythonObject` (see #2590)
* Add various methods to call more of Python's built-in special methods:
  - `@` (`__matmul__` -- this is consistent with Python's syntax even though we use `*` for matrix multiplication)
  - `abs` (`__abs__` -- see #2592)
  - `~` (`__invert__` -- see #2593)
  - `member` (`__contains__`)
  - `quotientRemainder` (`__divmod__` -- see #2595)
  - `round` (`__round__`)
  - `truncate` (`__trunc__` -- see #2594)
  - `floor` (`__floor__`)
  - `ceiling` (`__ceil__`)
  - `help` (`__doc__`)
 * Add tests and documentation for the above.