### PR TITLE
Add support for concatenating matrices w/ numbers (not just ZZ)

### DIFF
--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -384,15 +384,15 @@ concatRows = mats -> (
 Matrix | Matrix := Matrix => (f,g) -> concatCols(f,g)
 RingElement | Matrix := (f,g) -> concatCols(f**id_(target g),g)
 Matrix | RingElement := (f,g) -> concatCols(f,g**id_(target f))
-ZZ | Matrix := (f,g) -> concatCols(f*id_(target g),g)
-Matrix | ZZ := (f,g) -> concatCols(f,g*id_(target f))
+Number | Matrix := (f,g) -> concatCols(f*id_(target g),g)
+Matrix | Number := (f,g) -> concatCols(f,g*id_(target f))
 
 Matrix || Matrix := Matrix => (f,g) -> concatRows(f,g)
 RingElement || Matrix := (f,g) -> concatRows(f**id_(source g),g)
      -- we would prefer for f**id_(source g) to have the exact same source as g does
 Matrix || RingElement := (f,g) -> concatRows(f,g**id_(source f))
-ZZ || Matrix := (f,g) -> concatRows(f*id_(source g),g)
-Matrix || ZZ := (f,g) -> concatRows(f,g*id_(source f))
+Number || Matrix := (f,g) -> concatRows(f*id_(source g),g)
+Matrix || Number := (f,g) -> concatRows(f,g*id_(source f))
 
 -----------------------------------------------------------------------------
 -- submatrix, submatrixByDegrees

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -644,8 +644,8 @@ document {
 	  (symbol |, RingElement, Matrix),
 	  (symbol |, Matrix, RingElement),
 	  (symbol |, RingElement, RingElement),
-	  (symbol |, ZZ, Matrix),
-	  (symbol |, Matrix, ZZ)
+	  (symbol |, Number, Matrix),
+	  (symbol |, Matrix, Number)
 	  },
      Headline => "join matrices horizontally",
 	Usage => "f = g | h",
@@ -664,7 +664,7 @@ document {
       	  h = matrix {{m,n},{o,p}}
       	  f= g | h
 	  ///,
-     "If one of the arguments is a ring element or an integer, then it
+     "If one of the arguments is a ring element or a number, then it
      will be multiplied by a suitable identity matrix.",
 	EXAMPLE "f | (m-n)",
 	Caveat => {"It is assumed that the matrices ", TT "g", " and ", TT "h", " have the same ", TO Ring, "."},
@@ -697,8 +697,8 @@ document {
 	  (symbol ||, RingElement, Matrix),
 	  (symbol ||, Matrix, RingElement),
 	  (symbol ||, RingElement, RingElement),
-	  (symbol ||, Matrix, ZZ),
-	  (symbol ||, ZZ, Matrix)
+	  (symbol ||, Matrix, Number),
+	  (symbol ||, Number, Matrix)
 	  },
      Headline => "join matrices vertically",
 	Usage => "f = g || h",
@@ -717,7 +717,7 @@ document {
       	  h = matrix {{m,n},{o,p}}
       	  f= g || h
 	  ///,
-     "If one of the arguments is a ring element or an integer, then it
+     "If one of the arguments is a ring element or a number, then it
      will be multiplied by a suitable identity matrix.",
 	EXAMPLE "f || 33",
 	Caveat => {"It is assumed that the matrices ", TT "g", " and ", TT "h", " have the same ", TO Ring, "."},

--- a/M2/Macaulay2/tests/normal/matrix.m2
+++ b/M2/Macaulay2/tests/normal/matrix.m2
@@ -333,6 +333,30 @@ g = map(M,M, { (0,0) => x^2 } )
 assert (g == 0)
 assert isWellDefined g
 
+-- concatenation w/ ring elements
+A = matrix {{1, 2}, {2, 3}}
+assert Equation(A | 5, matrix {{1, 2, 5, 0}, {2, 3, 0, 5}})
+assert Equation(A | 1/2, matrix {{1, 2, 1/2, 0}, {2, 3, 0, 1/2}})
+assert Equation(A | 1.5, matrix {{1, 2, 1.5, 0}, {2, 3, 0, 1.5}})
+assert Equation(A | 1 + ii, matrix {{1, 2, 1 + ii, 0}, {2, 3, 0, 1 + ii}})
+assert Equation(A | x, matrix {{1, 2, x, 0}, {2, 3, 0, x}})
+assert Equation(5 | A, matrix {{5, 0, 1, 2}, {0, 5, 2, 3}})
+assert Equation(1/2 | A, matrix {{1/2, 0, 1, 2}, {0, 1/2, 2, 3}})
+assert Equation(1.5 | A, matrix {{1.5, 0, 1, 2}, {0, 1.5, 2, 3}})
+assert Equation(1 + ii | A, matrix {{1 + ii, 0, 1, 2}, {0, 1 + ii, 2, 3}})
+assert Equation(x | A, matrix {{x, 0, 1, 2}, {0, x, 2, 3}})
+assert Equation(A || 5, matrix {{1, 2}, {2, 3}, {5, 0}, {0, 5}})
+assert Equation(A || 1/2, matrix {{1, 2}, {2, 3}, {1/2, 0}, {0, 1/2}})
+assert Equation(A || 1.5, matrix {{1, 2}, {2, 3}, {1.5, 0}, {0, 1.5}})
+assert Equation(A || 1 + ii, matrix {{1, 2}, {2, 3}, {1 + ii, 0}, {0, 1 + ii}})
+assert Equation(A || x, map(R^4, R^2, matrix {{1, 2}, {2, 3}, {x, 0}, {0, x}}))
+assert Equation(5 || A, matrix {{5, 0}, {0, 5}, {1, 2}, {2, 3}})
+assert Equation(1/2 || A, matrix {{1/2, 0}, {0, 1/2}, {1, 2}, {2, 3}})
+assert Equation(1.5 || A, matrix {{1.5, 0}, {0, 1.5}, {1, 2}, {2, 3}})
+assert Equation(1 + ii || A, matrix {{1 + ii, 0}, {0, 1 + ii}, {1, 2}, {2, 3}})
+assert Equation(x || A, map(R^4, R^{{-1}, {-1}},
+	matrix {{x, 0}, {0, x}, {1, 2}, {2, 3}}))
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test matrix.out"
 -- End:


### PR DESCRIPTION
### Before

```m2
i1 : A = matrix {{1, 2}, {3, 4}}

o1 = | 1 2 |
     | 3 4 |

              2        2
o1 : Matrix ZZ  <--- ZZ

i2 : A | 1/2
stdio:2:3:(3): error: no method for binary operator | applied to objects:
--            | 1 2 | (of class Matrix)
--            | 3 4 |
--            1
--      |     - (of class QQ)
--            2
```

### After
```m2
i1 : A = matrix {{1, 2}, {3, 4}}

o1 = | 1 2 |
     | 3 4 |

              2        2
o1 : Matrix ZZ  <--- ZZ

i2 : A | 1/2

o2 = | 1 2 1/2 0   |
     | 3 4 0   1/2 |

              2        4
o2 : Matrix QQ  <--- QQ
```

`RR` and `CC` are supported as well, as is `||`:

```m2
i3 : A | exp 1

o3 = | 1 2 2.71828 0       |
     | 3 4 0       2.71828 |

                2          4
o3 : Matrix RR    <--- RR
              53         53

i4 : A | (2 + 3*ii)

o4 = | 1 2 2+3ii 0     |
     | 3 4 0     2+3ii |

                2          4
o4 : Matrix CC    <--- CC
              53         53

i5 : A || 1/2

o5 = | 1   2   |
     | 3   4   |
     | 1/2 0   |
     | 0   1/2 |

              4        2
o5 : Matrix QQ  <--- QQ
```

Closes: #2801