### PR TITLE
make 4.4 presents a problem ...

### DIFF
--- a/M2/Macaulay2/d/Makefile.in
+++ b/M2/Macaulay2/d/Makefile.in
@@ -87,6 +87,9 @@ clean::; rm -f distributed-packages.h
 actors4.o actors2.o : ../../include/M2/config.h
 
 ifeq "$(DEPENDS)" "yes"
+# We include all the files twice, once in reverse order.  Example: "include a b c d d c b a"
+# The reason for this is that some versions of gnu make build the needed files in reverse order, and some build in forward order.
+# (Compare version 4.3 to version 4.4)
 include $(patsubst %.d, %.dep, $(patsubst %.dd, %.dep, $(M2_DFILES) $(shell ../util/echoout -r $(M2_DFILES))))
 endif
 

--- a/M2/Macaulay2/d/Makefile.in
+++ b/M2/Macaulay2/d/Makefile.in
@@ -87,7 +87,7 @@ clean::; rm -f distributed-packages.h
 actors4.o actors2.o : ../../include/M2/config.h
 
 ifeq "$(DEPENDS)" "yes"
-include $(patsubst %.d, %.dep, $(patsubst %.dd, %.dep, $(shell ../util/echoout -r $(M2_DFILES))))
+include $(patsubst %.d, %.dep, $(patsubst %.dd, %.dep, $(M2_DFILES) $(shell ../util/echoout -r $(M2_DFILES))))
 endif
 
 .SUFFIXES: .d .sig .dep .res .test .m2


### PR DESCRIPTION
... in that it makes include files in the forward order now, not the reverse order.

See https://github.com/Macaulay2/M2/issues/2693

Here we fix it

resolves #2693