### PR TITLE
Bump "checkout" GitHub action to v3

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -62,7 +62,7 @@ jobs:
       VERBOSE: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
 # ----------------------
 #   Install missing tools and libraries for macOS

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -112,7 +112,7 @@ jobs:
           # Necessary for clang to find the right libomp
           echo "LIBRARY_PATH=`llvm-config --libdir`" >> $GITHUB_ENV
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         if: matrix.build-system == 'cmake'
         id: restore-cache
         with:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
            name: ${{ matrix.build-system }}-${{ matrix.os }}-${{ matrix.compiler }}-logs
            path: |
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload Macaulay2 package for Ubuntu (x86_64)
         if: matrix.build-system == 'cmake' && runner.os == 'Linux' && matrix.compiler == 'clang-14' && success()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Macaulay2-${{ env.GIT_COMMIT }}-ubuntu-x86_64
           path: |


### PR DESCRIPTION
This should fix the "Node.js 12 actions are deprecated" warnings we get for all the GitHub builds.