### PR TITLE
Polyhedra: Fix bug in regularSubdivision(Matrix, Matrix)

### DIFF
--- a/M2/Macaulay2/packages/Polyhedra/extended/polyhedron/methods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/extended/polyhedron/methods.m2
@@ -134,13 +134,21 @@ regularSubdivision (Polyhedron,Matrix) := (P,w) -> (
    apply (S, s -> convexHull LP_s)
 )
 
-regularSubdivision (Matrix,Matrix) := (M,w) -> (
+regularSubdivision (Matrix,Matrix) := (MM, w) -> (
+   M := promote(MM, QQ);
    n := numColumns M;
    -- Checking for input errors
    if numColumns w != numColumns M or numRows w != 1 then error("The weight must be a one row matrix with number of points many entries");
    P := convexHull(M||w,matrix (toList(numRows M:{0})|{{1}}));
    F := select(faces (1,P), f -> #(f#1) ==0);
-   apply (F, f -> f#0)
+   pointIndices := new MutableHashTable;
+   for i from 0 to numcols M-1 do
+      pointIndices#(M_{i}) = i;
+   permutation := new MutableHashTable;
+   vertP := (vertices P)^{0..numrows M - 1};
+   for i from 0 to numcols vertP - 1 do
+      permutation#i = pointIndices#(vertP_{i});
+   sort apply (F, f -> sort apply(f#0, i->permutation#i))
   )
 
 

--- a/M2/Macaulay2/packages/Polyhedra/tests/extended/regularSubdivision.m2
+++ b/M2/Macaulay2/packages/Polyhedra/tests/extended/regularSubdivision.m2
@@ -1,40 +1,53 @@
 -- Test Square Triangulation Input Polytope
 TEST ///
 P = convexHull matrix {{1,0,1,0},{1,1,0,0}};
-C1 = matrix {{0,1,1},{0,0,1}}; 
-C2 = matrix {{0,1,0},{0,0,1}};
+C1 = matrix {{0,1,0},{0,0,1}};
+C2 = matrix {{1,0,1},{0,1,1}}; 
 w = matrix {{1,0,1,0}};
 S = regularSubdivision (P,w);
 assert(S#0 == convexHull C1)
 assert(S#1 == convexHull C2)
-///
-
 
 -- Test Square Subdivision Input Polytope
-TEST ///
 P = convexHull matrix {{1,0,1,0},{1,1,0,0}};
 w = matrix {{1,1,0,0}};
 S = regularSubdivision (P,w);
 assert(S#0 == P)
-///
-
 
 --- Test Square Triangulation Input Points 
-TEST ///
 M = matrix {{1,0,1,0},{1,1,0,0}}; 
 w = matrix {{1,0,0,1}};
 C1 = matrix {{1,0,1},{1,1,0}}; 
-C2 = matrix {{1,0,0},{1,1,0}};
+C2 = matrix {{0,1,0},{1,0,0}};
 S = regularSubdivision (M,w); 
 assert(convexHull M_(S#0) == convexHull C1)
 assert(convexHull M_(S#1) == convexHull C2)
-///
-
 
 ---Test Square Subdivision Input Points 
-TEST ///
 M = matrix {{1,0,1,0},{1,1,0,0}}; 
 w = matrix {{1,1,0,0}};
 S = regularSubdivision (M,w);
 assert (convexHull M_(S#0) == convexHull M)
+
+A = matrix {
+ {0, -1, 2, 3, 4, -5, 6}, 
+ {0, 1, -4, 9, 16, 25, 36}, 
+ {0, 1, 8, -27, 64, 125, -216}};
+weights = matrix{{24235/1467081, 77731/5029992, 17659/838332, 0, 0, 0, 0}};
+tri0 = regularSubdivision(A, weights)
+ans = {{0, 1, 2, 3}, {0, 1, 3, 6}, {0, 2, 3, 6}, {1, 2, 3, 4}, {1, 2, 4, 5},
+{1, 3, 4, 5}, {1, 3, 5, 6}, {2, 3, 4, 6}, {3, 4, 5, 6}}
+assert(ans == tri0)
+
+M0 = matrix{{0,0,1,1},{0,1,0,1}};
+RS0 = regularSubdivision(M0, matrix {{1,0,0,0}})
+RS1 = regularSubdivision(M0, matrix {{0,1,0,0}})
+RS2 = regularSubdivision(M0, matrix {{0,0,1,0}})
+RS3 = regularSubdivision(M0, matrix {{0,0,0,1}})
+ans0 = {{0,1,2},{1,2,3}}
+ans1 = {{0,1,3},{0,2,3}}
+assert(RS0 == ans0)
+assert(RS1 == ans1)
+assert(RS2 == ans1)
+assert(RS3 == ans0)
 ///


### PR DESCRIPTION
In this method a lower envelope is computed whose (projected) facets in
turn are a regular subdivision of the input point set. Previously
the return values probably were actual polyhedra, but now these are just
sets of indices indicating which points together form a cell. However
these indices use the vertices of the intermediate polyhedron used for
computing the lower envelope. Thus they need to be remapped onto the
input points.