### PR TITLE
Use "lookup" instead of "lookup1" for getting iterator/next methods

### DIFF
--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -284,13 +284,13 @@ evalWhileListDoCode(c:whileListDoCode):Expr := (
 	       else new Sequence len i do foreach x in r do provide x)));
 
 export getIterator(e:Expr):Expr := (
-    f := lookup1(Class(e), getGlobalVariable(iteratorS));
+    f := lookup(Class(e), getGlobalVariable(iteratorS));
     if f == notfoundE
     then nullE
     else applyEE(f, e));
 
 export getNextFunction(e:Expr):Expr := (
-    f := lookup1(Class(e), getGlobalVariable(nextS));
+    f := lookup(Class(e), getGlobalVariable(nextS));
     if f == notfoundE
     then nullE
     else f);


### PR DESCRIPTION
Otherwise, iteration won't work for subclasses.

### Before
```m2
i1 : Foo = new Type of Iterator

o1 = Foo

o1 : Type

i2 : foo = new Foo from (() -> (r := random 5; if zero r then StopIteration else r))

o2 = iterator ()

o2 : Foo

i3 : toList foo
stdio:3:1:(3): error: expected a list, sequence, or iterable object
```

### After
```m2
i1 : Foo = new Type of Iterator

o1 = Foo

o1 : Type

i2 : foo = new Foo from (() -> (r := random 5; if zero r then StopIteration else r))

o2 = iterator ()

o2 : Foo

i3 : toList foo

o3 = {1, 1, 3, 1}

o3 : List
```