### PR TITLE
Fix ForeignFunction return values on big-endian systems

### DIFF
--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -590,7 +590,9 @@ ffiClosureFunction(cif:Pointer "ffi_cif *", ret:voidPointer,
 		Ccode(voidPointer, args, "[", i, "]"))));
     when applyEE(f, x)
     is ptr:pointerCell
-    do Ccode(void, "memcpy(", ret, ", ", ptr.v, ", ", cif, "->rtype->size)")
+    do Ccode(void, "memcpy(",
+	endianAdjust(ret, Ccode(voidPointer, "((ffi_cif *)", cif, ")->rtype")),
+	", ", ptr.v, ", ", cif, "->rtype->size)")
     else nothing);
 
 ffiClosureFinalizer(ptr:voidPointer, closure:voidPointer):void := (

--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -188,7 +188,8 @@ ffiCall(e:Expr):Expr :=
 				fn.v, ", ",
 				rvalue, ", ",
 				avalues, "->array)");
-			    toExpr(rvalue))
+			    toExpr(endianAdjust(rvalue, Ccode(voidPointer,
+					"((ffi_cif *)", cif.v, ")->rtype"))))
 			else WrongArg(4, "a list")
 		    else WrongArgZZ(3)
 		else WrongArgPointer(2)

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1775,10 +1775,10 @@ TEST ///
 --------------------------------
 -- foreignFunction (variadic) --
 --------------------------------
-sprintf = foreignFunction("sprintf", void, {charstar, charstar},
+sprintf = foreignFunction("sprintf", int, {charstar, charstar},
     Variadic => true)
 foo = charstar "foo"
-sprintf(foo, "%s", "bar")
+assert Equation(value sprintf(foo, "%s", "bar"), 3)
 assert Equation(value foo, "bar")
 ///
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1819,15 +1819,23 @@ TEST ///
 -------------------------------
 -- foreign function pointers --
 -------------------------------
-doubledouble = foreignFunctionPointerType(double, double)
-assert Equation(value (value doubledouble cos) pi, -1)
-intint = foreignFunctionPointerType(int, int)
-assert Equation(value (value intint abs)(-2), 2)
-doubledoubledouble = foreignFunctionPointerType(double, {double, double})
-assert Equation(value (value doubledoubledouble atan2)(-1, -1), -3*pi/4)
-compar = foreignFunctionPointerType(int, {voidstar, voidstar})
-qsort = foreignFunction("qsort", void, {voidstar, ulong, ulong, compar})
+assert Equation(
+    value (value (foreignFunctionPointerType(int8, int8)) abs) (-2), 2)
+assert Equation(
+    value (value (foreignFunctionPointerType(int16, int16)) abs) (-2), 2)
+assert Equation(
+    value (value (foreignFunctionPointerType(int32, int32)) abs) (-2), 2)
+assert Equation(
+    value (value (foreignFunctionPointerType(int64, int64)) abs) (-2), 2)
+assert Equation(
+    value (value (foreignFunctionPointerType(float, float)) abs) (-2), 2)
+assert Equation(
+    value (value (foreignFunctionPointerType(double, double)) abs) (-2), 2)
+assert Equation(value (value (foreignFunctionPointerType(double,
+		{double, double})) atan2)(-1, -1), -3*pi/4)
+qsort = foreignFunction("qsort", void, {voidstar, ulong, ulong,
+	foreignFunctionPointerType(int, {voidstar, voidstar})})
 x = (4 * int) {4, 2, 3, 1}
-qsort(x, 4, size int, compar((a, b) -> value int a - value int b))
+qsort(x, 4, size int, (a, b) -> value int a - value int b)
 assert Equation(value x, {1, 2, 3, 4})
 ///

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1769,6 +1769,8 @@ TEST ///
 ---------------------
 cCos = foreignFunction("cos", double, double)
 assert Equation(value cCos pi, -1)
+cAbs = foreignFunction("abs", int, int)
+assert Equation(value cAbs(-2), 2)
 ///
 
 TEST ///


### PR DESCRIPTION
After #2643 was merged, the PPA builds started failing on s390x, which is big-endian (e.g., [this one](https://launchpadlibrarian.net/631376916/buildlog_ubuntu-jammy-s390x.macaulay2_1.20.0.1+git202210311533-0ppa202210161904~ubuntu22.04.1_BUILDING.txt.gz)).  This is because of an existing bug that hadn't shown up in the previous unit tests.  For functions that return an integer type that fits in less than the system register size (e.g., on most 64-bit systems, `int` is 32 bits), libffi widens it into an `ffi_arg`.  This doesn't cause a problem in little-endian systems, but for big-endian systems, we need to adjust the pointer a bit so we get the correct value when we dereference.

This pull request adds the correct adjustment (heavily inspired by corresponding code in Python's `ctypes` module -- see https://github.com/python/cpython/blob/f4c03484da59049eb62a9bf7777b963e2267d187/Modules/_ctypes/callproc.c#L1265-L1282) and also adds some related unit tests.

In particular, the tests all pass after building on a Debian s390x porterbox:
```m2
i1 : version#"endianness"

o1 = abcd

i2 : check "ForeignFunctions"
 -- capturing check(0, "ForeignFunctions")                                   -- 0.0313451 seconds elapsed                                                     
 -- capturing check(1, "ForeignFunctions")                                   -- 0.0279751 seconds elapsed                                                     
 -- capturing check(2, "ForeignFunctions")                                   -- 0.0275555 seconds elapsed                                                     
 -- capturing check(3, "ForeignFunctions")                                   -- 0.0278307 seconds elapsed                                                     
 -- capturing check(4, "ForeignFunctions")                                   -- 0.0281505 seconds elapsed                                                     
 -- capturing check(5, "ForeignFunctions")                                   -- 0.0288734 seconds elapsed                                                     
 -- capturing check(6, "ForeignFunctions")                                   -- 0.0308897 seconds elapsed                                                     
```