### PR TITLE
Drop `brew --prefix python` from LDFLAGS for autotools-macos build

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -164,7 +164,7 @@ jobs:
             print(f'{version_info.major}.{version_info.minor}')"`
           export CPPFLAGS="-I`brew --prefix`/include -I`brew --prefix libomp`/include"
           export  LDFLAGS="-L`brew --prefix`/lib -L`brew --prefix libomp`/lib \
-            -L`brew --prefix python`/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
+            -L/Library/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
           ../../configure --enable-download --with-python --with-system-gc --enable-syntax-highlighting
 
       - name: Build Macaulay2 using Make


### PR DESCRIPTION
Not necessary; Python library should just be in `/Library`.

---

This should fix the recent `autotools-macos` workflow failures (e.g., [this one](https://github.com/Macaulay2/M2/actions/runs/3396754657/jobs/5648170193)).  The problem was that we were looking for something in ` -L/usr/local/opt/python@3.10/Frameworks/Python.framework/Versions/3.11/lib`, which is of course nonsense since we wouldn't expect 3.11 libraries in a 3.10 directory!

I think the problem was that GitHub must have upgraded its main Python executable to version 3.11, but brew was still defaulting to 3.10, so the version numbers weren't matching up when forming the directory name.  But calling `brew --prefix` isn't necessary -- we can just look under `/Library` and avoid this entirely.