### PR TITLE
keep OpenMP flags together

### DIFF
--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -73,6 +73,8 @@ foreach(lang IN ITEMS C CXX)
     string(REGEX REPLACE "^lib" "" _lib "${_lib}")
     set(OpenMP_${lang}_LDLIBS "${OpenMP_${lang}_LDLIBS} -L${_libdir} -Wl,-rpath,${_libdir} -l${_lib}")
   endforeach()
+  # TODO: remove when this is merged: https://gitlab.kitware.com/cmake/cmake/-/issues/24966
+  set_property(TARGET OpenMP::OpenMP_${lang} PROPERTY INTERFACE_LINK_OPTIONS "SHELL: ${OpenMP_${lang}_FLAGS}")
 endforeach()
 
 if(WITH_TBB)


### PR DESCRIPTION
Fixes https://github.com/Macaulay2/homebrew-tap/issues/181 and https://github.com/Macaulay2/M2/issues/2858 and part of https://github.com/Macaulay2/M2/issues/2809

Not sure if this is having the intended effect, but I also don't have time to fix it currently. If anyone wants to finish this feel free to.