### PR TITLE
Bump Probability and Python package version numbers in preparation for 1.21 release

### DIFF
--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -1,7 +1,7 @@
 newPackage("Probability",
     Headline => "basic probability functions",
-    Version => "0.1",
-    Date => "May 4, 2022",
+    Version => "0.2",
+    Date => "October 31, 2022",
     Authors => {{
 	    Name     => "Doug Torrance",
 	    Email    => "dtorrance@piedmont.edu",

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -5,8 +5,8 @@ this does not work unless M2 is compiled --with-python
 pythonPresent := Core#"private dictionary"#?"pythonRunString"
 
 newPackage("Python",
-    Version => "0.3",
-    Date => "May 4, 2022",
+    Version => "0.4",
+    Date => "October 31, 2022",
     Headline => "interface to Python",
     Authors => {
 	{Name => "Daniel R. Grayson",


### PR DESCRIPTION
Both have had some updates since 1.20:

### Probability
* #2521
* #2525
* #2566 
*  #2620
 
### Python
* #2523
* #2605
* #2613
* #2614
* #2639
