### PR TITLE
Updates for FreeBSD

### DIFF
--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-monlookup.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-monlookup.cpp
@@ -139,7 +139,7 @@ void ResF4MonomialLookupTableT<Key>::insert1(mi_node *&top,
           if (i.valid())
             {
               insert_node = new_mi_node(
-                  insert_var, insert_exp, reinterpret_cast<mi_node *>(NULL));
+                  insert_var, insert_exp, static_cast<mi_node *>(nullptr));
               q->insert_to_left(insert_node);
               q = insert_node;
             }
@@ -157,7 +157,7 @@ void ResF4MonomialLookupTableT<Key>::insert1(mi_node *&top,
   if (one_element)
     {
       // insert a header node and a var/exp = 0/0 leaf
-      top = new_mi_node(0, 0, reinterpret_cast<mi_node *>(NULL));
+      top = new_mi_node(0, 0, static_cast<mi_node *>(nullptr));
       mi_node *leaf_node = new_mi_node(0, 0, k);
       top->left = top->right = leaf_node;
       top->header = leaf_node->header = leaf_node->left = leaf_node->right =

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1026,9 +1026,9 @@ PATH="/usr/lib/4ti2/bin:/usr/lib64/4ti2/bin:$PATH"
 FOUND_4ti2=no
 for fourti2_prefix in "" "4ti2-" "4ti2_"
 do
-    if test "`type -t ${fourti2_prefix}circuits`" = file
+    if command -v ${fourti2_prefix}circuits
     then AC_MSG_RESULT([yes, using prefix "$fourti2_prefix"])
-         FILE_PREREQS="$FILE_PREREQS `type -p ${fourti2_prefix}circuits`"
+         FILE_PREREQS="$FILE_PREREQS `command -v ${fourti2_prefix}circuits`"
          FOUND_4ti2=yes
          break
     fi
@@ -1040,7 +1040,7 @@ fi
 PATH=$SAVE
 
 AC_MSG_CHECKING(whether the package cohomcalg is installed)
-if test "`type -t cohomcalg`" = file
+if command -v cohomcalg
 then if test "$OS" = Darwin -a "$DMG" = yes
      then # On the Mac, we have no way (yet) to install prerequisite homebrew packages:
           # the user just copies a directory tree to /Applications.  Change this when
@@ -1049,18 +1049,18 @@ then if test "$OS" = Darwin -a "$DMG" = yes
 	  AC_MSG_RESULT([yes, will build anyway])
           BUILD_cohomcalg=yes
      else AC_MSG_RESULT([yes])
-          FILE_PREREQS="$FILE_PREREQS `type -p cohomcalg`"
+          FILE_PREREQS="$FILE_PREREQS `command -v cohomcalg`"
      fi
 else AC_MSG_RESULT([no, will build])
      BUILD_cohomcalg=yes
 fi
 
 AC_MSG_CHECKING(whether the package gfan is installed)
-if test "`type -t gfan`" = file
+if command -v gfan
 then gfan_version=`gfan _version | head -2 | tail -1 | sed 's/gfan//'`
      AX_COMPARE_VERSION([$gfan_version], [ge], [0.6],
           [AC_MSG_RESULT([yes])
-           FILE_PREREQS="$FILE_PREREQS `type -p gfan`"],
+           FILE_PREREQS="$FILE_PREREQS `command -v gfan`"],
           [AC_MSG_RESULT([yes, but < 0.6, will build])
            BUILD_gfan=yes])
 else AC_MSG_RESULT([no, will build])
@@ -1070,7 +1070,7 @@ else AC_MSG_RESULT([no, will build])
 fi
 
 AC_MSG_CHECKING(whether the package lrs is installed)
-if test "`type -t lrs`" = file
+if command -v lrs
 then if test "$OS" = Darwin -a "$DMG" = yes
      then # On the Mac, we have no way (yet) to install prerequisite homebrew packages:
           # the user just copies a directory tree to /Applications.  Change this when
@@ -1078,26 +1078,26 @@ then if test "$OS" = Darwin -a "$DMG" = yes
 	  AC_MSG_RESULT([yes, will build anyway])
           BUILD_lrslib=yes
      else AC_MSG_RESULT(yes)
-          FILE_PREREQS="$FILE_PREREQS `type -p lrs`"
+          FILE_PREREQS="$FILE_PREREQS `command -v lrs`"
      fi
 else AC_MSG_RESULT([no, will build])
      BUILD_lrslib=yes
 fi
 
 AC_MSG_CHECKING(whether the package csdp is installed)
-if test "`type -t csdp`" = file
+if command -v csdp
 then AC_MSG_RESULT([yes])
-     FILE_PREREQS="$FILE_PREREQS `type -p csdp`"
+     FILE_PREREQS="$FILE_PREREQS `command -v csdp`"
 else AC_MSG_RESULT([no, will build])
      BUILD_csdp=yes
 fi
 
 AC_MSG_CHECKING(whether the package normaliz is installed)
-if test "`type -t normaliz`" = file
+if command -v normaliz
 then normaliz_version=`normaliz --version | head -1 | cut -d " " -f 2`
      AX_COMPARE_VERSION([$normaliz_version], [ge], [2.11],
           [AC_MSG_RESULT([yes])
-           FILE_PREREQS="$FILE_PREREQS `type -p normaliz`"],
+           FILE_PREREQS="$FILE_PREREQS `command -v normaliz`"],
           [AC_MSG_RESULT([yes, but < 2.11, will build])
            BUILD_normaliz=yes])
 else AC_MSG_RESULT([no, will build])
@@ -1110,13 +1110,13 @@ then dnl debian/fedora: nauty-
      FOUND_nauty=no
      for nauty_prefix in "" "nauty-"
      do
-	 if test "`type -t ${nauty_prefix}complg`" = file
+	 if command -v ${nauty_prefix}complg
 	 then
      dnl check if #1408 is a problem
 	     if ${nauty_prefix}biplabg < /dev/null 2>/dev/null
 	     then
 		 AC_MSG_RESULT([yes, using prefix "$nauty_prefix"])
-		 FILE_PREREQS="$FILE_PREREQS `type -p ${nauty_prefix}complg`"
+		 FILE_PREREQS="$FILE_PREREQS `command -v ${nauty_prefix}complg`"
 		 FOUND_nauty=yes
 		 break
 	     else
@@ -1143,9 +1143,9 @@ AC_MSG_CHECKING(whether the package topcom is installed)
 FOUND_topcom=no
 for topcom_prefix in "" "topcom-"
 do
-    if test "`type -t ${topcom_prefix}points2finetriangs`" = file
+    if command -v ${topcom_prefix}points2finetriangs
     then AC_MSG_RESULT([yes, using prefix "$topcom_prefix"])
-         FILE_PREREQS="$FILE_PREREQS `type -p ${topcom_prefix}points2finetriangs`"
+         FILE_PREREQS="$FILE_PREREQS `command -v ${topcom_prefix}points2finetriangs`"
          FOUND_topcom=yes
          break
     fi
@@ -1418,7 +1418,7 @@ fi
 # test for fflas_ffpack
 if test $BUILD_fflas_ffpack = no
 then AC_MSG_CHECKING([for fflas_ffpack library, version at least 2])
-     if test "`type -t fflas-ffpack-config`" = "file" && test "`fflas-ffpack-config --decimal-version`" -gt 20000
+     if command -v fflas-ffpack-config && test "`fflas-ffpack-config --decimal-version`" -gt 20000
      then AC_MSG_RESULT(found)
           FFLAS_FFPACK_CXXFLAGS=$(for x in $(fflas-ffpack-config --cflags 2>&1) ; do case $x in (-I*) /bin/echo -n "$x " ;; esac done)
 	  AC_MSG_NOTICE([adding fflas_ffpack flags $FFLAS_FFPACK_CXXFLAGS])


### PR DESCRIPTION
I played around a bit with building Macaulay2 on FreeBSD.  After making the following changes, the autotools build successfully creates an `M2` binary that kind of runs, although there's some GC-related crash making `tvalues.m2`.

The changes are:

* Using the POSIX-compatible `command -v` for finding locations of various programs during `configure` instead of `type`.
* Use `static_cast` with `nullptr` instead of `reinterpret_cast` with `NULL` for a couple lines of C++ code.

![image](https://user-images.githubusercontent.com/1992248/209916917-81a19351-6ae2-4e06-91a3-41110f65bd19.png)
