### PR TITLE
Set randomSeed to 0 for basic test

### DIFF
--- a/M2/Macaulay2/m2/basictests/W01.m2
+++ b/M2/Macaulay2/m2/basictests/W01.m2
@@ -1,5 +1,6 @@
 -- test the engine directly
 assert = x -> if not x then error "assertion failed "
+randomSeed = 0
 assert ( set keys tally apply(100, i -> rawRandomZZ 10) === set {0, 1, 2, 3, 4, 5, 6, 7, 8, 9} )
 
 -- if this test fails in eval(c:Code) in evaluate.d (build a debug version with


### PR DESCRIPTION
Although the probability of a given integer not appearing after calling `rawRandomZZ 10` 100 times is extraordinarily rare, it is possible, and has caused[ at least one PPA build](https://launchpadlibrarian.net/628254443/buildlog_ubuntu-jammy-arm64.macaulay2_1.20.0.1+git202210111525-0ppa202210071724~ubuntu22.04.1_BUILDING.txt.gz) to fail.

We set `randomSeed` to 0 so that we get deterministic results.
