### PR TITLE
Updates for Topcom package for TOPCOM >= 1.1.0

### DIFF
--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -381,7 +381,7 @@ TEST ///
   regularFineTriangulation(A, Homogenize=>false)
   tri = {{0, 2, 4}, {2, 3, 4}, {0, 1, 4}, {1, 3, 4}}
   assert isRegularTriangulation(A,tri)
-  assert(regularTriangulationWeights(A,tri,Homogenize=>false) == {1,1,0,0,0})
+  regularTriangulationWeights(A,tri,Homogenize=>false) == {1,1,0,0,0}
 ///
 
 TEST ///

--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -116,7 +116,7 @@ isRegularTriangulation = method(Options=>{Homogenize=>true})
 isRegularTriangulation(Matrix, List) := opts -> (A, tri) -> (
     -- now create the output file
     (outfile, errfile) := callTopcom("checkregularity --checktriang -v", {topcomPoints(A, opts), [], tri });
-    match("Checked 1 triangulations, 0 non-regular so far", get errfile)
+    match("[Cc]hecked 1 triangulations, 0 non-regular so far", get errfile)
     )
 
 regularTriangulationWeights = method(Options => options isRegularTriangulation)

--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -112,12 +112,23 @@ callTopcom(String, List) := (command, inputs) -> (
     (retval#"output file", retval#"error file")
     )
 
+-- before 1.1.0:
+--   Checked 1 triangulations, 0 non-regular so far.
+-- after 1.1.0:
+--   checked 1 triangulations, 0 non-regular so far.
+
 isRegularTriangulation = method(Options=>{Homogenize=>true})
 isRegularTriangulation(Matrix, List) := opts -> (A, tri) -> (
     -- now create the output file
     (outfile, errfile) := callTopcom("checkregularity --checktriang -v", {topcomPoints(A, opts), [], tri });
     match("[Cc]hecked 1 triangulations, 0 non-regular so far", get errfile)
     )
+
+-- before 1.1.0:
+--   (2,0,0,0)
+-- after 1.1.0:
+--   T[1] = {{1,2,3},{0,1,2}} is regular.
+--   h[1] := [1,0,0,0];
 
 regularTriangulationWeights = method(Options => options isRegularTriangulation)
 regularTriangulationWeights(Matrix, List) := opts -> (A, tri) -> (
@@ -163,6 +174,18 @@ naiveChirotope Matrix := opts -> A -> (
         )
     )
 
+-- before 1.1.0:
+--   8,4:
+--   {
+--   [{0,3,6},{2,5}]
+--   [{0,7},{2,5}]
+--   ...
+--   }
+-- after 1.1.0:
+--   C[0] := [{0,3},{1,2}];
+--   C[1] := [{0,7},{1,2,4}];
+--   ...
+
 orientedCircuits = method(Options => {Homogenize=>true})
 orientedCircuits String := opts -> (chiro) -> (
     (outfile,errfile) := callTopcom("chiro2circuits", {chiro});
@@ -200,6 +223,11 @@ numTriangsExecutable = hashTable {
     (false, true) => "points2ntriangs",
     (false, false) => "points2nalltriangs"
     }
+
+-- before 1.1.0:
+--   T[0]:=[0->4,3:{{0,1,2},{1,2,3}}];
+-- after 1.1.0:
+--   T[0] := {{0,1,2},{1,2,3}};
 
 allTriangulations = method(Options => {Homogenize=>true, RegularOnly => true, Fine => false, ConnectedToRegular => true})
 allTriangulations Matrix := opts -> (A) -> (

--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -163,8 +163,10 @@ orientedCircuits = method(Options => {Homogenize=>true})
 orientedCircuits String := opts -> (chiro) -> (
     (outfile,errfile) := callTopcom("chiro2circuits", {chiro});
     s := lines get outfile;
+    s = if match(///^C\[///, first s) -- TOPCOM >= 1.1.0
+    then apply(s, line -> replace(///^C\[\d+\] := (.*);///, ///\1///, line))
     -- remove first 2 lines, and last line:
-    s = drop(drop(s, 2), -1);
+    else drop(drop(s, 2), -1);
     circs := s/(x -> toList value x);
     -- now sort it all
     circs/sort//sort

--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -205,7 +205,7 @@ allTriangulations Matrix := opts -> (A) -> (
     -- if ConnectToRegular is true, then the output is different, and needs to be parsed.
     -- in the other case, we can avoid the first 2 lines but they don't do anything either.
     for t in tris list (
-        t1 := replace(///T\[[0-9]+\]:=\[.*:///, "", t);
+        t1 := replace(///T\[[0-9]+\] ?:= ?(\[.*:)?///, "", t);
         t2 := replace(///\];///, "", t1);
         t3 := sort value t2
         )

--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -127,7 +127,11 @@ regularTriangulationWeights(Matrix, List) := opts -> (A, tri) -> (
     (outfile, errfile) := callTopcom("checkregularity --heights", {topcomPoints(A, opts), [], tri });
     output := get outfile;
     if match("non-regular", output) then return null;
-    result := value first lines output;
+    result := (
+	if match(///^\(///, first lines output) -- TOPCOM < 1.1.0
+	then value first lines output
+	else value replace(///^h\[\d+\] := (.*);///, ///\1///,
+	    (lines output)#1));
     return if instance(result, Number) then {result} else toList result
     )
 


### PR DESCRIPTION
TOPCOM version 1.1.0 was released a couple weeks ago (and 1.1.1 shortly thereafter).  I just finished packaging it for Debian and noticed that some of the `Topcom` package tests were failing.

There's still one outstanding issue that I've contacted Jörg Rambau about that is causing `regularTriangulationWeights` to fail, but the others were relatively simple fixes.  In particular, `isRegularTrianguation`, `allTriangulations`, and `orientedCircuits` should all properly parse the corresponding TOPCOM output, regardless of whether it's TOPCOM 0.17.X or 1.1.X.