### PR TITLE
Add "join" support for iterators

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -1117,7 +1117,7 @@ sqrt(a:Expr):Expr := (
      else WrongArgRR());
 setupfun("sqrt",sqrt).Protected=false;
 
-toSequence(e:Expr):Expr := (
+export toSequence(e:Expr):Expr := (
      when e
      is Sequence do e
      is b:List do (

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1094,31 +1094,36 @@ denfun(e:Expr):Expr := (
      else WrongArg("a rational number"));
 setupfun("denominator",denfun);
 
+join(a:Sequence):Expr := (
+     newlen := 0;
+     foreach x in a do (
+	  when x
+	  is b:Sequence do (newlen = newlen + length(b);)
+	  is c:List do (newlen = newlen + length(c.v);)
+	  else return WrongArg("lists or sequences");
+	  );
+     z := new Sequence len newlen do (
+	  foreach x in a do (
+	       when x
+	       is b:Sequence do foreach y in b do provide y
+	       is c:List do foreach y in c.v do provide y
+	       else nothing;
+	       ));
+     when a.0
+     is Sequence do Expr(z)
+     is c:List do list(c.Class,z,c.Mutable)
+     else nullE			    -- shouldn't happen anyway
+     );
+
 join(e:Expr):Expr := (
      when e
      is a:Sequence do (
 	  n := length(a);
 	  if n == 0 then return e;
-	  newlen := 0;
-	  foreach x in a do (
-	       when x
-	       is b:Sequence do (newlen = newlen + length(b);)
-	       is c:List do (newlen = newlen + length(c.v);)
-	       else return WrongArg("lists or sequences");
-	       );
-	  z := new Sequence len newlen do (
-	       foreach x in a do (
-		    when x
-		    is b:Sequence do foreach y in b do provide y
-		    is c:List do foreach y in c.v do provide y
-		    else nothing;
-		    );
-	       );
 	  when a.0
-	  is Sequence do Expr(z)
-	  is c:List do list(c.Class,z,c.Mutable)
-	  else nullE			  -- shouldn't happen anyway
-	  )
+	  is Sequence do join(a)
+	  is List do join(a)
+	  else applyEE(getGlobalVariable(joinIteratorsS), e))
      is c:List do if c.Mutable then Expr(copy(c)) else e
      else WrongArg("lists or sequences"));
 setupfun("join",join);

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -3,6 +3,7 @@
 use getline;
 use actors;
 use actors2;
+use actors3;
 use struct;
 use pthread;
 use regex;
@@ -1096,12 +1097,24 @@ setupfun("denominator",denfun);
 
 join(a:Sequence):Expr := (
      newlen := 0;
-     foreach x in a do (
+     foreach x at i in a do (
 	  when x
 	  is b:Sequence do (newlen = newlen + length(b);)
 	  is c:List do (newlen = newlen + length(c.v);)
-	  else return WrongArg("lists or sequences");
-	  );
+	  else (
+	      -- if x is iterable, convert it to a sequence
+	      r := toSequence(x);
+	      when r
+	      is b:Sequence do (
+		  newlen = newlen + length(b);
+		  a.i = b)
+	      is err:Error do return buildErrorPacket(
+		  "while converting argument " + tostring(i + 1) +
+		  " to a sequence, the following error occurred: " +
+		  err.message)
+	      else return buildErrorPacket(
+		  "unknown error converting argument " + tostring(i + 1) +
+		  " to a sequence")));
      z := new Sequence len newlen do (
 	  foreach x in a do (
 	       when x

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -286,14 +286,14 @@ evalWhileListDoCode(c:whileListDoCode):Expr := (
 
 export getIterator(e:Expr):Expr := (
     f := lookup(Class(e), getGlobalVariable(iteratorS));
-    if f == notfoundE
-    then nullE
+    when f
+    is Nothing do nullE
     else applyEE(f, e));
 
 export getNextFunction(e:Expr):Expr := (
     f := lookup(Class(e), getGlobalVariable(nextS));
-    if f == notfoundE
-    then nullE
+    when f
+    is Nothing do nullE
     else f);
 
 export strtoseq(s:stringCell):Sequence := new Sequence len length(s.v) do

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -25,6 +25,7 @@ export chars := new array(Expr) len 256 do (
 export iteratorS := setupvar("iterator", nullE);
 export nextS := setupvar("next", nullE);
 export applyIteratorS := setupvar("applyIterator", nullE);
+export joinIteratorsS := setupvar("joinIterators", nullE);
 
 eval(c:Code):Expr;
 applyEE(f:Expr,e:Expr):Expr;

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -59,3 +59,5 @@ joinIterators = a -> (
 		    i = i + 1;
 		    if i >= n then return StopIteration);
 		r))))
+
+Iterator | Iterator := (x, y) -> joinIterators(x, y)

--- a/M2/Macaulay2/m2/iterators.m2
+++ b/M2/Macaulay2/m2/iterators.m2
@@ -43,3 +43,19 @@ select(Thing, Function) := Iterator => {} >> o -> (X, f) -> (
 	    if not instance(y, Boolean)
 	    then error("select: expected predicate to yield true or false");
 	    if y then return x)))
+
+joinIterators = a -> (
+    n := #a;
+    iters := iterator \ a;
+    i := 0;
+    Iterator(
+	() -> (
+	    if i >= n then StopIteration
+	    else (
+		while (
+		    r := next iters#i;
+		    r === StopIteration)
+		do (
+		    i = i + 1;
+		    if i >= n then return StopIteration);
+		r))))

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/join-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/join-doc.m2
@@ -5,14 +5,15 @@ doc///
  Key
   join
  Headline
-  join lists and sequences
+  join lists, sequences, and iterable objects
  Usage
   join(A, B, ...)
  Inputs
   A: BasicList
   B: BasicList
+    or any instance of a class  with the @TO iterator@ method installed
  Outputs
-  Z: BasicList
+  Z: {BasicList, Iterator}
  Description
   Text
    {\tt join(A, B, ...)} joins the elements of the lists or sequences
@@ -28,6 +29,19 @@ doc///
   Example
    {1,2,3} | {4,5,6}
    (1,2,3) | (4,5,6)
+  Text
+   If the first argument is a list or sequence and any later arguments are
+   instances of a class with the @TO iterator@ method installed, then these
+   instances are converted to sequences and are then joined.
+  Example
+   join({1, 2, 3}, iterator {4, 5, 6})
+  Text
+   If the first argument is not a list or sequence, then an @TO Iterator@
+   object is returned that iterates through each argument sequentially,
+   provided that each argument is an iterable object.
+  Example
+   join(iterator {1, 2, 3}, {4, 5, 6})
+   toList oo
  SeeAlso
   concatenate
   demark

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -41,3 +41,10 @@ assert Equation(take(P, 20), {2, 3, 5, 7, 11, 13, 17, 19})
 assert Equation(toList iterator {1, 2, 3}, {1, 2, 3})
 assert Equation(toList iterator (1, 2, 3), {1, 2, 3})
 assert Equation(toList iterator "foo", {"f", "o", "o"})
+
+assert Equation(toList join(iterator {1, 2}, iterator {3, 4}, iterator {5, 6}),
+    {1, 2, 3, 4, 5, 6})
+assert Equation(toList join(iterator {1, 2}, (3, 4), {5, 6}),
+    {1, 2, 3, 4, 5, 6})
+assert Equation(toList(iterator {1, 2, 3} | iterator {4, 5, 6}),
+    {1, 2, 3, 4, 5, 6})

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -48,3 +48,6 @@ assert Equation(toList join(iterator {1, 2}, (3, 4), {5, 6}),
     {1, 2, 3, 4, 5, 6})
 assert Equation(toList(iterator {1, 2, 3} | iterator {4, 5, 6}),
     {1, 2, 3, 4, 5, 6})
+assert Equation(join({1, 2, 3}, iterator {4, 5, 6}), {1, 2, 3, 4, 5, 6})
+assert Equation(join((1, 2, 3), iterator {4, 5, 6}), (1, 2, 3, 4, 5, 6))
+assert Equation(join([1, 2, 3], iterator {4, 5, 6}), [1, 2, 3, 4, 5, 6])


### PR DESCRIPTION
With this PR, we can use `join` on any instance of a class with the `iterator` method installed.  If the first argument is a sequence or some flavor of list, then an instance of that class is returned:

```m2
i1 : join({1, 2, 3}, iterator "foo")

o1 = {1, 2, 3, f, o, o}

o1 : List

i2 : join([1, 2, 3], iterator "foo")

o2 = [1, 2, 3, f, o, o]

o2 : Array
```

Otherwise, an `Iterator` object is returned:

```m2
i3 : join(iterator "foo", {1, 2, 3})

o3 = iterator (iterator "foo", {1, 2, 3})

o3 : Iterator

i4 : next o3

o4 = f

i5 : next o3

o5 = o

i6 : next o3

o6 = o

i7 : next o3

o7 = 1
```