### PR TITLE
Add support for older versions of libffi

### DIFF
--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -326,7 +326,7 @@ if(CHECK_LIBRARY_COMPATIBILITY)
 endif()
 
 ###############################################################################
-## Set three library related definitions
+## Set four library related definitions
 
 if(GIVARO_FOUND)
   set(CMAKE_REQUIRED_INCLUDES "${GIVARO_INCLUDE_DIRS}")
@@ -354,4 +354,11 @@ if(FROBBY_FOUND)
     int main(){frobby_version;return 0;}]] HAVE_FROBBY_VERSION)
 else()
   unset(HAVE_FROBBY_VERSION CACHE)
+endif()
+
+if(FFI_FOUND)
+  set(CMAKE_REQUIRED_LIBRARIES "${FFI_LIBRARIES}")
+  check_function_exists(ffi_get_struct_offsets HAVE_FFI_GET_STRUCT_OFFSETS)
+else()
+  unset(HAVE_FFI_GET_STRUCT_OFFSETS CACHE)
 endif()

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1685,7 +1685,8 @@ AS_IF([pkg-config --exists libffi],
        CPPFLAGS="$(pkg-config --cflags-only-I libffi) $CPPFLAGS"
        AC_CHECK_HEADER([ffi.h], [], [AC_MSG_ERROR([ffi.h not found])])
        AC_SEARCH_LIBS([ffi_call], [ffi], [],
-	   [AC_MSG_ERROR([libffi not found or not linkable])])],
+	   [AC_MSG_ERROR([libffi not found or not linkable])])
+       AC_CHECK_FUNCS([ffi_get_struct_offsets])],
       [AC_MSG_RESULT([no])
        AC_MSG_ERROR([libffi is required])])
 

--- a/M2/include/M2/config.h.cmake
+++ b/M2/include/M2/config.h.cmake
@@ -57,6 +57,9 @@
 /* whether frobby has frobby_version >=0.9.4 or constants::version <0.9.4 */
 #cmakedefine HAVE_FROBBY_VERSION 1
 
+/* whether libffi has ffi_get_struct_offsets; introduced in libffi 3.3 */
+#cmakedefine HAVE_FFI_GET_STRUCT_OFFSETS 1
+
 // TODO: only used in Macaulay2/d/scclib.c. Still needed?
 /* whether getaddrinfo can handle numeric service (port) numbers */
 #cmakedefine GETADDRINFO_WORKS 1


### PR DESCRIPTION
In the `ForeignFunctions` package, we use the relatively new `ffi_get_struct_offsets` function (introduced in libffi 3.3 in 2019) to find the addresses of the various elements of a C `struct`.

This causes problems building on older systems, e.g., I had to backport libffi for the Ubuntu 18.04 PPA and @pzinn reported a build failure on Fedora 35 in Slack.

We provide an alternate implementation of `ffi_get_struct_offsets` for these older systems.

This currently only works for the autotools build.  @mahrud: How would one add a check to the cmake build to determine if `ffi_get_struct_offsets` exists and if so, define the macro `HAVE_FFI_GET_STRUCT_OFFSETS`? Maybe `check_function_exists`?