### PR TITLE
Update "AfterPrint" methods for Python and ForeignFunctions packages

### DIFF
--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -123,10 +123,7 @@ Pointer - ZZ := (ptr, n) -> ptr + -n
 ForeignObject = new SelfInitializingType of HashTable
 ForeignObject.synonym = "foreign object"
 net ForeignObject := x -> net value x
-ForeignObject#{Standard, AfterPrint} = x -> (
-    << endl
-    << concatenate(interpreterDepth:"o") << lineNumber
-    << " : ForeignObject of type " << class x << endl)
+ForeignObject#AfterPrint = x -> "ForeignObject of type " | toString class x
 
 value ForeignObject := x -> error("no value function exists for ", class x)
 

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -81,12 +81,10 @@ pythonHelp = Command (() -> pythonValue ///help()///)
 toString PythonObject := pythonUnicodeAsUTF8 @@ pythonObjectStr
 
 PythonObject.synonym = "python object"
-PythonObject#{Standard,AfterPrint} = x -> (
-     << endl;
+PythonObject#AfterPrint = x -> (
      t := toString objectType x;
      t = replace("<([a-z]+) '(.*)'>","of \\1 \\2",t);
-     << concatenate(interpreterDepth:"o") << lineNumber << " : PythonObject " << t << endl;
-     )
+     "PythonObject " | t)
 
 pythonNone = getPythonNone()
 


### PR DESCRIPTION
This is a follow-up to @pzinn's work in #2729, updating classes in the `Python` and `ForeignFunctions` packages to use the new interface.  It's great not having to worry about the interpreter depth and line number anymore!