### PR TITLE
Add foreign function pointers for callbacks to Macaulay2 functions in ForeignFunctions package

### DIFF
--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1814,3 +1814,20 @@ assert Equation(value foreignSymbol(mpfi, "mpfi_error", int), 5)
 assert Equation(value foreignSymbol("mpfi_error", int), 5)
 (foreignFunction(mpfi, "mpfi_reset_error", void, void))()
 ///
+
+TEST ///
+-------------------------------
+-- foreign function pointers --
+-------------------------------
+doubledouble = foreignFunctionPointerType(double, double)
+assert Equation(value (value doubledouble cos) pi, -1)
+intint = foreignFunctionPointerType(int, int)
+assert Equation(value (value intint abs)(-2), 2)
+doubledoubledouble = foreignFunctionPointerType(double, {double, double})
+assert Equation(value (value doubledoubledouble atan2)(-1, -1), -3*pi/4)
+compar = foreignFunctionPointerType(int, {voidstar, voidstar})
+qsort = foreignFunction("qsort", void, {voidstar, ulong, ulong, compar})
+x = (4 * int) {4, 2, 3, 1}
+qsort(x, 4, size int, compar((a, b) -> value int a - value int b))
+assert Equation(value x, {1, 2, 3, 4})
+///

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1241,6 +1241,85 @@ doc ///
 
 doc ///
   Key
+    ForeignFunctionPointerType
+  Headline
+    foreign function pointer type
+  Description
+    Text
+      This is the class for @wikipedia "function pointer"@ types.  There
+      are no built-in types.  They must be  constructed using
+      @TO "foreignFunctionPointerType"@.
+///
+
+doc ///
+  Key
+    foreignFunctionPointerType
+    (foreignFunctionPointerType, ForeignType, ForeignType)
+    (foreignFunctionPointerType, ForeignType, VisibleList)
+    (foreignFunctionPointerType, String, ForeignType, ForeignType)
+    (foreignFunctionPointerType, String, ForeignType, VisibleList)
+  Headline
+    construct a foreign function pointer type
+  Usage
+    foreignFunctionPointerType(rtype, argtype)
+    foreignFunctionPointerType(rtype, argtypes)
+    foreignFunctionPointerType(name, rtype, argtype)
+    foreignFunctionPointerType(name, rtype, argtypes)
+  Inputs
+    name:String
+    rtype:ForeignType
+    argtype:ForeignType
+    argtypes:VisibleList -- of @TT "ForeignType"@ objects
+  Outputs
+    :ForeignFunctionPointerType
+  Description
+    Text
+      To construct a foreign function pointer type, (optionally) specify a name,
+      the return type, and either the argument type or a list of argument types.
+      If no name is specified, then one is constructed using the return
+      and argument types.
+    Example
+      foreignFunctionPointerType("compar", int, {voidstar, voidstar})
+      foreignFunctionPointerType(int, {voidstar, voidstar})
+///
+
+doc ///
+  Key
+    (symbol SPACE, ForeignFunctionPointerType, Function)
+  Headline
+    cast a Macaulay2 function to a foreign function pointer
+  Usage
+    T f
+  Inputs
+    T:ForeignFunctionPointerType
+    f:Function
+  Outputs
+    :ForeignObject
+  Description
+    Text
+      To cast a Macaulay2 function to a foreign object with a foreign function
+      type, give the type followed by the function.
+    Example
+      compar = foreignFunctionPointerType("compar", int, {voidstar, voidstar})
+      f = (a, b) -> value int a - value int b
+      intcmp = compar f
+    Text
+      The resulting function pointers may be passed as callbacks to
+      @TO ForeignFunction@ objects.
+    Example
+      qsort = foreignFunction("qsort", void, {voidstar, ulong, ulong, compar})
+      x = (4 * int) {4, 2, 3, 1}
+      qsort(x, 4, size int, intcmp)
+      x
+    Text
+      Foreign function pointers may be cast back to @TO ForeignFunction@ objects
+      using @TT "value"@ for testing purposes.
+    Example
+      (value intcmp)(address int 5, address int 6)
+///
+
+doc ///
+  Key
     ForeignObject
   Headline
     foreign object


### PR DESCRIPTION
This allows us to pass Macaulay2 functions to C code.  For example:

```m2
i2 : compar = foreignFunctionPointerType("compar", int, {voidstar, voidstar})

o2 = compar

o2 : ForeignFunctionPointerType

i3 : f = (a, b) -> value int a - value int b

o3 = f

o3 : FunctionClosure

i4 : intcmp = compar f

o4 = int32(*f)(void*,void*)

o4 : ForeignObject of type compar

i5 : qsort = foreignFunction("qsort", void, {voidstar, ulong, ulong, compar})

o5 = qsort

o5 : ForeignFunction

i6 : x = (4 * int) {4, 2, 3, 1}

o6 = {4, 2, 3, 1}

o6 : ForeignObject of type int32[4]

i7 : qsort(x, 4, size int, intcmp)

i8 : x

o8 = {1, 2, 3, 4}

o8 : ForeignObject of type int32[4]
```