### PR TITLE
Lint workflow updates

### DIFF
--- a/.codespell_ignore
+++ b/.codespell_ignore
@@ -7,6 +7,7 @@ ans
 anumber
 archiv
 assasin
+ba
 bloks
 braket
 bu
@@ -62,6 +63,7 @@ singl
 skelton
 sring
 strat
+sur
 te
 thets
 toom

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,12 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: { submodules: recursive }
-      - uses: conda-incubator/setup-miniconda@v2
-        with: { mamba-version: "*", channels: "conda-forge", channel-priority: true }
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          mamba install codespell=2.2.2 pycodestyle=2.9.1
+          sudo apt-get install -y codespell
       - name: Run codespell
         shell: bash -l {0}
         run: codespell --ignore-words=.codespell_ignore M2/Macaulay2/packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with: { submodules: recursive }
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   codespell:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with: { submodules: recursive }


### PR DESCRIPTION
We now use the Ubuntu package for `codespell` rather than getting it from Conda, which fixes the errors seen in recent pull requests (#2760, #2763, and #2764).

A few other small changes:

* We now run on `ubuntu-latest` rather than `ubuntu-20.04`.  This should simplify maintenance, since presumably GitHub will get rid of its `ubuntu-20.04` runners in a few years.
* We no longer check out the submodules, since `codespell` is only run inside the `packages` directory.
* We add two new words ("ba" and "sur") to the ignored word list.  I'm assuming this was needed because of a difference in versions between the `codespell` package in Ubuntu v. Conda.

Here's an example of a successful run of the workflow with these updates: https://github.com/d-torrance/M2/actions/runs/4096896422

Cc: @fchapoton