### PR TITLE
fixed bug in submatrix with repeated rows

### DIFF
--- a/M2/Macaulay2/m2/engine.m2
+++ b/M2/Macaulay2/m2/engine.m2
@@ -53,6 +53,7 @@ isSmall := i -> class i === ZZ and i < 2^15 and i > -2^15
 isCount := i -> class i === ZZ and i >= 0 and i < 2^15
 isListOfIntegers = x -> instance(x, List) and all(x,i -> class i === ZZ)
 isListOfListsOfIntegers = x -> instance(x, List) and all(x,isListOfIntegers)
+listZ = listZZ = v -> if isListOfIntegers(v = toList splice v) then v else error "expected a list of integers"
 checkCount := i -> if not isCount i then error "expected a small positive integer"
 
 fixup1 := method(Dispatch => Thing)			    -- stage 1, everything except Tiny and Small

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -394,7 +394,11 @@ Matrix || RingElement := (f,g) -> concatRows(f,g**id_(source f))
 ZZ || Matrix := (f,g) -> concatRows(f*id_(source g),g)
 Matrix || ZZ := (f,g) -> concatRows(f,g*id_(source f))
 
-listZ := v -> ( if not all(v,i -> instance(i, ZZ)) then error "expected list of integers"; v )
+-----------------------------------------------------------------------------
+-- submatrix, submatrixByDegrees
+-----------------------------------------------------------------------------
+
+listZ := v -> if isListOfIntegers v then v else error "expected list of integers"
 Matrix _ List := Matrix => (f,v) -> submatrix(f,listZ splice v)	-- get some columns
 Matrix ^ List := Matrix => (f,v) -> submatrix(f,listZ splice v,) -- get some rows
 
@@ -405,15 +409,27 @@ Matrix _ ZZ := Vector => (m,i) -> (
      h = map(M, R^1, h, Degree => first degrees source h);
      new target h from {h})
 
+-- given a map of free modules, find a submatrix of it
+submatrixFree = (m, rows, cols) -> map(ring m, if rows === null
+    then rawSubmatrix(raw cover m, listZ toList splice cols)
+    else rawSubmatrix(raw cover m, listZ toList splice rows,
+	if cols =!= null then listZ toList splice cols else 0 .. numgens source m - 1))
+-- given a module, find a part of the ambient module
+-- along with corresponding generators and relations
+submodule = (M, rows) -> (
+    rows = listZ toList splice rows;
+    if isFreeModule M    then (ring M)^((-degrees M)_rows) else
+    if not M.?relations  then image    submatrixFree(generators M, rows, ) else
+    if not M.?generators then cokernel submatrixFree(relations  M, rows, ) else
+    subquotient(submatrixFree(generators M, rows, ), submatrixFree(relations M, rows, )))
+
 submatrix  = method(TypicalValue => Matrix)
 submatrix' = method(TypicalValue => Matrix)
 
-submatrix(Matrix,VisibleList,VisibleList) := (m,rows,cols) -> map(ring m,rawSubmatrix(raw m, listZ toList splice rows, listZ toList splice cols))
-submatrix(Matrix,VisibleList            ) := (m,cols     ) -> map(target m,,rawSubmatrix(raw m, listZ toList splice cols))
-submatrix(Matrix,Nothing    ,VisibleList) := (m,null,cols) -> submatrix(m,cols)
-submatrix(Matrix,VisibleList,Nothing    ) := (m,rows,cols) -> (
-     rows = splice rows; 
-     map((ring m)^((- degrees target m)_rows),source m,rawSubmatrix(raw m, listZ toList rows, 0 .. numgens source m - 1)))
+submatrix(Matrix, VisibleList, VisibleList) := (m, rows, cols) -> map(submodule(target m, rows), submodule(source m, cols), submatrixFree(m, rows, cols))
+submatrix(Matrix, VisibleList, Nothing)     := (m, rows, null) -> map(submodule(target m, rows), source m,                  submatrixFree(m, rows, null))
+submatrix(Matrix, VisibleList)              := (m,       cols) -> map(target m,                  submodule(source m, cols), submatrixFree(m, null, cols))
+submatrix(Matrix, Nothing,     VisibleList) := (m, null, cols) -> submatrix(m, cols)
 
 compl := (m,v) -> toList (0 .. m-1) - set v
 submatrix'(Matrix,VisibleList,VisibleList) := (m,rows,cols) -> if #rows === 0 and #cols === 0 then m else submatrix(m,compl(numgens target m,listZ toList splice rows),compl(numgens source m,listZ toList splice cols))
@@ -456,6 +472,8 @@ submatrixByDegrees(Matrix, Sequence, Sequence) := (m, tarBox, srcBox) -> (
     )
 submatrixByDegrees(Matrix, ZZ, ZZ) := (m, lo, hi) -> submatrixByDegrees(m, ({lo},{lo}), ({hi},{hi}))
 submatrixByDegrees(Matrix, List, List) := (m, lo, hi) -> submatrixByDegrees(m, (lo,lo), (hi,hi))
+
+-----------------------------------------------------------------------------
 
 bothFree := (f,g) -> (
      if not isFreeModule source f or not isFreeModule target f

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -419,12 +419,9 @@ Module _ Array := Matrix => (M,w) -> if M.cache#?(symbol _,w) then M.cache#(symb
      map(M, directSum newcomps, (cover M)_(splice apply(w, i -> v#i))))
 
 -----------------------------------------------------------------------------
-Module ^ List := Matrix => (M,rows) -> submatrix(id_M,rows,)
+Module ^ List := Matrix => (M, rows) -> submatrix(map(cover M, M, id_M), rows,)
+Module _ List := Matrix => (M, cols) -> submatrix(map(M, cover M, id_M), cols)
 -----------------------------------------------------------------------------
-Module _ List := Matrix => (M,v) -> (
-     N := cover M;
-     f := id_N_v;
-     map(M, source f, f))
 
 -----------------------------------------------------------------------------
 isSubset(Module,Module) := (M,N) -> (

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -91,15 +91,14 @@ promote(MutableMatrix,Number) := Matrix => (f,S) -> (
 --------------------------------
 -- submatrices -----------------
 --------------------------------
-listZ := v -> ( if not all(v,i -> instance(i, ZZ)) then error "expected list of integers"; v )
 MutableMatrix _ List := Matrix => (f,v) -> submatrix(f,listZ splice v)	-- get some columns
 MutableMatrix ^ List := Matrix => (f,v) -> submatrix(f,listZ splice v,) -- get some rows
 submatrix(MutableMatrix,VisibleList,VisibleList) := (m,rows,cols) -> map(ring m,rawSubmatrix(raw m, listZ toList splice rows, listZ toList splice cols))
 submatrix(MutableMatrix,VisibleList            ) := (m,cols     ) -> map(ring m,rawSubmatrix(raw m, listZ toList splice cols))
 submatrix(MutableMatrix,Nothing    ,VisibleList) := (m,null,cols) -> submatrix(m,cols)
-submatrix(MutableMatrix,VisibleList,Nothing    ) := (m,rows,cols) -> (
-     rows = splice rows; 
-     map((ring m, rawSubmatrix(raw m, listZ toList rows, 0 .. numColumns m - 1))))
+submatrix(MutableMatrix, VisibleList, Nothing)     := (m, rows, null) -> map(ring m, rawSubmatrix(raw m, listZZ rows, 0 .. numColumns m - 1))
+submatrix(MutableMatrix, Nothing,     Nothing)     := (m, null, null) -> m
+
 --------------------------------
 numRows(RawMutableMatrix) := (m) -> rawNumberOfRows m
 numRows(MutableMatrix) := (m) -> rawNumberOfRows raw m

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/submatrix-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/submatrix-doc.m2
@@ -1,7 +1,10 @@
 document {
     Key => submatrix,
-    SeeAlso => {
+    Subnodes => TO \ {
 	submatrix',
+	submatrixByDegrees,
+	(submatrix, Matrix, VisibleList),
+	(submatrix, Matrix, VisibleList, VisibleList),
 	(symbol _, Matrix, List),
 	(symbol ^, Matrix, List),
 	(symbol _, Matrix, Array),
@@ -53,8 +56,10 @@ document {
      }
 
 undocumented {
+    (submatrix,Matrix,Nothing,Nothing),
     (submatrix,Matrix,Nothing,VisibleList),
     (submatrix,Matrix,VisibleList,Nothing),
+    (submatrix,MutableMatrix,Nothing,Nothing),
     (submatrix,MutableMatrix,Nothing,VisibleList),
     (submatrix,MutableMatrix,VisibleList,Nothing)
     }
@@ -144,11 +149,13 @@ document {
 	  (symbol^,Matrix,Array)
 	  },
      }
+
 document {
      Key => {submatrix',
 	  (submatrix',Matrix,VisibleList,VisibleList),
 	  (submatrix', Matrix, Nothing, VisibleList),
 	  (submatrix', Matrix, VisibleList, Nothing),
+	  (submatrix', Matrix, Nothing, Nothing),
 	  (submatrix', Matrix, VisibleList)},
      Headline => "exclude rows and/or columns of a matrix",
      Usage => "submatrix'(f, rows, cols)\nsubmatrix'(f,,cols)\nsubmatrix'(f,cols)\nsubmatrix'(f,rows,)",
@@ -207,8 +214,6 @@ doc ///
     Text
       If only one degree (as integer, or list of integers) is given for {\tt targetBox} or {\tt sourceBox}, then
       only rows or columns that match that exact degree are used.
-
-
     Example
       R = QQ[a..d];
       I = ideal"a2b-c3,abc-d3,ac2-bd2-cd2,abcd-c4"

--- a/M2/Macaulay2/packages/Normaliz.m2
+++ b/M2/Macaulay2/packages/Normaliz.m2
@@ -108,6 +108,10 @@ nmzVersion="";     -- normaliz
 nmzMinExecVersion="2.11"; -- minimal normaliz version
 nmzGen=true;      -- indicates whether ".gen" is generated
 
+normalizProgram = findProgram("normaliz", "normaliz --help",
+    Verbose => debugLevel > 0, MinimumVersion => (nmzMinExecVersion,
+	"normaliz --version | head -1 | cut -d' ' -f 2 | tr -d '\n'"))
+
 -- component 1 is name of option
 -- 2 is default value
 -- 3 is command line option to be passed to Normaliz
@@ -261,7 +265,7 @@ doWriteNmzData(List):=(matrices)->
       4 => "inequalities",
       5 => "equations",
       6 => "congruences",
-      10 => "lattice_ideal",
+      10 => "normal_toric_ideal",
       20 => "grading"
   };
 
@@ -288,10 +292,10 @@ doWriteNmzData(List):=(matrices)->
      if nmzModes#?nmzMode then(
         -- deprecated input type as integer
         print("Using Normaliz integer input types is deprecated, please use " | nmzModes#nmzMode | " instead of " | nmzMode);
-        outf << nmzModes#nmzMode << endl;
-     )
-     else
-        outf << nmzMode << endl;
+        nmzMode = nmzModes#nmzMode);
+     -- Until version 3.9.4, input type normal_toric_ideal was called lattice_ideal
+     if normalizProgram#"version" < "3.10" and nmzMode == "normal_toric_ideal" then nmzMode = "lattice_ideal";
+     outf << nmzMode << endl;
   );
   outf  << close;
 );
@@ -490,10 +494,6 @@ normaliz(List):=opts>>o->(s)->
   return runNormaliz(allComputations=>o.allComputations, grading=>o.grading, s);
 );
 
-
--- sequence should contain pairs (sgr,nmzMode)
-normalizProgram = null
-
 runNormaliz=method(Options=>true)
 opts={allComputations=>false, grading=>{}}
 runNormaliz(Matrix,String):=opts>>o->(sgr,nmzMode)->
@@ -502,13 +502,10 @@ runNormaliz(Matrix,String):=opts>>o->(sgr,nmzMode)->
                      {(sgr,nmzMode)});
 );
 
+-- sequence should contain pairs (sgr,nmzMode)
 runNormaliz(List):=opts>>o->(s)->
 (
     setNmzFile();
-    if normalizProgram === null then normalizProgram =
-	findProgram("normaliz", "normaliz --help",
-	    Verbose => debugLevel > 0, MinimumVersion => (nmzMinExecVersion,
-		"normaliz --version | head -1 | cut -d' ' -f 2 | tr -d '\n'"));
 
     if (#o.grading > 0) then (
         s = append(s, (matrix{o.grading}, "grading"));
@@ -714,7 +711,7 @@ normalToricRing (Ideal,Thing) :=opts>>o->(I,t)->(
      );
    );
    M=matrix M;
-   nmzCone:=normaliz(allComputations=>o.allComputations,grading=>o.grading,M,"lattice_ideal");
+   nmzCone:=normaliz(allComputations=>o.allComputations,grading=>o.grading,M,"normal_toric_ideal");
    nmzData:=nmzCone#"gen";
    r:=rank nmzData;
    n:=numgens R;
@@ -1268,7 +1265,7 @@ document {
    Key => "output files written by Normaliz",
 PARA{},"Depending on the options enabled (see ", TO setNmzOption, "), ", TT "Normaliz", " writes additional output files. To obtain the content of these files within Macaulay2, use ", TO readNmzData, " or ", TO allComputations,". The following files may be written, provided certain conditions are satisfied and the information that should go into them has been computed. We denote the files simply by their types.
 For the most types of inputs the ambient lattice is ", TEX "\\ZZ^n", " if the input of Normaliz is a matrix of n columns. In types polytope and rees_algebra the ambient lattice is ", TEX "\\ZZ^{n+1}", " since the input vectors are extended by 1 component. For congruences and inhomogeneous input it is ", TEX "\\ZZ^{n-1}", " and for inhomogeneous congruences ", TEX "\\ZZ^{n-2}", ".
-For input of type lattice_ideal the lattice is ", TEX "\\ZZ^{r}", " where n-r is the rank of the input matrix. The essential lattice is gp(M) where M is the monoid computed by Normaliz internally, i.e. after a linear transformation such that the cone is full-dimensional and the integral closure has to be computed.
+For input of type normal_toric_ideal the lattice is ", TEX "\\ZZ^{r}", " where n-r is the rank of the input matrix. The essential lattice is gp(M) where M is the monoid computed by Normaliz internally, i.e. after a linear transformation such that the cone is full-dimensional and the integral closure has to be computed.
 See the documentation of Normaliz at ", HREF "https://github.com/Normaliz/Normaliz/blob/master/doc/Normaliz.pdf", " for more details.",
 UL{
    {TT "gen      ", "   The Hilbert basis"},
@@ -1398,7 +1395,7 @@ document {
          "rees_algebra:   exponent vectors of monomials generating an ideal",
          "inequalities, equations, congruences:   constraints defining the cone to be computed",
          "inhom_inequalities, inhom_equations, inhom_congruences:   inhomogeneous constraints defining the cone to be computed",
-         "lattice_ideal:  generators of a lattice ideal",
+         "normal_toric_ideal:  generators of a lattice ideal",
          "grading:  a grading which gives positive degree to all generators"
      },
      "For a more detailed list see the Normaliz documentation.",
@@ -1526,7 +1523,7 @@ document {
         {"inhom_inequalities: Computes the Hilbert basis of the rational cone in ", TEX "\\RR^m", " given by the system of inhomogeneous inequalities. Each row (",TEX "x_1,\\dots,x_n,b",") represents an inequality ",TEX "x_1 z_1+\\dots+x_n z_n + b \\geq \\ 0","."},
         {"inhom_equations: Computes the Hilbert basis of the rational cone given by the nonnegative solutions of the inhomogeneous system ", TT "mat ", TEX "x\\ =\\ b", "."},
         {"inhom_congruences: Computes the Hilbert basis of the rational cone given by the nonnegative solutions of the system of congruences defined by the rows as follows: Each row (",TEX "x_1,\\dots,x_n,b,c",") represents a congruence ",TEX "x_1 z_1+\\dots+x_n z_n + b \\equiv \\ 0 \\mod \\ c","."},
-        {"lattice_ideal: Computes the monoid as a quotient of ", TEX"\\ZZ_+^n"," modulo a system of congruences (in the semigroup sense) defined by the rows of the input matrix."},
+        {"normal_toric_ideal: Computes the monoid as a quotient of ", TEX"\\ZZ_+^n"," modulo a system of congruences (in the semigroup sense) defined by the rows of the input matrix."},
      },
 PARA{},"It is possible to combine certain input types, see ", TO (normaliz,List),". If you want to input only one matrix you can also use ", TO (normaliz,Matrix,String),".",
  PARA{},"By default, the cone returned contains only the content of the output file .gen, under the key \"gen\", i.e. the generators that have been computed, line by line, and the content of the output file .inv, under the key \"inv\".",

--- a/M2/Macaulay2/tests/normal/000-core.m2
+++ b/M2/Macaulay2/tests/normal/000-core.m2
@@ -115,43 +115,6 @@ assert isDirectSum (QQ^1 ++ QQ^2)
 
 --
 clearAll
-     R = ZZ[x_1..x_12,y]
-     f = genericMatrix(R,3,4)
-     assert(source (f_{1,2}) == R^{-1,-1})
-     assert(target (f_{1,2}) == target f)
-     M1 = (target f)/(y * target f)
-     M2 = (source f)/(y * source f)
-     g = map(target f,M2,f)
-     h = map(M1,M2,f)
-     k = submatrix(g, {1})
-     assert(target k === target g)
-     l = submatrix(h, {1})
-     assert(target l === target h)
-     assert(source l === R^{-1})
-     m = submatrix(h, {1,2},{2,3})
-     assert(target m === R^2)
-     assert(source m === R^{2:-1})
-     n = submatrix(h, {1,2}, )
-     assert(target n === R^2)
-     assert(source n === source h)
-
-
-
---
-  -- test of submatrixByDegrees
-  R = QQ[a..d]
-  I = ideal"a2b-c3,abc-d3,ac2-bd2-cd2,abcd-c4"
-  C = res I
-  submatrixByDegrees(C.dd_2, (3,3),(6,6))
-  submatrixByDegrees(C.dd_2, ({3},{3}),({6},{6}))
-  submatrixByDegrees(C.dd_2, ({4},{4}),({},{}))
-  submatrixByDegrees(C.dd_2, ({3},{3}),({7},{7}))
-  F = source C.dd_2
-  -- rawSelectByDegrees(raw F, {-4}, {-3})
-  -- rawSelectByDegrees(raw F, {}, {8})
-
-
---
 R=ZZ/101[a..d]
 f = matrix {{a}}
 assert( isHomogeneous f )

--- a/M2/Macaulay2/tests/normal/submatrix.m2
+++ b/M2/Macaulay2/tests/normal/submatrix.m2
@@ -14,6 +14,14 @@ M = matrix"a,b;c,d"
 assert(M_{0,1,0,1} == M | M) -- produces the matrix with two columns equal to the first column of M, as it should
 assert(M^{0,1,0,1} == M || M) -- produces a matrix with a row of zeros followed by the first row of M -- wrong!
 
+R = S[x]
+N = coker matrix{{x}}
+m = map(N++R^1, N++R^1, sub(M, R))
+assert(m^{0} == map(N, N++R^1, {{a, b}}))
+assert(m^{1} == map(R^1, N++R^1, {{c, d}}))
+assert(m_{0} == map(N++R^1, N, {{a}, {c}}))
+assert(m_{1} == map(N++R^1, R^1, {{b}, {d}}))
+
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test submatrix.out"

--- a/M2/Macaulay2/tests/normal/submatrix.m2
+++ b/M2/Macaulay2/tests/normal/submatrix.m2
@@ -27,6 +27,39 @@ M = image vars R ++ coker vars R
 assert(M^{2} == map(R^{-1}, M, {{0, 0, 1, 0, 0}}))
 assert(M_{2} == map(M, R^{-1}, {{0}, {0}, {1}, {0}, {0}}))
 
+--
+R = ZZ[x_1..x_12,y]
+f = genericMatrix(R,3,4)
+assert(source (f_{1,2}) == R^{-1,-1})
+assert(target (f_{1,2}) == target f)
+M1 = (target f)/(y * target f)
+M2 = (source f)/(y * source f)
+g = map(target f,M2,f)
+h = map(M1,M2,f)
+k = submatrix(g, {1})
+assert(target k === target g)
+l = submatrix(h, {1})
+assert(target l === target h)
+assert(source l == coker map(R^{-1}, , {{0, y, 0, 0}}))
+m = submatrix(h, {1,2},{2,3})
+assert(target m == coker map(R^2, , {{0, y, 0}, {0, 0, y}}))
+assert(source m == coker map(R^{2:-1}, , {{0, 0, y, 0}, {0, 0, 0, y}}))
+n = submatrix(h, {1,2}, )
+assert(target n == coker map(R^2, , {{0, 0, y, 0}, {0, 0, 0, y}}))
+assert(source n === source h)
+
+-- test of submatrixByDegrees
+R = QQ[a..d]
+I = ideal"a2b-c3,abc-d3,ac2-bd2-cd2,abcd-c4"
+C = res I
+submatrixByDegrees(C.dd_2, (3,3),(6,6))
+submatrixByDegrees(C.dd_2, ({3},{3}),({6},{6}))
+submatrixByDegrees(C.dd_2, ({4},{4}),({},{}))
+submatrixByDegrees(C.dd_2, ({3},{3}),({7},{7}))
+F = source C.dd_2
+-- rawSelectByDegrees(raw F, {-4}, {-3})
+-- rawSelectByDegrees(raw F, {}, {8})
+
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test submatrix.out"

--- a/M2/Macaulay2/tests/normal/submatrix.m2
+++ b/M2/Macaulay2/tests/normal/submatrix.m2
@@ -22,6 +22,11 @@ assert(m^{1} == map(R^1, N++R^1, {{c, d}}))
 assert(m_{0} == map(N++R^1, N, {{a}, {c}}))
 assert(m_{1} == map(N++R^1, R^1, {{b}, {d}}))
 
+R = QQ[a..d];
+M = image vars R ++ coker vars R
+assert(M^{2} == map(R^{-1}, M, {{0, 0, 1, 0, 0}}))
+assert(M_{2} == map(M, R^{-1}, {{0}, {0}, {1}, {0}, {0}}))
+
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test submatrix.out"

--- a/M2/Macaulay2/tests/normal/submatrix.m2
+++ b/M2/Macaulay2/tests/normal/submatrix.m2
@@ -8,6 +8,12 @@ assert(rank source B == 1)
 assert(rank target B == 6)
 assert(B == B0)
 
+-- c.f. https://groups.google.com/g/macaulay2/c/P7t43OPwO0E/m/TStzslnIAAAJ
+S = ZZ/101[a,b,c,d]
+M = matrix"a,b;c,d"
+assert(M_{0,1,0,1} == M | M) -- produces the matrix with two columns equal to the first column of M, as it should
+assert(M^{0,1,0,1} == M || M) -- produces a matrix with a row of zeros followed by the first row of M -- wrong!
+
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test submatrix.out"


### PR DESCRIPTION
Reported by @eisenbud:
- fixed bug in submatrix with repeated rows

Also fixes a similar issue involving the source and target of the submatrix when the matrix is not a map of free modules:
- fixed bug in submatrix with non-free sources and targets
- fixed Module^List for new submatrix
- fixed and moved a submatrix test
- simplified submatrix' and updated docs
