### PR TITLE
Check brew library directory when using dlopen on Apple M1 systems

### DIFF
--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -521,7 +521,7 @@ net SharedLibrary := lib -> lib#1
 -- dlopen fails
 importFrom_Core {"isAbsolutePath"}
 if (version#"operating system" == "Darwin" and
-    version#"architecture" == "aarch64")
+    member(version#"architecture", {"aarch64", "arm64"}))
 then (
     brewPrefix := replace("\\s+$", "", get "!brew --prefix");
     dlopen' = filename -> (


### PR DESCRIPTION
This is an alternate to #2703 to fix 4 out of the 5 example errors in `ForeignFunctions` on Apple M1 systems.

The issue is that Homebrew installs its M1 libraries in `/opt/homebrew/lib`, but `dlopen` doesn't look there when it tries to open a shared library.  So we get around this by adding a wrapper around `dlopen` at top level:

* If we're on any other type of system, just run `dlopen` as usual.
* If the filename of the library has a leading `/` (i.e., the user specified an absolute path), then just run `dlopen` as usual.
* Try running `dlopen` as usual.
* If that fails, check if the desired library exists in `$(brew --prefix)/lib`, and if it does, run `dlopen` on it.