### PR TITLE
Add link to 1.22 changes from main ChangeLog node

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -6,6 +6,7 @@ document {
      Key => "changes to Macaulay2, by version",
      Subnodes => {
 	  TO "changes made for the next release",
+	  TO "changes, 1.22",
 	  TO "changes, 1.21",
 	  TO "changes, 1.20",
 	  TO "changes, 1.19.1",


### PR DESCRIPTION
I neglected to do this in #2848.