### PR TITLE
Quote string hash table keys

### DIFF
--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -190,7 +190,9 @@ net HashTable := x -> (
      	  net class x,
 	  "{", 
 	  -- the first line prints the parts vertically, second: horizontally
- 	  stack (horizontalJoin \ apply(sortByName pairs x,(k,v) -> (net k, " => ", net v))),
+ 	  stack (horizontalJoin \ apply(sortByName pairs x,(k,v) -> (
+		      (if instance(k, String) then format else net) k,
+		      " => ", net v))),
 	  -- between(", ", apply(pairs x,(k,v) -> net k | "=>" | net v)), 
 	  "}" 
      	  ))


### PR DESCRIPTION
Otherwise, it is difficult to distinguish which keys are symbols and which keys are strings.

This is something we talked about at an M2internals a few months ago.

### Before:

```m2
i1 : hashTable{"foo" => null, foo => null}

o1 = HashTable{foo => null}
               foo => null

o1 : HashTable
```

### After

```m2
i1 : hashTable{"foo" => null, foo => null}

o1 = HashTable{foo => null  }
               "foo" => null

o1 : HashTable
```
