### PR TITLE
Make delete a method

### DIFF
--- a/M2/Macaulay2/m2/structure.m2
+++ b/M2/Macaulay2/m2/structure.m2
@@ -19,7 +19,8 @@ position(VisibleList,VisibleList,Function) := o -> (v,w,f) -> (
      else (for i to #v-1 do if f(v#i,w#i) then return i)
      )
 
-delete = (x,v) -> select(v, i -> i =!= x)
+delete = method()
+delete(Thing, VisibleList) := (x,v) -> select(v, i -> i =!= x)
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "


### PR DESCRIPTION
Previously, it just called `select` without checking type types of the input, leading to strange behavior for non-lists.  According to the documentation, it is intended for use on lists.

Closes: #2623

Saw this issue pop up and seemed like a quick and easy fix!