### PR TITLE
4ti2 version bump

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -823,12 +823,13 @@ set(4ti2_PROGRAMS
   qsolve rays walk zbasis zsolve hilbert graver ppi genmodel gensymm output)
 list(TRANSFORM 4ti2_PROGRAMS PREPEND ${M2_HOST_PREFIX}/bin/ OUTPUT_VARIABLE 4ti2_PROGRAMS)
 ExternalProject_Add(build-4ti2
-  URL               https://github.com/4ti2/4ti2/releases/download/Release_1_6_9/4ti2-1.6.9.tar.gz
-  URL_HASH          SHA256=3053e7467b5585ad852f6a56e78e28352653943e7249ad5e5174d4744d174966
+  URL               https://github.com/4ti2/4ti2/releases/download/Release_1_6_10/4ti2-1.6.10.tar.gz
+  URL_HASH          SHA256=f7c191beb14246b643e4fd5b18b53d9966693b9e6d3a569441a0e3ca14b1a86b
   PREFIX            libraries/4ti2
   SOURCE_DIR        libraries/4ti2/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
+  PATCH_COMMAND     mkdir swig # needed because the tar doesn't have a swig directory but 4ti2's Makefile.am seems to need it
   CONFIGURE_COMMAND autoreconf -vif
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}

--- a/M2/libraries/4ti2/Makefile.in
+++ b/M2/libraries/4ti2/Makefile.in
@@ -1,13 +1,12 @@
 # temporary beta testing version
-VERSION = 1.6.9
+VERSION = 1.6.10
 TARDIR = 4ti2-$(VERSION)
 
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
-PRECONFIGURE = autoreconf -vif
+PRECONFIGURE = mkdir -p swig && autoreconf -vif
 
-# URL = http://www.4ti2.de/version_$(VERSION)
-# URL = https://github.com/4ti2/4ti2/releases/download/Release_1_6_9/4ti2-1.6.9.tar.gz
-URL = http://macaulay2.com/Downloads/OtherSourceCode
+VERSION_ = $(shell echo $(VERSION) | sed 's/\./_/g')
+URL = https://github.com/4ti2/4ti2/releases/download/Release_$(VERSION_)
 
 ifeq (@ENABLE_STRIP@,yes)
 INSTALLTARGET = install-strip


### PR DESCRIPTION
This fixes 4ti2 builds for me in cmake. I'm not certain how to make the equivalent change for configure builds, so someone who knows how should do the equivalent for configure builds, and so I've marked it draft until that is dealt with.

This should fix #2849.

The use of "mkdir swig" to fix a small build issue in 4ti2 also seems inelegant but I can't figure out a better way to do it