### PR TITLE
Add newline in Pygments header

### DIFF
--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -1,6 +1,7 @@
 """
     pygments.lexers.macaulay2
     ~~~~~~~~~~~~~~~~~~~~~~~~~
+
     Lexer for Macaulay2.
 
     :copyright: Copyright 2006-2022 by the Pygments team, see AUTHORS.


### PR DESCRIPTION
This was recently added to the corresponding file in the Pygments repository, and we should try to stay in sync.

See https://github.com/pygments/pygments/pull/2265

[ci skip]