### PR TITLE
Add libffi to "version" hash table

### DIFF
--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -229,6 +229,7 @@ setupconst("version", Expr(toHashTable(Sequence(
        stringize(EIGEN_WORLD_VERSION) \".\"
        stringize(EIGEN_MAJOR_VERSION) \".\"
        stringize(EIGEN_MINOR_VERSION)"),
+   "libffi version" => Ccode(constcharstar, "LIBFFI_VERSION"),
    "M2 suffix" => Ccode(constcharstar,"M2SUFFIX"),
    "executable extension" => Ccode(constcharstar,"EXEEXT"),
    "M2 name" => Ccode(constcharstar," \"M2\" M2SUFFIX EXEEXT "),

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -81,6 +81,10 @@ endif()
 
 if(WITH_FFI)
   find_package(FFI REQUIRED QUIET)
+  execute_process(COMMAND pkg-config --modversion libffi
+    OUTPUT_VARIABLE LIBFFI_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  set(LIBFFI_VERSION "not present")
 endif()
 
 ###############################################################################

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1691,10 +1691,13 @@ AS_IF([test x$with_libffi != xno ],
        AC_CHECK_HEADER([ffi.h], [], [AC_MSG_ERROR([ffi.h not found])])
        AC_SEARCH_LIBS([ffi_call], [ffi], [],
 	   [AC_MSG_ERROR([libffi not found or not linkable])])
-       AC_CHECK_FUNCS([ffi_get_struct_offsets])],
+       AC_CHECK_FUNCS([ffi_get_struct_offsets])
+       LIBFFI_VERSION=$(pkg-config --modversion libffi)],
       [AC_MSG_RESULT([no])
-       AC_MSG_ERROR([install libffi or use --without-libffi option])])])
+       AC_MSG_ERROR([install libffi or use --without-libffi option])])],
+    [LIBFFI_VERSION="not present"])
 AC_SUBST([LIBFFI], [$with_libffi])
+AC_DEFINE_UNQUOTED([LIBFFI_VERSION], ["$LIBFFI_VERSION"], [libffi version])
 
 # after this point we add no more libraries to $LIBS, e.g., with AC_SEARCH_LIBS()
 SAVELIBS=$LIBS

--- a/M2/include/M2/config.h.cmake
+++ b/M2/include/M2/config.h.cmake
@@ -60,6 +60,9 @@
 /* whether libffi has ffi_get_struct_offsets; introduced in libffi 3.3 */
 #cmakedefine HAVE_FFI_GET_STRUCT_OFFSETS 1
 
+/* libffi version */
+#define LIBFFI_VERSION "${LIBFFI_VERSION}"
+
 // TODO: only used in Macaulay2/d/scclib.c. Still needed?
 /* whether getaddrinfo can handle numeric service (port) numbers */
 #cmakedefine GETADDRINFO_WORKS 1


### PR DESCRIPTION
Unfortunately, the version of libffi isn't available in a header file like most other libraries.  Instead, we get it using `pkg-config`, which requires slightly different solutions for the autotools and cmake builds.

```m2
i1 : version#"libffi version"

o1 = 3.4.2
```