### PR TITLE
Only use __has_builtin if it's defined

### DIFF
--- a/M2/Macaulay2/e/overflow.hpp
+++ b/M2/Macaulay2/e/overflow.hpp
@@ -22,6 +22,12 @@
 #error integer type definitions not available
 #endif
 
+#if defined(__has_builtin)
+#define HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define HAS_BUILTIN(x) 0
+#endif
+
 #if __has_builtin(__builtin_expect)
 #define expect_false(x) (__builtin_expect(x, 0))
 #define expect_true(x) (__builtin_expect(x, 1))

--- a/M2/Macaulay2/e/overflow.hpp
+++ b/M2/Macaulay2/e/overflow.hpp
@@ -28,7 +28,7 @@
 #define HAS_BUILTIN(x) 0
 #endif
 
-#if __has_builtin(__builtin_expect)
+#if defined(__GNUC__) || HAS_BUILTIN(__builtin_expect)
 #define expect_false(x) (__builtin_expect(x, 0))
 #define expect_true(x) (__builtin_expect(x, 1))
 #else


### PR DESCRIPTION
It wasn't introduced until GCC 10, but older versions are still prevalent, e.g., GCC 7 in Ubuntu 18.04 and GCC 9 in Ubuntu 20.04.