### PR TITLE
[Polyhedra.m2] Fix lineality bug in affineImage

### DIFF
--- a/M2/Macaulay2/packages/Polyhedra/extended/affineImages.m2
+++ b/M2/Macaulay2/packages/Polyhedra/extended/affineImages.m2
@@ -19,7 +19,8 @@ affineImage(Matrix,Polyhedron,Matrix) := (A,P,v) -> (
    v = v * (matrix {toList((numColumns vertices P):1_QQ)});
    Mv := A*(vertices P) + v;
    Mr := A*(rays P);
-   convexHull(Mv,Mr)
+   Ml := A*(linealitySpace P);
+   convexHull(Mv, Mr, Ml)
 )
 
 

--- a/M2/Macaulay2/packages/Polyhedra/tests/extended/polyhedron.m2
+++ b/M2/Macaulay2/packages/Polyhedra/tests/extended/polyhedron.m2
@@ -16,3 +16,12 @@ A = transpose matrix{{0,0,0}, {1,0,0}, {0,1,0}, {1,1,3}}
 P = convexHull A
 assert not isVeryAmple P
 ///
+
+TEST ///
+raysP = transpose matrix {{1,0,0}}
+linealityP = transpose matrix {{0,1,0}}
+P = polyhedron coneFromVData(raysP, linealityP)
+A = matrix{{1,0,0},{0,1,0}}
+Q = affineImage(A,P)
+assert(linealitySpace Q == promote(transpose matrix {{0,1}}, QQ))
+///


### PR DESCRIPTION
`affineImage` does not treat lineality correctly, as reported by @dmaclagan :
```
needsPackage "Polyhedra"
raysP=transpose matrix {{1,0,0}}
linealityP = transpose matrix {{0,1,1}}
P=polyhedron coneFromVData(raysP,linealityP)

A=matrix{{1,0,0},{0,1,0}}

Q= affineImage(A,P)

linealitySpace Q
-- Should be span(0,1)
```