### PR TITLE
configure: Port numeric getaddrinfo check to C99

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1722,7 +1722,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([
     #ifdef HAVE_NETDB_H
      #include <netdb.h>
     #endif
-    main() { 
+    int main(void) {
        struct addrinfo *addr; 
        return 0 != getaddrinfo("1.2.3.4", "80", 0, &addr) ? 99 : 0 ;
        }


### PR DESCRIPTION
Avoid an implicit int, which was removed from the C99 revision of the C language.  This prevents altering the outcome of the check with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
