### PR TITLE
A few more 1.21 changelog updates

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -51,7 +51,8 @@ document {
 		    LI { TO (truncate, Number), " has been added, rounding numbers toward zero." },
 		    LI { TO (quotientRemainder, ZZ, ZZ), " has been added, for obtaining the quotient and remainder simultaneously when performing integer division." },
 		    LI { "The bitwise not operator, ", TO (symbol ~, ZZ), " has been added." },
-		    LI { "A new strategy ", TO "Dynamic", " is implemented for ", TO "det", ", ", TO "minors", ", and ", TO "exteriorPower", "." }
+		    LI { "A new strategy ", TO "Dynamic", " is implemented for ", TO "det", ", ", TO "minors", ", and ", TO "exteriorPower", "." },
+		    LI { TO changeBase, " has been added for changing integer bases."}
 		    }
 	       },
 	  LI { "improved packages:",

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -47,7 +47,7 @@ document {
 	  LI { "functionality added:",
 	       UL {
 		    LI { "New methods, ", TO iterator, " and ", TO next, ", and a new class, ", TO Iterator, " have been added to allow iteration over any Macaulay2 object." },
-		    LI { TO "for", " loops, as well as the methods ", TO scan, ", ", TO apply, ", ", TO select, ", ", TO fold, ", and, ", TO accumulate, " now work with any iterable object." },
+		    LI { TO "for", " loops, as well as the methods ", TO scan, ", ", TO apply, ", ", TO select, ", ", TO fold, ", ", TO accumulate, ", ", TO take, ", and ", TO join, ", now work with any iterable object." },
 		    LI { TO (truncate, Number), " has been added, rounding numbers toward zero." },
 		    LI { TO (quotientRemainder, ZZ, ZZ), " has been added, for obtaining the quotient and remainder simultaneously when performing integer division." },
 		    LI { "The bitwise not operator, ", TO (symbol ~, ZZ), " has been added." },


### PR DESCRIPTION
I wasn't sure if #2688, #2691, and #2695 were going to be accepted in time for the 1.21 release, so I didn't bother adding them to the changelog in the original PR's.  But it looks like they'll be in it, so blurbs have been added.