### PR TITLE
Update and document "remove" for lists

### DIFF
--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -745,12 +745,13 @@ export lookup(s:string,table:SymbolHashTable):(null or Symbol) := (
 	  then return entryListCell.entry;
 	  entryList = entryListCell.next));
 
+export ArrayIndexOutOfBounds(i:int, n:int):Expr := (
+     buildErrorPacket("array index " + tostring(i) + " out of bounds 0 .. " +
+	  tostring(n)));
+
 getvalue(x:Sequence,i:int):Expr := (
      if i < -length(x) || i >= length(x)
-     then buildErrorPacket("array index "
-	  + tostring(i)
-	  + " out of bounds 0 .. "
-	  + tostring(length(x)-1))
+     then ArrayIndexOutOfBounds(i, length(x) - 1)
      else (
 	  if i < 0
 	  then x.(length(x) + i)
@@ -760,10 +761,7 @@ export subvalue(left:Expr,right:Expr):Expr := (
      when left is x:Sequence do (
 	  when right is r:ZZcell do (
 	       if isInt(r) then getvalue(x,toInt(r))
-	       else buildErrorPacket("array index "
-		    + tostring(r.v)
-		    + " out of bounds 0 .. "
-		    + tostring(length(x)-1)))
+	       else WrongArgSmallInteger())
 	  else buildErrorPacket("expected subscript to be an integer"))
      is x:HashTable do lookup1force(x,right)
      is f:Database do (
@@ -777,10 +775,7 @@ export subvalue(left:Expr,right:Expr):Expr := (
      is x:List do (
 	  when right is r:ZZcell do (
 	       if isInt(r) then getvalue(x.v,toInt(r))
-	       else buildErrorPacket("array index "
-		    + tostring(r.v)
-		    + " out of bounds 0 .. "
-		    + tostring(length(x.v)-1)))
+	       else WrongArgSmallInteger())
 	  else buildErrorPacket("array index not an integer"))
      is dc:DictionaryClosure do (
 	  when right is s:stringCell do (

--- a/M2/Macaulay2/m2/basictests/A44.m2
+++ b/M2/Macaulay2/m2/basictests/A44.m2
@@ -1,19 +1,5 @@
 assert = x -> if not x then error "assertion failed "
 
--- test remove on lists
-
-assert( remove( {a} , 0 ) === {} )
-assert( remove( {a,b,c} , 1 ) === {a,c} )
-assert( remove( {a,b,c} , -1 ) === {a,b} )
-assert( remove( {a,b,c} , 6 ) === {a,b,c} )
-
-assert( remove( new BasicList from {a,b,c} , 6 ) === new BasicList from {a,b,c} )
-
-assert( remove( 1 : a , 0 ) === () )
-assert( remove( (a,b,c) , 1 ) === (a,c) )
-assert( remove( (a,b,c) , -1 ) === (a,b) )
-assert( remove( (a,b,c) , 6 ) === (a,b,c) )
-
 -- test drop
 
 assert( drop( {a,b}, 3 ) === {} )

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -113,6 +113,8 @@ toSequence String    :=
 toSequence Thing     := Sequence => toSequence
 ascii String := List => ascii
 ascii List := String => ascii
+remove(MutableList,ZZ) := Nothing => remove
+remove(Database,String) := Nothing => remove
 remove(HashTable,Thing) := Nothing => remove
 echoOff File := Nothing => echoOff
 echoOn File := Nothing => echoOn

--- a/M2/Macaulay2/packages/KustinMiller.m2
+++ b/M2/Macaulay2/packages/KustinMiller.m2
@@ -201,8 +201,8 @@ maximalElements List := L -> (
         M:=L;
         for j from 0 to #L-1 do (
           for jj from j+1 to #L-1 do (
-               if isSubset(L#j,L#jj) then (M=remove(L,j);break);
-               if isSubset(L#jj,L#j) then (M=remove(L,jj);break);
+               if isSubset(L#j,L#jj) then (M=drop(L,{j,j});break);
+               if isSubset(L#jj,L#j) then (M=drop(L,{jj,jj});break);
           );
         );
         if #M==#L then return L;

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -62,7 +62,13 @@ document {
 			 has been modified to accommodate both homological and internal
 			 grading in a simplied format." 
                 	 }
-	       	    }}
+		     }
+		 },
+	  LI { "functionality changed in a way that could break code:",
+	       UL {
+		    LI { TO remove, " may now be used to remove elements from mutable lists.  Its previous (undocumented) behavior was equivalent to ", TO drop, "."}
+		    }
+	       }
 	  }}
     
 document {

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_tables.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_tables.m2
@@ -282,14 +282,17 @@ doc ///
  Key
   remove
   (remove, HashTable, Thing)
+  (remove, MutableList, ZZ)
+  (remove, Database, String)
  Headline
-  remove an entry from a mutable hash table
+  remove an entry from a mutable hash table, list, or database
  Usage
   remove(T, k)
  Inputs
-  T:HashTable
+  T:{HashTable, MutableList, Database}
   k:
-   key
+    the key to remove (must be @ofClass ZZ@ if @TT "T"@ is a mutable list or
+    @ofClass String@ if it is a database)
  Outputs
   :Nothing
  Description
@@ -307,6 +310,22 @@ doc ///
   Example
    T = new HashTable from {a => 1, b => 2, c => 3}
    T = applyPairs(T, (k, v) -> if k =!= a then (k, v))
+  Text
+   @TT "remove"@ works similarly when @TT "T"@ is a database.  See @TO Database@
+   for more information.
+  Text
+    If @TT "T"@ is a mutable list, then @TT "k"@ gives the index of the element
+    to be removed.
+  Example
+    T = new MutableList from {1, 2, 3, 4}; peek T
+    remove(T, 0)
+    peek T
+  Text
+    If @TT "k"@ is negative, then the index is determined by counting backwards
+    from the end of @TT "T"@.
+  Example
+    remove(T, -1)
+    peek T
   Text
    The {\tt remove} command does not return any output.
  SeeAlso

--- a/M2/Macaulay2/packages/MonomialAlgebras.m2
+++ b/M2/Macaulay2/packages/MonomialAlgebras.m2
@@ -414,7 +414,7 @@ rem=method()
 rem(List,Set):=(L,I)->(
   while #I>0 do (
     m:=max(toList I);
-    L=remove(L,m);
+    L=drop(L,{m,m});
     I=I - set {m};
   );
   L)
@@ -730,7 +730,7 @@ randomSemigroup(ZZ,ZZ,ZZ):=opt->(a,d,c)->(
        j:=random(#E);
        if #E==0 then error("Codimension too large");
        B=append(B,E#j);
-       E=remove(E,j);
+       E=drop(E,{j,j});
      );
    ) else (
      dPB:=-1;
@@ -741,7 +741,7 @@ randomSemigroup(ZZ,ZZ,ZZ):=opt->(a,d,c)->(
          j=random(#E);
          if #E==0 then error("Codimension too large");
          B=append(B,E#j);
-         E=remove(E,j);
+         E=drop(E,{j,j});
        );
        PB:=posHull transpose matrix B;
        dPB=dim PB;

--- a/M2/Macaulay2/packages/PieriMaps.m2
+++ b/M2/Macaulay2/packages/PieriMaps.m2
@@ -182,7 +182,7 @@ standardTableaux = method()
 standardTableaux(ZZ, List) := (dim, mu) -> (
      if #mu == 0 then return {{}};
      output := {};
-     otherrows := standardTableaux(dim, remove(mu, 0));
+     otherrows := standardTableaux(dim, drop(mu, 1));
      firstrow := rsort compositions(dim, mu#0);
      for i in firstrow do (
      	  temp := {};
@@ -262,7 +262,7 @@ pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
 	       	    for T in keys h do (
 		    	 for b from 0 to #(T_(J_(i+1)))-1 when true do (
 		    	      U := new MutableList from T;
-     	       	    	      U#(J_(i+1)) = remove(U#(J_(i+1)), b);
+     	       	    	      U#(J_(i+1)) = drop(U#(J_(i+1)), {b, b});
 			      U#(J_i) = append(U#(J_i), (T_(J_(i+1)))_b);
 			      temp = append(temp, (new List from U, h#T));
 			      );
@@ -274,7 +274,7 @@ pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
      	  H = new MutableHashTable from H;
      	  memo := new MutableHashTable from {};
      	  for T in keys H do (
-	       U := apply(remove(T,0), i->sort(i));
+	       U := apply(drop(T,1), i->sort(i));
 	       coeff := H#T;
 	       remove(H, T);
 	       straighten(U, memo);
@@ -373,7 +373,7 @@ pureFree(List, PolynomialRing) := (d, P) -> (
      lambda := {counter - e#0};
      for i from 1 to #e-1 do
      lambda = append(lambda, lambda#(i-1) - e#i + 1);
-     lambda = prepend(counter, remove(lambda, 0));
+     lambda = prepend(counter, drop(lambda, 1));
      pieri(lambda, toList(e#0 : 1), P) ** P^{-d#0}
      )
 

--- a/M2/Macaulay2/packages/Polyhedra/core/cone/constructors.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/cone/constructors.m2
@@ -152,7 +152,7 @@ coneFromVData List := L -> (
       )
    );
    result := cones#0;
-   cones = remove(cones, 0);
+   cones = drop(cones, 1);
    -- Adding the cones is not expensive, since we will not do fourierMotzkin
    -- every time.
    for cone in cones do (

--- a/M2/Macaulay2/packages/SimplicialComplexes/Code.m2
+++ b/M2/Macaulay2/packages/SimplicialComplexes/Code.m2
@@ -855,7 +855,7 @@ scarfSimplicialComplex (List,Ring) := (L,A) -> (
     -- The scarfSimplicialComplex is the subcomplex of the (#L-1)-simplex
     -- whose faces have unique multidegrees. These unique multidegrees
     -- are called Scarf multidegrees.
-    faceList := remove(subsets L, 0);
+    faceList := drop(subsets L, 1);
     faceLabels := for F in faceList list lcm F;
     scarfMultidegrees := for m in faceLabels list(
     	if #positions(faceLabels, k -> k == m) > 1

--- a/M2/Macaulay2/tests/normal/remove.m2
+++ b/M2/Macaulay2/tests/normal/remove.m2
@@ -1,0 +1,22 @@
+x = new MutableHashTable from {"a" => 1, "b" => 2, "c" => 3}
+remove(x, "a")
+assert (pairs x == {("b", 2), ("c", 3)})
+remove(x, "d")
+assert (pairs x == {("b", 2), ("c", 3)})
+
+x = new MutableList from {1, 2, 3, 4}
+remove(x, 0)
+assert(toList x == {2, 3, 4})
+remove(x, -1)
+assert(toList x == {2, 3})
+
+filename = temporaryFileName() | ".dbm"
+x = openDatabaseOut filename
+x#"a" = "foo"
+x#"b" = "bar"
+x#"c" = "baz"
+assert(sort keys x == {"a", "b", "c"})
+remove(x, "a")
+assert(sort keys x == {"b", "c"})
+close x
+removeFile filename

--- a/M2/Macaulay2/tests/normal/remove.m2
+++ b/M2/Macaulay2/tests/normal/remove.m2
@@ -9,6 +9,10 @@ remove(x, 0)
 assert(toList x == {2, 3, 4})
 remove(x, -1)
 assert(toList x == {2, 3})
+remove(x, 1)
+assert(toList x == {2})
+remove(x, 0)
+assert(toList x == {})
 
 filename = temporaryFileName() | ".dbm"
 x = openDatabaseOut filename


### PR DESCRIPTION
Previously, `remove(L, i)` did the same thing as `drop(L, {i, i})` for a list (or sequence) `L` and an integer `i`, but this was undocumented ~~and not used anywhere~~.  (*Edit*: It's actually used in several packages.)

We change the behavior so that it behaves like `remove` for hash tables and dictionaries.  In particular, it now only works for *mutable* lists, modifies the existing list, and returns `null`:

```m2
i1 : x = new MutableList from {1, 2, 3, 4}

o1 = MutableList{...4...}

o1 : MutableList

i2 : remove(x, 0)

i3 : peek x

o3 = MutableList{2, 3, 4}
```

Closes: #2670

One other small change: we update the error message when subscripting a list or sequence with a `ZZ` that's too large to fit inside an `int`:

### Before
```m2
i1 : L = {}

o1 = {}

o1 : List

i2 : L_{2^31}
stdio:2:2:(3): error: array index 2147483648 out of bounds 0 .. -1
```
### After
```m2
i1 : L = {}

o1 = {}

o1 : List

i2 : L_(2^31)
stdio:2:2:(3): error: expected a small integer
```