### PR TITLE
ForeignFunctions updates (iteration, NULL-terminated arrays)

### DIFF
--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -15,6 +15,8 @@ voidPointerOrNull := voidPointer or null;
 toExpr(x:voidPointer):Expr := Expr(pointerCell(x));
 WrongArgPointer():Expr := WrongArg("a pointer");
 WrongArgPointer(n:int):Expr := WrongArg(n, "a pointer");
+setupconst("nullPointer", toExpr(nullPointer()));
+
 getMem(n:int):voidPointer := Ccode(voidPointer, "getmem(", n, ")");
 getMemAtomic(n:int):voidPointer := Ccode(voidPointer, "getmem_atomic(", n, ")");
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -63,6 +63,7 @@ export {
     "foreignPointerArrayType",
     "foreignStructType",
     "foreignUnionType",
+    "foreignSymbol",
 
 -- symbols
     "Variadic"
@@ -506,6 +507,15 @@ foreignFunction(Pointer, String, ForeignType, VisibleList) :=  o -> (
 		    then error("expected ", #argtypes, " arguments");
 		    avalues := apply(#args, i -> address (argtypes#i args#i));
 		    dereference_rtype ffiCall(cif, funcptr, 100, avalues)))))
+
+--------------------
+-- foreign symbol --
+--------------------
+
+foreignSymbol = method(TypicalValue => ForeignObject)
+foreignSymbol(SharedLibrary, String, ForeignType) := (
+    lib, symb, T) -> dereference_T dlsym(lib#0, symb)
+foreignSymbol(String, ForeignType) := (symb, T) -> dereference_T dlsym symb
 
 beginDocumentation()
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1364,6 +1364,23 @@ assert Equation(value x_(-1), 3)
 ptrarray = 3 * voidstar
 x = ptrarray {address int 1, address int 2, address int 3}
 assert Equation(for ptr in x list value int value ptr, {1, 2, 3})
+x = charstarstar {"foo", "bar", "baz"}
+assert Equation(length x, 3)
+assert Equation(value \ value x, {"foo", "bar", "baz"})
+assert Equation(value x_0, "foo")
+assert Equation(value x_(-1), "baz")
+x = voidstarstar {address int 1, address int 2, address int 3, address int 4}
+assert Equation(length x, 4)
+assert Equation(value \ for ptr in x list int value ptr, {1, 2, 3, 4})
+assert Equation(value int value x_0, 1)
+assert Equation(value int value x_(-1), 4)
+int3star = foreignPointerArrayType(3 * int)
+x = int3star {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}}
+assert Equation(length x, 4)
+assert Equation(for y in x list value \ value y,
+    {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}})
+assert Equation(value \ value x_0, {1, 2, 3})
+assert Equation(value \ value x_(-1), {10, 11, 12})
 
 -- struct types
 teststructtype = foreignStructType("foo",

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -235,6 +235,7 @@ foreignRealType(String, ZZ) := (name, bits) -> (
     T.Address = ffiRealType(bits);
     new T from RR := (T, x) -> new T from {Address => ffiRealAddress(x, bits)};
     value T := x -> ffiRealValue(address x, bits);
+    net T := x -> format(0, value x);
     T)
 
 float = foreignRealType("float", 32)

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1467,3 +1467,14 @@ asctime = foreignFunction("asctime", charstar, voidstar)
 epoch = tm value gmtime address long 0
 assert Equation(value asctime address epoch,"Thu Jan  1 00:00:00 1970\n")
 ///
+
+TEST ///
+-------------------
+-- foreignSymbol --
+-------------------
+mpfi = openSharedLibrary "mpfi"
+(foreignFunction(mpfi, "mpfi_set_error", void, int)) 5
+assert Equation(value foreignSymbol(mpfi, "mpfi_error", int), 5)
+assert Equation(value foreignSymbol("mpfi_error", int), 5)
+(foreignFunction(mpfi, "mpfi_reset_error", void, void))()
+///

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -566,6 +566,19 @@ doc ///
 
 doc ///
   Key
+    "nullPointer"
+  Headline
+    the null pointer
+  Description
+    Text
+      This @TO Pointer@ object represents the @wikipedia "null pointer"@,
+      indicating that the pointer does not refer to a valid object.
+    Example
+      nullPointer
+///
+
+doc ///
+  Key
     ForeignType
     (net, ForeignType)
   Headline

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -573,20 +573,15 @@ doc ///
     Text
       This is the abstract class from which all other foreign type classes
       should inherit.  All @TT "ForeignType"@ objects should have, at minimum,
-      three key-value pairs:
+      two key-value pairs:
 
       @UL {
-	  LI {TT "name", ", ", ofClass String, ", a human-readable name of ",
+	  LI {TT "Name", ", ", ofClass String, ", a human-readable name of ",
 	      "the class for display purposes, used by ",
 	      TT "net(ForeignType)", "."},
-	  LI {TT "address", ", ", ofClass Pointer, ", a pointer to the ",
+	  LI {TT "Address", ", ", ofClass Pointer, ", a pointer to the ",
 	      "corresponding ", TT "ffi_type", " object, used by ",
-	      TO (address, ForeignType), "."},
-	  LI {TT "value", ", ", ofClass Function, ", a function that sends ",
-	      "objects of this type to corresponding Macaulay2 values, ",
-	      "used by ", TO (value, ForeignObject), "."}}@
-
-      Subclasses may add additional key-value pairs as needed.
+	      TO (address, ForeignType), "."}}@
 ///
 
 doc ///

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -130,6 +130,7 @@ foreignObject VisibleList := x -> (
     types := unique(class \ foreignObject \ x);
     if #types == 1 then (foreignArrayType(first types, #x)) x
     else error("expected all elements to have the same type"))
+foreignObject Pointer := x -> voidstar x
 
 registerFinalizer(ForeignObject, Function) := (
     x, f) -> registerFinalizerForPointer(

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -704,8 +704,6 @@ doc ///
     "uint"
     "long"
     "ulong"
-    (symbol SPACE, ForeignIntegerType, Number)
-    (symbol SPACE, ForeignIntegerType, Constant)
   Headline
     foreign integer type
   Description
@@ -732,6 +730,30 @@ doc ///
       uint
       long
       ulong
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignIntegerType, Number)
+    (symbol SPACE, ForeignIntegerType, Constant)
+    (NewFromMethod, int8, ZZ)
+    (NewFromMethod, int16, ZZ)
+    (NewFromMethod, int32, ZZ)
+    (NewFromMethod, int64, ZZ)
+    (NewFromMethod, uint8, ZZ)
+    (NewFromMethod, uint16, ZZ)
+    (NewFromMethod, uint32, ZZ)
+    (NewFromMethod, uint64, ZZ)
+  Headline
+    cast a Macaulay2 number to a foreign integer object
+  Usage
+    T n
+  Inputs
+    T:ForeignIntegerType
+    n:Number
+  Outputs
+    :ForeignObject
+  Description
     Text
       To cast a Macaulay2 number to a foreign object with an integer type,
       give the type followed by the number.  Non-integers will be truncated.
@@ -746,9 +768,6 @@ doc ///
     ForeignRealType
     "float"
     "double"
-    (symbol SPACE, ForeignRealType, Constant)
-    (symbol SPACE, ForeignRealType, Number)
-    (symbol SPACE, ForeignRealType, RRi)
   Headline
     foreign real type
   Description
@@ -760,6 +779,25 @@ doc ///
     Example
       float
       double
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignRealType, Number)
+    (symbol SPACE, ForeignRealType, Constant)
+    (symbol SPACE, ForeignRealType, RRi)
+    (NewFromMethod, float, RR)
+    (NewFromMethod, double, RR)
+  Headline
+    cast a Macaulay2 number to a foreign real object
+  Usage
+    T x
+  Inputs
+    T:ForeignRealType
+    x:Number
+  Outputs
+    :ForeignObject
+  Description
     Text
       To cast a Macaulay2 number to a foreign object with a real type, give
       the type followed by the number.
@@ -784,32 +822,6 @@ doc ///
       @TT "voidstar"@.
     Example
       voidstar
-///
-
-doc ///
-  Key
-    (registerFinalizer, ForeignObject, Function)
-  Headline
-    register a finalizer for a foreign object
-  Usage
-    registerFinalizer(x, f)
-  Inputs
-    x:ForeignObject
-    f:Function
-  Description
-    Text
-      If a foreign pointer object corresponds to memory that was not allocated
-      by the @TO "GC garbage collector"@, then a function to properly
-      deallocate this memory when the @TO "Pointer"@ object that stores this
-      pointer is garbage collected should be called.  The function should
-      take a single argument, a foreign object, typically  of type
-      @TO "voidstar"@, which corresponds to the memory to deallocate.
-    Example
-      malloc = foreignFunction("malloc", voidstar, ulong)
-      free = foreignFunction("free", void, voidstar)
-      finalizer = x -> (print("freeing memory at " | net x); free x)
-      for i to 9 do (x := malloc 8; registerFinalizer(x, finalizer))
-      collectGarbage()
 ///
 
 doc ///
@@ -876,6 +888,24 @@ doc ///
     Text
       This is the class for array types.  There are no built-in types.  They
       must be constructed using @TO "foreignArrayType"@.
+    Example
+      x = (3 * int) {3, 5, 7}
+    Text
+      Foreign arrays may be subscripted using @TO "_"@.
+    Example
+      x_1
+      x_(-1)
+    Text
+      Their lengths may be found using @TO "length"@.
+    Example
+      length x
+    Text
+      They are also @TO2 {"iterators", "iterable"}@.
+    Example
+       i = iterator x;
+       next i
+       next i
+       for y in x list value y + 1
 ///
 
 doc ///
@@ -919,6 +949,8 @@ doc ///
 doc ///
   Key
     (symbol SPACE, ForeignArrayType, VisibleList)
+  Headline
+    cast a Macaulay2 list to a foreign array
   Usage
     T x
   Inputs
@@ -933,11 +965,6 @@ doc ///
     Example
       intarray5 = 5 * int
       x = intarray5 {2, 4, 6, 8, 10}
-    Text
-      Use @TT "_"@ to return a single element of a foreign array.
-    Example
-      x_2
-      x_(-1)
  Caveat
    The number of elements of @TT "x"@ must match the number of elements
    that were specified when @TT "T"@ was constructed.
@@ -1104,7 +1131,23 @@ doc ///
 doc ///
   Key
     (value, ForeignObject)
+    (value, charstar)
+    (value, charstarstar)
+    (value, double)
+    (value, float)
+    (value, int8)
+    (value, int16)
+    (value, int32)
+    (value, int64)
+    (value, uint8)
+    (value, uint16)
+    (value, uint32)
+    (value, uint64)
+    (value, voidstar)
+    (value, voidstarstar)
     (net, ForeignObject)
+    (net, double)
+    (net, float)
   Headline
     get the value of a foreign object as a Macaulay2 thing
   Usage
@@ -1185,6 +1228,10 @@ doc ///
     Example
       foreignObject "Hello, world!"
     Text
+      Pointers are converted to @TO "voidstar"@ objects.
+    Example
+      foreignObject nullPointer
+    Text
       Lists are converted to foreign objects with the appropriate
       @TO "ForeignArrayType"@.
     Example
@@ -1216,6 +1263,32 @@ doc ///
       x = chararray4 append(ascii "foo", 0)
       y = charstar x
       address x === address y
+///
+
+doc ///
+  Key
+    (registerFinalizer, ForeignObject, Function)
+  Headline
+    register a finalizer for a foreign object
+  Usage
+    registerFinalizer(x, f)
+  Inputs
+    x:ForeignObject
+    f:Function
+  Description
+    Text
+      If a foreign pointer object corresponds to memory that was not allocated
+      by the @TO "GC garbage collector"@, then a function to properly
+      deallocate this memory when the @TO "Pointer"@ object that stores this
+      pointer is garbage collected should be called.  The function should
+      take a single argument, a foreign object, typically  of type
+      @TO "voidstar"@, which corresponds to the memory to deallocate.
+    Example
+      malloc = foreignFunction("malloc", voidstar, ulong)
+      free = foreignFunction("free", void, voidstar)
+      finalizer = x -> (print("freeing memory at " | net x); free x)
+      for i to 9 do (x := malloc 8; registerFinalizer(x, finalizer))
+      collectGarbage()
 ///
 
 doc ///

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -94,7 +94,7 @@ importFrom_Core {
 -- pointer --
 -------------
 
-exportFrom_Core {"Pointer"}
+exportFrom_Core {"Pointer", "nullPointer"}
 Pointer.synonym = "pointer"
 Pointer + ZZ := (ptr, n) -> ptr + n -- defined in actors.d
 ZZ + Pointer := (n, ptr) -> ptr + n

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -775,13 +775,26 @@ doc ///
       @TT "voidstar"@.
     Example
       voidstar
+///
+
+doc ///
+  Key
+    (registerFinalizer, ForeignObject, Function)
+  Headline
+    register a finalizer for a foreign object
+  Usage
+    registerFinalizer(x, f)
+  Inputs
+    x:ForeignObject
+    f:Function
+  Description
     Text
       If a foreign pointer object corresponds to memory that was not allocated
       by the @TO "GC garbage collector"@, then a function to properly
       deallocate this memory when the @TO "Pointer"@ object that stores this
       pointer is garbage collected should be called.  The function should
-      take a single argument, a foreign object of type @TO "voidstar"@,
-      which corresponds to the memory to deallocate.
+      take a single argument, a foreign object, typically  of type
+      @TO "voidstar"@, which corresponds to the memory to deallocate.
     Example
       malloc = foreignFunction("malloc", voidstar, ulong)
       free = foreignFunction("free", void, voidstar)

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1319,6 +1319,36 @@ doc ///
       registerFinalizer(x, free)
 ///
 
+doc ///
+  Key
+    foreignSymbol
+    (foreignSymbol, SharedLibrary, String, ForeignType)
+    (foreignSymbol, String, ForeignType)
+  Headline
+    get a foreign symbol
+  Usage
+    foreignSymbol(lib, symb, T)
+    foreignSymbol(symb, T)
+  Inputs
+    lib:SharedLibrary
+    symb:String
+    T:ForeignType
+  Outputs
+    :ForeignObject
+  Description
+    Text
+      This function is a wrapper around the C function @TT "dlsym"@.  It
+      loads a symbol from a shared library using the specified foreign type.
+    Example
+      mps = openSharedLibrary "mps"
+      cplxT = foreignStructType("cplx_t", {"r" => double, "i" => double})
+      foreignSymbol(mps, "cplx_i", cplxT)
+    Text
+      If the shared library is already linked against Macaulay2, then it may
+      be omitted.
+    Example
+      foreignSymbol("cplx_i", cplxT)
+///
 
 TEST ///
 -----------

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -972,6 +972,104 @@ doc ///
 
 doc ///
   Key
+    ForeignPointerArrayType
+    charstarstar
+    voidstarstar
+    (symbol _, charstarstar, ZZ)
+    (symbol _, voidstarstar, ZZ)
+    (length, charstarstar)
+    (length, voidstarstar)
+    (iterator, charstarstar)
+    (iterator, voidstarstar)
+  Headline
+    foreign type for NULL-terminated arrays of pointers
+  Description
+    Text
+      This is the class for a particular kind of array type, where the entries
+      of each array are some sort of pointer type and the lengths are arbitrary.
+      There are two built-in types, @TT "charstarstar"@ (for arrays of strings)
+      and @TT "voidstarstar"@ (for arrays of pointers), but more types may be
+      constructed using @TO foreignPointerArrayType@.
+    Example
+      charstarstar {"foo", "bar", "baz"}
+      charstarstar {"the", "quick", "brown", "fox", "jumps", "over", "the",
+	  "lazy", "dog"}
+      voidstarstar {address int 0, address int 1, address int 2}
+    Text
+      Foreign pointer arrays may be subscripted using @TO "_"@.
+    Example
+      x = charstarstar {"foo", "bar", "baz"}
+      x_1
+      x_(-1)
+    Text
+      Their lengths may be found using @TO "length"@.
+    Example
+      length x
+    Text
+      They are also @TO2 {"iterators", "iterable"}@.
+    Example
+       i = iterator x;
+       next i
+       next i
+       scan(x, print)
+///
+
+doc ///
+  Key
+    foreignPointerArrayType
+    (foreignPointerArrayType, ForeignType)
+    (foreignPointerArrayType, String, ForeignType)
+  Headline
+    construct a foreign pointer array type
+  Usage
+    foreignArrayType(name, T)
+    foreignArrayType T
+  Inputs
+    name:String
+    T:ForeignType
+  Outputs
+    :ForeignPointerArrayType
+  Description
+    Text
+      To construct a foreign array pointer type, specify a name and the type of
+      the  elements of each array.  This type must necessarily be some kind of
+      pointer type.
+    Example
+      foreignPointerArrayType("myPointerArray", 3 * int)
+    Text
+      If the name is omitted, then a default one is chosen by taking the name of
+      the type of the elements and appending a star.
+    Example
+      foreignPointerArrayType(3 * int)
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignPointerArrayType, VisibleList)
+    (NewFromMethod, charstarstar, VisibleList)
+    (NewFromMethod, voidstarstar, VisibleList)
+  Headline
+    cast a Macaulay2 list to a foreign pointer array
+  Usage
+    T x
+  Inputs
+    T:ForeignPointerArrayType
+    x:VisibleList
+  Outputs
+    :ForeignObject -- of type @TT "T"@
+  Description
+    Text
+      To cast a Macaulay2 list to a foreign pointer array type, give the
+      type followed by the list.
+    Example
+      charstarstar {"foo", "bar"}
+      voidstarstar {address int 0, address int 1, address int 2}
+      int2star = foreignPointerArrayType(2 * int)
+      int2star {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}}
+///
+
+doc ///
+  Key
     ForeignStructType
   Headline
     foreign struct type

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -131,6 +131,10 @@ foreignObject VisibleList := x -> (
     if #types == 1 then (foreignArrayType(first types, #x)) x
     else error("expected all elements to have the same type"))
 
+registerFinalizer(ForeignObject, Function) := (
+    x, f) -> registerFinalizerForPointer(
+    address x, f, ffiPointerValue address x)
+
 -----------------------------------
 -- foreign type (abstract class) --
 -----------------------------------
@@ -251,9 +255,6 @@ voidstar.Address = ffiPointerType
 value voidstar := ffiPointerValue @@ address
 ForeignPointerType Pointer := (T, x) -> new T from {
     Address => ffiPointerAddress x}
-
-registerFinalizer(voidstar, Function) := (
-    x, f) -> registerFinalizerForPointer(address x, f, value x)
 
 -------------------------
 -- foreign string type --

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1304,9 +1304,8 @@ assert Equation(value \ value intarray3 ptr, {1, 2, 3})
 assert Equation(value x_0, 1)
 assert Equation(value x_(-1), 3)
 ptrarray = 3 * voidstar
-assert Equation(
-    apply(value ptrarray {address int 1, address int 2, address int 3},
-    x -> value int value x), {1, 2, 3})
+x = ptrarray {address int 1, address int 2, address int 3}
+assert Equation(for ptr in x list value int value ptr, {1, 2, 3})
 
 -- struct types
 teststructtype = foreignStructType("foo",


### PR DESCRIPTION
Some updates to the `ForeignFunction` package:

There is a new foreign type: `ForeignPointerArrayType`, for `NULL`-terminated arrays of strings, pointers, and arrays.  These arrays are now iterable, as are the original fixed-length arrays.

```m2
i2 : x = charstarstar {"foo", "bar", "baz"}

o2 = {foo, bar, baz}

o2 : ForeignObject of type char**

i3 : for s in x do print s
foo
bar
baz
```
There's also a new wrapper around `dlsym` (`foreignSymbol`) that loads non-function foreign objects from a shared library:

```m2
i4 : foreignSymbol("mpfi_error", int)

o4 = 0

o4 : ForeignObject of type int32
```
Also some documentation updates.