### PR TITLE
Add "packages" button to top of html documentation pages

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -240,6 +240,7 @@ BACKWARD  := tag -> if PREV#?tag then BACKWARD0 PREV#tag else if UP#?tag then UP
 topNodeButton  := (htmlDirectory, topFileName)   -> HREF {htmlDirectory | topFileName,   "top" };
 indexButton    := (htmlDirectory, indexFileName) -> HREF {htmlDirectory | indexFileName, "index"};
 tocButton      := (htmlDirectory, tocFileName)   -> HREF {htmlDirectory | tocFileName,   "toc"};
+pkgButton      := TO2 {"packages provided with Macaulay2", "packages"};
 homeButton     := HREF {"http://macaulay2.com/", "Macaulay2 website"};
 
 nextButton     := tag -> if NEXT#?tag then HREF { htmlFilename NEXT#tag, "next" }     else "next"
@@ -252,7 +253,7 @@ topButton      := tag -> if tag =!= topDocumentTag then topNodeButton(htmlDirect
 -- TODO: revamp this using Bootstrap
 buttonBar := tag -> TABLE { "class" => "buttons", TR { TD { DIV splice between_" | " {
 		nextButton tag, prevButton tag, forwardButton tag, backwardButton tag, upButton tag, topButton tag,
-		indexButton(htmlDirectory, indexFileName), tocButton(htmlDirectory, tocFileName), homeButton}}}}
+		indexButton(htmlDirectory, indexFileName), tocButton(htmlDirectory, tocFileName), pkgButton, homeButton}}}}
 
 -----------------------------------------------------------------------------
 -- makePackageIndex
@@ -387,7 +388,7 @@ makeSortedIndex := (nodes, verboseLog) -> (
      fn << html validate HTML {
 	  defaultHEAD title,
 	  BODY nonnull {
-	       DIV { topNodeButton(htmlDirectory, topFileName), " | ", tocButton(htmlDirectory, tocFileName), -* " | ", directoryButton, *- " | ", homeButton },
+	       DIV { topNodeButton(htmlDirectory, topFileName), " | ", tocButton(htmlDirectory, tocFileName), " | ", pkgButton, " | ", homeButton },
 	       HR{},
 	       HEADER1 title,
 	       DIV between(LITERAL "&nbsp;&nbsp;&nbsp;",apply(alpha, c -> HREF {"#"|c, c})),
@@ -405,7 +406,7 @@ makeTableOfContents := (pkg, verboseLog) -> (
      fn << html validate HTML {
 	  defaultHEAD title,
 	  BODY {
-	       DIV { topNodeButton(htmlDirectory, topFileName), " | ", indexButton(htmlDirectory, indexFileName), -* " | ", directoryButton, *- " | ", homeButton },
+	       DIV { topNodeButton(htmlDirectory, topFileName), " | ", indexButton(htmlDirectory, indexFileName), " | ", pkgButton, " | ", homeButton },
 	       HR{},
 	       HEADER1 title,
 	       toDoc unbag pkg#"table of contents"


### PR DESCRIPTION
This allows users to easily switch from viewing a documentation page in one package to viewing a documentation page for another package.

We replace some commented out code referring to a `directoryButton`, which may have been intended to point to the directory page that is installed in `applicationDirectory`.  However, the URL to this page would be impossible to know when the documentation is built for a distribution because it depends on the value of the user's `HOME` environment variable and the `applicationDirectorySuffix` variable.  The "packages provided with Macaulay2" page in Macaulay2Doc is the next best thing.

![image](https://user-images.githubusercontent.com/1992248/216790402-0a22087f-4a2b-4b5f-94f8-798cec91e8d9.png)
