### PR TITLE
Remove quotes around shell variable in HTML5 validation test

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -210,7 +210,7 @@ jobs:
             else
             # otherwise, just validate HTML docs for packages that have been updated
               PACKAGES=$(git diff --stat origin/development HEAD -- ../../Macaulay2/packages/ | grep -Po "(?<=Macaulay2/packages/)[^/\.]*(?=\.m2|/)" | uniq)
-              make validate-html PACKAGES="$PACKAGES"
+              make validate-html PACKAGES=$PACKAGES
             fi
           else
             # if not a pull request (scheduled or pre-master builds), then validate everything


### PR DESCRIPTION
When checking more than one package, this was causing build failures ("Syntax error: end of file unexpected").

---

This fixes the problem mentioned in https://github.com/Macaulay2/M2/pull/2916#issuecomment-1698181902.