### PR TITLE
Add integer argument to "tests" for specifying particular test

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -94,6 +94,7 @@ tests Package := pkg -> (
     previousMethodsFound = new HashTable from pkg#"test inputs"
     )
 tests String := pkg -> tests needsPackage(pkg, LoadDocumentation => true)
+tests(ZZ, Package) := tests(ZZ, String) := (i, pkg) -> (tests pkg)#i
 
 check = method(Options => {UserMode => null, Verbose => false})
 check String  :=

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/tests-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/tests-doc.m2
@@ -3,6 +3,8 @@ doc ///
     tests
     (tests, Package)
     (tests, String)
+    (tests, ZZ, Package)
+    (tests, ZZ, String)
     TestInput
     (code, TestInput)
     (locate, TestInput)
@@ -10,11 +12,12 @@ doc ///
     locate a package's tests
   Usage
     tests pkg
+    tests(i, pkg)
   Inputs
-    pkg:Package
-      or @ofClass String@
+    i:ZZ
+    pkg:{Package, String}
   Outputs
-    :HashTable
+    :{HashTable, TestInput}
   Description
     Text
       Returns @ofClass HashTable@ containing the tests for the given
@@ -25,7 +28,11 @@ doc ///
       source code of the test when using Emacs.
     Example
       tests "FirstPackage"
-      t = oo#0
+    Text
+      If the test number is also provided, then the corresponding
+      @TT "TestInput"@ object is returned.
+    Example
+      t = tests(0, "FirstPackage")
     Text
       The @TO locate@ and @TO code@ functions do the expected thing
       when given a @TT "TestInput"@ object.

--- a/M2/Macaulay2/tests/normal/testing.m2
+++ b/M2/Macaulay2/tests/normal/testing.m2
@@ -5,7 +5,7 @@ TEST "assert Equation(1 + 1, 2)"
 /// << close
 loadPackage("TestPackage", FileName => testpkg)
 check "TestPackage"
-pkgtest = (tests "TestPackage")#0
+pkgtest = tests(0, "TestPackage")
 assert instance(pkgtest, TestInput)
 assert Equation(locate pkgtest, (testpkg, 3, 1, 4, 1,,))
 assert Equation(toString pkgtest, testpkg | ":3:1-4:1:")


### PR DESCRIPTION
Thanks @mahrud for the suggestion!

For example:

```m2
i1 : tests(3, "Probability")

o1 = 
     ../src/macaulay2/M2/M2/Macaulay2/packages/Probability.m2:1267:1-1283:1:

o1 : TestInput
```
Previously, we would have needed to use `(tests "Probability")#3`, but that's pretty awkward.