### PR TITLE
Mode agnostic AfterPrint

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -1240,7 +1240,7 @@ o := () -> concatenate(interpreterDepth:"o")
 stdAfterPrint = x -> (
      << endl;				  -- double space
      << o() << lineNumber << " : ";
-     scan(deepSplice sequence x, y -> if y =!= null then << net y);
+     scan(deepSplice sequence x, y -> if y =!= null then << y);
      << endl;
      )
 

--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -397,7 +397,11 @@ Number ** RingElement :=
 RingElement ** Number := 
 RingElement ** RingElement := (r,s) -> matrix {{r}} ** matrix {{s}}
 
-Matrix#AfterPrint = Matrix#AfterNoPrint = f -> (class f, " ", new MapExpression from {target f,source f})
+-- Matrix#AfterPrint = Matrix#AfterNoPrint = f -> (class f, " ", new MapExpression from {target f,source f})
+Matrix#AfterPrint = Matrix#AfterNoPrint = f -> (
+    class f,
+    if isFreeModule target f and isFreeModule source f then  (" ", new MapExpression from {target f,source f})
+    )
 
 -- precedence Matrix := x -> precedence symbol x
 

--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -397,14 +397,7 @@ Number ** RingElement :=
 RingElement ** Number := 
 RingElement ** RingElement := (r,s) -> matrix {{r}} ** matrix {{s}}
 
-Matrix#{Standard,AfterPrint} = 
-Matrix#{Standard,AfterNoPrint} = f -> (
-     << endl;				  -- double space
-     << concatenate(interpreterDepth:"o") << lineNumber << " : Matrix";
-     if isFreeModule target f and isFreeModule source f
-     then << " " << target f << " <--- " << source f;
-     << endl;
-     )
+Matrix#AfterPrint = Matrix#AfterNoPrint = f -> (class f, " ", new MapExpression from {target f,source f})
 
 -- precedence Matrix := x -> precedence symbol x
 
@@ -491,10 +484,7 @@ generator Module := RingElement => (M) -> (
 Ideal / Ideal := Module => (I,J) -> module I / module J
 Module / Ideal := Module => (M,J) -> M / (J * M)
 
-Ideal#{Standard,AfterPrint} = Ideal#{Standard,AfterNoPrint} = (I) -> (
-     << endl;				  -- double space
-     << concatenate(interpreterDepth:"o") << lineNumber << " : Ideal of " << ring I << endl;
-     )
+Ideal#AfterPrint = Ideal#AfterNoPrint = (I) ->  (Ideal," of ",ring I)
 
 Ideal ^ ZZ := Ideal => (I,n) -> ideal symmetricPower(n,generators I)
 Ideal * Ideal := Ideal => ((I,J) -> ideal flatten (generators I ** generators J)) @@ samering

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -390,23 +390,18 @@ super(Module) := Module => (M) -> (
 
 End = (M) -> Hom(M,M)
 
-Module#{Standard,AfterPrint} = M -> (
-     << endl;				  -- double space
-     n := rank ambient M;
-     << concatenate(interpreterDepth:"o") << lineNumber << " : "
-     << ring M
-     << "-module";
-     if M.?generators then
-     if M.?relations then << ", subquotient of " << ambient M
-     else << ", submodule of " << ambient M
-     else if M.?relations then << ", quotient of " << ambient M
-     else if n > 0 then (
-	  << ", free";
-	  if not all(degrees M, d -> all(d, zero)) 
-	  then << ", degrees " << runLengthEncode if degreeLength M === 1 then flatten degrees M else degrees M;
-	  );
-     << endl;
-     )
+Module#AfterPrint = M -> (
+    ring M,"-module",
+    if M.?generators then
+    if M.?relations then (", subquotient of ",ambient M)
+    else (", submodule of ",ambient M)
+    else if M.?relations then (", quotient of ",ambient M)
+    else if rank ambient M > 0 then
+    (", free",
+	if not all(degrees M, d -> all(d, zero))
+	then (", degrees ",runLengthEncode if degreeLength M === 1 then flatten degrees M else degrees M)
+	)
+    )
 
 RingElement * Module := Module => ZZ * Module := (r,M) -> subquotient (r ** generators M, relations M)
 Module * RingElement := Module => Module * ZZ := (M,r) -> subquotient ((generators M) ** r, relations M)

--- a/M2/Macaulay2/m2/monideal.m2
+++ b/M2/Macaulay2/m2/monideal.m2
@@ -111,11 +111,7 @@ independentSets Ideal := o -> (M) -> independentSets(monomialIdeal M,o)
 
 expression MonomialIdeal := (I) -> (expression monomialIdeal) unsequence apply(toSequence first entries generators I, expression)
 
-MonomialIdeal#{Standard,AfterPrint} = MonomialIdeal#{Standard,AfterNoPrint} = (I) -> (
-     << endl;				  
-     << concatenate(interpreterDepth:"o") << lineNumber << " : MonomialIdeal of " 
-     << ring I << endl;
-     )
+MonomialIdeal#AfterPrint = MonomialIdeal#AfterNoPrint = (I) ->  (MonomialIdeal," of ",ring I)
 
 monomialIdeal Ideal :=  MonomialIdeal => (I) -> monomialIdeal generators gb I
 

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -301,13 +301,11 @@ toString Monoid := toString @@ expression
 net      Monoid :=      net @@ expression
 texMath  Monoid :=  texMath @@ expression
 
-Monoid#{Standard,AfterPrint} = M -> (
-    << endl << concatenate(interpreterDepth:"o") << lineNumber << " : "; -- standard template
-    << toString class M;
+Monoid#AfterPrint = M -> (
+    class M,
     if not isFreeModule degreeGroup M
-    then << ", with torsion degree group";
+    then ", with torsion degree group";
     -- TODO: print whether M is ordered, a free algebra, etc.
-    << endl;
     )
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -7,8 +7,6 @@ needs "methods.m2"
 
 Net.synonym = "net"
 
-Net#{Standard,AfterPrint} = identity
-
 toString MutableHashTable := s -> (
      concatenate ( toString class s, if parent s =!= Nothing then (" of ", toString parent s), "{...", toString(#s), "...}"))
 toString Type := X -> (

--- a/M2/Macaulay2/m2/orderedmonoidrings.m2
+++ b/M2/Macaulay2/m2/orderedmonoidrings.m2
@@ -13,14 +13,12 @@ needs "indeterminates.m2" -- runLengthEncode
 
 PolynomialRing = new Type of EngineRing
 PolynomialRing.synonym = "polynomial ring"
-PolynomialRing#{Standard,AfterPrint} = R -> (
-    << endl << concatenate(interpreterDepth:"o") << lineNumber << " : "; -- standard template
-    << "PolynomialRing";
+PolynomialRing#AfterPrint = R -> (
+    class R,
     if #R.monoid.Options.WeylAlgebra > 0
-    then << ", " << #R.monoid.Options.WeylAlgebra << " differential variables";
+    then (", ", #R.monoid.Options.WeylAlgebra, " differential variables"),
     if #R.monoid.Options.SkewCommutative > 0
-    then << ", " << #R.monoid.Options.SkewCommutative << " skew commutative variables";
-    << endl;
+    then (", ", #R.monoid.Options.SkewCommutative, " skew commutative variables")
     )
 
 isPolynomialRing = method(TypicalValue => Boolean)

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -419,22 +419,7 @@ withFullPrecision = f -> (
      printingAccuracy = acc;				    -- sigh, what if an interrupt or an error occurred?
      )
 InexactNumber#{Standard,Print} = x ->  withFullPrecision ( () -> Thing#{Standard,Print} x )
-InexactNumber#{Standard,AfterPrint} = x -> (
-     << endl;                             -- double space
-     << concatenate(interpreterDepth:"o") << lineNumber;
-     y := class x;
-     << " : " << y;
-     prec := precision x;
-     -- if prec =!= defaultPrecision then
-     << " (of precision " << prec << ")";
-     -*
-     while parent y =!= Thing do (
-	  y = parent y;
-	  << " < " << y;
-	  );
-     *-
-     << endl;
-     )
+InexactNumber#AfterPrint = x ->  (class x," (of precision ",precision x,")")
 
 isReal = method()
 isReal RRi := isReal RR := isReal QQ := isReal ZZ := x -> true

--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -136,11 +136,7 @@ map(Ring,Ring) := RingMap => opts -> (S,R) -> map(S,R,{},opts)
 
 Ring#id = (R) -> map(R,R,vars R)
 
-RingMap#{Standard,AfterPrint} = RingMap#{Standard,AfterNoPrint} = f -> (
-     << endl;				  -- double space
-     << concatenate(interpreterDepth:"o") << lineNumber << " : " << class f;
-     << " " << target f << " <--- " << source f << endl;
-     )
+RingMap#AfterPrint = RingMap#AfterNoPrint = f ->  (class f, " ", new MapExpression from {target f,source f})
 
 RingMap RingElement := RingElement => fff := (p,m) -> (
      R := source p;

--- a/M2/Macaulay2/m2/varieties.m2
+++ b/M2/Macaulay2/m2/varieties.m2
@@ -95,23 +95,22 @@ net CoherentSheaf := (F) -> net expression F
 texMath CoherentSheaf := (F) -> texMath expression F
 toString CoherentSheaf := (F) -> toString expression F
 
-CoherentSheaf#{Standard,AfterPrint} = F -> (
+CoherentSheaf#AfterPrint = F -> (
      X := variety F;
      M := module F;
-     << endl;				  -- double space
      n := rank ambient F;
-     << concatenate(interpreterDepth:"o") << lineNumber << " : coherent sheaf on " << X;
+     ("coherent sheaf on ",X,
      if M.?generators then
-     if M.?relations then << ", subquotient of " << ambient F
-     else << ", subsheaf of " << ambient F
-     else if M.?relations then << ", quotient of " << ambient F
+     if M.?relations then (", subquotient of ", ambient F)
+     else (", subsheaf of ", ambient F)
+     else if M.?relations then (", quotient of ", ambient F)
      else if n > 0 then (
-	  << ", free";
+	  ", free"
 	  -- if not all(degrees M, d -> all(d, zero))
 	  -- then << ", degrees " << if degreeLength M === 1 then flatten degrees M else degrees M;
-	  );
-     << endl;
+	  )
      )
+ )
 
 sheaf(Variety,Module) :=  CoherentSheaf => (X,M) -> if M.cache#?(sheaf,X) then M.cache#(sheaf,X) else M.cache#(sheaf,X) = (
      if ring M =!= ring X then error "expected module and variety to have the same ring";

--- a/M2/Macaulay2/m2/webapp.m2
+++ b/M2/Macaulay2/m2/webapp.m2
@@ -78,59 +78,18 @@ htmlAfterPrint :=  x -> (
     printFunc x;
     )
 
-Thing#{WebApp,AfterPrint} = x -> htmlAfterPrint class x;
-
-Boolean#{WebApp,AfterPrint} = identity
-
-Expression#{WebApp,AfterPrint} = x -> htmlAfterPrint (Expression," of class ",class x)
-
-Describe#{WebApp,AfterPrint} = identity
-
-Ideal#{WebApp,AfterPrint} = Ideal#{WebApp,AfterNoPrint} = (I) -> htmlAfterPrint (Ideal," of ",ring I)
-MonomialIdeal#{WebApp,AfterPrint} = MonomialIdeal#{WebApp,AfterNoPrint} = (I) -> htmlAfterPrint (MonomialIdeal," of ",ring I)
-
-InexactNumber#{WebApp,AfterPrint} = x -> htmlAfterPrint (class x," (of precision ",precision x,")")
-
-Module#{WebApp,AfterPrint} = M -> htmlAfterPrint(
-    ring M,"-module",
-    if M.?generators then
-    if M.?relations then (", subquotient of ",ambient M)
-    else (", submodule of ",ambient M)
-    else if M.?relations then (", quotient of ",ambient M)
-    else if rank ambient M > 0 then
-    (", free",
-	if not all(degrees M, d -> all(d, zero))
-	then (", degrees ",runLengthEncode if degreeLength M === 1 then flatten degrees M else degrees M)
-	)
+Thing#{WebApp,AfterPrint} = x -> (
+    l:=lookup(AfterPrint,class x);
+    if l === null then return;
+    s:=l x;
+    if s =!= null then htmlAfterPrint s
     )
-
-Net#{WebApp,AfterPrint} = identity
-
-Nothing#{WebApp,AfterPrint} = identity
-
-Matrix#{WebApp,AfterPrint} = Matrix#{WebApp,AfterNoPrint} =
-RingMap#{WebApp,AfterPrint} = RingMap#{WebApp,AfterNoPrint} = f -> htmlAfterPrint (class f, " ", new MapExpression from {target f,source f})
-
--- Sequence#{WebApp,AfterPrint} = Sequence#{WebApp,AfterNoPrint} = identity
-
-CoherentSheaf#{WebApp,AfterPrint} = F -> (
-     X := variety F;
-     M := module F;
-     n := rank ambient F;
-     htmlAfterPrint("coherent sheaf on ",X,
-     if M.?generators then
-     if M.?relations then (", subquotient of ", ambient F)
-     else (", subsheaf of ", ambient F)
-     else if M.?relations then (", quotient of ", ambient F)
-     else if n > 0 then (
-	  ", free"
-	  -- if not all(degrees M, d -> all(d, zero))
-	  -- then << ", degrees " << if degreeLength M === 1 then flatten degrees M else degrees M;
-	  )
-     )
- )
-
-ZZ#{WebApp,AfterPrint} = identity
+Thing#{WebApp,AfterNoPrint} = x -> (
+    l:=lookup(AfterNoPrint,class x);
+    if l === null then return;
+    s:=l x;
+    if s =!= null then htmlAfterPrint s
+    )
 
 if topLevelMode === WebApp then (
     compactMatrixForm = false;


### PR DESCRIPTION
Right now, there's a lot of repeats in the code involving `AfterPrint` and `AfterNoPrint`. One problem is, the output of `After(No)Print` is the same no matter the mode, yet the interpreter calls different methods (say `{Standard,AfterPrint}` vs `{WebApp,AfterPrint}`). The other is that each AfterPrint method has the same `concatenate(interpreterDepth:"o") << lineNumber` type code at the start.
I've decided to reorganize this. There is now a `Type#AfterPrint` method (and `Type#AfterNoPrint` similarly) which is by default called by both `{Standard,AfterPrint}` and `{WebApp,AfterPrint}` (the two currently working modes of output). One can still define the latter functions directly, so backwards compatibility is preserved. `Type#AfterPrint` does not output directly; rather, it returns an object or sequence of objects to be printed by AfterPrint. (if it returns `null`, then no AfterPrint is produced)
As mentioned above, advantages:
- standardized template for the output (the `o42: `)
- much less redundancy in the code
- mode agnosticity (e.g., recently, some new AfterPrints were defined for monoids and rings, and with the old system I'd have to manually redo it for the WebApp mode).