### PR TITLE
Add GMP support to ForeignFunctions

### DIFF
--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -270,7 +270,7 @@ export moveToRRiandclear(z:RRimutable):RRi := (
     clear(z);
     w);
      
-set(x:ZZmutable, y:ZZ   ) ::= Ccode( void, "mpz_set   (", x, ",", y, ")" );
+export set(x:ZZmutable, y:ZZ   ) ::= Ccode( void, "mpz_set   (", x, ",", y, ")" );
 set(x:ZZmutable, n:int  ) ::= Ccode( void, "mpz_set_si(", x, ",", n, ")" );
 set(x:ZZmutable, n:uint ) ::= Ccode( void, "mpz_set_ui(", x, ",", n, ")" );
 set(x:ZZmutable, n:long ) ::= Ccode( void, "mpz_set_si(", x, ",", n, ")" );

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -851,6 +851,8 @@ doc ///
       uint
       long
       ulong
+  SeeAlso
+    mpzT
 ///
 
 doc ///
@@ -882,6 +884,28 @@ doc ///
       int 12
       ulong pi
       short(-2.71828)
+///
+
+doc ///
+  Key
+    mpzT
+    (NewFromMethod, mpzT, ZZ)
+    (value, mpzT)
+  Headline
+    GMP arbitrary-precision integer type
+  Description
+    Text
+      Macaulay2's native @TO ZZ@ integer type wraps around @TT "mpz_t"@ from
+      @HREF{"https://gmplib.org/", "GMP"}@.  This type (which is an instance
+      of @TO ForeignIntegerType@) allows for conversion between Macaulay2
+      integers and GMP integers without loss of precision.
+    Example
+      mpzT 2^100
+      value oo
+      mpzAdd = foreignFunction("__gmpz_add", void, {mpzT, mpzT, mpzT})
+      x = mpzT 0
+      mpzAdd(x, 2, 3)
+      x
 ///
 
 doc ///

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -68,6 +68,7 @@ export {
     "uint",
     "long",
     "ulong",
+    "mpzT",
     "float",
     "double",
     "voidstar",
@@ -247,10 +248,16 @@ if version#"pointer size" == 4 then (
     long = int64;
     ulong = uint64)
 
+mpzT = new ForeignIntegerType;
+mpzT.Name = "mpz_t";
+mpzT.Address = ffiPointerType
+new mpzT from ZZ := (T, n) -> new T from {Address => ffiIntegerAddress n}
+value mpzT := ffiIntegerValue @@ address
+
 ForeignIntegerType Number :=
 ForeignIntegerType Constant := (T, x) -> new T from truncate x
 
-isAtomic ForeignIntegerType := T -> true
+isAtomic ForeignIntegerType := T -> if T === mpzT then false else true
 
 -----------------------
 -- foreign real type --

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1890,6 +1890,7 @@ longexp = 8 * version#"pointer size"
 assert Equation(value ulong(2^longexp - 1), 2^longexp - 1)
 assert Equation(value long(2^(longexp - 1) - 1), 2^(longexp - 1) - 1)
 assert Equation(value long(-2^(longexp - 1)), -2^(longexp - 1))
+assert Equation(value mpzT 10^100, 10^100)
 
 -- real types
 assert Equation(value float 3.14159, 3.14159p24)


### PR DESCRIPTION
This adds a new `mpzT` type to the `ForeignFunctions` package for working with GMP integers.  For example:

```m2
i1 : needsPackage "ForeignFunctions"

o1 = ForeignFunctions

o1 : Package

i2 : mpzAdd = foreignFunction("__gmpz_add", void, {mpzT, mpzT, mpzT})

o2 = __gmpz_add

o2 : ForeignFunction

i3 : x = mpzT 0

o3 = 0

o3 : ForeignObject of type mpz_t

i4 : mpzAdd(x, 2, 3)

i5 : x

o5 = 5

o5 : ForeignObject of type mpz_t

i6 : value oo

o6 = 5
```