### PR TITLE
Use constant hash for Python's "None" object

### DIFF
--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -430,8 +430,8 @@ setupfun("pythonWrapM2Function", PyWrapM2Function);
 -- none --
 ----------
 
-PyNone(e:Expr):Expr := toExpr(Ccode(pythonObjectOrNull, "Py_None"));
-setupfun("getPythonNone", PyNone);
+setupconst("pythonNone",
+    Expr(pythonObjectCell(Ccode(pythonObject, "Py_None"), 0xFCA86420)));
 
 ---------------
 -- importing --

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -69,7 +69,6 @@ exportFrom_Core {
     "objectType"}
 
 importFrom_Core {
-    "getPythonNone",
     "pythonComplexFromDoubles",
     "pythonDictNew",
     "pythonDictSetItem",
@@ -81,6 +80,7 @@ importFrom_Core {
     "pythonLongFromLong",
     "pythonFloatAsDouble",
     "pythonFloatFromDouble",
+    "pythonNone",
     "pythonObjectGetAttrString",
     "pythonObjectHasAttrString",
     "pythonObjectRichCompareBool",
@@ -119,8 +119,6 @@ PythonObject#AfterPrint = x -> (
      t := toString objectType x;
      t = replace("<([a-z]+) '(.*)'>"," of \\1 \\2",t);
      (PythonObject, t))
-
-pythonNone = getPythonNone()
 
 pythonValue = method(Dispatch => Thing)
 pythonValue String := s -> (


### PR DESCRIPTION
This way, we don't need the `getPythonNone` function, which was only called once, to create the object.  Beginning with Python 3.12, `None` will have a constant hash anyway.  We use this new value.  See https://github.com/python/cpython/pull/99541.