### PR TITLE
Add some more escape sequences for strings

### DIFF
--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -187,7 +187,8 @@ getstring(o:PosFile):(null or Word) := (
 		    hexcoming = hexcoming - 1;
 		    )
 	       else (
-		    printErrorMessage(o.filename,line,column,"expected hex digit in unicode sequence here");
+		    printErrorMessage(o.filename,line,column,"expected " +
+			tostring(hexcoming) + " more hex digit(s)");
 		    empty(tokenbuf);
 		    while true do (ch2 := getc(o); if ch2 == EOF || ch2 == ERROR || ch2 == int('\n') then return NULL;);
 		    )
@@ -206,6 +207,7 @@ getstring(o:PosFile):(null or Word) := (
 	       || char(ch) == 'E'
 	       || char(ch) == '\\'
 	       || (char(ch) == 'u' && (hexcoming = 4; true)) -- allow unicode entry this way : "\u53f7"
+	       || (char(ch) == 'x' && (hexcoming = 2; true))
 	       || int('0') <= ch && ch < int('8')
 	       then escaped = false
 	       else (

--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -196,10 +196,14 @@ getstring(o:PosFile):(null or Word) := (
 	  then (
 	       if char(ch) == '"' 				    -- "
 	       || char(ch) == 'r'
+	       || char(ch) == 'a'
 	       || char(ch) == 'b'
 	       || char(ch) == 'n'
 	       || char(ch) == 't'
+	       || char(ch) == 'v'
 	       || char(ch) == 'f'
+	       || char(ch) == 'e'
+	       || char(ch) == 'E'
 	       || char(ch) == '\\'
 	       || (char(ch) == 'u' && (hexcoming = 4; true)) -- allow unicode entry this way : "\u53f7"
 	       || int('0') <= ch && ch < int('8')

--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -74,9 +74,13 @@ export parseString(s:string):string := (
 	       if c == 'n' then v << '\n'
 	       else if c == '"' then v << '"'
 	       else if c == 'r' then v << '\r'
+	       else if c == 'a' then v << char(7)
 	       else if c == 'b' then v << '\b'
 	       else if c == 't' then v << '\t'
+	       else if c == 'v' then v << char(11)
 	       else if c == 'f' then v << '\f'
+	       else if c == 'e' then v << char(27)
+	       else if c == 'E' then v << char(27)
 	       else if c == '\\' then v << '\\'
 	       else if c == 'u' then (
 		    i = i+4;

--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -85,6 +85,9 @@ export parseString(s:string):string := (
 	       else if c == 'u' then (
 		    i = i+4;
 		    utf8(v, ((hexvalue(s.(i-3)) * 16 + hexvalue(s.(i-2))) * 16 + hexvalue(s.(i-1))) * 16 + hexvalue(s.i)))
+	       else if c == 'x' then (
+		    i = i + 2;
+		    v << char(hexvalue(s.(i - 1)) * 16 + hexvalue(s.i)))
 	       else if '0' <= c && c < '8' then (
 		    j := c - '0';
 		    c = s.(i+1);

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_strings.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_strings.m2
@@ -192,11 +192,16 @@ document {
       \\r             return
       \\\\             \\ 
       \\\"             \"
+      \\a             audible bell
+      \\b             backspace
+      \\e, \\E         escape
       \\t             tab
-      \\xxx           ascii character with octal value xxx
-      \\uxxxx         unicode character with hex value xxxx, encoded with utf-8",
+      \\v             vertical tab
+      \\nnn           ascii character with octal value nnn
+      \\xnn           ascii character with hex value nn
+      \\unnnn         unicode character with hex value nnnn, encoded with utf-8",
      EXAMPLE lines ///
-     x = " \" \f \r \\ \t \013 \u4f60 ";
+     x = " \" \f \r \\ \a\b\e\E\t\v \013 \x0b \u4f60 ";
      ascii x
      utf8 x
      ///,

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -70,3 +70,8 @@ assert Equation(pack(0, ""), pack("", 0))
 assert BinaryOperation(symbol ===, tally "Hello, world!", new Tally from {
 	" " => 1, "!" => 1, "r" => 1, "d" => 1, "e" => 1, "w" => 1,
 	"H" => 1, "l" => 3, "," => 1, "o" => 2})
+
+-- escape sequences
+assert Equation(ascii "\"\\\a\b\e\E\f\n\r\t\v",
+    {0x22, 0x5c, 0x07, 0x08, 0x1b, 0x1b, 0x0c, 0x0a, 0x0d, 0x09, 0x0b})
+assert Equation("\172\x7a\x7A\u007a\u007A", "zzzzz")


### PR DESCRIPTION
I noticed that Macaulay2 was missing a few string escape sequences that are common in other languages.  The following have been added:

* `\a` (audible bell)
* `\e` & `\E` (escape)
* `\v` (vertical tab)
* `\xnn` (character w/ hexadecimal ASCII encoding `nn`)

All of these are available in C, for example (`\e` and `\E` are GCC extensions).

Fun fact - you can get colors in Macaulay2 using [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code).  For example, `"\e[31mfoo\e[m"` is `"foo"`, but red.  (It might be cool to use this for syntax highlighting inside the REPL, but right now `net` thinks all these extra characters are visible and the spacing gets messed up.)