### PR TITLE
Various output fixes, fix #2811

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -196,10 +196,11 @@ info UL := ULop info
 net  UL := ULop net
 
 OLop := op -> x -> (
+     (o, ct) := override(options class x, toSequence x);
+     shft := try value o#"start" else 1;
      s := "000. ";
      printWidth = printWidth - #s;
-     x = toList noopts x;
-     r := stack apply(#x, i -> pad(3,toString (i+1)) | ". " | op x#i); -- html starts counting from 1!
+     r := stack apply(#ct, i -> pad(3,toString (i+shft)) | ". " | op ct#i);
      printWidth = printWidth + #s;
      r)
 info OL := OLop info

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -84,7 +84,10 @@ popIndentLevel  = (n, s) -> (indentLevel = indentLevel - n; s)
 
 -- This method applies to all types that inherit from Hypertext
 -- Most MarkUpTypes automatically work recursively
-html1 := x -> (if class x === String then htmlLiteral else html) x -- slightly annoying workaround for the ambiguous role of strings in/out of Hypertext
+html1 = method(Dispatch=>Thing)
+html1 String := htmlLiteral -- slightly annoying workaround for the ambiguous role of strings in/out of Hypertext
+html1 Thing := html
+html1 Nothing := x -> ""
 
 scan(methods hypertext, (h,t) -> html t := html @@ hypertext)
 html Hypertext := x -> (
@@ -164,7 +167,7 @@ html TO2  := x -> (
 -- html'ing non Hypertext
 ----------------------------------------------------------------------------
 
-html Nothing := x -> ""
+html Nothing := x -> "null"
 
 html Monoid :=
 html RingFamily :=

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -82,7 +82,9 @@ RingElement * Matrix := (r,m) -> (
     if ring r =!= ring m then try r = promote(r,ring m) else m = promote(m,ring r);
      map(target m, source m, reduce(target m, raw r * raw m)))
 Matrix * Number :=
-Matrix * RingElement := (m,r) -> r*m
+Matrix * RingElement := (m,r) -> (
+    if ring r =!= ring m then try r = promote(r,ring m) else m = promote(m,ring r);
+     map(target m, source m, reduce(target m, raw m * raw r)))
 
 toSameRing = (m,n) -> (
      if ring m =!= ring n then (

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -110,6 +110,10 @@ numeric(ZZ,Vector) := (prec,v) -> (
      if F === ZZ or F === QQ then return promote(v,RR_prec);
      error "expected vector of numbers"
      )
+lift(Vector,InexactNumber) :=
+lift(Vector,InexactNumber') :=
+lift(Vector,RingElement) :=
+lift(Vector,Number) := Vector => o -> (v,S) -> vector (lift(v#0,S))
 
 - Vector := Vector => v -> new class v from {-v#0}
 Number * Vector := RingElement * Vector := Vector => (r,v) -> vector(r * v#0)
@@ -382,9 +386,9 @@ End = (M) -> Hom(M,M)
 Module#AfterPrint = M -> (
     ring M,"-module",
     if M.?generators then
-    if M.?relations then (", subquotient of ",ambient M)
+    if M.?relations then (", ",subquotient," of ",ambient M)
     else (", submodule of ",ambient M)
-    else if M.?relations then (", quotient of ",ambient M)
+    else if M.?relations then (", ",quotient," of ",ambient M)
     else if rank ambient M > 0 then
     (", free",
 	if not all(degrees M, d -> all(d, zero))

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -335,7 +335,7 @@ texMath  Monoid :=  texMath @@ expression
 Monoid#AfterPrint = M -> (
     class M,
     if not isFreeModule degreeGroup M
-    then ", with torsion degree group";
+    then ", with torsion degree group"
     -- TODO: print whether M is ordered, a free algebra, etc.
     )
 

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -74,6 +74,7 @@ get File := get String := String => get
 getc File := String => getc
 getenv String := String => getenv
 hashTable List := HashTable => hashTable
+hashTable(Function,List) := HashTable => hashTable
 typicalValues#horizontalJoin = Net
 horizontalJoin BasicList := Net => horizontalJoin
 unstack Net := List => unstack

--- a/M2/Macaulay2/m2/validate.m2
+++ b/M2/Macaulay2/m2/validate.m2
@@ -28,7 +28,7 @@ noqname := (tag, x) -> (
 -- see content.m2
 chk := (p, x) -> (
     c := class x;
-    if c === Option or c === LITERAL then return;
+    if c === Option or c === OptionTable or c === LITERAL then return;
     if not c.?qname then return noqname(c, x);
     if not validContent#(p.qname)#?(c.qname) and c.qname =!= "comment"
     then flagError("element of type ", toString p, " may not contain an element of type ", toString c))

--- a/M2/Macaulay2/m2/webapp.m2
+++ b/M2/Macaulay2/m2/webapp.m2
@@ -74,7 +74,7 @@ InexactNumber#{WebApp,Print} = x ->  withFullPrecision ( () -> Thing#{WebApp,Pri
 
 htmlAfterPrint :=  x -> (
     << endl << on() | " : ";
-    if class x === Sequence then x = RowExpression deepSplice { x };
+    if class x === Sequence then x = SPAN deepSplice { x };
     printFunc x;
     )
 
@@ -91,6 +91,7 @@ Thing#{WebApp,AfterNoPrint} = x -> (
     if s =!= null then htmlAfterPrint s
     )
 
+removeWebAppTags = s -> if s === null then null else replace(webAppTagsRegex,"😀",s);
 if topLevelMode === WebApp then (
     compactMatrixForm = false;
     extractStr := x -> concatenate apply(x,y -> if instance(y,Hypertext) then extractStr y else if instance(y,String) then y);
@@ -105,5 +106,5 @@ if topLevelMode === WebApp then (
     editMethod FilePosition := f -> show editURL f;
     hypertext FilePosition := f -> TT HREF {editURL f,toString f};
     -- redefine htmlLiteral to exclude codes
-    htmlLiteral = (s -> if s===null then null else replace(webAppTagsRegex,"",s)) @@ htmlLiteral;
+    htmlLiteral = removeWebAppTags @@ htmlLiteral;
     )


### PR DESCRIPTION
- various small changes to output routines such as `html`, etc. including a fix to `net OL` -- note that this doesn't resolve the issue raised in #2795, just makes the output correct with the current `start` option.
- `lift(Vector,xxx)` was missing, added.
- fixed a typo I had introduced in `monoids.m2`
- fix #2811 -- I did not put any tests since as far as I understand, `AssociativeAlgebras` is still work in progress and I'll let its developers do that.