### PR TITLE
Fix Triangulations tests for TOPCOM >= 1.1.0

### DIFF
--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -193,6 +193,7 @@ orientedCircuits = method(Options => {Homogenize=>true})
 orientedCircuits String := List => opts -> (chiro) -> (
     (outfile,errfile) := callTopcom("chiro2circuits", {chiro});
     s := lines get outfile;
+    if #s == 0 then return s;
     s = if match(///^C\[///, first s) -- TOPCOM >= 1.1.0
     then apply(s, line -> replace(///^C\[\d+\] := (.*);///, ///\1///, line))
     -- remove first 2 lines, and last line:

--- a/M2/Macaulay2/packages/Triangulations.m2
+++ b/M2/Macaulay2/packages/Triangulations.m2
@@ -871,19 +871,6 @@ TEST ///
   restart
   needsPackage "Triangulations"
 *-
-  -- test of isRegularTriangulation
-  A = transpose matrix {{-1,-1,1},{-1,1,1},{1,-1,1},{1,1,1},{0,0,1}}
-  T = regularFineTriangulation(A, Homogenize=>false)
-  assert(max T == {{0, 1, 4}, {0, 2, 4}, {1, 3, 4}, {2, 3, 4}})
-  assert isRegularTriangulation T
-  assert(regularTriangulationWeights T == {1,1,0,0,0})
-///
-
-TEST ///
--*
-  restart
-  needsPackage "Triangulations"
-*-
   A = transpose matrix {{-1,-1},{-1,1},{1,-1},{1,1},{0,0}}
   T = regularFineTriangulation A
   naiveIsTriangulation T -- TODO: doc this, and allow A to be homogenized? Same with topcomIsTriangulation


### PR DESCRIPTION
@mikestillman: Here are a couple of small changes to fix #2704.

* Remove the second `Triangulations` test, since it was essentially identical to the second half of the first test.  It still had a failing `assert` that I'd removed in [#2630](https://github.com/Macaulay2/M2/pull/2630) because the output is slightly different with TOPCOM >= 1.1.0.
* Return the empty list from `orientedCircuits` when `chiro2circuits` has no output on `stdout`, which can sometimes happen with TOPCOM >= 1.1.0.  This fixes the `naiveIsTriangulation` test that was failing.