### PR TITLE
locate, code, html updates

### DIFF
--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -98,9 +98,8 @@ editMethod String := filename -> (
      chkrun concatenate(
 	  if getenv "DISPLAY" != "" and editor != "emacs" then "xterm -e ",
 	  editor, " ", filename))
-EDIT = method(Dispatch => Thing)
-EDIT Nothing := arg -> (stderr << "--warning: source code not available" << endl;)
-EDIT FilePosition := x -> (
+editMethod Nothing := arg -> (stderr << "--warning: source code not available" << endl;)
+editMethod FilePosition := x -> (
      filename := x#0; start := x#1;
      editor := getViewer("EDITOR", "emacs");
      if 0 != chkrun concatenate(
@@ -111,7 +110,7 @@ EDIT FilePosition := x -> (
 	  filename
 	  ) then error "command returned error code")
 editMethod Command := c -> editMethod c#0
-editMethod Function := args -> EDIT locate args
+editMethod Function := args -> editMethod locate args
 editMethod Sequence := args -> (
     if args === () then (
 	editor := getViewer("EDITOR", "emacs");
@@ -119,7 +118,7 @@ editMethod Sequence := args -> (
 	    if getenv "DISPLAY" != "" and editor != "emacs" then "xterm -e ",
 	    editor)
 	)
-    else EDIT locate args
+    else editMethod locate args
      )
 editMethod ZZ := i -> editMethod previousMethodsFound#i
 edit = Command editMethod

--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -35,7 +35,7 @@ getSourceLines FilePosition := x -> (
 	  if #file < stop then error("line number ",toString stop, " not found in file ", filename);
 	  while stop >= start and file#(stop-1) === "" do stop = stop-1;
 	  DIV {
-	      x, ": --source code",
+	      x, ": --source code:",
 	      PRE M2CODE concatenate between_"\n" toList apply(start-1 .. stop-1, i -> file#i)
 	      }
 	  ))
@@ -43,25 +43,25 @@ getSourceLines FilePosition := x -> (
 limit := 4
 
 codeFunction := (f,depth) -> (
-     if depth <= limit then (
-	 l := locate f;
-	  if l === null then DIV{"function ", f, ": source code not available"}
-	  else (
-	      syms := flatten \\ sortByHash \ values \ drop(localDictionaries f,-1);
-	      DIV flatten {
-		  getSourceLines l,
-	       	  if #syms > 0 then INDENT listSymbols syms,
-	       	  if codeHelper#?(functionBody f)
-	       	  then apply(
-		      codeHelper#(functionBody f) f,
-		      (comment,val) -> INDENT {
-			  comment, BR{},
-			  if instance(val, Function) then codeFunction(val,depth+1) else hold val -- hold for OptionTable or Option
-			  })
-	      }
-	  )
-      )
-  )
+    if depth <= limit then (
+	l := locate f;
+	if l === null then DIV{"function ", f, ": source code not available"}
+	else (
+	    syms := flatten \\ sortByHash \ values \ drop(localDictionaries f,-1);
+	    DIV flatten {
+		getSourceLines l,
+		if #syms > 0 then INDENT listSymbols syms,
+		if codeHelper#?(functionBody f)
+		then apply(
+		    codeHelper#(functionBody f) f,
+		    (comment,val) -> INDENT {
+			comment, BR{},
+			if instance(val, Function) then codeFunction(val,depth+1) else hold val -- hold for OptionTable or Option
+			})
+	      	}
+	    )
+      	)
+    )
 
 -- stores previously listed methods, hooks, or tests to be used by (code, ZZ)
 previousMethodsFound = null

--- a/M2/Macaulay2/m2/content.m2
+++ b/M2/Macaulay2/m2/content.m2
@@ -203,6 +203,7 @@ validContent#"pre" = PCDATA + Inlstruct + Inlphras + set { "tt", "i", "b" } + I1
 validContent#"head" = set {"title", "base", "script", "style", "meta", "link" }
 -----------------------------------------------------------------------------
 -- <!ENTITY % td.content "( #PCDATA | %Flow.mix; )*" >
+validContent#"th" =
 validContent#"td" = PCDATA + FlowMix
 -- <!ENTITY % tr.content  "( %th.qname; | %td.qname; )+" >
 validContent#"tr" = set { "th", "td" }

--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -3,11 +3,6 @@
 needs "nets.m2"
 needs "methods.m2"
 
-symbolLocation = s -> (
-     t := locate s;
-     if t =!= null then t#0 | ":" | toString t#1| ":" | toString (t#2+1) | "-" | toString t#3| ":" | toString (t#4+1)
-     else "")
-
 processArgs := args -> concatenate (
      args = sequence args;
      apply(args, x -> 
@@ -15,7 +10,7 @@ processArgs := args -> concatenate (
 	  else if class x === Symbol then ("'", toString x, "'")
 	  else silentRobustString(40,3,x)
 	  ),
-     apply(args, x -> if class x === Symbol then ("\n", symbolLocation x, ": here is the first use of '",toString x, "'") else "")
+     apply(args, x -> if class x === Symbol then ("\n", locate x, ": here is the first use of '",toString x, "'") else "")
      )
 olderror := error
 error = args -> (
@@ -139,7 +134,7 @@ show1(Sequence,Function) := show1(List,Function) := (types,pfun) -> (
 	       else install pfun v);
 --	  if hasAttribute(v,PrintNet) then v = getAttribute(v,PrintNet) else
 --	  if hasAttribute(v,PrintNames) then v = getAttribute(v,PrintNames) else
-	  if hasAttribute(v,ReverseDictionary) then v = getAttribute(v,ReverseDictionary);
+--	  if hasAttribute(v,ReverseDictionary) then v = getAttribute(v,ReverseDictionary);
 	  if w#?v then w#v else w#v = new Descent
 	  );
      scan(types, install);
@@ -187,16 +182,13 @@ localSymbols(Type,Pseudocode) := (X,f) -> select2(X,localSymbols f)
 
 localSymbols Type := X -> select2(X,localSymbols ())
 
-robust := y -> silentRobustNet(55,4,3,y)
-abbreviate := x -> (
-     if instance(x, Function) and match("^-\\*Function.*\\*-$", toString x) then "..."
-     else robust x)
 listSymbols = method()
 listSymbols Dictionary := d -> listSymbols values d
-listSymbols List := x -> (
-     netList(Boxes=>false, HorizontalSpace => 1, prepend(
-	  {"symbol" || "------","", "class" || "-----", "", "value" || "-----", "location of symbol" || "------------------"},
-	  apply (x, s -> {toString s,":", robust class value s, "--", abbreviate value s, symbolLocation s}))))
+listSymbols List := x -> TABLE prepend(
+    apply({"symbol", "class", "value", "location of symbol"},s->TH {s}),
+    apply(x, y -> apply({y,Abbreviate class value y,Abbreviate value y,locate y},s->TD {s}))
+    );
+
 
 listLocalSymbols = Command(f -> listSymbols localSymbols f)
 

--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -10,7 +10,7 @@ processArgs := args -> concatenate (
 	  else if class x === Symbol then ("'", toString x, "'")
 	  else silentRobustString(40,3,x)
 	  ),
-     apply(args, x -> if class x === Symbol then ("\n", locate x, ": here is the first use of '",toString x, "'") else "")
+     apply(args, x -> if class x === Symbol then ("\n", toString locate x, ": here is the first use of '",toString x, "'") else "")
      )
 olderror := error
 error = args -> (

--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -186,7 +186,7 @@ listSymbols = method()
 listSymbols Dictionary := d -> listSymbols values d
 listSymbols List := x -> TABLE prepend(
     apply({"symbol", "class", "value", "location of symbol"},s->TH {s}),
-    apply(x, y -> apply({y,Abbreviate class value y,Abbreviate value y,locate y},s->TD {s}))
+    apply(x, y -> apply({y,Abbreviate {class value y},Abbreviate {value y},locate y},s->TD {s}))
     );
 
 
@@ -234,6 +234,28 @@ generateAssertions List := y -> (
 	       )))^-1
 
 currentPosition = () -> new FilePosition from { currentFileName, currentRowNumber(), currentColumnNumber() }
+
+FilePosition = new Type of BasicList
+FilePosition.synonym = "file position"
+toString FilePosition :=
+net FilePosition := p -> concatenate(
+    p#0,":",toString p#1,":",toString p#2,
+    if #p>3 then ("-",toString p#3,":",toString p#4),
+--    if #p>5 then (" (",toString p#5,":",toString p#6,")")
+    )
+
+locate' = locate -- defined in d/actors4.d
+locate = method(Dispatch => Thing, TypicalValue => FilePosition)
+locate Nothing     :=
+locate FunctionBody:=
+locate Function    :=
+locate Pseudocode  :=
+locate Sequence    :=
+locate Symbol      := FilePosition => x -> if (x':=locate' x) =!= null then new FilePosition from x'
+locate List        := List     => x -> apply(x, locate)
+protect symbol locate
+
+
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -386,10 +386,10 @@ isUndocumented   = tag -> ( d := fetchRawDocumentation tag; d =!= null and d#?"u
 hasDocumentation = key -> null =!= fetchAnyRawDocumentation makeDocumentTag(key, Package => null)
 
 -- TODO: is it possible to expand to (filename, start,startcol, stop,stopcol, pos,poscol)?
-locate DocumentTag := tag -> (
+locate DocumentTag := tag -> new FilePosition from (
     if (rawdoc := fetchAnyRawDocumentation tag) =!= null
-    then (minimizeFilename rawdoc#"filename", rawdoc#"linenum")
-    else (currentFileName, currentRowNumber()))
+    then (minimizeFilename rawdoc#"filename", rawdoc#"linenum",0)
+    else (currentFileName, currentRowNumber(), currentColumnNumber()))
 
 -----------------------------------------------------------------------------
 -- helpers for the document function
@@ -550,7 +550,7 @@ getSourceCode :=  val         -> DIV {"class" => "waystouse",
     fixup DIV {SUBSECTION "Code", PRE M2CODE demark_newline unstack stack apply(enlist val, m -> (
 		f := lookup m; if f === null then error("SourceCode: ", toString m, ": not a method");
 		c := code f;   if c === null then error("SourceCode: ", toString m, ": code for method not found");
-		reproduciblePaths toString c))}}
+		reproduciblePaths toString net c))}}
 getSubnodes := val -> (
     val = nonnull enlist val;
     if #val == 0 then error "encountered empty Subnodes list"

--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -1338,16 +1338,14 @@ texMath Dots := x -> "\\" | simpleToString x -- note that \vdots has bad spacing
 toString Dots := x -> "..."
 net Dots := x -> if x === vdots then "."||"."||"." else if x === ddots then ".  "||" . "||"  ." else "..."
 
-shortLength := 8
 -- used e.g. in chaincomplexes.m2
-Short = new WrapperType of Holder
-unhold Short := identity
-short = method(Dispatch => Thing, TypicalValue => Short)
+shortLength := 8
+shortStringLength := 3*shortLength
+short = method(Dispatch => Thing, TypicalValue => Expression)
 short Thing := x -> short expression x
-short Holder := x -> Short unhold x
-expressionValue Short := x -> error "can't evaluate a shortened expression"
+short Holder := identity -- to avoid infinite loops
 short MatrixExpression :=
-short Table := x -> Short (
+short Table := x ->  (
     (opts,m) := matrixOpts x;
     shortRow := row -> apply(if #row>shortLength then { first row, cdots, last row } else row,short);
     new class x from
@@ -1355,17 +1353,25 @@ short Table := x -> Short (
 	    else m,shortRow)
     )
 short VisibleList :=
-short Expression := x -> Short { apply(if #x>shortLength then new class x from {
+short Expression := x -> apply(if #x>shortLength then new class x from {
 	first x,
 	if instance(x,VectorExpression) or instance(x,VerticalList) then vdots else if instance(x,VisibleList) then ldots else cdots,
 	last x
 	}
-    else x,short) }
-short Minus := identity
-short BinaryOperation := b -> Short BinaryOperation {b#0,short b#1,short b#2}
-short Power := p -> Short Power {short p#0,p#1}
-short String := s -> Short if #s > shortLength then first s | "..." | last s else s
-short Net := n -> Short if #n > shortLength then stack {short first n,".",".",".",short last n} else (stack apply(unstack n,short))^(height n-1)
+    else x,short)
+short BinaryOperation := b -> BinaryOperation {b#0,short b#1,short b#2}
+short String := s -> if #s > shortStringLength then substring(s,0,shortStringLength) | "..." | last s else s -- too radical, keep shortLength chars
+short Net := n -> (if #n > shortLength then stack (apply(shortLength,i->short n#i) | {".",".",".",short last n}) else stack apply(unstack n,short))^(height n-1) -- same
+short HashTable := H -> hold ( if #H <= shortLength then H else (
+    s := sortByName pairs H;
+    new class H from append(apply(shortLength,i->s#i),s#shortLength#0=>cdots)
+    ))
+short MutableHashTable := expression
+
+
+Abbreviate = new WrapperType of Holder -- only used once, for listSymbols
+net Abbreviate := y -> silentRobustNet(55,4,3,y#0)
+html Abbreviate := y -> html short y#0
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -1293,11 +1293,6 @@ Nothing#AfterPrint =
 ZZ#AfterPrint =
 Boolean#AfterPrint = nullf
 
-FilePosition = new Type of BasicList
-FilePosition.synonym = "file position"
-toString FilePosition :=
-net FilePosition := i -> concatenate(i#0,":",toString i#1,":",toString i#2)
-
 -- extra stuff
 expression Option := z -> BinaryOperation { symbol =>, unhold expression z#0, unhold expression z#1 }
 net Option := net @@ expression

--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -133,6 +133,8 @@ scan({net, info},
 	parser' BR     := x -> ("", BK);
 	-- and rendering for types that inherit from HypertextContainer, but
 	-- have special rendering rules which would lost with toSequence
+	parser' PRE := -- HACK -- might need to rethink
+	parser' INDENT :=
 	parser' TABLE :=
 	parser' MENU :=
 	parser' DL :=
@@ -154,6 +156,9 @@ scan({net, info},
 		BK -> ());
 	    -- Stack the pieces vertically
 	    stack x);
+	parser INDENT := x -> ( -- INDENT is like DIV but with extra |s on the left. sadly, can't be absorbed into DIV because of non-recursivity of this parser
+	    n := parser DIV toList x;
+	    "| "^(height n, depth n) | n )
 	))
 
 Hop := (op,filler) -> x -> (

--- a/M2/Macaulay2/m2/gb.m2
+++ b/M2/Macaulay2/m2/gb.m2
@@ -191,7 +191,7 @@ status GroebnerBasis := o -> g -> (
 net      GroebnerBasis :=
 toString GroebnerBasis := g -> "GroebnerBasis[" | status g | "]"
 texMath  GroebnerBasis := texMath @@ toString
-html     GroebnerBasis := html    @@ toString
+html     GroebnerBasis := g -> html class g | "[" | status g | "]"
 
 
 rawsort := m -> rawSubmatrix(m, rawSortColumns(m,1,1))

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -492,8 +492,11 @@ briefDocumentation Thing       := key -> (
 	S := getAttribute(key, ReverseDictionary);
 	-- TODO: use either "formation" to enhance the result
 	-- or enhance "describe" or "getTechnical" using "formation"
-	<< endl << S << " := " << describe key << endl;
-	<< endl << getTechnical(S, key) << endl;);
+	DIV {
+	    BinaryOperation{symbol :=, key, describe key},
+	    getTechnical(S, key)
+	    }
+	);
     rawdoc := fetchAnyRawDocumentation makeDocumentTag key;
     -- TODO: should it be getGlobalSymbol or getAttribute?
     symb := getGlobalSymbol toString key;
@@ -502,10 +505,12 @@ briefDocumentation Thing       := key -> (
     synopsis := getSynopsis(key, tag, rawdoc);
     waystouse := documentationValue(symb, key);
     technical := getTechnical(symb, key);
-    if title     =!= null then << endl << key << commentize title << endl;
-    if synopsis  =!= null then << endl << synopsis << endl;
-    if waystouse =!= null then << endl << waystouse << endl;
-    if technical =!= null then << endl << technical << endl;)
+    DIV {
+    if title     =!= null then PARA {key, commentize title},
+    synopsis,
+    waystouse,
+    technical }
+)
 
 ? ScriptedFunctor :=
 ? Function :=

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -147,6 +147,8 @@ html HREF := x -> (
 
 html MENU := x -> html redoMENU x
 
+html INDENT := x -> html DIV append(toList x, "class"=>"indent")
+
 html TO   := x -> html TO2{tag := x#0, format tag | if x#?1 then x#1 else ""}
 html TO2  := x -> (
     tag := getPrimaryTag fixup x#0;
@@ -162,40 +164,59 @@ html TO2  := x -> (
 -- html'ing non Hypertext
 ----------------------------------------------------------------------------
 
-html Thing := htmlLiteral @@ (x -> "$" | texMath x | "$") -- by default, we use math mode tex (as opposed to actual html)
+texHtml =
+html Thing := x -> "$" | htmlLiteral texMath x | "$" -- by default, we use math mode tex (as opposed to actual html)
 html Nothing := x -> ""
 
 -- text stuff: we use html instead of tex, much faster (and better spacing)
+-- TODO: rewrite next 2 using hypertext, just like the ones after, once PRE spacing/line break issues are fixed
 html Net := n -> concatenate("<pre style=\"display:inline-table;text-align:left;vertical-align:",
     toString(if #n>0 then 100*(height n-1) else 0), "%\">\n", -- the % is relative to line-height
     apply(unstack n, x-> htmlLiteral x | "<br/>"), "</pre>")
 html String := x -> concatenate("<pre style=\"display:inline\">\n", htmlLiteral x,
     if #x>0 and last x === "\n" then "\n" else "", -- fix for html ignoring trailing \n
     "</pre>")
-html Descent := x -> concatenate("<span style=\"display:inline-table;text-align:left\">\n", apply(sortByName pairs x,
+-- a few types are just strings
+hypertext Descent := x -> SPAN prepend( "style" => "display:inline-table;text-align:left", -- TODO move style to CSS
+    deepSplice apply(sortByName pairs x,
      (k,v) -> (
 	  if #v === 0
-	  then html k
-	  else html k | " : " | html v
-	  ) | "<br/>"), "</span>")
-html Time := x -> html x#1 | html DIV ("-- ", toString x#0, " seconds")
--- a few types are just strings
-html Command :=
-html File :=
-html IndeterminateNumber :=
-html Boolean :=
-html Function :=
-html FilePosition :=
-html Manipulator :=
-html Dictionary := html @@ toString
-html Type := x -> if x.?texMath then "$"|x.texMath|"$" else html toString x
+	  then k
+	  else (k, " : ", v)
+	  , BR{})))
+hypertext Time := x -> DIV { x#1, DIV ("-- ", toString x#0, " seconds", "class" => "token comment") }
+TTc = c -> x -> TT {toString x,"class"=>"token "|c}
+hypertext Pseudocode :=
+hypertext CompiledFunctionBody := TTc "function"
+hypertext Command :=
+hypertext FunctionBody :=
+hypertext Function := f -> TT deepSplice {
+    if hasAttribute(f,ReverseDictionary) then toString getAttribute(f,ReverseDictionary) else (
+	t := locate if instance(f,Command) then f#0 else f;
+	"-*",
+	SPAN class f,
+	if t =!= null then ("[", SPAN t, "]"),
+	"*-"
+	),
+    "class"=>"token function"
+    }
+hypertext Package :=
+hypertext File :=
+hypertext IndeterminateNumber :=
+hypertext Manipulator :=
+hypertext Boolean := TTc "constant"
+hypertext Type :=
+hypertext FilePosition :=
+hypertext Dictionary := TTc "class-name"
+--hypertext VerticalList         := x -> UL apply(x, y -> new LI from hold y)
+--hypertext NumberedVerticalList := x -> OL apply(x, y -> new LI from hold y)
+scan(methods hypertext, (h,t) -> html t := html @@ hypertext);
 -- except not these descendants
 html Monoid :=
 html RingFamily :=
-html Ring := lookup(html,Thing)
+html Ring := texHtml
 
---html VerticalList         := x -> html UL apply(x, y -> new LI from hold y)
---html NumberedVerticalList := x -> html OL apply(x, y -> new LI from hold y)
+hypertext Hypertext := identity
 
 -----------------------------------------------------------------------------
 -- Viewing rendered html in a browser

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -99,7 +99,7 @@ html Hypertext := x -> (
     (head, prefix, suffix, tail) := (
 	if instance(x, HypertextContainer) then (concatenate(indentLevel:"  "), newline, concatenate(indentLevel:"  "), newline) else
 	if instance(x, HypertextParagraph) then (concatenate(indentLevel:"  "), "", "", newline) else ("","","",""));
-    popIndentLevel(1, if #cont == 0
+    popIndentLevel(1, if instance(x, HypertextVoid)
 	then concatenate(head, "<", qname, attr, "/>", tail)
 	else concatenate(head, "<", qname, attr, ">", prefix,
 	    apply(cont, html1), suffix, "</", qname, ">", tail)))

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -164,13 +164,15 @@ html TO2  := x -> (
 
 html Nothing := x -> ""
 
--- TODO: rewrite next 2 using hypertext, once PRE spacing/line break issues are fixed
-html Net := n -> concatenate("<pre style=\"display:inline-table;text-align:left;vertical-align:",
+-- TODO: rewrite using hypertext, once PRE spacing/line break issues are fixed
+html Net := n -> concatenate("<pre class=\"token string\" style=\"display:inline-table;text-align:left;vertical-align:",
     toString(if #n>0 then 100*(height n-1) else 0), "%\">\n", -- the % is relative to line-height
     apply(unstack n, x-> htmlLiteral x | "<br/>"), "</pre>")
+-*
 html String := x -> concatenate("<pre style=\"display:inline\">\n", htmlLiteral x,
     if #x>0 and last x === "\n" then "\n" else "", -- fix for html ignoring trailing \n
     "</pre>")
+*-
 html Monoid :=
 html RingFamily :=
 html Ring :=

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -166,15 +166,6 @@ html TO2  := x -> (
 
 html Nothing := x -> ""
 
--- TODO: rewrite using hypertext, once PRE spacing/line break issues are fixed
-html Net := n -> concatenate("<pre class=\"token string\" style=\"display:inline-table;text-align:left;vertical-align:",
-    toString(if #n>0 then 100*(height n-1) else 0), "%\">\n", -- the % is relative to line-height
-    apply(unstack n, x-> htmlLiteral x | "<br/>"), "</pre>")
--*
-html String := x -> concatenate("<pre style=\"display:inline\">\n", htmlLiteral x,
-    if #x>0 and last x === "\n" then "\n" else "", -- fix for html ignoring trailing \n
-    "</pre>")
-*-
 html Monoid :=
 html RingFamily :=
 html Ring :=

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -3,9 +3,7 @@
 -- html output
 -----------------------------------------------------------------------------
 
-needs "debugging.m2" -- for Descent
 needs "format.m2"
-needs "packages.m2" -- for Package
 needs "system.m2" -- for getViewer
 
 getStyleFile := fn -> locateCorePackageFileRelative("Style",
@@ -164,59 +162,19 @@ html TO2  := x -> (
 -- html'ing non Hypertext
 ----------------------------------------------------------------------------
 
-texHtml =
-html Thing := x -> "$" | htmlLiteral texMath x | "$" -- by default, we use math mode tex (as opposed to actual html)
 html Nothing := x -> ""
 
--- text stuff: we use html instead of tex, much faster (and better spacing)
--- TODO: rewrite next 2 using hypertext, just like the ones after, once PRE spacing/line break issues are fixed
+-- TODO: rewrite next 2 using hypertext, once PRE spacing/line break issues are fixed
 html Net := n -> concatenate("<pre style=\"display:inline-table;text-align:left;vertical-align:",
     toString(if #n>0 then 100*(height n-1) else 0), "%\">\n", -- the % is relative to line-height
     apply(unstack n, x-> htmlLiteral x | "<br/>"), "</pre>")
 html String := x -> concatenate("<pre style=\"display:inline\">\n", htmlLiteral x,
     if #x>0 and last x === "\n" then "\n" else "", -- fix for html ignoring trailing \n
     "</pre>")
--- a few types are just strings
-hypertext Descent := x -> SPAN prepend( "style" => "display:inline-table;text-align:left", -- TODO move style to CSS
-    deepSplice apply(sortByName pairs x,
-     (k,v) -> (
-	  if #v === 0
-	  then k
-	  else (k, " : ", v)
-	  , BR{})))
-hypertext Time := x -> DIV { x#1, DIV ("-- ", toString x#0, " seconds", "class" => "token comment") }
-TTc = c -> x -> TT {toString x,"class"=>"token "|c}
-hypertext Pseudocode :=
-hypertext CompiledFunctionBody := TTc "function"
-hypertext Command :=
-hypertext FunctionBody :=
-hypertext Function := f -> TT deepSplice {
-    if hasAttribute(f,ReverseDictionary) then toString getAttribute(f,ReverseDictionary) else (
-	t := locate if instance(f,Command) then f#0 else f;
-	"-*",
-	SPAN class f,
-	if t =!= null then ("[", SPAN t, "]"),
-	"*-"
-	),
-    "class"=>"token function"
-    }
-hypertext Package :=
-hypertext File :=
-hypertext IndeterminateNumber :=
-hypertext Manipulator :=
-hypertext Boolean := TTc "constant"
-hypertext Type :=
-hypertext FilePosition :=
-hypertext Dictionary := TTc "class-name"
---hypertext VerticalList         := x -> UL apply(x, y -> new LI from hold y)
---hypertext NumberedVerticalList := x -> OL apply(x, y -> new LI from hold y)
-scan(methods hypertext, (h,t) -> html t := html @@ hypertext);
--- except not these descendants
 html Monoid :=
 html RingFamily :=
-html Ring := texHtml
-
-hypertext Hypertext := identity
+html Ring :=
+html Thing := x -> "$" | htmlLiteral texMath x | "$" -- by default, we use math mode tex (as opposed to actual html)
 
 -----------------------------------------------------------------------------
 -- Viewing rendered html in a browser

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -399,8 +399,8 @@ hypertext Boolean := TTc "constant"
 hypertext Type :=
 hypertext FilePosition :=
 hypertext Dictionary := TTc "class-name"
-hypertext String := TTc "token string"
-hypertext Net := n -> PRE { toString n, BR{} , "class"=>"token string", "style" => "display:inline-table;vertical-align:"|toString(if #n>0 then 100*(height n-1) else 0)|"%" }
+hypertext String := TTc "string"
+hypertext Net := n -> PRE { toString n, BR{}, "class"=>"token string", "style" => "display:inline-table;vertical-align:"|toString(if #n>0 then 100*(height n-1) else 0)|"%" }
 --hypertext VerticalList         := x -> UL apply(x, y -> new LI from hold y)
 --hypertext NumberedVerticalList := x -> OL apply(x, y -> new LI from hold y)
 

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -400,6 +400,7 @@ hypertext Boolean := TTc "constant"
 hypertext Type :=
 hypertext FilePosition :=
 hypertext Dictionary := TTc "class-name"
+hypertext String := TTc "token string"
 --hypertext VerticalList         := x -> UL apply(x, y -> new LI from hold y)
 --hypertext NumberedVerticalList := x -> OL apply(x, y -> new LI from hold y)
 

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -400,6 +400,7 @@ hypertext Type :=
 hypertext FilePosition :=
 hypertext Dictionary := TTc "class-name"
 hypertext String := TTc "token string"
+hypertext Net := n -> PRE { toString n, BR{} , "class"=>"token string", "style" => "display:inline-table;vertical-align:"|toString(if #n>0 then 100*(height n-1) else 0)|"%" }
 --hypertext VerticalList         := x -> UL apply(x, y -> new LI from hold y)
 --hypertext NumberedVerticalList := x -> OL apply(x, y -> new LI from hold y)
 

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -173,6 +173,7 @@ MENU       = new IntermediateMarkUpType of HypertextContainer -- e.g. help sum
 TO         = new IntermediateMarkUpType of Hypertext
 TO2        = new IntermediateMarkUpType of Hypertext
 TOH        = new IntermediateMarkUpType of Hypertext
+INDENT     = new IntermediateMarkUpType of HypertextContainer -- temporary: one day, once format.m2 sorted out, we can simply have INDENT = x -> append(DIV x, "class" => "indent")
 
 -----------------------------------------------------------------------------
 -- LATER
@@ -362,6 +363,14 @@ style Hypertext := true >> o -> x -> (
 	);
     append(x,"style"=>str)
     )
+
+-- hijacked "hypertext"
+hypertext = method(Dispatch => Thing)
+-*
+hypertext Hypertext := fixup
+hypertext Sequence  :=
+hypertext List      := x -> fixup DIV x
+*-
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -3,9 +3,7 @@
 
 needs "regex.m2" -- for toLower
 needs "lists.m2" -- for all
-needs "methods.m2"
-needs "packages.m2" -- for Package
-needs "monoids.m2" -- for Monoid etc
+needs "code.m2"
 
 -----------------------------------------------------------------------------
 -- Hypertext type declarations and basic constructors
@@ -392,7 +390,6 @@ hypertext Function := f -> TT deepSplice {
 	),
     "class"=>"token function"
     }
-hypertext Package :=
 hypertext File :=
 hypertext IndeterminateNumber :=
 hypertext Manipulator :=

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -252,6 +252,7 @@ new HREF from List      := (HREF, x) -> (
     then x#0 else error "HREF expected URL to be a string or a sequence of 2 strings";
     if x#?1 then prepend(url, drop(x, 1)) else {url})
 
+new OL from VisibleList := 
 new UL from VisibleList := (T, x) -> apply(nonnull x, e -> (
 	if class e === TO then LI{TOH{e#0}}
 	else if instance(e, LI) or instance(e,Option) or instance(e,OptionTable) then e

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -29,7 +29,7 @@ HypertextVoid.synonym = "void markup"
 toString         Hypertext := s -> concatenate(toString class s, toString         toList s)
 toExternalString Hypertext := s -> concatenate(toString class s, toExternalString toList s)
 
---new Hypertext from VisibleList := (M,x) -> x -- why is that needed? it's the default
+new Hypertext from VisibleList := (M,x) -> x
 new Hypertext from Thing  := (M,x) -> {x}
 new Hypertext from Net    := (M,x) -> {toString x}
 

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -220,10 +220,10 @@ expression Matrix := m -> (
     MatrixExpression x
     )
 
-net Matrix := m -> net expression m
-toString Matrix := m -> toString expression m
-texMath Matrix := m -> texMath expression m
---html Matrix := m -> html expression m
+net Matrix := net @@ expression
+toString Matrix := toString @@ expression
+texMath Matrix := texMath @@ expression
+short Matrix := short @@ expression
 
 describe Matrix := m -> (
     args:=(describe target m,describe source m);

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -700,15 +700,24 @@ Function Thing = (f,x,e) -> (
      if not storefuns#?f then error("no method for storing values of function ", toString f);
      storefuns#f (x,e))
 
--- defined in d/actors4.d
-locate' = locate -- TODO: why does (net, FunctionBody) in nets.m2 need locate'?
-locate = method(Dispatch => Thing, TypicalValue => Sequence)
-locate Nothing    := Sequence => x -> locate' x
-locate Function   := Sequence => x -> locate' x
-locate Pseudocode := Sequence => x -> locate' x
-locate Sequence   := Sequence => x -> locate' x
-locate Symbol     := Sequence => x -> locate' x
-locate List       := List     => x -> apply(x, locate)
+FilePosition = new Type of BasicList
+FilePosition.synonym = "file position"
+toString FilePosition :=
+net FilePosition := p -> concatenate(
+    p#0,":",toString p#1,":",toString p#2,
+    if #p>3 then ("-",toString p#3,":",toString p#4),
+--    if #p>5 then (" (",toString p#5,":",toString p#6,")")
+    )
+
+locate' = locate -- defined in d/actors4.d
+locate = method(Dispatch => Thing, TypicalValue => FilePosition)
+locate Nothing     :=
+locate FunctionBody:=
+locate Function    :=
+locate Pseudocode  :=
+locate Sequence    :=
+locate Symbol      := FilePosition => x -> if (x':=locate' x) =!= null then new FilePosition from x'
+locate List        := List     => x -> apply(x, locate)
 protect symbol locate
 
 -- registerFinalizer

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -700,26 +700,6 @@ Function Thing = (f,x,e) -> (
      if not storefuns#?f then error("no method for storing values of function ", toString f);
      storefuns#f (x,e))
 
-FilePosition = new Type of BasicList
-FilePosition.synonym = "file position"
-toString FilePosition :=
-net FilePosition := p -> concatenate(
-    p#0,":",toString p#1,":",toString p#2,
-    if #p>3 then ("-",toString p#3,":",toString p#4),
---    if #p>5 then (" (",toString p#5,":",toString p#6,")")
-    )
-
-locate' = locate -- defined in d/actors4.d
-locate = method(Dispatch => Thing, TypicalValue => FilePosition)
-locate Nothing     :=
-locate FunctionBody:=
-locate Function    :=
-locate Pseudocode  :=
-locate Sequence    :=
-locate Symbol      := FilePosition => x -> if (x':=locate' x) =!= null then new FilePosition from x'
-locate List        := List     => x -> apply(x, locate)
-protect symbol locate
-
 -- registerFinalizer
 registerFinalizer' = registerFinalizer
 registerFinalizer = method()

--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -44,20 +44,20 @@ toExternalString Function := f -> (
      if hasAttribute(f,ReverseDictionary) then return toString getAttribute(f,ReverseDictionary);
      t := locate f;
      if t === null then error "can't convert anonymous function to external string"
-     else error("can't convert anonymous function (",t#0, ":", toString t#1| ":", toString t#2, "-", toString t#3| ":", toString t#4,") to external string")
+     else error("can't convert anonymous function (",toString t,") to external string")
      )
 
 net Function := toString Function := f -> (
      if hasAttribute(f,ReverseDictionary) then return toString getAttribute(f,ReverseDictionary);
      t := locate f;
      if t === null then "-*Function*-" 
-     else concatenate("-*Function[", t#0, ":", toString t#1| ":", toString (t#2+1), "-", toString t#3| ":", toString (t#4+1), "]*-")
+     else concatenate("-*Function[", toString t, "]*-")
      )
 
 net FunctionBody := toString FunctionBody := f -> (
-     t := locate' f;
+     t := locate f;
      if t === null then "-*FunctionBody*-" 
-     else concatenate("-*FunctionBody[", t#0, ":", toString t#1| ":", toString (t#2+1), "-", toString t#3| ":", toString (t#4+1), "]*-")
+     else concatenate("-*FunctionBody[", toString t, "]*-")
      )
 
 toExternalString Manipulator := f -> (

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -111,7 +111,6 @@ Package.GlobalReleaseHook = globalReleaseFunction
 
 net      Package :=
 toString Package := pkg -> if pkg#?"pkgname" then pkg#"pkgname" else "-*package*-"
-html     Package := pkg -> html    toString pkg
 texMath  Package := pkg -> texMath toString pkg
 options  Package := pkg -> pkg.Options
 methods  Package := memoize(pkg -> select(methods(), m -> package m === pkg))
@@ -406,7 +405,7 @@ export List   := v -> (
 	    if instance(sym, Option) then (
 		nam = sym#0;
 		if class nam =!= String then error("expected a string: ", nam);
-		if pd#?nam then error("symbol intended as exported synonym already used internally: ", format nam, "\n", symbolLocation pd#nam, ": it was used here");
+		if pd#?nam then error("symbol intended as exported synonym already used internally: ", format nam, "\n", locate pd#nam, ": it was used here");
 		if class sym#1 =!= String then error("expected a string: ", nam);
 		sym = getGlobalSymbol(pd, sym#1))
 	    else if instance(sym, String) then (

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -8,6 +8,7 @@ needs "lists.m2"
 needs "methods.m2"
 needs "regex.m2"
 needs "system.m2"
+needs "hypertext.m2"
 
 loadedPackages = {}
 
@@ -114,6 +115,7 @@ toString Package := pkg -> if pkg#?"pkgname" then pkg#"pkgname" else "-*package*
 texMath  Package := pkg -> texMath toString pkg
 options  Package := pkg -> pkg.Options
 methods  Package := memoize(pkg -> select(methods(), m -> package m === pkg))
+hypertext Package := TTc "constant"
 
 -- TODO: should this go elsewhere?
 toString Dictionary := dict -> (

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -25,7 +25,7 @@ locate TestInput := T -> new FilePosition from (T#"filename",
     T#"line number", 1,,)
 toString TestInput := toString @@ locate
 net TestInput := T -> "-*TestInput[" | toString T | "]*-"
-editMethod TestInput := EDIT @@ locate
+editMethod TestInput := editMethod @@ locate
 
 -----------------------------------------------------------------------------
 -- TEST

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -20,13 +20,10 @@ new TestInput from Sequence := (T, S) -> TestInput {
 TestInput.synonym = "test input"
 
 code TestInput := T -> T#"code"
-locate TestInput := T -> (T#"filename",
+locate TestInput := T -> new FilePosition from (T#"filename",
     T#"line number" - depth net code T, 1,
     T#"line number", 1,,)
-toString TestInput := T -> (
-    loc := locate T;
-    loc#0 | ":" | loc#1 | ":" | loc#2 | "-" | loc#3 | ":" | loc#4 | ":"
-    )
+toString TestInput := T -> toString locate T | ":"
 net TestInput := T -> (toString T)^-1
 editMethod TestInput := EDIT @@ locate
 

--- a/M2/Macaulay2/m2/validate.m2
+++ b/M2/Macaulay2/m2/validate.m2
@@ -118,12 +118,6 @@ fixup TO          :=
 fixup TO2         :=
 fixup TOH         := identity
 
--- TODO: move this
-hypertext = method(Dispatch => Thing)
-hypertext Hypertext := fixup
-hypertext Sequence  :=
-hypertext List      := x -> fixup DIV x
-
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/m2/webapp.m2
+++ b/M2/Macaulay2/m2/webapp.m2
@@ -98,10 +98,12 @@ if topLevelMode === WebApp then (
     processExamplesLoop ExampleItem := (x->new LITERAL from extractStr x) @@ (lookup(processExamplesLoop,ExampleItem));
     -- the help hack 2 (incidentally, this regex is safer than in standard mode)
     M2outputRE      = "(?="|webAppCellTag|")";
-    -- the show hack
-    showURL := lookup(show,URL);
-    show URL := url -> if topLevelMode === WebApp then (<< webAppUrlTag | url#0 | webAppEndTag;) else showURL url;
-    EDIT Sequence := x -> ((filename,start,startcol,stop,stopcol,pos,poscol) -> show URL concatenate("#editor:",filename,":",toString start,":",toString startcol,"-",toString stop,":",toString stopcol))x;
+    -- the show/edit hack
+    show URL := url -> (<< webAppUrlTag | url#0 | webAppEndTag;);
+    editURL := f -> "#editor:"|toString f;
+    editMethod String :=
+    editMethod FilePosition := f -> show editURL f;
+    hypertext FilePosition := f -> TT HREF {editURL f,toString f};
     -- redefine htmlLiteral to exclude codes
     htmlLiteral = (s -> if s===null then null else replace(webAppTagsRegex,"",s)) @@ htmlLiteral;
     )

--- a/M2/Macaulay2/packages/Macaulay2Doc/debugging.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/debugging.m2
@@ -213,8 +213,8 @@ document {
      TT "FilePosition", " -- a type of list designed to represent a position
      in a file.",
      PARA{},
-     "It's implemented as a list whose three elements are the file name,
-     the line number, and the column number."
+     "It's implemented as a list with 3, 5 or 7 elements. The first part is the file name, then each pair is a row/column position.
+     A single pair is a position, two form a range. The last pair is the central point of interest in that range."
      }
 
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/installAssignmentMethod-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/installAssignmentMethod-doc.m2
@@ -56,7 +56,7 @@ document {
 	  x_c
      ///,
      "The source code explains how it works, behind the scenes.",
-     PRE ("    " | code {(symbol _,Symbol,Thing),((symbol _,symbol =),Symbol,Thing)}),
+     PRE ("    " | net code {(symbol _,Symbol,Thing),((symbol _,symbol =),Symbol,Thing)}),
      EXAMPLE lines ///
 	  peek x
      ///,

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/locate-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/locate-doc.m2
@@ -10,6 +10,7 @@ Node
    (locate, Sequence)
    (locate, Pseudocode)
    (locate, Function)
+   (locate, FunctionBody)
    (locate, Nothing)
    (locate, List)
    (locate, ZZ)
@@ -20,11 +21,11 @@ Node
   Inputs
     x:{Function,Sequence,Symbol,List,ZZ}
   Outputs
-    :{Sequence,List,Nothing}
-      {\tt (filename, start,startcol, stop,stopcol, pos,poscol)}, respectively
+    :{FilePosition,List,Nothing}
+      {\tt {filename, start,startcol, stop,stopcol, pos,poscol}}, respectively
   Description
     Text
-      For a symbol interpreted function {\tt f}, returns a sequence {\tt (n,i,c,j,d,k,e)}
+      For a symbol interpreted function {\tt f}, returns a {\tt FilePosition{n,i,c,j,d,k,e}}
       describing the location of the definition in the source code:
     Tree
       :The name of the source file is {\tt n};
@@ -44,6 +45,7 @@ Node
       locate methods resolution
       methods doc
       locate 0
+      peek oo
     Text
       If the function {\tt f} is compiled, or if {\tt f} is @TO "null"@,
       then a location is not available and @TO "null"@ is returned.

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview4.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview4.m2
@@ -5,7 +5,8 @@
 undocumented (hypertext, Hypertext)
 
 document {
-     Key => {hypertext,(hypertext, List),(hypertext, Sequence)},
+--     Key => {hypertext,(hypertext, List),(hypertext, Sequence)},
+     Key => hypertext,
      Headline => "prepare hypertext for display",
      Usage => "hypertext x",
      Inputs => {

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview4.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview4.m2
@@ -2,10 +2,9 @@
 --		Copyright 1993-2002 by Daniel R. Grayson
 
 
-undocumented (hypertext, Hypertext)
+undocumented methods hypertext
 
 document {
---     Key => {hypertext,(hypertext, List),(hypertext, Sequence)},
      Key => hypertext,
      Headline => "prepare hypertext for display",
      Usage => "hypertext x",

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/SLP.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/SLP.m2
@@ -27,8 +27,8 @@ slpPRODUCT = 3; --"PRODUCT";
 slpDET = 4; --"DET";
 
 
-CONST = symbol CONST;
-INPUT = symbol INPUT;
+CONST := symbol CONST;
+INPUT := symbol INPUT;
 protect CONST
 protect INPUT
 

--- a/M2/Macaulay2/packages/Text.m2
+++ b/M2/Macaulay2/packages/Text.m2
@@ -9,7 +9,7 @@ newPackage("Text",
 
 exportFrom_Core {
      "ANCHOR", "BLOCKQUOTE", "BODY", "BOLD", "BR", "CDATA", "CODE", "COMMENT", "DD", "DIV", "DL", "DT", "EM", "ExampleItem", "HEAD", "HEADER1",
-     "HEADER2", "HEADER3", "HEADER4", "HEADER5", "HEADER6", "HR", "HREF", "HTML", "Hypertext", "HypertextContainer", "HypertextParagraph", "IMG", "ITALIC",
+     "HEADER2", "HEADER3", "HEADER4", "HEADER5", "HEADER6", "HR", "HREF", "HTML", "Hypertext", "HypertextContainer", "HypertextParagraph", "HypertextVoid", "IMG", "ITALIC",
      "LABEL", "LATER", "LI", "LINK", "LITERAL", "M2CODE", "MENU", "META", "PARA", "PRE", "SCRIPT", "SMALL", "SPAN", "STRONG", "STYLE", "SUB", "SUBSECTION", "SUP", "TABLE", "TD", "TH",
      "TEX", "TITLE", "TO", "TO2", "TOH", "TR", "TT", "UL", "OL", "INPUT", "BUTTON", "validate",
      "MarkUpType", "IntermediateMarkUpType",

--- a/M2/Macaulay2/packages/Text.m2
+++ b/M2/Macaulay2/packages/Text.m2
@@ -11,7 +11,7 @@ exportFrom_Core {
      "ANCHOR", "BLOCKQUOTE", "BODY", "BOLD", "BR", "CDATA", "CODE", "COMMENT", "DD", "DIV", "DL", "DT", "EM", "ExampleItem", "HEAD", "HEADER1",
      "HEADER2", "HEADER3", "HEADER4", "HEADER5", "HEADER6", "HR", "HREF", "HTML", "Hypertext", "HypertextContainer", "HypertextParagraph", "IMG", "ITALIC",
      "LABEL", "LATER", "LI", "LINK", "LITERAL", "M2CODE", "MENU", "META", "PARA", "PRE", "SCRIPT", "SMALL", "SPAN", "STRONG", "STYLE", "SUB", "SUBSECTION", "SUP", "TABLE", "TD", "TH",
-     "TEX", "TITLE", "TO", "TO2", "TOH", "TR", "TT", "UL", "OL", "validate",
+     "TEX", "TITLE", "TO", "TO2", "TOH", "TR", "TT", "UL", "OL", "INPUT", "BUTTON", "validate",
      "MarkUpType", "IntermediateMarkUpType",
      "style"
      }

--- a/M2/Macaulay2/packages/VectorGraphics.m2
+++ b/M2/Macaulay2/packages/VectorGraphics.m2
@@ -595,10 +595,10 @@ svg = g -> (
     )
 
 shortSize := 3.8
-short GraphicsObject := g -> (
-    if not g.?Size then return Short(g++{Size=>shortSize});
+short GraphicsObject := g -> hold (
+    if not g.?Size then return g++{Size=>shortSize};
     s := if instance(g.Size,Vector) then sqrt(g.Size_0^2+g.Size_1^2) else g.Size;
-    if s<shortSize then hold g else Short(g++{Size=>shortSize})
+    if s<shortSize then g else g++{Size=>shortSize}
     )
 
 GraphicsObject ? GraphicsObject := (x,y) -> y.cache.Distance ? x.cache.Distance
@@ -719,7 +719,8 @@ new SVG from GraphicsObject := (S,g) -> (
     ss
     )
 
-html GraphicsObject := g -> html SVG g;
+hypertext GraphicsObject := g -> SVG g
+html GraphicsObject := html @@ hypertext
 
 -- tex output
 tikzscale := 1; -- not thread-safe

--- a/M2/Macaulay2/tests/ComputationsBook/geometry/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/geometry/test.out.expected
@@ -763,8 +763,6 @@ o100 = -- ../../../../../../Macaulay2/packages/ComputationsBook/geometry/mystery
           trim kernel map(ringC5, ringP3,
              matrix{{x_0+x_1,x_2,x_3,x_5}}))
 
-o100: DIV
-
 i101 : code prettyPrint
 
 o101 = -- ../../../../../../Macaulay2/packages/ComputationsBook/geometry/mystery.m2:15-51
@@ -806,7 +804,5 @@ o101 = -- ../../../../../../Macaulay2/packages/ComputationsBook/geometry/mystery
                       ))));
           print stack strings;  -- stack them vertically, then print
           )
-
-o101: DIV
 
 i102 : 

--- a/M2/Macaulay2/tests/ComputationsBook/geometry/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/geometry/test.out.expected
@@ -763,6 +763,8 @@ o100 = -- ../../../../../../Macaulay2/packages/ComputationsBook/geometry/mystery
           trim kernel map(ringC5, ringP3,
              matrix{{x_0+x_1,x_2,x_3,x_5}}))
 
+o100: DIV
+
 i101 : code prettyPrint
 
 o101 = -- ../../../../../../Macaulay2/packages/ComputationsBook/geometry/mystery.m2:15-51
@@ -804,5 +806,7 @@ o101 = -- ../../../../../../Macaulay2/packages/ComputationsBook/geometry/mystery
                       ))));
           print stack strings;  -- stack them vertically, then print
           )
+
+o101: DIV
 
 i102 : 

--- a/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/patterns
+++ b/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/patterns
@@ -1,4 +1,4 @@
 s/primaryDecomposition MonomialIdeal := .*/primaryDecomposition MonomialIdeal := XXX/
-s/\| opts*//
-s/\| f*//
+s/\| opts.*//
+s/\| f.*//
 s/.*if J == 1 then return.*//

--- a/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/patterns
+++ b/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/patterns
@@ -1,4 +1,4 @@
 s/primaryDecomposition MonomialIdeal := .*/primaryDecomposition MonomialIdeal := XXX/
-s/\| opts.*//
-s/\| f.*//
+s/| opts.*//
+s/| f.*//
 s/.*if J == 1 then return.*//

--- a/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/patterns
+++ b/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/patterns
@@ -1,4 +1,4 @@
 s/primaryDecomposition MonomialIdeal := .*/primaryDecomposition MonomialIdeal := XXX/
-s/opts   : OptionTable.*//
-s/f      : FunctionClosure.*//
+s/\| opts*//
+s/\| f*//
 s/.*if J == 1 then return.*//

--- a/M2/Macaulay2/tests/normal/testing.m2
+++ b/M2/Macaulay2/tests/normal/testing.m2
@@ -7,7 +7,7 @@ loadPackage("TestPackage", FileName => testpkg)
 check "TestPackage"
 pkgtest = (tests "TestPackage")#0
 assert instance(pkgtest, TestInput)
-assert Equation(locate pkgtest, (testpkg, 3, 1, 4, 1,,))
+assert Equation(toSequence locate pkgtest, (testpkg, 3, 1, 4, 1,,))
 assert Equation(toString pkgtest, testpkg | ":3:1-4:1:")
 assert Equation(net pkgtest, (testpkg | ":3:1-4:1:")^-1)
 expectedCode =  "--" | toAbsolutePath testpkg |


### PR DESCRIPTION
This is a continuation of #2421. Besides #2375, it also addresses #2655, #2777, and is tangentially related to #2754 and #2757.
phew. overall, the goal of this PR is to make several methods related to debugging more "semantic" by producing more meaningful output than simply a `Net` or `String`.
- `locate` now outputs a `FilePosition`, and this in turn helps remove the huge redundancy in formatting output of the form `filename:0:0-42:42` which is all over the place in the code. not entirely finished (also, I'm not entirely happy with the way `locate` internally finds the position of code, but that's for another PR -- see comments below and related issue #2569 )
- `code` and `showSymbols` now output HTML rather than a `Net`.
- the `AfterPrint` of `Hypertext` types is suppressed (following @mahrud 's suggestion)
- in relation to #2757, I've decided to go ahead with my idea to hijack the `hypertext` method as an intemediate step to producing html. It's strictly speaking not necessary but I think the code is much cleaner this way; there's no obligation for anyone to use this and the overall effect is at this stage invisible, but since `hypertext` already existed, there's no reason not to use it.
- still, in relation to #2757, I have *not* touched documentation at all. So these changes should not have any impact on it even though I'm already experimenting with this on the web app, but I think it's too early to PR.
- there's a couple of assorted minor fixes, like missing `validContent` and some `short` changes (still not ready for export).
- one thing I am not happy about at this stage is various hacks I had to use because of the oddities of converting `Hypertext` to `net` in `format.m2` (which is relevant since several methods now output `Hypertext` and in standard mode, it gets converted to `net`). Eventually, I want to rewrite some of `format.m2` so that it behaves more reasonably, but at this stage, I had to create another of these `IntermediateMarkupType`s (that we'll need to get rid of at some point) just to have `DIV` with an extra vertical bar on the left. Not great but only way to circumvent the non-recursivity of the `parser` of `format.m2`. I also had to hack the spacing of `PRE`, see #2754.
- #2655 is now moot because now the output of code is properly semantic, there's a clear separation between the code itself and what precedes it, so it's irrelevant if the latter is not valid code itself.