### PR TITLE
fixes a (typo) bug introduced in commit 2eb9c32c9a33374

### DIFF
--- a/M2/Macaulay2/e/monideal.cpp
+++ b/M2/Macaulay2/e/monideal.cpp
@@ -199,7 +199,7 @@ bool MonomialIdeal::is_equal(const MonomialIdeal &mi0) const
   while (i != sentinel)
     {
       const int *m = (*i).monom().raw();
-      const int *n = (*i).monom().raw();
+      const int *n = (*j).monom().raw();
       if (!varpower::is_equal(m, n)) return false;
       i++;
       j++;

--- a/M2/Macaulay2/tests/normal/monideal.m2
+++ b/M2/Macaulay2/tests/normal/monideal.m2
@@ -40,7 +40,15 @@ I3 = monomialIdeal matrix{{a,b}}
 I4 = monomialIdeal matrix{{a^3,b^3,c^3,d^3}}
 I = intersect(intersect(I1,I2),intersect(I3,I4))
 
-end
+-- Bug in newly added code 29 Dec 2022), fixed today.
+R = ZZ/101[a,b,c,d]
+I1 = monomialIdeal(a^2*b*c,b^3*c,b*d^3)
+I2 = monomialIdeal(a*b*c^2,b*c^2*d,c^3*d)
+assert(hash I1 == hash I2)
+assert(I1 =!= I2)
+assert(# unique{I1, I2} == 2)
+
+end--
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test monideal.out"
 -- End:


### PR DESCRIPTION
I should not have merged that branch into development directly.  It did have an interesting bug: a typo in MonomialIdeal::is_equal.  It only gets to this code if the hash codes are the same, which rarely happens.  However it did happen with one of the MonomialOrbit tests.  I have also added in a test that the two ideals in question (which have the same hash code) are in fact different.