### PR TITLE
Use FilePosition for test errors

### DIFF
--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -137,11 +137,11 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
 	  );
      if debugLevel == 0 then stderr << endl;
      stderr << cmd << endl;
-     stderr << tmpf << ":0:1: (output file) error: Macaulay2 " << describeReturnCode r << endl;
+     stderr << (new FilePosition from (tmpf, 0, 1)) << ":(" << loadDepth << "):[" << recursionDepth() << "]: (output file) error: Macaulay2 " << describeReturnCode r << endl;
      stderr << aftermatch(M2errorRegexp,get tmpf);
-     stderr << inf  << ":0:1: (input file)" << endl;
-     scan(statusLines get inf, x -> stderr << x << endl);
      infcontents := get inf;
+     stderr << (new FilePosition from (inf, 0, 1)) << ": (input file)" << endl;
+     scan(statusLines infcontents, x -> stderr << x << endl);
      m := regex("^--([^\n]+): location of test code", infcontents);
      if m =!= null then stderr << (
 	 substring(m#1, infcontents)) << ": (location of test code)" << endl;

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -141,6 +141,10 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
      stderr << aftermatch(M2errorRegexp,get tmpf);
      stderr << inf  << ":0:1: (input file)" << endl;
      scan(statusLines get inf, x -> stderr << x << endl);
+     infcontents := get inf;
+     m := regex("^--([^\n]+): location of test code", infcontents);
+     if m =!= null then stderr << (
+	 substring(m#1, infcontents)) << ": (location of test code)" << endl;
      if # findFiles rundir == 1
      then removeDirectory rundir
      else stderr << rundir << ": error: files remain in temporary run directory after program exits abnormally" << endl;

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -7,7 +7,8 @@ needs "run.m2"
 -----------------------------------------------------------------------------
 
 sourceFileStamp = (filename, linenum) -> concatenate(
-    "--", toAbsolutePath filename, ":", toString linenum, ": location of test code")
+    pos := new FilePosition from (toAbsolutePath filename, linenum, 1);
+    concatenate("--", toString pos, ": location of test code"));
 
 -----------------------------------------------------------------------------
 -- TestInput

--- a/M2/Macaulay2/tests/normal/testing.m2
+++ b/M2/Macaulay2/tests/normal/testing.m2
@@ -11,7 +11,7 @@ assert Equation(locate pkgtest, (testpkg, 3, 1, 4, 1,,))
 assert Equation(toString pkgtest, testpkg | ":3:1-4:1:")
 assert Equation(net pkgtest, (testpkg | ":3:1-4:1:")^-1)
 expectedCode =  "--" | toAbsolutePath testpkg |
-	":4: location of test code" | newline | "assert Equation(1 + 1, 2)"
+	":4:1: location of test code" | newline | "assert Equation(1 + 1, 2)"
 assert Equation(code pkgtest, expectedCode)
 assert Equation(code 0, expectedCode)
 


### PR DESCRIPTION
@mahrud -- I'm not sure if this fully addresses #2773, but it's a start.

The source file stamp at the top of test input files now includes the column number.  (Although, since you'd generally view these in `M2-mode` and not `M2-comint-mode`, jumping to source in Emacs wouldn't work.)

```m2
--/home/profzoom/tmp/Foo.m2:13:1: location of test code
1/0
```
The original test location is now included in the error message for easy jumping to source in Emacs:

```m2
i1 : check loadPackage("Foo", FileName => "~/tmp/Foo.m2")
 -- capturing check(0, "Foo")                                                -- capture failed; retrying ...
 -- running   check(0, "Foo")                                               
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-3312901-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --no-randomize --no-readline --silent --stop --print-width 77 --srcdir "/home/profzoom/src/macaulay2/M2/M2" -e 'needsPackage("Foo",Reload=>true,FileName=>"/home/profzoom/tmp/Foo.m2")' <"/tmp/M2-3312901-0/0.m2" >>"/tmp/M2-3312901-0/0.tmp" 2>&1
/tmp/M2-3312901-0/0.tmp:0:1:(3):[9]: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-3312901-0/0.m2:0:1: (input file)
/home/profzoom/tmp/Foo.m2:13:1: (location of test code)
M2: *** Error 1
 -- 0.8866 seconds elapsed
stdio:1:1:(3): error: test(s) #0 of package Foo failed.
```
Note the `(3):[9]` in the output file message -- this is so that Emacs would mark this line as an error if https://github.com/Macaulay2/M2-emacs/pull/39 is merged.