### PR TITLE
minor HTML/CSS, doc

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -120,20 +120,21 @@ html HTML := x -> demark(newline, {
 treatImgSrc := x -> apply(x, y -> if class y === Option and y#0 === "src" then "src" => toURL y#1 else y)
 html IMG := (lookup(html, IMG)) @@ treatImgSrc
 
-fixNewLines := method()
-fixNewLines Hypertext :=
-fixNewLines Nothing :=
-fixNewLines Option := identity
-fixNewLines Thing := x -> replace("\r\n","\n",toString x) -- toString prevents LaTeX being inserted...
+toStringMaybe := method()
+toStringMaybe Hypertext :=
+toStringMaybe Nothing :=
+toStringMaybe OptionTable :=
+toStringMaybe Option := identity
+toStringMaybe Thing := x -> replace("\r\n","\n",toString x) -- toString prevents LaTeX being inserted...
 -- ... since non HTML types should *not* be KaTeX-ified inside these tags:
 html PRE :=
 html SAMP :=
 html KBD :=
-html CODE := (lookup(html, Hypertext)) @@ (x -> apply(x,fixNewLines))
+html CODE := (lookup(html, Hypertext)) @@ (x -> apply(x,toStringMaybe))
 
 -- hack for HTML5 validation
 -- ideally, TT should be removed and replaced with CODE, KBD, SAMP, and/or VAR
-html TT := x -> html SPAN prepend("class" => "tt", toList x)
+html TT := x -> html SPAN prepend("class" => "tt", apply(toList x,toStringMaybe))
 
 html CDATA   := x -> concatenate("<![CDATA[", x ,"]]>", newline)
 html COMMENT := x -> if match("--", concatenate x) then

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -623,7 +623,8 @@ document {
       	  ///x|"x"|x///,
 	  },
      "If one of the two arguments is an integer, it is converted to a string first.",
-     EXAMPLE ///"t = " | 333///
+     EXAMPLE ///"t = " | 333///,
+     SeeAlso => {horizontalJoin}
      }
 
 document {

--- a/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
@@ -351,7 +351,7 @@ document {
 document {
      Key => Print,
      Headline => "top level method for printing results",
-     Usage => "X#{Standard,Print} = f",
+     Usage => "X#{topLevelMode,Print} = f",
      Inputs => {
 	  "X" => Type,
 	  "f" => Function => { " that can print something of type ", TT "X"}
@@ -365,7 +365,7 @@ document {
 document {
      Key => NoPrint,
      Headline => "top level method for non-printing results",
-     Usage => "X#{Standard,NoPrint} = f",
+     Usage => "X#{topLevelMode,NoPrint} = f",
      Inputs => {
 	  "X" => Type,
 	  "f" => Function => { " that can accept something of type ", TT "X"}
@@ -379,7 +379,7 @@ document {
 document {
      Key => BeforePrint,
      Headline => "top level method applied before printing results",
-     Usage => "X#{Standard,BeforePrint} = f",
+     Usage => "X#{topLevelMode,BeforePrint} = f",
      Inputs => {
 	  "f" => { "a function to be applied before printing a top-level evaluation result ", TT "r", " of type ", TT "X", "." },
 	  },
@@ -401,7 +401,7 @@ document {
 document {
      Key => AfterPrint,
      Headline => "top level method applied after printing",
-     Usage => "X#{Standard,AfterPrint} = f",
+     Usage => "X#{topLevelMode,AfterPrint} = f",
      Inputs => {
 	  "f" => { "a function to be applied after printing a top-level evaluation result ", TT "r", " of type ", TT "X", "."}
 	  },
@@ -414,14 +414,14 @@ document {
 	  },
      "We could suppress that output for a single type as follows.",
      EXAMPLE {
-	  "QQ#{Standard,AfterPrint} = r -> r;",
+	  "QQ#{topLevelMode,AfterPrint} = r -> r;",
 	  "3/4"
 	  }
      }
 document {
      Key => AfterNoPrint,
      Headline => "top level method applied after not printing",
-     Usage => "X#{Standard,AfterNoPrint} = f",
+     Usage => "X#{topLevelMode,AfterNoPrint} = f",
      Inputs => {
 	  "f" => { "a function to be applied after not printing a top-level evaluation result ", TT "r", " of type ", TT "X", "." }
 	  },
@@ -440,7 +440,7 @@ document {
      Headline => "the current top level mode",
      Usage => "topLevelMode = x",
      Inputs => {
-	  "x" => Symbol => {TO "TeXmacs", ", or ", TO "Standard"}
+	  "x" => Symbol => {TO "TeXmacs", ", or ", TO "Standard", " or ", TO "WebApp", " or ", TO "Jupyter"}
 	  },
      Consequences => {
 	  {"the interpreter will produce input and output prompts appropriate for the mode, and will

--- a/M2/Macaulay2/packages/Style/doc.css
+++ b/M2/Macaulay2/packages/Style/doc.css
@@ -78,6 +78,11 @@ dl.element {
   margin: 0px;
 }
 
+div.indent {
+    border-left:3px solid;
+    padding:10px;
+}
+
 span.tt {
   font-family: monospace;
 }

--- a/M2/Macaulay2/packages/Text.m2
+++ b/M2/Macaulay2/packages/Text.m2
@@ -9,7 +9,7 @@ newPackage("Text",
 
 exportFrom_Core {
      "ANCHOR", "BLOCKQUOTE", "BODY", "BOLD", "BR", "CDATA", "CODE", "COMMENT", "DD", "DIV", "DL", "DT", "EM", "ExampleItem", "HEAD", "HEADER1",
-     "HEADER2", "HEADER3", "HEADER4", "HEADER5", "HEADER6", "HR", "HREF", "HTML", "Hypertext", "HypertextContainer", "HypertextParagraph", "HypertextVoid", "IMG", "ITALIC", "KBD",
+     "HEADER2", "HEADER3", "HEADER4", "HEADER5", "HEADER6", "HR", "HREF", "HTML", "Hypertext", "HypertextContainer", "HypertextParagraph", "HypertextVoid", "IMG", "INDENT", "ITALIC", "KBD",
      "LABEL", "LATER", "LI", "LINK", "LITERAL", "M2CODE", "MENU", "META", "PARA", "PRE", "SAMP", "SCRIPT", "SMALL", "SPAN", "STRONG", "STYLE", "SUB", "SUBSECTION", "SUP", "TABLE", "TD", "TH",
      "TEX", "TITLE", "TO", "TO2", "TOH", "TR", "TT", "UL", "VAR", "OL", "INPUT", "BUTTON", "validate",
      "MarkUpType", "IntermediateMarkUpType",


### PR DESCRIPTION
- fix for #2853 as mentioned in comments. I also renamed `fixNewLines` to something more meaningful.
- minor doc improvements
- when I introduced `INDENT` in #2760, I forgot to export it and to PR the corresponding css. fixed.