### PR TITLE
Properly allocate memory for ForeignFunction return value

### DIFF
--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -132,8 +132,7 @@ ffiCall(e:Expr):Expr :=
 		is fn:pointerCell do when a.2
 		    is n:ZZcell do when a.3
 			is z:List do (
-			    rvalue := Ccode(voidPointer,
-				"getmem(", toInt(n), ")");
+			    rvalue := getMem(toInt(n));
 			    avalues := new array(voidPointer)
 				len length(z.v) at i
 				    do provide when z.v.i is p:pointerCell

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -488,6 +488,7 @@ foreignFunction(Pointer, String, ForeignType, VisibleList) :=  o -> (
 	    if not o.Variadic and #argtypes == 1 then argtypes = {}
 	    else error("void must be the only parameter"));
 	argtypePointers := address \ argtypes;
+	rsize := max(size rtype, version#"pointer size");
 	if o.Variadic then (
 	    nfixedargs := #argtypes;
 	    ForeignFunction(args -> (
@@ -499,7 +500,7 @@ foreignFunction(Pointer, String, ForeignType, VisibleList) :=  o -> (
 			argtypePointers | varargtypePointers);
 		    avalues := apply(nfixedargs, i ->
 			address (argtypes#i args#i)) | address \ varargs;
-		    dereference_rtype ffiCall(cif, funcptr, 100, avalues))))
+		    dereference_rtype ffiCall(cif, funcptr, rsize, avalues))))
 	else (
 	    cif := ffiPrepCif(address rtype, argtypePointers);
 	    ForeignFunction(args -> (
@@ -507,7 +508,7 @@ foreignFunction(Pointer, String, ForeignType, VisibleList) :=  o -> (
 		    if #argtypes != #args
 		    then error("expected ", #argtypes, " arguments");
 		    avalues := apply(#args, i -> address (argtypes#i args#i));
-		    dereference_rtype ffiCall(cif, funcptr, 100, avalues)))))
+		    dereference_rtype ffiCall(cif, funcptr, rsize, avalues)))))
 
 --------------------
 -- foreign symbol --


### PR DESCRIPTION
I had left 100 bytes in as a dummy value during initial testing but neglected to go back and fix it until now.  We either allocate the memory needed to store the type of the return value, or if it's a smaller type, widen that to the system register size (libffi has a special typedef for this, `ffi_arg`, but we just use `version#"pointer size"`).

We also simplify one line of corresponding code in the `d` directory, using the helper function `getMem` instead of calling `Ccode` directly.