### PR TITLE
Don't percent encode "#" in URL's (breaks named anchors)

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -200,7 +200,8 @@ percentEncoding =  new MutableHashTable from toList apply(
     -- unreserved characters from RFC 3986
     -- ALPHA / DIGIT / "-" / "." / "_" / "~"
     -- we also add "/" and ":" since they're standard URL characters
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234567890-._~/:",
+    -- also "#" for named anchors
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234567890-._~/:#",
     c -> (c, c))
     -- everything else will be percent encoded and added to the hash table
     -- as needed

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/urlEncode-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/urlEncode-doc.m2
@@ -13,7 +13,7 @@ doc ///
     :String
   Description
     Text
-      Encode all of the characters in a URL except for "/", ":", and
+      Encode all of the characters in a URL except for "/", ":", "#", and
       the "unreserved characters" specified by
       @HREF{"https://www.rfc-editor.org/rfc/rfc3986.html", "RFC 3986"}@,
       i.e., the alphanumeric characters, "-", ".", "_", and "~", using


### PR DESCRIPTION
This fixes a bug pointed out in today's M2internals where clicking the letters of the alphabet on a package's "index" page in the documentation leads to a 404 error.  See for example http://www2.macaulay2.com/Macaulay2/doc/Macaulay2-1.22/share/doc/Macaulay2/Macaulay2Doc/html/master.html.