### PR TITLE
Generalize "delete" so that it works for all BasicList objects

### DIFF
--- a/M2/Macaulay2/m2/structure.m2
+++ b/M2/Macaulay2/m2/structure.m2
@@ -20,7 +20,7 @@ position(VisibleList,VisibleList,Function) := o -> (v,w,f) -> (
      )
 
 delete = method()
-delete(Thing, VisibleList) := (x,v) -> select(v, i -> i =!= x)
+delete(Thing, BasicList) := (x,v) -> select(v, i -> i =!= x)
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/delete-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/delete-doc.m2
@@ -4,6 +4,7 @@
 doc///
  Key
   delete
+  (delete, Thing, BasicList)
  Headline
   delete some elements of a list
  Usage

--- a/M2/Macaulay2/tests/normal/lists.m2
+++ b/M2/Macaulay2/tests/normal/lists.m2
@@ -9,6 +9,7 @@ assert( sum(3,g) == 9 )
 assert( product(3,g) == 24 )
 assert( sum(a,b,h) == 18 )
 assert( product(a,b,h) == 192 )
+assert( delete(2, a) == {1, 3})
 
 i = <| x,y,z |>
 assert (#i == 3)
@@ -16,3 +17,4 @@ assert (toString i == "<|x, y, z|>")
 assert (net i == "<|x, y, z|>"^0)
 assert (toList i === {x,y,z})
 assert (class i === AngleBarList)
+assert (delete(y, i) == <| x, z |>)


### PR DESCRIPTION
This is in response to https://github.com/Macaulay2/M2/pull/2668#issuecomment-1306525384.

### Before

```m2
i1 : x = new MutableList from {1, 2, 3}

o1 = MutableList{...3...}

o1 : MutableList

i2 : delete(2, x)
stdio:2:1:(3): error: no method found for applying delete to:
     argument 1 :  2 (of class ZZ)
     argument 2 :  MutableList{...3...} (of class MutableList)
```

### After

```m2
i1 : x = new MutableList from {1, 2, 3}

o1 = MutableList{...3...}

o1 : MutableList

i2 : delete(2, x)

o2 = MutableList{...2...}

o2 : MutableList

i3 : peek oo

o3 = MutableList{1, 3}
```

