### PR TITLE
Improve genericSkewMatrix/genericSymmetricMatrix error messages

### DIFF
--- a/M2/Macaulay2/m2/genmat.m2
+++ b/M2/Macaulay2/m2/genmat.m2
@@ -13,8 +13,8 @@ genericMatrix = method(TypicalValue => Matrix)
 genericMatrix(Ring,ZZ,ZZ) := (R,nrows,ncols) -> genericMatrix(R,R_0,nrows,ncols)
 genericMatrix(Ring,RingElement,ZZ,ZZ) := (R,first,nrows,ncols) -> (
      first = getIndex(R,first);
-     if not instance(nrows,ZZ) or not instance(ncols,ZZ) or nrows < 0 or ncols < 0
-     then error "expected nonnegative integers";
+     if nrows < 1 or ncols < 1
+     then error "expected positive integers";
      if first + nrows * ncols > numgens R
      then error "not enough variables in this ring";
      matrix table(nrows, ncols, (i,j)->R_(first + i + nrows*j)))

--- a/M2/Macaulay2/m2/genmat.m2
+++ b/M2/Macaulay2/m2/genmat.m2
@@ -22,7 +22,10 @@ genericMatrix(Ring,RingElement,ZZ,ZZ) := (R,first,nrows,ncols) -> (
 genericSkewMatrix = method(TypicalValue => Matrix)
 genericSkewMatrix(Ring,ZZ) := (R,n) -> genericSkewMatrix(R,R_0,n)
 genericSkewMatrix(Ring,RingElement,ZZ) := (R,first,n) -> (
+     if n < 1 then error "expected a positive integer";
      first = getIndex(R,first);
+     if numgens R - first < binomial(n, 2)
+     then error "not enough variables in this ring";
      vars := new MutableHashTable;
      nextvar := first;
      scan(0..n-1, 

--- a/M2/Macaulay2/m2/genmat.m2
+++ b/M2/Macaulay2/m2/genmat.m2
@@ -39,7 +39,10 @@ genericSkewMatrix(Ring,RingElement,ZZ) := (R,first,n) -> (
 genericSymmetricMatrix = method(TypicalValue => Matrix)
 genericSymmetricMatrix(Ring,ZZ) := (R,n) -> genericSymmetricMatrix(R,R_0,n)
 genericSymmetricMatrix(Ring,RingElement,ZZ) := (R,first,n) -> (
+     if n < 1 then error "expected a positive integer";
      first = getIndex(R,first);
+     if numgens R - first < binomial(n + 1, 2)
+     then error "not enough variables in this ring";
      vars := new MutableHashTable;
      nextvar := first;
      scan(0..n-1, i -> scan(i..n-1, j -> (


### PR DESCRIPTION
`genericMatrix` has some helpful error messages when the user gives it bad input:

```m2
i1 : genericMatrix(QQ[x, y, z, w], -1, 2)
stdio:1:1:(3): error: expected nonnegative integers

i2 : genericMatrix(QQ[x, y, z, w], 3, 2)
stdio:2:1:(3): error: not enough variables in this ring
```

However, its friends `genericSkewMatrix` and `genericSymmetricMatrix` give much less helpful messages:

```m2
i3 : genericSkewMatrix(QQ[x, y, z, w], -1)
stdio:3:1:(3): error: expected nonempty list

i4 : genericSkewMatrix(QQ[x, y, z, w], 4)
stdio:4:1:(3): error: index 4 out of bounds 0 .. 3

i5 : genericSymmetricMatrix(QQ[x, y, z, w], -1)
stdio:5:1:(3): error: expected nonempty list

i6 : genericSymmetricMatrix(QQ[x, y, z, w], 3)
stdio:6:1:(3): error: index 4 out of bounds 0 .. 3
```

We add checks to these two methods similar to the ones in `genericMatrix`, and also improve the `genericMatrix` check as well.  Previously, it redundantly called `instance` to check that the inputs were really `ZZ` objects even though it's a method and also allowed values of 0, which also resulted in a strange error:

```m2
i7 : genericMatrix(QQ[x, y, z, w], 0, 2)
stdio:7:1:(3): error: expected nonempty list
```

### After

```m2
i1 : genericSkewMatrix(QQ[x, y, z, w], -1)
stdio:1:1:(3): error: expected a positive integer

i2 : genericSkewMatrix(QQ[x, y, z, w], 4)
stdio:2:1:(3): error: not enough variables in this ring

i3 : genericSymmetricMatrix(QQ[x, y, z, w], -1)
stdio:3:1:(3): error: expected a positive integer

i4 : genericSymmetricMatrix(QQ[x, y, z, w], 3)
stdio:4:1:(3): error: not enough variables in this ring

i5 : genericMatrix(QQ[x, y, z, w], 0, 2)
stdio:5:1:(3): error: expected positive integers
```