### PR TITLE
A few ForeignFunctions updates

### DIFF
--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -593,6 +593,7 @@ ffiClosureFunction(cif:Pointer "ffi_cif *", ret:voidPointer,
     do Ccode(void, "memcpy(",
 	endianAdjust(ret, Ccode(voidPointer, "((ffi_cif *)", cif, ")->rtype")),
 	", ", ptr.v, ", ", cif, "->rtype->size)")
+    is err:Error do printErrorMessage(err)
     else nothing);
 
 ffiClosureFinalizer(ptr:voidPointer, closure:voidPointer):void := (

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -604,6 +604,7 @@ memcpy = foreignFunction("memcpy", voidstar, {voidstar, voidstar, ulong})
 * voidstar = (ptr, val) -> (
     if not instance(val, ForeignObject) then val = foreignObject val;
     memcpy(ptr, address val, size class val))
+* Pointer = (ptr, val) -> value (*voidstar ptr = val)
 
 ForeignType * voidstar := (T, ptr) -> T value ptr
 
@@ -1772,12 +1773,13 @@ doc ///
 doc ///
   Key
     ((symbol *, symbol =), voidstar)
+    ((symbol *, symbol =), Pointer)
   Headline
     assign value to object at address
   Usage
     *ptr = val
   Inputs
-    ptr:voidstar
+    ptr:{voidstar, Pointer}
     val:Thing
   Description
     Text
@@ -1785,7 +1787,7 @@ doc ///
       @TT "ptr"@.
     Example
       x = int 5
-      ptr = voidstar address x
+      ptr = address x
       *ptr = int 6
       x
     Text

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -141,6 +141,7 @@ value ForeignObject := x -> error("no value function exists for ", class x)
 
 address = method(TypicalValue => Pointer)
 address ForeignObject := x -> x.Address
+address Nothing := identity
 
 foreignObject = method(TypicalValue => ForeignObject)
 foreignObject ForeignObject := identity
@@ -199,6 +200,7 @@ ForeignVoidType = new Type of ForeignType
 ForeignVoidType.synonym = "foreign void type"
 
 dereference(ForeignVoidType, Pointer) := (T, x) -> null
+ForeignVoidType Nothing := (T, x) -> null
 
 void = new ForeignVoidType
 void.Name = "void"

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -393,7 +393,7 @@ foreignPointerArrayType(String, ForeignType) := (name, T) -> (
 	    if ffiPointerValue ptr === nullPointer then StopIteration
 	    else (
 		r := dereference_T ptr;
-		ptr = ptr + version#"pointer size";
+		ptr = ptr + sz;
 		r)));
     S)
 


### PR DESCRIPTION
If we create a foreign function pointer to a Macaulay2 function that raises an error, we now see the error:

```m2
i2 : (foreignFunctionPointerType(void, void)) (() -> 1/0)

o2 = void(*-*Function[stdio:2:46-2:51]*-)()

o2 : ForeignObject of type void(*)(void)

i3 : (value oo)()
stdio:2:50:(3):[4]: error: division by zero
src/macaulay2/M2/M2/Macaulay2/packages/ForeignFunctions.m2:501:26:(2):[2]: error: division by zero
```
Following up #2678, we can copy to memory given by a `Pointer` object, and not just a `voidstar` object:

```m2
i2 : x = int 3

o2 = 3

o2 : ForeignObject of type int32

i3 : ptr = address x

o3 = 0x7f76f68d2ad0

o3 : Pointer

i4 : *ptr = 4

o4 = 0x7f76f68d2ad0

o4 : Pointer

i5 : x

o5 = 4

o5 : ForeignObject of type int32
```
Plus a couple of other small things.
