### PR TITLE
Remove erroneous statement in "plus" documentation

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
@@ -10,8 +10,7 @@ document {
      Headline => "addition",
      TT "plus(x,y,...)", " -- yields the sum of its arguments.",
      PARA{},
-     "If the arguments are strings, they are concatenated.  If there
-     are no arguments, the answer is the integer 0."
+     "If there are no arguments, the answer is the integer 0."
      }
 
 document {


### PR DESCRIPTION
It does not concatenate strings

---

### Before

The first sentence of the description is definitely not correct!

```m2
i1 : help plus

o1 = plus -- addition
     ****************

     Description
     ===========

     plus(x,y,...) -- yields the sum of its arguments.


     If the arguments are strings, they are concatenated.  If there are no
     arguments, the answer is the integer 0.

     For the programmer
     ==================

     The object "plus" is a "compiled function".

o1 : DIV

i2 : plus("foo", "bar")
stdio:2:1:(3): error: no method for binary operator + applied to objects:
--            "foo" (of class String)
--      +     "bar" (of class String)
```
### After

```m2
i2 : help plus

o2 = plus -- addition
     ****************

     Description
     ===========

     plus(x,y,...) -- yields the sum of its arguments.


     If there are no arguments, the answer is the integer 0.

     For the programmer
     ==================

     The object "plus" is a "compiled function".

o2 : DIV
```