### PR TITLE
LieTypes major update / fix #2730

### DIFF
--- a/M2/Macaulay2/packages/LieTypes.m2
+++ b/M2/Macaulay2/packages/LieTypes.m2
@@ -2,14 +2,15 @@
 -- licensed under GPL v2 or any later version
 newPackage(
     "LieTypes",
-    Version => "0.5",
-    Date => "June 22, 2018",
+    Version => "0.6",
+    Date => "Jan 6, 2023",
     Headline => "common types for Lie groups and Lie algebras",
     Authors => {
 	  {Name => "Dave Swinarski", Email => "dswinarski@fordham.edu"}
 	  },
     Keywords => {"Lie Groups and Lie Algebras"},
     PackageImports => {"ReesAlgebra"},
+    DebuggingMode => true,
     Certification => {
 	 -- same article as for package ConformalBlocks
 	  "journal name" => "The Journal of Software for Algebra and Geometry",
@@ -38,7 +39,7 @@ export {
     "weylAlcove",
     --for the LieAlgebraModule type
     "LieAlgebraModule", 
-    "irreducibleLieAlgebraModule",
+    "irreducibleLieAlgebraModule", "LL",
     "isIsomorphic",
     "casimirScalar",
     "weightDiagram",
@@ -46,9 +47,14 @@ export {
     "fusionProduct",
     "fusionCoefficient",
     "MaxWordLength",
-    "positiveRoots"
+    "positiveRoots",
+    "LieAlgebraModuleFromWeights",
+    "trivialModule",
+    "isIrreducible",
+    "character"
     }
 
+tim=0;
 
 -- Access hasAttribute, getAttribute
 debug Core
@@ -74,7 +80,7 @@ starInvolution
 KillingForm
 weylAlcove
 
-LieAlgebraModules have three keys: LieAlgebra, HighestWeight, and isIrreducible
+LieAlgebraModules have two keys: LieAlgebra and DecompositionIntoIrreducibles
 The functions available for LieAlgebraModules are:
 dimension
 weights
@@ -97,6 +103,26 @@ Many of these functions are copied over from early versions of Swinarski's Confo
 Fixed a minor bug in multiplicity function (needed to allow for options, since multiplicity is 
 a method with options.)  Changed the LieAlgebra and LieAlgebraModule classes to print out the
 global variable names instead of the hash table contents. 
+
+-----------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------
+-- Summary, Version 0.6, January 2023 (Paul Zinn-Justin)
+-----------------------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------
+
+* Improved output methods
+* Introduced shorthand LL for simple (irreducible) modules
+* Fixed and exported LieAlgebraModuleFromWeights
+* Fixed and optimized tensor product of modules
+* Added ^** and ^ for modules
+* Added trivialModule
+* Additional sanity checks
+* Allow inputting weights as vectors
+* isIrreducible is now a method
+* use of Tally rather than HashTable for its methods
+* Added character method
+* character and weightDiagram have 2 strategies, Weyl or Freudenthal
+  (Weyl seems slower for small reps, but significantly faster for large highest weights)
 *-
 
 
@@ -111,18 +137,15 @@ global variable names instead of the hash table contents.
 LieAlgebra = new Type of HashTable  
 LieAlgebra.GlobalAssignHook = globalAssignFunction
 LieAlgebra.GlobalReleaseHook = globalReleaseFunction
-expression LieAlgebra := g -> (
-    if hasAttribute(g,ReverseDictionary) then return expression toString getAttribute(g,ReverseDictionary);
-    if not hasAttribute(g,ReverseDictionary) then (
-        if g#"isSimple" then return concatenate("Simple Lie algebra, type ",toString(g#"RootSystemType"),", rank ",toString(g#"LieAlgebraRank"));
-	if not g#"isSimple" then return concatenate("Nonsimple Lie algebra, type ",toString(g#"RootSystemType"),", rank ",toString(g#"LieAlgebraRank"))
-    );
+describe LieAlgebra := g -> Describe (
+    if g#"isSimple" then (expression simpleLieAlgebra) (g#"RootSystemType",g#"LieAlgebraRank")
+    else concatenate("Nonsimple Lie algebra, type ",toString(g#"RootSystemType"),", rank ",toString(g#"LieAlgebraRank"))
 )	
+expression LieAlgebra := g -> if hasAttribute(g,ReverseDictionary) then expression getAttribute(g,ReverseDictionary) else unhold describe g;
 net LieAlgebra := X -> net expression X;
+texMath LieAlgebra := X -> texMath expression X;
 
-
-
-
+rank LieAlgebra := g -> g#"LieAlgebraRank"
 
 LieAlgebra == LieAlgebra := (V,W)-> (V===W)
 
@@ -137,8 +160,10 @@ simpleLieAlgebra(String,ZZ) := (type,m) -> (
     if type=="D" and m<= 2 then error "The rank for type D must be >= 3.";
     if type=="E" and not member(m,{6,7,8}) then error "The rank for type E must be 6, 7, or 8.";
     if type=="F" and m!=4 then error "The rank for type F must be 4.";
-    if type=="G" and m!=2 then error "The rank for type G must be 2.";                    
-    new LieAlgebra from {"LieAlgebraRank"=>m,"RootSystemType"=>type,"isSimple"=>true}
+    if type=="G" and m!=2 then error "The rank for type G must be 2.";
+    new LieAlgebra from {"LieAlgebraRank"=>m,"RootSystemType"=>type,"isSimple"=>true,cache=>new CacheTable from {
+	    x:=getSymbol "x";
+	    "Ring" => ZZ(monoid [x_1..x_m,Inverses=>true,MonomialOrder=>Lex])}}
     )
 -*simpleLieAlgebra(IndexedVariable) := (v) -> (
     if #v > 2 or not member(v#0,{symbol sl, symbol so, symbol sp}) or not instance(v#1,ZZ) then error "Input not understood; enter sl_k, sp_k, or so_k, or use the syntax simpleLieAlgebra(\"A\",1) instead";
@@ -196,23 +221,25 @@ highestRoot(LieAlgebra) := memoize((g) -> (--see Appendix 13.A, [DMS]
     highestRoot(type,m)
 ));
 
-starInvolution = method(
-    TypicalValue => List
-    )
+starInvolution = method()
 starInvolution(String,ZZ,List) := memoize((type, m, w) ->  ( N:=#w;
-    if type == "A" then return apply(N,i-> w_(N-i-1));
+    if type == "A" then return reverse w;
     if type == "B" or type == "C" or type == "F" or type == "G" then return w;
     if type == "E" and m!= 6 then return w;
-    if type == "D" and even(m) == true then return w;
-    if type == "D" and odd(m) == true then (x:=w;
+    if type == "D" and even(m) then return w;
+    if type == "D" and odd(m) then (x:=w;
         return append(drop(x,{#x-2,#x-2}),w_(#w-2)));
     if type == "E" and m== 6 then return {w_5,w_1,w_4,w_3,w_2,w_0};
     ));
+starInvolution(String,ZZ,Vector) := (type,m,w) -> starInvolution(type,m,entries w)
 starInvolution(List,LieAlgebra) := memoize((v,g) -> (
     type:=g#"RootSystemType";
     m:=g#"LieAlgebraRank";   
     starInvolution(type,m,v)
 ));
+starInvolution(Vector,LieAlgebra) := (v,g) -> starInvolution(entries v,g)
+
+ring LieAlgebra := g -> g.cache#"Ring"
 -----------------------------------------------------------------------------------------------
 -----------------------------------------------------------------------------------------------
 -- The LieAlgebraModule type
@@ -222,74 +249,94 @@ starInvolution(List,LieAlgebra) := memoize((v,g) -> (
 
 -- LieAlgebraModule= {
 --   LieAlgebra => 
---   isIrreducible => Boolean
---   highestWeight
 --   }
 --Functions: weights, dimension, **
 
 LieAlgebraModule = new Type of HashTable 
 LieAlgebraModule.GlobalAssignHook = globalAssignFunction
 LieAlgebraModule.GlobalReleaseHook = globalReleaseFunction
-expression LieAlgebraModule := V -> (
-    if hasAttribute(V,ReverseDictionary) then expression toString getAttribute(V,ReverseDictionary) else toString(pairs V)
-);
-net LieAlgebraModule := V -> (
-    if hasAttribute(V,ReverseDictionary) then return net expression V; 
-    if not hasAttribute(V,ReverseDictionary) then return (
-	orderedPairs:=delete(null,{("LieAlgebra",V#"LieAlgebra"),("isIrreducible",V#"isIrreducible"),if V#?"highestWeight" then ("highestWeight",V#"highestWeight"),("DecompositionIntoIrreducibles",V#"DecompositionIntoIrreducibles")});
-	horizontalJoin flatten (
-          "{",
-          -- the first line prints the parts vertically, second: horizontally    
-          stack (horizontalJoin \ apply(orderedPairs,(k,v) -> (net k, " => ", net v))),                                        
-          "}"
-          )
-      )
-);
-LieAlgebraModule#{Standard,AfterPrint} = V -> ( s:="";
-    if not hasAttribute(V#"LieAlgebra",ReverseDictionary) then s = " : LieAlgebraModule";
-    if hasAttribute(V#"LieAlgebra",ReverseDictionary) then (
-	s = concatenate(" : ",expression(V#"LieAlgebra")," module")	
-    );	
-    << endl;				  -- double space
-    << concatenate(interpreterDepth:"o") << lineNumber << s;
-    << endl;
- );
+LL = new ScriptedFunctor from { subscript => w -> g -> irreducibleLieAlgebraModule(deepSplice toList w,g) }
+LL.texMath = ///{\mathcal L}///
+
+describe LieAlgebraModule := M -> Describe (
+    dec := M#"DecompositionIntoIrreducibles";
+    g := Parenthesize expression M#"LieAlgebra";
+    if #dec == 0 then expression 0
+    else fold((a,b)->a++b, -- TODO rewrite using DirectSum to avoid error: at print: recursion limit of 300 exceeded
+	apply(pairs dec,(v,mul) -> ((expression LL)_(toSequence v) g)^mul))
+    )
+expression LieAlgebraModule := M -> if hasAttribute(M,ReverseDictionary) then expression getAttribute(M,ReverseDictionary) else unhold describe M;
+
+net LieAlgebraModule := V -> net expression V
+texMath LieAlgebraModule := V -> texMath expression V
 
 
+isIrreducible = method()
+isIrreducible LieAlgebraModule := M -> (
+    dec := M#"DecompositionIntoIrreducibles";
+    #dec == 1 and first values dec == 1
+    )
 
+LieAlgebraModule ^ ZZ := (M,n) -> (
+    if n<0 then error "nonnegative powers only"
+    else if n==1 then M
+    else new LieAlgebraModule from hashTable {
+	"LieAlgebra" => M#"LieAlgebra",
+	"DecompositionIntoIrreducibles" => if n==0 then new Tally else applyValues(M#"DecompositionIntoIrreducibles", a -> a*n)
+	}
+    )
+
+LieAlgebraModule#AfterPrint = V -> (
+    if isIrreducible V then "irreducible ",
+    V#"LieAlgebra",
+    " - module"
+ )
+
+trivialModule = method(TypicalValue => LieAlgebraModule)
+trivialModule LieAlgebra := g -> irreducibleLieAlgebraModule(toList(g#"LieAlgebraRank":0),g)
+
+LieAlgebraModule ^** ZZ := (M,n) -> (
+    if n<0 then "error nonnegative powers only"
+    else if n==0 then trivialModule M#"LieAlgebra"
+    else if n==1 then M
+    else M**(M^**(n-1)) -- order matters for speed purposes
+    )
+
+starInvolution LieAlgebraModule := M -> new LieAlgebraModule from {
+    "LieAlgebra" => M#"LieAlgebra",
+    "DecompositionIntoIrreducibles" => applyKeys(M#"DecompositionIntoIrreducibles", v -> starInvolution(v,M#"LieAlgebra"))
+    }
+dual LieAlgebraModule := {} >> o -> lookup(starInvolution,LieAlgebraModule)
 
 
 isIsomorphic = method(
     TypicalValue => Boolean
     )
-isIsomorphic(LieAlgebraModule,LieAlgebraModule) := (M,N) -> (
+isIsomorphic(LieAlgebraModule,LieAlgebraModule) := (M,N) -> ( -- actually this is the same as ===
     if M#"LieAlgebra" != N#"LieAlgebra" then return false;
     M#"DecompositionIntoIrreducibles"===N#"DecompositionIntoIrreducibles"
 )
 
+LieAlgebraModule == ZZ := (M,n) -> if n=!=0 then error "attempted to compare module to nonzero integer" else #(M#"DecompositionIntoIrreducibles") == 0
 
-LieAlgebraModule ++ LieAlgebraModule := (M,N) -> (
-    if dim(M) == 0 then return N;
-    if dim(N) == 0 then return M; 
-    if M#"LieAlgebra" != N#"LieAlgebra" then error "Modules must be over the same Lie algebra";
-    g:=M#"LieAlgebra";
-    Mdecomposition:=new MutableHashTable from pairs(M#"DecompositionIntoIrreducibles");
-    Ndecomposition:= pairs(N#"DecompositionIntoIrreducibles");
-    for i from 0 to #Ndecomposition-1 do (
-        if Mdecomposition#?(Ndecomposition_i_0) then Mdecomposition#(Ndecomposition_i_0) = Mdecomposition#(Ndecomposition_i_0) + Ndecomposition_i_1;
-	if not (Mdecomposition#?(Ndecomposition_i_0)) then Mdecomposition#(Ndecomposition_i_0) = Ndecomposition_i_1;
-    );
-    D:=new HashTable from pairs(Mdecomposition);
-    new LieAlgebraModule from {"LieAlgebra"=>g,"isIrreducible"=>false,"DecompositionIntoIrreducibles"=>D}
+directSum LieAlgebraModule := identity
+LieAlgebraModule.directSum = args -> (
+    if not same apply(args, M -> M#"LieAlgebra") then error "modules must be over the same Lie algebra";
+    new LieAlgebraModule from {
+	"LieAlgebra"=>(first args)#"LieAlgebra",
+	"DecompositionIntoIrreducibles"=>sum(args,M->M#"DecompositionIntoIrreducibles")
+	}
 )
-
+LieAlgebraModule ++ LieAlgebraModule := directSum
 
 irreducibleLieAlgebraModule = method(
     TypicalValue => LieAlgebraModule
     )
 irreducibleLieAlgebraModule(List,LieAlgebra) := (v,g) -> (
-    new LieAlgebraModule from {"LieAlgebra"=>g,"highestWeight"=>v,"isIrreducible"=>true,"DecompositionIntoIrreducibles"=>(new HashTable from {v=>1})}
+    if #v != rank g or not all(v, a -> class a === ZZ) then error "wrong highest weight";
+    new LieAlgebraModule from {"LieAlgebra"=>g,"DecompositionIntoIrreducibles"=>tally {v}}
     )
+irreducibleLieAlgebraModule(Vector,LieAlgebra) := (v,g) -> irreducibleLieAlgebraModule(entries v,g)
 
 
 -*-----------------------------------------------------------------------------------------------
@@ -425,10 +472,11 @@ casimirScalar(String,ZZ,List) := memoize((type, m, w) -> (
     KillingForm(type,m,w,w) + 2*KillingForm(type,m,w,rho)
 ));
 casimirScalar(LieAlgebraModule) := memoize((M) -> (
+    if not isIrreducible M then error "Casimir scalar on irreducible modules only";
     g:=M#"LieAlgebra";
     type:=g#"RootSystemType";
     m:=g#"LieAlgebraRank";
-    v:=M#"highestWeight";
+    v:=first keys M#"DecompositionIntoIrreducibles";
     casimirScalar(type,m,v)	  
 ));
   
@@ -501,16 +549,12 @@ positiveRoots(LieAlgebra):=(g) -> (
 --The function Freud computes the set of weights in a Lie algebra module without their multiplicities
 Freud = memoize ((type,m,v) -> (
     simpleroots:=simpleRoots(type,m);
-    if apply(#v, i -> v_i < 0) == apply(#v, i->true) then return set({v});
+    if all(v, a -> a < 0) then return set{v};
     answer:=set {v};
-    for i from 0 to #v-1 do (
-        if v_i < 0 then continue;
-        for j from 1 to lift(v_i,ZZ) do (
-            answer= answer+Freud(type,m,v-j*simpleroots_i)
-    ));
-    answer=toList answer;
-    answer=apply(#answer, i -> apply(#(answer_i), j-> lift(answer_i_j,ZZ)));
-    set answer
+    for i from 0 to #v-1 do
+        for j from 1 to v_i do
+            answer = answer + Freud(type,m,v-j*simpleroots_i);
+    answer
 ))
 
 
@@ -547,18 +591,17 @@ multiplicityOfWeightInLieAlgebraModule = memoize((type,m,v,w) -> (
     if v==w then return 1;
     Omega:=Freud(type,m,v);
     if not member(w,Omega) then return 0;
-    L:=weightsAboveMu(type,m,v,w);
+--    L:=weightsAboveMu(type,m,v,w);
     posroots:=positiveRoots(type,m);
     rhs:=0;
-    lhs:=1;
-    K:=0;
+    k:=0;
     for a from 0 to #posroots-1 do (
-        K=0;
-        while isSubset(set {w+K*(posroots_a)},Omega) do (K=K+1);
-        if K <= 1 then continue;
-        for k from 1 to K-1 do (
-            rhs= rhs+KillingForm(type,m,w+k*(posroots_a),posroots_a)*multiplicityOfWeightInLieAlgebraModule(type,m,v,w+k*(posroots_a)) ));
-    lhs=KillingForm(type,m,v+rho,v+rho)-KillingForm(type,m,w+rho,w+rho);
+        k=1;
+        while member(w+k*(posroots_a),Omega) do (
+	    rhs=rhs+KillingForm(type,m,w+k*(posroots_a),posroots_a)*multiplicityOfWeightInLieAlgebraModule(type,m,v,w+k*(posroots_a));
+	    k=k+1;
+	    ));
+    lhs:=KillingForm(type,m,v+rho,v+rho)-KillingForm(type,m,w+rho,w+rho);
     lift(2*rhs/lhs,ZZ)
 ))
 
@@ -567,31 +610,108 @@ multiplicityOfWeightInLieAlgebraModule = memoize((type,m,v,w) -> (
 
 multiplicity(List,LieAlgebraModule) := o -> (w,M) -> (
     W:=weightDiagram(M);
-    W#w 
+    W_w 
 )
+multiplicity(Vector,LieAlgebraModule) := o -> (w,M) -> multiplicity(entries w,M)
 
+character = method(
+    Options=>{Strategy=>null},
+    TypicalValue => RingElement
+    )
 
-weightDiagram = method(
-    TypicalValue=>HashTable)
-weightDiagram(String,ZZ,List) := memoize((type,m,v) -> (
-    Omega:=toList Freud(type,m,v);     
-    new HashTable from apply(#Omega, i-> {Omega_i,multiplicityOfWeightInLieAlgebraModule(type,m,v,Omega_i)})     
-))
-
-weightDiagram(LieAlgebraModule) := (M) -> (
-    if not M#?"isIrreducible" or not M#"isIrreducible" then error "Weight diagrams are currently implemented only for irreducible Lie algebra modules";
-    g:=M#"LieAlgebra";
+stdVars = method()
+stdVars(LieAlgebra) := (cacheValue stdVars) ( g -> (
     type:=g#"RootSystemType";
     m:=g#"LieAlgebraRank";
-    v:=M#"highestWeight";    
-    weightDiagram(type,m,v)
+    R := ring g;
+    if type == "A" then apply(m+1, i -> (if i==m then 1 else R_i) * (if i==0 then 1 else R_(i-1)^-1))
+    else if type=="B" then apply(m, i -> (if i==m-1 then R_i^2 else R_i) * (if i==0 then 1 else R_(i-1)^-1))
+    else if type == "C" then apply(m, i -> R_i * (if i==0 then 1 else R_(i-1)^-1))
+    else if type == "D" then apply(m-2, i -> R_i*(if i==0 then 1 else R_(i-1)^-1)) | {R_(m-2)*R_(m-1)*R_(m-3)^-1,R_(m-1)*R_(m-2)^-1}
+    ))
+
+characterAlgorithms := new MutableHashTable;
+-- Jacobi Trudi formulae
+elemSym = memoize((L,i) -> (
+    if i<0 or i>#L then 0
+    else sum(subsets(L,i),product)
+    ))
+characterAlgorithms#"JacobiTrudi'" = (g,v) -> ( -- good for high rank algebras, small weights
+    type:=g#"RootSystemType";
+    if type != "A" then return;
+    z := stdVars g;
+    m:=g#"LieAlgebraRank";
+    conj:=reverse splice apply(m,i -> v#i : i+1);
+    if #conj == 0 then 1_(ring g) else det matrix table(#conj,#conj,(i,j)->elemSym(z,conj#i+j-i))
+    )
+completeSym = memoize((L,i) -> (
+    if i<0 then 0
+    else sum(compositions(#L,i),c->product(L,c,(v,k)->v^k))
+    ))
+characterAlgorithms#"JacobiTrudi" = (g,v) -> ( -- good for high rank algebras, high weights
+    type:=g#"RootSystemType";
+    if type != "A" then return;
+    z := stdVars g;
+    m:=g#"LieAlgebraRank";
+    pows := apply(m+1,j->sum(j..m-1,k->v#k));
+    det matrix table(m+1,m+1,(i,j)->completeSym(z,pows#i+j-i))
+    )
+
+-- Weyl character formula
+characterAlgorithms#"Weyl" = (g,v) -> ( -- good for low rank algebras
+    type:=g#"RootSystemType";
+    m:=g#"LieAlgebraRank";
+    z := stdVars g;
+    if type == "A" then (
+	pows := apply(m+1,j->sum(j..m-1,k->1+v#k));
+    	num := det matrix table(m+1,m+1,(i,j)->z_i^(pows#j));
+    	den := product(m+1,j->product(j,i->z_i-z_j)); --  type A Weyl denominator formula
+	)
+    else if type=="B" then (
+	pows = apply(m,j->sum(j..m-2,k->1+v#k)+(1+v#(m-1))//2);
+	par := (1+v#(m-1)) % 2; -- shift of 1/2 to avoid half-integer powers
+	num = (ring g)_(m-1)^(1-par)*det matrix table(m,m,(i,j)->z_i^(pows#j+par)-z_i^(-pows#j));
+    	den = product(m,i->z_i-1)*product(m,j->product(j,i->(z_i^-1 - z_j)*(1-z_i*z_j^-1))); --  type B Weyl denominator formula
+	)
+    else if type == "C" then (
+	pows = apply(m,j->sum(j..m-1,k->1+v#k));
+    	num = det matrix table(m,m,(i,j)->z_i^(pows#j)-z_i^(-pows#j));
+    	den = product(m,i->z_i-z_i^-1)*product(m,j->product(j,i->(z_i^-1 - z_j)*(1-z_i*z_j^-1))); --  type C Weyl denominator formula
+	)
+    else if type == "D" then (
+	pows = append(apply(m-1,j->sum(j..m-3,k->1+v#k)+(2+v#(m-2)+v#(m-1))//2),(v#(m-1)-v#(m-2))//2);
+	par = (v#(m-2)+v#(m-1)) % 2; -- shift of 1/2 to avoid half-integer powers
+    	num1 := det matrix table(m,m,(i,j)->z_i^(pows#j+par)+z_i^(-pows#j));
+	num2 := det matrix table(m,m,(i,j)->z_i^(pows#j+par)-z_i^(-pows#j));
+    	den = product(m,j->product(j,i->(z_i^-1 - z_j)*(1-z_i*z_j^-1))); --  type D Weyl denominator formula
+	num = (ring g)_(m-1)^(-par)*(num1+num2)//2;
+	)
+    else return;
+    num//den -- would factoring be faster?
 )
 
-dim LieAlgebraModule := M -> (
-    Mdecomposition:=pairs(M#"DecompositionIntoIrreducibles");
-    Mdecomposition=apply(#Mdecomposition, i -> {irreducibleLieAlgebraModule(Mdecomposition_i_0,M#"LieAlgebra"), Mdecomposition_i_1});
-    sum apply(#Mdecomposition, i -> (Mdecomposition_i_1)*(sum values weightDiagram(Mdecomposition_i_0)))
-)	  
+characterAlgorithms#"Freudenthal" = (g,v) -> (
+    type:=g#"RootSystemType";
+    m:=g#"LieAlgebraRank";
+    R:= ring g;
+    sum(toList Freud(type,m,v), w -> multiplicityOfWeightInLieAlgebraModule(type,m,v,w) * R_w)
+    )
+
+-- last strategy = first choice
+scan({"Freudenthal","Weyl","JacobiTrudi","JacobiTrudi'"}, strat -> addHook((character,LieAlgebraModule),characterAlgorithms#strat,Strategy=>strat))
+character (LieAlgebra,List) := o -> (g,v) ->  if g.cache#?(character,v) then g.cache#(character,v) else g.cache#(character,v) = runHooks((character,LieAlgebraModule),(g,v),o)
+character (LieAlgebra,Vector) := o -> (g,v) -> character(g,entries v,o)
+character LieAlgebraModule := o -> (M) -> sum(pairs M#"DecompositionIntoIrreducibles",(v,a) -> a * character (M#"LieAlgebra",v,o))
+
+weightDiagram = method(
+    Options=>{Strategy=>null},
+    TypicalValue=>Tally
+    )
+
+weightDiagram LieAlgebraModule := o -> (M) -> new Tally from listForm character(M,o)
+weightDiagram(LieAlgebra,Vector) := weightDiagram(LieAlgebra,List) := o -> (g,v) -> new Tally from listForm character(g,v,o)
+
+dim LieAlgebraModule := M -> sum values weightDiagram M
 
 findOneHighestWeight = (type,m,W) -> (
     DeltaPlus :=positiveRoots(type,m);
@@ -601,47 +721,23 @@ findOneHighestWeight = (type,m,W) -> (
         v=K_i;
         if apply(DeltaPlus, w-> member(w+v,set(K))) == apply(#DeltaPlus, j -> false) then return v   
     );
-    error "no highest weights found"
+    return null;
 )
 
-
---Function to subtract one mutable hash table from another
---In the application below, the answers are all supposed be positive.  This functions throws an error if not
-subtractMutableHashTable = (T,U) -> (
-    U= pairs U;
-    for i from 0 to #U-1 do (
-        if T#?(U_i_0) then (
-	    if T#(U_i_0) >= U_i_1 then T#(U_i_0) = T#(U_i_0) - U_i_1;
-	    if T#(U_i_0) < U_i_1 then error "Can't subtract these hash tables"
-	);
-	if not (T#?(U_i_0)) then error "Can't subtract these hash tables"
-    );
-    new MutableHashTable from pairs(U)
-)
 
 
 LieAlgebraModuleFromWeights = method(
     TypicalValue => LieAlgebraModule
     )
-LieAlgebraModuleFromWeights(List,LieAlgebra) := (W,g) -> (
+LieAlgebraModuleFromWeights(Tally,LieAlgebra) := (W,g) -> (
     type:=g#"RootSystemType";
     m:=g#"LieAlgebraRank";
-    M:=new MutableHashTable from pairs(W);
-    mu:=0;
-    v:={};
-    decompositionData:={};
     --find and peel off irreducibles
-    while #M>0 do (
-        v=findOneHighestWeight M;     
-        mu=M#v;
-        decompositionData = append(decompositionData,{v,mu});
-        WDv:=weightDiagram v;
-        M= subtractMutableHashTable(M,WDv)
+    decompositionData := while (v:=findOneHighestWeight (type,m,W)) =!= null list (v,mu:=W#v) do (
+        WDv:=weightDiagram (g,v); assert(WDv#v === 1);
+	W=W-applyValues(WDv,i->i*mu);
     );
-    if #decompositionData == 1 and decompositionData_0_0 ==1 then (
-        return new LieAlgebraModule from {"LieAlgebra"=>g,"highestWeight"=>decompositionData_0_1,"isIrreducible"=>true,"DecompositionIntoIrreducibles"=>(new HashTable from decompositionData)}  
-    );
-    new LieAlgebraModule from {"LieAlgebra"=>g,"isIrreducible"=>false,"DecompositionIntoIrreducibles"=>(new HashTable from decompositionData)}
+    new LieAlgebraModule from {"LieAlgebra"=>g,"DecompositionIntoIrreducibles"=>new Tally from decompositionData}
 )     
 
 ---------------------------------------------------------
@@ -658,8 +754,8 @@ wordAction = (type,m,l,I,v) -> (
     for j from 0 to #J-1 do (     
         if J_j >0 then (
 	    rho:=apply(#w, i-> 1);
-            w=w+rho;     
-            w = w-(w_(J_j-1))*simpleroots_(J_j-1);     
+            w=w+rho;
+            w = w-(w_(J_j-1))*simpleroots_(J_j-1);
             w=w-rho);
         if J_j ==0 then (
             theta:=highestRoot(type,m);
@@ -672,7 +768,7 @@ wordAction = (type,m,l,I,v) -> (
 
 
 squarefreeWordsOfLengthP = (L,p) -> (
-    if p==0 then return {};     
+    if p==0 then return {};
     if p==1 then return apply(#L, i -> {L_i});
     wlm1:=squarefreeWordsOfLengthP(L,p-1);
     answer:=delete(null, flatten apply(#L, i -> apply(#wlm1, j -> if L_i != wlm1_j_0 then prepend(L_i,wlm1_j))));
@@ -684,88 +780,36 @@ isIdentity = (type,m,l,w) -> (
     apply(m, i -> wordAction(type,m,l,w,fdw_i)) == fdw      
 )
 
-
-
-tensorReflectionData = memoize( (type,m,maxwordlength,remainingWeights) -> (
-    theta:=highestRoot(type,m);
-    l:=max apply(#remainingWeights, i -> KillingForm(type,m,remainingWeights_i,theta));	
-    l=lift(l,ZZ);
-    Pl:=weylAlcove(type,m,l);
-    wl:=1;
---initialize;
-    remainingWeights=toList(set(remainingWeights)-set(Pl));
-    found:= set Pl;
-    answer:= set apply(#Pl, i -> {Pl_i,{}});
-    fixed:={};
-    S:=apply(m,i->i+1);
-    while #remainingWeights >0 and wl<=maxwordlength do (
-        words:=squarefreeWordsOfLengthP(S,wl);
-        for i from 0 to #words-1 do (
-            if isIdentity(type,m,l,words_i) then continue;
-            newremainingWeights:={};
-            for j from 0 to #remainingWeights-1 do ( 
-                if wordAction(type,m,l,words_i,remainingWeights_j)==remainingWeights_j then (
-                    answer = answer + set {{remainingWeights_j,reverse(words_i)}};
-                    fixed = append(fixed,remainingWeights_j)) 
-	        else newremainingWeights=append(newremainingWeights,remainingWeights_j)   
-            );
-            remainingWeights=newremainingWeights;
---image of basis under words_i
-            im:=apply(#Pl, j -> wordAction(type,m,l,words_i,Pl_j));
-            if member(im,found) then continue else (
-                found = found + set(im);
-                remainingWeights=toList(set(remainingWeights)-set(im));
-                answer=answer+set apply(#im, k -> {im_k,reverse(words_i)});
-            ));
-            wl=wl+1);
-    if #remainingWeights==0 then return {sort toList(answer),sort fixed,true,remainingWeights} else return {sort toList(answer), sort fixed,false,remainingWeights}
-))
-
-
-
-LieAlgebraModule ** LieAlgebraModule := memoize( (V,W) -> (
-    if V#"LieAlgebra" != W#"LieAlgebra" then error "V and W must be modules over the same Lie algebra";	  
-    g:=V#"LieAlgebra"; 
+LieAlgebraModule ** LieAlgebraModule := (V,W) -> ( -- cf Humpheys' intro to LA & RT sec 24 exercise 9
+    g:=V#"LieAlgebra";
+    if g != W#"LieAlgebra" then error "V and W must be modules over the same Lie algebra";
+    wd:=weightDiagram V;
     type:=g#"RootSystemType";
-    m:=g#"LieAlgebraRank";	  
-    posRoots:=positiveRoots(type,m);
-    wl:=#posRoots;	  
-    lambda:=V#"highestWeight";
-    mu:=W#"highestWeight";
-    wd:=pairs weightDiagram(type,m,lambda);
-    theta:=highestRoot(type,m);
-    l:=max apply(#wd, i -> KillingForm(type,m,wd_i_0,theta));
-    l=lift(l,ZZ);	  
-    Pl:=weylAlcove(type,m,l);
-    wd=apply(#wd, i -> {wd_i_0+mu,wd_i_1});
-    rd:=tensorReflectionData(type,m,wl,apply(#wd, i -> wd_i_0));
-    if rd_2 == false then error "Need to allow longer words";
-    fixed:=rd_1;
-    rd=hashTable(rd_0);
-    wtsinPl:=delete(null, apply(#wd, i -> if member(wd_i_0,Pl) and not member(wd_i_0,fixed) then wd_i));     
-    wdh:=new MutableHashTable from wtsinPl;
-    for i from 0 to #wd-1 do (
-        if member(wd_i_0,Pl) then continue;     
-        if member(wd_i_0,fixed) then continue;
-        word:=rd#(wd_i_0);
-        e:=#word;
-        e=(-1)^e;
-        im:=wordAction(type,m,l,word,wd_i_0);
-        if not wdh#?im  then  wdh#im = (e)*(wd_i_1) else  wdh#im = wdh#im + (e)*(wd_i_1)     
-    );
-    wdh=pairs(wdh);
-    newwdh:=delete(null, apply(#wdh, i -> if wdh_i_1 != 0 then wdh_i));
-    newdim:=(dim V)*(dim W);
-    if #newwdh == 1 and newwdh_0_1 == 1 then return irreducibleLieAlgebraModule(newwdh_0_0,g);
-    return new LieAlgebraModule from {"LieAlgebra"=>g,"DecompositionIntoIrreducibles"=>new HashTable from newwdh,"isIrreducible"=>false};
-))
+    m:=g#"LieAlgebraRank";
+    sr:=simpleRoots(type,m);
+    rho:=toList(m:1);
+    ans := new MutableHashTable;
+    add := (w,a) -> if ans#?w then ( s := ans#w+a; if s!=0 then ans#w = s else remove(ans,w) ) else ans#w = a;
+    scanPairs(W#"DecompositionIntoIrreducibles", (w,a) -> -- loop over highest weights of W
+    	scanPairs(wd, (v,b) -> ( -- loop over all weights of V
+    		u:=v+w+rho;
+		t:=1; i:=-1;
+		while not any(u,zero) and ((i=position(u,j->j<0)) =!= null) do (
+	    	    u=u-u#i*sr#i;
+	    	    t=-t;
+	    	    );
+		if i === null then add(u-rho,a*b*t);
+		)));
+    new LieAlgebraModule from {"LieAlgebra"=>g,"DecompositionIntoIrreducibles"=>new Tally from ans}
+    )
 
 tensorCoefficient = method(
     TypicalValue=>ZZ)
 tensorCoefficient(LieAlgebraModule, LieAlgebraModule,LieAlgebraModule) := memoize((U,V,W) -> (
-    nu:=W#"highestWeight";	  
-    fullTensorProduct:=(U**V)#"DecompositionIntoIrreducibles";
-    if fullTensorProduct#?nu then return lift(fullTensorProduct#nu,ZZ) else return 0     
+	if not isIrreducible W then error "third module must be irreducible";
+    	nu:=first keys W#"DecompositionIntoIrreducibles";
+    	fullTensorProduct:=(U**V)#"DecompositionIntoIrreducibles";
+    	fullTensorProduct_nu
     ))
 
 
@@ -792,7 +836,7 @@ fusionReflectionData = memoize( (type,m,l,maxwordlength,remainingWeights) -> (
             for j from 0 to #remainingWeights-1 do (
                 if wordAction(type,m,l,words_i,remainingWeights_j)==remainingWeights_j then (
                     answer = answer + set {{remainingWeights_j,reverse(words_i)}};
-                    fixed = append(fixed,remainingWeights_j)) else newremainingWeights=append(newremainingWeights,remainingWeights_j)   
+                    fixed = append(fixed,remainingWeights_j)) else newremainingWeights=append(newremainingWeights,remainingWeights_j)
             );
             remainingWeights=newremainingWeights;
             im:=apply(#Pl, j -> wordAction(type,m,l,words_i,Pl_j));
@@ -810,35 +854,36 @@ fusionProduct = method(
     TypicalValue=>HashTable,Options=>{MaxWordLength=>10})
 
 fusionProduct(LieAlgebraModule,LieAlgebraModule,ZZ) := memoize( opts-> (M,N,l) -> (
-    wl:= opts.MaxWordLength;	 
+    wl:= opts.MaxWordLength;
     if M#"LieAlgebra" != N#"LieAlgebra" then error "The Lie algebra modules must be over the same Lie algebra.";
     g:=M#"LieAlgebra";
     type:=g#"RootSystemType";
     m:=g#"LieAlgebraRank";
-    lambda:=M#"highestWeight";
-    mu:=N#"highestWeight";
-    wd:=pairs weightDiagram(type,m,lambda);
+    if not isIrreducible M or not isIrreducible N then error "modules need to be irreducible";
+    lambda:=first keys M#"DecompositionIntoIrreducibles";
+    mu:=first keys N#"DecompositionIntoIrreducibles";
+    wd:=pairs weightDiagram(g,lambda);
     wd=apply(#wd, i -> {wd_i_0+mu,wd_i_1});
     rd:=fusionReflectionData(type,m,l,wl,apply(#wd, i -> wd_i_0));
     if rd_2 == false then error "Need to allow longer words";
     fixed:=rd_1;
     rd=hashTable(rd_0);
     Pl:=weylAlcove(type,m,l);
-    wtsinPl:=delete(null, apply(#wd, i -> if member(wd_i_0,Pl) and not member(wd_i_0,fixed) then wd_i));     
+    wtsinPl:=delete(null, apply(#wd, i -> if member(wd_i_0,Pl) and not member(wd_i_0,fixed) then wd_i));
     wdh:=new MutableHashTable from wtsinPl;
     for i from 0 to #wd-1 do (
-        if member(wd_i_0,Pl) then continue;     
+        if member(wd_i_0,Pl) then continue;
         if member(wd_i_0,fixed) then continue;
         word:=rd#(wd_i_0);
         e:=#word;
         e=(-1)^e;
         im:=wordAction(type,m,l,word,wd_i_0);
-        wdh#im = wdh#im + (e)*(wd_i_1)     
+        wdh#im = wdh#im + (e)*(wd_i_1)
     );
     wdh=pairs(wdh);
     newwdh:=delete(null, apply(#wdh, i -> if wdh_i_1 != 0 then wdh_i));
     if #newwdh == 1 and newwdh_0_1 == 1 then return irreducibleLieAlgebraModule(newwdh_0_0,simpleLieAlgebra(type,m));
-    return new LieAlgebraModule from {"LieAlgebra"=>simpleLieAlgebra(type,m),"DecompositionIntoIrreducibles"=>new HashTable from newwdh,"isIrreducible"=>false};	  
+    return new LieAlgebraModule from {"LieAlgebra"=>simpleLieAlgebra(type,m),"DecompositionIntoIrreducibles"=>new Tally from newwdh,"isIrreducible"=>false};
 ))
 
 
@@ -850,10 +895,8 @@ fusionCoefficient(LieAlgebraModule,LieAlgebraModule,LieAlgebraModule,ZZ) := memo
     type:=g#"RootSystemType";
     m:=g#"LieAlgebraRank";
     fullFusionProduct:=(fusionProduct(U,V,l,MaxWordLength=>wl))#"DecompositionIntoIrreducibles";
-    if fullFusionProduct#?(W#"highestWeight") then return lift(fullFusionProduct#(W#"highestWeight"),ZZ) else return 0     
+    if fullFusionProduct#?(first keys W#"DecompositionIntoIrreducibles") then return lift(fullFusionProduct#(first keys W#"DecompositionIntoIrreducibles"),ZZ) else return 0
 ))
-
-
 
 beginDocumentation()
 
@@ -911,7 +954,7 @@ doc ///
 ///	 	 
 
 TEST ///
-    assert(simpleLieAlgebra("A",1) === new LieAlgebra from {"LieAlgebraRank"=>1,"RootSystemType"=>"A","isSimple"=>true} )
+    assert(A=simpleLieAlgebra("A",1); A#"LieAlgebraRank"===1 and A#"RootSystemType"==="A" and A#"isSimple")
 ///
 
 doc ///
@@ -1033,7 +1076,11 @@ doc ///
     Key
         starInvolution
 	(starInvolution,List,LieAlgebra)
+	(starInvolution,Vector,LieAlgebra)
 	(starInvolution,String,ZZ,List)
+	(starInvolution,String,ZZ,Vector)
+	(starInvolution,LieAlgebraModule)
+	(dual,LieAlgebraModule)
     Headline
         computes w* for a weight w
     Usage
@@ -1147,6 +1194,8 @@ doc ///
     Key
         irreducibleLieAlgebraModule
 	(irreducibleLieAlgebraModule,List,LieAlgebra)
+	(irreducibleLieAlgebraModule,Vector,LieAlgebra)
+	LL
     Headline
         construct the irreducible Lie algebra module with given highest weight
     Usage
@@ -1160,19 +1209,23 @@ doc ///
     Description
         Text
             This function creates the irreducible Lie algebra module with a given highest weight.
-        
 	Example
 	    g=simpleLieAlgebra("A",2)
             irreducibleLieAlgebraModule({1,1},g)
+        Text
+	    One can also use the shorthand LL:
+	Example
+            LL_(1,1) (g)
 ///
 
 TEST ///
-    assert(irreducibleLieAlgebraModule({1,1},simpleLieAlgebra("A",2)) === new LieAlgebraModule from {"LieAlgebra"=>simpleLieAlgebra("A",2),"highestWeight"=>{1,1}, "DecompositionIntoIrreducibles"=>new HashTable from {{1,1}=>1}, "isIrreducible"=>true})
+    assert(irreducibleLieAlgebraModule({1,1},simpleLieAlgebra("A",2)) === new LieAlgebraModule from {"LieAlgebra"=>simpleLieAlgebra("A",2),"DecompositionIntoIrreducibles"=>new Tally from {{1,1}=>1} })
 ///	
 		
 doc ///
     Key 
 	(multiplicity,List,LieAlgebraModule)
+	(multiplicity,Vector,LieAlgebraModule)
     Headline
         compute the multiplicity of a weight in a Lie algebra module
     Usage
@@ -1183,9 +1236,6 @@ doc ///
     Outputs
         k:ZZ
     Description
-        Text
-	    This function implements Freudenthal's recursive algorithm; see Humphreys, {\it Introduction to Lie Algebras and Representation Theory}, Section 22.3. This function returns the multiplicity of the weight v in the irreducible Lie algebra module M.  For Type A (that is, $g = sl_k$), these multiplicities are related to the Kostka numbers (though in this package, irreducible representations are indexed by the Dynkin labels of their highest weights, rather than by partitions).      
-	       
 	Text     
 	    The example below shows that the $sl_3$ module with highest weight $(2,1)$ contains the weight $(-1,1)$ with multiplicity 2.
          
@@ -1229,7 +1279,9 @@ doc ///
     Key
         weightDiagram
 	(weightDiagram,LieAlgebraModule)
-	(weightDiagram,String,ZZ,List)
+	(weightDiagram,LieAlgebra,List)
+	(weightDiagram,LieAlgebra,Vector)
+	[weightDiagram,Strategy]
     Headline
         computes the weights in a Lie algebra module and their multiplicities
     Usage
@@ -1237,10 +1289,11 @@ doc ///
     Inputs
         V:LieAlgebraModule
     Outputs
-        T:HashTable
+        T:Tally
     Description
         Text
-	    This function implements Freudenthal's recursive algorithm; see Humphreys, {\it Introduction to Lie Algebras and Representation Theory}, Section 22.3.  Let $V$ be the irreducible $\mathbf{g}$-module with highest weight $v$.  This function returns a hash table whose keys are the weights appearing in $V$ and whose values are the multiplicities of these weights.  The character of $V$ can be easily computed from this information (but characters of Lie algebra modules have not been implemented in this version of LieTypes).  
+	    Let $V$ be the irreducible $\mathbf{g}$-module with highest weight $v$.  This function returns a tally whose keys are the weights appearing in $V$ and whose values are the multiplicities of these weights.
+	    An optional argument {\tt "Strategy"} allows to specify which algorithm to use, see @TO character@.
 	     
         Example
 	     g=simpleLieAlgebra("A",2)
@@ -1248,11 +1301,12 @@ doc ///
 	     weightDiagram(V)
 	     
     SeeAlso
-        (multiplicity,List,LieAlgebraModule)     
+        (multiplicity,List,LieAlgebraModule)
+	character
 ///
 
 TEST ///
-    assert(weightDiagram(irreducibleLieAlgebraModule({2,1},simpleLieAlgebra("A",2))) === new HashTable from {{{-1, 1}, 2}, {{1, 0}, 2}, {{3, -1}, 1}, {{-2, 0}, 1}, {{0, -1}, 2}, {{2, -2}, 1}, {{-2, 3}, 1}, {{0, 2}, 1}, {{2, 1}, 1}, {{-1, -2}, 1}, {{1, -3}, 1}, {{-3, 2}, 1}})
+    assert(weightDiagram(irreducibleLieAlgebraModule({2,1},simpleLieAlgebra("A",2))) === new Tally from {{{-1, 1}, 2}, {{1, 0}, 2}, {{3, -1}, 1}, {{-2, 0}, 1}, {{0, -1}, 2}, {{2, -2}, 1}, {{-2, 3}, 1}, {{0, 2}, 1}, {{2, 1}, 1}, {{-1, -2}, 1}, {{1, -3}, 1}, {{-3, 2}, 1}})
 ///	
 
 	
@@ -1284,12 +1338,13 @@ doc ///
 ///
 
 TEST ///
-    assert(irreducibleLieAlgebraModule({2,1},simpleLieAlgebra("A",2)) ** irreducibleLieAlgebraModule({1,2},simpleLieAlgebra("A",2)) === new LieAlgebraModule from {"LieAlgebra"=>simpleLieAlgebra("A",2),"isIrreducible"=>false, ,"DecompositionIntoIrreducibles"=>new HashTable from {{{1, 1}, 2}, {{3, 0}, 1}, {{1, 4}, 1}, {{3, 3}, 1}, {{0, 0}, 1}, {{0, 3}, 1}, {{2, 2}, 2}, {{4, 1}, 1}} })
+    assert(irreducibleLieAlgebraModule({2,1},simpleLieAlgebra("A",2)) ** irreducibleLieAlgebraModule({1,2},simpleLieAlgebra("A",2)) === new LieAlgebraModule from {"LieAlgebra"=>simpleLieAlgebra("A",2),"DecompositionIntoIrreducibles"=>new Tally from {{{1, 1}, 2}, {{3, 0}, 1}, {{1, 4}, 1}, {{3, 3}, 1}, {{0, 0}, 1}, {{0, 3}, 1}, {{2, 2}, 2}, {{4, 1}, 1}} })
 ///
 
 doc ///
     Key
 	(symbol ++, LieAlgebraModule, LieAlgebraModule)
+	(directSum, LieAlgebraModule)
     Headline
         direct sum of LieAlgebraModules
     Usage
@@ -1311,7 +1366,7 @@ doc ///
 ///
 
 TEST ///
-    assert(irreducibleLieAlgebraModule({2,1},simpleLieAlgebra("A",2)) ** irreducibleLieAlgebraModule({1,2},simpleLieAlgebra("A",2)) === new LieAlgebraModule from {"LieAlgebra"=>simpleLieAlgebra("A",2),"isIrreducible"=>false, ,"DecompositionIntoIrreducibles"=>new HashTable from {{{1, 1}, 2}, {{3, 0}, 1}, {{1, 4}, 1}, {{3, 3}, 1}, {{0, 0}, 1}, {{0, 3}, 1}, {{2, 2}, 2}, {{4, 1}, 1}} })
+    assert(irreducibleLieAlgebraModule({2,1},simpleLieAlgebra("A",2)) ** irreducibleLieAlgebraModule({1,2},simpleLieAlgebra("A",2)) === new LieAlgebraModule from {"LieAlgebra"=>simpleLieAlgebra("A",2),"DecompositionIntoIrreducibles"=>new Tally from {{{1, 1}, 2}, {{3, 0}, 1}, {{1, 4}, 1}, {{3, 3}, 1}, {{0, 0}, 1}, {{0, 3}, 1}, {{2, 2}, 2}, {{4, 1}, 1}} })
 ///
 
 doc ///
@@ -1393,6 +1448,25 @@ doc ///
 	    fusionCoefficient(U,V,W,3)
 ///
 
+doc ///
+    Key
+       LieAlgebraModuleFromWeights
+       (LieAlgebraModuleFromWeights,Tally,LieAlgebra)
+    Headline
+       finds a Lie algebra module based on its weights
+    Usage
+        LieAlgebraModuleFromWeights(T,g)
+    Inputs
+        T:Tally
+	g:LieAlgebra
+    Description
+        Example
+	    g=simpleLieAlgebra("A",2);
+	    U=irreducibleLieAlgebraModule({1,1},g);
+	    M=U**U
+	    T=weightDiagram M
+            LieAlgebraModuleFromWeights(T,g)
+///
 doc ///
     Key
         fusionProduct
@@ -1511,29 +1585,7 @@ TEST ///
 doc ///
     Key
         MaxWordLength
-    Headline
-        Optional argument to specify the allowable length of words in the affine Weyl group when computing fusion products.
-    Description
-        Text
-	    The Weyl group of a simple Lie algebra is finite; in contrast, the affine Weyl group of an affine Lie algebra is infinite.  To keep Macaulay2 from trying to compute infinitely long words in this group, the default length of allowed words is set to 10.   The user may override this with the optional argument "MaxWordLength".  If the word length is too small, the program will return an error.  
-
-///
-
-doc ///
-    Key
         [fusionCoefficient, MaxWordLength]
-    Headline
-        Optional argument to specify the allowable length of words in the affine Weyl group when computing fusion products.
-    Description
-        Text
-            The Weyl group of a simple Lie algebra is finite; in contrast, the affine Weyl group of an affine Lie algebra is infinite.  To keep Macaulay2 from trying to compute infinitely long words in this group, the default length of allowed words is set to 10.   The user may override this with the optional argument "MaxWordLength".  If the word length is too small, the program will return an error.
-
-///
-
-
-
-doc ///
-    Key
         [fusionProduct, MaxWordLength]
     Headline
         Optional argument to specify the allowable length of words in the affine Weyl group when computing fusion products.
@@ -1543,5 +1595,73 @@ doc ///
 
 ///
 
+doc ///
+    Key
+        character
+	(character,LieAlgebraModule)
+	(character,LieAlgebra,List)
+	(character,LieAlgebra,Vector)
+	[character,Strategy]
+    Headline
+        Computes the character of a Lie algebra module
+    Usage
+        character V
+    Inputs
+        V:LieAlgebraModule
+    Outputs
+        C:RingElement
+    Description
+        Text
+	    An optional argument {\tt "Strategy"} allows to specify which algorithm to use:
+	    {\tt "Freudenthal"} for Freudenthal's recursive algorithm; see Humphreys, {\it Introduction to Lie Algebras and Representation Theory}, Section 22.3.
+	    {\tt "Weyl"} for Weyl's character formula (in classical types).
+	    {\tt "JacobiTrudi"} and {\tt "JacobiTrudi'"} for Jacobi-Trudi and dual Jacobi-Trudi formulae (in type A).
+    SeeAlso
+        weightDiagram
+///
 
+TEST ///
+    g=simpleLieAlgebra("D",4);
+    M=LL_(1,1,0,0) g;
+    N=LL_(1,0,0,1) g;
+    assert(character(M**N) == character M * character N)
+///
+
+doc ///
+    Key
+        isIrreducible
+	(isIrreducible,LieAlgebraModule)
+    Headline
+        Whether a Lie algebra module is irreducible or not
+    Description
+        Example
+	    g=simpleLieAlgebra("A",2)
+	    M=irreducibleLieAlgebraModule({2,1},g)
+	    isIrreducible M
+	    isIrreducible(M++M)
+	    isIrreducible(M**M)
+///	
+
+TEST ///
+    g=simpleLieAlgebra("A",2);
+    assert(isIrreducible irreducibleLieAlgebraModule({2,1},g))
+///
+
+doc ///
+    Key
+        trivialModule
+	(trivialModule,LieAlgebra)
+    Headline
+        The trivial module of a Lie algebra
+    Description
+        Text
+	    Returns the one-dimensional module with zero highest weight.
+///	
+
+TEST ///
+    g=simpleLieAlgebra("A",2);
+    M=irreducibleLieAlgebraModule({2,1},g)
+    assert(M ** trivialModule g == M)
+///
+	    
 endPackage "LieTypes" 

--- a/M2/Macaulay2/packages/LieTypes.m2
+++ b/M2/Macaulay2/packages/LieTypes.m2
@@ -10,7 +10,7 @@ newPackage(
 	  },
     Keywords => {"Lie Groups and Lie Algebras"},
     PackageImports => {"ReesAlgebra"},
-    DebuggingMode => true,
+    DebuggingMode => false,
     Certification => {
 	 -- same article as for package ConformalBlocks
 	  "journal name" => "The Journal of Software for Algebra and Geometry",

--- a/M2/Macaulay2/packages/LieTypes.m2
+++ b/M2/Macaulay2/packages/LieTypes.m2
@@ -1661,7 +1661,7 @@ doc ///
 TEST ///
     g=simpleLieAlgebra("A",2);
     M=irreducibleLieAlgebraModule({2,1},g)
-    assert(M ** trivialModule g == M)
+    assert(M ** trivialModule g === M)
 ///
 	    
 endPackage "LieTypes" 


### PR DESCRIPTION
I've rewritten quite a bit of the package `LieTypes`:
* Improved output methods
* Introduced the shorthand `LL_(...) (g)` for `irreducibleLieAlgebraModule({...},g)`
* Fixed and exported `LieAlgebraModuleFromWeights`
* Fixed and optimized tensor product of modules (cf #2730)
There's a lot to say here, but to make a long story short, I improved the search for a Weyl group conjugate in the dominant chamber, and also I improved `weightDiagram`, see `character` below.
* Added `^**`, `symmetricPower`, `exteriorPower`, `adams` and `^` for various operations on Lie algebra modules
* Added `trivialModule`
* Additional sanity checks
* Allow inputting weights as vectors
* `isIrreducible` is now a method (no reason to have a field for it when it can be recomputed on the fly)
* use of `VirtualTally` rather than `HashTable` to take advantage of its methods (for the decomposition into irreducibles, and for weights)
* Added `character` method which computes the character of a module: this is strictly equivalent to `weightDiagram` and in fact now `weightDiagram` just applies `listForm` to `character`. I've played around with various stategies to compute characters depending on the type. I kept intact the original code for Freudenthal's method, but added 3 more strategies, all of which are coded via hooks and accessible with `Strategy => ...` Surprisingly Freudenthal's method is almost never the fastest except maybe for small rank algebras and small highest weights, for which it doesn't really matter anyway.

As usual, the code is already available on the cloud, cf https://www.unimelb-macaulay2.cloud.edu.au/?user=LieTypes

what I will provide in the next commit:
* `fusionProduct` suffers from the same problems as tensor product, will fix.
* I will remove the method `isIsomorphic` as it is not really useful: in fact it's strictly equivalent to `===` (there's no fundamental distinction between equality and isomorphism of `LieAlgebraModule`s...)
* provide Dynkin diagrams with the numbering of the vertices (either in the doc or via a method).