### PR TITLE
Convert NumPy integer types to Python ints before converting to ZZ

### DIFF
--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -197,10 +197,11 @@ addPyToM2Function(
     {"float", "float16", "float32", "float64", "float128"},
     pythonFloatAsDouble,
     "float -> RR")
+pyInt = toFunction pythonValue "int"
 addPyToM2Function(
     {"int", "int8", "uint8", "int16", "uint16", "int32", "uint32",
 	"int64", "uint64", "longlong", "ulonglong"},
-    pythonLongAsLong,
+    pythonLongAsLong @@ pyInt,
     "int -> ZZ")
 addPyToM2Function(
     {"bool", "bool_"},


### PR DESCRIPTION
Otherwise, we may get incorrect results, or even segfault.

### Before

```m2
i1 : needsPackage "Python"

o1 = Python

o1 : Package

i2 : np = import "numpy"

o2 = <module 'numpy' from '/usr/lib/python3/dist-packages/numpy/__init__.py'>

o2 : PythonObject of class module

i3 : np@@uint64(2^64 - 1)

o3 = 18446744073709551615

o3 : PythonObject of class numpy.uint64

i4 : value oo

o4 = -643368512

i5 : np@@uint64 2^63

o5 = 9223372036854775808

o5 : PythonObject of class numpy.uint64

i6 : value oo
-- SIGSEGV
-* stack trace, pid: 1085744
M2-binary: malloc.c:2617: sysmalloc: Assertion `(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_top) && ((unsigned long) old_end & (pagesize - 1)) == 0)' failed.
Aborted (core dumped)
```

### After
```m2
i1 : needsPackage "Python"

o1 = Python

o1 : Package

i2 : np = import "numpy"

o2 = <module 'numpy' from '/usr/lib/python3/dist-packages/numpy/__init__.py'>

o2 : PythonObject of class module

i3 : np@@uint64(2^64 - 1)

o3 = 18446744073709551615

o3 : PythonObject of class numpy.uint64

i4 : value oo

o4 = 18446744073709551615

i5 : np@@uint64 2^63

o5 = 9223372036854775808

o5 : PythonObject of class numpy.uint64

i6 : value oo

o6 = 9223372036854775808
```