### PR TITLE
Add "take" for iterators.

### DIFF
--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -69,6 +69,7 @@ concatenate Nothing := concatenate String := concatenate Symbol := concatenate Z
 deepSplice BasicList := BasicList => deepSplice
 drop(BasicList,ZZ) := drop(BasicList,List) := BasicList => drop
 take(BasicList,ZZ) := take(BasicList,List) := BasicList => take
+take(Thing,ZZ) := List => take
 get File := get String := String => get
 getc File := String => getc
 getenv String := String => getenv

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/take-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/take-doc.m2
@@ -6,13 +6,16 @@ doc ///
   take
   (take, BasicList, ZZ)
   (take, BasicList, List)
+  (take, Thing, ZZ)
  Headline
   Take some elements from a list or sequence.
  Usage
   take(L, i)
   take(L, {j,k})
+  take(x, i)
  Inputs
   L: BasicList
+  x: Thing
   i: ZZ
   j: ZZ
   k: ZZ
@@ -32,6 +35,15 @@ doc ///
   Example
    take({a,b,c,d,e,f,g}, {3,1})
    take({a,b,c,d,e,f,g}, {4,-1})
+  Text
+   If @TT "x"@ is any object belonging to a class with the @TO iterator@ method
+   installed, then a list containing the first @TT "i"@ objects returned when
+   @TO next@ is called on the output of @M2CODE "iterator x"@ is returned.
+   If fewer then @TT "i"@ objects are returned before the @TO StopIteration@
+   symbol is encountered, then the list will have length less than @TT "i"@.
+  Example
+   take("Hello, world!", 5)
+   take("Hello, world!", 20)
  SeeAlso
   drop
   select

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -34,6 +34,10 @@ assert Equation(fold(plus, P), 77)
 i = iterator P
 assert Equation(fold(plus, next i, i), 77)
 
+assert Equation(take(P, 0), {})
+assert Equation(take(P, 5), {2, 3, 5, 7, 11})
+assert Equation(take(P, 20), {2, 3, 5, 7, 11, 13, 17, 19})
+
 assert Equation(toList iterator {1, 2, 3}, {1, 2, 3})
 assert Equation(toList iterator (1, 2, 3), {1, 2, 3})
 assert Equation(toList iterator "foo", {"f", "o", "o"})


### PR DESCRIPTION
This should be useful for getting a finite number of elements from an infinite iterator:

```m2
i1 : take(Iterator(() -> random 20), 5)

o1 = {12, 18, 3, 14, 8}

o1 : List
```
Question: Should this return an `Iterator` instead?  There's definitely an argument for that since `take` preserves the class of the input in other cases.  But it seems like returning a `List` might be more desirable, for when you really just want the first few elements from an iterator.