### PR TITLE
Iterator updates

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -1590,12 +1590,11 @@ map(e:Expr,f:Expr):Expr := (
 	  if !isInt(i)
 	  then WrongArgSmallInteger()
 	  else map(toInt(i),f))
-     is s:stringCell do map(strtoseq(s), f)
      else (
 	 iter := getIterator(e);
 	 if iter != nullE
 	 then applyEEE(getGlobalVariable(applyIteratorS), iter, f)
-	 else WrongArg(1,"a list, sequence, integer, string, or iterable")));
+	 else WrongArg(1,"a list, sequence, integer, or iterable")));
 map(e1:Expr,e2:Expr,f:Expr):Expr := (
      when e1
      is a1:Sequence do (
@@ -2078,7 +2077,6 @@ scan(e:Expr,f:Expr):Expr := (
 	  if !isInt(i)
 	  then WrongArgSmallInteger(1)
 	  else scan(toInt(i),f))
-     is s:stringCell do scan(strtoseq(s), f)
      else (
 	 i := getIterator(e);
 	 if i != nullE
@@ -2097,7 +2095,7 @@ scan(e:Expr,f:Expr):Expr := (
 		     else nothing);
 		 nullE)
 	     else buildErrorPacket("no method for applying next to iterator"))
-	 else WrongArg(1, "a list, sequence, integer, string, or iterable")));
+	 else WrongArg(1, "a list, sequence, integer, or iterable")));
 scan(e:Expr):Expr := (
      when e is a:Sequence do (
 	  if length(a) == 2

--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -1591,7 +1591,11 @@ map(e:Expr,f:Expr):Expr := (
 	  then WrongArgSmallInteger()
 	  else map(toInt(i),f))
      is s:stringCell do map(strtoseq(s), f)
-     else WrongArg(1,"a list, sequence, integer, or string"));
+     else (
+	 iter := getIterator(e);
+	 if iter != nullE
+	 then applyEEE(getGlobalVariable(applyIteratorS), iter, f)
+	 else WrongArg(1,"a list, sequence, integer, string, or iterable")));
 map(e1:Expr,e2:Expr,f:Expr):Expr := (
      when e1
      is a1:Sequence do (

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -21,10 +21,10 @@ export chars := new array(Expr) len 256 do (
 	i = i+1;
 	));
 
--- symbols for iteration
--- "iterator" and "next" will be reassigned as methods at top level
+-- symbols for iteration; will be reassigned at top level
 export iteratorS := setupvar("iterator", nullE);
 export nextS := setupvar("next", nullE);
+export applyIteratorS := setupvar("applyIterator", nullE);
 
 eval(c:Code):Expr;
 applyEE(f:Expr,e:Expr):Expr;

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -315,7 +315,6 @@ evalForCode(c:forCode):Expr := (
 	  when invalue is Error do return invalue
 	  is ww:Sequence do w = ww
 	  is vv:List do w = vv.v
-	  is s:stringCell do w = strtoseq(s)
 	  else (
 	      iter = getIterator(invalue);
 	      if iter != nullE
@@ -326,7 +325,7 @@ evalForCode(c:forCode):Expr := (
 		  else return printErrorMessageE(c.inClause,
 		      "no method for applying next to iterator"))
 	      else return printErrorMessageE(c.inClause,
-		  "expected a list, sequence, string, or iterable")))
+		  "expected a list, sequence, or iterable")))
      else (
 	  if c.fromClause != dummyCode then (
 	       fromvalue := eval(c.fromClause);

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -224,6 +224,7 @@ export {
 	"Inverses",
 	"Invertible",
 	"Iterate",
+	"Iterator",
 	"Jacobian",
 	"Join",
 	"Jupyter",

--- a/M2/Macaulay2/m2/files.m2
+++ b/M2/Macaulay2/m2/files.m2
@@ -272,7 +272,7 @@ tt#"\\"= "_bs"			 -- can't occur in a file name: MS-DOS and sh
 tt#"_" = "_us"					      -- our escape character
 
 -- some OSes are case insensitive:
-apply("ABCDEFGHIJKLMNOPQRSTUVWXYZ", cap -> tt#cap = concatenate("__", cap))
+for cap in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" do tt#cap = concatenate("__", cap)
 
 toFilename = method()
 toFilename String := s -> (
@@ -283,7 +283,7 @@ toFilename String := s -> (
      -- from occurring in the first position, where it would have a special
      -- meaning to Macaulay2.
      -- We should check which characters are allowed in URLs.
-     s = concatenate("_",apply(s, c -> tt#c));
+     s = concatenate("_", for c in s list tt#c);
      s)
 
 regexpString := s -> replace(///([][\.^$+*{()}])///,///\\1///,s)

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -29,3 +29,16 @@ applyIterator = (iter, f) -> Iterator (
 	x := next iter;
 	if x === StopIteration then StopIteration
 	else f x))
+
+select(Thing, Function) := Iterator => {} >> o -> (X, f) -> (
+    if lookup(iterator, class X) === null
+    then error "expected argument 1 to be iterable";
+    iter := iterator X;
+    Iterator (
+	() -> while true do (
+	    x := next iter;
+	    if x === StopIteration then return StopIteration;
+	    y := f x;
+	    if not instance(y, Boolean)
+	    then error("select: expected predicate to yield true or false");
+	    if y then return x)))

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -1,0 +1,13 @@
+-- originally defined (as null) in evaluate.d
+iterator = method(Dispatch => Thing)
+next = method()
+
+Iterator = new SelfInitializingType of FunctionClosure
+Iterator.synonym = "iterator"
+
+iterator Iterator := identity
+next Iterator := iter -> iter()
+net Iterator := iter -> (
+    x := if not (first frames iter)#?0 then () else first first frames iter;
+    net FunctionApplication(iterator,
+	(if instance(x, String) then format else identity) x))

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -11,3 +11,14 @@ net Iterator := iter -> (
     x := if not (first frames iter)#?0 then () else first first frames iter;
     net FunctionApplication(iterator,
 	(if instance(x, String) then format else identity) x))
+
+iterator Sequence    :=
+iterator VisibleList :=
+iterator String      := x -> Iterator (
+    i := 0;
+    () -> (
+	if i >= #x then StopIteration
+	else (
+	    r := x#i;
+	    i = i + 1;
+	    r)))

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -22,3 +22,10 @@ iterator String      := x -> Iterator (
 	    r := x#i;
 	    i = i + 1;
 	    r)))
+
+-- called by map(Expr,Expr) in actors3.d
+applyIterator = (iter, f) -> Iterator (
+    () -> (
+	x := next iter;
+	if x === StopIteration then StopIteration
+	else f x))

--- a/M2/Macaulay2/m2/latex.m2
+++ b/M2/Macaulay2/m2/latex.m2
@@ -38,7 +38,7 @@ texLiteralTable#"\n" = "\n"
 texLiteralTable#"\r" = "\r"
 texLiteralTable#"\t" = "\t"
 texLiteralTable#"`"  = "{`}" -- break ligatures ?` and !` in font \tt. See page 381 of TeX Book.
-texLiteral = s -> concatenate apply(s, c -> texLiteralTable#c)
+texLiteral = s -> concatenate for c in s list texLiteralTable#c
 
 HALFLINE    := "\\vskip 4.75pt\n"
 ENDLINE     := "\\leavevmode\\hss\\endgraf\n"
@@ -47,7 +47,8 @@ ENDVERBATIM := "\\endgroup{}"
 
 texExtraLiteralTable := copy texLiteralTable
 texExtraLiteralTable#" " = "\\ "
-texExtraLiteral := s -> demark(ENDLINE, apply(lines s, l -> apply(l, c -> texExtraLiteralTable#c)))
+texExtraLiteral := s -> demark(ENDLINE,
+    apply(lines s, l -> for c in l list texExtraLiteralTable#c))
 
 --------------------------------------------
 -- this loop depends on the feature of hash tables that when the keys

--- a/M2/Macaulay2/m2/loadsequence
+++ b/M2/Macaulay2/m2/loadsequence
@@ -10,6 +10,7 @@ regex.m2
 profile.m2
 debugging.m2
 remember.m2
+iterators.m2
 files.m2
 
 set.m2
@@ -19,7 +20,6 @@ structure.m2
 combinatorics.m2
 lists.m2
 tables.m2
-iterators.m2
 
 nets.m2
 robust.m2

--- a/M2/Macaulay2/m2/loadsequence
+++ b/M2/Macaulay2/m2/loadsequence
@@ -19,6 +19,7 @@ structure.m2
 combinatorics.m2
 lists.m2
 tables.m2
+iterators.m2
 
 nets.m2
 robust.m2

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -454,10 +454,6 @@ scanKeys(Database,Function) := (x,f) -> (
 	       s = nextkey x;
 	       ))
 
--- originally defined (as null) in evaluate.d
-iterator = method()
-next = method()
-
 -- TODO: eventually move this to lists.m2
 select' = select
 select = method(Options => true)

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -47,7 +47,6 @@ append(BasicList,Thing) := BasicList => append
 prepend(Thing,BasicList) := BasicList => prepend
 apply(BasicList,Function) := BasicList => apply
 apply(BasicList,BasicList,Function) := BasicList => apply
-apply(String,Function) := Sequence => apply
 apply(BasicList,String,Function) := Sequence => apply
 apply(String,BasicList,Function) := Sequence => apply
 apply(String,String,Function) := Sequence => apply
@@ -129,7 +128,7 @@ read (File,ZZ) := String => read
 read Sequence := String => read
 read String := String => read
 Function Thing := Thing => x -> (dummy x;)
-scan(BasicList,Function) := scan(String,Function) := Nothing => scan
+scan(BasicList,Function) := Nothing => scan
 scan(BasicList,BasicList,Function) := Nothing => scan
 scan(ZZ,Function) := Nothing => scan
 scan(Thing,Function) := Nothing => scan

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -51,6 +51,7 @@ apply(BasicList,String,Function) := Sequence => apply
 apply(String,BasicList,Function) := Sequence => apply
 apply(String,String,Function) := Sequence => apply
 apply(ZZ,Function) := List => apply
+apply(Thing,Function) := Iterator => apply
 applyKeys(HashTable,Function) := HashTable => applyKeys
 applyKeys(HashTable,Function,Function) := HashTable => applyKeys
 applyPairs(HashTable,Function) := HashTable => applyPairs

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_iterators.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_iterators.m2
@@ -1,82 +1,102 @@
 doc ///
   Key
-    "iterators"
+    Iterator
   Headline
-    an overview of iterators in Macaulay2
+    class for iterators
   Description
     Text
-      A class in Macaulay2 is @EM "iterable"@ if there is a method
-      function installed for @TO iterator@ that takes as input instances
-      of that class and returns instances of an @EM "iterator"@ class, which
-      has method functions installed for @TO iterator@ (typically @TO identity@)
-      and @TO next@.  Note that iterators are themselves iterable.
+      This is a class designed to simplify writing @TO iterator@ methods.
+      Each instance is a nullary @TO FunctionClosure@ that serves as the
+      @TO next@ method for the iterator.
     Example
-      PrimeIterator = new SelfInitializingType of MutableHashTable;
-      iterator PrimeIterator := identity;
-      next PrimeIterator := p -> p#"val" = nextPrime(p#"val" + 1);
-      i = PrimeIterator {"val" => 1};
-      next i
-      next i
-      next i
+      iter = iterator {1, 2, 3}
+      code iter
     Text
-      If we wish to iterate over an object more than once, then it should have
-      a separate corresponding iterator class.
+      Each call of @TT "next iter"@ is equivalent to @TT "iter()"@.
     Example
-      PrimeIterable = new Type of HashTable;
-      iterator PrimeIterable := x -> PrimeIterator {"val" => 1};
-      P = new PrimeIterable;
-      i = iterator P;
-      next i
-      next i
-      j = iterator P;
-      next j
-      next j
+      next iter
+      iter()
+      next iter
+      iter()
     Text
-      If we would like iteration to stop at a certain point, then the @TO next@
-      method should return the symbol @TO StopIteration@.
+      For example, let us create a class that we may use to iterate over the
+      Fibonacci numbers.
     Example
-      BoundedPrimeIterator = new SelfInitializingType of MutableHashTable;
-      iterator BoundedPrimeIterator := identity;
-      next BoundedPrimeIterator := i -> (
-	  q := nextPrime(i#"val" + 1);
-	  if q > i#"max" then StopIteration else i#"val" = q);
-      BoundedPrimeIterable = new SelfInitializingType of HashTable;
-      iterator BoundedPrimeIterable := x -> BoundedPrimeIterator {
-	  "val" => 1, "max" => x#"max"};
-      P = BoundedPrimeIterable {"max" => 6};
-      i = iterator P;
-      next i
-      next i
-      next i
-      next i
-    Text
-      When an iterator eventually returns @TO StopIteration@, then it (or the
-      iterable to which it corresponds) may be used with @TO toList@, @TO scan@,
-      and @TO "for"@.
-    Example
-      toList P
-      scan(P, print)
-      for x in P list x + 2
+      FibonacciNumbers = new Type of HashTable;
+      iterator FibonacciNumbers := fib -> Iterator(
+	  a := 0;
+	  b := 1;
+	  () -> (
+	      r := a;
+	      (a, b) = (b, a + b);
+	      r));
+      fibonacci = new FibonacciNumbers;
+      for i in fibonacci list if i > 100 then break else i
+  SeeAlso
+    iterator
+    next
+    StopIteration
 ///
 
 doc ///
   Key
     iterator
+    (iterator, Iterator)
+    (iterator, Sequence)
+    (iterator, String)
+    (iterator, VisibleList)
   Headline
-    get an iterator for an iterable
+    get an iterator
   Usage
     iterator x
   Inputs
-    x:Thing -- an instance of an iterable class
+    x:Thing
   Outputs
-    :Thing -- an iterator for @TT "x"@
+    :Thing -- likely an @TO Iterator@
+  Description
+    Text
+      An iterator is an object that is used to traverse through @TT "x"@.
+      Usually, but not necessarily, this will be an instance of the
+      @TO Iterator@ class.
+    Example
+      iter = iterator {1, 2, 3}
+    Text
+      The class of an iterator should have a @TO next@ method installed that
+      gets the next element of @TT "x"@.
+    Example
+      next iter
+      next iter
+      next iter
+    Text
+      If @TT "x"@ contains only a finite number of elements, then @TO next@
+      should return the symbol @TO StopIteration@ after exhausting them all.
+    Example
+      next iter
+    Text
+      Instances of classes with this method installed can be used like lists
+      in @TO "for"@ loops and @TO scan@.
+    Example
+      lookup(iterator, String)
+      for i in "foo" list i
+      scan("foo", print)
+    Text
+      They can also be passed to @TO apply@ and @TO select@.  In each case, an
+      @TO Iterator@ object will be returned that is an iterator for itself.
+    Example
+      apply("foo", toUpper)
+      for i in oo list i
+      select("foo", i -> i == "o")
+      for i in oo list i
   SeeAlso
-    "iterators"
+    Iterator
+    next
+    StopIteration
 ///
 
 doc ///
   Key
     next
+    (next, Iterator)
   Headline
     get the next object from an iterator
   Usage
@@ -84,9 +104,25 @@ doc ///
   Inputs
     x:Thing -- an iterator
   Outputs
-    :Thing -- the next object in an iterable
+    :Thing -- the next object from @TT "x"@
+  Description
+    Text
+      This gets the next object from an iterator, i.e., something returned by
+      @TO iterator@.
+    Example
+      iter = iterator {1, 2, 3}
+      next iter
+      next iter
+      next iter
+    Text
+      If the iterator is exhausted, then the symbol @TO StopIteration@ is
+      returned.
+    Example
+      next iter
   SeeAlso
-    "iterators"
+    Iterator
+    iterator
+    StopIteration
 ///
 
 doc ///
@@ -97,6 +133,14 @@ doc ///
   Description
     Text
       This symbol is returned by @TO next@ to signal that iteration is complete.
+    Example
+      iter = iterator {1, 2, 3}
+      next iter
+      next iter
+      next iter
+      next iter
   SeeAlso
-    "iterators"
+    Iterator
+    iterator
+    next
 ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
@@ -74,3 +74,35 @@ document {
      	  },
      }
 
+doc ///
+  Key
+    (apply, Thing, Function)
+  Headline
+    apply a function to an object with an iterator
+  Usage
+    apply(x, f)
+  Inputs
+    x:Thing -- an instance of a class with the @TO iterator@ method installed
+    f:Function
+  Outputs
+    :Iterator
+  Description
+    Text
+      Suppose @TT "x"@ is an instance of a class with the @TO iterator@ method
+      installed, e.g., a string, and suppose @TT "iter"@ is the output of
+      @TT "iterator x"@.  Then a new @TO Iterator@ object is returned whose
+      @TO next@ method returns @TT "f next iter"@  until @TT "next iter"@
+      returns @TO StopIteration@, in which case this new iterator does the same.
+    Example
+      applyiter = apply("foo", toUpper)
+      next applyiter
+      next applyiter
+      next applyiter
+      next applyiter
+  SeeAlso
+    iterator
+    Iterator
+    next
+    StopIteration
+    (select, Thing, Function)
+///

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
@@ -11,7 +11,7 @@ document {
      SeeAlso => {"applyKeys", "applyPairs", "applyValues", "applyTable", "lists and sequences"}
      }
 document { 
-     Key => {(apply,BasicList,Function), (apply,String,Function)},
+     Key => {(apply,BasicList,Function)},
      Headline => "apply a function to each element of a list",
      Usage => "apply(L,f)",
      Inputs => {

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/scan-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/scan-doc.m2
@@ -7,7 +7,6 @@ doc///
   (scan, BasicList, Function)
   (scan, BasicList, BasicList, Function)
   (scan, ZZ, Function)
-  (scan, String, Function)
   (scan, Thing, Function)
  Headline
   apply a function to each element in a list or sequence
@@ -15,11 +14,10 @@ doc///
   scan(L, f)
   scan(L, L', f)
   scan(n, f)
-  scan(x, f)
  Inputs
-  L: {BasicList, String}
+  L: BasicList
+   or instance of a class with the @TO iterator@ method installed
   n: ZZ
-  x: Thing -- an instance of an iterable class (see @TO "iterators"@)
   f: Function
  Description
   Text
@@ -40,6 +38,13 @@ doc///
    use it to locate the first even number in a list.
   Example
    scan({3,5,7,11,44,55,77}, i -> if even i then break i)
+  Text
+   If @TT "L"@ is an instance of a class with the @TO iterator@ method installed
+   (e.g., a string), then @TT "f"@ is applied to the values obtained by
+   repeatedly calling @TO next@ on the output of @TT "iterator L"@ until
+   @TO StopIteration@ is returned.
+  Example
+   scan("foo", print)
  SeeAlso
   apply
   accumulate

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/select-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/select-doc.m2
@@ -186,3 +186,36 @@ document {
 	  },
      SeeAlso => {(select,ZZ,BasicList,Function), partition, positions}
      }
+
+doc ///
+  Key
+    (select, Thing, Function)
+  Headline
+    select elements from an object with an iterator
+  Usage
+    select(x, f)
+  Inputs
+    x:Thing -- an instance of a class with the @TO iterator@ method installed
+    f:Function -- returning either @TO true@ or @TO false@
+  Outputs
+    :Iterator
+  Description
+    Text
+      Suppose @TT "x"@ is an instance of a class with the @TO iterator@ method
+      installed, e.g., a string, and suppose @TT "iter"@ is the output of
+      @TT "iterator x"@.  Then a new @TO Iterator@ object is returned
+      whose @TO next@ method returns the next output of @TT "next iter"@
+      for which @TT "f next iter" @ is true, unless @TT "next iter"@ returns
+      @TO StopIteration@, in which case this new iterator does the same.
+    Example
+      selectiter = select("foo", i -> i == "o")
+      next selectiter
+      next selectiter
+      next selectiter
+  SeeAlso
+    iterator
+    Iterator
+    next
+    StopIteration
+    (apply, Thing, Function)
+///

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/toList-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/toList-doc.m2
@@ -14,7 +14,7 @@ doc///
   toList A
  Inputs
   A:{Set,String,BasicList,ZZ}
-   or an instance of an iterable class (see @TO "iterators"@)
+   or an instance of a class with the @TO iterator@ method installed
  Outputs
   L:List
    a list whose elements are the elements of {\tt A}

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2
@@ -63,7 +63,6 @@ document {
 	      TO "printing and formatting for new classes",
 	      TO "making a new method function",
 	      TO "methods",
-	      TO "iterators",
 	  "input and output",
 	      TO "printing to the screen",
 	      TO "reading files",
@@ -861,9 +860,9 @@ document { Key => "for",
 		 }}),
      SYNOPSIS (
 	  Usage => "for i in v when p list x do z",
-	  Inputs => {"v" => {ofClass{BasicList, String},
-		  ", or an instance of an iterable class (see ", TO "iterators",
-		  ")"}},
+	  Inputs => {"v" => {ofClass{BasicList},
+		  " or an instance of a class with the ", TO iterator,
+		  " method installed"}},
 	  Consequences => {{"The variable ", TT "i", " is set to consecutive values of the list ", TT "v", ".  First ", TT "p", " is evaluated.  
 	       As long as the value of ", TT "p", " is true, evaluation of the loop continues.  Next ", TT "x", " is evaluated, and its value is saved.  Then
 	       ", TT "z", " is evaluated and its value is discarded.  Then the loop repeats with the next element of ", TT "v", ".  When the value of ", TT "p", " is false,
@@ -912,8 +911,12 @@ document { Key => "for",
      PARA { "If ", TO "break", " is executed by ", TT "x", ", then the loop is stopped and the list accumulated so far is returned as the value." },
      EXAMPLE "for i from 0 when i < 10 list (if i== 5 then break; i^2)",
      EXAMPLE "for i in 0..3 list i^2",
-     PARA { "You may also iterate over strings." },
-     EXAMPLE ///for c in "foo" do print c///
+     PARA { "If ", TT "v", " is an instance of any class with the ",
+	 TO iterator, " method installed (e.g., a string), then the values of ",
+	  TT "i", " are obtained by repeatedly calling ", TO next,
+	  " on the output of ", TT "iterator v", " until ", TO StopIteration,
+	 " is returned."},
+     EXAMPLE ///for i in "foo" do print i///
      }
 
 document {

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -22,3 +22,7 @@ for x in P do n = n + x
 assert Equation(n, 77)
 assert Equation(for x in P list if x % 4 == 1 then x else continue, {5, 13, 17})
 assert Equation(for x in P list if x == 11 then break x, 11)
+
+assert Equation(toList iterator {1, 2, 3}, {1, 2, 3})
+assert Equation(toList iterator (1, 2, 3), {1, 2, 3})
+assert Equation(toList iterator "foo", {"f", "o", "o"})

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -1,14 +1,12 @@
-BoundedPrimeIterator = new SelfInitializingType of MutableHashTable;
-iterator BoundedPrimeIterator := identity;
-next BoundedPrimeIterator := i -> (
-    q := nextPrime(i#"val" + 1);
-    if q > i#"max" then StopIteration else i#"val" = q);
-BoundedPrimeIterable = new SelfInitializingType of HashTable;
-iterator BoundedPrimeIterable := x -> BoundedPrimeIterator {
-    "val" => 1, "max" => x#"max"};
-P = BoundedPrimeIterable {"max" => 20};
-i = iterator P
+BoundedPrimeNumbers = new SelfInitializingType of HashTable
+iterator BoundedPrimeNumbers := P -> Iterator(
+    q := 1;
+    () -> (
+	q = nextPrime(q + 1);
+	if q > 20 then StopIteration else q))
+P = new BoundedPrimeNumbers
 
+i = iterator P
 assert Equation(next i, 2)
 assert Equation(next i, 3)
 assert Equation(next i, 5)

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -23,6 +23,9 @@ assert Equation(n, 77)
 assert Equation(for x in P list if x % 4 == 1 then x else continue, {5, 13, 17})
 assert Equation(for x in P list if x == 11 then break x, 11)
 
+assert Equation(toList apply(P, x -> x + 1), {3, 4, 6, 8, 12, 14, 18, 20})
+assert Equation(toList select(iterator P, x -> x % 4 == 1), {5, 13, 17})
+
 assert Equation(toList iterator {1, 2, 3}, {1, 2, 3})
 assert Equation(toList iterator (1, 2, 3), {1, 2, 3})
 assert Equation(toList iterator "foo", {"f", "o", "o"})

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -51,7 +51,6 @@ assert Equation(for c in "foo" list c, {"f", "o", "o"})
 i = 0
 scan("aaaaaaaaaa", c -> (assert Equation(c, "a"); i = i + 1))
 assert Equation(i, 10)
-assert Equation(apply("foo", identity), ("f", "o", "o"))
 assert Equation(apply("foo", "bar", concatenate), ("fb", "oa", "or"))
 assert Equation(apply("foo", ("b", "a", "r"), concatenate), ("fb", "oa", "or"))
 assert Equation(apply(("f", "o", "o"), "bar", concatenate), ("fb", "oa", "or"))


### PR DESCRIPTION
A few updates:

* There is a new `Iterator` class to simplify creating iterators.  It will likely work most of the time for writing `iterator` methods for classes.  Each `Iterator` object is a nullary `FunctionClosure` that serves as its own `next` method, so `next iter` is equivalent to `iter()`.
* `iterator` methods have been installed for several of the basic Macaulay2 types for which it makes sense (`VisibleList`, `Sequence`, and `String`), using the above `Iterator` class.
* A few features I added in [#1897](https://github.com/Macaulay2/M2/issues/1897) were removed since we can just fall back on iterators now.  In particular, `apply`, `scan`, and `for` used to create a copy of each string (as a sequence) and iterated over it, but now we can just use the new `iterator` method and traverse through the original string without copying.
* Support is added for `apply` (just the 2-argument version for now) and `select` for iterators.  In both instances, we return a new `Iterator` object.
* The two iterator classes for arrays in `ForeignFunctions` have been removed and replaced with `Iterator`.  (I didn't touch iteration in `Python` -- that's one case where it's easier to use a `PythonObject` as an iterator than an `Iterator`.)
* The documentation has been rewritten from scratch and hopefully is less confusing.  In particular, the focus is much less on writing new classes with `iterator` and `next` methods and much more on just using them.  The term "iterable" has been mostly removed (it's still in some error messages in the `d` directory for brevity, but I'm open to removing it there as well).

One thing I'm not 100% happy with is my code for `(net, Iterator)`.  Right now it uses `frames` to guess a representation of the thing we're iterating over, which works great for some common cases:

```m2
i1 : code (net, Iterator)

o1 = -- code for method: net(Iterator)
     M2/Macaulay2/m2/iterators.m2:10:22-13:55: --source code:
     net Iterator := iter -> (
         x := first first frames iter;
         FunctionApplication("iterator",
             (if instance(x, String) then format else net) x))

i2 : iterator "foo"

o2 = iterator "foo"

o2 : Iterator

i3 : iterator {1, 2, 3}

o3 = iterator {1, 2, 3}

o3 : Iterator
```
But sometimes it fails miserably.  For example, this simple iterator that just keeps returning random numbers:

```m2
i4 : Iterator(() -> random 20)

--error or time limit reached in conversion of output to net: type 'debugError()' to run it again; will try conversion to string

o4 = -*Function[stdio:4:14-4:24]*-

o4 : Iterator
```
Any suggestions?