### PR TITLE
Remove Py_SetProgramName call (optional & deprecated in Python 3.11)

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -72,10 +72,6 @@ int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[]
   system_cpuTime_init();
 
 #ifdef WITH_PYTHON
-  wchar_t *program;
-
-  program = Py_DecodeLocale(argv[0], NULL);
-  Py_SetProgramName(program);
   Py_Initialize();
 #endif
 


### PR DESCRIPTION
Since Python 3.11, we get deprecation warnings:

```
main.cpp:78:20: warning: ‘void Py_SetProgramName(const wchar_t*)’ is deprecated [-Wdeprecated-declarations]
   78 |   Py_SetProgramName(program);
      |   ~~~~~~~~~~~~~~~~~^~~~~~~~~
In file included from /usr/include/python3.11/Python.h:94,
                 from types.h:168,
                 from main.cpp:9:
/usr/include/python3.11/pylifecycle.h:37:38: note: declared here
   37 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) Py_SetProgramName(const wchar_t *);
      |                                      ^~~~~~~~~~~~~~~~~
```

We'd previously been setting the program name to `argv[0]` (so probably something like `M2-binary`), but this doesn't seem to matter for anything.  By not calling this function, the default value (`python3`) is used instead.