### PR TITLE
Allow commas in allTriangulations regular expression

### DIFF
--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -239,7 +239,7 @@ allTriangulations Matrix := opts -> (A) -> (
     -- if ConnectToRegular is true, then the output is different, and needs to be parsed.
     -- in the other case, we can avoid the first 2 lines but they don't do anything either.
     for t in tris list (
-        t1 := replace(///T\[[0-9]+\] ?:= ?(\[.*:)?///, "", t);
+        t1 := replace(///T\[[0-9,]+\] ?:= ?(\[.*:)?///, "", t);
         t2 := replace(///\];///, "", t1);
         t3 := sort value t2
         )


### PR DESCRIPTION
@mikestillman - This fixes that failing example I emailed you about.  In that particular case, TOPCOM's output has some commas that didn't appear in the other cases, e.g., `T[0,0,0] = `.