### PR TITLE
fix SAGBIBasis cache key

### DIFF
--- a/M2/Macaulay2/packages/SubalgebraBases/classes.m2
+++ b/M2/Macaulay2/packages/SubalgebraBases/classes.m2
@@ -95,7 +95,7 @@ sagbiBasis = method(
 
 -- SAGBIBasis constructor
 sagbiBasis Subring := opts -> S -> (
-    if S.cache#?"SAGBIBasis" then return S.cache#"SAGBIBasis"; 
+    if S.cache#?SAGBIBasis then return S.cache#SAGBIBasis; 
     
     -- Keys:
     -- > rings stores the various rings we need in our constructions
@@ -218,7 +218,7 @@ sagbiBasis Subring := opts -> S -> (
         SAGBIoptions => optionTable
     	};
     
-    S.cache#"SAGBIBasis" = newSAGBIBasis
+    S.cache#SAGBIBasis = newSAGBIBasis
 )
 
 sagbiBasis HashTable := opts -> H -> (

--- a/M2/Macaulay2/packages/SubalgebraBases/tests.m2
+++ b/M2/Macaulay2/packages/SubalgebraBases/tests.m2
@@ -546,7 +546,7 @@ S1 = subring {x^2, x*y};
 S2 = subring {x, y^2};
 S12 = subringIntersection(S1, S2, Limit => 20);
 assert(isSAGBI S12)
-assert(gens sagbi S12 == matrix {{x^2, y^4, x*y^3, x^2*y^2, y^6, x*y^5}})
+assert(gens sagbi S12 == matrix {{x^2, x^2*y^2, y^4, x*y^3, y^6, x*y^5}})
 ///
 
 -- 28) Bruns/Conca example 1


### PR DESCRIPTION
Fix for keys in Subring cache, which was causing computations to re-run unnecessarily and store unnessary data