### PR TITLE
Restore apply(String, Function) behavior (returns a Sequence)

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -1632,6 +1632,9 @@ map(e:Expr,f:Expr):Expr := (
 	  if !isInt(i)
 	  then WrongArgSmallInteger()
 	  else map(toInt(i),f))
+     is s:stringCell do (
+	 toSequence(applyEEE(
+		 getGlobalVariable(applyIteratorS), getIterator(e), f)))
      else (
 	 iter := getIterator(e);
 	 if iter != nullE

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -48,6 +48,7 @@ prepend(Thing,BasicList) := BasicList => prepend
 apply(BasicList,Function) := BasicList => apply
 apply(BasicList,BasicList,Function) := BasicList => apply
 apply(BasicList,String,Function) := Sequence => apply
+apply(String,Function) := Sequence => apply
 apply(String,BasicList,Function) := Sequence => apply
 apply(String,String,Function) := Sequence => apply
 apply(ZZ,Function) := List => apply

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
@@ -11,7 +11,7 @@ document {
      SeeAlso => {"applyKeys", "applyPairs", "applyValues", "applyTable", "lists and sequences"}
      }
 document { 
-     Key => {(apply,BasicList,Function)},
+     Key => {(apply,BasicList,Function), (apply,String,Function)},
      Headline => "apply a function to each element of a list",
      Usage => "apply(L,f)",
      Inputs => {

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
@@ -89,12 +89,12 @@ doc ///
   Description
     Text
       Suppose @TT "x"@ is an instance of a class with the @TO iterator@ method
-      installed, e.g., a string, and suppose @TT "iter"@ is the output of
+      installed and suppose @TT "iter"@ is the output of
       @TT "iterator x"@.  Then a new @TO Iterator@ object is returned whose
       @TO next@ method returns @TT "f next iter"@  until @TT "next iter"@
       returns @TO StopIteration@, in which case this new iterator does the same.
     Example
-      applyiter = apply("foo", toUpper)
+      applyiter = apply(iterator "foo", toUpper)
       next applyiter
       next applyiter
       next applyiter

--- a/M2/Macaulay2/packages/OnlineLookup.m2
+++ b/M2/Macaulay2/packages/OnlineLookup.m2
@@ -24,7 +24,7 @@ percentEncoding = hashTable transpose {
 -- TODO: use in/move to html.m2
 urlEncode = method()
 urlEncode Nothing := identity
-urlEncode String := s -> concatenate toList apply(s, c -> if percentEncoding#?c then percentEncoding#c else c)
+urlEncode String := s -> concatenate apply(s, c -> if percentEncoding#?c then percentEncoding#c else c)
 
 oeisHTTP := "http://oeis.org";
 oeisHTTPS := "https://oeis.org";

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -51,6 +51,7 @@ assert Equation(for c in "foo" list c, {"f", "o", "o"})
 i = 0
 scan("aaaaaaaaaa", c -> (assert Equation(c, "a"); i = i + 1))
 assert Equation(i, 10)
+assert Equation(apply("foo", identity), ("f", "o", "o"))
 assert Equation(apply("foo", "bar", concatenate), ("fb", "oa", "or"))
 assert Equation(apply("foo", ("b", "a", "r"), concatenate), ("fb", "oa", "or"))
 assert Equation(apply(("f", "o", "o"), "bar", concatenate), ("fb", "oa", "or"))


### PR DESCRIPTION
Dan's comment (https://github.com/Macaulay2/M2/pull/2650#issuecomment-1297272479) got me thinking a little more about the changes I made in #2631 in the return value of `apply(String, Function)` (returning an `Iterator` instead of a `Sequence`). For example:

* While in general there's no guarantee that iterating over an `Iterator` object will terminate, there definitely is when iterating over a `String`, so returning a `Sequence` makes about as much sense as anything else.
* The change in behavior broke at least five lines of code -- four in `Core` and one in `OnlineLookup`.  It may break even more code out there, so it's probably a good idea to restore the earlier behavior before the 1.21 release.

So we, on the surface, restore the original behavior.  It now returns a `Sequence` again, but still uses iterators under the hood so that it doesn't make a copy of each character of the string into a new sequence like it did pre-#2631.

### 1.20 behavior
```m2
i1 : apply("foo", identity)

o1 = (f, o, o)

o1 : Sequence
```

### Current development branch behavior
```m2
i1 : apply("foo", identity)

o1 = iterator iterator "foo"

o1 : Iterator
```

### Behavior after this pull request
```m2
i1 : apply("foo", identity)

o1 = (f, o, o)

o1 : Sequence
```