### PR TITLE
Remove unused StartDictionary from ParseTree union

### DIFF
--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -672,7 +672,6 @@ bindassignment(assn:Binary,dictionary:Dictionary,colon:bool):void := (
 	  "left hand side of assignment inappropriate"));
 export bind(e:ParseTree,dictionary:Dictionary):void := (
      when e
-     is s:StartDictionary do bind(s.body,dictionary)
      is i:IfThen do (
 	  bind(i.predicate,dictionary);
 	  -- i.thenclause = bindnewdictionary(i.thenclause,dictionary);

--- a/M2/Macaulay2/d/convertr.d
+++ b/M2/Macaulay2/d/convertr.d
@@ -133,11 +133,6 @@ parallelAssignment(e:ParseTree,b:Binary,p:Parentheses):Code := (
 
 export convert(e:ParseTree):Code := (
      when e
-     is s:StartDictionary do (
-	  if s.dictionary.framesize != 0
-	  then Code(newLocalFrameCode(s.dictionary.frameID,s.dictionary.framesize,convert(s.body)))
-	  else convert(s.body)
-	  )
      is w:For do Code(
 	  forCode(
 	       convert(w.inClause), convert(w.fromClause), convert(w.toClause),

--- a/M2/Macaulay2/d/parse.d
+++ b/M2/Macaulay2/d/parse.d
@@ -146,10 +146,9 @@ export ArrayParseTree := array(ParseTree);
 export Parentheses := {+ left:Token, contents:ParseTree, right:Token };
 export EmptyParentheses := {+ left:Token, right:Token };
 export dummy := {+position:Position};
-export StartDictionary := {+dictionary:Dictionary, body:ParseTree};
 export ParseTree := (
      Token or Adjacent or Binary or Unary or Postfix or Parentheses 
-     or EmptyParentheses or IfThen or IfThenElse or StartDictionary 
+     or EmptyParentheses or IfThen or IfThenElse
      or Quote or GlobalQuote or ThreadQuote or LocalQuote
      or TryThenElse or TryElse or Try or Catch or WhileDo or For or WhileList or WhileListDo or Arrow or New or dummy );
 

--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -527,7 +527,6 @@ export treePosition(e:ParseTree):Position := (
      	  is w:WhileDo do return position(w.whileToken)
      	  is w:WhileList do return position(w.whileToken)
      	  is w:WhileListDo do return position(w.whileToken)
-     	  is s:StartDictionary do e = s.body
 	  is n:New do return position(n.newtoken)
 	  )
      );
@@ -560,7 +559,6 @@ export size(e:ParseTree):int := (
      is x:WhileDo do Ccode(int,"sizeof(*",x,")") + size(x.whileToken) + size(x.predicate) + size(x.dotoken) + size(x.doClause)
      is x:WhileList do Ccode(int,"sizeof(*",x,")") + size(x.whileToken) + size(x.predicate) + size(x.listtoken) + size(x.listClause)
      is x:WhileListDo do Ccode(int,"sizeof(*",x,")") + size(x.whileToken) + size(x.predicate) + size(x.dotoken) + size(x.doClause) + size(x.listtoken) + size(x.listClause)
-     is x:StartDictionary do Ccode(int,"sizeof(*",x,")") + size(x.body)
      is x:New do Ccode(int,"sizeof(*",x,")") + size(x.newtoken) + size(x.newclass) + size(x.newparent) + size(x.newinitializer)
      );
 


### PR DESCRIPTION
We never actually create any `StartDictionary` objects.