### PR TITLE
Empty JSON arrays and objects

### DIFF
--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -152,28 +152,29 @@ incIndentLevel JSONEncoder := e -> e.IndentLevel = e.IndentLevel + 1
 decIndentLevel = method()
 decIndentLevel JSONEncoder := e -> e.IndentLevel = e.IndentLevel - 1
 
+demarkValues = method()
+demarkValues(JSONEncoder, Function) := (e, f) -> concatenate(
+    maybeNewline e,
+    (incIndentLevel e; indent e),
+    demark(e.ValueSeparator | maybeNewline e | indent e, f()),
+    maybeNewline e,
+    (decIndentLevel e; indent e))
+
 toJSON(JSONEncoder, VisibleList):= o -> (e, L) -> (
-    if #L > 0 then concatenate("[",
-	maybeNewline e,
-	(incIndentLevel e; indent e),
-	demark(e.ValueSeparator | maybeNewline e | indent e,
-	    apply(L, x -> toJSON(e, x))),
-	maybeNewline e,
-	(decIndentLevel e; indent e),
+    if #L > 0 then concatenate(
+	"[",
+	demarkValues(e, () -> apply(L, x -> toJSON(e, x))),
 	"]")
     else "[]")
 
 toJSON(JSONEncoder, HashTable) := o -> (e, H) -> (
-    if #H > 0 then concatenate("{",
-	maybeNewline e,
-	(incIndentLevel e; indent e),
-	demark(e.ValueSeparator | maybeNewline e | indent e,
-	    (if e.Sort then sort else identity) apply(keys H, k -> concatenate(
+    if #H > 0 then concatenate(
+	"{",
+	demarkValues(e, () -> (if e.Sort then sort else identity) apply(
+		keys H, k -> concatenate(
 		    toJSON(e, toString k),
 		    e.NameSeparator,
 		    toJSON(e, H#k)))),
-	maybeNewline e,
-	(decIndentLevel e; indent e),
 	"}")
     else "{}")
 

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -153,17 +153,18 @@ decIndentLevel = method()
 decIndentLevel JSONEncoder := e -> e.IndentLevel = e.IndentLevel - 1
 
 toJSON(JSONEncoder, VisibleList):= o -> (e, L) -> (
-    concatenate("[",
+    if #L > 0 then concatenate("[",
 	maybeNewline e,
 	(incIndentLevel e; indent e),
 	demark(e.ValueSeparator | maybeNewline e | indent e,
 	    apply(L, x -> toJSON(e, x))),
 	maybeNewline e,
 	(decIndentLevel e; indent e),
-	"]"))
+	"]")
+    else "[]")
 
 toJSON(JSONEncoder, HashTable) := o -> (e, H) -> (
-    concatenate("{",
+    if #H > 0 then concatenate("{",
 	maybeNewline e,
 	(incIndentLevel e; indent e),
 	demark(e.ValueSeparator | maybeNewline e | indent e,
@@ -173,7 +174,8 @@ toJSON(JSONEncoder, HashTable) := o -> (e, H) -> (
 		    toJSON(e, H#k)))),
 	maybeNewline e,
 	(decIndentLevel e; indent e),
-	"}"))
+	"}")
+    else "{}")
 
 beginDocumentation()
 

--- a/M2/Macaulay2/packages/JSON/test-encode.m2
+++ b/M2/Macaulay2/packages/JSON/test-encode.m2
@@ -47,6 +47,11 @@ assert Equation(toJSON({1, 2, 3, {4, 5}}, Indent => "  "), ///[
   ]
 ]///)
 
+assert Equation(toJSON({}, Indent => 2), "[]")
+assert Equation(toJSON({{}}, Indent => 2), ///[
+  []
+]///)
+
 -- objects
 assert Equation(toJSON(hashTable{"a" => 1, "b" => 2, "c" => 3}, Sort => true),
     "{\"a\": 1, \"b\": 2, \"c\": 3}")


### PR DESCRIPTION
### Before

Previously,  two newlines were used when formatting empty JSON arrays and objects with a non-null `Indent` option.

```m2
i1 : needsPackage "JSON"

o1 = JSON

o1 : Package

i2 : toJSON({}, Indent => 4)

o2 = [
         
     ]

i3 : toJSON({hashTable {}}, Indent => 4)

o3 = [
         {
             
         }
     ]
```

### After

We remove these newlines.

```m2
i1 : needsPackage "JSON"

o1 = JSON

o1 : Package

i2 : toJSON({}, Indent => 4)

o2 = []

i3 : toJSON({hashTable {}}, Indent => 4)

o3 = [
         {}
     ]
```

This is consistent with the behavior of Python's `json` module:

```python
>>> import json
>>> print(json.dumps([], indent=4))
[]
>>> print(json.dumps([{}], indent=4))
[
    {}
]
```