### PR TITLE
Autotools updates for editors directory for in-tree builds

### DIFF
--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -33,10 +33,22 @@ prism/%: @srcdir@/prism/% prism
 
 highlightjs/%: @srcdir@/highlightjs/% highlightjs
 	cp $< $@
+
+clean:
+	rm -rf @pre_emacsdir@/* atom emacs highlightjs prism pygments vim
+
+else
+clean:
+	rm -rf @pre_emacsdir@/* $(addprefix emacs/, $(MADEFILES)) \
+		atom/macaulay2.cson pygments/macaulay2.py         \
+		$(PRISM_MADEFILES) $(HIGHLIGHTJS_MADEFILES)
 endif
 
 %/node_modules: %/package.json
 	cd $* && npm install
+
+PRISM_MADEFILES = $(addprefix prism/, node_modules package-lock.json \
+	prism.js prism.js.LICENSE.txt macaulay2.js)
 
 prism/prism.js: prism/macaulay2.js        \
 	prism/package.json      \
@@ -45,6 +57,9 @@ prism/prism.js: prism/macaulay2.js        \
 	prism/index.js          \
 	prism/prism-M2.css
 	cd $(@D) && npm run build
+
+HIGHLIGHTJS_MADEFILES = $(addprefix highlightjs/, node_modules \
+	package-lock.json highlight.js macaulay2.js)
 
 highlightjs/highlight.js: highlightjs/macaulay2.js \
 	highlightjs/package.json      \
@@ -62,7 +77,6 @@ update-syntax-highlighting: prism/prism.js
 
 .PHONY: update-syntax-highlighting
 
-clean::; rm -rf @pre_emacsdir@/* atom emacs highlightjs prism pygments vim
 distclean:: clean; rm -f Makefile
 
 # Local Variables:

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -20,6 +20,8 @@ emacs/M2-symbols.el prism/macaulay2.js highlightjs/macaulay2.js: \
 emacs/M2-emacs.m2 emacs/M2-emacs-help.txt: emacs/make-M2-emacs-help.m2 @pre_exec_prefix@/bin/M2@EXE@ @pre_exec_prefix@/bin/M2
 	cd emacs; @pre_exec_prefix@/bin/M2 $(ARGS) @abs_srcdir@/emacs/make-M2-emacs-help.m2 -e 'exit 0'
 
+# copy files to build directory for out-of-tree builds
+ifneq (@srcdir@,.)
 emacs prism highlightjs:
 	$(MKDIR_P) $@
 
@@ -31,6 +33,7 @@ prism/%: @srcdir@/prism/% prism
 
 highlightjs/%: @srcdir@/highlightjs/% highlightjs
 	cp $< $@
+endif
 
 %/node_modules: %/package.json
 	cd $* && npm install


### PR DESCRIPTION
I introduced a bug in #2790 for in-tree builds -- see https://github.com/Macaulay2/M2/pull/2790#issuecomment-1467132048.

This PR fixes it and also an issue I noticed in the process where `make -C Macaulay2/editors clean` was deleting a bunch of source files that are under version control.