### PR TITLE
Update URL to Macaulay2 webpage in docs

### DIFF
--- a/M2/Macaulay2/editors/highlightjs/macaulay2.js.in
+++ b/M2/Macaulay2/editors/highlightjs/macaulay2.js.in
@@ -2,7 +2,7 @@
 Language: Macaulay2
 Author: Doug Torrance <dtorrance@piedmont.edu>
 Description: Macaulay2 is a software system devoted to supporting research in algebraic geometry and commutative algebra
-Website: https://faculty.math.illinois.edu/Macaulay2/
+Website: https://macaulay2.com
 Category: scientific
 */
 

--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -35,7 +35,7 @@ class Macaulay2Lexer(RegexLexer):
     """Lexer for Macaulay2, a software system for research in algebraic geometry."""
 
     name = 'Macaulay2'
-    url = 'https://faculty.math.illinois.edu/Macaulay2/'
+    url = 'https://macaulay2.com'
     aliases = ['macaulay2']
     filenames = ['*.m2']
 

--- a/M2/Macaulay2/packages/Cremona/documentation.m2
+++ b/M2/Macaulay2/packages/Cremona/documentation.m2
@@ -178,7 +178,7 @@ Inputs => {
 "phi" => RationalMap => {"a birational map"}}, 
 Outputs => { 
 RationalMap => {"the inverse map of ",TT"phi"}},
-PARA{"If the source variety is a projective space and if a further technical condition is satisfied, then the algorithm used is that described in the paper by Russo and Simis - On birational maps and Jacobian matrices - Compos. Math. 126 (3), 335-358, 2001. For the general case, the algorithm used is the same as for ", HREF{"http://www.math.uiuc.edu/Macaulay2/doc/Macaulay2-1.16/share/doc/Macaulay2/Parametrization/html/_invert__Birational__Map.html","invertBirationalMap"}, " in the package ", HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.16/share/doc/Macaulay2/Parametrization/html","Parametrization"}, ". Note that in this case, the analogous method ",HREF{"http://www2.macaulay2.com/Macaulay2/doc/Macaulay2-1.16/share/doc/Macaulay2/RationalMaps/html/_inverse__Of__Map.html","inverseOfMap"}," in the package ",HREF{"http://www2.macaulay2.com/Macaulay2/doc/Macaulay2-1.16/share/doc/Macaulay2/RationalMaps/html/index.html","RationalMaps"}," generally turns out to be faster."},
+PARA{"If the source variety is a projective space and if a further technical condition is satisfied, then the algorithm used is that described in the paper by Russo and Simis - On birational maps and Jacobian matrices - Compos. Math. 126 (3), 335-358, 2001. For the general case, the algorithm used is the same as for ", TO "Parametrization::invertBirationalMap", " in the package ", TO "Parametrization", ". Note that in this case, the analogous method ", TO "RationalMaps::inverseOfMap", " in the package ", TO "RationalMaps"," generally turns out to be faster."},
 EXAMPLE { 
 "-- A Cremona transformation of P^20 
 phi = rationalMap map quadroQuadricCremonaTransformation(20,1)", 
@@ -348,7 +348,7 @@ Headline => "the class of all rational maps between absolutely irreducible proje
 PARA{"An object of the class ",EM "RationalMap", " can be basically replaced by a homogeneous ring map of quotients of polynomial rings by homogeneous ideals. One main advantage to using this class is that things computed using non-probabilistic algorithms are stored internally (or partially stored)."},
 PARA{"The constructor for the class is ",TO "rationalMap",", which works quite similar to ",TO "toMap",". 
 See in particular the methods: ",TO (rationalMap,RingMap),", ",TO (rationalMap,Ideal,ZZ,ZZ),", ",TO (rationalMap,Tally),", and ",TO (rationalMap,PolynomialRing,List),"."},
-PARA{"In the package ",HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/MultiprojectiveVarieties/html/index.html","MultiprojectiveVarieties"},", this class has been extended to provide support to rational maps between multi-projective varieties, see ",HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/MultiprojectiveVarieties/html/___Multirational__Map.html", TT "MultirationalMap"},"."}}
+PARA{"In the package ", TO "MultiprojectiveVarieties",", this class has been extended to provide support to rational maps between multi-projective varieties, see ", TO "MultiprojectiveVarieties::MultirationalMap", "."}}
 
 document { 
 Key => {(symbol ^**,RationalMap,Ideal),(symbol ^*,RationalMap)}, 
@@ -681,7 +681,7 @@ SeeAlso => {(image,RationalMap),(image,RationalMap,ZZ),groebnerBasis}}
 
 document {Key => {parametrize}, 
 Headline => "parametrization of a rational projective variety", 
-PARA{"See ",HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/MultiprojectiveVarieties/html/_parametrize_lp__Multiprojective__Variety_rp.html", TT "parametrize(MultiprojectiveVariety)"},
+PARA{"See ", TO "MultiprojectiveVarieties::parametrize(MultiprojectiveVariety)",
 " and ",TO2{(parametrize,QuotientRing),"parametrize(QuotientRing)"},"."}}
 
 document { 
@@ -692,7 +692,7 @@ Inputs => {
 "I" => Ideal => {"the ideal of a linear variety or of a hyperquadric"}}, 
 Outputs => { 
 RationalMap => {"a birational map ",TT"phi"," such that ",TT"I == image phi"}},
-PARA{"This function has been improved and extended in the package ",HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/MultiprojectiveVarieties/html/index.html","MultiprojectiveVarieties"},", see ",HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/MultiprojectiveVarieties/html/_parametrize_lp__Multiprojective__Variety_rp.html", TT "parametrize(MultiprojectiveVariety)"},"."},
+PARA{"This function has been improved and extended in the package ", TO "MultiprojectiveVarieties", ", see ", TO "MultiprojectiveVarieties::parametrize(MultiprojectiveVariety)", "."},
 EXAMPLE {
 "P9 := ZZ/10000019[x_0..x_9]",
  "L = trim ideal(random(1,P9),random(1,P9),random(1,P9),random(1,P9))",
@@ -1012,7 +1012,7 @@ SeeAlso => {(image,RationalMap),forceInverseMap}}
 
 document {Key => {point}, 
 Headline => "pick a random rational point on a projective variety", 
-PARA{"See ",HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/MultiprojectiveVarieties/html/_point_lp__Multiprojective__Variety_rp.html","point(MultiprojectiveVarieties)"},
+PARA{"See ", TO "MultiprojectiveVarieties::point(MultiprojectiveVarieties)",
 " and ",TO2{(point,QuotientRing),"point(QuotientRing)"},"."}}
 
 undocumented {(point,Ideal),(point,Ideal,Boolean)}
@@ -1024,7 +1024,7 @@ Inputs => {
 QuotientRing => "R" => {"the homogeneous coordinate ring of a closed subscheme ",TEX///$X\subseteq\mathbb{P}^n$///," over a finite ground field"}}, 
 Outputs => { 
 Ideal => {"an ideal in ",TT "R"," defining a point on ",TEX///$X$///}}, 
-PARA{"This function is a variant of the ",TO randomKRationalPoint," function, which has been further improved and extended in the package ",HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/MultiprojectiveVarieties/html/index.html","MultiprojectiveVarieties"},", see ",HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/MultiprojectiveVarieties/html/_point_lp__Multiprojective__Variety_rp.html", TT "point(MultiprojectiveVariety)"},"."},
+PARA{"This function is a variant of the ",TO randomKRationalPoint," function, which has been further improved and extended in the package ", TO "MultiprojectiveVarieties", ", see ", TO "MultiprojectiveVarieties::point(MultiprojectiveVariety)", "."},
 PARA{"Below we verify the birationality of a rational map."},
 EXAMPLE { 
 "f = inverseMap specialQuadraticTransformation(9,ZZ/33331);",

--- a/M2/Macaulay2/packages/HyperplaneArrangements.m2
+++ b/M2/Macaulay2/packages/HyperplaneArrangements.m2
@@ -3348,7 +3348,7 @@ doc ///
 	    @HREF("https://arxiv.org/abs/math/9912212", "arXiv:math/9912212")@,
 	    as well as Sheaf Algorithms Using the Exterior Algebra, 
 	    by Wolfram Decker and David Eisenbud, in 
-	    @HREF("https://faculty.math.illinois.edu/Macaulay2/Book/",
+	    @HREF("https://macaulay2.com/Book/",
 		    "Computations in algebraic geometry with Macaulay 2")@,
 		 Algorithms and Computations in Mathematics, Springer-Verlag, 
 		 Berlin, 2001.

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/polarize-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/polarize-doc.m2
@@ -29,8 +29,8 @@ doc ///
       
       This is code adapted from the Monomial Ideals chapter, written by Greg Smith and Serkan Hosten, of
       {\bf Computations in algebraic geometry with Macaulay 2}. See @HREF
-      "https://faculty.math.illinois.edu/Macaulay2/Book/ComputationsBook/chapters/monomialIdeals/chapter-wrapper.pdf"@ for
-      the chapter PDF, and @HREF"https://faculty.math.illinois.edu/Macaulay2/Book/"@ for more information
+      "https://macaulay2.com/Book/ComputationsBook/chapters/monomialIdeals/chapter-wrapper.pdf"@ for
+      the chapter PDF, and @HREF"https://macaulay2.com/Book/"@ for more information
       on this book.
     Example
       R = QQ[x,y,z];

--- a/M2/Macaulay2/packages/MultiGradedRationalMap.m2
+++ b/M2/Macaulay2/packages/MultiGradedRationalMap.m2
@@ -605,19 +605,19 @@ Description
    We also implement the Jacobian dual criterion in the multi-graded setting.
       
       
-    {\bf Overlap with other packages:} {\bf -}  The package @ HREF("https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.12/share/doc/Macaulay2/Cremona/html/", "Cremona") @ performs several computations related to rational and birational maps between irreducible projective varieties.
+    {\bf Overlap with other packages:} {\bf -}  The package @ TO "Cremona" @ performs several computations related to rational and birational maps between irreducible projective varieties.
     Among other things, it can compute the degree of a rational map, test birationality and find the inverse of a birational map. 
     There is a deterministic implementation and a fast probabilistic implementation.
       
-    {\bf -} The package @ HREF("https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.11/share/doc/Macaulay2/RationalMaps/html/index.html", "RationalMaps") @ computes several things related to rational maps between projective varieties.
+    {\bf -} The package @ TO "RationalMaps" @ computes several things related to rational maps between projective varieties.
     Among other things, it can detect birationality and compute the inverse of a rational map.
     It contains an implementation of the remarkable Jacobian dual criterion.
     
-    {\bf -} The package @ HREF("https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.11/share/doc/Macaulay2/Parametrization/html/index.html", "Parametrization") @ mostly deals with rational parametrizations of rational curves defined over ℚ.
+    {\bf -} The package @ TO "Parametrization" @ mostly deals with rational parametrizations of rational curves defined over ℚ.
     It includes a function to compute the inverse of a rational map.
     
     {\bf -} The present implementation of this package can only handle rational maps where the source is a multiprojective space. 
-    On the other hand, the packages @ HREF("https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.12/share/doc/Macaulay2/Cremona/html/", "Cremona") @, @ HREF("https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.11/share/doc/Macaulay2/RationalMaps/html/index.html", "RationalMaps") @ and @ HREF("https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.11/share/doc/Macaulay2/Parametrization/html/index.html", "Parametrization") @  can handle more general varieties.
+    On the other hand, the packages @ TO "Cremona" @, @ TO "RationalMaps" @ and @ TO "Parametrization" @  can handle more general varieties.
         
     {\bf Acknowledgements:} The author is grateful to the organizers of the Macaulay2 workshop in Leipzig.
     The author is grateful to Laurent Busé for his support on the preparation of this package.

--- a/M2/Macaulay2/packages/Polyhedra/documentation/documentation.m2
+++ b/M2/Macaulay2/packages/Polyhedra/documentation/documentation.m2
@@ -481,7 +481,7 @@ doc ///
    Description
       Text
          Method used by the package
-         @ HREF("https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.12/share/doc/Macaulay2/Tropical/html/", "Tropical.m2") @ to construct a fan from {\tt Gfan} output.
+	 @ TO "Tropical" @ to construct a fan from {\tt Gfan} output.
          Gfan produces more data than just rays and maximal cones and this constructor will save that data to avoid recomputation.
 ///
 

--- a/M2/Macaulay2/packages/RandomCurvesOverVerySmallFiniteFields.m2
+++ b/M2/Macaulay2/packages/RandomCurvesOverVerySmallFiniteFields.m2
@@ -1019,7 +1019,7 @@ document {
   Key => RandomCurvesOverVerySmallFiniteFields,
   Headline => "randomly chosen smooth canonical curves over small finite fields",
   "This package can be seen as a refined version of the ",
-  HREF("https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2-1.11/share/doc/Macaulay2/RandomCanonicalCurves/html/","RandomCanonicalCurves"),  
+  TO "RandomCanonicalCurves",
   " package, which catches all possible missteps in the constructions. 
   The construction follows the unirationality proof of M_g for g<=14 and the article ",
   HREF("http://arxiv.org/abs/1311.6962","Matrix factorizations and families of curves of genus 15"),

--- a/M2/Macaulay2/packages/RationalMaps.m2
+++ b/M2/Macaulay2/packages/RationalMaps.m2
@@ -1364,20 +1364,20 @@ document {
 	  {"A. Simis, ",EM "  Cremona Transformations and some Related Algebras", ", Journal of Algebra, Volume 280, Issue 1, 1 October 2004, Pages 162--179"},
 	},
     BOLD "Functionality overlap with other packages:\n\n",BR{},BR{},
-    EM HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/index.html", "Parametrization"},
-      ":  While the package ", HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/index.html", "Parametrization"}, " focuses mostly on curves, it also includes a function ", HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/_invert__Birational__Map.html", "invertBirationalMap"}, "
+    EM  TO "Parametrization",
+      ":  While the package ", TO "Parametrization", " focuses mostly on curves, it also includes a function ", TO "Parametrization::invertBirationalMap", "
       that has the same functionality as ", TO "inverseOfMap", ".  On the other hand, these two functions were implemented differently and so sometimes one function can be substantially faster than the other.\n", BR{}, BR{},
-    EM HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/index.html", "Cremona"},
-    ":  The package ", HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/index.html", "Cremona"}, " focuses on  fast probabilistic computations in general cases and  deterministic computations for special
+    EM TO "Cremona",
+    ":  The package ", TO "Cremona", " focuses on  fast probabilistic computations in general cases and  deterministic computations for special
      kinds of maps from projective space.  More precisely, ",BR{},
     UL {
-        {HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/_is__Birational.html","isBirational"}, " gives a probabilistic answer to the question of whether a map between varieties is birational.  Furthermore, if the
+        {TO "Cremona::isBirational", " gives a probabilistic answer to the question of whether a map between varieties is birational.  Furthermore, if the
 	     source is projective space, then ", TT "degreeOfRationalMap", " with ", TT   "MathMode=>true", " gives a deterministic correct answer.
 	      In some cases, the speed of the latter  is comparable with ", TO "isBirationalMap", " with ", TT   "AssumeDominant=>true." },
-        {HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/_inverse__Map.html","inverseMap"}, " gives a  fast computation of the inverse of a birational map if the source is projective space ", EM " and ",
+        {TO "Cremona::inverseMap", " gives a  fast computation of the inverse of a birational map if the source is projective space ", EM " and ",
 	     "the map has maximal linear rank.   In some cases, even if the map has maximal linear rank, our function ", TO "inverseOfMap",
 	       " appears to be competitive however.  If you pass inverseMap a map not from projective space, then it calls a modified and improved version of ",
-	      HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/_invert__Birational__Map.html", "invertBirationalMap"}, " from ", HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/index.html", "Parametrization"}, "."},
+	      TO "Parametrization::invertBirationalMap", " from ", TO "Parametrization", "."},
     },
 }
 
@@ -1733,7 +1733,7 @@ doc ///
         SimisStrategy
         ReesStrategy
     Caveat
-        Also see the very fast probabilistic birationality checking of the @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/index.html", "Cremona"}@ package: @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/_is__Birational.html","isBirational"}@.
+        Also see the very fast probabilistic birationality checking of the @TO "Cremona"@ package: @TO "Cremona::isBirational"@.
 ///
 --***************************************************************
 
@@ -2277,7 +2277,7 @@ doc ///
         SimisStrategy
         ReesStrategy
     Caveat
-        The current implementation of this function works only for irreducible varieties.  Also see the function @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/_inverse__Map.html","inverseMap"}@ in the package @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/index.html", "Cremona"}@, which for some maps from projective space is faster.  Additionally, also compare with the function @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/_invert__Birational__Map.html", "invertBirationalMap"}@ of the package @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/index.html", "Parametrization"}@.
+        The current implementation of this function works only for irreducible varieties.  Also see the function @TO "Cremona::inverseMap"@ in the package @TO "Cremona"@, which for some maps from projective space is faster.  Additionally, also compare with the function @TO "Parametrization::invertBirationalMap"@ of the package @TO "Parametrization"@.
 ///
 --***************************************************************
 
@@ -2334,7 +2334,7 @@ doc ///
              phi=map(S,S,transpose jacobian ideal g);
              sourceInversionFactor(phi, Verbosity=>0)
     Caveat
-        The current implementation of this function works only for irreducible varieties..  Also see the function @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/_inverse__Map.html","inverseMap"}@ in the package @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Cremona/html/index.html", "Cremona"}@, which for some maps from projective space is faster.  Additionally, also compare with the function @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/_invert__Birational__Map.html", "invertBirationalMap"}@ of the package @HREF{"https://faculty.math.illinois.edu/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Parametrization/html/index.html", "Parametrization"}@.
+        The current implementation of this function works only for irreducible varieties..  Also see the function @TO "Cremona::inverseMap"@ in the package @TO "Cremona"@, which for some maps from projective space is faster.  Additionally, also compare with the function @TO "Parametrization::invertBirationalMap"@ of the package @TO"Parametrization"@.
     SeeAlso
         HybridStrategy
         SimisStrategy


### PR DESCRIPTION
Now that https://faculty.math.illinois.edu/ doesn't exist anymore, we fix various links in the documentation, either using local links (for packages referring to other packages) or replacing with https://macaulay2.com/.

@DanGrayson -- do you have an updated URL to replace https://faculty.math.illinois.edu/~dan/?  Or should we just remove the `HomePage` from your packages?