### PR TITLE
Use xargs and restore quotes in validate-html check

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -209,8 +209,8 @@ jobs:
               make validate-html
             else
             # otherwise, just validate HTML docs for packages that have been updated
-              PACKAGES=$(git diff --stat origin/development HEAD -- ../../Macaulay2/packages/ | grep -Po "(?<=Macaulay2/packages/)[^/\.]*(?=\.m2|/)" | uniq)
-              make validate-html PACKAGES=$PACKAGES
+              PACKAGES=$(git diff --stat origin/development HEAD -- ../../Macaulay2/packages/ | grep -Po "(?<=Macaulay2/packages/)[^/\.]*(?=\.m2|/)" | uniq | xargs)
+              make validate-html PACKAGES="$PACKAGES"
             fi
           else
             # if not a pull request (scheduled or pre-master builds), then validate everything


### PR DESCRIPTION
This *should* work to fix the failing HTML validation in some of the GitHub builds. :crossed_fingers: 

Here's the basic idea:  When a pull request touches just some packages (and not `Core`), we only bother validating the HTML documentation for those packages, e.g., if we've updated the `Foo` and `Bar` packages, we want to run the following:

```
make validate-html PACKAGES="Foo Bar"
```

But in the GitHub builds, we can't hardcode the package names to validate -- we find them on the fly based on the output of `git diff` (piped through some other things), store these to a shell variable `PACKAGES` , and call

```
make validate-html PACKAGES="$PACKAGES"
```

This was causing a weird syntax error, which I now realize is because the output of `git diff` was returning the packages on separate lines.

Yesterday's "fix" (#2920)  just got rid of the quotes, which was equivalent to something like:

```
make validate-html PACKAGES=Foo Bar
```

So it would validate the HTML for the `Foo` package, but it would try to run `make Bar` and complain that no such target exists.  So removing quotes was definitely the wrong thing to do!

What this PR does is pipe the output of `git diff` through `xargs` before assigning to the `PACKAGES` variable, which essentially changes the newline-delimited list of packages to a space-delimited list of packages.  After restoring the quotes, everything works as expected.