### PR TITLE
fix #2713 and assorted alphanum clarifications

### DIFF
--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1503,6 +1503,7 @@ getglobalsym(d:Dictionary,s:string):Expr := (
      w := makeUniqueWord(s,parseWORD);
      when lookup(w,d.symboltable) is x:Symbol do Expr(SymbolClosure(globalFrame,x))
      is null do (
+          if !isvalidsymbol(s) then return buildErrorPacket("invalid symbol");
 	  if d.Protected then return buildErrorPacket("attempted to create symbol in protected dictionary");
 	  t := makeSymbol(w,dummyPosition,d);
 	  globalFrame.values.(t.frameindex)));

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -124,7 +124,7 @@ export makeEntry(word:Word,position:Position,dictionary:Dictionary):Symbol := (
      makeEntry(word,position,dictionary,false,false));
 export makeSymbol(word:Word,position:Position,dictionary:Dictionary,thread:bool,locallyCreated:bool):Symbol := (
      entry := makeEntry(word,position,dictionary,thread,locallyCreated);
-     if dictionary.frameID == 0 && isalnum(word.name) && !thread
+     if dictionary.frameID == 0 && isvalidsymbol(word.name) && !thread
      then globalFrame.values.(entry.frameindex) = Expr(SymbolClosure(globalFrame,entry));
      entry);
 export makeSymbol(word:Word,position:Position,dictionary:Dictionary,thread:bool):Symbol := (

--- a/M2/Macaulay2/d/ctype.d
+++ b/M2/Macaulay2/d/ctype.d
@@ -9,12 +9,12 @@ WHITE := 8;
 NEWLINE := 16;
 QUOTE := 32;
 CTRL := 64;
-DOLLAR := 128;
+ALNUMEXTRA := 128;
 HEX := 256;
 BINARY := 512;
 SPACE := WHITE | NEWLINE;
 ALPHA := UPPER | LOWER;
-ALNUM := ALPHA | DIGIT | DOLLAR;
+ALNUM := ALPHA | DIGIT | ALNUMEXTRA;
 
 foreach c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"  do setchartype(c,UPPER);
 foreach c in "abcdefghijklmnopqrstuvwxyz"  do setchartype(c,LOWER);
@@ -23,11 +23,10 @@ foreach c in "0123456789abcdefABCDEF"      do setchartype(c,HEX);
 foreach c in "01"                          do setchartype(c,BINARY);
 foreach c in " \t\r"	                   do setchartype(c,WHITE);
 foreach c in "\n"                          do setchartype(c,NEWLINE);
-foreach c in "$"                           do setchartype(c,DOLLAR);
+foreach c in "$'"                          do setchartype(c,ALNUMEXTRA);
 
-for c from 128 to 225	       	    	   do setchartype(char(c),ALPHA);  -- 226 is unicode math symbol
+for c from 128 to 225	       	    	   do setchartype(char(c),ALPHA);  -- 226 is unicode math symbols
 for c from 227 to 255	       	    	   do setchartype(char(c),ALPHA);
-					      setchartype('\'',ALPHA);
 					      setchartype('\"',QUOTE);
 
 chartype(c:int):int := if (c & ~255) == 0 then int(chartypes.c) else 0;
@@ -53,8 +52,9 @@ export isspace    (c:char):bool := (chartype(c) & SPACE    ) != 0;
 export isnewline  (c:char):bool := (chartype(c) & NEWLINE  ) != 0;
 export isquote    (c:char):bool := (chartype(c) & QUOTE    ) != 0;
 
-export isalnum  (s:string):bool := (
-     if int(uchar(s.0)) == 226 && length(s) == 3 then return true; -- unicode math symbol
+export isvalidsymbol  (s:string):bool := (
+     if int(uchar(s.0)) == 226 && length(s) == 3 then return true; -- ugly unicode math symbol hack
+     if !isalpha(s.0) then return false;
      foreach c in s do if !isalnum(c) then return false;
      true);
 

--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -307,7 +307,7 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 	       return Token(
 		    if file.file.fulllines then wordEOC else NewlineW,
 		    file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline))
-	  else if isalpha(ch) && ch != int('\'') then (
+	  else if isalpha(ch) then ( -- valid symbols are an alpha (letters, any unicode except 226) followed by any number of alphanum (alpha, digit, dollar, prime)
 	       tokenbuf << char(getc(file));
 	       while isalnum(peek(file)) do tokenbuf << char(getc(file));
 	       return Token(makeUniqueWord(takestring(tokenbuf),parseWORD),file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline))
@@ -398,7 +398,7 @@ gettoken1(file:PosFile,sawNewline:bool):Token := (
 		    return errorToken
 		    )
 	       is word:Word do return Token(word,file.filename, line, column, loadDepth,globalDictionary,dummySymbol,sawNewline))
-	  else if ch == 226 then (
+	  else if ch == 226 then ( -- unicode math symbols
 	       tokenbuf << char(getc(file));
 	       tokenbuf << char(getc(file));
 	       tokenbuf << char(getc(file));

--- a/M2/Macaulay2/d/nets.d
+++ b/M2/Macaulay2/d/nets.d
@@ -210,7 +210,7 @@ splitcolumn(i:int, t:array(array(string))):bool := (			    -- whether we can spl
      if i <= 0 then return false;			    -- shouldn't happen!
      foreach s in t do if length(s) > i && (
           x := s.(i-1);	    	     y := s.i;
-	  a := isalnum(x);           b := isalnum(y);
+	  a := isalnum(x.0);           b := isalnum(y.0);
 	  a && b
 	  ||
 	  (!a && x.0 != ' ') && (!b && y.0 != ' ')		    -- not between two punctuation characters


### PR DESCRIPTION
cf discussion in #2713. I've preserved the status quo as in #2463: symbols are either
- single mathematical characters like ⊗
- or multiple alphanumeric characters (which means, alpha, num, $, ', or any unicode except mathematical characters) starting with an alpha character.
This is now checked when using `getSymbol`. I've added a few comments in the code and renamed a function whose name was misleading.