### PR TITLE
Add support for 0th powers of ring maps

### DIFF
--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -510,7 +510,7 @@ BinaryPowerMethod(x:Expr,y:Expr):Expr := (
 	       if onex == nullE then (
 		    return buildErrorPacket("missing unit element")
 		    )
-	       else return onex;
+	       else return applyEE(onex, x);
 	       );
 	  if i < 0 then (
 	       i = -i;
@@ -550,7 +550,7 @@ SimplePowerMethod(x:Expr,y:Expr):Expr := (
 	       onex := lookup(Class(x),oneE);
 	       if onex == nullE
 	       then return buildErrorPacket("missing unit element")
-	       else return onex;
+	       else return applyEE(onex, x);
 	       );
 	  if i <= 0 then (
 	       i = -i;

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -190,9 +190,8 @@ Matrix * Matrix := Matrix => (m,n) -> (
 	  then map(M,N,n.RingMap,f)
 	  else map(M,N,f)))
 
-Matrix ^ ZZ := Matrix => (f,n) -> (
-     if n === 0 then id_(target f)
-     else SimplePowerMethod (f,n))
+Matrix#1 = f -> id_(target f)
+Matrix ^ ZZ := Matrix => BinaryPowerMethod
 
 transpose Matrix := Matrix => (cacheValue symbol transpose) (
      (m) -> (

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -190,7 +190,9 @@ Matrix * Matrix := Matrix => (m,n) -> (
 	  then map(M,N,n.RingMap,f)
 	  else map(M,N,f)))
 
-Matrix#1 = f -> id_(target f)
+Matrix#1 = f -> (
+    if source f =!= target f then error "expected source and target to agree"
+    else id_(target f))
 Matrix ^ ZZ := Matrix => BinaryPowerMethod
 
 transpose Matrix := Matrix => (cacheValue symbol transpose) (

--- a/M2/Macaulay2/m2/monideal.m2
+++ b/M2/Macaulay2/m2/monideal.m2
@@ -49,10 +49,10 @@ addHook((codim, Module), Strategy => Default, (opts, M) -> (
 	  c - codim monomialIdealOfRow(0,matrix{{0_R}}) -- same as c - codim R, except works for iterated rings
 	  )))
 
+MonomialIdeal#1 = I -> monomialIdeal 1_(ring I)
 MonomialIdeal ^ ZZ := MonomialIdeal => (I,n) -> (
      if n < 0 then error "expected nonnegative exponent"
-     else if n === 0 then monomialIdeal 1_(ring I)
-     else SimplePowerMethod(I,n)
+     else BinaryPowerMethod(I,n)
      )
 
 MonomialIdeal ^ Array := (I, e) -> (

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -209,7 +209,6 @@ new CC from RawRingElement := (CCC,x) -> ( assert( CCC === CC ); rawToCC x)
 -- arithmetic operations
 
 CC.InverseMethod = y -> conjugate y / y^2
-CC ^ ZZ := BinaryPowerMethod
 
 scan((QQ,RR,CC), F -> (
 	  F // F := (x,y) -> if y == 0 then 0_F else x/y;

--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -384,6 +384,9 @@ RingMap * RingMap := RingMap => (g,f) -> (
 	  }
      )
 
+RingMap#1 = f -> (
+    if source f =!= target f then error "expected source and target to agree"
+    else id_(target f))
 RingMap ^ ZZ := BinaryPowerMethod
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -529,7 +529,7 @@ undocumented {
      }
 
 document {
-     Key => {symbol ^, (symbol ^,CC,ZZ)},
+     Key => {symbol ^},
      Headline => "a binary operator, usually used for powers",
      Usage => "x ^ y",
      PARA{},

--- a/M2/Macaulay2/tests/normal/000-core.m2
+++ b/M2/Macaulay2/tests/normal/000-core.m2
@@ -581,7 +581,6 @@ R=ZZ/101[a,b]
 f=matrix(R,{{1,a},{0,1}})
 g=matrix(R,{{1,0},{b,1}})
 h=f*g*f*g
-assert( h^3 * h^-1 == h^2 * h^0 )
 assert( h * h^-1 == 1 )
 
 
@@ -591,9 +590,6 @@ f = matrix {{a}}
 assert( source f != target f)
 assert( target f == target f^2 )
 assert( source f == source f^2 )
-assert( target f == target f^0 )
-assert( source f != source f^0 )
-
 
 --
 R = ZZ/101[a..d]

--- a/M2/Macaulay2/tests/normal/hashtables.m2
+++ b/M2/Macaulay2/tests/normal/hashtables.m2
@@ -1,13 +1,15 @@
+importFrom_Core {"BinaryPowerMethod"}
 plus' = (x,y) -> ( z := x+y ; if z == 0 then continue ; z )
 Poly = new Type of HashTable
 assert( (one = new Poly from {1 => 1}) === new Poly from {1 => 1} )
+Poly#1 = x -> one
 assert( (T = new Poly from {2 => 1}) === new Poly from {2 => 1} )
 - Poly := (f) -> applyValues(f,minus);
 Poly + Poly := (f,g) -> merge(f,g,plus');
 Poly - Poly := (f,g) -> f + -g;
 Poly * Poly := (f,g) -> combine(f,g,times,times,plus');
-Poly ^ ZZ := lookup(symbol ^,CC,ZZ)
-assert( (f = one+T+T^2+T^3+T^4+T^5) === new Poly from {32 => 1, 16 => 1, 8 => 1, 1 => 1, 2 => 1, 4 => 1} )
+Poly ^ ZZ := BinaryPowerMethod
+assert( (f = T^0+T^1+T^2+T^3+T^4+T^5) === new Poly from {32 => 1, 16 => 1, 8 => 1, 1 => 1, 2 => 1, 4 => 1} )
 assert( ((T-one)*f) === new Poly from {64 => 1, 1 => -1} )
 assert( (f - (T^3 + T^5)) === new Poly from {16 => 1, 1 => 1, 2 => 1, 4 => 1} )
 assert( (tally {1,1,1,2,4} - tally {1,2}) === new Tally from {4 => 1, 1 => 2} )
@@ -23,32 +25,6 @@ assert( (r + new VirtualTally from tally {1,1,4}) === new VirtualTally from {4 =
 assert( class(tally{1,2,3}+set{3,4,5}) === Tally )
 assert( mutable( merge(new Type of List, new Type of Ring, first) ) )
 assert( class((new VirtualTally from {1 => -1, 2 => -2, 3 => -3}) + tally {1,2,3}) === VirtualTally )
-
-end
-
-print generateAssertions ///
-plus' = (x,y) -> ( z := x+y ; if z == 0 then continue ; z )
-Poly = new Type of HashTable
-one = new Poly from {1 => 1}
-T = new Poly from {2 => 1}
-- Poly := (f) -> applyValues(f,minus);
-Poly + Poly := (f,g) -> merge(f,g,plus');
-Poly - Poly := (f,g) -> f + -g;
-Poly * Poly := (f,g) -> combine(f,g,times,times,plus');
-Poly ^ ZZ := lookup(symbol ^,CC,ZZ)
-f = one+T+T^2+T^3+T^4+T^5
-(T-one)*f
-f - (T^3 + T^5)
-tally {1,1,1,2,4} - tally {1,2}
-tally {1,1,1,2,4} ? tally {1,2}
-tally {1,2} ? tally {1,1,1,2,4}
-tally {1,1,1,2,4,10} ? tally {1,2,11}
-tally {1,2,10} ? tally {1,1,1,2,4,11}
-tally {1,1,1,2,4} ? tally {1,1,1,2,4}
- - (new VirtualTally from tally {1,2,3,4})
-r = (new VirtualTally from tally {1,1,1,2,4}) - (new VirtualTally from tally {1,2,3,4})
-r + new VirtualTally from tally {1,1,4}
-///
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test hashtables.out"

--- a/M2/Macaulay2/tests/normal/ringmap4.m2
+++ b/M2/Macaulay2/tests/normal/ringmap4.m2
@@ -65,6 +65,9 @@ x' = promote(A_0,B)
 assert( x != x' )
 assert( f x == x^2 )
 assert( f x' == x' )
+assert( f^0 === id_B )
+assert( f^1 === f )
+assert( f^2 === map(B, B, {x^4}) )
 
 C = ZZ[x][y]
 g = map(ZZ,C,{2})


### PR DESCRIPTION
This fixes #2792:

```m2
i1 : R = ZZ[x, y, z];

i2 : f = map(R, R, {y, x*z, x^2 + 1});

o2 : RingMap R <--- R

i3 : f^0

o3 = map (R, R, {x, y, z})

o3 : RingMap R <--- R
```