### PR TITLE
Associative Algebras Duplicate Large Block Temporary Fix

### DIFF
--- a/M2/Macaulay2/e/interface/groebner.cpp
+++ b/M2/Macaulay2/e/interface/groebner.cpp
@@ -919,7 +919,7 @@ const Matrix* rawNCGroebnerBasisTwoSided(const Matrix* input, int maxdeg, int st
       if (isF4)
         {
           int numthreads = M2_numTBBThreads; // settable from front end.
-          std::cout << "Using numthreads = " << numthreads << std::endl;
+          // std::cout << "Using numthreads = " << numthreads << std::endl;
           NCF4 G(A->freeAlgebra(), elems, maxdeg, strategy, (isParallel ? numthreads : 1));
           G.compute(maxdeg); // this argument is actually the soft degree limit
           auto result = copyPolyVector(A, G.currentValue());

--- a/M2/Macaulay2/packages/AssociativeAlgebras.m2
+++ b/M2/Macaulay2/packages/AssociativeAlgebras.m2
@@ -1408,7 +1408,7 @@ ncMatrixMult (Matrix, Matrix) := (A,B) -> (
    matrix table (numrows A, numcols B, (i,j) -> sum apply(numcols A, k -> A_(i,k)*B_(k,j)))
 )
 
-rightKernel = method(Options=>{DegreeLimit=>10})
+rightKernel = method(Options=>{DegreeLimit=>10,Strategy=>"F4"})
 rightKernel Matrix := opts -> M -> (
    -- this function computes the right kernel of a map between free
    -- modules over a noncommutative ring.
@@ -1435,11 +1435,11 @@ rightKernel Matrix := opts -> M -> (
    outputs := matrix {(entries transpose ncMatrixMult(diagMat,phi liftM)) / sum};
    inputs := matrix {colVars};
    IM := phi I + ideal (inputs - outputs);
-   IMgb := NCGB(IM, opts#DegreeLimit);
+   IMgb := NCGB(IM, opts#DegreeLimit, Strategy => opts#Strategy);
    kerGens := ideal select(flatten entries IMgb, f -> isSubset(support f,gensAVars | colVars) and not isSubset(support f, gensAVars));
    if kerGens == 0 then return map(source M, (ring M)^0,0);
    mkerGens := phi I + sum apply(gensAVars, v -> kerGens*v);
-   mkerGensGB := NCGB(mkerGens,opts#DegreeLimit);
+   mkerGensGB := NCGB(mkerGens,opts#DegreeLimit, Strategy => opts#Strategy);
    minKerGens := compress NCReductionTwoSided(gens kerGens,mkerGensGB);
    (minKerMons, minKerCoeffs) := coefficients minKerGens;
    linIndepKer := mingens image sub(minKerCoeffs,coefficientRing A);


### PR DESCRIPTION
This pull request prevents calls to the noncommutative F4 code for garbage collected rings at the front end.  Some improvements on how skew polynomial rings are handled are also added.  Some extra output regarding a number of threads setting were also removed.

This should hopefully end most of the duplicate large block errors arising from AssociativeAlgebras, at least until we figure out the root cause.