### PR TITLE
More iterator updates

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -1594,7 +1594,7 @@ map(e:Expr,f:Expr):Expr := (
 	 iter := getIterator(e);
 	 if iter != nullE
 	 then applyEEE(getGlobalVariable(applyIteratorS), iter, f)
-	 else WrongArg(1,"a list, sequence, integer, or iterable")));
+	 else WrongArg(1,"a list, sequence, integer, or iterable object")));
 map(e1:Expr,e2:Expr,f:Expr):Expr := (
      when e1
      is a1:Sequence do (
@@ -2095,7 +2095,7 @@ scan(e:Expr,f:Expr):Expr := (
 		     else nothing);
 		 nullE)
 	     else buildErrorPacket("no method for applying next to iterator"))
-	 else WrongArg(1, "a list, sequence, integer, or iterable")));
+	 else WrongArg(1, "a list, sequence, integer, or iterable object")));
 scan(e:Expr):Expr := (
      when e is a:Sequence do (
 	  if length(a) == 2
@@ -2153,7 +2153,7 @@ toSequence(e:Expr):Expr := (
 		     else new Sequence len j do (
 			 foreach x in r do provide x)))
 	     else buildErrorPacket("no method for applying next to iterator"))
-	 else WrongArg("a list, sequence, string, or iterable")));
+	 else WrongArg("a list, sequence, string, or iterable object")));
 setupfun("toSequence",toSequence);
 
 sequencefun(e:Expr):Expr := (

--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -2124,7 +2124,36 @@ toSequence(e:Expr):Expr := (
 	  else Expr(b.v)
 	  )
      is s:stringCell do Expr(strtoseq(s))
-     else WrongArg("a list, sequence, or string"));
+     else (
+	 iter := getIterator(e);
+	 if iter != nullE
+	 then (
+	     nextfunc := getNextFunction(iter);
+	     if nextfunc != nullE
+	     then (
+		 r := new Sequence len 1 do provide nullE;
+		 j := 0;
+		 y := nullE;
+		 while (
+		     y = applyEE(nextfunc, iter);
+		     when y
+		     is Error do return returnFromFunction(y)
+		     else nothing;
+		     y != StopIterationE)
+		 do (
+		     if j == length(r) then (
+			 r = new Sequence len 2 * length(r) do (
+			     foreach x in r do provide x;
+			     while true do provide nullE));
+		     r.j = y;
+		     j = j + 1);
+		 Expr(
+		     if j == 0 then emptySequence
+		     else if j == length(r) then r
+		     else new Sequence len j do (
+			 foreach x in r do provide x)))
+	     else buildErrorPacket("no method for applying next to iterator"))
+	 else WrongArg("a list, sequence, string, or iterable")));
 setupfun("toSequence",toSequence);
 
 sequencefun(e:Expr):Expr := (

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -325,7 +325,7 @@ evalForCode(c:forCode):Expr := (
 		  else return printErrorMessageE(c.inClause,
 		      "no method for applying next to iterator"))
 	      else return printErrorMessageE(c.inClause,
-		  "expected a list, sequence, or iterable")))
+		  "expected a list, sequence, or iterable object")))
      else (
 	  if c.fromClause != dummyCode then (
 	       fromvalue := eval(c.fromClause);

--- a/M2/Macaulay2/m2/fold.m2
+++ b/M2/Macaulay2/m2/fold.m2
@@ -23,14 +23,19 @@ accumulate(Function, Thing) := Iterator => (f, v) -> (
     else accumulate(f, x, iter))
 
 fold = method()
-fold(Function,Thing,VisibleList) := VisibleList => foldL
+fold(Function,Thing,Thing) := VisibleList => foldL
 fold(VisibleList,Thing,Function) := VisibleList => (v,x,f) -> (scan(reverse v, w -> x = f(w,x)); x)
 fold(Function,VisibleList) := VisibleList => (f,v) -> (
      if # v === 0 then error "expected a nonempty list";
      fold(f,v#0,drop(v,1)))
 fold(VisibleList,Function) := VisibleList => (v,f) -> (
      if #v === 0 then error "expected a nonempty list";
-     fold(drop(v,-1),v#-1,f))     
+     fold(drop(v,-1),v#-1,f))
+fold(Function, Thing) := (f, v) -> (
+    iter := iterator v;
+    x := next iter;
+    if x === StopIteration then error "expected a nonempty iterator"
+    else fold(f, x, iter))
 
 demark = (s,v) -> concatenate between(s,v)
 

--- a/M2/Macaulay2/m2/fold.m2
+++ b/M2/Macaulay2/m2/fold.m2
@@ -6,14 +6,21 @@
 needs "methods.m2"
 
 accumulate = method()
-accumulate(Function,Thing,VisibleList) := VisibleList => (f,x,v) -> apply(v, y -> x = f(x,y))
+accumulate(Function, Thing, VisibleList) := VisibleList =>
+accumulate(Function, Thing, Thing)       := Iterator    => (f, x, v) -> (
+    apply(v, y -> x = f(x, y)))
 accumulate(VisibleList,Thing,Function) := VisibleList => (v,x,f) -> reverse apply(reverse v, w -> x = f(w,x))
 accumulate(Function,VisibleList) := VisibleList => (f,v) -> (
      if #v === 0 then error "expected a nonempty list";
      accumulate(f,v#0,drop(v,1)))
 accumulate(VisibleList,Function) := VisibleList => (v,f) -> (
      if #v === 0 then error "expected a nonempty list";
-     accumulate(drop(v,-1),v#-1,f))     
+     accumulate(drop(v,-1),v#-1,f))
+accumulate(Function, Thing) := Iterator => (f, v) -> (
+    iter := iterator v;
+    x := next iter;
+    if x === StopIteration then error "expected a nonempty iterator"
+    else accumulate(f, x, iter))
 
 fold = method()
 fold(Function,Thing,VisibleList) := VisibleList => foldL

--- a/M2/Macaulay2/m2/fold.m2
+++ b/M2/Macaulay2/m2/fold.m2
@@ -23,12 +23,12 @@ accumulate(Function, Thing) := Iterator => (f, v) -> (
     else accumulate(f, x, iter))
 
 fold = method()
-fold(Function,Thing,Thing) := VisibleList => foldL
-fold(VisibleList,Thing,Function) := VisibleList => (v,x,f) -> (scan(reverse v, w -> x = f(w,x)); x)
-fold(Function,VisibleList) := VisibleList => (f,v) -> (
+fold(Function,Thing,Thing) := foldL
+fold(VisibleList,Thing,Function) := (v,x,f) -> (scan(reverse v, w -> x = f(w,x)); x)
+fold(Function,VisibleList) := (f,v) -> (
      if # v === 0 then error "expected a nonempty list";
      fold(f,v#0,drop(v,1)))
-fold(VisibleList,Function) := VisibleList => (v,f) -> (
+fold(VisibleList,Function) := (v,f) -> (
      if #v === 0 then error "expected a nonempty list";
      fold(drop(v,-1),v#-1,f))
 fold(Function, Thing) := (f, v) -> (

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -12,7 +12,6 @@ net Iterator := iter -> (
     net FunctionApplication(iterator,
 	(if instance(x, String) then format else identity) x))
 
-iterator Sequence    :=
 iterator VisibleList :=
 iterator String      := x -> Iterator (
     i := 0;

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -31,7 +31,7 @@ applyIterator = (iter, f) -> Iterator (
 
 select(Thing, Function) := Iterator => {} >> o -> (X, f) -> (
     if lookup(iterator, class X) === null
-    then error "expected argument 1 to be iterable";
+    then error "expected argument 1 to be an iterable object";
     iter := iterator X;
     Iterator (
 	() -> while true do (

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -22,6 +22,8 @@ iterator String      := x -> Iterator (
 	    i = i + 1;
 	    r)))
 
+toList Thing := x -> for y in x list y
+
 -- called by map(Expr,Expr) in actors3.d
 applyIterator = (iter, f) -> Iterator (
     () -> (

--- a/M2/Macaulay2/m2/lists.m2
+++ b/M2/Macaulay2/m2/lists.m2
@@ -250,9 +250,6 @@ deepApply' = (L, f, g) -> flatten if g L then toList apply(L, e -> deepApply'(e,
 deepApply  = (L, f) ->  deepApply'(L, f, e -> instance(e, BasicList))
 deepScan   = (L, f) -> (deepApply'(L, f, e -> instance(e, BasicList));) -- not memory efficient
 
--- for iterables
-toList Thing := x -> for y in x list y
-
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -107,7 +107,9 @@ substring(String,ZZ,ZZ) := String => substring
 substring(ZZ,String) := String => substring
 substring(Sequence,String) := String => substring
 substring(ZZ,ZZ,String) := String => substring
-toSequence BasicList := toSequence String := Sequence => toSequence
+toSequence BasicList :=
+toSequence String    :=
+toSequence Thing     := Sequence => toSequence
 ascii String := List => ascii
 ascii List := String => ascii
 remove(HashTable,Thing) := Nothing => remove

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -890,7 +890,7 @@ doc ///
     Example
       length x
     Text
-      They are also @TO2 {"iterators", "iterable"}@.
+      They are also @TO2 {iterator, "iterable"}@.
     Example
        i = iterator x;
        next i
@@ -996,7 +996,7 @@ doc ///
     Example
       length x
     Text
-      They are also @TO2 {"iterators", "iterable"}@.
+      They are also @TO2 {iterator, "iterable"}@.
     Example
        i = iterator x;
        next i

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_iterators.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_iterators.m2
@@ -54,7 +54,6 @@ doc ///
   Key
     iterator
     (iterator, Iterator)
-    (iterator, Sequence)
     (iterator, String)
     (iterator, VisibleList)
   Headline

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_iterators.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_iterators.m2
@@ -19,19 +19,31 @@ doc ///
       next iter
       iter()
     Text
-      For example, let us create a class that we may use to iterate over the
-      Fibonacci numbers.
+      Every @TT "Iterator"@ object is an iterator for itself.
     Example
-      FibonacciNumbers = new Type of HashTable;
-      iterator FibonacciNumbers := fib -> Iterator(
-	  a := 0;
-	  b := 1;
+      primes = Iterator (
+	  p := 2;
 	  () -> (
-	      r := a;
-	      (a, b) = (b, a + b);
+	      r := p;
+	      p = nextPrime(p + 1);
 	      r));
-      fibonacci = new FibonacciNumbers;
-      for i in fibonacci list if i > 100 then break else i
+      iterator primes === primes
+    Text
+      However, we cannot "rewind" an @TT "Iterator"@ object.  Every time that
+      it is iterated upon using @TO "for"@, @TO scan@, etc., iteration will
+      resume where it left off previously.
+    Example
+      for p in primes list if p > 20 then break else p
+      for p in primes list if p > 20 then break else p
+    Text
+      Contrast this with most other classes with the @TO iterator@ method
+      installed, like, strings, for which a new @TT "Iterator"@ object is
+      created every time it is iterated upon, and so iteration starts over
+      from the beginning
+    Example
+      s = "Hello, world!"
+      for c in s list c
+      for c in s list c
   SeeAlso
     iterator
     next

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_lists.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_lists.m2
@@ -615,18 +615,33 @@ document {
      SeeAlso => {splice, (symbol..,ZZ,ZZ), "lists and sequences"}
      }
 
-document {
-     Key => {toSequence,(toSequence, BasicList),(toSequence, String)},
-     Headline => "convert to sequence",
-     TT "toSequence x", " -- yields the elements of a list or string ", TT "x", " as a sequence.",
-     PARA{},
-     "If ", TT "x", " is a sequence, then ", TT "x", " is returned.",
-     PARA{},
-     EXAMPLE {
-	  "toSequence {1,2,3}",
-	  ///toSequence "foo"///
-	  },
-     }
+doc ///
+  Key
+    toSequence
+    (toSequence, BasicList)
+    (toSequence, String)
+    (toSequence, Thing)
+  Headline
+    convert to sequence
+  Usage
+    toSequence x
+  Inputs
+    x:{BasicList, String}
+      or an instance of a class with the @TO iterator@ method installed
+  Outputs
+     :Sequence
+  Description
+    Text
+      @TT "toSequence x"@ yields the elements of a @TT "x"@ as a sequence.
+    Example
+      toSequence {1, 2, 3}
+      toSequence "foo"
+      toSequence iterator {1, 2, 3}
+    Text
+      If @TT "x"@ is already a sequence, then @TT "x"@ is returned.
+    Example
+      toSequence (1, 2, 3)
+///
 
 document {
      Key => sequence,

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/accumulate-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/accumulate-doc.m2
@@ -4,6 +4,8 @@
 doc///
  Key
   accumulate
+  (accumulate, Function, Thing)
+  (accumulate, Function, Thing, Thing)
   (accumulate, Function, Thing, VisibleList)
   (accumulate, Function, VisibleList)
   (accumulate, VisibleList, Thing, Function)
@@ -19,6 +21,7 @@ doc///
   f:Function
   x:Thing
   L:VisibleList
+    or an instance of a class with the @TO iterator@ method installed
  Outputs
   M:List
  Description
@@ -51,6 +54,16 @@ doc///
    accumulate({a,b,c,d,e}, concatenate)
    accumulate({a,b,c,d}, e, concatenate)  
    accumulate({2,3,2,1}, 2, (x, y) -> x^y)
+  Text
+   If @TT "L"@ is an instance of class the the @TO iterator@ method installed,
+   e.g., a string, then it may also be used with @TT "accumulate"@, but only the
+   versions with @TT "f"@ as the first argument.  Its return value in this case
+   is an @TO Iterator@ object.
+  Example
+   iter = accumulate(identity, "abcde")
+   next iter
+   next iter
+   next iter
   Text
    The difference between {\tt fold} and @TO accumulate@ is that {\tt fold} returns the
    final result of all the nested evaluations of {\tt f}, while {\tt accumulate} lists 

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/fold-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/fold-doc.m2
@@ -4,7 +4,8 @@
 doc///
  Key
   fold
-  (fold, Function, Thing, VisibleList)
+  (fold, Function, Thing)
+  (fold, Function, Thing, Thing)
   (fold, Function, VisibleList)
   (fold, VisibleList, Thing, Function)
   (fold, VisibleList, Function)
@@ -19,6 +20,7 @@ doc///
   f:Function
   x:Thing
   L:VisibleList
+    or an instance of a class with the @TO iterator@ method installed
  Outputs
   M:List
  Description
@@ -51,6 +53,13 @@ doc///
    fold({a,b,c,d,e}, identity)
    fold({a,b,c,d}, e, identity)  
    fold({2,3,2,1}, 2, (x, y) -> x^y)
+  Text
+   If @TT "L"@ is an instance of class the the @TO iterator@ method installed,
+   e.g., a string, then it may also be used with @TT "fold"@, but only the
+   versions with @TT "f"@ as the first argument.
+  Example
+   fold(identity, "abcde")
+   fold(identity, "a", "bcde")
   Text
    The difference between @TO fold@ and {\tt accumulate} is that {\tt fold} returns the
    final result of all the nested evaluations of {\tt f}, while {\tt accumulate} lists 

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -11,6 +11,7 @@ assert Equation(next i, 2)
 assert Equation(next i, 3)
 assert Equation(next i, 5)
 assert Equation(toList P, {2, 3, 5, 7, 11, 13, 17, 19})
+assert Equation(toSequence P, (2, 3, 5, 7, 11, 13, 17, 19))
 n = 0
 scan(P, x -> n = n + x)
 assert Equation(n, 77)

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -26,6 +26,13 @@ assert Equation(for x in P list if x == 11 then break x, 11)
 assert Equation(toList apply(P, x -> x + 1), {3, 4, 6, 8, 12, 14, 18, 20})
 assert Equation(toList select(iterator P, x -> x % 4 == 1), {5, 13, 17})
 
+assert Equation(toList accumulate(plus, P), {5, 10, 17, 28, 41, 58, 77})
+i = iterator P
+assert Equation(toList accumulate(plus, next i, i), {5, 10, 17, 28, 41, 58, 77})
+assert Equation(fold(plus, P), 77)
+i = iterator P
+assert Equation(fold(plus, next i, i), 77)
+
 assert Equation(toList iterator {1, 2, 3}, {1, 2, 3})
 assert Equation(toList iterator (1, 2, 3), {1, 2, 3})
 assert Equation(toList iterator "foo", {"f", "o", "o"})


### PR DESCRIPTION
We remove the `FibonacciNumbers` class example and add some explanation about how iteration over an `Iterator` differs from other classes.