### PR TITLE
fix #2503

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -1073,9 +1073,9 @@ texMath Product := v -> (
     else (
 	v = apply(v, x -> if class x === Power and (x#1 === 1 or x#1 === ONE) then x#0 else x);
 	p := precedence v;
-	nums := apply(v, x -> isNumber x);
+	nums := apply(v, x -> isNumber x or (class x === Power and isNumber x#0));
 	precs := apply(v, x -> precedence x <= p);
-	seps := apply (n-1, i-> if nums#i and (nums#(i+1) or class v#(i+1) === Power and isNumber v#(i+1)#0) then "\\cdot "
+	seps := apply (n-1, i-> if nums#(i+1) then "\\times "
 	    else if class v#i =!= Power and class v#i =!= Subscript and not precs#i and not precs#(i+1) then
 	    if nums#i or class v#i === Symbol then "\\," else "\\ "
 	    else "");

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -75,19 +75,14 @@ reduce = (tar,rawF) -> (
 
 addHook(ReduceHooks, Strategy => Default, (tar, rawF) -> rawF % raw gb presentation tar)
 
-Matrix * Number := Matrix * ZZ := (m,i) -> i * m
-Number * Matrix := (r,m) -> (
-     S := ring m;
-     try r = promote(r,S) else error "can't promote scalar to ring of matrix";
-     map(target m, source m, reduce(target m, raw r * raw m)))
 InfiniteNumber * Matrix := (r,m) -> (map(target m, source m, matrix(r*(entries m))))
 Matrix * InfiniteNumber := (m,r) -> r*m
+Number * Matrix :=
 RingElement * Matrix := (r,m) -> (
-     r = promote(r,ring m);
+    if ring r =!= ring m then try r = promote(r,ring m) else m = promote(m,ring r);
      map(target m, source m, reduce(target m, raw r * raw m)))
-Matrix * RingElement := (m,r) -> (
-     r = promote(r,ring m);
-     map(target m, source m, reduce(target m, raw m * raw r)))
+Matrix * Number :=
+Matrix * RingElement := (m,r) -> r*m
 
 toSameRing = (m,n) -> (
      if ring m =!= ring n then (

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -111,8 +111,8 @@ numeric(ZZ,Vector) := (prec,v) -> (
      error "expected vector of numbers"
      )
 
-- Vector := Vector => v -> vector (-v#0)
-Number * Vector := RingElement * Vector := Vector => (r,v) -> new class v from {r * v#0}
+- Vector := Vector => v -> new class v from {-v#0}
+Number * Vector := RingElement * Vector := Vector => (r,v) -> vector(r * v#0)
 Vector + Vector := Vector => (v,w) -> vector(v#0+w#0)
 Vector - Vector := Vector => (v,w) -> vector(v#0-w#0)
 Vector ** Vector := Vector => (v,w) -> vector(v#0**w#0)

--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -361,7 +361,7 @@ sub2 = (S,R,v) -> (				   -- S is the target ring or might be null, meaning targ
 	  if S === null
 	  then try commonzero = commonzero + 0_(ring y) else error "expected substitution values to be in compatible rings"
 	  else try y = promote(y,S) else error "expected to be able to promote value to target ring";
-	  if not h#?x then error( "expected ", toString x, " to be a generator of ", toString R );
+	  if not h#?x and ((try x=promote(x,R))===null or not h#?x) then error( "expected ", toString x, " to be a generator of ", toString R );
 	  for i in h#x do (
 	       if m#i =!= symbol dummy and m#i =!= y then error "multiple destinations specified for a generator";
 	       m#i = y;
@@ -378,7 +378,9 @@ sub2 = (S,R,v) -> (				   -- S is the target ring or might be null, meaning targ
 	       try commonzero = commonzero + 0_A
 	       else error "expected substitution values and omitted generators to be in compatible rings";
 	       );
-	  for i from 0 to #m-1 do m#i = promote(m#i, ring commonzero);
+	  S = ring commonzero;
+	  if instance(R,FractionField) then S=frac S;
+	  for i from 0 to #m-1 do m#i = promote(m#i, S);
 	  )
      else if R === S and S === ring commonzero then (
      	  -- if source==target, then the default is to leave generators alone

--- a/M2/Macaulay2/packages/CotangentSchubert/cotangent.m2
+++ b/M2/Macaulay2/packages/CotangentSchubert/cotangent.m2
@@ -164,7 +164,7 @@ new DiagonalAlgebra from Module := (X,M) -> (
     Number == DD := (n,x) -> x == new D from n;
     D + D := D + Vector := Vector + D := (x,y) -> new D from {x#0+y#0};
     D - D := D + Vector := Vector + D := (x,y) -> new D from {x#0-y#0};
-    Number * D := (n,x) -> new D from {n*x#0};
+    RingElement * D := Number * D := (n,x) -> new D from {n*x#0};
     D)
 ring DiagonalAlgebra := D -> ring D.Module;
 rank DiagonalAlgebra := D -> rank D.Module;

--- a/M2/Macaulay2/packages/CotangentSchubert/cotangent.m2
+++ b/M2/Macaulay2/packages/CotangentSchubert/cotangent.m2
@@ -162,7 +162,9 @@ new DiagonalAlgebra from Module := (X,M) -> (
     D == Vector := Vector == D := (x,y) -> x#0 == y#0;
     D == Number := (x,n) -> x == new D from n;
     Number == DD := (n,x) -> x == new D from n;
-    D + D := D + Vector := Vector + D := (x,y) -> new D from vector (x#0+y#0); -- shouldn't be needed but whatever
+    D + D := D + Vector := Vector + D := (x,y) -> new D from {x#0+y#0};
+    D - D := D + Vector := Vector + D := (x,y) -> new D from {x#0-y#0};
+    Number * D := (n,x) -> new D from {n*x#0};
     D)
 ring DiagonalAlgebra := D -> ring D.Module;
 rank DiagonalAlgebra := D -> rank D.Module;

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -69,7 +69,6 @@ document {
     (symbol *,Constant,Number),
     (symbol *,InexactNumber,Constant),
     (symbol *,Matrix,Number),
-    (symbol *,Matrix,ZZ),
     (symbol *,Number,Constant),
     (symbol *,Number,Matrix),
     (symbol *,QQ,CC),

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -735,7 +735,7 @@ DiffOp - DiffOp := DiffOp => (a,b) -> (
     else error"expected pair to have a method for '-'"
 )
 --Left action
-RingElement * DiffOp := DiffOp => (r,d) -> (
+Number * DiffOp := RingElement * DiffOp := DiffOp => (r,d) -> (
     R := class r;
     S := class d;
     if ring r === ring d or member(ring r, (ring d).baseRings) then new S from diffOp(promote(r,ring d)*matrix d)
@@ -1816,6 +1816,7 @@ assert(M == U)
 undocumented {
     (symbol +, DiffOp, DiffOp),
     (symbol -, DiffOp, DiffOp),
+    (symbol *, Number, DiffOp),
     (symbol *, RingElement, DiffOp),
     (symbol ?, DiffOp, DiffOp),
     (symbol ==, DiffOp, DiffOp),

--- a/M2/Macaulay2/packages/WeylGroups.m2
+++ b/M2/Macaulay2/packages/WeylGroups.m2
@@ -444,8 +444,8 @@ Weight + Weight := (p1,p2) -> new Weight from ((new Vector from p1)+(new Vector 
 --redefining difference of two weights
 Weight - Weight := (p1,p2) -> new Weight from ((new Vector from p1)-(new Vector from p2))
 
---defining opposite to a weight
-- Weight := (p) -> (-1)*p
+--defining scalar times weight
+ZZ * Weight := (n,p) -> new Weight from {n*p#0}
 
 --check whether a weight is a positive root
 isPositiveRoot = method()

--- a/M2/Macaulay2/packages/WeylGroups.m2
+++ b/M2/Macaulay2/packages/WeylGroups.m2
@@ -3,8 +3,8 @@
 
 newPackage(
 	"WeylGroups",
-	Version => "0.5.2",
-	Date => "November 1, 2021",
+	Version => "0.5.3",
+	Date => "October 15, 2022",
 	Authors => {
 		{Name => "Baptiste Calmès",
 		HomePage => "http://bcalmes.perso.math.cnrs.fr/"},
@@ -18,26 +18,30 @@ newPackage(
 
 -- Put here the name of functions that should be visible to users
 export{
-"RootSystem", 
-"cartanMatrix", 
-"rootSystem", "rootSystemA", "rootSystemB", "rootSystemC", "rootSystemD", "rootSystemE", "rootSystemF4", "rootSystemG2", 
-"Weight", 
-"weight", 
-"Root", 
+"RootSystem",
+"cartanMatrix",
+"rootSystem", "rootSystemA", "rootSystemB", "rootSystemC", "rootSystemD", "rootSystemE", "rootSystemF4", "rootSystemG2",
+"Weight",
+"weight",
+"Root",
 "isPositiveRoot", "isRoot", "addRoots",
-"halfSumOfRoots", "reflect", "simpleRoot", "rootCoefficients", 
-"WeylGroupElement", 
-"reduce", "reducedDecomposition", "isReduced", "coxeterLength", "longestWeylGroupElement", "positiveRoots", "reflection", "scalarProduct", "eval", "isReflection", "whoseReflection", 
-"Parabolic", "WeylGroupLeftCoset", "WeylGroupRightCoset", "WeylGroupDoubleCoset", 
-"parabolic", "minimalRepresentative", "isMinimalRepresentative", 
-"DynkinDiagram", "DynkinType", 
-"dynkinDiagram", "connectedComponents", "endVertices", "dynkinType", "dynkinExponents",
-"poincareSeries",
-"HasseDiagram", "HasseGraph", 
+"numberOfPositiveRoots",
+"halfSumOfRoots", "reflect", "simpleRoot", "rootCoefficients",
+"WeylGroupElement",
+"reduce", "reducedDecomposition", "isReduced", "coxeterLength", "longestWeylGroupElement",
+"underBruhat", "aboveBruhat", "isLtBruhat", "intervalBruhat",
+"positiveRoots", "reflection", "scalarProduct", "eval", "isReflection", "whoseReflection",
+"listWeylGroupElements", "neutralWeylGroupElement",
+"Parabolic", "parabolic",
+"WeylGroupLeftCoset", "WeylGroupRightCoset", "WeylGroupDoubleCoset",
+"minimalRepresentative", "isMinimalRepresentative",
+"DynkinDiagram",
+"dynkinDiagram", "connectedComponents", "endVertices", "dynkinType",
+"DynkinType",
+"dynkinExponents",
+"HasseDiagram", "HasseGraph",
 "hasseDiagramToGraph", "hasseGraphToPicture", "storeHasseGraph", "loadHasseGraph",
-"underBruhat", "aboveBruhat",
-"isLtBruhat", "intervalBruhat",
-"numberOfPositiveRoots", "listWeylGroupElements", "neutralWeylGroupElement"
+"poincareSeries"
 }
 
 -- Variables that can be modified by the user
@@ -446,6 +450,9 @@ Weight - Weight := (p1,p2) -> new Weight from ((new Vector from p1)-(new Vector 
 
 --defining scalar times weight
 ZZ * Weight := (n,p) -> new Weight from {n*p#0}
+
+--defining opposite to a weight
+- Weight := (p) -> (-1)*p
 
 --check whether a weight is a positive root
 isPositiveRoot = method()
@@ -1535,6 +1542,19 @@ doc ///
 			This package provides functions to compute in Weyl groups of root systems. In particular, it can compute intervals for the Bruhat order.
 		Text	
 			Here is a quick @HREF(currentLayout#"packages" | "WeylGroups/tutorial.html","tutorial")@ on how to use it.
+	Subnodes
+		RootSystem
+		Weight
+		Root
+		WeylGroupElement
+		Parabolic
+		WeylGroupLeftCoset
+		WeylGroupRightCoset
+		WeylGroupDoubleCoset
+		DynkinDiagram
+		DynkinType
+		HasseDiagram
+		HasseGraph
 ///
 
 doc ///
@@ -1542,6 +1562,18 @@ doc ///
 		RootSystem
 	Headline
 		the class of all root systems
+	Subnodes
+		rootSystem
+		cartanMatrix
+		(rank, RootSystem)
+		(rootSystem,DynkinType)
+		rootSystemA
+		rootSystemB
+		rootSystemC
+		rootSystemD
+		rootSystemE
+		(rootSystem,RootSystem,Parabolic)
+		(rootSystem,DynkinDiagram)
 ///
 
 doc ///
@@ -1829,6 +1861,12 @@ doc ///
 	Description
 		Text
 			a weight is represented by an element of ZZ^n, the basis consisting in the fundamental weights
+	Subnodes
+		weight
+		(weight,RootSystem,BasicList)
+		(weight,RootSystem,Vector)
+		isPositiveRoot
+		isRoot
 ///
 
 doc ///
@@ -1913,6 +1951,32 @@ doc ///
 TEST ///
 	R=rootSystemA(3);
 	p=weight(R,{1,2,1});
+	assert(2*p==weight(R,{2,4,2}))
+///
+
+doc ///
+	Key
+		(symbol -,Weight)
+	Headline
+		the negative of a weight
+	Usage
+		- p
+	Inputs
+		p: Weight
+	Outputs
+		: Weight
+			the negative of {\tt p}
+	Description
+		Example
+			R=rootSystemA(4)
+			M=cartanMatrix R
+			p=weight(R,M_2)
+			-p
+///
+
+TEST ///
+	R=rootSystemA(3);
+	p=weight(R,{1,2,1});
 	assert(-p==weight(R,{-1,-2,-1}))
 ///
 
@@ -1981,6 +2045,16 @@ doc ///
 	Description
 		Text
 			a root is represented by the respective weight
+	Subnodes
+		addRoots
+		(addRoots, RootSystem, Root, Root)
+		(symbol *, ZZ, Root)
+		halfSumOfRoots
+		simpleRoot
+		(norm, RootSystem, Root)
+		rootCoefficients
+		positiveRoots
+		numberOfPositiveRoots
 ///
 
 doc ///
@@ -2730,6 +2804,21 @@ doc ///
 	Description
 		Text
 			{\tt w} is represented by the list consisting of a root system and {\tt w} applied to the half-sum of positive roots
+	Subnodes
+		reduce
+		reducedDecomposition
+		isReduced
+		coxeterLength
+		longestWeylGroupElement
+		reflection
+		isReflection
+		whoseReflection
+		listWeylGroupElements
+		neutralWeylGroupElement
+		underBruhat
+		aboveBruhat
+		isLtBruhat
+		intervalBruhat
 ///
 
 doc ///
@@ -4276,6 +4365,11 @@ doc ///
 	Description
 		Text
 			A Hasse graph is a Hasse diagram ready for display. It contains labels instead of Weyl group elements and reflections.
+	Subnodes
+		hasseDiagramToGraph
+		hasseGraphToPicture
+		storeHasseGraph
+		loadHasseGraph
 ///
 
 doc ///
@@ -4511,6 +4605,9 @@ doc ///
 	SeeAlso	
 		"storeHasseGraph(HasseGraph,String)"
 ///
+
+
+
 
 
 

--- a/M2/Macaulay2/packages/WeylGroups.m2
+++ b/M2/Macaulay2/packages/WeylGroups.m2
@@ -1891,22 +1891,23 @@ TEST ///
 
 doc ///
 	Key
-		(symbol -,Weight)
+		(symbol *,ZZ,Weight)
 	Headline
-		the negative of a weight
+		the multiple of a weight
 	Usage
-		- p
+		n * p
 	Inputs
+	        n: ZZ
 		p: Weight
 	Outputs
 		: Weight
-			the negative of {\tt p}
+			n times {\tt p}
 	Description
 		Example
 			R=rootSystemA(4)
 			M=cartanMatrix R
 			p=weight(R,M_2)
-			-p
+			-2*p
 ///
 
 TEST ///


### PR DESCRIPTION
- fixes the various promotion / substitution issues mentioned in #2503 
- fixes a related bug with `Number * Vector` ( `1/2 * vector {1}` would return the wrong type of vector)
- unrelated simplification of `texMath Product` that I threw in