### PR TITLE
Use CSS counters instead of OL "start" element for zero-based numbering

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -96,7 +96,15 @@ html Hypertext := x -> (
     attr := "";
     cont := if T.?Options then (
 	(op, ct) := override(options T, toSequence x);
-	scanPairs(op, (key, val) -> if val =!= null then attr = " " | key | "=" | format val | attr);
+	scanPairs(op, (key, val) -> (
+		-- workaround for "start" attribute not being valid XHTML 1.1
+		if T === OL and key == "start"
+		then (
+		    element := toString(changeBase(val, 10) - 1);
+		    attr = concatenate(" style=\"counter-reset: element ",
+			element, ";\"", attr))
+		else if val =!= null
+		then attr = " " | key | "=" | format val | attr));
 	sequence ct) else x;
     pushIndentLevel 1;
     (head, prefix, suffix, tail) := (

--- a/M2/Macaulay2/packages/Style/doc.css
+++ b/M2/Macaulay2/packages/Style/doc.css
@@ -78,6 +78,14 @@ dl.element {
   margin: 0px;
 }
 
+ol li::marker {
+  content: counter(element) ". ";
+}
+
+ol li {
+  counter-increment: element;
+}
+
 /*
 
  Local Variables:


### PR DESCRIPTION
A small change from #2760 adding `start=0` to each `<ol>` tag for zero-based numbering of ordered lists is causing `make validate-html` to fail due to 3 html documentation pages with `<ol>` tags. From a [recent PPA build](https://launchpadlibrarian.net/655577774/buildlog_ubuntu-jammy-amd64.macaulay2_1.20.0.1+git202303111459-0ppa202302030934~ubuntu22.04.1_BUILDING.txt.gz):

```
 *** invalid HTML: /<<PKGBUILDDIR>>/M2/usr-dist/common/share/doc/Macaulay2/Macaulay2Doc/html/_writing_spdocumentation.html
error: line 72: there is no attribute "start"
...
*** invalid HTML: /<<PKGBUILDDIR>>/M2/usr-dist/common/share/doc/Macaulay2/Macaulay2Doc/html/_document.html
error: line 109: there is no attribute "start"
...
*** invalid HTML: /<<PKGBUILDDIR>>/M2/usr-dist/common/share/doc/Macaulay2/Text/html/___O__L.html
error: line 74: there is no attribute "start"
```
An alternate solution is to use CSS counters to achieve the same result but still have valid XHTML code.

Cc: @pzinn 