### PR TITLE
Fix urlEncode now that apply(String, Function) returns an Iterator

### DIFF
--- a/M2/Macaulay2/packages/OnlineLookup.m2
+++ b/M2/Macaulay2/packages/OnlineLookup.m2
@@ -24,7 +24,7 @@ percentEncoding = hashTable transpose {
 -- TODO: use in/move to html.m2
 urlEncode = method()
 urlEncode Nothing := identity
-urlEncode String := s -> concatenate apply(s, c -> if percentEncoding#?c then percentEncoding#c else c)
+urlEncode String := s -> concatenate toList apply(s, c -> if percentEncoding#?c then percentEncoding#c else c)
 
 oeisHTTP := "http://oeis.org";
 oeisHTTPS := "https://oeis.org";


### PR DESCRIPTION
We need a list to pass to `concatenate`.

I broke this in #2631 -- sorry, @pzinn!

### Before
```m2

i1 : oeis apply(30, n -> binomial(n + 2, 2))
stdio:1:1:(3): error: expected a sequence or list of strings, integers, or symbols
```

### After
```m2
i1 : oeis apply(30, n -> binomial(n + 2, 2))

o1 =   1. A000217 (see https://oeis.org/A000217 ) Triangular numbers: a(n) =
          binomial(n+1,2) = n*(n+1)/2 = 0 + 1 + 2 + ... + n.
       2. A161680 (see https://oeis.org/A161680 ) a(n) = binomial(n,2): number
          of size-2 subsets of {0,1,...,n} that contain no consecutive integers.
       3. A179865 (see https://oeis.org/A179865 ) Number of n-bit binary numbers
          containing one run of 0's.
       4. A105340 (see https://oeis.org/A105340 ) a(n) = n*(n+1)/2 mod 2048.
       5. A105338 (see https://oeis.org/A105338 ) a(n) = n*(n+1)/2 mod 512.
       6. A105339 (see https://oeis.org/A105339 ) a(n) = n*(n+1)/2 mod 1024.
       7. A089594 (see https://oeis.org/A089594 ) Alternating sum of squares to
          n.

o1 : OL
```