### PR TITLE
Add ability to opt out of compiling with libffi

### DIFF
--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -377,6 +377,16 @@ to LDFLAGS.  For example, if Python has been installed using brew, then add
 the following to LDFLAGS, replacing X with the appropriate minor version:
 "-L`brew --prefix python`/Frameworks/Python.framework/Versions/3.X/lib".
 
+-------------------------------
+Building without libffi support
+-------------------------------
+
+Use of the "ForeignFunctions" package requires linking the Macaulay2 binary
+against libffi (https://sourceware.org/libffi/).  This has been known to
+cause issues on Apple silicon machines, and so it is possible to opt out of
+this feature by adding the "--without-libffi" option to the "configure" command
+line below.
+
 -----------------------
 Compiling Macaulay2
 -----------------------

--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -87,7 +87,7 @@ set(DLIST
   interface.dd interface2.d
   texmacs.d
   boostmath.dd
-  ffi.d
+  ffi.d		# removed unless WITH_FFI
   interp.dd	# this one is last, because it contains the top level interpreter
   version.dd
   )
@@ -103,6 +103,9 @@ else()
 endif()
 if(NOT WITH_PYTHON)
   list(REMOVE_ITEM DLIST python.d)
+endif()
+if(NOT WITH_FFI)
+  list(REMOVE_ITEM DLIST ffi.d)
 endif()
 
 ###############################################################################
@@ -141,7 +144,8 @@ add_library(M2-interpreter OBJECT ${CLIST} ${CXXLIST} ${TAGS}
   $<$<BOOL:${WITH_XML}>:xml-c.c xml-c.h>
   $<$<BOOL:${WITH_PYTHON}>:python-c.c>)
 
-target_link_libraries(M2-interpreter PRIVATE M2-supervisor Boost::regex TBB::tbb FFI::ffi)
+target_link_libraries(M2-interpreter PRIVATE M2-supervisor Boost::regex TBB::tbb
+  $<$<BOOL:${WITH_FFI}>:FFI::ffi>)
 
 target_include_directories(M2-interpreter
   PUBLIC

--- a/M2/Macaulay2/d/Makefile.files.in
+++ b/M2/Macaulay2/d/Makefile.files.in
@@ -97,7 +97,11 @@ endif
 M2_DFILES += interface.dd interface2.d
 M2_DFILES += texmacs.d
 M2_DFILES += boostmath.dd
+ifneq (@LIBFFI@,no)
 M2_DFILES += ffi.d
+else
+M2_SRCFILES += ffi.d
+endif
 # this one is last, because it contains the top level interpreter
 M2_DFILES += interp.dd
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -7,6 +7,8 @@ newPackage("ForeignFunctions",
 	    Email => "dtorrance@piedmont.edu",
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
     Keywords => {"Interfaces"},
+    CacheExampleOutput => true,
+    AuxiliaryFiles => true,
     OptionalComponentsPresent => Core#"private dictionary"#?"ffiCall"
     )
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -6,7 +6,8 @@ newPackage("ForeignFunctions",
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
-    Keywords => {"Interfaces"}
+    Keywords => {"Interfaces"},
+    OptionalComponentsPresent => Core#"private dictionary"#?"ffiCall"
     )
 
 -------------------------
@@ -71,7 +72,7 @@ export {
     "Variadic"
     }
 
-importFrom_Core {
+ffiDFunctions = {
     "dlopen",
     "dlsym",
     "ffiPrepCif",
@@ -97,12 +98,24 @@ importFrom_Core {
     "registerFinalizerForPointer"
     }
 
+if (options currentPackage).OptionalComponentsPresent
+then importFrom_Core ffiDFunctions else
+for f in ffiDFunctions do (
+    currentPackage#"private dictionary"#f = getSymbol f;
+    getSymbol f <- (
+	if member(f, {"ffiIntegerType", "ffiRealType"}) then x -> null
+	else x -> error "Macaulay2 built without libffi"))
 
 -------------
 -- pointer --
 -------------
 
-exportFrom_Core {"Pointer", "nullPointer"}
+exportFrom_Core {"Pointer"}
+if (options currentPackage).OptionalComponentsPresent
+then exportFrom_Core {"nullPointer"} else (
+    currentPackage#"private dictionary"#"nullPointer" = getSymbol "nullPointer";
+    getSymbol "nullPointer" <- null)
+
 Pointer.synonym = "pointer"
 Pointer + ZZ := (ptr, n) -> ptr + n -- defined in actors.d
 ZZ + Pointer := (n, ptr) -> ptr + n

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1431,6 +1431,7 @@ doc ///
     (foreignObject, Number)
     (foreignObject, String)
     (foreignObject, ZZ)
+    (foreignObject, Pointer)
   Headline
     construct a foreign object
   Usage

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Array__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Array__Type.out
@@ -1,0 +1,45 @@
+-- -*- M2-comint -*- hash: 991196957
+
+i1 : x = (3 * int) {3, 5, 7}
+
+o1 = {3, 5, 7}
+
+o1 : ForeignObject of type int32[3]
+
+i2 : x_1
+
+o2 = 5
+
+o2 : ForeignObject of type int32
+
+i3 : x_(-1)
+
+o3 = 7
+
+o3 : ForeignObject of type int32
+
+i4 : length x
+
+o4 = 3
+
+i5 : i = iterator x;
+
+i6 : next i
+
+o6 = 3
+
+o6 : ForeignObject of type int32
+
+i7 : next i
+
+o7 = 5
+
+o7 : ForeignObject of type int32
+
+i8 : for y in x list value y + 1
+
+o8 = {4, 6, 8}
+
+o8 : List
+
+i9 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Array__Type_sp__Visible__List.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Array__Type_sp__Visible__List.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: 63681661
+
+i1 : intarray5 = 5 * int
+
+o1 = int32[5]
+
+o1 : ForeignArrayType
+
+i2 : x = intarray5 {2, 4, 6, 8, 10}
+
+o2 = {2, 4, 6, 8, 10}
+
+o2 : ForeignObject of type int32[5]
+
+i3 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Function__Pointer__Type_sp__Function.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Function__Pointer__Type_sp__Function.out
@@ -1,0 +1,47 @@
+-- -*- M2-comint -*- hash: -470257883
+
+i1 : compar = foreignFunctionPointerType("compar", int, {voidstar, voidstar})
+
+o1 = compar
+
+o1 : ForeignFunctionPointerType
+
+i2 : f = (a, b) -> value int a - value int b
+
+o2 = f
+
+o2 : FunctionClosure
+
+i3 : intcmp = compar f
+
+o3 = int32(*f)(void*,void*)
+
+o3 : ForeignObject of type compar
+
+i4 : qsort = foreignFunction("qsort", void, {voidstar, ulong, ulong, compar})
+
+o4 = qsort
+
+o4 : ForeignFunction
+
+i5 : x = (4 * int) {4, 2, 3, 1}
+
+o5 = {4, 2, 3, 1}
+
+o5 : ForeignObject of type int32[4]
+
+i6 : qsort(x, 4, size int, intcmp)
+
+i7 : x
+
+o7 = {1, 2, 3, 4}
+
+o7 : ForeignObject of type int32[4]
+
+i8 : (value intcmp)(address int 5, address int 6)
+
+o8 = -1
+
+o8 : ForeignObject of type int32
+
+i9 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Functions.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Functions.out
@@ -1,0 +1,21 @@
+-- -*- M2-comint -*- hash: -394951237
+
+i1 : mycos = foreignFunction("cos", double, double)
+
+o1 = cos
+
+o1 : ForeignFunction
+
+i2 : mycos pi
+
+o2 = -1
+
+o2 : ForeignObject of type double
+
+i3 : value oo
+
+o3 = -1
+
+o3 : RR (of precision 53)
+
+i4 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Integer__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Integer__Type.out
@@ -1,0 +1,63 @@
+-- -*- M2-comint -*- hash: -2090051081
+
+i1 : int8
+
+o1 = int8
+
+o1 : ForeignIntegerType
+
+i2 : uint32
+
+o2 = uint32
+
+o2 : ForeignIntegerType
+
+i3 : char'
+
+o3 = int8
+
+o3 : ForeignIntegerType
+
+i4 : uchar
+
+o4 = uint8
+
+o4 : ForeignIntegerType
+
+i5 : short
+
+o5 = int16
+
+o5 : ForeignIntegerType
+
+i6 : ushort
+
+o6 = uint16
+
+o6 : ForeignIntegerType
+
+i7 : int
+
+o7 = int32
+
+o7 : ForeignIntegerType
+
+i8 : uint
+
+o8 = uint32
+
+o8 : ForeignIntegerType
+
+i9 : long
+
+o9 = int64
+
+o9 : ForeignIntegerType
+
+i10 : ulong
+
+o10 = uint64
+
+o10 : ForeignIntegerType
+
+i11 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Integer__Type_sp__Number.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Integer__Type_sp__Number.out
@@ -1,0 +1,21 @@
+-- -*- M2-comint -*- hash: -1772908876
+
+i1 : int 12
+
+o1 = 12
+
+o1 : ForeignObject of type int32
+
+i2 : ulong pi
+
+o2 = 3
+
+o2 : ForeignObject of type uint64
+
+i3 : short(-2.71828)
+
+o3 = -2
+
+o3 : ForeignObject of type int16
+
+i4 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Object.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Object.out
@@ -1,0 +1,25 @@
+-- -*- M2-comint -*- hash: -1004909576
+
+i1 : x = int 5
+
+o1 = 5
+
+o1 : ForeignObject of type int32
+
+i2 : peek x
+
+o2 = int32{Address => 0x7f856be82fd0}
+
+i3 : address x
+
+o3 = 0x7f856be82fd0
+
+o3 : Pointer
+
+i4 : class x
+
+o4 = int32
+
+o4 : ForeignIntegerType
+
+i5 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Pointer__Array__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Pointer__Array__Type.out
@@ -1,0 +1,63 @@
+-- -*- M2-comint -*- hash: 732806782
+
+i1 : charstarstar {"foo", "bar", "baz"}
+
+o1 = {foo, bar, baz}
+
+o1 : ForeignObject of type char**
+
+i2 : charstarstar {"the", "quick", "brown", "fox", "jumps", "over", "the",
+         "lazy", "dog"}
+
+o2 = {the, quick, brown, fox, jumps, over, the, lazy, dog}
+
+o2 : ForeignObject of type char**
+
+i3 : voidstarstar {address int 0, address int 1, address int 2}
+
+o3 = {0x7faa3c916400, 0x7faa3c9163f0, 0x7faa3c9163e0}
+
+o3 : ForeignObject of type void**
+
+i4 : x = charstarstar {"foo", "bar", "baz"}
+
+o4 = {foo, bar, baz}
+
+o4 : ForeignObject of type char**
+
+i5 : x_1
+
+o5 = bar
+
+o5 : ForeignObject of type char*
+
+i6 : x_(-1)
+
+o6 = baz
+
+o6 : ForeignObject of type char*
+
+i7 : length x
+
+o7 = 3
+
+i8 : i = iterator x;
+
+i9 : next i
+
+o9 = foo
+
+o9 : ForeignObject of type char*
+
+i10 : next i
+
+o10 = bar
+
+o10 : ForeignObject of type char*
+
+i11 : scan(x, print)
+foo
+bar
+baz
+
+i12 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Pointer__Array__Type_sp__Visible__List.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Pointer__Array__Type_sp__Visible__List.out
@@ -1,0 +1,27 @@
+-- -*- M2-comint -*- hash: 1675747268
+
+i1 : charstarstar {"foo", "bar"}
+
+o1 = {foo, bar}
+
+o1 : ForeignObject of type char**
+
+i2 : voidstarstar {address int 0, address int 1, address int 2}
+
+o2 = {0x7fb345907030, 0x7fb345907020, 0x7fb345907010}
+
+o2 : ForeignObject of type void**
+
+i3 : int2star = foreignPointerArrayType(2 * int)
+
+o3 = int32[2]*
+
+o3 : ForeignPointerArrayType
+
+i4 : int2star {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}}
+
+o4 = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}}
+
+o4 : ForeignObject of type int32[2]*
+
+i5 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Pointer__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Pointer__Type.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: -952057602
+
+i1 : voidstar
+
+o1 = void*
+
+o1 : ForeignPointerType
+
+i2 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Pointer__Type_sp__Pointer.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Pointer__Type_sp__Pointer.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: -1443663782
+
+i1 : ptr = address int 0
+
+o1 = 0x7fabe3a41c80
+
+o1 : Pointer
+
+i2 : voidstar ptr
+
+o2 = 0x7fabe3a41c80
+
+o2 : ForeignObject of type void*
+
+i3 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Real__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Real__Type.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: 1705149349
+
+i1 : float
+
+o1 = float
+
+o1 : ForeignRealType
+
+i2 : double
+
+o2 = double
+
+o2 : ForeignRealType
+
+i3 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Real__Type_sp__Number.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Real__Type_sp__Number.out
@@ -1,0 +1,21 @@
+-- -*- M2-comint -*- hash: -1289209129
+
+i1 : float 3
+
+o1 = 3
+
+o1 : ForeignObject of type float
+
+i2 : double pi
+
+o2 = 3.14159265358979
+
+o2 : ForeignObject of type double
+
+i3 : double(2 + 3*ii)
+
+o3 = 2
+
+o3 : ForeignObject of type double
+
+i4 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__String__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__String__Type.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: 308105664
+
+i1 : charstar
+
+o1 = char*
+
+o1 : ForeignStringType
+
+i2 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__String__Type_sp__String.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__String__Type_sp__String.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: 530812175
+
+i1 : charstar "Hello, world!"
+
+o1 = Hello, world!
+
+o1 : ForeignObject of type char*
+
+i2 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Struct__Type_sp__Visible__List.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Struct__Type_sp__Visible__List.out
@@ -1,0 +1,28 @@
+-- -*- M2-comint -*- hash: -2015927410
+
+i1 : mystruct = foreignStructType("mystruct", {"foo" => int, "bar" => double})
+
+o1 = mystruct
+
+o1 : ForeignStructType
+
+i2 : x = mystruct {"foo" => 5, "bar" => pi}
+
+o2 = HashTable{bar => 3.14159}
+               foo => 5
+
+o2 : ForeignObject of type mystruct
+
+i3 : x_"foo"
+
+o3 = 5
+
+o3 : ForeignObject of type int32
+
+i4 : x_"bar"
+
+o4 = 3.14159265358979
+
+o4 : ForeignObject of type double
+
+i5 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Type_sp__Foreign__Object.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Type_sp__Foreign__Object.out
@@ -1,0 +1,25 @@
+-- -*- M2-comint -*- hash: 460668767
+
+i1 : chararray4 = 4 * char'
+
+o1 = int8[4]
+
+o1 : ForeignArrayType
+
+i2 : x = chararray4 append(ascii "foo", 0)
+
+o2 = {102, 111, 111, 0}
+
+o2 : ForeignObject of type int8[4]
+
+i3 : y = charstar x
+
+o3 = foo
+
+o3 : ForeignObject of type char*
+
+i4 : address x === address y
+
+o4 = true
+
+i5 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Type_sp__Pointer.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Type_sp__Pointer.out
@@ -1,0 +1,21 @@
+-- -*- M2-comint -*- hash: -1184332995
+
+i1 : x = int 5
+
+o1 = 5
+
+o1 : ForeignObject of type int32
+
+i2 : ptr = address x
+
+o2 = 0x7f5b2a9ec850
+
+o2 : Pointer
+
+i3 : int ptr
+
+o3 = 5
+
+o3 : ForeignObject of type int32
+
+i4 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Union__Type_sp__Thing.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Union__Type_sp__Thing.out
@@ -1,0 +1,30 @@
+-- -*- M2-comint -*- hash: 292894177
+
+i1 : myunion = foreignUnionType("myunion", {"foo" => int, "bar" => double})
+
+o1 = myunion
+
+o1 : ForeignUnionType
+
+i2 : myunion 27
+
+o2 = HashTable{bar => 6.93511e-310}
+               foo => 27
+
+o2 : ForeignObject of type myunion
+
+i3 : myunion pi
+
+o3 = HashTable{bar => 3.14159   }
+               foo => 1413754136
+
+o3 : ForeignObject of type myunion
+
+i4 : myunion double 5
+
+o4 = HashTable{bar => 5}
+               foo => 0
+
+o4 : ForeignObject of type myunion
+
+i5 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Void__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Foreign__Void__Type.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: -1124752212
+
+i1 : void
+
+o1 = void
+
+o1 : ForeignVoidType
+
+i2 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Pointer.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Pointer.out
@@ -1,0 +1,31 @@
+-- -*- M2-comint -*- hash: 417319600
+
+i1 : x = int 20
+
+o1 = 20
+
+o1 : ForeignObject of type int32
+
+i2 : peek x
+
+o2 = int32{Address => 0x7f80c319a120}
+
+i3 : ptr = address x
+
+o3 = 0x7f80c319a120
+
+o3 : Pointer
+
+i4 : ptr + 5
+
+o4 = 0x7f80c319a125
+
+o4 : Pointer
+
+i5 : ptr - 3
+
+o5 = 0x7f80c319a11d
+
+o5 : Pointer
+
+i6 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/___Shared__Library.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/___Shared__Library.out
@@ -1,0 +1,13 @@
+-- -*- M2-comint -*- hash: 715115677
+
+i1 : mpfr = openSharedLibrary "mpfr"
+
+o1 = mpfr
+
+o1 : SharedLibrary
+
+i2 : peek mpfr
+
+o2 = SharedLibrary{0x7fc4806a1f90, mpfr}
+
+i3 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_address.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_address.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: -954131557
+
+i1 : address int
+
+o1 = 0x55d51cf75da0
+
+o1 : Pointer
+
+i2 : address int 5
+
+o2 = 0x7fcf86172df0
+
+o2 : Pointer
+
+i3 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Array__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Array__Type.out
@@ -1,0 +1,21 @@
+-- -*- M2-comint -*- hash: -691301693
+
+i1 : foreignArrayType("myArrayType", int, 5)
+
+o1 = myArrayType
+
+o1 : ForeignArrayType
+
+i2 : foreignArrayType(int, 5)
+
+o2 = int32[5]
+
+o2 : ForeignArrayType
+
+i3 : 5 * int
+
+o3 = int32[5]
+
+o3 : ForeignArrayType
+
+i4 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Function.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Function.out
@@ -1,0 +1,109 @@
+-- -*- M2-comint -*- hash: 2002912010
+
+i1 : mpfr = openSharedLibrary "mpfr"
+
+o1 = mpfr
+
+o1 : SharedLibrary
+
+i2 : mpfrVersion = foreignFunction(mpfr, "mpfr_get_version", charstar, void)
+
+o2 = mpfr::mpfr_get_version
+
+o2 : ForeignFunction
+
+i3 : mpfrVersion()
+
+o3 = 4.1.0
+
+o3 : ForeignObject of type char*
+
+i4 : mpfrVersion = foreignFunction("mpfr_get_version", charstar, void)
+
+o4 = mpfr_get_version
+
+o4 : ForeignFunction
+
+i5 : mpfrVersion()
+
+o5 = 4.1.0
+
+o5 : ForeignObject of type char*
+
+i6 : myatan2 = foreignFunction("atan2", double, {double, double})
+
+o6 = atan2
+
+o6 : ForeignFunction
+
+i7 : myatan2(1, sqrt 3)
+
+o7 = .523598775598299
+
+o7 : ForeignObject of type double
+
+i8 : sprintf = foreignFunction("sprintf", void, {charstar, charstar},
+         Variadic => true)
+
+o8 = sprintf
+
+o8 : ForeignFunction
+
+i9 : buf = charstar "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+o9 = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+o9 : ForeignObject of type char*
+
+i10 : sprintf(buf, "%s %d", "foo", 3)
+
+i11 : buf
+
+o11 = foo 3
+
+o11 : ForeignObject of type char*
+
+i12 : sprintf(buf, "%s %.1f", "foo", 3)
+
+i13 : buf
+
+o13 = foo 0.0
+
+o13 : ForeignObject of type char*
+
+i14 : sprintf(buf, "%s %.1f", "foo", double 3)
+
+i15 : buf
+
+o15 = foo 3.0
+
+o15 : ForeignObject of type char*
+
+i16 : stopIfError = false
+
+o16 = false
+
+i17 : sprintf(buf, "%c", char' 77)
+stdio:18:1:(3): error: libffi: bad argtype
+
+i18 : malloc = foreignFunction("malloc", voidstar, ulong)
+
+o18 = malloc
+
+o18 : ForeignFunction
+
+i19 : free = foreignFunction("free", void, voidstar)
+
+o19 = free
+
+o19 : ForeignFunction
+
+i20 : x = malloc 8
+
+o20 = 0x7fd21c052280
+
+o20 : ForeignObject of type void*
+
+i21 : registerFinalizer(x, free)
+
+i22 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Function__Pointer__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Function__Pointer__Type.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: -2050113690
+
+i1 : foreignFunctionPointerType("compar", int, {voidstar, voidstar})
+
+o1 = compar
+
+o1 : ForeignFunctionPointerType
+
+i2 : foreignFunctionPointerType(int, {voidstar, voidstar})
+
+o2 = int32(*)(void*,void*)
+
+o2 : ForeignFunctionPointerType
+
+i3 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Object.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Object.out
@@ -1,0 +1,39 @@
+-- -*- M2-comint -*- hash: -1402656156
+
+i1 : foreignObject 5
+
+o1 = 5
+
+o1 : ForeignObject of type int32
+
+i2 : foreignObject pi
+
+o2 = 3.14159265358979
+
+o2 : ForeignObject of type double
+
+i3 : foreignObject "Hello, world!"
+
+o3 = Hello, world!
+
+o3 : ForeignObject of type char*
+
+i4 : foreignObject nullPointer
+
+o4 = (nil)
+
+o4 : ForeignObject of type void*
+
+i5 : foreignObject {1, 3, 5, 7, 9}
+
+o5 = {1, 3, 5, 7, 9}
+
+o5 : ForeignObject of type int32[5]
+
+i6 : foreignObject oo
+
+o6 = {1, 3, 5, 7, 9}
+
+o6 : ForeignObject of type int32[5]
+
+i7 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Pointer__Array__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Pointer__Array__Type.out
@@ -1,0 +1,15 @@
+-- -*- M2-comint -*- hash: 1358981666
+
+i1 : foreignPointerArrayType("myPointerArray", 3 * int)
+
+o1 = myPointerArray
+
+o1 : ForeignPointerArrayType
+
+i2 : foreignPointerArrayType(3 * int)
+
+o2 = int32[3]*
+
+o2 : ForeignPointerArrayType
+
+i3 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Struct__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Struct__Type.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: 23391580
+
+i1 : foreignStructType("mystruct", {"foo" => int, "bar" => double})
+
+o1 = mystruct
+
+o1 : ForeignStructType
+
+i2 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Symbol.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Symbol.out
@@ -1,0 +1,29 @@
+-- -*- M2-comint -*- hash: 180350256
+
+i1 : mps = openSharedLibrary "mps"
+
+o1 = mps
+
+o1 : SharedLibrary
+
+i2 : cplxT = foreignStructType("cplx_t", {"r" => double, "i" => double})
+
+o2 = cplx_t
+
+o2 : ForeignStructType
+
+i3 : foreignSymbol(mps, "cplx_i", cplxT)
+
+o3 = HashTable{i => 1}
+               r => 0
+
+o3 : ForeignObject of type cplx_t
+
+i4 : foreignSymbol("cplx_i", cplxT)
+
+o4 = HashTable{i => 1}
+               r => 0
+
+o4 : ForeignObject of type cplx_t
+
+i5 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Union__Type.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_foreign__Union__Type.out
@@ -1,0 +1,29 @@
+-- -*- M2-comint -*- hash: 1089828994
+
+i1 : myunion = foreignUnionType("myunion",
+         {"foo" => 4 * char', "bar" => charstar})
+
+o1 = myunion
+
+o1 : ForeignUnionType
+
+i2 : x = myunion (4 * char') append(ascii "hi!", 0)
+
+o2 = HashTable{bar => hi!              }
+               foo => {104, 105, 33, 0}
+
+o2 : ForeignObject of type myunion
+
+i3 : x_"foo"
+
+o3 = {104, 105, 33, 0}
+
+o3 : ForeignObject of type int8[4]
+
+i4 : x_"bar"
+
+o4 = hi!
+
+o4 : ForeignObject of type char*
+
+i5 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_null__Pointer.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_null__Pointer.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: 130641358
+
+i1 : nullPointer
+
+o1 = (nil)
+
+o1 : Pointer
+
+i2 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_open__Shared__Library.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_open__Shared__Library.out
@@ -1,0 +1,9 @@
+-- -*- M2-comint -*- hash: -945631043
+
+i1 : openSharedLibrary "mpfr"
+
+o1 = mpfr
+
+o1 : SharedLibrary
+
+i2 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_register__Finalizer_lp__Foreign__Object_cm__Function_rp.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_register__Finalizer_lp__Foreign__Object_cm__Function_rp.out
@@ -1,0 +1,34 @@
+-- -*- M2-comint -*- hash: -641194708
+
+i1 : malloc = foreignFunction("malloc", voidstar, ulong)
+
+o1 = malloc
+
+o1 : ForeignFunction
+
+i2 : free = foreignFunction("free", void, voidstar)
+
+o2 = free
+
+o2 : ForeignFunction
+
+i3 : finalizer = x -> (print("freeing memory at " | net x); free x)
+
+o3 = finalizer
+
+o3 : FunctionClosure
+
+i4 : for i to 9 do (x := malloc 8; registerFinalizer(x, finalizer))
+
+i5 : collectGarbage()
+freeing memory at 0x7f18f8052280
+freeing memory at 0x7f18f804d9a0
+freeing memory at 0x7f18f801c8f0
+freeing memory at 0x7f18f804dfa0
+freeing memory at 0x7f18f804de20
+freeing memory at 0x7f18f804e630
+freeing memory at 0x7f18f8010960
+freeing memory at 0x7f18f80493a0
+freeing memory at 0x7f18f804ec00
+
+i6 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_size_lp__Foreign__Type_rp.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_size_lp__Foreign__Type_rp.out
@@ -1,0 +1,11 @@
+-- -*- M2-comint -*- hash: -1127849569
+
+i1 : size char'
+
+o1 = 1
+
+i2 : size voidstar
+
+o2 = 8
+
+i3 : 

--- a/M2/Macaulay2/packages/ForeignFunctions/examples/_value_lp__Foreign__Object_rp.out
+++ b/M2/Macaulay2/packages/ForeignFunctions/examples/_value_lp__Foreign__Object_rp.out
@@ -1,0 +1,79 @@
+-- -*- M2-comint -*- hash: -1042004422
+
+i1 : x = int 5
+
+o1 = 5
+
+o1 : ForeignObject of type int32
+
+i2 : value x
+
+o2 = 5
+
+i3 : x = double 5
+
+o3 = 5
+
+o3 : ForeignObject of type double
+
+i4 : value x
+
+o4 = 5
+
+o4 : RR (of precision 53)
+
+i5 : x = voidstar address int 5
+
+o5 = 0x7fe18dc10a40
+
+o5 : ForeignObject of type void*
+
+i6 : value x
+
+o6 = 0x7fe18dc10a40
+
+o6 : Pointer
+
+i7 : x = charstar "Hello, world!"
+
+o7 = Hello, world!
+
+o7 : ForeignObject of type char*
+
+i8 : value x
+
+o8 = Hello, world!
+
+i9 : x = (4 * int) {2, 4, 6, 8}
+
+o9 = {2, 4, 6, 8}
+
+o9 : ForeignObject of type int32[4]
+
+i10 : value x
+
+o10 = {2, 4, 6, 8}
+
+o10 : List
+
+i11 : mystruct = foreignStructType("mystruct", {"a" => int, "b" => float})
+
+o11 = mystruct
+
+o11 : ForeignStructType
+
+i12 : x = mystruct {"a" => 2, "b" => sqrt 2}
+
+o12 = HashTable{a => 2      }
+                b => 1.41421
+
+o12 : ForeignObject of type mystruct
+
+i13 : value x
+
+o13 = HashTable{a => 2      }
+                b => 1.41421
+
+o13 : HashTable
+
+i14 : 

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1679,8 +1679,13 @@ AC_SEARCH_LIBS(gzopen,z,,AC_MSG_ERROR(libz not found or not linkable))
 AC_SEARCH_LIBS(lzma_end,lzma,,AC_MSG_ERROR(library lzma not found or not linkable))
 AC_SEARCH_LIBS(xmlNewNode,xml2,,AC_MSG_ERROR(library xml2 not found or not linkable))
 
-AC_MSG_CHECKING([whether package libffi is provided])
-AS_IF([pkg-config --exists libffi],
+AC_ARG_WITH([libffi],
+    [AS_HELP_STRING([--without-libffi],
+        [don't link with libffi, disabling the ForeignFunctions package])],,
+    [with_libffi=yes])
+AS_IF([test x$with_libffi != xno ],
+    [AC_MSG_CHECKING([whether package libffi is provided])
+     AS_IF([pkg-config --exists libffi],
       [AC_MSG_RESULT([yes])
        CPPFLAGS="$(pkg-config --cflags-only-I libffi) $CPPFLAGS"
        AC_CHECK_HEADER([ffi.h], [], [AC_MSG_ERROR([ffi.h not found])])
@@ -1688,7 +1693,8 @@ AS_IF([pkg-config --exists libffi],
 	   [AC_MSG_ERROR([libffi not found or not linkable])])
        AC_CHECK_FUNCS([ffi_get_struct_offsets])],
       [AC_MSG_RESULT([no])
-       AC_MSG_ERROR([libffi is required])])
+       AC_MSG_ERROR([install libffi or use --without-libffi option])])])
+AC_SUBST([LIBFFI], [$with_libffi])
 
 # after this point we add no more libraries to $LIBS, e.g., with AC_SEARCH_LIBS()
 SAVELIBS=$LIBS


### PR DESCRIPTION
@mikestillman has reported issues compiling on Apple silicon machines due to the `ForeignFunctions` package and libffi.  We add the ability to opt out of compiling with libffi using either `--without-libffi` in autotools or `-DWITH_FFI=OFF` in cmake.

As a consequence, we cache the `ForeignFunctions` examples and provide dummy values for the interpreter-level functions that would have otherwise been imported from `Core`.

The last commit sets up the GitHub builds to try building without libffi to make sure that this all works, which is why this is currently a draft.  I'll restore the GitHub builds to their current behavior afterward.