### PR TITLE
Add the Homebrew library directory to rpath in macOS

### DIFF
--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -61,6 +61,8 @@ M2_LDFLAGS += -Wl,-rpath,@executable_path/../@tail_librariesdir@
 # We also look in the standard place, for system libraries, but based on the prefix
 # given at configure time:
 M2_LDFLAGS += -Wl,-rpath,@executable_path/../@tail_libdir@
+# And the Homebrew library directory:
+M2_LDFLAGS += -Wl,-rpath,$(shell brew --prefix)/lib
 endif
 
 ifeq (@HAVE_WL_X_NOEXECSTACK@,yes)


### PR DESCRIPTION
This will enable `dlopen` to find various shared libraries used by the `ForeignFunctions` package. 

This fixes 4 out of the 5 failing examples from the `ForeignFunctions` package reported by @mikestillman on Apple M1 machines, at least for the autotools build.

@mahrud -- Any suggestions on how to make the corresponding fix for the cmake build?  I'm assuming somewhere in `Macaulay2/bin/CMakeLists.txt`, but this seems like it'd part of the `TODO: plenty of Darwin specific linker flags` comment.  :)

### Before
```m2
i2 : openSharedLibrary "mpfr"
stdio:2:1:(3): error: dlopen(libmpfr.dylib, 0x0001): tried: 'usr-dist/aarch64-Darwin-macOS-12.6.1/bin/../lib/Macaulay2/lib/libmpfr.dylib' (no such file), '/opt/homebrew/li/libmpfr.dylib' (no such file), '/libmpfr.dylib' (no such file), '/Users/dtorrance/src/macaulay2/M2/M2/BUILD/doug/usr-dist/aarch64-Darwin-macOS-12.6.1/bin/../lib/Macaulay2/lib/libmpfr.dylib' (no such file), '/Users/dtorrance/src/macaulay2/M2/M2/BUILD/doug/usr-dist/aarch64-Darwin-macOS-12.6.1/bin/../lib/libmpfr.dylib' (no such file), '/opt/homebrew/opt/flint/lib/libmpfr.dylib' (no such file), '/opt/homebrew/opt/gmp/lib/libmpfr.dylib' (no such file), '/Users/dtorrance/src/macaulay2/M2/M2/BUILD/doug/usr-dist/aarch64-Darwin-macOS-12.6.1/bin/../lib/Macaulay2/lib/libmpfr.dylib' (no such file), '/Users/dtorrance/src/macaulay2/M2/M2/BUILD/doug/usr-dist/aarch64-Darwin-macOS-12.6.1/bin/../lib/libmpfr.dylib' (no such file), '/opt/homebrew/opt/flint/lib/libmpfr.dylib' (no such file), '/opt/homebrew/opt/gmp/lib/libmpfr.dylib' (no such file), 'libmpfr.dylib' (no such file), '/usr/local/lib/libmpfr.dylib' (no such file), '/usr/lib/libmpfr.dylib' (no such file), 'usr-dist/aarch64-Darwin-macOS-12.6.1/bin/../lib/Macaulay2/lib/libmpfr.dylib' (no such file), '/opt/homebrew/li/libmpfr.dylib' (no such file), '/libmpfr.dylib' (no such file), '/Users/dtorrance/src/macaulay2/M2/M2/BUILD/doug/libmpfr.dylib' (no such file)
```

### After
```m2
i2 : openSharedLibrary "mpfr"

o2 = mpfr

o2 : SharedLibrary
```