### PR TITLE
Python updates (remove redundant code & integer conversion improvements)

### DIFF
--- a/M2/Macaulay2/d/basic.d
+++ b/M2/Macaulay2/d/basic.d
@@ -3,13 +3,6 @@
 use expr;
 
 header "#include <engine.h>"; -- required for raw hash functions
-header "
-#ifdef WITH_PYTHON
-#  include <Python.h>
-#else
-#  define PyObject_Hash(o) 0
-#  define PyErr_Clear()    0
-#endif";
 
 export hash(e:Expr):int := (
      when e
@@ -70,12 +63,7 @@ export hash(e:Expr):int := (
      is x:CompiledFunction do x.hash
      is x:CompiledFunctionClosure do x.hash
      is f:CompiledFunctionBody do 12347
-     is po:pythonObjectCell do (
-	 h := int(Ccode(long, "PyObject_Hash(",po.v,")"));
-	 if h == -1 then ( -- unhashable object (e.g., a list)
-	     Ccode(void, "PyErr_Clear()");
-	     int(123455))
-	 else h)
+     is po:pythonObjectCell do po.hash
      is xmlNodeCell do int(123456)
      is xmlAttrCell do int(123457)
      is t:TaskCell do t.body.hash

--- a/M2/Macaulay2/d/parse.d
+++ b/M2/Macaulay2/d/parse.d
@@ -352,7 +352,7 @@ export MysqlField  := Pointer "struct st_mysql_field *";
 export MysqlFieldWrapper  := {+res:MysqlResultWrapper, fld:MysqlField};
 
 export pythonObject := Pointer "struct _object *";
-export pythonObjectCell := {+v:pythonObject};
+export pythonObjectCell := {+v:pythonObject, hash:int};
 
 export TaskCellBody := {+
      hash:int,

--- a/M2/Macaulay2/d/python-c.c
+++ b/M2/Macaulay2/d/python-c.c
@@ -95,6 +95,46 @@ void python_initspam() {
  * Copyright 2008-2022 Case Van Horsen
  * LGPL-3.0+ */
 
+mpz_ptr python_LongAsZZ(mpz_ptr z, PyObject *obj)
+{
+  int negative;
+  Py_ssize_t len;
+  PyLongObject *templong;
+
+  templong = (PyLongObject *)obj;
+
+  switch (Py_SIZE(templong)) {
+  case -1:
+    mpz_set_si(z, -(sdigit)templong->ob_digit[0]);
+    break;
+  case 0:
+    mpz_set_si(z, 0);
+    break;
+  case 1:
+    mpz_set_si(z, templong->ob_digit[0]);
+    break;
+  default:
+    mpz_set_si(z, 0);
+
+    if (Py_SIZE(templong) < 0) {
+      len = -Py_SIZE(templong);
+      negative = 1;
+    } else {
+      len = Py_SIZE(templong);
+      negative = 0;
+    }
+
+    mpz_import(z, len, -1, sizeof(templong->ob_digit[0]), 0,
+	       sizeof(templong->ob_digit[0])*8 - PyLong_SHIFT,
+	       templong->ob_digit);
+
+    if (negative)
+      mpz_neg(z, z);
+  }
+
+  return z;
+}
+
 PyObject *python_LongFromZZ(mpz_srcptr z)
 {
   int negative;

--- a/M2/Macaulay2/d/python-c.c
+++ b/M2/Macaulay2/d/python-c.c
@@ -37,10 +37,6 @@ int python_ErrOccurred(void) {
 		return (PyErr_Occurred() != NULL);
 }
 
-void python_ErrPrint(void) {
-	PyErr_Print();
-}
-
 PyObject *python_RunString(M2_string s) {
   char *t = M2_tocharstar(s);
   init();
@@ -59,30 +55,6 @@ int python_Main() {
 /***********
  * objects *
  ***********/
-
-PyObject *python_ObjectType(PyObject *o) {
-  return PyObject_Type(o);
-}
-
-int python_ObjectRichCompareBool(PyObject *o1, PyObject *o2, int opid) {
-	return PyObject_RichCompareBool(o1, o2, opid);
-}
-
-int python_ObjectHasAttrString(PyObject *o, char *attr) {
-	return PyObject_HasAttrString(o, attr);
-}
-
-PyObject *python_ObjectGetAttrString(PyObject *o, char *attr) {
-	return PyObject_GetAttrString(o, attr);
-}
-
-int python_ObjectSetAttrString(PyObject *o, char *attr_name, PyObject *v) {
-	return PyObject_SetAttrString(o, attr_name, v);
-}
-
-PyObject *python_ObjectStr(PyObject *o) {
-	return PyObject_Str(o);
-}
 
 /* see http://docs.python.org/extending/extending.html for this example */
 
@@ -109,123 +81,6 @@ void python_initspam() {
   SpamError = PyErr_NewException(name, NULL, NULL);
   Py_INCREF(SpamError);
   PyModule_AddObject(m, "error", SpamError);
-}
-
-/*********
- * bools *
- *********/
-
-PyObject *python_True = Py_True;
-PyObject *python_False = Py_False;
-
-/********
- * ints *
- ********/
-
-long python_LongAsLong(PyObject *o) {
-	return PyLong_AsLong(o);
-}
-
-PyObject *python_LongFromLong(long v) {
-	return PyLong_FromLong(v);
-}
-
-/**********
- * floats *
- **********/
-
-double python_FloatAsDouble(PyObject *o) {
-	return PyFloat_AsDouble(o);
-}
-
-PyObject *python_FloatFromDouble(double v) {
-	return PyFloat_FromDouble(v);
-}
-
-/*************
- * complexes *
- *************/
-
-PyObject* python_ComplexFromDoubles(double real, double imag) {
-	return PyComplex_FromDoubles(real, imag);
-}
-
-/***********
- * strings *
- ***********/
-
-const char *python_UnicodeAsUTF8(PyObject *o) {
-	return PyUnicode_AsUTF8(o);
-}
-
-PyObject *python_UnicodeFromString(char *u) {
-	return PyUnicode_FromString(u);
-}
-
-/**********
- * tuples *
- **********/
-
-PyObject *python_TupleNew(int n) {
-	return PyTuple_New(n);
-}
-
-int python_TupleSetItem(PyObject *L, int i, PyObject *item) {
-	return PyTuple_SetItem(L, i, item);
-}
-
-/*********
- * lists *
- *********/
-
-PyObject *python_ListNew(int n) {
-	return PyList_New(n);
-}
-
-int python_ListSetItem(PyObject *L, int i, PyObject *item) {
-	return PyList_SetItem(L, i, item);
-}
-
-/****************
- * dictionaries *
- ****************/
-
-PyObject *python_DictNew(void) {
-	return PyDict_New();
-}
-
-int python_DictSetItem(PyObject *p, PyObject *key, PyObject *val) {
-	return PyDict_SetItem(p, key, val);
-}
-
-/********
- * sets *
- ********/
-
-PyObject *python_SetNew(PyObject *o) {
-	return PySet_New(o);
-}
-
-/*************
- * callables *
- *************/
-
-PyObject *python_ObjectCall(PyObject *o, PyObject *args, PyObject *kwargs) {
-	return PyObject_Call(o, args, kwargs);
-}
-
-/********
- * none *
- ********/
-
-PyObject *python_None = Py_None;
-
-/*************
- * importing *
- *************/
-
-PyObject *python_ImportImportModule(char *name) {
-	return PyImport_ImportModule(name);
 }
 
 #if 0

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -383,7 +383,8 @@ setupfun("pythonObjectCall",PyObjectCall);
 -- none --
 ----------
 
-setupconst("pythonNone", toExpr(Ccode(pythonObjectOrNull, "Py_None")));
+PyNone(e:Expr):Expr := toExpr(Ccode(pythonObjectOrNull, "Py_None"));
+setupfun("getPythonNone", PyNone);
 
 ---------------
 -- importing --

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -162,10 +162,15 @@ PyLongAsLong(e:Expr):Expr :=
     else WrongArgPythonObject();
 setupfun("pythonLongAsLong",PyLongAsLong);
 
+import LongFromZZ(x:ZZ):pythonObjectOrNull;
 PyLongFromLong(e:Expr):Expr :=
     when e
-    is x:ZZcell do toExpr(Ccode(pythonObjectOrNull,
-	    "PyLong_FromLong(", toLong(x), ")"))
+    is x:ZZcell do (
+	if isLong(x) then toExpr(Ccode(pythonObjectOrNull,
+		"PyLong_FromLong(", toLong(x), ")"))
+	else if isULong(x) then toExpr(Ccode(pythonObjectOrNull,
+		"PyLong_FromUnsignedLong(", toULong(x), ")"))
+	else toExpr(LongFromZZ(x.v)))
     else WrongArgPythonObject();
 setupfun("pythonLongFromLong",PyLongFromLong);
 

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -153,8 +153,10 @@ setupfun("initspam",runinitspam);
 -- bools -
 ----------
 
-setupconst("pythonTrue", toExpr(Ccode(pythonObjectOrNull, "Py_True")));
-setupconst("pythonFalse", toExpr(Ccode(pythonObjectOrNull, "Py_False")));
+setupconst("pythonTrue",
+    Expr(pythonObjectCell(Ccode(pythonObject, "Py_True"), 1)));
+setupconst("pythonFalse",
+    Expr(pythonObjectCell(Ccode(pythonObject, "Py_False"), 0)));
 
 ----------
 -- ints --

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -35,12 +35,12 @@ exportFrom_Core {
     "objectType"}
 
 importFrom_Core {
+    "getPythonNone",
     "pythonComplexFromDoubles",
     "pythonDictNew",
     "pythonDictSetItem",
     "pythonFalse",
     "pythonImportImportModule",
-    "pythonNone",
     "pythonListNew",
     "pythonListSetItem",
     "pythonLongAsLong",
@@ -87,6 +87,8 @@ PythonObject#{Standard,AfterPrint} = x -> (
      t = replace("<([a-z]+) '(.*)'>","of \\1 \\2",t);
      << concatenate(interpreterDepth:"o") << lineNumber << " : PythonObject " << t << endl;
      )
+
+pythonNone = getPythonNone()
 
 pythonValue = method(Dispatch => Thing)
 pythonValue String := s -> (

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -57,7 +57,6 @@ importFrom_Core {
     "pythonSetNew",
     "pythonTrue",
     "pythonTupleNew",
-    "pythonTupleSetItem",
     "pythonUnicodeAsUTF8",
     "pythonUnicodeFromString"
 }
@@ -314,11 +313,7 @@ toPython ZZ := pythonLongFromLong
 toPython Boolean := x -> if x then pythonTrue else pythonFalse
 toPython Constant := x -> toPython(x + 0)
 toPython String := pythonUnicodeFromString
-toPython Sequence := L -> (
-    n := #L;
-    result := pythonTupleNew n;
-    for i to n - 1 do pythonTupleSetItem(result, i, toPython L_i);
-    result)
+toPython Sequence := x -> pythonTupleNew \\ toPython \ x
 toPython VisibleList := L -> (
     n := #L;
     result := pythonListNew n;

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -576,6 +576,14 @@ assert instance(x, String)
 assert match("cosine", x)
 ///
 
+TEST ///
+-- large integers
+assert Equation(toPython 10^100, pythonValue "10**100")
+assert Equation(toPython(-10^100), pythonValue "-10**100")
+assert Equation(value pythonValue "10**100", 10^100)
+assert Equation(value pythonValue "-10**100", -10^100)
+///
+
 end --------------------------------------------------------
 
 


### PR DESCRIPTION
`python-c.c` was full of lots of one-line wrappers around Python C API functions, which just as easily could have been put in `Ccode` statements in `python.d`.  We make this change to ease maintenance.