### PR TITLE
Link against libquadmath for Boost Math Toolkit (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1395,6 +1395,7 @@ LIBS="$LIBS $BOOST_REGEX_LIB"
 
 AC_CHECK_HEADERS([boost/math/special_functions.hpp], [],
     [AC_MSG_ERROR([Boost Math Toolkit not available])])
+AC_SEARCH_LIBS([ldexpq], [quadmath])
 
 AC_SUBST(ULIMIT_T,yes)
 AC_SUBST(ULIMIT_M,yes)


### PR DESCRIPTION
This is an autotools fix for #2682, which I finally ran into during a Debian build (they're starting to transition from Boost 1.74 to 1.81).
