### PR TITLE
Add some more pointer-related features to ForeignFunctions

### DIFF
--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1746,6 +1746,27 @@ doc ///
       ptr = getMemory int
 ///
 
+doc ///
+  Key
+    (symbol *, ForeignType, voidstar)
+  Headline
+    dereference a voidstar object
+  Usage
+    T * ptr
+  Inputs
+    T:ForeignType
+    ptr:voidstar
+  Outputs
+    :ForeignObject -- of type @TT "T"@
+  Description
+    Text
+      This is syntactic sugar for @M2CODE "T value ptr"@ (see
+      @TO (symbol SPACE, ForeignType, Pointer)@) for dereferencing pointers.
+    Example
+      ptr = voidstar address int 5
+      int * ptr
+///
+
 TEST ///
 -----------
 -- value --

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1710,6 +1710,42 @@ doc ///
       foreignSymbol("cplx_i", cplxT)
 ///
 
+doc ///
+  Key
+    getMemory
+    (getMemory, ZZ)
+    (getMemory, ForeignType)
+    (getMemory, ForeignVoidType)
+    Atomic
+    [getMemory, Atomic]
+  Headline
+    allocate memory using the garbage collector
+  Usage
+    getMemory n
+    getMemory T
+  Inputs
+    n:ZZ -- must be positive
+    T:ForeignType
+  Outputs
+    :voidstar
+  Description
+    Text
+      Allocate @TT "n"@ bytes of memory using the @TO "GC garbage collector"@.
+    Example
+      ptr = getMemory 8
+    Text
+      If the memory will not contain any pointers, then set the @TT "Atomic"@
+      option to @TO true@.
+    Example
+      ptr = getMemory(8, Atomic => true)
+    Text
+      Alternatively, a foreign object type @TT "T"@ may be specified.  In
+      this case, the number of bytes and whether the @TT "Atomic"@ option
+      should be set will be determined automatically.
+    Example
+      ptr = getMemory int
+///
+
 TEST ///
 -----------
 -- value --

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -598,6 +598,10 @@ getMemory ZZ := o -> n -> (
 getMemory ForeignType := o -> T -> getMemory(size T, Atomic => isAtomic T)
 getMemory ForeignVoidType := o -> T -> error "can't allocate a void"
 
+memcpy = foreignFunction("memcpy", voidstar, {voidstar, voidstar, ulong})
+* voidstar = (ptr, val) -> (
+    if not instance(val, ForeignObject) then val = foreignObject val;
+    memcpy(ptr, address val, size class val))
 
 beginDocumentation()
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -603,6 +603,8 @@ memcpy = foreignFunction("memcpy", voidstar, {voidstar, voidstar, ulong})
     if not instance(val, ForeignObject) then val = foreignObject val;
     memcpy(ptr, address val, size class val))
 
+ForeignType * voidstar := (T, ptr) -> T value ptr
+
 beginDocumentation()
 
 doc ///
@@ -1763,7 +1765,7 @@ assert Equation(value x_0, 1)
 assert Equation(value x_(-1), 3)
 ptrarray = 3 * voidstar
 x = ptrarray {address int 1, address int 2, address int 3}
-assert Equation(for ptr in x list value int value ptr, {1, 2, 3})
+assert Equation(for ptr in x list value (int * ptr), {1, 2, 3})
 x = charstarstar {"foo", "bar", "baz"}
 assert Equation(length x, 3)
 assert Equation(value x, {"foo", "bar", "baz"})
@@ -1771,9 +1773,9 @@ assert Equation(value x_0, "foo")
 assert Equation(value x_(-1), "baz")
 x = voidstarstar {address int 1, address int 2, address int 3, address int 4}
 assert Equation(length x, 4)
-assert Equation(value \ for ptr in x list int value ptr, {1, 2, 3, 4})
-assert Equation(value int value x_0, 1)
-assert Equation(value int value x_(-1), 4)
+assert Equation(value \ for ptr in x list (int * ptr), {1, 2, 3, 4})
+assert Equation(value (int * x_0), 1)
+assert Equation(value (int * x_(-1)), 4)
 int3star = foreignPointerArrayType(3 * int)
 x = int3star {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}}
 assert Equation(length x, 4)
@@ -1789,7 +1791,7 @@ assert instance(value x, HashTable)
 assert Equation(value x_"a", 1)
 assert Equation(value x_"b", 2.0)
 assert Equation(value x_"c", "foo")
-assert Equation(value int value x_"d", 4)
+assert Equation(value (int * x_"d"), 4)
 
 -- union types
 testuniontype = foreignUnionType("bar", {"a" => float, "b" => uint32})
@@ -1853,7 +1855,7 @@ tm = foreignStructType("tm", {
 	"tm_zone" => charstar})
 gmtime = foreignFunction("gmtime", voidstar, voidstar)
 asctime = foreignFunction("asctime", charstar, voidstar)
-epoch = tm value gmtime address long 0
+epoch = tm * gmtime address long 0
 assert Equation(value asctime address epoch,"Thu Jan  1 00:00:00 1970\n")
 ///
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1767,6 +1767,36 @@ doc ///
       int * ptr
 ///
 
+doc ///
+  Key
+    ((symbol *, symbol =), voidstar)
+  Headline
+    assign value to object at address
+  Usage
+    *ptr = val
+  Inputs
+    ptr:voidstar
+    val:Thing
+  Description
+    Text
+      Assign the value @TT "val"@ to an object at the address given by
+      @TT "ptr"@.
+    Example
+      x = int 5
+      ptr = voidstar address x
+      *ptr = int 6
+      x
+    Text
+      If @TT "val"@ is not a @TO ForeignObject@, then @TO foreignObject@ is
+      called first.
+    Example
+      *ptr = 7
+      x
+    Text
+      Make sure that the memory at which @TT "ptr"@ points is properly
+      allocated.  Otherwise, segmentation faults may occur!
+///
+
 TEST ///
 -----------
 -- value --

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1894,3 +1894,27 @@ x = (4 * int) {4, 2, 3, 1}
 qsort(x, 4, size int, (a, b) -> value int a - value int b)
 assert Equation(value x, {1, 2, 3, 4})
 ///
+
+TEST ///
+-- allocating and dereferencing pointers
+ptr = getMemory int
+*ptr = int 5
+assert Equation(value (int * ptr), 5)
+ptr = getMemory double
+*ptr = double pi
+assert Equation(value (double * ptr), pi)
+ptr = getMemory charstar
+*ptr = charstar "Hello, world!"
+assert Equation(value (charstar * ptr), "Hello, world!")
+ptr = getMemory (3 * int)
+*ptr = (3 * int) {1, 2, 3}
+assert Equation(value ((3 * int) * ptr), {1, 2, 3})
+ptr = getMemory charstarstar
+*ptr = charstarstar {"foo", "bar", "baz"}
+assert Equation(value (charstarstar * ptr), {"foo", "bar", "baz"})
+foo = foreignStructType("foo", {"a" => int, "b" => double, "c" => charstar})
+ptr = getMemory foo
+*ptr = foo {"a" => 5, "b" => pi, "c" => "Hello, world!"}
+assert BinaryOperation(symbol ===, value (foo * ptr),
+    hashTable{"a" => 5, "b" => numeric pi, "c" => "Hello, world!"})
+///


### PR DESCRIPTION
Three new methods:

* `getMemory`, which wraps around `GC_malloc` or `GC_malloc_atomic` for allocating memory using the garbage collector.
* `ForeignType * voidstar`, which is syntactic sugar for dereferencing pointers.
* `*voidstar = Thing`, which wraps around `memcpy` and allows us to assign values to objects at a given address, a feature I realized was needed while working on another package that uses `ForeignFunctions`.

For example:

```m2
i2 : ptr = getMemory int

o2 = 0x7fd0242d4650

o2 : ForeignObject of type void*

i3 : *ptr = 5

o3 = 0x7fd0242d4650

o3 : ForeignObject of type void*

i4 : int * ptr

o4 = 5

o4 : ForeignObject of type int32
```
No new D code was necessary -- `foreignFunction` was used for the wrappers.