### PR TITLE
Use source directory for startup.m2.in path (autotools)

### DIFF
--- a/M2/Macaulay2/d/Makefile.in
+++ b/M2/Macaulay2/d/Makefile.in
@@ -219,7 +219,7 @@ startup.c: startup-header.h ../m2/startup.m2 @srcdir@/../m2/basictests/*.m2 Make
 	@(\
 	 cat @srcdir@/startup-header.h; \
 	 echo 'cached_file startupFile = {' ; \
-	     echo Macaulay2/Core/startup.m2.in | sed $(BSTRING) ; \
+	     echo @abs_top_srcdir@/Macaulay2/m2/startup.m2.in | sed $(BSTRING) ; \
 	     echo  ',' ; \
 	     cat ../m2/startup.m2 | sed $(SSTRING) ; \
 	 echo  '};' ; \


### PR DESCRIPTION
This makes the autotools build more consistent with the cmake build.

### Before
```m2
profzoom@peg-amy:~/src/macaulay2/M2/M2/BUILD/doug$ M2 --check 4
Macaulay2/Core/startup.m2.in:563:33:(0):[1]: --check 4: expected 1, 2, or 3
```
The file `Macaulay2/Core/startup.m2.in` does not exist.

### After
```m2
profzoom@peg-amy:~/src/macaulay2/M2/M2/BUILD/doug$ usr-dist/x86_64-Linux-Ubuntu-22.04/bin/M2 --check 4
../../Macaulay2/m2/startup.m2.in:562:33:(0):[1]: --check 4: expected 1, 2, or 3
```
This is the correct path to the source file, so that, for instance, jumping to source in Emacs works nicely.  This is also identical to the current cmake behavior.

This addresses half of #2780.

One downside of this change is that the build would not be reproducible since the source directory would be hardcoded into `M2-binary`.  (I'm planning on patching this to point instead to `/usr/share/Macaulay2/Core/startup.m2` in the Debian package.)