### PR TITLE
Revert "Use clang-tidy to use nullptr instead of 0 or NULL in e direc…

### DIFF
--- a/M2/Macaulay2/e/Eschreyer.cpp
+++ b/M2/Macaulay2/e/Eschreyer.cpp
@@ -104,7 +104,7 @@ GBMatrix *GBKernelComputation::get_syzygies()
   for (int i = 0; i < syzygies.size(); i++)
     {
       result->append(syzygies[i]);
-      syzygies[i] = nullptr;
+      syzygies[i] = 0;
     }
   return result;
 }
@@ -132,20 +132,20 @@ void GBKernelComputation::strip_gb(const GBMatrix *m)
   int i;
   int *components = newarray_atomic_clear(int, F->rank());
   for (i = 0; i < g.size(); i++)
-    if (g[i] != nullptr) components[g[i]->comp - 1]++;
+    if (g[i] != 0) components[g[i]->comp - 1]++;
 
   for (i = 0; i < g.size(); i++)
     {
       gbvector head;
       gbvector *last = &head;
-      for (gbvector *v = g[i]; v != nullptr; v = v->next)
+      for (gbvector *v = g[i]; v != 0; v = v->next)
         if (components[v->comp - 1] > 0)
           {
             gbvector *t = GR->gbvector_copy_term(v);
             last->next = t;
             last = t;
           }
-      last->next = nullptr;
+      last->next = 0;
       gb.push_back(head.next);
     }
   for (i = 0; i < F->rank(); i++) mi.push_back(new MonomialIdeal(R));
@@ -182,7 +182,7 @@ void GBKernelComputation::new_pairs(int i)
           {
             thisvp.resize(0);
             varpower::var(w, 1, thisvp);
-            Bag *b = new Bag(static_cast<void *>(nullptr), thisvp);
+            Bag *b = new Bag(static_cast<void *>(0), thisvp);
             elems.push_back(b);
           }
 
@@ -203,7 +203,7 @@ void GBKernelComputation::new_pairs(int i)
           varpower::quotient(a.monom().data(), vp.data(), thisvp);
           if (varpower::is_equal(a.monom().data(), thisvp.data()))
             continue;
-          Bag *b = new Bag(static_cast<void *>(nullptr), thisvp);
+          Bag *b = new Bag(static_cast<void *>(0), thisvp);
           elems.push_back(b);
         }
     }
@@ -297,9 +297,9 @@ int GBKernelComputation::find_divisor(const MonomialIdeal *this_mi,
 
 gbvector *GBKernelComputation::s_pair(gbvector *gsyz)
 {
-  gbvector *result = nullptr;
+  gbvector *result = NULL;
   monomial si = M->make_one();
-  for (gbvector *f = gsyz; f != nullptr; f = f->next)
+  for (gbvector *f = gsyz; f != 0; f = f->next)
     {
       SG->schreyer_down(f->monom, f->comp - 1, si);
       gbvector *h = GR->mult_by_term(F, gb[f->comp - 1], f->coeff, si, 0);
@@ -318,7 +318,7 @@ void GBKernelComputation::wipe_unneeded_terms(gbvector *&f)
   // int nterms = 1;
   // int nsaved = 0;
   gbvector *g = f;
-  while (g->next != nullptr)
+  while (g->next != 0)
     {
       // First check to see if the term g->next is in the monideal
       // nterms++;
@@ -335,7 +335,7 @@ void GBKernelComputation::wipe_unneeded_terms(gbvector *&f)
           // nsaved++;
           gbvector *tmp = g->next;
           g->next = tmp->next;
-          tmp->next = nullptr;
+          tmp->next = 0;
           GR->gbvector_remove(tmp);
         }
     }
@@ -367,7 +367,7 @@ void GBKernelComputation::reduce(gbvector *&f, gbvector *&fsyz)
   int count = 0;
   if (M2_gbTrace >= 4) emit_wrapped(",");
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       if (SF)
         {
@@ -452,14 +452,14 @@ void GBKernelComputation::geo_reduce(gbvector *&f, gbvector *&fsyz)
   const gbvector *r;
   gbvectorHeap fb(GR, F);
   fb.add(f);
-  f = nullptr;
+  f = NULL;
   const gbvector *lead;
   int q;
 
   int count = 0;
   if (M2_gbTrace >= 4) emit_wrapped(",");
 
-  while ((lead = fb.get_lead_term()) != nullptr)
+  while ((lead = fb.get_lead_term()) != NULL)
     {
       if (SF)
         {

--- a/M2/Macaulay2/e/GF.cpp
+++ b/M2/Macaulay2/e/GF.cpp
@@ -127,7 +127,7 @@ GF::~GF() {}
 GF *GF::create(const RingElement *prim)
 {
   GF *result = new GF;
-  if (!result->initialize_GF(prim)) return nullptr;
+  if (!result->initialize_GF(prim)) return 0;
 
   return result;
 }

--- a/M2/Macaulay2/e/LLL.cpp
+++ b/M2/Macaulay2/e/LLL.cpp
@@ -30,7 +30,7 @@ bool LLLoperations::initializeLLL(const MutableMatrix *A,
                                   MutableMatrix *&LLLstate)
 {
   // First check m: should be a matrix over globalZZ.
-  if (A == nullptr || A->get_ring() != globalZZ)
+  if (A == 0 || A->get_ring() != globalZZ)
     {
       ERROR("LLL only defined for matrices over ZZ");
       return false;

--- a/M2/Macaulay2/e/NAG.cpp
+++ b/M2/Macaulay2/e/NAG.cpp
@@ -61,18 +61,18 @@ Matrix* StraightLineProgram::evaluate(const Matrix* vals)
 template <class Field>
 SLP<Field>::SLP()
 {
-  C = nullptr;
-  handle = nullptr;
+  C = NULL;
+  handle = NULL;
   eval_time = 0;
   n_calls = 0;
-  nodes = nullptr;
+  nodes = NULL;
 }
 
 template <class Field>
 SLP<Field>::~SLP()
 {
   freemem(nodes);
-  if (handle != nullptr)
+  if (handle != NULL)
     {
       printf("closing library\n");
       dlclose(handle);
@@ -93,12 +93,12 @@ SLP<Field> /* or null */* SLP<Field>::make(const Matrix* m_consts,
   if (num_slps > MAX_NUM_SLPs)
     {
       ERROR("max number of slps exceeded");
-      res = nullptr;
+      res = NULL;
     }
   else if (program->len < 3)
     {
       ERROR("invalid SLP");
-      res = nullptr;
+      res = NULL;
     }
   else
     {
@@ -131,10 +131,10 @@ SLP<Field> /* or null */* SLP<Field>::make(const Matrix* m_consts,
               const char* funname = "slpFN";
               printf("loading slpFN from %s\n", libname);
               res->handle = dlopen(libname, RTLD_LAZY | RTLD_GLOBAL);
-              if (res->handle == nullptr) ERROR("can't load library %s", libname);
+              if (res->handle == NULL) ERROR("can't load library %s", libname);
               res->compiled_fn = (void (*)(element_type*, element_type*))dlsym(
                   res->handle, funname);
-              if (res->compiled_fn == nullptr)
+              if (res->compiled_fn == NULL)
                 ERROR(
                     "can't link function %s from library %s", funname, libname);
             }
@@ -193,10 +193,10 @@ Nterm* extract_divisible_by_x(Nterm*& ff, int i)  // auxiliary
   /* Extracts into fx the terms divisible by the (n-1-i)-th variable "x"
      and divides them by x. (exponent vectors are assumed to be reversed)
      Note: terms in fx may not be in monomial order. */
-  Nterm* fx = nullptr;
+  Nterm* fx = NULL;
   Nterm* f = ff;
-  Nterm* prev_f = nullptr;
-  while (f != nullptr)
+  Nterm* prev_f = NULL;
+  while (f != NULL)
     {
       if (f->monom[i] == 0)
         {
@@ -206,7 +206,7 @@ Nterm* extract_divisible_by_x(Nterm*& ff, int i)  // auxiliary
       else
         {
           f->monom[i]--;  // divide by x
-          if (prev_f != nullptr)
+          if (prev_f != NULL)
             {
               prev_f->next = f->next;  // extract
             }
@@ -216,7 +216,7 @@ Nterm* extract_divisible_by_x(Nterm*& ff, int i)  // auxiliary
             }
           f->next = fx;  // prepend to fx
           fx = f;
-          f = (prev_f == nullptr) ? ff : prev_f->next;
+          f = (prev_f == NULL) ? ff : prev_f->next;
         }
     }
   return fx;
@@ -244,7 +244,7 @@ int SLP<Field>::poly_to_horner_slp(int n,
   for (int i = 0; i < n; i++)
     {
       Nterm* fx = extract_divisible_by_x(f, i);
-      if (fx == nullptr)
+      if (fx == NULL)
         part_pos[i] = ZERO_CONST;
       else
         {
@@ -258,7 +258,7 @@ int SLP<Field>::poly_to_horner_slp(int n,
         }
     }
   int c = 0;  // count nonzeros
-  if (f != nullptr) c++;
+  if (f != NULL) c++;
   for (int i = 0; i < n; i++)
     if (part_pos[i] != ZERO_CONST) c++;
   if (c == 0) return ZERO_CONST;
@@ -268,7 +268,7 @@ int SLP<Field>::poly_to_horner_slp(int n,
   node_index.push_back(prog.size());
   prog.push_back(slpMULTIsum);
   prog.push_back(c);
-  if (f != nullptr)
+  if (f != NULL)
     prog.push_back(CONST_OFFSET +
                 add_constant_get_position<Field>(
                     consts, element_type(toBigComplex(C, f->coeff))));
@@ -281,7 +281,7 @@ int SLP<Field>::poly_to_horner_slp(int n,
 void monomials_to_conventional_expvectors(int n, Nterm* f)  // auxiliary
 /* "unpack" monomials */
 {
-  for (; f != nullptr; f = f->next)
+  for (; f != NULL; f = f->next)
     for (int i = 0; i < n - 1; i++) f->monom[i] -= f->monom[i + 1];
 }
 
@@ -293,7 +293,7 @@ SLP<Field> /* or null */* SLP<Field>::make(const PolyRing* R, ring_elem e)
   if (num_slps > MAX_NUM_SLPs)
     {
       ERROR("max number of slps exceeded");
-      res = nullptr;
+      res = NULL;
     }
   else
     {
@@ -356,7 +356,7 @@ SLP<Field> /* or null */* SLP<Field>::concatenate(const SLP<Field>* slp)
       num_inputs != slp->num_inputs || rows_out != slp->rows_out)
     {
       ERROR("slps unstackable");
-      return nullptr;
+      return NULL;
     }
   int num_outputs = rows_out * cols_out;
   int* end_program = program->array + program->len - num_outputs;
@@ -619,7 +619,7 @@ SLP<Field> /* or null */* SLP<Field>::jacobian(bool makeHxH,
   if (rows_out != 1)
     {
       ERROR("1-row slp expected");
-      return nullptr;
+      return NULL;
     };
 
   int num_outputs = rows_out * cols_out;
@@ -714,7 +714,7 @@ void SLP<Field>::evaluate(int n, const element_type* values, element_type* ret)
 {
   if (n != num_inputs) ERROR("wrong number of inputs");
 
-  element_type* out = nullptr;   // used by compiledSLP
+  element_type* out = NULL;   // used by compiledSLP
   int out_entries_shift = 0;  // position of "out matrix"
 
   int cur_node = num_consts;
@@ -804,7 +804,7 @@ void SLP<Field>::evaluate(int n, const element_type* values, element_type* ret)
 template <class Field>
 Matrix* SLP<Field>::evaluate(const Matrix* values)
 {
-  element_type* out = nullptr;   // used by compiledSLP
+  element_type* out = NULL;   // used by compiledSLP
   int out_entries_shift = 0;  // position of "out matrix" in slp->program
 
   int cur_node = num_consts;
@@ -856,7 +856,7 @@ Matrix* SLP<Field>::evaluate(const Matrix* values)
                   break;
                 default:
                   ERROR("unknown SLP operation");
-                  return nullptr;
+                  return NULL;
               }
           }
         out_entries_shift = i + 1;
@@ -1417,9 +1417,9 @@ PathTracker* PathTracker::catalog[MAX_NUM_PATH_TRACKERS];
 
 PathTracker::PathTracker()
 {
-  raw_solutions = nullptr;
-  solutions = nullptr;
-  DMforPN = nullptr;
+  raw_solutions = NULL;
+  solutions = NULL;
+  DMforPN = NULL;
 }
 
 PathTracker::~PathTracker()
@@ -1440,14 +1440,14 @@ PathTracker /* or null */* PathTracker::make(const Matrix* S,
   if (S->n_rows() != 1 || T->n_rows() != 1)
     {
       ERROR("1-row matrices expected");
-      return nullptr;
+      return NULL;
     };
   PathTracker* p = new PathTracker;
   const PolyRing* R = p->homotopy_R = S->get_ring()->cast_to_PolyRing();
-  if (R == nullptr)
+  if (R == NULL)
     {
       ERROR("polynomial ring expected");
-      return nullptr;
+      return NULL;
     }
   p->C = cast_to_CCC(R->getCoefficients());
   // const Ring* K = R->getCoefficients();
@@ -1455,7 +1455,7 @@ PathTracker /* or null */* PathTracker::make(const Matrix* S,
   if (!p->C)
     {
       ERROR("complex coefficients expected");
-      return nullptr;
+      return NULL;
     }
   p->productST = mpfr_get_d(productST, MPFR_RNDN);
   // p->bigT = asin(sqrt(1-p->productST*p->productST));
@@ -1469,14 +1469,14 @@ PathTracker /* or null */* PathTracker::make(const Matrix* S,
   p->DMforPN = newarray_atomic(double, n);
   p->DMforPN[n - 1] = 1;
   p->S = S;
-  p->slpS = nullptr;
+  p->slpS = NULL;
   for (int i = 0; i < n - 1; i++)
     {
       int d = degree_ring_elem(R, S->elem(0, i));
       if (d > p->maxDegreeTo3halves) p->maxDegreeTo3halves = d;
       p->DMforPN[i] = 1 / sqrt(d);
       StraightLineProgram* slp = StraightLineProgram::make(R, S->elem(0, i));
-      if (p->slpS == nullptr)
+      if (p->slpS == NULL)
         p->slpS = slp;
       else
         {
@@ -1490,11 +1490,11 @@ PathTracker /* or null */* PathTracker::make(const Matrix* S,
   p->maxDegreeTo3halves = p->maxDegreeTo3halves * sqrt(p->maxDegreeTo3halves);
 
   p->T = T;
-  p->slpT = nullptr;
+  p->slpT = NULL;
   for (int i = 0; i < T->n_cols(); i++)
     {
       StraightLineProgram* slp = StraightLineProgram::make(R, T->elem(0, i));
-      if (p->slpT == nullptr)
+      if (p->slpT == NULL)
         p->slpT = slp;
       else
         {
@@ -1518,30 +1518,30 @@ PathTracker /* or null */* PathTracker::make(const Matrix* HH)
   if (HH->n_rows() != 1)
     {
       ERROR("1-row matrix expected");
-      return nullptr;
+      return NULL;
     };
 
   PathTracker* p = new PathTracker;
   const PolyRing* R = p->homotopy_R = HH->get_ring()->cast_to_PolyRing();
-  if (R == nullptr)
+  if (R == NULL)
     {
       ERROR("polynomial ring expected");
-      return nullptr;
+      return NULL;
     }
   const Ring* K = R->getCoefficients();
   p->C = cast_to_CCC(K);  // cast to ConcreteRing<ARingCCC> for now
   if (!p->C)
     {
       ERROR("complex coefficients expected");
-      return nullptr;
+      return NULL;
     }
 
   p->H = HH;
-  p->slpH = nullptr;
+  p->slpH = NULL;
   for (int i = 0; i < HH->n_cols(); i++)
     {
       StraightLineProgram* slp = StraightLineProgram::make(R, HH->elem(0, i));
-      if (p->slpH == nullptr)
+      if (p->slpH == NULL)
         p->slpH = slp;
       else
         {
@@ -1560,11 +1560,11 @@ PathTracker /* or null */* PathTracker::make(StraightLineProgram* slp_pred,
                                              StraightLineProgram* slp_corr)
 {
   PathTracker* p = new PathTracker;
-  p->H = nullptr;
-  p->slpH = nullptr;
+  p->H = NULL;
+  p->slpH = NULL;
   p->slpHxt = p->slpHxtH = slp_pred;
   p->slpHxH = slp_corr;
-  p->C = nullptr;
+  p->C = NULL;
   return p;
 }
 
@@ -1650,7 +1650,7 @@ int PathTracker::track(const Matrix* start_sols)
   infinity_threshold2 *= infinity_threshold2;
   double end_zone_factor_dbl = mpfr_get_d(end_zone_factor, MPFR_RNDN);
 
-  if (C == nullptr)
+  if (C == NULL)
     C = cast_to_CCC(
         start_sols->get_ring());  // fixes the problem for PrecookedSLPs
 
@@ -1985,12 +1985,12 @@ Matrix /* or null */* PathTracker::refine(const Matrix* sols,
   if (!cast_to_CCC(sols->get_ring()))
     {
       ERROR("complex coordinates expected");
-      return nullptr;
+      return NULL;
     }
   if (sols->n_cols() != n)
     {
       ERROR("incorrect number of coordinates");
-      return nullptr;
+      return NULL;
     }
   n_sols = sols->n_rows();
 
@@ -2073,7 +2073,7 @@ Matrix /* or null */* PathTracker::refine(const Matrix* sols,
 
 Matrix /* or null */* PathTracker::getSolution(int solN)
 {
-  if (solN < 0 || solN >= n_sols) return nullptr;
+  if (solN < 0 || solN >= n_sols) return NULL;
   // construct output
   FreeModule* SS = C->make_FreeModule(n_coords);
   FreeModule* TT = C->make_FreeModule(1);
@@ -2139,7 +2139,7 @@ int PathTracker::getSolutionSteps(int solN)
 
 gmp_RRorNull PathTracker::getSolutionLastT(int solN)
 {
-  if (solN < 0 || solN >= n_sols) return nullptr;
+  if (solN < 0 || solN >= n_sols) return NULL;
   gmp_RRmutable result = getmemstructtype(gmp_RRmutable);
   mpfr_init2(result, C->get_precision());
   mpfr_set_d(result, raw_solutions[solN].t, MPFR_RNDN);
@@ -2148,7 +2148,7 @@ gmp_RRorNull PathTracker::getSolutionLastT(int solN)
 
 gmp_RRorNull PathTracker::getSolutionRcond(int solN)
 {
-  if (solN < 0 || solN >= n_sols) return nullptr;
+  if (solN < 0 || solN >= n_sols) return NULL;
   gmp_RRmutable result = getmemstructtype(gmp_RRmutable);
   mpfr_init2(result, C->get_precision());
   mpfr_set_d(result, raw_solutions[solN].cond, MPFR_RNDN);

--- a/M2/Macaulay2/e/ZZ.cpp
+++ b/M2/Macaulay2/e/ZZ.cpp
@@ -67,7 +67,7 @@ std::pair<bool, long> RingZZ::coerceToLongInteger(ring_elem a) const
                                mpz_get_si(a.get_mpz()));
 }
 
-ring_elem RingZZ::random() const { return ring_elem(rawRandomInteger(nullptr)); }
+ring_elem RingZZ::random() const { return ring_elem(rawRandomInteger(0)); }
 
 void RingZZ::elem_text_out(buffer &o,
                            const ring_elem ap,

--- a/M2/Macaulay2/e/ZZp.cpp
+++ b/M2/Macaulay2/e/ZZp.cpp
@@ -64,7 +64,7 @@ bool Z_mod::initialize_Z_mod(int p)
 Z_mod *Z_mod::create(int p)
 {
   Z_mod *result = new Z_mod;
-  if (!result->initialize_Z_mod(p)) return nullptr;
+  if (!result->initialize_Z_mod(p)) return 0;
 
   return result;
 }

--- a/M2/Macaulay2/e/aring-gf-flint-big.cpp
+++ b/M2/Macaulay2/e/aring-gf-flint-big.cpp
@@ -64,7 +64,7 @@ ARingGFFlintBig::ARingGFFlintBig(const PolynomialRing& R, const ring_elem a)
 ARingGFFlintBig::~ARingGFFlintBig()
 {
   fq_nmod_ctx_clear(mContext);
-  mPrimitiveElement = nullptr;
+  mPrimitiveElement = 0;
   freemem(mPPowers);
   flint_randclear(mRandomState);
 

--- a/M2/Macaulay2/e/aring-gf-flint.cpp
+++ b/M2/Macaulay2/e/aring-gf-flint.cpp
@@ -63,7 +63,7 @@ ARingGFFlint::~ARingGFFlint()
 {
   fq_zech_ctx_clear(mContext);
   fq_nmod_ctx_clear(mBigContext);
-  mPrimitiveElement = nullptr;
+  mPrimitiveElement = 0;
   freemem(mPPowers);
   flint_randclear(mRandomState);
 

--- a/M2/Macaulay2/e/aring-glue.hpp
+++ b/M2/Macaulay2/e/aring-glue.hpp
@@ -73,9 +73,9 @@ class ConcreteRing : public Ring
   // These are declared below for Galois fields, and the definitions appear
   // where?
 
-  const RingElement *getMinimalPolynomial() const { return nullptr; }
-  const RingElement *getGenerator() const { return nullptr; }
-  const RingElement *getRepresentation(const ring_elem &a) const { return nullptr; }
+  const RingElement *getMinimalPolynomial() const { return 0; }
+  const RingElement *getGenerator() const { return 0; }
+  const RingElement *getRepresentation(const ring_elem &a) const { return 0; }
   virtual long discreteLog(const ring_elem &a) const
   {
     throw exc::engine_error("cannot compute discrete logarithm in this ring");

--- a/M2/Macaulay2/e/aring-qq-gmp.hpp
+++ b/M2/Macaulay2/e/aring-qq-gmp.hpp
@@ -219,7 +219,7 @@ class ARingQQGMP : public SimpleARing<ARingQQGMP>
   void swap(ElementType& a, ElementType& b) const { mpq_swap(&a, &b); }
   void random(ElementType& result) const
   {
-    rawSetRandomQQ(&result, nullptr);
+    rawSetRandomQQ(&result, 0);
 #if 0
       mpz_urandomb(mpq_numref(&result), mRandomState, mMaxHeight);
       mpz_urandomb(mpq_denref(&result), mRandomState, mMaxHeight);

--- a/M2/Macaulay2/e/aring-tower.cpp
+++ b/M2/Macaulay2/e/aring-tower.cpp
@@ -34,7 +34,7 @@ ARingTower::ARingTower(const BaseRingType &baseRing,
           // mExtensions.push_back(mRing.copy(i, extensions[i]));
         }
       else
-        mExtensions.push_back(static_cast<ElementType>(nullptr));
+        mExtensions.push_back(static_cast<ElementType>(NULL));
     }
 }
 
@@ -49,7 +49,7 @@ ARingTower *ARingTower::create(const ARingTower &R,
                                const std::vector<std::string> &new_names)
 {
   // TODO: write
-  return nullptr;
+  return 0;
 }
 
 ARingTower *ARingTower::create(const ARingTower &R,
@@ -72,7 +72,7 @@ ARingPolynomial ARingTower::alloc_poly_n(int deg) const
   result->polys = new ARingPolynomial[deg + 1];
   result->deg = deg;
   result->len = deg + 1;
-  for (int i = 0; i <= deg; i++) result->polys[i] = nullptr;
+  for (int i = 0; i <= deg; i++) result->polys[i] = 0;
   return result;
 }
 
@@ -89,16 +89,16 @@ ARingPolynomial ARingTower::alloc_poly_0(int deg) const
 void ARingTower::dealloc_poly(ARingPolynomial &f) const
 // only f is freed, not any pointers in the array of f
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   delete[] f->polys;
   delete f;
-  f = nullptr;
+  f = 0;
 }
 
 void ARingTower::clear(int level, ARingPolynomial &f) const
 // free all space associated to f, set f to 0.
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   if (level == 0)
     {
       for (int i = 0; i <= f->deg; i++) mBaseRing.clear(f->coeffs[i]);
@@ -110,15 +110,15 @@ void ARingTower::clear(int level, ARingPolynomial &f) const
       delete[] f->polys;
     }
   delete f;
-  f = nullptr;
+  f = 0;
 }
 
 void ARingTower::reset_degree(ARingPolynomial &f) const
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   int fdeg = f->deg;
   for (int j = fdeg; j >= 0; --j)
-    if (f->polys[j] != nullptr)
+    if (f->polys[j] != 0)
       {
         f->deg = j;
         return;
@@ -129,7 +129,7 @@ void ARingTower::reset_degree(ARingPolynomial &f) const
 
 ARingPolynomial ARingTower::copy(int level, const ARingPolynomial f) const
 {
-  if (f == nullptr) return nullptr;
+  if (f == 0) return 0;
   ARingPolynomial result = alloc_poly_n(f->deg);
   if (level == 0)
     for (int i = 0; i <= f->deg; i++) result->coeffs[i] = f->coeffs[i];
@@ -148,7 +148,7 @@ void ARingTower::increase_capacity(int newdeg, ARingPolynomial &f) const
       ARingPolynomial *newelems = newarray(ARingPolynomial, newdeg + 1);
       ARingPolynomial *fp = f->polys;
       for (int i = 0; i <= f->deg; i++) newelems[i] = fp[i];
-      for (int i = f->deg + 1; i < newdeg + 1; i++) newelems[i] = nullptr;
+      for (int i = f->deg + 1; i < newdeg + 1; i++) newelems[i] = 0;
       delete[] fp;
       f->polys = newelems;
       f->len = newdeg + 1;
@@ -173,7 +173,7 @@ void ARingTower::extensions_text_out(buffer &o) const
 {
   for (int i = 0; i < mExtensions.size(); i++)
     {
-      if (mExtensions[i] != nullptr)
+      if (mExtensions[i] != 0)
         {
           o << newline << "    ";
           elem_text_out(o, i, mExtensions[i], true, false, false);
@@ -184,7 +184,7 @@ void ARingTower::extensions_text_out(buffer &o) const
 namespace {
   int n_nonzero_terms(int level, ARingPolynomial f)
   {
-    if (f == nullptr) return 0;
+    if (f == 0) return 0;
     int nterms = 0;
     if (level == 0)
       {
@@ -194,7 +194,7 @@ namespace {
     else
       {
         for (int i = 0; i <= f->deg; i++)
-          if (f->polys[i] != nullptr) nterms++;
+          if (f->polys[i] != 0) nterms++;
       }
     return nterms;
   }
@@ -202,7 +202,7 @@ namespace {
 
 bool ARingTower::is_one(int level, const ARingPolynomial f) const
 {
-  if (f == nullptr) return false;
+  if (f == 0) return false;
   if (f->deg != 0) return false;
   if (level == 0)
     return 1 == f->coeffs[0];
@@ -218,7 +218,7 @@ void ARingTower::elem_text_out(buffer &o,
                                bool p_parens) const
 {
   // o << to_string(level, f);
-  if (f == nullptr)
+  if (f == 0)
     {
       o << "0";
       return;
@@ -264,7 +264,7 @@ void ARingTower::elem_text_out(buffer &o,
     {
       bool firstterm = true;
       for (int i = f->deg; i >= 0; i--)
-        if (f->polys[i] != nullptr)
+        if (f->polys[i] != 0)
           {
             bool this_p_parens = p_parens || (i > 0);
 
@@ -289,7 +289,7 @@ void ARingTower::elem_text_out(buffer &o,
 ARingPolynomial ARingTower::var(int level, int v) const
 // make the variable v (but at level 'level')
 {
-  if (v > level) return nullptr;
+  if (v > level) return 0;
   int which = (v == 0 ? 1 : 0);
   ARingPolynomial result =
       alloc_poly_0(which);  // TODO: check that this initializes elements to 0
@@ -306,12 +306,12 @@ ARingPolynomial ARingTower::var(int level, int v) const
 
 bool ARingTower::is_equal(int level, const ARingPolynomial f, const ARingPolynomial g) const
 {
-  if (f == nullptr)
+  if (f == 0)
     {
-      if (g == nullptr) return true;
+      if (g == 0) return true;
       return false;
     }
-  if (g == nullptr || f->deg != g->deg) return false;
+  if (g == 0 || f->deg != g->deg) return false;
   if (level == 0)
     {
       BaseCoefficientType *fp = f->coeffs;
@@ -330,8 +330,8 @@ bool ARingTower::is_equal(int level, const ARingPolynomial f, const ARingPolynom
 
 void ARingTower::add_in_place(int level, ARingPolynomial &f, const ARingPolynomial g) const
 {
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == 0) return;
+  if (f == 0)
     {
       f = copy(level, g);
       return;
@@ -355,7 +355,7 @@ void ARingTower::add_in_place(int level, ARingPolynomial &f, const ARingPolynomi
 
 void ARingTower::negate_in_place(int level, ARingPolynomial &f) const
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   int deg = f->deg;
   if (level == 0)
     {
@@ -365,14 +365,14 @@ void ARingTower::negate_in_place(int level, ARingPolynomial &f) const
   else
     {
       for (int i = 0; i <= deg; i++)
-        if (f->polys[i] != nullptr) negate_in_place(level - 1, f->polys[i]);
+        if (f->polys[i] != 0) negate_in_place(level - 1, f->polys[i]);
     }
 }
 
 void ARingTower::subtract_in_place(int level, ARingPolynomial &f, const ARingPolynomial g) const
 {
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == 0) return;
+  if (f == 0)
     {
       f = copy(level, g);
       negate_in_place(level, f);
@@ -400,7 +400,7 @@ void ARingTower::mult_by_coeff(int level,
                                const BaseCoefficientType &b) const
 {
   assert(!mBaseRing.is_zero(b));
-  if (f == nullptr) return;
+  if (f == 0) return;
 
   long deg = f->deg;
   if (level == 0)
@@ -411,13 +411,13 @@ void ARingTower::mult_by_coeff(int level,
   else
     {
       for (int i = 0; i <= deg; i++)
-        if (f->polys[i] != nullptr) mult_by_coeff(level - 1, f->polys[i], b);
+        if (f->polys[i] != 0) mult_by_coeff(level - 1, f->polys[i], b);
     }
 }
 
 void ARingTower::mult_by_coeff(ARingPolynomial &f, const BaseCoefficientType &b) const
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   if (mBaseRing.is_zero(b))
     {
       clear(f);

--- a/M2/Macaulay2/e/aring-tower.hpp
+++ b/M2/Macaulay2/e/aring-tower.hpp
@@ -143,7 +143,7 @@ class ARingTower : public RingInterface
   /////////////////////////////////
 
   bool is_unit(ElementType f) const { return false; }  // TODO: write this
-  bool is_zero(ElementType f) const { return f == nullptr; }
+  bool is_zero(ElementType f) const { return f == NULL; }
   bool is_equal(ElementType f, ElementType g) const
   {
     return is_equal(mStartLevel, f, g);
@@ -183,9 +183,9 @@ class ARingTower : public RingInterface
 
   // 'init', 'init_set' functions
 
-  void init(elem &result) const { result = nullptr; }
+  void init(elem &result) const { result = NULL; }
   void clear(elem &f) const { clear(mStartLevel, f); }
-  void set_zero(elem &result) const { result = nullptr; }
+  void set_zero(elem &result) const { result = NULL; }
   void copy(elem &result, elem a) const { result = copy(mStartLevel, a); }
   void set_from_long(elem &result, long a) const
   {  // TODO: write this
@@ -216,9 +216,9 @@ class ARingTower : public RingInterface
   void invert(elem &result, elem a) const {}  // TODO: write this
   void add(elem &result, elem a, elem b) const
   {
-    if (a == nullptr)
+    if (a == 0)
       result = b;
-    else if (b == nullptr)
+    else if (b == 0)
       result = a;
     else
       {

--- a/M2/Macaulay2/e/aring-zz-flint.cpp
+++ b/M2/Macaulay2/e/aring-zz-flint.cpp
@@ -49,7 +49,7 @@ void ARingZZ::elem_text_out(buffer& o,
     }
   else
     {
-      str = fmpz_get_str(static_cast<char*>(nullptr), 10, &a);
+      str = fmpz_get_str(static_cast<char*>(0), 10, &a);
       o << str;
     }
 }

--- a/M2/Macaulay2/e/aring-zz-gmp.cpp
+++ b/M2/Macaulay2/e/aring-zz-gmp.cpp
@@ -36,7 +36,7 @@ void ARingZZGMP::elem_text_out(buffer& o,
     }
   else
     {
-      str = mpz_get_str(static_cast<char*>(nullptr), 10, &a);
+      str = mpz_get_str(static_cast<char*>(0), 10, &a);
       o << str;
       delete str;
     }

--- a/M2/Macaulay2/e/aring-zz-gmp.hpp
+++ b/M2/Macaulay2/e/aring-zz-gmp.hpp
@@ -196,7 +196,7 @@ class ARingZZGMP : public SimpleARing<ARingZZGMP>
   void random(ElementType& result) const
   {
     // TODO: this leaks a gmp_ZZ
-    mpz_set(&result, rawRandomInteger(nullptr));
+    mpz_set(&result, rawRandomInteger(0));
   }
   /** @} */
 

--- a/M2/Macaulay2/e/aring.hpp
+++ b/M2/Macaulay2/e/aring.hpp
@@ -165,13 +165,13 @@ class DummyRing : public SimpleARing<DummyRing>
     return static_cast<unsigned int>(a);
   }
 
-  M2_arrayint getModPolynomialCoeffs() const { return nullptr; }
-  M2_arrayint getGeneratorCoeffs() const { return nullptr; }
+  M2_arrayint getModPolynomialCoeffs() const { return 0; }
+  M2_arrayint getGeneratorCoeffs() const { return 0; }
   void getGenerator(elem &result) const { result = 0; }
   const PolynomialRing &originalRing() const { return *mOriginalRing; }
   long coerceToLongInteger(ElementType a) const { return a; }
   void lift_to_original_ring(ring_elem &result, const ElementType &f) const {}
-  M2_arrayint fieldElementToM2Array(ElementType el) const { return nullptr; }
+  M2_arrayint fieldElementToM2Array(ElementType el) const { return 0; }
   void to_ring_elem(ring_elem &result, const ElementType &a) const {}
   void from_ring_elem(ElementType &result, const ring_elem &a) const {}
   bool promote(const Ring *Rf, const ring_elem f, ElementType &result) const

--- a/M2/Macaulay2/e/assprime.cpp
+++ b/M2/Macaulay2/e/assprime.cpp
@@ -10,7 +10,7 @@ AssociatedPrimes::AssociatedPrimes(const MonomialIdeal *const &I)
       ass_primes(new MonomialIdeal(I->get_ring()))
 {
   exps = newarray(int *, nvars + 2);
-  for (int i = 0; i <= nvars + 1; i++) exps[i] = nullptr;
+  for (int i = 0; i <= nvars + 1; i++) exps[i] = 0;
 }
 
 AssociatedPrimes::AssociatedPrimes(const MonomialIdeal *const &I, int cod)
@@ -21,12 +21,12 @@ AssociatedPrimes::AssociatedPrimes(const MonomialIdeal *const &I, int cod)
       ass_primes(new MonomialIdeal(I->get_ring()))
 {
   exps = newarray(int *, nvars + 2);
-  for (int i = 0; i <= nvars + 1; i++) exps[i] = nullptr;
+  for (int i = 0; i <= nvars + 1; i++) exps[i] = 0;
 }
 AssociatedPrimes::~AssociatedPrimes()
 {
   for (int i = 0; i <= nvars + 1; i++)
-    if (exps[i] != nullptr) freemem(exps[i]);
+    if (exps[i] != 0) freemem(exps[i]);
   freemem(exps);
 }
 
@@ -51,7 +51,7 @@ MonomialIdeal *AssociatedPrimes::associated_primes(int count)
     }
   minprime_limit = count;
   n_minprimes = 0;
-  if (exps[0] == nullptr) exps[0] = newarray_atomic_clear(int, nvars);
+  if (exps[0] == 0) exps[0] = newarray_atomic_clear(int, nvars);
   ass_prime_generator(mi->first_node(), 0);
   return ass_primes;
 }
@@ -89,12 +89,12 @@ static void to_prime_ideal(int n, int *exp)
 void AssociatedPrimes::ass_prime_generator(Nmi_node *p, int codim)
 {
   int i = codim + 1;
-  if (exps[i] == nullptr) exps[i] = newarray_atomic(int, nvars);
+  if (exps[i] == 0) exps[i] = newarray_atomic(int, nvars);
   exponents_t exp = exps[i];
   for (int j = 0; j < nvars; j++) exp[j] = exps[codim][j];
   for (;;)
     {
-      if (p == nullptr)
+      if (p == NULL)
         {
           if (state == do_codim)
             {

--- a/M2/Macaulay2/e/betti.cpp
+++ b/M2/Macaulay2/e/betti.cpp
@@ -5,7 +5,7 @@
 BettiDisplay::BettiDisplay()
     : mLoDegree(0), mHiDegree(0), mHiLength(0), mNLevels(0)
 {
-  mValues = nullptr;
+  mValues = 0;
 }
 
 BettiDisplay::BettiDisplay(int lodegree, int hidegree, int hilen)
@@ -52,7 +52,7 @@ BettiDisplay& BettiDisplay::operator=(const BettiDisplay& B)
 BettiDisplay::~BettiDisplay()
 {
   delete[] mValues;
-  mValues = nullptr;
+  mValues = 0;
 }
 
 void BettiDisplay::resize(int new_lo_degree, int new_hi_degree, int new_length)

--- a/M2/Macaulay2/e/bibasis/allocator.cpp
+++ b/M2/Macaulay2/e/bibasis/allocator.cpp
@@ -23,7 +23,7 @@ namespace BIBasis
         : MemoryPageSize(1048576)
         , TSize(int_divide_ceil(blockSize,sizeof(void*)))
         , PageSize(int_divide_floor(MemoryPageSize,blockSize))
-        , FreeBlock(nullptr) 
+        , FreeBlock(0) 
     {
     }
 

--- a/M2/Macaulay2/e/bibasis/launcher.cpp
+++ b/M2/Macaulay2/e/bibasis/launcher.cpp
@@ -22,7 +22,7 @@ namespace BIBasis
     {
         if (!CheckMatrix(matrix))
         {
-            return nullptr;
+            return NULL;
         }
         
         switch(GetSettingsManager().GetMonomialOrder())
@@ -43,7 +43,7 @@ namespace BIBasis
                     return basis.ToMatrix();
                 }
             default:
-                return nullptr;
+                return 0;
         };
     }
 

--- a/M2/Macaulay2/e/bibasis/monom.hpp
+++ b/M2/Macaulay2/e/bibasis/monom.hpp
@@ -66,7 +66,7 @@ namespace BIBasis
 
     inline Monom::VarsListNode::VarsListNode()
         : Value(0)
-        , Next(nullptr)
+        , Next(0)
     {
     }
 
@@ -85,7 +85,7 @@ namespace BIBasis
     }
 
     inline Monom::Monom()
-        : ListHead(nullptr)
+        : ListHead(0)
         , TotalDegree(0)
     {
     }

--- a/M2/Macaulay2/e/bibasis/monomDL.hpp
+++ b/M2/Macaulay2/e/bibasis/monomDL.hpp
@@ -63,13 +63,13 @@ namespace BIBasis
 
     inline MonomDL::MonomDL()
         : Monom()
-        , Next(nullptr)
+        , Next(0)
     {
     }
 
     inline MonomDL::MonomDL(const MonomDL& anotherMonom)
         : Monom()
-        , Next(nullptr)
+        , Next(0)
     {
         if (!anotherMonom.ListHead)
         {
@@ -110,7 +110,7 @@ namespace BIBasis
     {
         if (!ListHead || ListHead->Value > var)
         {
-            return nullptr;
+            return 0;
         }
         
         VarsListNode* position = ListHead;
@@ -169,7 +169,7 @@ namespace BIBasis
             if (*iterator)
             {
                 VarsListNode *nodeToDelete = (*iterator)->Next;
-                *iterator = nullptr;
+                *iterator = 0;
                 while (nodeToDelete)
                 {
                     iteratorAnother = nodeToDelete;

--- a/M2/Macaulay2/e/bibasis/monomDRL.hpp
+++ b/M2/Macaulay2/e/bibasis/monomDRL.hpp
@@ -63,13 +63,13 @@ namespace BIBasis
 
     inline MonomDRL::MonomDRL()
         : Monom()
-        , Next(nullptr)
+        , Next(0)
     {
     }
 
     inline MonomDRL::MonomDRL(const MonomDRL& anotherMonom)
         : Monom()
-        , Next(nullptr)
+        , Next(0)
     {
         if (!anotherMonom.ListHead)
         {
@@ -110,7 +110,7 @@ namespace BIBasis
     {
         if (!ListHead || ListHead->Value < var)
         {
-            return nullptr;
+            return 0;
         }
 
         VarsListNode* position = ListHead;
@@ -169,7 +169,7 @@ namespace BIBasis
             if (*iterator)
             {
                 VarsListNode *nodeToDelete = (*iterator)->Next;
-                *iterator = nullptr;
+                *iterator = 0;
                 while (nodeToDelete)
                 {
                     iteratorAnother = nodeToDelete;

--- a/M2/Macaulay2/e/bibasis/monomLex.hpp
+++ b/M2/Macaulay2/e/bibasis/monomLex.hpp
@@ -62,13 +62,13 @@ namespace BIBasis
 
     inline MonomLex::MonomLex()
         : Monom()
-        , Next(nullptr)
+        , Next(0)
     {
     }
 
     inline MonomLex::MonomLex(const MonomLex& anotherMonom)
         : Monom()
-        , Next(nullptr)
+        , Next(0)
     {
         if (!anotherMonom.ListHead)
         {
@@ -109,7 +109,7 @@ namespace BIBasis
     {
         if (!ListHead || ListHead->Value > var)
         {
-            return nullptr;
+            return 0;
         }
 
         VarsListNode* position = ListHead;
@@ -168,7 +168,7 @@ namespace BIBasis
             if (*iterator)
             {
                 VarsListNode *nodeToDelete = (*iterator)->Next;
-                *iterator = nullptr;
+                *iterator = 0;
                 while (nodeToDelete)
                 {
                     iteratorAnother = nodeToDelete;

--- a/M2/Macaulay2/e/comp-gb-declared.cpp
+++ b/M2/Macaulay2/e/comp-gb-declared.cpp
@@ -28,7 +28,7 @@ GBDeclared::GBDeclared(const Matrix *m0,
       POLY g;
       ring_elem denom1, denom2, u, v;
 
-      if (gb->elem(i) == nullptr)
+      if (gb->elem(i) == 0)
         continue;  // Do not even consider including 0 elements.
       g.f = P->translate_gbvector_from_vec(F, gb->elem(i), denom1);
       g.fsyz = P->translate_gbvector_from_vec(Fsyz, change->elem(i), denom2);
@@ -71,7 +71,7 @@ GBDeclared::GBDeclared(const Matrix *leadterms,
       gbvector *lead;
       ring_elem denom1, denom2, denom3, u, v;
 
-      if (gb->elem(i) == nullptr)
+      if (gb->elem(i) == 0)
         continue;  // Do not even consider including 0 elements.
       g.f = P->translate_gbvector_from_vec(F, gb->elem(i), denom1);
       g.fsyz = P->translate_gbvector_from_vec(Fsyz, change->elem(i), denom2);
@@ -101,14 +101,14 @@ GBComputation *GBDeclared::create(const Matrix *m,
   if (R != m->get_ring() || R != change->get_ring() || R != syz->get_ring())
     {
       ERROR("expected the same ring");
-      return nullptr;
+      return 0;
     }
 
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("declaring a GB requires a polynomial ring");
-      return nullptr;
+      return 0;
     }
   // Then: create and return the object
   return new GBDeclared(m, gb, change, syz);
@@ -130,14 +130,14 @@ GBComputation *GBDeclared::create(const Matrix *leadterms,
       R != change->get_ring() || R != syz->get_ring())
     {
       ERROR("expected the same ring");
-      return nullptr;
+      return 0;
     }
 
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("declaring a GB requires a polynomial ring");
-      return nullptr;
+      return 0;
     }
   if (leadterms->n_rows() != gb->n_rows() ||
       leadterms->n_cols() != gb->n_cols())
@@ -145,7 +145,7 @@ GBComputation *GBDeclared::create(const Matrix *leadterms,
       ERROR(
           "expected same number of lead terms as marked Groebner basis "
           "elements");
-      return nullptr;
+      return 0;
     }
   // Then: create and return the object
   return new GBDeclared(leadterms, m, gb, change, syz);

--- a/M2/Macaulay2/e/comp-gb.cpp
+++ b/M2/Macaulay2/e/comp-gb.cpp
@@ -40,7 +40,7 @@ GBComputation *GBComputation::choose_gb(const Matrix *m,
   const Ring *R1 = m->get_ring();
   const PolynomialRing *R2 = R1->cast_to_PolynomialRing();
 
-  if (R2 == nullptr)
+  if (R2 == 0)
     {
       // Look for the correct computation type here.
       if (R1 == globalZZ)
@@ -55,7 +55,7 @@ GBComputation *GBComputation::choose_gb(const Matrix *m,
 #warning "handle non polynomial rings"
 #endif
       ERROR("GB computation for non-polynomial rings not yet re-implemented");
-      return nullptr;
+      return 0;
     }
 
 //  const PolynomialRing *R = R2->get_flattened_ring();
@@ -123,7 +123,7 @@ GBComputation *GBComputation::choose_gb(const Matrix *m,
         break;
     }
   intern_GB(result);
-  return result != nullptr ? new GBProxy(result) : nullptr;
+  return result != NULL ? new GBProxy(result) : NULL;
 
 #if 0
 //   if (is_graded)
@@ -191,7 +191,7 @@ Computation /* or null */ *GBComputation::set_hilbert_function(
 // used.
 {
   ERROR("Hilbert function use is not implemented for this GB algorithm");
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *GBComputation::get_parallel_lead_terms(
@@ -200,7 +200,7 @@ const Matrix /* or null */ *GBComputation::get_parallel_lead_terms(
   ERROR(
       "Cannot compute parallel lead terms for this kind of Groebner "
       "computation");
-  return nullptr;
+  return 0;
 }
 
 // Local Variables:

--- a/M2/Macaulay2/e/comp-res.cpp
+++ b/M2/Macaulay2/e/comp-res.cpp
@@ -241,7 +241,7 @@ MutableMatrix /* or null */ *ResolutionComputation::get_matrix(int level,
 {
   // the default version gives an error that it isn't defined
   ERROR("this function not defined for this resolution type");
-  return nullptr;
+  return 0;
 }
 
 // Local Variables:

--- a/M2/Macaulay2/e/comp.cpp
+++ b/M2/Macaulay2/e/comp.cpp
@@ -20,7 +20,7 @@ Computation /* or null */ *Computation::set_stop_conditions(
     M2_arrayint length_limit)
 {
   stop_.always_stop = always_stop;
-  stop_.stop_after_degree = (degree_limit != nullptr && degree_limit->len > 0);
+  stop_.stop_after_degree = (degree_limit != 0 && degree_limit->len > 0);
   stop_.degree_limit = degree_limit;
   stop_.basis_element_limit = basis_element_limit;
   stop_.syzygy_limit = syzygy_limit;
@@ -34,7 +34,7 @@ Computation /* or null */ *Computation::set_stop_conditions(
   if (stop_conditions_ok())
     return this;
   else
-    return nullptr;
+    return 0;
 }
 
 Computation::Computation()
@@ -43,7 +43,7 @@ Computation::Computation()
 
   stop_.always_stop = false;
   stop_.stop_after_degree = false;
-  stop_.degree_limit = nullptr;
+  stop_.degree_limit = 0;
   stop_.basis_element_limit = 0;
   stop_.syzygy_limit = 0;
   stop_.pair_limit = 0;
@@ -51,7 +51,7 @@ Computation::Computation()
   stop_.codim_limit = 0;
   stop_.subring_limit = 0;
   stop_.just_min_gens = false;
-  stop_.length_limit = nullptr;
+  stop_.length_limit = 0;
 }
 
 Computation::~Computation() {}

--- a/M2/Macaulay2/e/cra.cpp
+++ b/M2/Macaulay2/e/cra.cpp
@@ -203,7 +203,7 @@ vec ChineseRemainder::CRA(const PolyRing *R,
             }
           break;
         }
-      if (f == nullptr)
+      if (f == NULL)
         {
           // mult each term of g by n:
           for (; g != nullptr; g = g->next)

--- a/M2/Macaulay2/e/debug.cpp
+++ b/M2/Macaulay2/e/debug.cpp
@@ -95,7 +95,7 @@ void dvec(const Ring *R, const vec v)
 void dgbvec(const GBRing *R, gbvector *v)
 {
   buffer o;
-  const FreeModule *F = nullptr;
+  const FreeModule *F = 0;
   R->gbvector_text_out(o, F, v);
   emit(o.str());
 }

--- a/M2/Macaulay2/e/det.cpp
+++ b/M2/Macaulay2/e/det.cpp
@@ -15,11 +15,11 @@ DetComputation::DetComputation(const Matrix *M0,
       p(p0),
       do_exterior(do_exterior0),
       strategy(strategy0),
-      row_set(nullptr),
-      col_set(nullptr),
+      row_set(NULL),
+      col_set(NULL),
       this_row(0),
       this_col(0),
-      D(nullptr),
+      D(0),
       dynamic_cache(0)
 {
   if (do_exterior)
@@ -258,12 +258,12 @@ void DetComputation::clear()
 void DetComputation::set_next_minor(const int *rows, const int *cols)
 {
   if (do_exterior) return;
-  if (rows != nullptr && Subsets::isValid(M->n_rows(), p, rows))
+  if (rows != NULL && Subsets::isValid(M->n_rows(), p, rows))
     for (size_t i = 0; i < p; i++) row_set[i] = rows[i];
   else
     for (size_t i = 0; i < p; i++) row_set[i] = i;
 
-  if (cols != nullptr && Subsets::isValid(M->n_cols(), p, cols))
+  if (cols != NULL && Subsets::isValid(M->n_cols(), p, cols))
     for (size_t i = 0; i < p; i++) col_set[i] = cols[i];
   else
     for (size_t i = 0; i < p; i++) col_set[i] = i;
@@ -428,7 +428,7 @@ Matrix /* or null */ *Matrix::exterior(int p, int strategy) const
     {
       ERROR(
           "determinant computations over RR or CC requires Strategy=>Cofactor");
-      return nullptr;
+      return 0;
     }
   DetComputation *d = new DetComputation(this, p, 1, strategy);
   d->calc(-1);
@@ -443,7 +443,7 @@ Matrix /* or null */ *Matrix::minors(int p, int strategy) const
     {
       ERROR(
           "determinant computations over RR or CC requires Strategy=>Cofactor");
-      return nullptr;
+      return 0;
     }
   DetComputation *d = new DetComputation(this, p, 0, strategy);
   d->calc(-1);
@@ -464,24 +464,24 @@ Matrix /* or null */ *Matrix::minors(
     {
       ERROR(
           "determinant computations over RR or CC requires Strategy=>Cofactor");
-      return nullptr;
+      return 0;
     }
-  if (first_row != nullptr || first_col != nullptr)
+  if (first_row != 0 || first_col != 0)
     {
       // Make sure these are the correct size, and both are given
-      if (first_row == nullptr || first_row->len != p)
+      if (first_row == 0 || first_row->len != p)
         {
           ERROR("row index set inappropriate");
-          return nullptr;
+          return 0;
         }
-      if (first_col == nullptr || first_col->len != p)
+      if (first_col == 0 || first_col->len != p)
         {
           ERROR("column index set inappropriate");
-          return nullptr;
+          return 0;
         }
     }
   DetComputation *d = new DetComputation(this, p, 0, strategy);
-  if (first_row != nullptr && first_col != nullptr)
+  if (first_row != 0 && first_col != 0)
     d->set_next_minor(first_row->array, first_col->array);
   d->calc(n_to_compute);
   Matrix *result = d->determinants();

--- a/M2/Macaulay2/e/dmat.cpp
+++ b/M2/Macaulay2/e/dmat.cpp
@@ -143,7 +143,7 @@ size_t nullSpace(const DMatZZpFFPACK& mat, DMatZZpFFPACK& nullspace)
   size_t nr = mat.numRows();
   size_t nc = mat.numColumns();
 
-  DMatZZpFFPACK::ElementType* nullspaceFFPACK = nullptr;
+  DMatZZpFFPACK::ElementType* nullspaceFFPACK = 0;
 
   size_t nullspace_dim;
   size_t nullspace_leading_dim;

--- a/M2/Macaulay2/e/dpoly.cpp
+++ b/M2/Macaulay2/e/dpoly.cpp
@@ -83,8 +83,8 @@ void DPoly::initialize(long p, int nvars0, const TowerPolynomial* ext0)
   nvars = nvars0;
   nlevels = nvars0;
   extensions = newarray(TowerPolynomial, nlevels);
-  if (ext0 == nullptr)
-    for (int i = 0; i < nlevels; i++) extensions[i] = nullptr;
+  if (ext0 == 0)
+    for (int i = 0; i < nlevels; i++) extensions[i] = 0;
   else
     for (int i = 0; i < nlevels; i++)
       {
@@ -102,13 +102,13 @@ int DPoly::degree_of_extension(int level)
   // if negative, then that variable is transcendental over lower vars
   if (level < 0 || level >= nlevels) return -1;
   TowerPolynomial f = extensions[level];
-  if (f == nullptr) return -1;
+  if (f == 0) return -1;
   return f->deg;
 }
 
 bool DPoly::down_level(int newlevel, int oldlevel, TowerPolynomial& f)
 {
-  if (f == nullptr) return true;
+  if (f == 0) return true;
   for (int i = oldlevel; i > newlevel; i--)
     {
       if (f->deg > 0)
@@ -117,7 +117,7 @@ bool DPoly::down_level(int newlevel, int oldlevel, TowerPolynomial& f)
           return false;
         }
       TowerPolynomial g = f->arr.polys[0];
-      f->arr.polys[0] = nullptr;
+      f->arr.polys[0] = 0;
       dealloc_poly(f);
       f = g;
     }
@@ -126,7 +126,7 @@ bool DPoly::down_level(int newlevel, int oldlevel, TowerPolynomial& f)
 
 static int n_nonzero_terms(int level, const TowerPolynomial f)
 {
-  if (f == nullptr) return 0;
+  if (f == 0) return 0;
   int nterms = 0;
   if (level == 0)
     {
@@ -136,7 +136,7 @@ static int n_nonzero_terms(int level, const TowerPolynomial f)
   else
     {
       for (int i = 0; i <= f->deg; i++)
-        if (f->arr.polys[i] != nullptr) nterms++;
+        if (f->arr.polys[i] != 0) nterms++;
     }
   return nterms;
 }
@@ -150,7 +150,7 @@ void DPoly::elem_text_out(buffer &o,
                           M2_ArrayString names) const
 {
   // o << to_string(level, f);
-  if (f == nullptr)
+  if (f == 0)
     {
       o << "0";
       return;
@@ -195,7 +195,7 @@ void DPoly::elem_text_out(buffer &o,
     {
       bool firstterm = true;
       for (int i = f->deg; i >= 0; i--)
-        if (f->arr.polys[i] != nullptr)
+        if (f->arr.polys[i] != 0)
           {
             bool this_p_parens = p_parens || (i > 0);
 
@@ -222,7 +222,7 @@ void DPoly::extensions_text_out(buffer &o, M2_ArrayString names) const
 {
   for (int i = 0; i < nlevels; i++)
     {
-      if (extensions[i] != nullptr)
+      if (extensions[i] != 0)
         {
           o << newline << "    ";
           elem_text_out(o, i, extensions[i], true, false, false, names);
@@ -254,7 +254,7 @@ void DPoly::increase_size_n(int newdeg, TowerPolynomial& f)
       TowerPolynomial *newelems = newarray(TowerPolynomial, newdeg + 1);
       TowerPolynomial *fp = f->arr.polys;
       for (int i = 0; i <= f->deg; i++) newelems[i] = fp[i];
-      for (int i = f->deg + 1; i < newdeg + 1; i++) newelems[i] = nullptr;
+      for (int i = f->deg + 1; i < newdeg + 1; i++) newelems[i] = 0;
       freemem(fp);
       f->arr.polys = newelems;
       f->len = newdeg + 1;
@@ -269,8 +269,8 @@ TowerPolynomial DPoly::alloc_poly_n(int deg, TowerPolynomial *elems)
   result->arr.polys = newarray(TowerPolynomial, deg + 1);
   result->deg = deg;
   result->len = deg + 1;
-  if (elems == nullptr)
-    for (int i = 0; i <= deg; i++) result->arr.polys[i] = nullptr;
+  if (elems == 0)
+    for (int i = 0; i <= deg; i++) result->arr.polys[i] = 0;
   else
     for (int i = 0; i <= deg; i++) result->arr.polys[i] = elems[i];
   return result;
@@ -282,7 +282,7 @@ TowerPolynomial DPoly::alloc_poly_0(int deg, long *elems)
   result->arr.ints = newarray_atomic(long, deg + 1);
   result->deg = deg;
   result->len = deg + 1;
-  if (elems == nullptr)
+  if (elems == 0)
     for (int i = 0; i <= deg; i++) result->arr.ints[i] = 0;
   else
     for (int i = 0; i <= deg; i++) result->arr.ints[i] = elems[i];
@@ -292,17 +292,17 @@ TowerPolynomial DPoly::alloc_poly_0(int deg, long *elems)
 void DPoly::dealloc_poly(TowerPolynomial &f)
 // only f is freed, not any pointers in the array of f
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   freemem(f->arr.polys);
   delete f;
-  f = nullptr;
+  f = 0;
 }
 
 TowerPolynomial DPoly::read_poly_n(char *&str, int level)
 {
   int len = 0;
   TowerPolynomial *elems = newarray(TowerPolynomial, 100);
-  TowerPolynomial this_elem = nullptr;
+  TowerPolynomial this_elem = 0;
   if (*str != '[')
     {
       fprintf(stderr, "expected '[', got %s\n", str);
@@ -329,7 +329,7 @@ TowerPolynomial DPoly::read_poly_n(char *&str, int level)
           exit(1);
         }
       elems[len++] = this_elem;
-      this_elem = nullptr;
+      this_elem = 0;
     }
   // the only way to get here is if *str == ']'.  Eat that char.
   str++;
@@ -388,7 +388,7 @@ TowerPolynomial DPoly::read_poly(char *&str, int level)
 
 std::ostream &DPoly::append_to_stream(std::ostream &o, int level, const TowerPolynomial f)
 {
-  if (f == nullptr)
+  if (f == 0)
     o << "0";
   else if (level == 0)
     {
@@ -408,7 +408,7 @@ std::ostream &DPoly::append_to_stream(std::ostream &o, int level, const TowerPol
       for (int i = 0; i <= f->deg; i++)
         {
           if (i > 0) o << ",";
-          if (p[i] != nullptr) append_to_stream(o, level - 1, p[i]);
+          if (p[i] != 0) append_to_stream(o, level - 1, p[i]);
         }
       o << "]";
     }
@@ -427,7 +427,7 @@ char *DPoly::to_string(int level, const TowerPolynomial f)
 
 void DPoly::display_poly(FILE *fil, int level, const TowerPolynomial f)
 {
-  if (f == nullptr)
+  if (f == 0)
     fprintf(fil, "0");
   else if (level == 0)
     {
@@ -449,7 +449,7 @@ void DPoly::display_poly(FILE *fil, int level, const TowerPolynomial f)
       for (int i = 0; i <= f->deg; i++)
         {
           if (i > 0) fprintf(fil, ",");
-          if (p[i] != nullptr) display_poly(fil, level - 1, p[i]);
+          if (p[i] != 0) display_poly(fil, level - 1, p[i]);
         }
       fprintf(fil, "]");
     }
@@ -458,12 +458,12 @@ void DPoly::display_poly(FILE *fil, int level, const TowerPolynomial f)
 void dpoly(int level, const TowerPolynomial f) { DPoly::display_poly(stdout, level, f); }
 bool DPoly::is_equal(int level, const TowerPolynomial f, const TowerPolynomial g)
 {
-  if (f == nullptr)
+  if (f == 0)
     {
-      if (g == nullptr) return true;
+      if (g == 0) return true;
       return false;
     }
-  if (g == nullptr || f->deg != g->deg) return false;
+  if (g == 0 || f->deg != g->deg) return false;
   if (level == 0)
     {
       long *fp = f->arr.ints;
@@ -482,7 +482,7 @@ bool DPoly::is_equal(int level, const TowerPolynomial f, const TowerPolynomial g
 
 TowerPolynomial DPoly::copy(int level, const TowerPolynomial f)
 {
-  if (f == nullptr) return nullptr;
+  if (f == 0) return 0;
   TowerPolynomial result;
   if (level == 0)
     {
@@ -500,7 +500,7 @@ TowerPolynomial DPoly::copy(int level, const TowerPolynomial f)
 
 TowerPolynomial DPoly::from_long(int level, long c)
 {
-  if (c == 0) return nullptr;
+  if (c == 0) return 0;
   TowerPolynomial result = alloc_poly_0(0);
   result->arr.ints[0] = c;
   for (int i = 1; i <= level; i++)
@@ -515,7 +515,7 @@ TowerPolynomial DPoly::from_long(int level, long c)
 TowerPolynomial DPoly::var(int level, int v)
 // make the variable v (but at level 'level')
 {
-  if (v > level) return nullptr;
+  if (v > level) return 0;
   int which = (v == 0 ? 1 : 0);
   TowerPolynomial result =
       alloc_poly_0(which);  // TODO: check that this initializes elements to 0
@@ -562,12 +562,12 @@ int DPoly::compare(int level, TowerPolynomial f, TowerPolynomial g)
 // order used: first degree, then compare elements 0..charac-1
 // 0 is the lowest
 {
-  if (f == nullptr)
+  if (f == 0)
     {
-      if (g == nullptr) return 0;
+      if (g == 0) return 0;
       return 1;
     }
-  if (g == nullptr) return -1;
+  if (g == 0) return -1;
   if (f->deg > g->deg) return -1;
   if (f->deg < g->deg) return 1;
 
@@ -594,7 +594,7 @@ int DPoly::compare(int level, TowerPolynomial f, TowerPolynomial g)
 
 bool DPoly::is_one(int level, TowerPolynomial f)
 {
-  if (f == nullptr) return false;
+  if (f == 0) return false;
   if (f->deg != 0) return false;
   if (level == 0)
     return 1 == f->arr.ints[0];
@@ -603,7 +603,7 @@ bool DPoly::is_one(int level, TowerPolynomial f)
 }
 void DPoly::negate_in_place(int level, TowerPolynomial &f)
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   if (level == 0)
     {
       int deg = f->deg;
@@ -616,7 +616,7 @@ void DPoly::negate_in_place(int level, TowerPolynomial &f)
       int deg = f->deg;
       TowerPolynomial *p = f->arr.polys;
       for (int i = 0; i <= deg; i++)
-        if (p[i] != nullptr) negate_in_place(level - 1, p[i]);
+        if (p[i] != 0) negate_in_place(level - 1, p[i]);
     }
 }
 
@@ -636,7 +636,7 @@ void DPoly::reset_degree_n(int level, TowerPolynomial &f)
 {
   int fdeg = f->deg;
   for (int j = fdeg; j >= 0; --j)
-    if (f->arr.polys[j] != nullptr)
+    if (f->arr.polys[j] != 0)
       {
         f->deg = j;
         return;
@@ -655,8 +655,8 @@ void DPoly::add_term(int level, TowerPolynomial &result, long coeff, exponents_t
 
   int e = exp[0];
 
-  if (result == nullptr)
-    result = alloc_poly_n(e, nullptr);
+  if (result == 0)
+    result = alloc_poly_n(e, 0);
   else if (result->deg < e)
     increase_size_n(e, result);
 
@@ -669,8 +669,8 @@ void DPoly::add_term(int level, TowerPolynomial &result, long coeff, exponents_t
 void DPoly::add_in_place_0(TowerPolynomial &f, const TowerPolynomial g)
 {
   int i;
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == 0) return;
+  if (f == 0)
     {
       f = copy(0, g);
       return;
@@ -690,8 +690,8 @@ void DPoly::add_in_place_0(TowerPolynomial &f, const TowerPolynomial g)
 void DPoly::add_in_place_n(int level, TowerPolynomial &f, const TowerPolynomial g)
 {
   int i;
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == 0) return;
+  if (f == 0)
     {
       f = copy(level, g);
       return;
@@ -708,7 +708,7 @@ void DPoly::add_in_place_n(int level, TowerPolynomial &f, const TowerPolynomial 
     {
       // need to change the degree
       for (int j = fdeg; j >= 0; --j)
-        if (f->arr.polys[j] != nullptr)
+        if (f->arr.polys[j] != 0)
           {
             f->deg = j;
             return;
@@ -729,8 +729,8 @@ void DPoly::add_in_place(int level, TowerPolynomial &f, const TowerPolynomial g)
 void DPoly::subtract_in_place_0(TowerPolynomial &f, const TowerPolynomial g)
 {
   int i;
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == 0) return;
+  if (f == 0)
     {
       f = copy(0, g);
       negate_in_place(0, f);
@@ -761,8 +761,8 @@ void DPoly::subtract_in_place_0(TowerPolynomial &f, const TowerPolynomial g)
 void DPoly::subtract_in_place_n(int level, TowerPolynomial &f, const TowerPolynomial g)
 {
   int i;
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == 0) return;
+  if (f == 0)
     {
       f = copy(level, g);
       negate_in_place(level, f);
@@ -780,7 +780,7 @@ void DPoly::subtract_in_place_n(int level, TowerPolynomial &f, const TowerPolyno
     {
       // need to change the degree
       for (int j = fdeg; j >= 0; --j)
-        if (f->arr.polys[j] != nullptr)
+        if (f->arr.polys[j] != 0)
           {
             f->deg = j;
             return;
@@ -800,7 +800,7 @@ void DPoly::subtract_in_place(int level, TowerPolynomial &f, const TowerPolynomi
 
 TowerPolynomial DPoly::mult_0(const TowerPolynomial f, const TowerPolynomial g, bool reduce_by_extension)
 {
-  if (f == nullptr || g == nullptr) return nullptr;
+  if (f == 0 || g == 0) return 0;
   TowerPolynomial result = alloc_poly_0(f->deg + g->deg);
 
   for (int i = 0; i <= f->deg; i++)
@@ -810,7 +810,7 @@ TowerPolynomial DPoly::mult_0(const TowerPolynomial f, const TowerPolynomial g, 
         ZZp_APXY(charac, result->arr.ints[i + j], a, g->arr.ints[j]);
     }
 
-  if (reduce_by_extension && extensions[0] != nullptr)
+  if (reduce_by_extension && extensions[0] != 0)
     remainder(0, result, extensions[0]);
   return result;
 }
@@ -819,18 +819,18 @@ TowerPolynomial DPoly::mult_n(int level,
                    const TowerPolynomial g,
                    bool reduce_by_extension)
 {
-  if (f == nullptr || g == nullptr) return nullptr;
+  if (f == 0 || g == 0) return 0;
   TowerPolynomial result = alloc_poly_n(f->deg + g->deg);
 
   for (int i = 0; i <= f->deg; i++)
     {
       TowerPolynomial a = f->arr.polys[i];
-      if (a != nullptr)
+      if (a != 0)
         for (int j = 0; j <= g->deg; j++)
           {
             TowerPolynomial b = g->arr.polys[j];
             TowerPolynomial c = mult(level - 1, a, b, true);
-            if (c != nullptr)
+            if (c != 0)
               {
                 add_in_place(level - 1, result->arr.polys[i + j], c);
                 dealloc_poly(c);
@@ -838,7 +838,7 @@ TowerPolynomial DPoly::mult_n(int level,
           }
     }
 
-  if (reduce_by_extension && extensions[level] != nullptr)
+  if (reduce_by_extension && extensions[level] != 0)
     remainder(level, result, extensions[level]);
   return result;
 }
@@ -870,7 +870,7 @@ TowerPolynomial DPoly::invert(int level, const TowerPolynomial a)
 
 void DPoly::mult_by_coeff_0(TowerPolynomial &f, long b)
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   long *p = f->arr.ints;
   long deg = f->deg;
   if (b == 0)
@@ -884,23 +884,23 @@ void DPoly::mult_by_coeff_0(TowerPolynomial &f, long b)
 }
 void DPoly::mult_by_coeff_n(int level, TowerPolynomial &f, TowerPolynomial b)
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   TowerPolynomial *p = f->arr.polys;
   long deg = f->deg;
-  if (b == nullptr)
+  if (b == 0)
     {
       dealloc_poly(f);
     }
   else if (!is_one(level - 1, b))
     for (int i = 0; i <= deg; i++)
       {
-        if (*p != nullptr) *p = mult(level - 1, *p, b, true);
+        if (*p != 0) *p = mult(level - 1, *p, b, true);
         p++;
       }
 }
 void DPoly::make_monic_0(TowerPolynomial &f, long &result_multiplier)
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   long *p = f->arr.ints;
   long a = p[f->deg];
   long b;
@@ -910,7 +910,7 @@ void DPoly::make_monic_0(TowerPolynomial &f, long &result_multiplier)
 }
 void DPoly::make_monic_n(int level, TowerPolynomial &f, TowerPolynomial &result_multiplier)
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   TowerPolynomial *p = f->arr.polys;
   TowerPolynomial a = p[f->deg];
   TowerPolynomial b = invert(level - 1, a);
@@ -920,7 +920,7 @@ void DPoly::make_monic_n(int level, TowerPolynomial &f, TowerPolynomial &result_
 
 void DPoly::make_monic(int level, TowerPolynomial &f)
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   if (level == 0)
     {
       long not_used;
@@ -940,7 +940,7 @@ bool DPoly::make_monic3(int level, TowerPolynomial &u1, TowerPolynomial &u2, Tow
 // else return true
 // replace u1, u2, u3 by c*u1, c*u2, c*u3
 {
-  if (u3 == nullptr) return true;
+  if (u3 == 0) return true;
 
   if (level == 0)
     {
@@ -952,9 +952,9 @@ bool DPoly::make_monic3(int level, TowerPolynomial &u1, TowerPolynomial &u2, Tow
     }
   else
     {
-      TowerPolynomial c = nullptr;
+      TowerPolynomial c = 0;
       make_monic_n(level, u3, c);
-      if (c == nullptr) return false;
+      if (c == 0) return false;
       mult_by_coeff_n(level, u1, c);
       mult_by_coeff_n(level, u2, c);
       dealloc_poly(c);
@@ -965,10 +965,10 @@ bool DPoly::make_monic3(int level, TowerPolynomial &u1, TowerPolynomial &u2, Tow
 TowerPolynomial DPoly::division_in_place_monic(int level, TowerPolynomial &f, const TowerPolynomial g)
 {
   // ASSUMPTION: g is MONIC, non-zero
-  if (f == nullptr) return nullptr;
+  if (f == 0) return 0;
   if (f->deg < g->deg)
     {
-      return nullptr;
+      return 0;
     }
   int shift = f->deg - g->deg;
   TowerPolynomial quot = alloc_poly_n(shift);
@@ -997,7 +997,7 @@ TowerPolynomial DPoly::division_in_place_monic(int level, TowerPolynomial &f, co
       for (int d = f->deg; shift >= 0; d--, shift--)
         {
           TowerPolynomial a = p[d];
-          if (a != nullptr)
+          if (a != 0)
             {
               quot->arr.polys[shift] = copy(level - 1, a);
               for (int j = 0; j <= g->deg; j++)
@@ -1018,9 +1018,9 @@ bool DPoly::division_in_place(int level,
 // returns false if the lead coeff is not invertible
 {
   assert(g != 0);
-  if (f == nullptr || f->deg < g->deg)
+  if (f == 0 || f->deg < g->deg)
     {
-      result_quot = nullptr;
+      result_quot = 0;
       return true;
     }
   int shift = f->deg - g->deg;
@@ -1064,12 +1064,12 @@ bool DPoly::division_in_place(int level,
       else
         {
           invlead = invert(level - 1, leadcoeff);
-          if (invlead == nullptr) return false;
+          if (invlead == 0) return false;
         }
       for (int d = f->deg; shift >= 0; d--, shift--)
         {
           TowerPolynomial a = p[d];
-          if (a != nullptr)
+          if (a != 0)
             {
               TowerPolynomial b = mult(level - 1, invlead, a, true);
               result_quot->arr.polys[shift] = copy(level - 1, b);
@@ -1087,27 +1087,27 @@ bool DPoly::division_in_place(int level,
 
 void DPoly::remainder(int level, TowerPolynomial &f, const TowerPolynomial g)
 {
-  if (g == nullptr) return;
-  TowerPolynomial quot = nullptr;
+  if (g == 0) return;
+  TowerPolynomial quot = 0;
   division_in_place(level, f, g, quot);
   dealloc_poly(quot);
 }
 
 void DPoly::pseudo_remainder(int level, TowerPolynomial &f, const TowerPolynomial g)
 {
-  if (g == nullptr) return;
+  if (g == 0) return;
   // TODO: write
 }
 TowerPolynomial DPoly::pseudo_division(int level, TowerPolynomial &f, const TowerPolynomial g)
 {
-  if (g == nullptr) return nullptr;
+  if (g == 0) return 0;
   // TODO: write
-  return nullptr;
+  return 0;
 }
 TowerPolynomial DPoly::resultant(int level, TowerPolynomial f, TowerPolynomial g)
 {
   // TODO: write
-  return nullptr;
+  return 0;
 }
 static void swap_poly(TowerPolynomial &f, TowerPolynomial &g)
 {
@@ -1119,10 +1119,10 @@ TowerPolynomial DPoly::gcd(int level, const TowerPolynomial f, const TowerPolyno
 {
   TowerPolynomial F = copy(level, f);
   TowerPolynomial G = copy(level, g);
-  if (G == nullptr)
+  if (G == 0)
     {
       G = F;
-      F = nullptr;
+      F = 0;
     }
   for (;;)
     {
@@ -1130,7 +1130,7 @@ TowerPolynomial DPoly::gcd(int level, const TowerPolynomial f, const TowerPolyno
       printf("G = %s\n", to_string(level, G));
 #endif
       make_monic(level, G);
-      if (G == nullptr) return nullptr;  // failed
+      if (G == 0) return 0;  // failed
 
 #ifdef DEBUGGCD
       printf("monic G = %s\n", to_string(level, G));
@@ -1138,7 +1138,7 @@ TowerPolynomial DPoly::gcd(int level, const TowerPolynomial f, const TowerPolyno
 #endif
 
       remainder(level, F, G);  // modifies F
-      if (F == nullptr) return G;
+      if (F == 0) return G;
 
 #ifdef DEBUGGCD
       printf("F mod G     = %s\n", to_string(level, F));
@@ -1158,17 +1158,17 @@ TowerPolynomial DPoly::gcd_coefficients(int level,
   //  f and g are non-zero
   TowerPolynomial v1, v2, v3;
   TowerPolynomial u1, u2, u3;
-  TowerPolynomial q = nullptr;
+  TowerPolynomial q = 0;
 
-  v1 = nullptr;
+  v1 = 0;
   v2 = from_long(level, 1);
   v3 = copy(level, g);
 
   u1 = from_long(level, 1);
-  u2 = nullptr;
+  u2 = 0;
   u3 = copy(level, f);
 
-  if (v3 == nullptr || (u3 != nullptr && v3->deg > u3->deg))
+  if (v3 == 0 || (u3 != 0 && v3->deg > u3->deg))
     {
       swap_poly(u1, v1);
       swap_poly(u2, v2);
@@ -1193,7 +1193,7 @@ TowerPolynomial DPoly::gcd_coefficients(int level,
     }
 #endif
 
-  while (v3 != nullptr)
+  while (v3 != 0)
     {
       if (!make_monic3(level, v1, v2, v3))
         {
@@ -1205,9 +1205,9 @@ TowerPolynomial DPoly::gcd_coefficients(int level,
           dealloc_poly(v1);
           dealloc_poly(v2);
           dealloc_poly(v3);
-          result_u = nullptr;
-          result_v = nullptr;
-          return nullptr;
+          result_u = 0;
+          result_v = 0;
+          return 0;
         }
       q = division_in_place_monic(
           level,
@@ -1265,14 +1265,14 @@ TowerPolynomial DPoly::gcd_coefficients(int level,
 
 int DPoly::degree(int level, int whichvar, const TowerPolynomial f) const
 {
-  if (f == nullptr) return -1;
+  if (f == 0) return -1;
   if (whichvar == 0) return f->deg;
   // At this point, we need to find the max degree of the given var
   int deg = -1;
   for (int i = 0; i <= f->deg; i++)
     {
       TowerPolynomial g = f->arr.polys[i];
-      if (g != nullptr)
+      if (g != 0)
         {
           int d = degree(level - 1, whichvar - 1, g);
           if (d > deg) deg = d;
@@ -1302,7 +1302,7 @@ TowerPolynomial DPoly::mult_by_int_n(int level, long a, const TowerPolynomial f)
   for (int i = 0; i <= f->deg; i++)
     {
       TowerPolynomial c = f->arr.polys[i];
-      if (c != nullptr) result->arr.polys[i] = mult_by_int(level - 1, a, c);
+      if (c != 0) result->arr.polys[i] = mult_by_int(level - 1, a, c);
     }
   reset_degree_n(level, result);
   return result;
@@ -1310,14 +1310,14 @@ TowerPolynomial DPoly::mult_by_int_n(int level, long a, const TowerPolynomial f)
 
 TowerPolynomial DPoly::mult_by_int(int level, long a, const TowerPolynomial f)
 {
-  if (f == nullptr) return nullptr;
+  if (f == 0) return 0;
   if (level == 0) return mult_by_int_0(a, f);
   return mult_by_int_n(level, a, f);
 }
 
 TowerPolynomial DPoly::diff_0(const TowerPolynomial f)
 {
-  if (f == nullptr || f->deg == 0) return nullptr;
+  if (f == 0 || f->deg == 0) return 0;
   TowerPolynomial result = alloc_poly_0(f->deg - 1);
   for (int i = 1; i <= f->deg; i++)
     {
@@ -1341,7 +1341,7 @@ TowerPolynomial DPoly::diff_n(int level, int whichvar, const TowerPolynomial f)
       for (int i = 1; i <= f->deg; i++)
         {
           TowerPolynomial c = f->arr.polys[i];
-          if (c != nullptr) result->arr.polys[i - 1] = mult_by_int(level - 1, i, c);
+          if (c != 0) result->arr.polys[i - 1] = mult_by_int(level - 1, i, c);
         }
     }
   else
@@ -1350,7 +1350,7 @@ TowerPolynomial DPoly::diff_n(int level, int whichvar, const TowerPolynomial f)
       for (int i = 0; i <= f->deg; i++)
         {
           TowerPolynomial c = f->arr.polys[i];
-          if (c != nullptr) result->arr.polys[i] = diff(level - 1, whichvar - 1, c);
+          if (c != 0) result->arr.polys[i] = diff(level - 1, whichvar - 1, c);
         }
     }
   reset_degree_n(level, result);
@@ -1359,7 +1359,7 @@ TowerPolynomial DPoly::diff_n(int level, int whichvar, const TowerPolynomial f)
 
 TowerPolynomial DPoly::diff(int level, int whichvar, const TowerPolynomial f)
 {
-  if (f == nullptr) return nullptr;
+  if (f == 0) return 0;
   if (level == 0) return diff_0(f);
   return diff_n(level, whichvar, f);
 }
@@ -1414,7 +1414,7 @@ TowerPolynomial DPoly::lowerP(int level, const TowerPolynomial f)
 {
   int i, j;
   TowerPolynomial result;
-  if (f == nullptr) return nullptr;
+  if (f == 0) return 0;
   int charac_as_int = static_cast<int>(charac);
   int newdeg = f->deg / charac_as_int;  // should be exact...
   if (level == 0)
@@ -1447,7 +1447,7 @@ TowerPolynomial DPoly::lowerP(int level, const TowerPolynomial f)
 
 int DPoly::index_of_var(int level, const TowerPolynomial f) const
 {
-  if (f == nullptr or level < 0 or f->deg >= 2) return -1;
+  if (f == 0 or level < 0 or f->deg >= 2) return -1;
   if (level == 0)
     {
       if (f->deg == 0) return -1;
@@ -1459,7 +1459,7 @@ int DPoly::index_of_var(int level, const TowerPolynomial f) const
     }
   else
     {
-      if (f->arr.polys[0] == nullptr and is_one(level - 1, f->arr.polys[1]))
+      if (f->arr.polys[0] == 0 and is_one(level - 1, f->arr.polys[1]))
         return level;
       if (f->deg == 1) return -1;
       return index_of_var(level - 1, f->arr.polys[0]);
@@ -1474,7 +1474,7 @@ void DPoly::degrees_of_vars(int level,
   result_maxdegs[level] = std::max(result_maxdegs[level], f->deg);
   if (level == 0) return;
   for (int i = 0; i <= f->deg; i++)
-    if (f->arr.polys[i] != nullptr)
+    if (f->arr.polys[i] != 0)
       degrees_of_vars(level - 1, f->arr.polys[i], result_maxdegs);
 }
 
@@ -1513,7 +1513,7 @@ bool DRing::set_from_mpq(TowerPolynomial &result, mpq_srcptr r)
   if (cbottom < 0) cbottom += P;
   if (cbottom == 0)
     {
-      result = nullptr;
+      result = 0;
       return false;
     }
   ZZp_INVERT(P, cbottom, cbottom);
@@ -1580,7 +1580,7 @@ bool DPolyTraverser::traverse1(int level, const TowerPolynomial f, exponents_t e
     {
       TowerPolynomial *cfs = f->arr.polys;
       for (int i = f->deg; i >= 0; --i)
-        if (cfs[i] != nullptr)
+        if (cfs[i] != 0)
           {
             exp[level] = i;
             if (!traverse1(level - 1, cfs[i], exp)) return false;

--- a/M2/Macaulay2/e/dpoly.hpp
+++ b/M2/Macaulay2/e/dpoly.hpp
@@ -91,8 +91,8 @@ class DPoly
 
   static void increase_size_0(int newdeg, TowerPolynomial &f);
   static void increase_size_n(int newdeg, TowerPolynomial &f);
-  static TowerPolynomial alloc_poly_n(int deg, TowerPolynomial *elems = nullptr);
-  static TowerPolynomial alloc_poly_0(int deg, long *elems = nullptr);
+  static TowerPolynomial alloc_poly_n(int deg, TowerPolynomial *elems = 0);
+  static TowerPolynomial alloc_poly_0(int deg, long *elems = 0);
   static void dealloc_poly(TowerPolynomial &f);
 
   static void display_poly(FILE *fil, int level, const TowerPolynomial f);
@@ -107,7 +107,7 @@ class DPoly
 
   static TowerPolynomial from_long(int level, long c);  // c should be reduced mod p
 
-  static bool is_zero(TowerPolynomial f) { return f == nullptr; }
+  static bool is_zero(TowerPolynomial f) { return f == 0; }
   void remove(int level, TowerPolynomial &f);
 
   int compare(int level, const TowerPolynomial f, const TowerPolynomial g);  // this is a total order
@@ -178,7 +178,7 @@ class DPoly
 
   // DPoly management
   ~DPoly() {}
-  DPoly(long p, int nvars0, const TowerPolynomial* extensions = nullptr);
+  DPoly(long p, int nvars0, const TowerPolynomial* extensions = 0);
 };
 
 /**
@@ -201,29 +201,29 @@ class DRing : public our_new_delete
   // ext0 should be an array of poly's of level 'nvars0'? 0..nvars0-1
 
   void init_set(elem &result, elem a) const { result = a; }
-  void set_zero(elem &result) const { result = nullptr; }
+  void set_zero(elem &result) const { result = 0; }
   void set(elem &result, elem a) const
   {
     D.remove(level, result);
     result = a;
   }
 
-  bool is_zero(elem result) const { return result == nullptr; }
+  bool is_zero(elem result) const { return result == 0; }
   bool invert(elem &result, elem a) const
   // returns true if invertible.  Returns true if not, and then result is set to
   // 0.
   {
     result = D.invert(level, a);
-    return result != nullptr;
+    return result != 0;
   }
 
   void add_term(elem &result, long coeff, exponents_t exp) const;
 
   void add(elem &result, elem a, elem b) const
   {
-    if (a == nullptr)
+    if (a == 0)
       result = b;
-    else if (b == nullptr)
+    else if (b == 0)
       result = a;
     else
       {
@@ -242,35 +242,35 @@ class DRing : public our_new_delete
 
   void subtract_multiple(elem &result, elem a, elem b) const
   {
-    if (a == nullptr || b == nullptr) return;
+    if (a == 0 || b == 0) return;
     elem ab = D.mult(level, a, b, true);
     D.subtract_in_place(level, result, ab);
   }
 
   void mult(elem &result, elem a, elem b) const
   {
-    if (a == nullptr || b == nullptr)
-      result = nullptr;
+    if (a == 0 || b == 0)
+      result = 0;
     else
       result = D.mult(level, a, b, true);
   }
 
   void divide(elem &result, elem a, elem b) const
   {
-    if (a == nullptr || b == nullptr)
-      result = nullptr;
+    if (a == 0 || b == 0)
+      result = 0;
     else
       {
         elem a1 = D.copy(level, a);
-        if (!D.division_in_place(level, a1, b, result)) result = nullptr;
+        if (!D.division_in_place(level, a1, b, result)) result = 0;
         D.dealloc_poly(a1);
       }
   }
 
   void remainder(elem &result, elem a, elem b) const
   {
-    if (a == nullptr || b == nullptr)
-      result = nullptr;
+    if (a == 0 || b == 0)
+      result = 0;
     else
       {
         result = D.copy(level, a);

--- a/M2/Macaulay2/e/f4/f4-computation.cpp
+++ b/M2/Macaulay2/e/f4/f4-computation.cpp
@@ -123,9 +123,9 @@ const Matrix /* or null */ *F4Computation::get_mingens()
   return nullptr;
 }
 
-const Matrix /* or null */ *F4Computation::get_change() { return nullptr; }
-const Matrix /* or null */ *F4Computation::get_syzygies() { return nullptr; }
-const Matrix /* or null */ *F4Computation::get_initial(int nparts) { return nullptr; }
+const Matrix /* or null */ *F4Computation::get_change() { return 0; }
+const Matrix /* or null */ *F4Computation::get_syzygies() { return 0; }
+const Matrix /* or null */ *F4Computation::get_initial(int nparts) { return 0; }
 const Matrix /* or null */ *F4Computation::matrix_remainder(const Matrix *m)
 {
   return nullptr;

--- a/M2/Macaulay2/e/f4/f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/f4/f4-m2-interface.cpp
@@ -107,8 +107,8 @@ vec F4toM2Interface::to_M2_vec(const VectorArithmetic* VA,
   Nterm **last = newarray(Nterm *, F->rank());
   for (int i = 0; i < F->rank(); i++)
     {
-      comps[i] = nullptr;
-      last[i] = nullptr;
+      comps[i] = 0;
+      last[i] = 0;
     }
 
   int *exp = newarray_atomic(int, M->n_vars() + 1);
@@ -125,7 +125,7 @@ vec F4toM2Interface::to_M2_vec(const VectorArithmetic* VA,
       ring_elem a = VA->ringElemFromElementArray(f.coeffs, i);
       Nterm *g = R->make_flat_term(a, m1);
       g->next = nullptr;
-      if (last[comp] == nullptr)
+      if (last[comp] == 0)
         {
           comps[comp] = g;
           last[comp] = g;
@@ -139,12 +139,12 @@ vec F4toM2Interface::to_M2_vec(const VectorArithmetic* VA,
   vec result = nullptr;
   for (int i = 0; i < F->rank(); i++)
     {
-      if (comps[i] != nullptr)
+      if (comps[i] != 0)
         {
           vec v = R->make_vec(i, comps[i]);
           R->add_vec_to(result, v);
-          comps[i] = nullptr;
-          last[i] = nullptr;
+          comps[i] = 0;
+          last[i] = 0;
         }
     }
 

--- a/M2/Macaulay2/e/f4/f4-mem.hpp
+++ b/M2/Macaulay2/e/f4/f4-mem.hpp
@@ -47,12 +47,12 @@ class F4Vec
   }
 
   F4Vec(const char *name0) : name(name0) { reset(); }
-  ~F4Vec() { name = nullptr; }
+  ~F4Vec() { name = 0; }
   int size(f4vec a) { return (SIZE_MASK & (a[-1])); }
   int alloc_stash(f4vec a) { return (a[-1]) >> STASH_SHIFT; }
   f4vec allocate(int alloc_sz)
   {
-    if (alloc_sz == 0) return nullptr;
+    if (alloc_sz == 0) return 0;
     int s = find_alloc_size(alloc_sz);
     int nextlen = doublesize[s];
     nallocs[s]++;
@@ -65,12 +65,12 @@ class F4Vec
 
   void deallocate(f4vec &a)
   {
-    if (a == nullptr) return;
+    if (a == 0) return;
     int s = alloc_stash(a);
     ndeallocs[s]++;
     current[s]--;
     freemem(a - 1);
-    a = nullptr;
+    a = 0;
   }
 
   void clear(f4vec &a)
@@ -128,7 +128,7 @@ class F4Mem : public our_new_delete
 
   monomial_word *allocate_monomial_array(int len)
   {
-    if (len == 0) return nullptr;
+    if (len == 0) return 0;
     monom_alloc++;
     monom_total += len;
     monom_current += len;
@@ -144,7 +144,7 @@ class F4Mem : public our_new_delete
     monom_freed += len;
     monom_current -= len;
     freemem(a);
-    a = nullptr;
+    a = 0;
   }
 
   void show();

--- a/M2/Macaulay2/e/f4/f4-monlookup.hpp
+++ b/M2/Macaulay2/e/f4/f4-monlookup.hpp
@@ -66,7 +66,7 @@ class F4MonomialLookupTableT : public our_new_delete
   void insert1(mi_node *&p, const_varpower_monomial m, Key k);
 
  public:
-  F4MonomialLookupTableT(int nvars, stash *mi_stash = nullptr);
+  F4MonomialLookupTableT(int nvars, stash *mi_stash = 0);
   ~F4MonomialLookupTableT();
 
   //  // Should we write these two routines?
@@ -123,7 +123,7 @@ class F4MonomialLookupTableT : public our_new_delete
 
 void minimalize_varpower_monomials(const VECTOR(varpower_monomial) & elems,
                                    VECTOR(int) & result_minimals,
-                                   stash *mi_stash = nullptr);
+                                   stash *mi_stash = 0);
 
 #endif
 

--- a/M2/Macaulay2/e/f4/f4-spairs.cpp
+++ b/M2/Macaulay2/e/f4/f4-spairs.cpp
@@ -12,11 +12,11 @@
 #include <vector>             // for vector, vector<>::iterator
 
 F4SPairSet::F4SPairSet(const MonomialInfo *M0, const gb_array &gb0)
-    : M(M0), gb(gb0), heap(nullptr), this_set(nullptr), nsaved_unneeded(0)
+    : M(M0), gb(gb0), heap(0), this_set(0), nsaved_unneeded(0)
 {
   max_varpower_size = 2 * M->n_vars() + 1;
 
-  spair *used_to_determine_size = nullptr;
+  spair *used_to_determine_size = 0;
   size_t spair_size =
       sizeofspair(used_to_determine_size, M->max_monomial_size());
   spair_stash = new stash("F4 spairs", spair_size);
@@ -26,16 +26,16 @@ F4SPairSet::~F4SPairSet()
 {
   // Deleting the stash deletes all memory used here
   // PS, VP are deleted automatically.
-  M = nullptr;
-  heap = nullptr;
-  this_set = nullptr;
+  M = 0;
+  heap = 0;
+  this_set = 0;
   delete spair_stash;
 }
 
 spair *F4SPairSet::make_spair(spair_type type, int deg, int i, int j)
 {
   spair *result = reinterpret_cast<spair *>(spair_stash->new_elem());
-  result->next = nullptr;
+  result->next = 0;
   result->type = type;
   result->deg = deg;
   result->i = i;
@@ -87,13 +87,13 @@ int F4SPairSet::remove_unneeded_pairs()
   int nremoved = 0;
 
   head.next = heap;
-  while (p->next != nullptr)
+  while (p->next != 0)
     if (pair_not_needed(p->next, m))
       {
         nremoved++;
         spair *tmp = p->next;
         p->next = tmp->next;
-        tmp->next = nullptr;
+        tmp->next = 0;
         delete_spair(tmp);
       }
     else
@@ -107,13 +107,13 @@ int F4SPairSet::determine_next_degree(int &result_number)
   spair *p;
   int nextdeg;
   int len = 1;
-  if (heap == nullptr)
+  if (heap == 0)
     {
       result_number = 0;
       return 0;
     }
   nextdeg = heap->deg;
-  for (p = heap->next; p != nullptr; p = p->next)
+  for (p = heap->next; p != 0; p = p->next)
     if (p->deg > nextdeg)
       continue;
     else if (p->deg < nextdeg)
@@ -132,7 +132,7 @@ int F4SPairSet::prepare_next_degree(int max, int &result_number)
 // most 'max', if max>0) spairs in this lowest degree.
 // Returns the degree, sets result_number.
 {
-  this_set = nullptr;
+  this_set = 0;
   int result_degree = determine_next_degree(result_number);
   if (result_number == 0) return 0;
   if (max > 0 && max < result_number) result_number = max;
@@ -141,7 +141,7 @@ int F4SPairSet::prepare_next_degree(int max, int &result_number)
   spair *p;
   head.next = heap;
   p = &head;
-  while (p->next != nullptr)
+  while (p->next != 0)
     if (p->next->deg != result_degree)
       p = p->next;
     else
@@ -162,11 +162,11 @@ spair *F4SPairSet::get_next_pair()
 // returns 0 if at the end
 {
   spair *result;
-  if (!this_set) return nullptr;
+  if (!this_set) return 0;
 
   result = this_set;
   this_set = this_set->next;
-  result->next = nullptr;
+  result->next = 0;
   return result;
 }
 
@@ -197,13 +197,13 @@ void F4SPairSet::display()
 // A debugging routine which displays the spairs in the set
 {
   fprintf(stderr, "spair set\n");
-  for (spair *p = heap; p != nullptr; p = p->next)
+  for (spair *p = heap; p != 0; p = p->next)
     {
       fprintf(stderr, "   ");
       display_spair(p);
     }
   fprintf(stderr, "current set\n");
-  for (spair *p = this_set; p != nullptr; p = p->next)
+  for (spair *p = this_set; p != 0; p = p->next)
     {
       fprintf(stderr, "   ");
       display_spair(p);

--- a/M2/Macaulay2/e/f4/f4.cpp
+++ b/M2/Macaulay2/e/f4/f4.cpp
@@ -955,7 +955,7 @@ void F4GB::show_row_info() const
   for (int i = 0; i < mat->rows.size(); i++)
     {
       fprintf(stderr, "%4d ", mat->rows[i].elem);
-      if (mat->rows[i].monom == nullptr)
+      if (mat->rows[i].monom == 0)
         fprintf(stderr, "generator");
       else
         M->show(mat->rows[i].monom);

--- a/M2/Macaulay2/e/f4/gausser.cpp
+++ b/M2/Macaulay2/e/f4/gausser.cpp
@@ -9,8 +9,8 @@
 Gausser *Gausser::newGausser(const Ring *K, F4Mem *Mem0)
 {
   const Z_mod *Kp = K->cast_to_Z_mod();
-  if (Kp != nullptr) return new Gausser(Kp, Mem0);
-  return nullptr;
+  if (Kp != 0) return new Gausser(Kp, Mem0);
+  return 0;
 }
 
 Gausser::Gausser(const Z_mod *K0, F4Mem *Mem0)
@@ -33,7 +33,7 @@ F4CoefficientArray Gausser::from_ringelem_array(int len, ring_elem *elems) const
         for (i = 0; i < len; i++) result[i] = elems[i].get_int();
         return result;
     };
-  return nullptr;
+  return 0;
 }
 
 void Gausser::to_ringelem_array(int len,
@@ -61,7 +61,7 @@ F4CoefficientArray Gausser::copy_F4CoefficientArray(int len,
         for (i = 0; i < len; i++) result[i] = elems[i];
         return result;
     };
-  return nullptr;
+  return 0;
 }
 
 void Gausser::deallocate_F4CCoefficientArray(F4CoefficientArray &F,
@@ -72,7 +72,7 @@ void Gausser::deallocate_F4CCoefficientArray(F4CoefficientArray &F,
     {
       case ZZp:
         Mem->coefficients.deallocate(elems);
-        F = nullptr;
+        F = 0;
     };
 }
 /////////////////////////////////////////////////////////////////////

--- a/M2/Macaulay2/e/f4/hilb-fcn.cpp
+++ b/M2/Macaulay2/e/f4/hilb-fcn.cpp
@@ -20,11 +20,11 @@ class Matrix;
 HilbertController::HilbertController(const FreeModule *F0,
                                      const RingElement *hf)
     : F(F0),
-      leadterms(nullptr),  // set later
+      leadterms(0),  // set later
       hilb_new_elems(true),
       hilb_n_in_degree(0),  // will be really set later
       hf_orig(hf),
-      hf_diff(nullptr)  // will be set later
+      hf_diff(0)  // will be set later
 {
   // TODO: check and write
   R = F->get_ring()->cast_to_PolynomialRing();
@@ -35,9 +35,9 @@ HilbertController::~HilbertController()
 {
   // TODO: check and write
   delete leadterms;
-  F = nullptr;
-  hf_orig = nullptr;
-  hf_diff = nullptr;
+  F = 0;
+  hf_orig = 0;
+  hf_diff = 0;
 }
 
 bool HilbertController::setDegree(int this_degree)
@@ -73,7 +73,7 @@ bool HilbertController::recomputeHilbertFunction()
       // Recompute h, hf_diff
       Matrix *M = make_lead_term_matrix();
       RingElement *h = hilb_comp::hilbertNumerator(M);
-      if (h == nullptr) return false;  // computation was interrupted
+      if (h == 0) return false;  // computation was interrupted
       hf_diff = (*h) - (*hf_orig);
       hilb_new_elems = false;
     }

--- a/M2/Macaulay2/e/f4/moninfo.cpp
+++ b/M2/Macaulay2/e/f4/moninfo.cpp
@@ -29,7 +29,7 @@ MonomialInfo::MonomialInfo(int nvars0, const MonomialOrdering *mo)
   ncalls_quotient_as_vp = 0;
 
   nweights = 0;
-  weight_vectors = nullptr;
+  weight_vectors = 0;
   if (moIsLex(mo))
     {
       compare = &MonomialInfo::compare_lex;

--- a/M2/Macaulay2/e/finalize.cpp
+++ b/M2/Macaulay2/e/finalize.cpp
@@ -62,7 +62,7 @@ void intern_monideal(MonomialIdeal *G)
 #ifdef MEMDEBUG
   GC_REGISTER_FINALIZER(M2_debug_to_outer(G), remove_monideal, 0, 0, 0);
 #else
-  GC_REGISTER_FINALIZER(G,                    remove_monideal, nullptr, nullptr, nullptr);
+  GC_REGISTER_FINALIZER(G,                    remove_monideal, 0, 0, 0);
 #endif
   AO_t nfinalized = AO_fetch_and_add1(&monideals_nfinalized);
   if (M2_gbTrace >= 3)
@@ -88,7 +88,7 @@ void intern_polyring(const PolynomialRing *G)
 #ifdef MEMDEBUG
   GC_REGISTER_FINALIZER_IGNORE_SELF(M2_debug_to_outer(const_cast<PolynomialRing *>(G)), remove_polyring, 0, 0, 0);
 #else
-  GC_REGISTER_FINALIZER_IGNORE_SELF(                  const_cast<PolynomialRing *>(G) , remove_polyring, nullptr, nullptr, nullptr);
+  GC_REGISTER_FINALIZER_IGNORE_SELF(                  const_cast<PolynomialRing *>(G) , remove_polyring, 0, 0, 0);
 #endif
   AO_t nfinalized = AO_fetch_and_add1(&polyrings_nfinalized);
   if (M2_gbTrace >= 3)
@@ -114,7 +114,7 @@ void intern_GB(GBComputation *G)
 #ifdef MEMDEBUG
   GC_REGISTER_FINALIZER_IGNORE_SELF(M2_debug_to_outer(G), remove_gb, 0, 0, 0);
 #else
-  GC_REGISTER_FINALIZER_IGNORE_SELF(                  G , remove_gb, nullptr, nullptr, nullptr);
+  GC_REGISTER_FINALIZER_IGNORE_SELF(                  G , remove_gb, 0, 0, 0);
 #endif
   AO_t nfinalized = AO_fetch_and_add1(&gbs_nfinalized);
   if (M2_gbTrace >= 3)
@@ -144,7 +144,7 @@ void intern_res(ResolutionComputation *G)
 #ifdef MEMDEBUG
   GC_REGISTER_FINALIZER(M2_debug_to_outer(G), remove_res, 0, 0, 0);
 #else
-  GC_REGISTER_FINALIZER(                  G , remove_res, nullptr, nullptr, nullptr);
+  GC_REGISTER_FINALIZER(                  G , remove_res, 0, 0, 0);
 #endif
   AO_t nfinalized = AO_fetch_and_add1(&res_nfinalized);
   if (M2_gbTrace >= 3)
@@ -168,7 +168,7 @@ void intern_SchreyerOrder(SchreyerOrder *G)
 #ifdef MEMDEBUG
   GC_REGISTER_FINALIZER(M2_debug_to_outer(G), remove_SchreyerOrder, 0, 0, 0);
 #else
-  GC_REGISTER_FINALIZER(                  G , remove_SchreyerOrder, nullptr, nullptr, nullptr);
+  GC_REGISTER_FINALIZER(                  G , remove_SchreyerOrder, 0, 0, 0);
 #endif
   AO_t nfinalized = AO_fetch_and_add1(&schorder_nfinalized);
   if (M2_gbTrace >= 3)
@@ -192,11 +192,11 @@ extern "C" void remove_MutableMatrix(void *p, void *cd)
 }
 MutableMatrix *internMutableMatrix(MutableMatrix *G)
 {
-  if (G == nullptr) return nullptr;
+  if (G == 0) return 0;
 #ifdef MEMDEBUG
   GC_REGISTER_FINALIZER(M2_debug_to_outer(G), remove_MutableMatrix, 0, 0, 0);
 #else
-  GC_REGISTER_FINALIZER(                  G,  remove_MutableMatrix, nullptr, nullptr, nullptr);
+  GC_REGISTER_FINALIZER(                  G,  remove_MutableMatrix, 0, 0, 0);
 #endif
   AO_t nfinalized = AO_fetch_and_add1(&mutablematrices_nfinalized);
   if (M2_gbTrace >= 3)

--- a/M2/Macaulay2/e/frac.cpp
+++ b/M2/Macaulay2/e/frac.cpp
@@ -115,7 +115,7 @@ void FractionField::simplify(frac_elem *f) const
       x = f->numer;
       const RingElement *a = RingElement::make_raw(R_, x);
       const RingElement *b = RingElement::make_raw(R_, y);
-      const RingElement *c = rawGCDRingElement(a, b, nullptr, false);
+      const RingElement *c = rawGCDRingElement(a, b, NULL, false);
 
 #if 0
       // Debugging code
@@ -203,9 +203,9 @@ void FractionField::lower_content(ring_elem &c, const ring_elem g) const
   const RingElement *g1 = RingElement::make_raw(R_, gf->numer);
   const RingElement *g2 = RingElement::make_raw(R_, gf->denom);
 
-  c1 = rawGCDRingElement(c1, g1, nullptr, false);
+  c1 = rawGCDRingElement(c1, g1, NULL, false);
 
-  const RingElement *cc2 = rawGCDRingElement(c2, g2, nullptr, false);
+  const RingElement *cc2 = rawGCDRingElement(c2, g2, NULL, false);
   const RingElement *cc3 = (*c2) * (*g2);
   const RingElement *cc4 = (*cc3) / (*cc2);
 

--- a/M2/Macaulay2/e/fractionfreeLU.cpp
+++ b/M2/Macaulay2/e/fractionfreeLU.cpp
@@ -8,7 +8,7 @@
 ////////////////////////////////////////
 
 FF_LUComputation::FF_LUComputation(MutableMatrix *M0)
-    : R(M0->get_ring()), M(M0), col_perm(nullptr), need_div(nullptr)
+    : R(M0->get_ring()), M(M0), col_perm(0), need_div(0)
 {
   int ncols = static_cast<int>(M->n_cols());
   col_perm = newarray_atomic(int, ncols);
@@ -116,7 +116,7 @@ M2_arrayint FF_LUComputation::get_column_permutation()
 M2_arrayintOrNull FF_LUComputation::DO(MutableMatrix *M)
 {
   FF_LUComputation F(M);
-  if (!F.calc()) return nullptr;
+  if (!F.calc()) return NULL;
   M2_arrayint col_permutation = F.get_column_permutation();
   return col_permutation;
 }

--- a/M2/Macaulay2/e/franzi-interface.cpp
+++ b/M2/Macaulay2/e/franzi-interface.cpp
@@ -49,7 +49,7 @@ IntermediateBasis BRPSfromMatrix(const Matrix *m)
   for (int i = 0; i < m->n_cols(); i++)
     {
       vec v = m->elem(i);
-      if (v == nullptr) continue;
+      if (v == 0) continue;
       BRP temp;
       for (Nterm& f : v->coeff)
         {
@@ -103,26 +103,26 @@ extern "C" const Matrix *rawGbBoolean(const Matrix *m)
   // cout << "first BRP in F " << F.begin()->second << endl;
   const Ring *R = m->get_ring();
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected a polynomial ring");
-      return nullptr;
+      return 0;
     }
   if (P->characteristic() != 2)
     {
       ERROR("expected coefficient ring ZZ/2");
-      return nullptr;
+      return 0;
     }
   if (not P->getCoefficientRing()->isFinitePrimeField())
     {
       ERROR("expected coefficient ring ZZ/2");
-      return nullptr;
+      return 0;
     }
   int n = P->n_vars();
   if (n > 64)
     {
       ERROR("Cannot handle more than 64 variables yet");
-      return nullptr;
+      return 0;
     }
   gb(F, n);
   // cout << "first BRP in F after gb() " << F.begin()->second << endl;

--- a/M2/Macaulay2/e/freemod.cpp
+++ b/M2/Macaulay2/e/freemod.cpp
@@ -16,7 +16,7 @@
 void FreeModule::initialize(const Ring *RR)
 {
   R = RR;
-  schreyer = nullptr;
+  schreyer = 0;
 }
 
 unsigned int FreeModule::computeHashValue() const
@@ -45,14 +45,14 @@ FreeModule::FreeModule(const Ring *RR, int n, bool has_schreyer_order)
       schreyer = SchreyerOrder::create(P->getMonoid());
     }
   else
-    schreyer = nullptr;
+    schreyer = 0;
 }
 
 FreeModule *FreeModule::make_schreyer(const Matrix *m)
 {
   int i;
   const PolynomialRing *R = m->get_ring()->cast_to_PolynomialRing();
-  if (R == nullptr)
+  if (R == 0)
     {
       ERROR("expected a polynomial ring");
       return nullptr;
@@ -72,7 +72,7 @@ FreeModule *FreeModule::make_schreyer(const GBMatrix *m)
 {
   const FreeModule *F = m->get_free_module();
   const PolynomialRing *R = F->get_ring()->cast_to_PolynomialRing();
-  if (R == nullptr)
+  if (R == 0)
     {
       ERROR("expected a polynomial ring");
       return nullptr;
@@ -85,7 +85,7 @@ FreeModule *FreeModule::make_schreyer(const GBMatrix *m)
     {
       monomial deg = R->degree_monoid()->make_one();
       gbvector *v = m->elems[i];
-      if (v != nullptr) R->get_gb_ring()->gbvector_multidegree(F, v, deg);
+      if (v != 0) R->get_gb_ring()->gbvector_multidegree(F, v, deg);
       G->append(deg);
     }
 
@@ -97,14 +97,14 @@ FreeModule *FreeModule::make_schreyer(const GBMatrix *m)
 Matrix *FreeModule::get_induced_order() const
 {
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (!schreyer || P == nullptr) return Matrix::zero(R->make_FreeModule(0), this);
+  if (!schreyer || P == 0) return Matrix::zero(R->make_FreeModule(0), this);
   const SchreyerOrder *S = schreyer;
   int i;
   int maxtie = 0;
   for (i = 0; i < rank(); i++)
     if (S->compare_num(i) > maxtie) maxtie = S->compare_num(i);
   const FreeModule *F = R->make_FreeModule(maxtie + 1);
-  MatrixConstructor mat(F, this, nullptr);
+  MatrixConstructor mat(F, this, 0);
   for (i = 0; i < rank(); i++)
     {
       ring_elem f = P->make_flat_term(P->getCoefficients()->from_long(1),
@@ -160,8 +160,8 @@ bool FreeModule::is_equal(const FreeModule *F) const
     for (i = 0; i < rank(); i++)
       if (0 != D->compare(degree(i), F->degree(i))) return false;
 
-  if (schreyer != nullptr) return schreyer->is_equal(F->schreyer);
-  if (F->schreyer != nullptr) return false;
+  if (schreyer != NULL) return schreyer->is_equal(F->schreyer);
+  if (F->schreyer != NULL) return false;
 
   return true;
 }
@@ -182,7 +182,7 @@ FreeModule *FreeModule::shift(const_monomial d) const
       result->append(deg);
     }
 
-  if (schreyer != nullptr) result->schreyer = schreyer->copy();
+  if (schreyer != NULL) result->schreyer = schreyer->copy();
 
   degree_monoid()->remove(deg);
   return result;
@@ -193,12 +193,12 @@ FreeModule *FreeModule::sub_space(int n) const
   if (n < 0 || n > rank())
     {
       ERROR("subfreemodule: index out of bounds");
-      return nullptr;
+      return NULL;
     }
   FreeModule *result = new_free();
   for (int i = 0; i < n; i++) result->append(degree(i));
 
-  if (schreyer != nullptr) result->schreyer = schreyer->sub_space(n);
+  if (schreyer != NULL) result->schreyer = schreyer->sub_space(n);
   return result;
 }
 
@@ -212,9 +212,9 @@ FreeModule *FreeModule::sub_space(M2_arrayint a) const
       {
         ERROR("subfreemodule: index out of bounds");
         freemem(result);
-        return nullptr;
+        return NULL;
       }
-  if (schreyer != nullptr) result->schreyer = schreyer->sub_space(a);
+  if (schreyer != NULL) result->schreyer = schreyer->sub_space(a);
   return result;
 }
 
@@ -241,7 +241,7 @@ FreeModule *FreeModule::direct_sum(const FreeModule *G) const
   if (get_ring() != G->get_ring())
     {
       ERROR("expected free modules over the same ring");
-      return nullptr;
+      return 0;
     }
   FreeModule *result = new_free();
   for (i = 0; i < rank(); i++) result->append(degree(i));
@@ -267,7 +267,7 @@ FreeModule *FreeModule::tensor(const FreeModule *G) const
   if (get_ring() != G->get_ring())
     {
       ERROR("expected free modules over the same ring");
-      return nullptr;
+      return 0;
     }
   FreeModule *result = new_free();
   monomial deg = degree_monoid()->make_one();
@@ -280,7 +280,7 @@ FreeModule *FreeModule::tensor(const FreeModule *G) const
       }
 
   degree_monoid()->remove(deg);
-  if (schreyer != nullptr && G->schreyer != nullptr)
+  if (schreyer != NULL && G->schreyer != NULL)
     result->schreyer = schreyer->tensor(G->schreyer);
   return result;
 }
@@ -316,7 +316,7 @@ FreeModule *FreeModule::exterior(int pp) const
 
   degree_monoid()->remove(deg);
 
-  if (schreyer != nullptr) result->schreyer = schreyer->exterior(pp);
+  if (schreyer != NULL) result->schreyer = schreyer->exterior(pp);
   return result;
 }
 
@@ -350,13 +350,13 @@ struct FreeModule_symm
   }
 
   FreeModule_symm(const FreeModule *F0, int n0)
-      : F(F0), D(F0->degree_monoid()), n(n0), symm1_result(nullptr), symm1_deg(nullptr)
+      : F(F0), D(F0->degree_monoid()), n(n0), symm1_result(0), symm1_deg(0)
   {
   }
 
   FreeModule *value()
   {
-    if (symm1_result == nullptr)
+    if (symm1_result == 0)
       {
         symm1_result = F->get_ring()->make_FreeModule();
         if (n >= 0)
@@ -375,7 +375,7 @@ FreeModule *FreeModule::symm(int n) const
 {
   FreeModule_symm SF(this, n);
   FreeModule *result = SF.value();
-  if (schreyer != nullptr) result->schreyer = schreyer->symm(n);
+  if (schreyer != NULL) result->schreyer = schreyer->symm(n);
   return result;
 }
 
@@ -458,7 +458,7 @@ void FreeModule::text_out(buffer &o) const
       degree_monoid()->elem_text_out(o, degree(i));
     }
   o << "}";
-  if (schreyer != nullptr) schreyer->text_out(o);
+  if (schreyer != NULL) schreyer->text_out(o);
   o << ')';
 }
 

--- a/M2/Macaulay2/e/gauss.cpp
+++ b/M2/Macaulay2/e/gauss.cpp
@@ -25,15 +25,15 @@ gm_elem *GaussElimComputation::new_gen(int i)
   if (i < n_comps_per_syz)
     result->fsyz = R->make_vec(i, R->one());
   else
-    result->fsyz = nullptr;
-  result->next = nullptr;
+    result->fsyz = NULL;
+  result->next = NULL;
   return result;
 }
 void GaussElimComputation::insert(gm_elem *p)
 {
-  if (p->f == nullptr)
+  if (p->f == NULL)
     {
-      if (p->fsyz != nullptr && collect_syz)
+      if (p->fsyz != NULL && collect_syz)
         {
           syz_list.push_back(p->fsyz);
           n_syz++;
@@ -47,7 +47,7 @@ void GaussElimComputation::insert(gm_elem *p)
       R->mult_vec_to(p->fsyz, leadinv, false);
       p->nterms = R->n_nonzero_terms(p->f);
       int i = p->f->comp;
-      if (gb_list[i] == nullptr)
+      if (gb_list[i] == NULL)
         {
           gb_list[i] = p;
           n_gb++;
@@ -85,8 +85,8 @@ GaussElimComputation::GaussElimComputation(const Matrix *m,
 
   for (i = 0; i < m->n_rows(); i++)
     {
-      reduce_list[i] = nullptr;
-      gb_list[i] = nullptr;
+      reduce_list[i] = NULL;
+      gb_list[i] = NULL;
     }
 
   if (nsyz < 0 || nsyz > m->n_cols()) nsyz = m->n_cols();
@@ -102,12 +102,12 @@ GaussElimComputation::GaussElimComputation(const Matrix *m,
 
 void GaussElimComputation::remove_gm_elem(gm_elem *&p)
 {
-  if (p != nullptr)
+  if (p != NULL)
     {
       R->remove_vec(p->f);
       R->remove_vec(p->fsyz);
       freemem(p);
-      p = nullptr;
+      p = NULL;
     }
 }
 
@@ -117,7 +117,7 @@ GaussElimComputation::~GaussElimComputation()
     {
       // remove the gm_elem list
       gm_elem *p = reduce_list[i];
-      while (p != nullptr)
+      while (p != NULL)
         {
           gm_elem *tmp = p;
           p = p->next;
@@ -154,10 +154,10 @@ void GaussElimComputation::reduce(vec &f)
   vecterm head;
   vecterm *result = &head;
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       int r = f->comp;
-      if (gb_list[r] != nullptr)
+      if (gb_list[r] != NULL)
         {
           // Reduce w.r.t. this term
           ring_elem c = f->coeff;
@@ -173,12 +173,12 @@ void GaussElimComputation::reduce(vec &f)
         }
     }
 
-  result->next = nullptr;
+  result->next = NULL;
   f = head.next;
 }
 void GaussElimComputation::reduce(vec &f, vec &fsyz, bool tail_only)
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
   vecterm head;
   vecterm *result = &head;
 
@@ -189,10 +189,10 @@ void GaussElimComputation::reduce(vec &f, vec &fsyz, bool tail_only)
       f = f->next;
       result = result->next;
     }
-  while (f != nullptr)
+  while (f != NULL)
     {
       int r = f->comp;
-      if (gb_list[r] != nullptr)
+      if (gb_list[r] != NULL)
         {
           // Reduce w.r.t. this term
           ring_elem c = f->coeff;
@@ -210,7 +210,7 @@ void GaussElimComputation::reduce(vec &f, vec &fsyz, bool tail_only)
         }
     }
 
-  result->next = nullptr;
+  result->next = NULL;
   f = head.next;
 }
 void GaussElimComputation::start_computation()
@@ -218,18 +218,18 @@ void GaussElimComputation::start_computation()
   if (status() == COMP_DONE) return;
   for (; row >= 0; row--)
     {
-      if (gb_list[row] == nullptr) continue;
-      while (reduce_list[row] != nullptr)
+      if (gb_list[row] == NULL) continue;
+      while (reduce_list[row] != NULL)
         {
           gm_elem *p = reduce_list[row];
           reduce_list[row] = p->next;
-          p->next = nullptr;
+          p->next = NULL;
           reduce(gb_list[row], p);  // replaces p
           if (M2_gbTrace >= 3)
             {
-              if (p->f == nullptr)
+              if (p->f == NULL)
                 {
-                  if (p->fsyz == nullptr)
+                  if (p->fsyz == NULL)
                     emit_wrapped("o");
                   else
                     emit_wrapped("z");
@@ -262,7 +262,7 @@ void GaussElimComputation::start_computation()
   // Now auto reduce these
   for (int r = 1; r < gens->n_rows(); r++)
     {
-      if (gb_list[r] == nullptr) continue;
+      if (gb_list[r] == 0) continue;
       reduce(gb_list[r]->f, gb_list[r]->fsyz, true);
     }
   if (M2_gbTrace >= 10)
@@ -279,7 +279,7 @@ const Matrix *GaussElimComputation::get_initial(int nparts)
 {
   MatrixConstructor mat(gens->rows(), 0);
   for (int i = 0; i < gens->n_rows(); i++)
-    if (gb_list[i] != nullptr)
+    if (gb_list[i] != NULL)
       {
         vec v = gb_list[i]->f;
         mat.append(R->make_vec(v->comp, v->coeff));
@@ -291,7 +291,7 @@ const Matrix *GaussElimComputation::get_gb()
 {
   MatrixConstructor mat(gens->rows(), 0);
   for (int i = 0; i < gens->n_rows(); i++)
-    if (gb_list[i] != nullptr) mat.append(R->copy_vec(gb_list[i]->f));
+    if (gb_list[i] != NULL) mat.append(R->copy_vec(gb_list[i]->f));
   return mat.to_matrix();
 }
 
@@ -299,7 +299,7 @@ const Matrix *GaussElimComputation::get_change()
 {
   MatrixConstructor mat(Fsyz, 0);
   for (int i = 0; i < gens->n_rows(); i++)
-    if (gb_list[i] != nullptr) mat.append(R->copy_vec(gb_list[i]->fsyz));
+    if (gb_list[i] != NULL) mat.append(R->copy_vec(gb_list[i]->fsyz));
   return mat.to_matrix();
 }
 
@@ -316,16 +316,16 @@ void GaussElimComputation::text_out(buffer &o) const
   o << newline;
   for (int i = 0; i < gens->n_rows(); i++)
     {
-      if (gb_list[i] != nullptr)
+      if (gb_list[i] != NULL)
         {
           o << "--- component " << i << " -----" << newline;
           o << "gb elem = ";
           R->vec_text_out(o, gb_list[i]->f);
           o << newline;
         }
-      else if (reduce_list[i] != nullptr)
+      else if (reduce_list[i] != NULL)
         o << "--- component " << i << " -----" << newline;
-      for (gm_elem *p = reduce_list[i]; p != nullptr; p = p->next)
+      for (gm_elem *p = reduce_list[i]; p != NULL; p = p->next)
         {
           o << p->nterms;
           o << " ## ";
@@ -346,12 +346,12 @@ const Matrix /* or null */ *GaussElimComputation::matrix_remainder(
   if (m->get_ring() != R)
     {
       ERROR("encountered different rings");
-      return nullptr;
+      return 0;
     }
   if (m->n_rows() != gens->rows()->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      return nullptr;
+      return 0;
     }
   MatrixConstructor mat_remainder(m->rows(), m->cols(), m->degree_shift());
   for (int i = 0; i < m->n_cols(); i++)
@@ -372,28 +372,28 @@ M2_bool GaussElimComputation::matrix_lift(
   if (m->get_ring() != R)
     {
       ERROR("encountered different rings");
-      *result_remainder = nullptr;
-      *result_quotient = nullptr;
+      *result_remainder = 0;
+      *result_quotient = 0;
       return false;
     }
   if (m->n_rows() != gens->rows()->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      *result_remainder = nullptr;
-      *result_quotient = nullptr;
+      *result_remainder = 0;
+      *result_quotient = 0;
       return false;
     }
   MatrixConstructor mat_remainder(m->rows(), m->cols(), m->degree_shift());
-  MatrixConstructor mat_quotient(Fsyz, m->cols(), nullptr);
+  MatrixConstructor mat_quotient(Fsyz, m->cols(), 0);
   bool all_zeroes = true;
   for (int i = 0; i < m->n_cols(); i++)
     {
       vec f = R->copy_vec(m->elem(i));
-      vec fsyz = nullptr;
+      vec fsyz = NULL;
 
       reduce(f, fsyz);
       R->negate_vec_to(fsyz);
-      if (f != nullptr) all_zeroes = false;
+      if (f != 0) all_zeroes = false;
       mat_remainder.set_column(i, f);
       mat_quotient.set_column(i, fsyz);
     }
@@ -417,7 +417,7 @@ int GaussElimComputation::contains(const Matrix *m)
     {
       vec f = R->copy_vec(m->elem(i));
       reduce(f);
-      if (f != nullptr)
+      if (f != NULL)
         {
           R->remove_vec(f);
           return i;

--- a/M2/Macaulay2/e/gb-default.cpp
+++ b/M2/Macaulay2/e/gb-default.cpp
@@ -62,7 +62,7 @@ gbA *gbA::create(const Matrix *m,
                  int max_reduction_count)
 {
   const PolynomialRing *origR = m->get_ring()->cast_to_PolynomialRing();
-  if (origR == nullptr)
+  if (origR == NULL)
     {
       ERROR("ring is not a polynomial ring");
       return nullptr;
@@ -114,7 +114,7 @@ void gbA::initialize(const Matrix *m,
   max_reduction_count = max_reduction_count0;
 
   const PolynomialRing *origR = m->get_ring()->cast_to_PolynomialRing();
-  if (origR == nullptr)
+  if (origR == NULL)
     {
       ERROR("ring is not a polynomial ring");
       // MES: throw an error here.
@@ -177,8 +177,8 @@ void gbA::initialize(const Matrix *m,
   divisor_previous_comp = -1;
 
   // ZZZZ split
-  lookup = nullptr;
-  lookupZZ = nullptr;
+  lookup = 0;
+  lookupZZ = 0;
   if (over_ZZ())
     lookupZZ = MonomialTableZZ::make(R->n_vars());
   else
@@ -208,7 +208,7 @@ void gbA::initialize(const Matrix *m,
       ring_elem denom;
       gbvector *f = originalR->translate_gbvector_from_vec(_F, (*m)[i], denom);
       spair *p = new_gen(i, f, denom);
-      if (p != nullptr)
+      if (p != NULL)
         {
           spair_set_insert(p);
         }
@@ -238,7 +238,7 @@ gbA::spair *gbA::new_gen(int i, gbvector *f, ring_elem denom)
           // vec fsyzvec = _GR->gbvector_to_vec(_Fsyz,fsyz);
           collect_syzygy(fsyz);
         }
-      return nullptr;
+      return NULL;
     }
 
   POLY g;
@@ -347,7 +347,7 @@ gbA::gbelem *gbA::gbelem_ring_make(gbvector *f)
   int f_leadweight;
   gbelem *g = reinterpret_cast<gbelem *>(gbelem_stash->new_elem());
   g->g.f = f;
-  g->g.fsyz = nullptr;
+  g->g.fsyz = 0;
   g->lead = exponents_make();
   R->gbvector_get_lead_exponents(_F, f, g->lead);
   g->deg = weightInfo_->gbvector_weight(f, f_leadweight);
@@ -371,7 +371,7 @@ gbA::gbelem *gbA::gbelem_make(gbvector *f,     // grabs f
   g->deg = deg;
   weightInfo_->gbvector_weight(f, f_leadweight);  // return value not used
   g->gap = deg - weightInfo_->gbvector_term_weight(f);
-  if (f->next == nullptr)  // a monomial.  This is a hack: we should lower the gap
+  if (f->next == 0)  // a monomial.  This is a hack: we should lower the gap
                      // value when we can.
     // the problem though is that this sometimes slows down the computation
     // dramatically.
@@ -426,14 +426,14 @@ void gbA::gbelem_text_out(buffer &o, int i, int nterms) const
 gbA::spair *gbA::spair_node()
 {
   spair *result = reinterpret_cast<spair *>(spair_stash->new_elem());
-  result->next = nullptr;
-  result->lead_of_spoly = nullptr;
+  result->next = 0;
+  result->lead_of_spoly = 0;
   return result;
 }
 
 void gbA::spair_delete(spair *&p)
 {
-  if (p == nullptr) return;
+  if (p == 0) return;
   if (p->type == SPAIR::SPAIR_GEN || p->type == SPAIR::SPAIR_ELEM)
     {
       R->gbvector_remove(p->x.f.f);
@@ -451,7 +451,7 @@ gbA::spair *gbA::spair_make(int i, int j)
   exponents_t exp1 = g1->lead;
   exponents_t exp2 = g2->lead;
   spair *result = spair_node();
-  result->next = nullptr;
+  result->next = 0;
   result->type = SPAIR::SPAIR_SPAIR;
   result->lcm = exponents_make();
   exponents_lcm(
@@ -477,7 +477,7 @@ gbA::spair *gbA::spair_make_gen(POLY f)
   R->gbvector_get_lead_exponents(_F, f.f, exp1);
   int deg = weightInfo_->gbvector_weight(f.f);
   spair *result = spair_node();
-  result->next = nullptr;
+  result->next = 0;
   result->type = SPAIR::SPAIR_GEN;
   result->deg = deg;
   result->lcm = exp1;
@@ -497,7 +497,7 @@ gbA::spair *gbA::spair_make_skew(int i, int v)
   for (j = 0; j < _nvars; j++) exp2[j] = 0;
   exp2[vvar] = 2;
   result = spair_node();
-  result->next = nullptr;
+  result->next = 0;
   result->type = SPAIR::SPAIR_SKEW;
   result->lcm = exp2;
   exponents_lcm(_nvars, g1->deg, exp1, exp2, exp2, gb_weights, result->deg);
@@ -630,13 +630,13 @@ void gbA::remove_unneeded_pairs(int id)
   gbelem *m = gb[id];
 
   head.next = S->heap;
-  while (p->next != nullptr)
+  while (p->next != 0)
     if (pair_not_needed(p->next, m))
       {
         nsaved_unneeded++;
         spair *tmp = p->next;
         p->next = tmp->next;
-        tmp->next = nullptr;
+        tmp->next = 0;
         if (M2_gbTrace >= 10)
           {
             buffer o;
@@ -733,9 +733,9 @@ class SPolySorter
             (a->type > gbA::SPAIR::SPAIR_SKEW ? a->f() : a->lead_of_spoly);
         gbvector *b1 =
             (b->type > gbA::SPAIR::SPAIR_SKEW ? b->f() : b->lead_of_spoly);
-        if (a1 == nullptr)
+        if (a1 == 0)
           {
-            if (b1 == nullptr)
+            if (b1 == 0)
               result = EQ;
             else
               result = LT;
@@ -853,7 +853,7 @@ void gbA::minimalize_pairs_ZZ(spairs &new_set)
       if (a->type == SPAIR::SPAIR_SKEW)
         {
           coeffs.push_back(globalZZ->one().get_mpz());
-          coeffs2.push_back(nullptr);  // will never be referred to below
+          coeffs2.push_back(0);  // will never be referred to below
         }
       else
         {
@@ -977,12 +977,12 @@ void gbA::update_pairs(int id)
 gbA::SPairSet::SPairSet()
     : nelems(0),
       n_in_degree(0),
-      heap(nullptr),
+      heap(0),
       n_computed(0),
-      spair_list(nullptr),
-      spair_last_deferred(nullptr),
-      gen_list(nullptr),
-      gen_last_deferred(nullptr)
+      spair_list(0),
+      spair_last_deferred(0),
+      gen_list(0),
+      gen_last_deferred(0)
 {
 }
 
@@ -994,7 +994,7 @@ void gbA::remove_spair_list(spair *&set)
       set = set->next;
       spair_delete(tmp);
     }
-  set = nullptr;
+  set = 0;
 }
 
 void gbA::remove_SPairSet()
@@ -1004,14 +1004,14 @@ void gbA::remove_SPairSet()
   remove_spair_list(S->spair_deferred_list.next);
   remove_spair_list(S->gen_list);
   remove_spair_list(S->gen_deferred_list.next);
-  S->spair_last_deferred = nullptr;
-  S->gen_last_deferred = nullptr;
+  S->spair_last_deferred = 0;
+  S->gen_last_deferred = 0;
 }
 
 void gbA::spair_set_insert(gbA::spair *p)
 /* Insert a LIST of s pairs into S */
 {
-  while (p != nullptr)
+  while (p != 0)
     {
       if (p->type == SPAIR::SPAIR_GEN) n_gens_left++;
       spair_set_lead_spoly(p);
@@ -1034,14 +1034,14 @@ gbA::spair *gbA::spair_set_next()
     }
   else
     {
-      if (S->spair_deferred_list.next != nullptr)
+      if (S->spair_deferred_list.next != 0)
         {
           if (M2_gbTrace >= 4)
             {
               emit_line("considering deferred pairs: ");
             }
           S->spair_list = S->spair_deferred_list.next;
-          S->spair_deferred_list.next = nullptr;
+          S->spair_deferred_list.next = 0;
           S->spair_last_deferred = &S->spair_deferred_list;
           result = S->spair_list;
           S->spair_list = result->next;
@@ -1056,25 +1056,25 @@ gbA::spair *gbA::spair_set_next()
             }
           else
             {
-              if (S->gen_deferred_list.next != nullptr)
+              if (S->gen_deferred_list.next != 0)
                 {
                   if (M2_gbTrace >= 4)
                     {
                       emit_line("  deferred gen pairs: ");
                     }
                   S->gen_list = S->gen_deferred_list.next;
-                  S->gen_deferred_list.next = nullptr;
+                  S->gen_deferred_list.next = 0;
                   S->gen_last_deferred = &S->gen_deferred_list;
                   result = S->gen_list;
                   S->gen_list = result->next;
                 }
               else
-                return nullptr;
+                return 0;
             }
         }
     }
 
-  result->next = nullptr;
+  result->next = 0;
   S->nelems--;
   S->n_in_degree--;
   S->n_computed++;
@@ -1114,9 +1114,9 @@ int gbA::spair_set_determine_next_degree(int &nextdegree)
   spair *p;
   int nextdeg;
   int len = 1;
-  if (S->heap == nullptr) return 0;
+  if (S->heap == 0) return 0;
   nextdeg = S->heap->deg;
-  for (p = S->heap->next; p != nullptr; p = p->next)
+  for (p = S->heap->next; p != 0; p = p->next)
     if (p->deg > nextdeg)
       continue;
     else if (p->deg < nextdeg)
@@ -1134,12 +1134,12 @@ int gbA::spair_set_prepare_next_degree(int &nextdegree)
 /* Finds the next degree to consider, returning the number of spairs in that
  * degree */
 {
-  S->spair_list = nullptr;
-  S->spair_deferred_list.next = nullptr;
+  S->spair_list = 0;
+  S->spair_deferred_list.next = 0;
   S->spair_last_deferred = &S->spair_deferred_list;
 
-  S->gen_list = nullptr;
-  S->gen_deferred_list.next = nullptr;
+  S->gen_list = 0;
+  S->gen_deferred_list.next = 0;
   S->gen_last_deferred = &S->gen_deferred_list;
 
   int len = spair_set_determine_next_degree(nextdegree);
@@ -1149,7 +1149,7 @@ int gbA::spair_set_prepare_next_degree(int &nextdegree)
   spair *p;
   head.next = S->heap;
   p = &head;
-  while (p->next != nullptr)
+  while (p->next != 0)
     if (p->next->deg != nextdegree)
       p = p->next;
     else
@@ -1182,9 +1182,9 @@ int gbA::spair_set_prepare_next_degree(int &nextdegree)
 void gbA::spair_set_show_mem_usage() {}
 void gbA::spairs_reverse(spair *&ps)
 {
-  spair *reversed = nullptr;
+  spair *reversed = 0;
   spair *p = ps;
-  while (p != nullptr)
+  while (p != 0)
     {
       spair *tmp = p;
       p = p->next;
@@ -1197,13 +1197,13 @@ void gbA::spairs_reverse(spair *&ps)
 /* Sorting a list of spairs */
 void gbA::spairs_sort(int len, spair *&ps)
 {
-  if (ps == nullptr || ps->next == nullptr) return;
+  if (ps == 0 || ps->next == 0) return;
   if (len <= 1) return;
   spairs a;  // array of spair's
   spairs b;  // these are the ones which are uncomputed, but whose lead_of_spoly
              // is 0.
   a.reserve(len);
-  for (spair *p = ps; p != nullptr; p = p->next)
+  for (spair *p = ps; p != 0; p = p->next)
     {
       if ((p->type > SPAIR::SPAIR_SKEW) || p->lead_of_spoly)
         a.push_back(p);
@@ -1229,15 +1229,15 @@ void gbA::spairs_sort(int len, spair *&ps)
     }
   else
     {
-      ps = nullptr;
+      ps = 0;
       return;
     }
 
-  if (asize > 0) a[asize - 1]->next = (bsize > 0 ? b[0] : nullptr);
+  if (asize > 0) a[asize - 1]->next = (bsize > 0 ? b[0] : 0);
   if (bsize > 0)
     {
       for (int i = 1; i < bsize; i++) b[i - 1]->next = b[i];
-      b[bsize - 1]->next = nullptr;
+      b[bsize - 1]->next = 0;
     }
 }
 
@@ -1247,12 +1247,12 @@ void gbA::spairs_sort(int len, spair *&ps)
 
 void gbA::spair_set_lead_spoly(spair *p)
 {
-  gbvector *ltsyz = nullptr;
+  gbvector *ltsyz = 0;
   POLY f, g;
   if (p->type > SPAIR::SPAIR_SKEW)
     {
       R->gbvector_remove(p->lead_of_spoly);
-      p->lead_of_spoly = nullptr;
+      p->lead_of_spoly = 0;
       return;
     }
   f = gb[p->x.pair.i]->g;
@@ -1260,24 +1260,24 @@ void gbA::spair_set_lead_spoly(spair *p)
     {
       const int *mon = R->skew_monomial_var(p->x.pair.j);
       R->gbvector_mult_by_term(
-          _F, _Fsyz, R->one(), mon, f.f, nullptr, p->lead_of_spoly, ltsyz);
+          _F, _Fsyz, R->one(), mon, f.f, 0, p->lead_of_spoly, ltsyz);
     }
   else if (p->type == SPAIR::SPAIR_GCD_ZZ)
     {
       g = gb[p->x.pair.j]->g;
       R->gbvector_combine_lead_terms_ZZ(
-          _F, _Fsyz, f.f, nullptr, g.f, nullptr, p->lead_of_spoly, ltsyz);
+          _F, _Fsyz, f.f, 0, g.f, 0, p->lead_of_spoly, ltsyz);
     }
   else
     {
       g = gb[p->x.pair.j]->g;
       R->gbvector_cancel_lead_terms(
-          _F, _Fsyz, f.f, nullptr, g.f, nullptr, p->lead_of_spoly, ltsyz);
+          _F, _Fsyz, f.f, 0, g.f, 0, p->lead_of_spoly, ltsyz);
     }
-  if (p->lead_of_spoly != nullptr)
+  if (p->lead_of_spoly != 0)
     {
       gbvector *tmp = p->lead_of_spoly->next;
-      p->lead_of_spoly->next = nullptr;
+      p->lead_of_spoly->next = 0;
       R->gbvector_remove(tmp);
     }
 }
@@ -1294,7 +1294,7 @@ void gbA::compute_s_pair(spair *p)
     }
   if (p->type > SPAIR::SPAIR_SKEW) return;
   R->gbvector_remove(p->lead_of_spoly);
-  p->lead_of_spoly = nullptr;
+  p->lead_of_spoly = 0;
   i = get_resolved_gb_index(p->x.pair.i);
   f = gb[i]->g;
   if (p->type == SPAIR::SPAIR_SKEW)
@@ -1384,7 +1384,7 @@ bool gbA::reduce_kk(spair *p)
 
       R->gbvector_reduce_lead_term(_F,
                                    _Fsyz,
-                                   nullptr,
+                                   0,
                                    p->f(),
                                    p->fsyz(), /* modifies these */
                                    g.f,
@@ -1824,7 +1824,7 @@ void gbA::remainder_ZZ(POLY &f, int degf, bool use_denom, ring_elem &denom)
 
   exponents_t EXP = ALLOCATE_EXPONENTS(exp_size);
 
-  frem->next = nullptr;
+  frem->next = 0;
   int count = 0;
   POLY h = f;
   while (!R->gbvector_is_zero(h.f))
@@ -1839,7 +1839,7 @@ void gbA::remainder_ZZ(POLY &f, int degf, bool use_denom, ring_elem &denom)
           frem->next = h.f;
           frem = frem->next;
           h.f = h.f->next;
-          frem->next = nullptr;
+          frem->next = 0;
         }
       else
         {
@@ -1851,7 +1851,7 @@ void gbA::remainder_ZZ(POLY &f, int degf, bool use_denom, ring_elem &denom)
               frem->next = h.f;
               frem = frem->next;
               h.f = h.f->next;
-              frem->next = nullptr;
+              frem->next = 0;
             }
           count++;
           if (M2_gbTrace == 15)
@@ -1866,7 +1866,7 @@ void gbA::remainder_ZZ(POLY &f, int degf, bool use_denom, ring_elem &denom)
     }
   h.f = head.next;
   // Negate these if needed
-  if (h.f != nullptr && mpz_sgn(h.f->coeff.get_mpz()) < 0)
+  if (h.f != 0 && mpz_sgn(h.f->coeff.get_mpz()) < 0)
     {
       R->gbvector_mult_by_coeff_to(h.f, globalZZ->minus_one());
       R->gbvector_mult_by_coeff_to(h.fsyz, globalZZ->minus_one());
@@ -1899,7 +1899,7 @@ void gbA::tail_remainder_ZZ(POLY &f, int degf)
   frem->next = h.f;
   frem = frem->next;
   h.f = h.f->next;
-  frem->next = nullptr;
+  frem->next = 0;
 
   while (!R->gbvector_is_zero(h.f))
     {
@@ -1914,7 +1914,7 @@ void gbA::tail_remainder_ZZ(POLY &f, int degf)
           frem->next = h.f;
           frem = frem->next;
           h.f = h.f->next;
-          frem->next = nullptr;
+          frem->next = 0;
         }
       else
         {
@@ -1926,7 +1926,7 @@ void gbA::tail_remainder_ZZ(POLY &f, int degf)
               frem->next = h.f;
               frem = frem->next;
               h.f = h.f->next;
-              frem->next = nullptr;
+              frem->next = 0;
             }
           count++;
           //      stats_ntail++;
@@ -1942,7 +1942,7 @@ void gbA::tail_remainder_ZZ(POLY &f, int degf)
     }
   h.f = head.next;
   // Negate these if needed
-  if (h.f != nullptr && mpz_sgn(h.f->coeff.get_mpz()) < 0)
+  if (h.f != 0 && mpz_sgn(h.f->coeff.get_mpz()) < 0)
     {
       R->gbvector_mult_by_coeff_to(h.f, globalZZ->minus_one());
       R->gbvector_mult_by_coeff_to(h.fsyz, globalZZ->minus_one());
@@ -1994,7 +1994,7 @@ void gbA::remainder_non_ZZ(POLY &f, int degf, bool use_denom, ring_elem &denom)
   gbvector head;
   gbvector *frem = &head;
 
-  frem->next = nullptr;
+  frem->next = 0;
   int count = 0;
   POLY h = f;
   while (!R->gbvector_is_zero(h.f))
@@ -2009,7 +2009,7 @@ void gbA::remainder_non_ZZ(POLY &f, int degf, bool use_denom, ring_elem &denom)
           frem->next = h.f;
           frem = frem->next;
           h.f = h.f->next;
-          frem->next = nullptr;
+          frem->next = 0;
         }
       else
         {
@@ -2294,8 +2294,8 @@ bool gbA::process_spair(spair *p)
       (p->type == SPAIR::SPAIR_GEN ? ELEM_MINGEN : 0) | ELEM_MINGB;
 
   POLY f = p->x.f;
-  p->x.f.f = nullptr;
-  p->x.f.fsyz = nullptr;
+  p->x.f.f = 0;
+  p->x.f.fsyz = 0;
   spair_delete(p);
 
   if (!R->gbvector_is_zero(f.f))
@@ -2354,7 +2354,7 @@ Matrix *gbA::make_lead_term_matrix()
           assert(f != 0);
           // Only grab the lead term, which should be non-null
           gbvector *fnext = f->next;
-          f->next = nullptr;
+          f->next = 0;
           vec v = originalR->translate_gbvector_to_vec(_F, f);
           f->next = fnext;
           result.append(v);
@@ -2430,7 +2430,7 @@ void gbA::do_computation()
                 // Recompute h, hf_diff
                 Matrix *hf = make_lead_term_matrix();
                 RingElement *h = hilb_comp::hilbertNumerator(hf);
-                if (h == nullptr)
+                if (h == 0)
                   {
                     set_status(COMP_INTERRUPTED);
                     return;
@@ -2504,7 +2504,7 @@ void gbA::do_computation()
           case STATE_SPAIRS:
           case STATE_GENS:
             // Compute the spairs for this degree
-            while ((p = spair_set_next()) != nullptr)
+            while ((p = spair_set_next()) != 0)
               {
                 process_spair(p);
                 npairs--;
@@ -2636,7 +2636,7 @@ void gbA::minimalize_gb()
 void gbA::flush_pairs()
 {
   spair *p;
-  while ((p = spair_set_next()) != nullptr)
+  while ((p = spair_set_next()) != 0)
     {
       n_saved_hilb++;
       spair_delete(p);
@@ -2777,7 +2777,7 @@ void gbA::debug_spair(spair *p)
 void gbA::debug_spairs(spair *spairlist)
 {
   spair *p = spairlist;
-  while (p != nullptr)
+  while (p != 0)
     {
       debug_spair(p);
       p = p->next;

--- a/M2/Macaulay2/e/gb-homog2.cpp
+++ b/M2/Macaulay2/e/gb-homog2.cpp
@@ -32,7 +32,7 @@ void GB_comp::initialize0(const Matrix *m,
 {
   int i;
   const PolynomialRing *R = m->get_ring()->cast_to_PolynomialRing();
-  if (R == nullptr)
+  if (R == NULL)
     {
       ERROR("ring is not a polynomial ring");
       // MES: throw an error here.
@@ -101,7 +101,7 @@ void GB_comp::initialize(const Matrix *m,
       ring_elem denom;
       gbvector *f = originalR->translate_gbvector_from_vec(_F, (*m)[i], denom);
       s_pair *p = new_gen(i, f, denom);
-      if (p != nullptr)
+      if (p != NULL)
         {
           _gens->insert(p);
           _n_gens_left++;
@@ -126,12 +126,12 @@ void GB_comp::remove_pair(s_pair *&p)
 {
   _GR->gbvector_remove(p->f);
   _GR->gbvector_remove(p->fsyz);
-  p->first = nullptr;
-  p->second = nullptr;
-  p->next = nullptr;
+  p->first = NULL;
+  p->second = NULL;
+  p->next = NULL;
   _M->remove(p->lcm);
   freemem(p);
-  p = nullptr;
+  p = NULL;
 }
 
 GB_comp::~GB_comp() {}
@@ -147,16 +147,16 @@ s_pair *GB_comp::new_var_pair(gb_elem *p, const int *lcm)
 s_pair *GB_comp::new_ring_pair(gb_elem *p, const int *lcm)
 {
   s_pair *result = new s_pair;
-  result->next = nullptr;
+  result->next = NULL;
   result->syz_type = SPAIR_RING;
   result->degree = weightInfo_->monomial_weight(
       lcm, p->f->comp);  //_M->primary_degree(lcm) +
                          //_F->primary_degree(p->f->comp-1);
   result->compare_num = 0;
   result->first = p;
-  result->second = nullptr;
-  result->f = nullptr;
-  result->fsyz = nullptr;
+  result->second = NULL;
+  result->f = NULL;
+  result->fsyz = NULL;
 
   result->lcm = _M->make_new(lcm);
   return result;
@@ -166,7 +166,7 @@ s_pair *GB_comp::new_s_pair(gb_elem *p, gb_elem *q, const int *lcm)
 {
   // p and q should have 'f' field defined.
   s_pair *result = new s_pair;
-  result->next = nullptr;
+  result->next = NULL;
   result->syz_type = SPAIR_PAIR;
   result->degree = weightInfo_->monomial_weight(
       lcm, p->f->comp);  //_M->primary_degree(lcm) +
@@ -174,8 +174,8 @@ s_pair *GB_comp::new_s_pair(gb_elem *p, gb_elem *q, const int *lcm)
   result->compare_num = 0;
   result->first = p;
   result->second = q;
-  result->f = nullptr;
-  result->fsyz = nullptr;
+  result->f = NULL;
+  result->fsyz = NULL;
 
   result->lcm = _M->make_new(lcm);
   return result;
@@ -197,16 +197,16 @@ s_pair *GB_comp::new_gen(int i, gbvector *f, ring_elem denom)
           _syz.push_back(fsyz);
           _n_syz++;
         }
-      return nullptr;
+      return NULL;
     }
 
   s_pair *result = new s_pair;
-  result->next = nullptr;
+  result->next = NULL;
   result->syz_type = SPAIR_GEN;
   result->degree = weightInfo_->gbvector_weight(f);
   result->compare_num = 0;
-  result->first = nullptr;
-  result->second = nullptr;
+  result->first = NULL;
+  result->second = NULL;
   result->f = f; /* NOTE THAT WE GRAB f */
   result->fsyz = fsyz;
 
@@ -372,7 +372,7 @@ void GB_comp::find_pairs(gb_elem *p)
 
 void GB_comp::compute_s_pair(s_pair *p)
 {
-  if (p->f == nullptr)
+  if (p->f == NULL)
     {
       monomial s = _M->make_one();
       _M->divide(p->lcm, p->first->f->monom, s);
@@ -381,7 +381,7 @@ void GB_comp::compute_s_pair(s_pair *p)
           _F, _Fsyz, _GR->one(), s, p->first->f, p->first->fsyz, p->f, p->fsyz);
       if (p->syz_type == SPAIR_PAIR)
         _GR->gbvector_reduce_lead_term(
-            _F, _Fsyz, nullptr, p->f, p->fsyz, p->second->f, p->second->fsyz);
+            _F, _Fsyz, 0, p->f, p->fsyz, p->second->f, p->second->fsyz);
       _M->remove(s);
     }
 }
@@ -395,7 +395,7 @@ void GB_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
     }
   gbvector head;
   gbvector *result = &head;
-  result->next = nullptr;
+  result->next = 0;
 
   exponents_t div_totalexp = newarray_atomic(int, _M->n_vars());
   int count = 0;
@@ -406,7 +406,7 @@ void GB_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
       _GR->gbvector_text_out(o, _F, f);
       emit_line(o.str());
     }
-  while (f != nullptr)
+  while (f != NULL)
     {
       Bag *b;
       _GR->gbvector_get_lead_exponents(_F, f, div_totalexp);
@@ -415,7 +415,7 @@ void GB_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
                                                                 b))
         {
           const gbvector *g = originalR->quotient_gbvector(b->basis_elem());
-          _GR->gbvector_reduce_lead_term(_F, _Fsyz, head.next, f, fsyz, g, nullptr);
+          _GR->gbvector_reduce_lead_term(_F, _Fsyz, head.next, f, fsyz, g, 0);
           count++;
           _n_reductions++;
         }
@@ -444,7 +444,7 @@ void GB_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
           result->next = f;
           f = f->next;
           result = result->next;
-          result->next = nullptr;
+          result->next = 0;
         }
     }
 
@@ -462,7 +462,7 @@ void GB_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
 {
   gbvector head;
   gbvector *result = &head;
-  result->next = nullptr;
+  result->next = 0;
 
   exponents_t div_totalexp = newarray_atomic(int, _M->n_vars());
   int count = 0;
@@ -472,7 +472,7 @@ void GB_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
   fb.add(f);
   fsyzb.add(fsyz);
   const gbvector *lead;
-  while ((lead = fb.get_lead_term()) != nullptr)
+  while ((lead = fb.get_lead_term()) != NULL)
     {
       Bag *b;
       _GR->gbvector_get_lead_exponents(_F, lead, div_totalexp);
@@ -489,7 +489,7 @@ void GB_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
                                      fb,
                                      fsyzb,
                                      g,
-                                     nullptr);
+                                     0);
           count++;
         }
       else if (_monideals[lead->comp]->mi_search->search_expvector(div_totalexp,
@@ -511,7 +511,7 @@ void GB_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
         {
           result->next = fb.remove_lead_term();
           result = result->next;
-          result->next = nullptr;
+          result->next = 0;
         }
     }
 
@@ -530,7 +530,7 @@ void GB_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
 void GB_comp::flush_pairs(int deg)
 {
   s_pair *p;
-  while ((p = _spairs->remove()) != nullptr)
+  while ((p = _spairs->remove()) != NULL)
     if (p->degree != deg)
       {
         _spairs->put_back(p);
@@ -541,7 +541,7 @@ void GB_comp::flush_pairs(int deg)
         _n_saved_hilb++;
         remove_pair(p);
       }
-  while ((p = _gens->remove()) != nullptr)
+  while ((p = _gens->remove()) != NULL)
     if (p->degree != deg)
       {
         _gens->put_back(p);
@@ -596,7 +596,7 @@ int GB_comp::s_pair_step()
 // values.
 {
   s_pair *p = _spairs->remove();
-  if (p == nullptr) return SPAIR_DONE;
+  if (p == NULL) return SPAIR_DONE;
   if (p->degree != _this_degree)
     {
       _spairs->put_back(p);
@@ -614,8 +614,8 @@ int GB_comp::s_pair_step()
 
   gbvector *f = p->f;
   gbvector *fsyz = p->fsyz;
-  p->f = nullptr;
-  p->fsyz = nullptr;
+  p->f = NULL;
+  p->fsyz = NULL;
   remove_pair(p);
 
   gb_reduce(f, fsyz);
@@ -656,7 +656,7 @@ int GB_comp::gen_step()
 // values.
 {
   s_pair *p = _gens->remove();
-  if (p == nullptr) return SPAIR_DONE;
+  if (p == NULL) return SPAIR_DONE;
   if (p->degree != _this_degree)
     {
       _gens->put_back(p);
@@ -670,8 +670,8 @@ int GB_comp::gen_step()
 
   gbvector *f = p->f;
   gbvector *fsyz = p->fsyz;
-  p->f = nullptr;
-  p->fsyz = nullptr;
+  p->f = NULL;
+  p->fsyz = NULL;
   remove_pair(p);
 
   gb_reduce(f, fsyz);
@@ -763,17 +763,17 @@ int GB_comp::next_degree()
   int result = 0;
   p = _spairs->remove();
   q = _gens->remove();
-  if (p != nullptr)
+  if (p != NULL)
     {
       result = p->degree;
-      if (q != nullptr && q->degree < p->degree) result = q->degree;
+      if (q != NULL && q->degree < p->degree) result = q->degree;
     }
-  else if (q != nullptr)
+  else if (q != NULL)
     result = q->degree;
   else
     assert(0);
-  if (p != nullptr) _spairs->put_back(p);
-  if (q != nullptr) _gens->put_back(q);
+  if (p != NULL) _spairs->put_back(p);
+  if (q != NULL) _gens->put_back(q);
   return result;
 }
 
@@ -786,7 +786,7 @@ RingElement /* or null */ *GB_comp::compute_hilbert_function() const
 #ifdef DEVELOPMENT
 #warning "not implemented yet"
 #endif
-  return nullptr;
+  return NULL;
 }
 
 //---- state machine (roughly) for the computation ----
@@ -829,7 +829,7 @@ void GB_comp::start_computation()
                   {
                     // Recompute h, _hf_diff
                     RingElement *h = compute_hilbert_function();
-                    if (h == nullptr)
+                    if (h == 0)
                       {
                         is_done = COMP_INTERRUPTED;
                         break;
@@ -962,15 +962,15 @@ void GB_comp::start_computation()
 
 void GB_comp::debug_out(s_pair *q) const
 {
-  if (q == nullptr) return;
+  if (q == NULL) return;
   buffer o;
   o << "(" << q->compare_num << " ";
-  if (q->first != nullptr)
+  if (q->first != NULL)
     o << q->first->me;
   else
     o << ".";
   o << " ";
-  if (q->second != nullptr)
+  if (q->second != NULL)
     o << q->second->me;
   else
     o << ".";
@@ -1070,13 +1070,13 @@ const Matrix /* or null */ *GB_comp::matrix_remainder(const Matrix *m)
   if (m->get_ring() != originalR)
     {
       ERROR("expected matrix over the same ring");
-      return nullptr;
+      return 0;
     }
 
   if (m->n_rows() != _F->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      return nullptr;
+      return 0;
     }
   start_computation();
   MatrixConstructor red(m->rows(), m->cols(), m->degree_shift());
@@ -1101,15 +1101,15 @@ M2_bool GB_comp::matrix_lift(const Matrix *m,
   if (m->get_ring() != originalR)
     {
       ERROR("expected matrix over the same ring");
-      *result_remainder = nullptr;
-      *result_quotient = nullptr;
+      *result_remainder = 0;
+      *result_quotient = 0;
       return false;
     }
   if (m->n_rows() != _F->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      *result_remainder = nullptr;
-      *result_quotient = nullptr;
+      *result_remainder = 0;
+      *result_quotient = 0;
       return false;
     }
   start_computation();
@@ -1123,7 +1123,7 @@ M2_bool GB_comp::matrix_lift(const Matrix *m,
       gbvector *fsyz = _GR->gbvector_zero();
 
       gb_reduce(f, fsyz);
-      if (f != nullptr) all_zeroes = false;
+      if (f != 0) all_zeroes = false;
 
       vec fv = originalR->translate_gbvector_to_vec_denom(_F, f, denom);
       _K->negate_to(denom);
@@ -1154,10 +1154,10 @@ int GB_comp::contains(const Matrix *m)
       ring_elem denom;
       gbvector *f = originalR->translate_gbvector_from_vec(_F, (*m)[i], denom);
       _K->remove(denom);
-      gbvector *fsyz = nullptr;
+      gbvector *fsyz = NULL;
       gb_reduce(f, fsyz);
       _GR->gbvector_remove(fsyz);
-      if (f != nullptr)
+      if (f != NULL)
         {
           _GR->gbvector_remove(f);
           return i;

--- a/M2/Macaulay2/e/gb-sugarless.cpp
+++ b/M2/Macaulay2/e/gb-sugarless.cpp
@@ -23,7 +23,7 @@ void GBinhom_comp::set_up0(const Matrix *m,
 {
   int i;
   const PolynomialRing *R = m->get_ring()->cast_to_PolynomialRing();
-  if (R == nullptr)
+  if (R == NULL)
     {
       ERROR("ring is not a polynomial ring");
       // MES: throw an error here.
@@ -38,8 +38,8 @@ void GBinhom_comp::set_up0(const Matrix *m,
   spairs = new s_pair_heap(M);
 
   gb = gbLarge = new gb_elem;  // List head for the GB computed so far
-  gb->next = nullptr;             // (both minimal, and large GB's)
-  gb->next_min = nullptr;
+  gb->next = NULL;             // (both minimal, and large GB's)
+  gb->next_min = NULL;
 
   if (nsyz < 0 || nsyz > m->n_cols()) nsyz = m->n_cols();
   n_comps_per_syz = nsyz;
@@ -97,7 +97,7 @@ void GBinhom_comp::add_gens(int lo, int hi, const Matrix *m)
       ring_elem denom;
       gbvector *f = originalR->translate_gbvector_from_vec(F, (*m)[i], denom);
       s_pair *p = new_gen(i, f, denom);
-      if (p != nullptr) spairs->insert(p);
+      if (p != NULL) spairs->insert(p);
       n_pairs++;
     }
 }
@@ -111,10 +111,10 @@ GBinhom_comp *GBinhom_comp::create(const Matrix *m,
                                    int max_degree_limit)
 {
   const PolynomialRing *P = m->get_ring()->cast_to_PolynomialRing();
-  if (P == nullptr || P->getCoefficients()->is_ZZ())
+  if (P == 0 || P->getCoefficients()->is_ZZ())
     {
       ERROR("expected polynomial ring over a field");
-      return nullptr;
+      return 0;
     }
   GBinhom_comp *result =
       new GBinhom_comp(m, collect_syz, n_rows_to_keep, gb_weights, strategy);
@@ -134,12 +134,12 @@ void GBinhom_comp::remove_pair(s_pair *&p)
 {
   GR->gbvector_remove(p->f);
   GR->gbvector_remove(p->fsyz);
-  p->first = nullptr;
-  p->second = nullptr;
-  p->next = nullptr;
+  p->first = NULL;
+  p->second = NULL;
+  p->next = NULL;
   M->remove(p->lcm);
   freemem(p);
-  p = nullptr;
+  p = NULL;
 }
 
 GBinhom_comp::~GBinhom_comp() {}
@@ -162,16 +162,16 @@ s_pair *GBinhom_comp::new_var_pair(gb_elem *p, const int *lcm)
 s_pair *GBinhom_comp::new_ring_pair(gb_elem *p, const int *lcm)
 {
   s_pair *result = new s_pair;
-  result->next = nullptr;
+  result->next = NULL;
   result->syz_type = SPAIR_RING;
   result->degree = weightInfo_->monomial_weight(
       lcm,
       p->f->comp);  // M->primary_degree(lcm) + F->primary_degree(p->f->comp-1);
   result->compare_num = 0;
   result->first = p;
-  result->second = nullptr;
-  result->f = nullptr;
-  result->fsyz = nullptr;
+  result->second = NULL;
+  result->f = NULL;
+  result->fsyz = NULL;
 
   result->lcm = M->make_new(lcm);
   return result;
@@ -181,7 +181,7 @@ s_pair *GBinhom_comp::new_s_pair(gb_elem *p, gb_elem *q, const int *lcm)
 {
   // p and q should have 'f' field defined.
   s_pair *result = new s_pair;
-  result->next = nullptr;
+  result->next = NULL;
   result->syz_type = SPAIR_PAIR;
   result->degree = weightInfo_->monomial_weight(
       lcm,
@@ -189,8 +189,8 @@ s_pair *GBinhom_comp::new_s_pair(gb_elem *p, gb_elem *q, const int *lcm)
   result->compare_num = 0;
   result->first = p;
   result->second = q;
-  result->f = nullptr;
-  result->fsyz = nullptr;
+  result->f = NULL;
+  result->fsyz = NULL;
 
   result->lcm = M->make_new(lcm);
   return result;
@@ -213,16 +213,16 @@ s_pair *GBinhom_comp::new_gen(int i, gbvector *f, ring_elem denom)
           n_syz++;
           syz.append(fsyzvec);
         }
-      return nullptr;
+      return NULL;
     }
 
   s_pair *result = new s_pair;
-  result->next = nullptr;
+  result->next = NULL;
   result->syz_type = SPAIR_GEN;
   result->degree = weightInfo_->gbvector_weight(f);
   result->compare_num = 0;
-  result->first = nullptr;
-  result->second = nullptr;
+  result->first = NULL;
+  result->second = NULL;
   result->f = f; /* NOTE THAT WE GRAB f */
   result->fsyz = fsyz;
 
@@ -234,7 +234,7 @@ s_pair *GBinhom_comp::new_gen(int i, gbvector *f, ring_elem denom)
 int GBinhom_comp::mark_pair(gb_elem *p, gb_elem *q) const
 {
   s_pair *r;
-  for (r = p->pair_list; r != nullptr; r = r->next_same)
+  for (r = p->pair_list; r != NULL; r = r->next_same)
     if (r->second == q)
       {
         if (r->compare_num >= 0)
@@ -252,7 +252,7 @@ int GBinhom_comp::mark_pair(gb_elem *p, gb_elem *q) const
         else
           return 0;
       }
-  for (r = q->pair_list; r != nullptr; r = r->next_same)
+  for (r = q->pair_list; r != NULL; r = r->next_same)
     if (r->second == p)
       {
         if (r->compare_num >= 0)
@@ -330,7 +330,7 @@ void GBinhom_comp::find_pairs(gb_elem *p)
     }
 
   // Add in syzygies arising as s-pairs
-  for (gb_elem *s = gb->next_min; s != nullptr; s = s->next_min)
+  for (gb_elem *s = gb->next_min; s != NULL; s = s->next_min)
     {
       if (p->f->comp != s->f->comp) continue;
 
@@ -383,13 +383,13 @@ void GBinhom_comp::find_pairs(gb_elem *p)
         }
     }
   n_pairs += len;
-  nextsame->next = nullptr;
+  nextsame->next = NULL;
   p->pair_list = head.next;
   spairs->sort_list(p->pair_list);
   if (M2_gbTrace >= 8)
     {
       buffer o;
-      for (q = p->pair_list; q != nullptr; q = q->next)
+      for (q = p->pair_list; q != NULL; q = q->next)
         {
           o << "insert ";
           debug_out(o, q);
@@ -397,7 +397,7 @@ void GBinhom_comp::find_pairs(gb_elem *p)
         }
       emit(o.str());
     }
-  for (q = p->pair_list; q != nullptr; q = q->next) q->next_same = q->next;
+  for (q = p->pair_list; q != NULL; q = q->next) q->next_same = q->next;
   spairs->insert(p->pair_list, len);
 
   // remove those pairs (i,j) for which gcd(p:i, p:j) = 1
@@ -406,7 +406,7 @@ void GBinhom_comp::find_pairs(gb_elem *p)
   // Also much optimization might be able to be done, as far as removing
   // keeping the 'correct' minimal generator of the lcms.
 
-  for (s_pair *s1 = p->pair_list; s1 != nullptr; s1 = s1->next_same)
+  for (s_pair *s1 = p->pair_list; s1 != NULL; s1 = s1->next_same)
     {
       if (s1->syz_type != SPAIR_PAIR) continue;
 
@@ -414,7 +414,7 @@ void GBinhom_comp::find_pairs(gb_elem *p)
 
       M->divide(s1->lcm, f_m, pi);
 
-      for (s_pair *t1 = s1->next_same; t1 != nullptr; t1 = t1->next_same)
+      for (s_pair *t1 = s1->next_same; t1 != NULL; t1 = t1->next_same)
         {
           if (t1->syz_type != SPAIR_PAIR) continue;
           GR->gbvector_get_lead_monomial(F, t1->second->f, f_m);
@@ -442,7 +442,7 @@ void GBinhom_comp::find_pairs(gb_elem *p)
 
 void GBinhom_comp::compute_s_pair(s_pair *p)
 {
-  if (p->f == nullptr)
+  if (p->f == NULL)
     {
       monomial s = M->make_one();
       M->divide(p->lcm, p->first->f->monom, s);
@@ -451,7 +451,7 @@ void GBinhom_comp::compute_s_pair(s_pair *p)
           F, Fsyz, GR->one(), s, p->first->f, p->first->fsyz, p->f, p->fsyz);
       if (p->syz_type == SPAIR_PAIR)
         GR->gbvector_reduce_lead_term(
-            F, Fsyz, nullptr, p->f, p->fsyz, p->second->f, p->second->fsyz);
+            F, Fsyz, 0, p->f, p->fsyz, p->second->f, p->second->fsyz);
       M->remove(s);
     }
 }
@@ -461,7 +461,7 @@ int GBinhom_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
   if ((strategy & STRATEGY_LONGPOLYNOMIALS) != 0) return gb_geo_reduce(f, fsyz);
   gbvector head;
   gbvector *result = &head;
-  result->next = nullptr;
+  result->next = 0;
   gb_elem *q;
 
   exponents_t div_totalexp = newarray_atomic(int, M->n_vars());
@@ -473,7 +473,7 @@ int GBinhom_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
       GR->gbvector_text_out(o, F, f);
       emit_line(o.str());
     }
-  while (f != nullptr)
+  while (f != NULL)
     {
       GR->gbvector_get_lead_exponents(F, f, div_totalexp);
 #ifdef DEVELOPMENT
@@ -485,7 +485,7 @@ int GBinhom_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
                                                                 b))
         {
           const gbvector *g = originalR->quotient_gbvector(b->basis_elem());
-          GR->gbvector_reduce_lead_term(F, Fsyz, head.next, f, fsyz, g, nullptr);
+          GR->gbvector_reduce_lead_term(F, Fsyz, head.next, f, fsyz, g, 0);
           count++;
         }
       else if (search(div_totalexp, f->comp, q))
@@ -499,7 +499,7 @@ int GBinhom_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
           result->next = f;
           f = f->next;
           result = result->next;
-          result->next = nullptr;
+          result->next = 0;
         }
     }
   if (M2_gbTrace >= 4)
@@ -520,7 +520,7 @@ int GBinhom_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
 
   gbvector head;
   gbvector *result = &head;
-  result->next = nullptr;
+  result->next = 0;
   exponents_t div_totalexp = newarray_atomic(int, M->n_vars());
   int count = 0;
 
@@ -530,7 +530,7 @@ int GBinhom_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
   fsyzb.add(fsyz);
   const gbvector *lead;
 
-  while ((lead = fb.get_lead_term()) != nullptr)
+  while ((lead = fb.get_lead_term()) != NULL)
     {
       GR->gbvector_get_lead_exponents(F, lead, div_totalexp);
 #ifdef DEVELOPMENT
@@ -550,7 +550,7 @@ int GBinhom_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
                                     fb,
                                     fsyzb,
                                     g,
-                                    nullptr);
+                                    0);
           count++;
         }
       else if (search(div_totalexp, lead->comp, q))
@@ -563,7 +563,7 @@ int GBinhom_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
         {
           result->next = fb.remove_lead_term();
           result = result->next;
-          result->next = nullptr;
+          result->next = 0;
         }
     }
 
@@ -594,7 +594,7 @@ int GBinhom_comp::search(const int *exp, int comp, gb_elem *&result)
 {
   int nvars = M->n_vars();
   int *exp2;
-  for (gb_elem *p = gbLarge->next; p != nullptr; p = p->next)
+  for (gb_elem *p = gbLarge->next; p != NULL; p = p->next)
     {
       if (p->f->comp != comp) continue;
       exp2 = p->lead_exp;
@@ -636,7 +636,7 @@ void GBinhom_comp::gb_insert(gbvector *f, gbvector *fsyz, int minlevel)
   gb_elem *prevmin = gb;
   for (;;)
     {
-      if (q->next == nullptr || compare(p, q->next) == LT)
+      if (q->next == NULL || compare(p, q->next) == LT)
         {
           p->next = q->next;
           q->next = p;
@@ -656,14 +656,14 @@ void GBinhom_comp::gb_insert(gbvector *f, gbvector *fsyz, int minlevel)
   // At this point 'p' has been inserted.  Now we need to remove the
   // non-minimal elements.
   q = p;
-  while (q->next_min != nullptr)
+  while (q->next_min != NULL)
     // MES: this loop would be a good place to put in auto-reduction?
     if (p->f->comp == q->next_min->f->comp &&
         M->divides(p->f->monom, q->next_min->f->monom))
       {
         gb_elem *tmp = q->next_min;
         q->next_min = tmp->next_min;
-        tmp->next_min = nullptr;
+        tmp->next_min = NULL;
         tmp->is_min ^= MINGB_MASK;  // I.e. not in the minimal GB
         n_gb--;
       }
@@ -697,9 +697,9 @@ int GBinhom_comp::s_pair_step(s_pair *p)
     }
   gbvector *f = p->f;
   gbvector *fsyz = p->fsyz;
-  p->f = nullptr;
-  p->fsyz = nullptr;
-  if (p->first != nullptr)
+  p->f = NULL;
+  p->fsyz = NULL;
+  if (p->first != NULL)
     {
       // Then 'p' should be the first element on the p->first->pair_list
       assert(p->first->pair_list == p);
@@ -788,7 +788,7 @@ void GBinhom_comp::start_computation()
           break;
         }
       s_pair *p = spairs->remove();
-      if (p == nullptr)
+      if (p == NULL)
         {
           is_done = COMP_DONE;
           break;
@@ -838,7 +838,7 @@ void GBinhom_comp::minimalize_gb()
 
   VECTOR(POLY) polys;
 
-  for (gb_elem *q = gb->next_min; q != nullptr; q = q->next_min)
+  for (gb_elem *q = gb->next_min; q != NULL; q = q->next_min)
     {
       POLY g;
       g.f = q->f;
@@ -895,7 +895,7 @@ void GBinhom_comp::text_out(buffer &o) const
 const Matrix /* or null */ *GBinhom_comp::get_mingens()
 {
   MatrixConstructor mat(F, 0);
-  for (gb_elem *q = gb->next; q != nullptr; q = q->next)
+  for (gb_elem *q = gb->next; q != NULL; q = q->next)
     if (q->is_min & MINGEN_MASK)
       mat.append(originalR->translate_gbvector_to_vec(F, q->f));
   return mat.to_matrix();
@@ -944,26 +944,26 @@ void GBinhom_comp::debug_out(s_pair *q) const
 
 void GBinhom_comp::debug_out(buffer &o, s_pair *q) const
 {
-  if (q == nullptr) return;
+  if (q == NULL) return;
   monomial m = M->make_one();
   o << "(";
-  if (q->first != nullptr)
+  if (q->first != NULL)
     o << q->first->me;
   else
     o << ".";
   o << " ";
-  if (q->second != nullptr)
+  if (q->second != NULL)
     o << q->second->me;
   else
     o << ".";
   o << " ";
-  if (q->first != nullptr)
+  if (q->first != NULL)
     {
       M->divide(q->lcm, q->first->f->monom, m);
       M->elem_text_out(o, m);
       o << ' ';
     }
-  if (q->second != nullptr)
+  if (q->second != NULL)
     {
       M->divide(q->lcm, q->second->f->monom, m);
       M->elem_text_out(o, m);
@@ -985,7 +985,7 @@ void GBinhom_comp::debug_pairs_out(buffer &o, gb_elem *p) const
 {
   s_pair *q;
   int n = 0;
-  for (q = p->pair_list; q != nullptr; q = q->next_same)
+  for (q = p->pair_list; q != NULL; q = q->next_same)
     {
       debug_out(o, q);
       n++;
@@ -1002,16 +1002,16 @@ void GBinhom_comp::debug_pairs() const
 }
 void GBinhom_comp::debug_pairs(buffer &o) const
 {
-  for (gb_elem *p = gbLarge->next; p != nullptr; p = p->next)
+  for (gb_elem *p = gbLarge->next; p != NULL; p = p->next)
     debug_pairs_out(o, p);
 
   for (int i = 0; i < NHEAP; i++)
     {
       s_pair *q = spairs->debug_list(i);
-      if (q == nullptr) continue;
+      if (q == NULL) continue;
       o << "---- pairs in bin " << i << " -----" << newline;
       int n = 0;
-      for (; q != nullptr; q = q->next)
+      for (; q != NULL; q = q->next)
         {
           debug_out(o, q);
           n++;
@@ -1027,7 +1027,7 @@ void GBinhom_comp::stats() const
   if (M2_gbTrace >= 5 && M2_gbTrace % 2 == 1)
     {
       int i = 0;
-      for (gb_elem *q = gb->next_min; q != nullptr; q = q->next_min)
+      for (gb_elem *q = gb->next_min; q != NULL; q = q->next_min)
         {
           o << i << '\t';
           i++;

--- a/M2/Macaulay2/e/gb-toric.cpp
+++ b/M2/Macaulay2/e/gb-toric.cpp
@@ -18,8 +18,8 @@ binomial_ring::binomial_ring(const PolynomialRing *RR, int *wts, bool revlex0)
     : R(RR),
       F(RR->make_FreeModule(1)),
       nvars(RR->n_vars()),
-      have_weights(wts != nullptr),
-      weights(nullptr),
+      have_weights(wts != NULL),
+      weights(NULL),
       revlex(revlex0)
 {
   int i;
@@ -53,9 +53,9 @@ binomial_ring::~binomial_ring()
 
 void binomial_ring::remove_monomial(monomial &m) const
 {
-  if (m == nullptr) return;
+  if (m == NULL) return;
   monstash->delete_elem(m);
-  m = nullptr;
+  m = NULL;
 }
 
 monomial binomial_ring::new_monomial() const
@@ -284,7 +284,7 @@ void binomial_ring::translate_monomial(const binomial_ring *old_ring,
                                        monomial &m) const
 {
   int i;
-  if (m == nullptr) return;
+  if (m == NULL) return;
   monomial result = new_monomial();
   for (i = 0; i < old_ring->nvars; i++) result[i] = m[i];
   for (i = old_ring->nvars; i < nvars; i++) result[i] = 0;
@@ -302,7 +302,7 @@ void binomial_ring::translate_binomial(const binomial_ring *old_ring,
 
 vec binomial_ring::monomial_to_vector(monomial m) const
 {
-  if (m == nullptr) return nullptr;
+  if (m == NULL) return NULL;
   ring_elem f = R->make_logical_term(
       R->getCoefficients(), R->getCoefficients()->one(), m);
   return R->make_vec(0, f);
@@ -339,9 +339,9 @@ bool binomial_ring::vector_to_binomial(vec f, binomial &result) const
 // result should already have both monomials allocated
 // returns false if f is not a binomial, otherwise result is set.
 {
-  if (f == nullptr) return false;
+  if (f == NULL) return false;
   Nterm *t = f->coeff;
-  if (t == nullptr || t->next == nullptr || t->next->next != nullptr) return false;
+  if (t == NULL || t->next == NULL || t->next->next != NULL) return false;
 
   R->getMonoid()->to_expvector(t->monom, result.lead);
   set_weights(result.lead);
@@ -362,7 +362,7 @@ void binomial_ring::intvector_to_binomial(vec f, binomial &result) const
       result.tail[i] = 0;
     }
 
-  for (; f != nullptr; f = f->next)
+  for (; f != NULL; f = f->next)
     {
       std::pair<bool, long> res = globalZZ->coerceToLongInteger(f->coeff);
       assert(res.first);
@@ -418,7 +418,7 @@ bool binomial_ring::calc_s_pair(binomial_s_pair &s, binomial &result) const
 
 void binomial_ring::monomial_out(buffer &o, const_exponents m) const
 {
-  if (m == nullptr) return;
+  if (m == NULL) return;
   gc_vector<int> vp;
   varpower::from_expvector(nvars, m, vp);
   monomial n = R->getMonoid()->make_one();
@@ -430,7 +430,7 @@ void binomial_ring::monomial_out(buffer &o, const_exponents m) const
 void binomial_ring::elem_text_out(buffer &o, const binomial &f) const
 {
   monomial_out(o, f.lead);
-  if (f.tail == nullptr) return;
+  if (f.tail == NULL) return;
   o << "-";
   monomial_out(o, f.tail);
 }
@@ -439,7 +439,7 @@ void binomial_ring::elem_text_out(buffer &o, const binomial &f) const
 ///////////////////////
 
 binomial_s_pair_set::binomial_s_pair_set(const binomial_ring *RR)
-    : R(RR), _prev_lcm(nullptr), _n_elems(0), _max_degree(0)
+    : R(RR), _prev_lcm(NULL), _n_elems(0), _max_degree(0)
 {
   _pairs = new s_pair_degree_list;  // list header
   _npairs.push_back(0);
@@ -452,17 +452,17 @@ void binomial_s_pair_set::enlarge(const binomial_ring *newR)
   R = newR;
 
   old_ring->remove_monomial(_prev_lcm);
-  _prev_lcm = nullptr;
-  for (s_pair_degree_list *thisdeg = _pairs->next; thisdeg != nullptr;
+  _prev_lcm = NULL;
+  for (s_pair_degree_list *thisdeg = _pairs->next; thisdeg != NULL;
        thisdeg = thisdeg->next)
-    for (s_pair_lcm_list *thislcm = thisdeg->pairs; thislcm != nullptr;
+    for (s_pair_lcm_list *thislcm = thisdeg->pairs; thislcm != NULL;
          thislcm = thislcm->next)
       R->translate_monomial(old_ring, thislcm->lcm);
 }
 
 void binomial_s_pair_set::remove_lcm_list(s_pair_lcm_list *p)
 {
-  while (p->pairs != nullptr)
+  while (p->pairs != NULL)
     {
       s_pair_elem *thispair = p->pairs;
       p->pairs = thispair->next;
@@ -473,7 +473,7 @@ void binomial_s_pair_set::remove_lcm_list(s_pair_lcm_list *p)
 }
 void binomial_s_pair_set::remove_pair_list(s_pair_degree_list *p)
 {
-  while (p->pairs != nullptr)
+  while (p->pairs != NULL)
     {
       s_pair_lcm_list *thislcm = p->pairs;
       p->pairs = thislcm->next;
@@ -483,7 +483,7 @@ void binomial_s_pair_set::remove_pair_list(s_pair_degree_list *p)
 }
 binomial_s_pair_set::~binomial_s_pair_set()
 {
-  while (_pairs != nullptr)
+  while (_pairs != NULL)
     {
       s_pair_degree_list *thisdeg = _pairs;
       _pairs = thisdeg->next;
@@ -500,13 +500,13 @@ void binomial_s_pair_set::insert_pair(s_pair_degree_list *q, binomial_s_pair &s)
   s_pair_lcm_list *r = &head;
   while (true)
     {
-      if (r->next == nullptr || ((cmp = R->compare(s.lcm, r->next->lcm)) == GT))
+      if (r->next == NULL || ((cmp = R->compare(s.lcm, r->next->lcm)) == GT))
         {
           // Insert new lcm node
           s_pair_lcm_list *r1 = new s_pair_lcm_list;
           r1->next = r->next;
           r1->lcm = s.lcm;
-          r1->pairs = nullptr;
+          r1->pairs = NULL;
           r->next = r1;
           break;
         }
@@ -527,7 +527,7 @@ void binomial_s_pair_set::insert_pair(s_pair_degree_list *q, binomial_s_pair &s)
 void binomial_s_pair_set::insert(binomial_gb_elem *p)
 {
   monomial lcm = R->make_monomial(R->lead_monomial(p->f));
-  binomial_s_pair s(p, nullptr, lcm);
+  binomial_s_pair s(p, NULL, lcm);
   insert(s);
 }
 
@@ -548,13 +548,13 @@ void binomial_s_pair_set::insert(binomial_s_pair s)
   s_pair_degree_list *q = _pairs;
   while (true)
     {
-      if (q->next == nullptr || q->next->deg > deg)
+      if (q->next == NULL || q->next->deg > deg)
         {
           // Insert new degree node
           s_pair_degree_list *q1 = new s_pair_degree_list;
           q1->next = q->next;
           q1->deg = deg;
-          q1->pairs = nullptr;
+          q1->pairs = NULL;
           q->next = q1;
           break;
         }
@@ -574,8 +574,8 @@ bool binomial_s_pair_set::next(const int *d,
 // the caller should not free any of the three fields of the
 // s_pair!!
 {
-  if (_pairs->next == nullptr) return false;
-  if (d != nullptr && _pairs->next->deg > *d) return false;
+  if (_pairs->next == NULL) return false;
+  if (d != NULL && _pairs->next->deg > *d) return false;
   s_pair_degree_list *thisdeg = _pairs->next;
   s_pair_lcm_list *thislcm = thisdeg->pairs;
   s_pair_elem *s = thislcm->pairs;
@@ -588,16 +588,16 @@ bool binomial_s_pair_set::next(const int *d,
   result = binomial_s_pair(s->f1, s->f2, thislcm->lcm);
 
   thislcm->pairs = s->next;
-  if (thislcm->pairs == nullptr)
+  if (thislcm->pairs == NULL)
     {
       // Now we must remove this set
       thisdeg->pairs = thislcm->next;
       R->remove_monomial(_prev_lcm);
       _prev_lcm = thislcm->lcm;
-      thislcm->lcm = nullptr;
+      thislcm->lcm = NULL;
       freemem(thislcm);
 
-      if (thisdeg->pairs == nullptr)
+      if (thisdeg->pairs == NULL)
         {
           // Now we must remove this larger degree list
           _pairs->next = thisdeg->next;
@@ -611,15 +611,15 @@ bool binomial_s_pair_set::next(const int *d,
 
 int binomial_s_pair_set::lowest_degree() const
 {
-  if (_pairs->next == nullptr) return -1;
+  if (_pairs->next == NULL) return -1;
   return _pairs->next->deg;
 }
 
 int binomial_s_pair_set::n_elems(int d) const
 {
   s_pair_degree_list *p = _pairs;
-  while (p->next != nullptr && p->next->deg < d) p = p->next;
-  if (p->next == nullptr || p->next->deg != d) return 0;
+  while (p->next != NULL && p->next->deg < d) p = p->next;
+  if (p->next == NULL || p->next->deg != d) return 0;
   return p->next->n_elems;
 }
 
@@ -660,7 +660,7 @@ void binomial_s_pair_set::stats() const
 ///////////////////////
 binomialGB::binomialGB(const binomial_ring *R0, bool bigcell, bool homogprime)
     : R(R0),
-      first(nullptr),
+      first(NULL),
       _max_degree(0),
       // use_bigcell(bigcell),
       is_homogeneous_prime(homogprime)
@@ -672,8 +672,8 @@ binomialGB::~binomialGB()
   // Do nothing much, except maybe clear out stuff
   // so no stray pointers are around
 
-  R = nullptr;
-  first = nullptr;  // MES: BUG!! We are leaking stuff here!!
+  R = NULL;
+  first = NULL;  // MES: BUG!! We are leaking stuff here!!
 }
 
 void binomialGB::enlarge(const binomial_ring *newR) { R = newR; }
@@ -687,7 +687,7 @@ void binomialGB::minimalize_and_insert(binomial_gb_elem *f)
   head.next = first;
   int deg = R->degree(m);
   if (deg > _max_degree) _max_degree = deg;
-  for (p = &head; p->next != nullptr; p = p->next)
+  for (p = &head; p->next != NULL; p = p->next)
     {
       if (R->graded_compare(m, p->next->elem->f.lead) == LT) break;
     }
@@ -696,7 +696,7 @@ void binomialGB::minimalize_and_insert(binomial_gb_elem *f)
   first = head.next;
 
   p = fm;
-  while (p->next != nullptr)
+  while (p->next != NULL)
     {
       if (R->degree(p->next->elem->f.lead) > deg &&
           R->divides(m, p->next->elem->f.lead))
@@ -705,7 +705,7 @@ void binomialGB::minimalize_and_insert(binomial_gb_elem *f)
           gbmin_elem *q = p->next;
           binomial_gb_elem *qe = q->elem;
           p->next = q->next;
-          q->next = nullptr;
+          q->next = NULL;
           qe->smaller = f;
         }
       else
@@ -722,20 +722,20 @@ binomialGB::monomial_list *binomialGB::find_divisor(
 {
   unsigned int mask = ~(R->mask(m));
   int d = R->degree(m);
-  for (monomial_list *p = I; p != nullptr; p = p->next)
+  for (monomial_list *p = I; p != NULL; p = p->next)
     {
-      if (R->degree(p->m) > d) return nullptr;
+      if (R->degree(p->m) > d) return NULL;
       if (mask & p->mask) continue;
       if (R->divides(p->m, m)) return p;
     }
-  return nullptr;
+  return NULL;
 }
 
 binomialGB::monomial_list *binomialGB::ideal_quotient(monomial m) const
 {
   monomial_list *r;
   monomial_list **deglist = newarray(monomial_list *, _max_degree + 1);
-  for (int i = 0; i <= _max_degree; i++) deglist[i] = nullptr;
+  for (int i = 0; i <= _max_degree; i++) deglist[i] = NULL;
 
   for (iterator p = begin(); p != end(); p++)
     {
@@ -747,13 +747,13 @@ binomialGB::monomial_list *binomialGB::ideal_quotient(monomial m) const
       nl->next = deglist[d];
       deglist[d] = nl;
     }
-  monomial_list *result = nullptr;
+  monomial_list *result = NULL;
 
   for (int d = 0; d <= _max_degree; d++)
-    if (deglist[d] != nullptr)
+    if (deglist[d] != NULL)
       {
-        monomial_list *currentresult = nullptr;
-        while (deglist[d] != nullptr)
+        monomial_list *currentresult = NULL;
+        while (deglist[d] != NULL)
           {
             monomial_list *p = deglist[d];
             deglist[d] = p->next;
@@ -777,16 +777,16 @@ binomialGB::monomial_list *binomialGB::ideal_quotient(monomial m) const
                 currentresult = p;
               }
           }
-        if (result == nullptr)
+        if (result == NULL)
           result = currentresult;
-        else if (currentresult != nullptr)
+        else if (currentresult != NULL)
           {
             monomial_list *q;
-            for (q = result; q->next != nullptr; q = q->next)
+            for (q = result; q->next != NULL; q = q->next)
               ;
             q->next = currentresult;
           }
-        currentresult = nullptr;
+        currentresult = NULL;
       }
   freemem(deglist);
   return result;
@@ -805,7 +805,7 @@ void binomialGB::make_new_pairs(binomial_s_pair_set *Pairs,
   monomial m = f->f.lead;
   monomial_list *I = ideal_quotient(m);
 
-  for (monomial_list *q = I; q != nullptr; q = q->next)
+  for (monomial_list *q = I; q != NULL; q = q->next)
     {
       gbmin_elem *ge = q->tag;  // a list of possibles
 
@@ -834,7 +834,7 @@ void binomialGB::make_new_pairs(binomial_s_pair_set *Pairs,
 
 void binomialGB::remove_monomial_list(monomial_list *mm) const
 {
-  while (mm != nullptr)
+  while (mm != NULL)
     {
       R->remove_monomial(mm->m);
       monomial_list *tmp = mm;
@@ -864,13 +864,13 @@ binomial_gb_elem *binomialGB::find_divisor(monomial m) const
 {
   unsigned int mask = ~(R->mask(m));
   int d = R->degree(m);
-  for (gbmin_elem *p = first; p != nullptr; p = p->next)
+  for (gbmin_elem *p = first; p != NULL; p = p->next)
     {
-      if (R->degree(p->elem->f.lead) > d) return nullptr;
+      if (R->degree(p->elem->f.lead) > d) return NULL;
       if (mask & p->mask) continue;
       if (R->divides(p->elem->f.lead, m)) return p->elem;
     }
-  return nullptr;
+  return NULL;
 }
 
 void binomialGB::reduce_monomial(monomial m) const
@@ -885,7 +885,7 @@ bool binomialGB::reduce(binomial &f) const
   while (true)
     {
       binomial_gb_elem *p = find_divisor(f.lead);
-      if (p == nullptr)
+      if (p == NULL)
         {
           reduce_monomial(f.tail);
           return R->normalize(f);
@@ -936,7 +936,7 @@ int binomialGB::n_masks() const
   buffer o;
   unsigned int nmasks = 1;
   masks[0] = first->mask;
-  for (gbmin_elem *p = first; p != nullptr; p = p->next)
+  for (gbmin_elem *p = first; p != NULL; p = p->next)
     {
       o << " " << p->mask;
       bool found = false;
@@ -1000,15 +1000,15 @@ binomialGB_comp *binomialGB_comp::create(const Matrix *m,
   if (collect_syz || n_rows_to_keep > 0)
     {
       ERROR("Groebner basis Algorithm=>Toric cannot keep syzygies");
-      return nullptr;
+      return 0;
     }
   const PolynomialRing *R = m->get_ring()->cast_to_PolynomialRing();
-  if (R == nullptr)
+  if (R == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
-  binomialGB_comp *result = new binomialGB_comp(R, nullptr, true, strategy);
+  binomialGB_comp *result = new binomialGB_comp(R, 0, true, strategy);
   result->add_generators(m);
   return result;
 }
@@ -1023,8 +1023,8 @@ void binomialGB_comp::remove_gb()
   // remove each element of G
   for (i = 0; i < G.size(); i++) freemem(G[i]);
   // The following is just to ease garbage collection
-  for (i = 0; i < mingens.size(); i++) mingens[i] = nullptr;
-  for (i = 0; i < mingens_subring.size(); i++) mingens_subring[i] = nullptr;
+  for (i = 0; i < mingens.size(); i++) mingens[i] = NULL;
+  for (i = 0; i < mingens_subring.size(); i++) mingens_subring[i] = NULL;
   freemem(R);
 }
 
@@ -1094,7 +1094,7 @@ void binomialGB_comp::process_pair(binomial_s_pair s)
   bool ismin, subringmin;
   binomial f;
 
-  if (s.f2 == nullptr)
+  if (s.f2 == NULL)
     {
       // A generator
       ismin = true;
@@ -1104,7 +1104,7 @@ void binomialGB_comp::process_pair(binomial_s_pair s)
     }
   else
     {
-      if (s.f1->smaller != nullptr || s.f2->smaller != nullptr)
+      if (s.f1->smaller != NULL || s.f2->smaller != NULL)
         {
           if (s.f1->smaller != s.f2 && s.f2->smaller != s.f1)
             {
@@ -1161,7 +1161,7 @@ ComputationStatusCode binomialGB_comp::gb_done() const
 void binomialGB_comp::start_computation()
 {
   binomial_s_pair s;
-  int *deg = nullptr;
+  int *deg = 0;
   if (stop_.always_stop) return;  // don't change status
   if (stop_.stop_after_degree) deg = &stop_.degree_limit->array[0];
   while (Pairs->next(deg, s, top_degree))
@@ -1193,7 +1193,7 @@ Matrix *binomialGB_comp::subring()
   for (int i = 0; i < mingens_subring.size(); i++)
     {
       result.append(R->binomial_to_vector(mingens_subring[i]->f));
-      mingens_subring[i] = nullptr;
+      mingens_subring[i] = NULL;
     }
   mingens_subring.clear();
   return result.to_matrix();
@@ -1211,7 +1211,7 @@ Matrix *binomialGB_comp::subringGB()
 Matrix *binomialGB_comp::reduce(const Matrix *m, Matrix *& /*lift*/)
 {
   ERROR("MES: not implemented yet");
-  return nullptr;
+  return 0;
 }
 
 int binomialGB_comp::contains(const Matrix * /*m*/)
@@ -1244,12 +1244,12 @@ const Matrix *binomialGB_comp::get_gb()
   return result.to_matrix();
 }
 
-const Matrix *binomialGB_comp::get_change() { return nullptr; }
-const Matrix *binomialGB_comp::get_syzygies() { return nullptr; }
+const Matrix *binomialGB_comp::get_change() { return 0; }
+const Matrix *binomialGB_comp::get_syzygies() { return 0; }
 const Matrix /* or null */ *binomialGB_comp::matrix_remainder(const Matrix *m)
 // likely not planned to be implemented
 {
-  return nullptr;
+  return 0;
 }
 M2_bool binomialGB_comp::matrix_lift(
     const Matrix *m,
@@ -1257,8 +1257,8 @@ M2_bool binomialGB_comp::matrix_lift(
     const Matrix /* or null */ **result_quotient)
 // not planned to be implemented
 {
-  *result_remainder = nullptr;
-  *result_quotient = nullptr;
+  *result_remainder = 0;
+  *result_quotient = 0;
   ERROR("rawGBMatrixLift not implemented for toric GB's");
   return false;
 }

--- a/M2/Macaulay2/e/gb-toric.hpp
+++ b/M2/Macaulay2/e/gb-toric.hpp
@@ -19,7 +19,7 @@ struct binomial : public our_new_delete
   monomial0 lead;
   monomial0 tail;
 
-  binomial() : lead(nullptr), tail(nullptr) {}
+  binomial() : lead(NULL), tail(NULL) {}
   binomial(monomial0 lead0, monomial0 tail0) : lead(lead0), tail(tail0) {}
 };
 
@@ -31,7 +31,7 @@ struct binomial_gb_elem : public our_new_delete
                               // this lead term.
   binomial f;
 
-  binomial_gb_elem(binomial ff) : next(nullptr), smaller(nullptr), f(ff) {}
+  binomial_gb_elem(binomial ff) : next(NULL), smaller(NULL), f(ff) {}
 };
 
 struct binomial_s_pair : public our_new_delete
@@ -156,7 +156,7 @@ class binomial_s_pair_set : public our_new_delete
     binomial_gb_elem *f1;
     binomial_gb_elem *f2;
     s_pair_elem(binomial_gb_elem *ff1, binomial_gb_elem *ff2)
-        : next(nullptr), f1(ff1), f2(ff2)
+        : next(NULL), f1(ff1), f2(ff2)
     {
     }
   };
@@ -262,7 +262,7 @@ class binomialGB : public our_new_delete
   };
 
   iterator begin() const { return iterator(first); }
-  iterator end() const { return iterator(nullptr); }
+  iterator end() const { return iterator(NULL); }
   int n_masks() const;
   void debug_display() const;
 };
@@ -361,7 +361,7 @@ class binomialGB_comp : public GBComputation
 
   virtual const Ring *get_ring() const
   {
-    return nullptr;
+    return 0;
   } /* doesn't have a ring !!  */
   virtual const Matrix /* or null */ *get_gb();
 

--- a/M2/Macaulay2/e/gb-walk.cpp
+++ b/M2/Macaulay2/e/gb-walk.cpp
@@ -52,7 +52,7 @@ GBWalker::GBWalker(MarkedGB *G0, long **order1, long **order2)
       G(G0),
       monorder1(order1),  // or create this from the monomial order?
       monorder2(order2),
-      ww(nullptr)
+      ww(0)
 {
   // TODO: need to set what else?
   //
@@ -98,14 +98,14 @@ GBComputation *GBWalker::make_gb(const Matrix *M) const
                                                /* , max_reduction_count */
                                                );
   G0->set_stop_conditions(false,
-                          nullptr,
+                          NULL,
                           -1,
                           -1,  // syzygy limit
                           -1,
                           -1,
                           -1,
                           false,
-                          nullptr);
+                          NULL);
   return G0;
 }
 
@@ -113,12 +113,12 @@ void GBWalker::initialize()
 {
   // Initialize the local variables of the computation
   state = STATE_compute_w;
-  ww = nullptr;
-  inwwG = nullptr;
-  gb_inwwG = nullptr;
+  ww = 0;
+  inwwG = 0;
+  gb_inwwG = 0;
   next_to_reduce = 0;
   // G is already set
-  G1 = nullptr;
+  G1 = 0;
 }
 
 bool GBWalker::compute_next_w()
@@ -178,7 +178,7 @@ void GBWalker::start_computation()
           G->remove_gb();
           delete G;
           G1 = static_cast<MarkedGB *>(
-              GBDeclared::create(gb_inwwG->get_initial(-1), H, H, nullptr, nullptr));
+              GBDeclared::create(gb_inwwG->get_initial(-1), H, H, 0, 0));
           state = STATE_compute_w;
         case STATE_done:
           set_status(COMP_DONE);
@@ -189,55 +189,55 @@ void GBWalker::start_computation()
 const PolynomialRing *GBWalker::get_ring() const
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 Computation /* or null */ *GBWalker::set_hilbert_function(const RingElement *h)
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *GBWalker::get_gb()
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *GBWalker::get_mingens()
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *GBWalker::get_change()
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *GBWalker::get_syzygies()
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *GBWalker::get_initial(int nparts)
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *GBWalker::get_parallel_lead_terms(M2_arrayint w)
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *GBWalker::matrix_remainder(const Matrix *m)
 {
   // MES: TO WRITE
-  return nullptr;
+  return 0;
 }
 
 M2_bool GBWalker::matrix_lift(const Matrix *m,
@@ -245,8 +245,8 @@ M2_bool GBWalker::matrix_lift(const Matrix *m,
                               const Matrix /* or null */ **result_quotient)
 {
   // MES: TO WRITE, should this be written?
-  *result_remainder = nullptr;
-  *result_quotient = nullptr;
+  *result_remainder = 0;
+  *result_quotient = 0;
   ERROR("rawGBMatrixLift not implemented for GB walks");
   return false;
 }

--- a/M2/Macaulay2/e/gbring.cpp
+++ b/M2/Macaulay2/e/gbring.cpp
@@ -57,26 +57,26 @@ GBRing::GBRing(const Ring *K0, const Monoid *M0)
       M(M0),
       K(K0),
       _coeffs_ZZ(false),  // set below
-      zzp(nullptr),
+      zzp(0),
       _nvars(M->n_vars()),
       _up_order(false),
       _is_skew(false),
       _skew(),
-      _skew_monoms(nullptr),
+      _skew_monoms(0),
       is_weyl(false),
-      weyl(nullptr),
+      weyl(0),
       is_solvable(false),
-      solvable(nullptr),
+      solvable(0),
       _one(K->from_long(1))
 {
   exp_size = EXPONENT_BYTE_SIZE(_nvars + 2);
   monom_size = MONOMIAL_BYTE_SIZE(M->monomial_size());
 
-  gbvector_size = sizeofgbvector(((gbvector *)nullptr), M->monomial_size());
+  gbvector_size = sizeofgbvector(((gbvector *)0), M->monomial_size());
   mem = new stash("gbvector", gbvector_size);
 
   const Z_mod *Kp = K->cast_to_Z_mod();
-  if (Kp != nullptr) zzp = Kp->get_CoeffRing();
+  if (Kp != 0) zzp = Kp->get_CoeffRing();
 
   if (K == globalQQ) K = globalZZ;
   if (K == globalZZ) _coeffs_ZZ = true;
@@ -106,17 +106,17 @@ gbvector *GBRingPoly::mult_by_term1(const FreeModule *F,
   gbvector *inresult = &head;
   int monlen = M->monomial_size();
 
-  for (const gbvector *s = f; s != nullptr; s = s->next)
+  for (const gbvector *s = f; s != NULL; s = s->next)
     {
       gbvector *t = new_raw_term();
-      t->next = nullptr;
+      t->next = 0;
       t->comp = s->comp + comp;
       t->coeff = K->mult(u, s->coeff);
       exponents::mult(monlen, monom, s->monom, t->monom);
       inresult->next = t;
       inresult = inresult->next;
     }
-  inresult->next = nullptr;
+  inresult->next = 0;
   return head.next;
 }
 
@@ -165,14 +165,14 @@ gbvector *GBRingSkew::mult_by_term1(const FreeModule *F,
 
   M->to_expvector(m, EXP1);
 
-  for (const gbvector *s = f; s != nullptr; s = s->next)
+  for (const gbvector *s = f; s != NULL; s = s->next)
     {
       gbvector_get_lead_exponents(F, s, EXP2);
       int sign = _skew.mult_sign(EXP1, EXP2);
       if (sign == 0) continue;
 
       gbvector *t = new_raw_term();
-      t->next = nullptr;
+      t->next = 0;
       t->comp = s->comp + comp;
       t->coeff = K->mult(c, s->coeff);
       if (sign < 0) K->negate_to(t->coeff);
@@ -181,7 +181,7 @@ gbvector *GBRingSkew::mult_by_term1(const FreeModule *F,
       inresult->next = t;
       inresult = inresult->next;
     }
-  inresult->next = nullptr;
+  inresult->next = 0;
   return head.next;
 }
 
@@ -263,7 +263,7 @@ gbvector *GBRingSolvable::mult_by_term1(const FreeModule *F,
 #ifdef DEVELOPMENT
 #warning "implement GBRingSolvable::mult_by_term"
 #endif
-  return nullptr;
+  return 0;
 }
 
 //////////////////////
@@ -273,7 +273,7 @@ gbvector *GBRingSolvable::mult_by_term1(const FreeModule *F,
 void GBRing::gbvector_remove_term(gbvector *f)
 {
   // It is not clear whether we should try to free elements of K
-  f->next = nullptr;
+  f->next = 0;
   f->coeff = ZERO_RINGELEM;
   mem->delete_elem(f);
   // GC_FREE(reinterpret_cast<char *>(f));
@@ -283,7 +283,7 @@ void GBRing::gbvector_remove(gbvector *f0)
 {
   // It is not clear whether we should try to free elements of K
   gbvector *f = f0;
-  while (f != nullptr)
+  while (f != 0)
     {
       gbvector *g = f;
       f = f->next;
@@ -297,11 +297,11 @@ gbvector *GBRing::gbvector_term(const FreeModule *F, ring_elem coeff, int comp)
   gbvector *v = new_raw_term();
   v->coeff = coeff;
   v->comp = comp;
-  v->next = nullptr;
+  v->next = 0;
   M->one(v->monom);
 
   const SchreyerOrder *S;
-  if (comp > 0 && _schreyer_encoded && (S = F->get_schreyer_order()) != nullptr)
+  if (comp > 0 && _schreyer_encoded && (S = F->get_schreyer_order()) != 0)
     S->schreyer_up(v->monom, comp - 1, v->monom);
 
   return v;
@@ -314,7 +314,7 @@ gbvector *GBRing::gbvector_raw_term(ring_elem coeff, const int *monom, int comp)
   gbvector *v = new_raw_term();
   v->coeff = coeff;
   v->comp = comp;
-  v->next = nullptr;
+  v->next = 0;
   M->copy(monom, v->monom);
 
   return v;
@@ -330,7 +330,7 @@ gbvector *GBRing::gbvector_term(const FreeModule *F,
   gbvector *v = gbvector_raw_term(coeff, monom, comp);
 
   const SchreyerOrder *S;
-  if (comp > 0 && _schreyer_encoded && (S = F->get_schreyer_order()) != nullptr)
+  if (comp > 0 && _schreyer_encoded && (S = F->get_schreyer_order()) != 0)
     S->schreyer_up(v->monom, comp - 1, v->monom);
 
   return v;
@@ -347,11 +347,11 @@ gbvector *GBRing::gbvector_term_exponents(const FreeModule *F,
   gbvector *v = new_raw_term();
   v->coeff = coeff;
   v->comp = comp;
-  v->next = nullptr;
+  v->next = 0;
   M->from_expvector(exp, v->monom);
 
   const SchreyerOrder *S;
-  if (comp > 0 && _schreyer_encoded && (S = F->get_schreyer_order()) != nullptr)
+  if (comp > 0 && _schreyer_encoded && (S = F->get_schreyer_order()) != 0)
     S->schreyer_up(v->monom, comp - 1, v->monom);
 
   return v;
@@ -360,7 +360,7 @@ gbvector *GBRing::gbvector_term_exponents(const FreeModule *F,
 gbvector *GBRing::gbvector_copy_term(const gbvector *t)
 {
   gbvector *v = new_raw_term();
-  v->next = nullptr;
+  v->next = 0;
   v->coeff = t->coeff;
   v->comp = t->comp;
   M->copy(t->monom, v->monom);
@@ -371,12 +371,12 @@ bool GBRing::gbvector_is_equal(const gbvector *a, const gbvector *b) const
 {
   for (;; a = a->next, b = b->next)
     {
-      if (a == nullptr)
+      if (a == NULL)
         {
-          if (b == nullptr) return true;
+          if (b == NULL) return true;
           return false;
         }
-      if (b == nullptr) return false;
+      if (b == NULL) return false;
       if (a->comp != b->comp) return false;
       if (!K->is_equal(a->coeff, b->coeff)) return false;
       if (M->compare(a->monom, b->monom) != 0) return false;
@@ -386,7 +386,7 @@ bool GBRing::gbvector_is_equal(const gbvector *a, const gbvector *b) const
 int GBRing::gbvector_n_terms(const gbvector *v) const
 {
   int result = 0;
-  for (; v != nullptr; v = v->next) result++;
+  for (; v != NULL; v = v->next) result++;
   return result;
 }
 
@@ -442,7 +442,7 @@ gbvector *GBRing::gbvector_lead_term(int nparts,
 #ifdef DEVELOPMENT
 #warning "Schreyer order question"
 #endif
-  if (v == nullptr) return nullptr;
+  if (v == NULL) return NULL;
   if (nparts < 0)
     {
       return gbvector_copy_term(v);
@@ -452,13 +452,13 @@ gbvector *GBRing::gbvector_lead_term(int nparts,
       int nslots = M->n_slots(nparts);
       gbvector head;
       gbvector *result = &head;
-      for (const gbvector *t = v; t != nullptr; t = t->next)
+      for (const gbvector *t = v; t != NULL; t = t->next)
         {
           if (M->compare(nslots, t->monom, v->monom) != 0) break;
           result->next = gbvector_copy_term(t);
           result = result->next;
         }
-      result->next = nullptr;
+      result->next = NULL;
       return head.next;
     }
 }
@@ -490,7 +490,7 @@ gbvector *GBRing::gbvector_parallel_lead_terms(M2_arrayint w,
                                                const gbvector *leadv,
                                                const gbvector *v)
 {
-  if (v == nullptr) return nullptr;
+  if (v == NULL) return NULL;
 
   // loop through every term of v.  Keep those t that satisfy: exp(leadv) -
   // exp(t)
@@ -504,7 +504,7 @@ gbvector *GBRing::gbvector_parallel_lead_terms(M2_arrayint w,
 
   gbvector head;
   gbvector *result = &head;
-  for (const gbvector *t = v; t != nullptr; t = t->next)
+  for (const gbvector *t = v; t != NULL; t = t->next)
     {
       M->to_expvector(t->monom, e);
       if (leadv == t || isparallel(w, lead, e))
@@ -513,7 +513,7 @@ gbvector *GBRing::gbvector_parallel_lead_terms(M2_arrayint w,
           result = result->next;
         }
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -524,7 +524,7 @@ void GBRing::gbvector_get_lead_monomial(const FreeModule *F,
 // the result will NOT be the total monomial.
 {
   const SchreyerOrder *S;
-  if (_schreyer_encoded && (S = F->get_schreyer_order()) != nullptr && f->comp > 0)
+  if (_schreyer_encoded && (S = F->get_schreyer_order()) != 0 && f->comp > 0)
     S->schreyer_down(f->monom, f->comp - 1, result);
   else
     M->copy(f->monom, result);
@@ -535,7 +535,7 @@ void GBRing::gbvector_get_lead_exponents(const FreeModule *F,
                                          int *result)
 {
   const SchreyerOrder *S;
-  if (_schreyer_encoded && (S = F->get_schreyer_order()) != nullptr && f->comp > 0)
+  if (_schreyer_encoded && (S = F->get_schreyer_order()) != 0 && f->comp > 0)
     {
       monomial MONOM1 = ALLOCATE_MONOMIAL(monom_size);
 
@@ -548,25 +548,25 @@ void GBRing::gbvector_get_lead_exponents(const FreeModule *F,
 
 void GBRing::gbvector_mult_by_coeff_to(gbvector *f, ring_elem u)
 {
-  for (; f != nullptr; f = f->next) K->mult_to(f->coeff, u);
+  for (; f != 0; f = f->next) K->mult_to(f->coeff, u);
 }
 
 void GBRing::gbvector_negate_to(gbvector *f) const
 {
-  for (; f != nullptr; f = f->next) K->negate_to(f->coeff);
+  for (; f != 0; f = f->next) K->negate_to(f->coeff);
 }
 
 gbvector *GBRing::gbvector_mult_by_coeff(const gbvector *v, ring_elem u)
 {
   gbvector head;
   gbvector *result = &head;
-  for (const gbvector *t = v; t != nullptr; t = t->next)
+  for (const gbvector *t = v; t != NULL; t = t->next)
     {
       result->next = gbvector_copy_term(t);
       result = result->next;
       K->mult_to(result->coeff, u);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -574,8 +574,8 @@ gbvector *GBRing::gbvector_copy(const gbvector *f)
 {
   gbvector head;
   gbvector *b = &head;
-  for (; f != nullptr; f = f->next, b = b->next) b->next = gbvector_copy_term(f);
-  b->next = nullptr;
+  for (; f != 0; f = f->next, b = b->next) b->next = gbvector_copy_term(f);
+  b->next = 0;
   return head.next;
 }
 
@@ -583,11 +583,11 @@ void GBRing::gbvector_add_to_zzp(const FreeModule *F,
                                  gbvector *&f,
                                  gbvector *&g)
 {
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == NULL) return;
+  if (f == NULL)
     {
       f = g;
-      g = nullptr;
+      g = NULL;
       return;
     }
   gbvector head;
@@ -600,7 +600,7 @@ void GBRing::gbvector_add_to_zzp(const FreeModule *F,
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               f = head.next;
@@ -612,11 +612,11 @@ void GBRing::gbvector_add_to_zzp(const FreeModule *F,
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               f = head.next;
-              g = nullptr;
+              g = NULL;
               return;
             }
         }
@@ -640,17 +640,17 @@ void GBRing::gbvector_add_to_zzp(const FreeModule *F,
               result = result->next;
             }
           gbvector_remove_term(tmg);
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               f = head.next;
               return;
             }
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               f = head.next;
-              g = nullptr;
+              g = NULL;
               return;
             }
         }
@@ -659,11 +659,11 @@ void GBRing::gbvector_add_to_zzp(const FreeModule *F,
 
 void GBRing::gbvector_add_to(const FreeModule *F, gbvector *&f, gbvector *&g)
 {
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == NULL) return;
+  if (f == NULL)
     {
       f = g;
-      g = nullptr;
+      g = NULL;
       return;
     }
   if (zzp)
@@ -679,7 +679,7 @@ void GBRing::gbvector_add_to(const FreeModule *F, gbvector *&f, gbvector *&g)
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               f = head.next;
@@ -690,11 +690,11 @@ void GBRing::gbvector_add_to(const FreeModule *F, gbvector *&f, gbvector *&g)
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               f = head.next;
-              g = nullptr;
+              g = NULL;
               return;
             }
           break;
@@ -722,17 +722,17 @@ void GBRing::gbvector_add_to(const FreeModule *F, gbvector *&f, gbvector *&g)
               result = result->next;
             }
           gbvector_remove_term(tmg);
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               f = head.next;
               return;
             }
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               f = head.next;
-              g = nullptr;
+              g = NULL;
               return;
             }
           break;
@@ -745,17 +745,17 @@ void GBRing::gbvector_sort(const FreeModule *F, gbvector *&f)
   // then add them together.  This allows the same monomial
   // to appear more than once in 'f'.
 
-  if (f == nullptr || f->next == nullptr) return;
-  gbvector *f1 = nullptr;
-  gbvector *f2 = nullptr;
-  while (f != nullptr)
+  if (f == NULL || f->next == NULL) return;
+  gbvector *f1 = NULL;
+  gbvector *f2 = NULL;
+  while (f != NULL)
     {
       gbvector *t = f;
       f = f->next;
       t->next = f1;
       f1 = t;
 
-      if (f == nullptr) break;
+      if (f == NULL) break;
       t = f;
       f = f->next;
       t->next = f2;
@@ -773,7 +773,7 @@ void GBRing::gbvector_text_out(buffer &o,
                                const gbvector *v,
                                int nterms) const
 {
-  if (v == nullptr)
+  if (v == NULL)
     {
       o << "0";
       return;
@@ -784,15 +784,15 @@ void GBRing::gbvector_text_out(buffer &o,
   bool p_parens = false;
   int count = nterms;
   const gbvector *t;
-  for (t = v; t != nullptr && count != 0; t = t->next, count--)
+  for (t = v; t != NULL && count != 0; t = t->next, count--)
     {
-      int isone = (M == nullptr || M->is_one(t->monom));
+      int isone = (M == NULL || M->is_one(t->monom));
       K->elem_text_out(o, t->coeff, p_one, p_plus, p_parens);
       if (!isone) M->elem_text_out(o, t->monom, p_one);
       if (t->comp >= 1) o << "<" << t->comp << ">";
       p_plus = true;
     }
-  if (t != nullptr) o << "+...";
+  if (t != NULL) o << "+...";
 }
 
 void GBRing::divide_exponents(const_exponents exp1,
@@ -835,9 +835,9 @@ gbvector *GBRing::mult_by_term(const FreeModule *F,
 {
   gbvector *result = mult_by_term1(F, f, u, monom, comp);
   const SchreyerOrder *S;
-  if (comp > 0 && _schreyer_encoded && (S = F->get_schreyer_order()) != nullptr)
+  if (comp > 0 && _schreyer_encoded && (S = F->get_schreyer_order()) != 0)
     {
-      for (gbvector *t = result; t != nullptr; t = t->next)
+      for (gbvector *t = result; t != 0; t = t->next)
         S->schreyer_up(t->monom, comp - 1, t->monom);
     }
   return result;
@@ -923,7 +923,7 @@ void GBRing::find_reduction_monomial(
     {
       comp = f->comp;
       const SchreyerOrder *S;
-      if (_schreyer_encoded && (S = F->get_schreyer_order()) != nullptr)
+      if (_schreyer_encoded && (S = F->get_schreyer_order()) != 0)
         S->schreyer_down(monom, comp - 1, monom);
     }
   else
@@ -960,7 +960,7 @@ void GBRing::gbvector_reduce_lead_term(const FreeModule *F,
 
   gbvector *result1 = mult_by_term(F, g, v, MONOM1, comp);
   gbvector_add_to(F, f, result1);
-  if (gsyz != nullptr)
+  if (gsyz != 0)
     {
       gbvector *result_syz1 = mult_by_term(Fsyz, gsyz, v, MONOM1, comp);
       gbvector_add_to(Fsyz, fsyz, result_syz1);
@@ -996,7 +996,7 @@ void GBRing::gbvector_reduce_with_marked_lead_term(const FreeModule *F,
 
   gbvector *result1 = mult_by_term(F, g, v, MONOM1, comp);
   gbvector_add_to(F, f, result1);
-  if (gsyz != nullptr)
+  if (gsyz != 0)
     {
       gbvector *result_syz1 = mult_by_term(Fsyz, gsyz, v, MONOM1, comp);
       gbvector_add_to(Fsyz, fsyz, result_syz1);
@@ -1036,7 +1036,7 @@ bool GBRing::gbvector_reduce_lead_term_ZZ(const FreeModule *F,
 
   gbvector *result1 = mult_by_term(F, g, v, MONOM1, comp);
   gbvector_add_to(F, f, result1);
-  if (gsyz != nullptr)
+  if (gsyz != 0)
     {
       gbvector *result_syz1 = mult_by_term(Fsyz, gsyz, v, MONOM1, comp);
       gbvector_add_to(Fsyz, fsyz, result_syz1);
@@ -1092,8 +1092,8 @@ void GBRing::gbvector_cancel_lead_terms(const FreeModule *F,
   result = mult_by_term(F, f, u, MONOM1, 0);
   gbvector *result1 = mult_by_term(F, g, v, MONOM2, comp);
   gbvector_add_to(F, result, result1);
-  if (fsyz == nullptr && gsyz == nullptr)
-    result_syz = nullptr;
+  if (fsyz == 0 && gsyz == 0)
+    result_syz = 0;
   else
     {
       result_syz = mult_by_term(Fsyz, fsyz, u, MONOM1, 0);
@@ -1121,10 +1121,10 @@ void GBRing::gbvector_replace_2by2_ZZ(const FreeModule *F,
   mpz_init(gd);
   mpz_gcdext(gd, u, v, f->coeff.get_mpz(), g->coeff.get_mpz());
 
-  gbvector *new_g = nullptr;
-  gbvector *g2 = nullptr;
-  gbvector *new_gsyz = nullptr;
-  gbvector *gsyz2 = nullptr;
+  gbvector *new_g = 0;
+  gbvector *g2 = 0;
+  gbvector *new_gsyz = 0;
+  gbvector *gsyz2 = 0;
 
   if (mpz_sgn(v) != 0)
     {
@@ -1203,8 +1203,8 @@ void GBRing::gbvector_combine_lead_terms_ZZ(const FreeModule *F,
   ring_elem v = ring_elem(v1);
   if (globalZZ->is_zero(u) || globalZZ->is_zero(v))
     {
-      result = nullptr;
-      result_syz = nullptr;
+      result = 0;
+      result_syz = 0;
       mpz_clear(u1);
       mpz_clear(v1);
       return;
@@ -1227,8 +1227,8 @@ void GBRing::gbvector_combine_lead_terms_ZZ(const FreeModule *F,
   result = mult_by_term(F, f, u, MONOM1, 0);
   gbvector *result1 = mult_by_term(F, g, v, MONOM2, comp);
   gbvector_add_to(F, result, result1);
-  if (fsyz == nullptr && gsyz == nullptr)
-    result_syz = nullptr;
+  if (fsyz == 0 && gsyz == 0)
+    result_syz = 0;
   else
     {
       result_syz = mult_by_term(Fsyz, fsyz, u, MONOM1, 0);
@@ -1256,7 +1256,7 @@ void GBRing::gbvector_apply(const FreeModule *F,
   // [combines: freemod::apply_quotient_ring_elements,
   // GBZZ_comp::apply_gb_elements]
 
-  for (; gsyz != nullptr; gsyz = gsyz->next)
+  for (; gsyz != 0; gsyz = gsyz->next)
     {
       if (gsyz->comp < 0)
         {
@@ -1283,7 +1283,7 @@ void GBRing::divide_coeff_exact_to_ZZ(gbvector *f, gmp_ZZ u) const
 {
   mpz_t a;
   mpz_init(a);
-  for (; f != nullptr; f = f->next)
+  for (; f != 0; f = f->next)
     {
       mpz_divexact(a, f->coeff.get_mpz(), u);
       f->coeff = globalZZ->RingZZ::from_int(a);
@@ -1295,8 +1295,8 @@ void GBRing::lower_content_ZZ(gbvector *f, mpz_ptr content) const
 // content should be a positive number.  Modify this value
 // so that new value of content = gcd(old-content, content(f)).
 {
-  if (f == nullptr) return;
-  for (; f != nullptr; f = f->next)
+  if (f == 0) return;
+  for (; f != 0; f = f->next)
     {
       mpz_gcd(content, content, f->coeff.get_mpz());
       if (mask_mpz_cmp_si(content, 1) == 0) return;
@@ -1316,13 +1316,13 @@ void GBRing::gbvector_remove_content_ZZ(gbvector *f,
   gbvector *gsyz = fsyz;
   mpz_t content;
   int leadsign;
-  if (g != nullptr)
+  if (g != 0)
     {
       leadsign = mpz_sgn(g->coeff.get_mpz());
       mpz_init_set(content, g->coeff.get_mpz());
       g = g->next;
     }
-  else if (gsyz != nullptr)
+  else if (gsyz != 0)
     {
       leadsign = mpz_sgn(gsyz->coeff.get_mpz());
       mpz_init_set(content, gsyz->coeff.get_mpz());
@@ -1374,9 +1374,9 @@ void GBRing::gbvector_remove_content(gbvector *f,
   // At this point, our coefficient ring is a field (What about
   // finite extensions of ZZ?)
   ring_elem c, cinv;
-  if (f != nullptr)
+  if (f != 0)
     c = f->coeff;
-  else if (fsyz != nullptr)
+  else if (fsyz != 0)
     c = fsyz->coeff;
   else
     return;
@@ -1403,7 +1403,7 @@ const gbvector *GBRing::find_coeff(const FreeModule *F,
 /* If the monomial (g->monom,g->comp) appears exactly in f,
    then return a pointer to that term, if not, return 0. */
 {
-  while (f != nullptr)
+  while (f != 0)
     {
       int cmp = gbvector_compare(F, f, g);
       if (cmp == LT)
@@ -1413,7 +1413,7 @@ const gbvector *GBRing::find_coeff(const FreeModule *F,
       else
         f = f->next;
     }
-  return nullptr;
+  return 0;
 }
 
 void GBRing::gbvector_auto_reduce(const FreeModule *F,
@@ -1428,7 +1428,7 @@ void GBRing::gbvector_auto_reduce(const FreeModule *F,
 // then set f := u*f - v*g, fsyz := u*fsyz - v*gsyz
 {
   const gbvector *t;
-  if ((t = find_coeff(F, f, g)) != nullptr)
+  if ((t = find_coeff(F, f, g)) != 0)
     {
       ring_elem u, v;
       K->syzygy(t->coeff, g->coeff, u, v);
@@ -1469,7 +1469,7 @@ void GBRing::gbvector_auto_reduce_ZZ(const FreeModule *F,
 {
   assert(globalZZ == K);
   const gbvector *t;
-  if ((t = find_coeff(F, f, g)) != nullptr)
+  if ((t = find_coeff(F, f, g)) != 0)
     {
       ring_elem v = globalZZ->quotient(t->coeff, g->coeff);
       if (globalZZ->is_zero(v)) return;
@@ -1504,7 +1504,7 @@ gbvectorHeap::gbvectorHeap(GBRing *GR0, const FreeModule *FF)
 {
   // set K
   int i;
-  for (i = 0; i < GEOHEAP_SIZE; i++) heap[i] = nullptr;
+  for (i = 0; i < GEOHEAP_SIZE; i++) heap[i] = NULL;
 }
 
 gbvectorHeap::~gbvectorHeap()
@@ -1517,7 +1517,7 @@ gbvectorHeap::~gbvectorHeap()
 void gbvectorHeap::mult_by_coeff(ring_elem a)
 {
   for (int i = top_of_heap; i >= 0; i--)
-    if (heap[i] != nullptr) GR->gbvector_mult_by_coeff_to(heap[i], a);
+    if (heap[i] != 0) GR->gbvector_mult_by_coeff_to(heap[i], a);
 }
 
 void gbvectorHeap::add(gbvector *p)
@@ -1528,13 +1528,13 @@ void gbvectorHeap::add(gbvector *p)
   while (len >= heap_size[i]) i++;
   GR->gbvector_add_to(F, heap[i], p);
   len = GR->gbvector_n_terms(heap[i]);
-  p = nullptr;
+  p = NULL;
   while (len >= heap_size[i])
     {
       i++;
       GR->gbvector_add_to(F, heap[i], heap[i - 1]);
       len = GR->gbvector_n_terms(heap[i]);
-      heap[i - 1] = nullptr;
+      heap[i - 1] = NULL;
     }
   if (i > top_of_heap) top_of_heap = i;
 }
@@ -1544,7 +1544,7 @@ const gbvector *gbvectorHeap::get_lead_term()
   int lead_so_far = -1;
   for (int i = 0; i <= top_of_heap; i++)
     {
-      if (heap[i] == nullptr) continue;
+      if (heap[i] == NULL) continue;
       if (lead_so_far < 0)
         {
           lead_so_far = i;
@@ -1561,7 +1561,7 @@ const gbvector *gbvectorHeap::get_lead_term()
       K->add_to(heap[lead_so_far]->coeff, heap[i]->coeff);
       gbvector *tmp = heap[i];
       heap[i] = tmp->next;
-      tmp->next = nullptr;
+      tmp->next = NULL;
       GR->gbvector_remove(tmp);
 
       if (K->is_zero(heap[lead_so_far]->coeff))
@@ -1569,36 +1569,36 @@ const gbvector *gbvectorHeap::get_lead_term()
           // Remove, and start over
           tmp = heap[lead_so_far];
           heap[lead_so_far] = tmp->next;
-          tmp->next = nullptr;
+          tmp->next = NULL;
           GR->gbvector_remove(tmp);
           lead_so_far = -1;
           i = -1;
         }
     }
   mLead = lead_so_far;
-  if (lead_so_far < 0) return nullptr;
+  if (lead_so_far < 0) return NULL;
   gbvector *result = heap[lead_so_far];
   return result;
 }
 gbvector *gbvectorHeap::remove_lead_term()
 {
   if (mLead < 0) get_lead_term();
-  if (mLead < 0) return nullptr;
+  if (mLead < 0) return NULL;
   gbvector *result = heap[mLead];
   heap[mLead] = result->next;
-  result->next = nullptr;
+  result->next = NULL;
   mLead = -1;
   return result;
 }
 
 gbvector *gbvectorHeap::value()
 {
-  gbvector *result = nullptr;
+  gbvector *result = NULL;
   for (int i = 0; i <= top_of_heap; i++)
     {
-      if (heap[i] == nullptr) continue;
+      if (heap[i] == NULL) continue;
       GR->gbvector_add_to(F, result, heap[i]);
-      heap[i] = nullptr;
+      heap[i] = NULL;
     }
   top_of_heap = -1;
   return result;
@@ -1606,10 +1606,10 @@ gbvector *gbvectorHeap::value()
 
 gbvector *gbvectorHeap::current_value() const
 {
-  gbvector *result = nullptr;
+  gbvector *result = NULL;
   for (int i = 0; i <= top_of_heap; i++)
     {
-      if (heap[i] == nullptr) continue;
+      if (heap[i] == NULL) continue;
       gbvector *tmp = GR->gbvector_copy(heap[i]);
       GR->gbvector_add_to(F, result, tmp);
     }
@@ -1621,7 +1621,7 @@ void gbvectorHeap::show() const
 {
   for (int i = 0; i <= top_of_heap; i++)
     {
-      if (heap[i] == nullptr) continue;
+      if (heap[i] == NULL) continue;
       printf("%d ", i);
       dgbvec(GR, heap[i]);
       printf("\n");
@@ -1658,7 +1658,7 @@ void GBRing::reduce_marked_lead_term_heap(
 
   gbvector *result1 = mult_by_term(F, g, v, MONOM1, comp);
   f.add(result1);
-  if (gsyz != nullptr)
+  if (gsyz != 0)
     {
       gbvector *result_syz1 = mult_by_term(Fsyz, gsyz, v, MONOM1, comp);
       fsyz.add(result_syz1);

--- a/M2/Macaulay2/e/gbring.hpp
+++ b/M2/Macaulay2/e/gbring.hpp
@@ -229,13 +229,13 @@ class GBRing : public our_new_delete
   // Returns coeff*exp*e_sub_i in F, where exp is an exponent vector.
   // If comp==0, F is never considered (so it can be NULL)
 
-  gbvector *gbvector_zero() const { return nullptr; }
+  gbvector *gbvector_zero() const { return 0; }
   void gbvector_sort(const FreeModule *F,
                      gbvector *&f);  // TO BE USED CAREFULLY: gbvector's should
   // mostly be kept in monomial order.  This is here when the construction
   // doesn't satisfy this property.
 
-  bool gbvector_is_zero(const gbvector *f) const { return f == nullptr; }
+  bool gbvector_is_zero(const gbvector *f) const { return f == 0; }
   bool gbvector_is_equal(const gbvector *f, const gbvector *g) const;
   // f,g can be both be in F, or both in Fsyz
 

--- a/M2/Macaulay2/e/gbweight.cpp
+++ b/M2/Macaulay2/e/gbweight.cpp
@@ -52,7 +52,7 @@ GBWeight::GBWeight(const FreeModule *F, M2_arrayint wts0) : F_(F)
       for (int j = 0; j < F->rank(); j++) Fdegs_[j + 1] = F->primary_degree(j);
     }
   else
-    Fdegs_ = nullptr;
+    Fdegs_ = 0;
 }
 
 int GBWeight::exponents_weight(const_exponents e, int comp) const
@@ -64,7 +64,7 @@ int GBWeight::exponents_weight(const_exponents e, int comp) const
 
 int GBWeight::gbvector_term_weight(const gbvector *f) const
 {
-  if (f == nullptr) return 0;
+  if (f == 0) return 0;
   exponents_t EXP = ALLOCATE_EXPONENTS(exp_size);
   R_->gbvector_get_lead_exponents(F_, f, EXP);
   return exponents_weight(EXP, f->comp);
@@ -74,14 +74,14 @@ int GBWeight::gbvector_weight(const gbvector *f, int &initial_term_weight) const
 {
   /* Return the maximum degree of any term of f */
 
-  if (f == nullptr)
+  if (f == 0)
     {
       initial_term_weight = 0;
       return 0;
     }
   int deg = gbvector_term_weight(f);
   initial_term_weight = deg;
-  for (const gbvector *t = f->next; t != nullptr; t = t->next)
+  for (const gbvector *t = f->next; t != 0; t = t->next)
     {
       int tdeg = gbvector_term_weight(t);
       if (tdeg > deg) deg = tdeg;

--- a/M2/Macaulay2/e/hermite.cpp
+++ b/M2/Macaulay2/e/hermite.cpp
@@ -23,9 +23,9 @@ hm_elem *HermiteComputation::new_gen(int i)
   hm_elem *result = new hm_elem;
   nallocs_hm_elem++;
   mpz_init(result->lead);
-  if ((*gens)[i] == nullptr)
+  if ((*gens)[i] == NULL)
     {
-      result->f = nullptr;
+      result->f = NULL;
     }
   else
     {
@@ -35,15 +35,15 @@ hm_elem *HermiteComputation::new_gen(int i)
   if (i < n_comps_per_syz)
     result->fsyz = globalZZ->e_sub_i(i);
   else
-    result->fsyz = nullptr;
-  result->next = nullptr;
+    result->fsyz = NULL;
+  result->next = NULL;
   return result;
 }
 void HermiteComputation::insert(hm_elem *p)
 {
-  if (p->f == nullptr)
+  if (p->f == NULL)
     {
-      if (p->fsyz != nullptr && collect_syz) syz_list.push_back(p->fsyz);
+      if (p->fsyz != NULL && collect_syz) syz_list.push_back(p->fsyz);
       mpz_clear(p->lead);
       delete p;
       nfree_hm_elem++;
@@ -59,13 +59,13 @@ void HermiteComputation::insert(hm_elem *p)
 HermiteComputation::HermiteComputation(const Matrix *m, int collsyz, int nsyz)
     : row(m->n_rows() - 1),
       gens(m),
-      GB_list(nullptr),
+      GB_list(NULL),
       n_gb(0),
       collect_syz(collsyz)
 {
   int i;
 
-  for (i = 0; i < m->n_rows(); i++) initial.push_back(nullptr);
+  for (i = 0; i < m->n_rows(); i++) initial.push_back(NULL);
 
   if (nsyz < 0 || nsyz > m->n_cols()) nsyz = m->n_cols();
   n_comps_per_syz = nsyz;
@@ -84,7 +84,7 @@ void HermiteComputation::remove_hm_elem(hm_elem *&p)
   globalZZ->remove_vec(p->f);
   globalZZ->remove_vec(p->fsyz);
   delete p;
-  p = nullptr;
+  p = NULL;
 }
 
 HermiteComputation::~HermiteComputation()
@@ -105,7 +105,7 @@ HermiteComputation::~HermiteComputation()
 
   // Remove the Groebner basis:
 
-  while (GB_list != nullptr)
+  while (GB_list != NULL)
     {
       hm_elem *tmp = GB_list;
       GB_list = tmp->next;
@@ -123,8 +123,8 @@ int HermiteComputation::compare_elems(hm_elem *f, hm_elem *g) const
 
 hm_elem *HermiteComputation::merge(hm_elem *f, hm_elem *g)
 {
-  if (g == nullptr) return f;
-  if (f == nullptr) return g;
+  if (g == NULL) return f;
+  if (f == NULL) return g;
   hm_elem head;
   hm_elem *result = &head;
   hm_elem *h;
@@ -134,7 +134,7 @@ hm_elem *HermiteComputation::merge(hm_elem *f, hm_elem *g)
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               return head.next;
@@ -159,10 +159,10 @@ hm_elem *HermiteComputation::merge(hm_elem *f, hm_elem *g)
 
           h = g;
           // We need to reset the lead term
-          if (g->f != nullptr) mpz_abs(h->lead, g->f->coeff.get_mpz());
+          if (g->f != NULL) mpz_abs(h->lead, g->f->coeff.get_mpz());
           g = g->next;
           insert(h);
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               return head.next;
@@ -172,7 +172,7 @@ hm_elem *HermiteComputation::merge(hm_elem *f, hm_elem *g)
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               return head.next;
@@ -184,17 +184,17 @@ hm_elem *HermiteComputation::merge(hm_elem *f, hm_elem *g)
 void HermiteComputation::sort(hm_elem *&p)
 {
   // Sort in ascending absolute value of lead term
-  if (p == nullptr || p->next == nullptr) return;
-  hm_elem *p1 = nullptr;
-  hm_elem *p2 = nullptr;
-  while (p != nullptr)
+  if (p == NULL || p->next == NULL) return;
+  hm_elem *p1 = NULL;
+  hm_elem *p2 = NULL;
+  while (p != NULL)
     {
       hm_elem *tmp = p;
       p = p->next;
       tmp->next = p1;
       p1 = tmp;
 
-      if (p == nullptr) break;
+      if (p == NULL) break;
       tmp = p;
       p = p->next;
       tmp->next = p2;
@@ -251,7 +251,7 @@ void HermiteComputation::reduce(hm_elem *&p, hm_elem *q)
 
   q->f = q1;
   q->fsyz = qsyz1;
-  if (q->f != nullptr) mpz_abs(q->lead, q->f->coeff.get_mpz());
+  if (q->f != NULL) mpz_abs(q->lead, q->f->coeff.get_mpz());
 
   insert(q);
 }
@@ -265,10 +265,10 @@ void HermiteComputation::start_computation()
   for (; row >= 0; row--)
     {
       hm_elem *p = initial[row];
-      if (p == nullptr) continue;
-      initial[row] = nullptr;
+      if (p == NULL) continue;
+      initial[row] = NULL;
       sort(p);  // This can remove elements, inserting them back
-      while (p != nullptr && p->next != nullptr)
+      while (p != NULL && p->next != NULL)
         {
           hm_elem *pnext = p->next->next;
           reduce(p, p->next);  // replaces p1, and re-inserts p2.
@@ -289,7 +289,7 @@ void HermiteComputation::start_computation()
   // We use the following: the lead components of elements of GB_list are in
   // increasing order
 
-  for (hm_elem *p = GB_list; p != nullptr; p = p->next)
+  for (hm_elem *p = GB_list; p != 0; p = p->next)
     {
       if (!globalZZ->is_positive(p->f->coeff))
         {
@@ -316,7 +316,7 @@ void HermiteComputation::start_computation()
 const Matrix /* or null */ *HermiteComputation::get_gb()
 {
   MatrixConstructor mat(gens->rows(), 0);
-  for (hm_elem *p = GB_list; p != nullptr; p = p->next)
+  for (hm_elem *p = GB_list; p != NULL; p = p->next)
     mat.append(globalZZ->copy_vec(p->f));
   return mat.to_matrix();
 }
@@ -330,7 +330,7 @@ const Matrix /* or null */ *HermiteComputation::get_mingens()
 const Matrix /* or null */ *HermiteComputation::get_change()
 {
   MatrixConstructor mat(Fsyz, 0);
-  for (hm_elem *p = GB_list; p != nullptr; p = p->next)
+  for (hm_elem *p = GB_list; p != NULL; p = p->next)
     mat.append(globalZZ->copy_vec(p->fsyz));
   return mat.to_matrix();
 }
@@ -346,7 +346,7 @@ const Matrix /* or null */ *HermiteComputation::get_syzygies()
 const Matrix /* or null */ *HermiteComputation::get_initial(int nparts)
 {
   MatrixConstructor mat(gens->rows(), 0);
-  for (hm_elem *p = GB_list; p != nullptr; p = p->next)
+  for (hm_elem *p = GB_list; p != NULL; p = p->next)
     {
       vec v = p->f;
       mat.append(globalZZ->make_vec(v->comp, v->coeff));
@@ -360,10 +360,10 @@ void HermiteComputation::text_out(buffer &o) const
 {
   o << newline;
   for (int i = 0; i < gens->n_rows(); i++)
-    if (initial[i] != nullptr)
+    if (initial[i] != NULL)
       {
         o << "--- component " << i << " -----" << newline;
-        for (hm_elem *p = initial[i]; p != nullptr; p = p->next)
+        for (hm_elem *p = initial[i]; p != NULL; p = p->next)
           {
             bignum_text_out(o, p->lead);
             o << " ## ";
@@ -388,12 +388,12 @@ void HermiteComputation::gb_reduce(vec &f) const
   // (in absolute value).
   vecterm head;
   vecterm *result = &head;
-  head.next = nullptr;
-  while (f != nullptr)
+  head.next = 0;
+  while (f != 0)
     {
       int x = f->comp;
       hm_elem *h = initial[x];
-      if (h != nullptr)
+      if (h != 0)
         {
           ring_elem v;
           ring_elem rem =
@@ -411,7 +411,7 @@ void HermiteComputation::gb_reduce(vec &f) const
       result->next = f;
       f = f->next;
       result = result->next;
-      result->next = nullptr;
+      result->next = 0;
       continue;
     }
 
@@ -424,12 +424,12 @@ void HermiteComputation::gb_reduce(vec &f, vec &fsyz) const
   // (in absolute value).
   vecterm head;
   vecterm *result = &head;
-  head.next = nullptr;
-  while (f != nullptr)
+  head.next = 0;
+  while (f != 0)
     {
       int x = f->comp;
       hm_elem *h = initial[x];
-      if (h != nullptr)
+      if (h != 0)
         {
           ring_elem v;
           ring_elem rem =
@@ -449,7 +449,7 @@ void HermiteComputation::gb_reduce(vec &f, vec &fsyz) const
       result->next = f;
       f = f->next;
       result = result->next;
-      result->next = nullptr;
+      result->next = 0;
       continue;
     }
 
@@ -462,12 +462,12 @@ const Matrix /* or null */ *HermiteComputation::matrix_remainder(
   if (m->get_ring() != globalZZ)
     {
       ERROR("expected matrix over ZZ");
-      return nullptr;
+      return 0;
     }
   if (m->n_rows() != gens->rows()->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      return nullptr;
+      return 0;
     }
   MatrixConstructor mat_remainder(m->rows(), m->cols(), m->degree_shift());
   for (int i = 0; i < m->n_cols(); i++)
@@ -488,27 +488,27 @@ M2_bool HermiteComputation::matrix_lift(
   if (m->get_ring() != globalZZ)
     {
       ERROR("expected matrix over ZZ");
-      *result_remainder = nullptr;
-      *result_quotient = nullptr;
+      *result_remainder = 0;
+      *result_quotient = 0;
       return false;
     }
   if (m->n_rows() != gens->rows()->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      *result_remainder = nullptr;
-      *result_quotient = nullptr;
+      *result_remainder = 0;
+      *result_quotient = 0;
       return false;
     }
   MatrixConstructor mat_remainder(m->rows(), m->cols(), m->degree_shift());
-  MatrixConstructor mat_quotient(Fsyz, m->cols(), nullptr);
+  MatrixConstructor mat_quotient(Fsyz, m->cols(), 0);
   bool all_zeroes = true;
   for (int i = 0; i < m->n_cols(); i++)
     {
       vec f = globalZZ->copy_vec(m->elem(i));
-      vec fsyz = nullptr;
+      vec fsyz = NULL;
 
       gb_reduce(f, fsyz);
-      if (f != nullptr) all_zeroes = false;
+      if (f != 0) all_zeroes = false;
 
       globalZZ->negate_vec_to(fsyz);
       mat_remainder.set_column(i, f);
@@ -534,7 +534,7 @@ int HermiteComputation::contains(const Matrix *m)
     {
       vec f = globalZZ->copy_vec(m->elem(i));
       gb_reduce(f);
-      if (f != nullptr)
+      if (f != NULL)
         {
           globalZZ->remove_vec(f);
           return i;

--- a/M2/Macaulay2/e/hilb.cpp
+++ b/M2/Macaulay2/e/hilb.cpp
@@ -190,7 +190,7 @@ static int popular_var(const MonomialIdeal &I,
   for (k = 0; k < nvars; k++) hits[k] = 0;
   for (k = 0; k < nvars; k++) minnonzero[k] = MAX_EXP;
 
-  non_pure_power = nullptr;
+  non_pure_power = NULL;
 
   for (Bag& a : I)
     {
@@ -325,15 +325,15 @@ void hilb_comp::next_monideal()
 void hilb_comp::reset()
 {
   depth = 0;
-  if (current == nullptr)
+  if (current == NULL)
     {
       current = new hilb_step;
-      current->up = current->down = nullptr;
+      current->up = current->down = NULL;
       current->h0 = R->from_long(0);
       current->h1 = R->from_long(0);
     }
   else
-    while (current->up != nullptr) current = current->up;
+    while (current->up != NULL) current = current->up;
 
   R->remove(current->h0);  // This line should not be needed...
   R->remove(current->h1);
@@ -349,7 +349,7 @@ hilb_comp::hilb_comp(const PolynomialRing *RR, const Matrix *m)
       input_mat(m),
       this_comp(0),
       n_components(m->n_rows()),
-      current(nullptr),
+      current(NULL),
       part_table(S->n_vars(), mi_stash)
 {
   assert(D == R->getMonoid());
@@ -374,10 +374,10 @@ hilb_comp::hilb_comp(const PolynomialRing *RR, const MonomialIdeal *I)
       M(S->getMonoid()),
       D(S->degree_monoid()),
       mi_stash(new stash("hilb mi", sizeof(Nmi_node))),
-      input_mat(nullptr),
+      input_mat(0),
       this_comp(0),
       n_components(1),
-      current(nullptr),
+      current(NULL),
       part_table(S->n_vars(), mi_stash)
 {
   assert(D == R->getMonoid());
@@ -401,7 +401,7 @@ hilb_comp::hilb_comp(const PolynomialRing *RR, const MonomialIdeal *I)
 hilb_comp::~hilb_comp()
 {
   // free 'current' (which is most of the stuff here...)
-  while (current != nullptr)
+  while (current != NULL)
     {
       hilb_step *p = current;
       current = current->down;
@@ -470,7 +470,7 @@ int hilb_comp::step()
       current->h0 = R->from_long(0);
       current->h1 = R->from_long(0);
       current->monids.clear();
-      if (current->up == nullptr)
+      if (current->up == NULL)
         {
           if (input_mat)
             {
@@ -502,11 +502,11 @@ void hilb_comp::recurse(MonomialIdeal *&I, const_varpower pivot_vp)
   depth++;
   if (depth > maxdepth) maxdepth = depth;
   nrecurse++;
-  if (current->down == nullptr)
+  if (current->down == NULL)
     {
       current->down = new hilb_step;  // MES: is this ok?
       current->down->up = current;
-      current->down->down = nullptr;
+      current->down->down = NULL;
     }
   current = current->down;
   current->h0 = R->from_long(0);
@@ -601,7 +601,7 @@ void hilb_comp::do_ideal(MonomialIdeal *I)
 
 int hilb_comp::is_done() const
 {
-  return (current != nullptr && current->up == nullptr);
+  return (current != NULL && current->up == NULL);
 }
 
 RingElement *hilb_comp::value()
@@ -609,7 +609,7 @@ RingElement *hilb_comp::value()
   if (!is_done())
     {
       ERROR("Hilbert function computation not complete");
-      return nullptr;
+      return 0;
     }
   RingElement *result = RingElement::make_raw(R, R->copy(result_poincare));
   return result;
@@ -627,7 +627,7 @@ void hilb_comp::stats() const
 
   hilb_step *p = current;
   int d = depth;
-  while (p != nullptr)
+  while (p != NULL)
     {
       o << "----- depth " << d << " -------------" << newline;
       o << "  " << p->monids.size() << " monomial ideals total" << newline;
@@ -669,10 +669,10 @@ RingElement *hilb_comp::hilbertNumerator(const Matrix *M)
    computing Hilbert series, or the computation was interrupted. */
 {
   const PolynomialRing *P = M->get_ring()->get_degree_ring();
-  if (P == nullptr) return nullptr;
+  if (P == 0) return 0;
   hilb_comp *hf = new hilb_comp(P, M);
   int retval = hf->calc(-1);
-  if (retval != COMP_DONE) return nullptr;
+  if (retval != COMP_DONE) return 0;
   RingElement *result = hf->value();
   delete hf;
   return result;
@@ -680,7 +680,7 @@ RingElement *hilb_comp::hilbertNumerator(const Matrix *M)
 
 RingElement *hilb_comp::hilbertNumerator(const FreeModule *F)
 {
-  const Matrix *Fmatrix = Matrix::make(F, 0, nullptr);
+  const Matrix *Fmatrix = Matrix::make(F, 0, 0);
   RingElement *result = hilbertNumerator(Fmatrix);
   delete Fmatrix;
   return result;
@@ -692,10 +692,10 @@ RingElement /* or null */ *hilb_comp::hilbertNumerator(const MonomialIdeal *I)
    computing Hilbert series, or the computation was interrupted. */
 {
   const PolynomialRing *P = I->get_ring()->get_degree_ring();
-  if (P == nullptr) return nullptr;
+  if (P == 0) return 0;
   hilb_comp *hf = new hilb_comp(P, I);
   int retval = hf->calc(-1);
-  if (retval != COMP_DONE) return nullptr;
+  if (retval != COMP_DONE) return 0;
   RingElement *result = hf->value();
   delete hf;
   return result;

--- a/M2/Macaulay2/e/imonorder.cpp
+++ b/M2/Macaulay2/e/imonorder.cpp
@@ -33,7 +33,7 @@ static void mo_block_revlex(struct mo_block *b, int nvars)
   b->first_exp = 0;  /* will be set later */
   b->first_slot = 0; /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_grevlex(struct mo_block *b, int nvars)
@@ -44,7 +44,7 @@ static void mo_block_grevlex(struct mo_block *b, int nvars)
   b->first_exp = 0;  /* will be set later */
   b->first_slot = 0; /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_grevlex2(struct mo_block *b, int nvars)
@@ -55,7 +55,7 @@ static void mo_block_grevlex2(struct mo_block *b, int nvars)
   b->first_exp = 0;            /* will be set later */
   b->first_slot = 0;           /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_grevlex4(struct mo_block *b, int nvars)
@@ -66,7 +66,7 @@ static void mo_block_grevlex4(struct mo_block *b, int nvars)
   b->first_exp = 0;            /* will be set later */
   b->first_slot = 0;           /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_grevlex_wts(struct mo_block *b, int nvars)
@@ -77,7 +77,7 @@ static void mo_block_grevlex_wts(struct mo_block *b, int nvars)
   b->first_exp = 0;  /* will be set later */
   b->first_slot = 0; /* will be set later */
   b->nweights = nvars;
-  b->weights = nullptr; /* will be set later */
+  b->weights = 0; /* will be set later */
 }
 
 static void mo_block_grevlex2_wts(struct mo_block *b, int nvars)
@@ -88,7 +88,7 @@ static void mo_block_grevlex2_wts(struct mo_block *b, int nvars)
   b->first_exp = 0;            /* will be set later */
   b->first_slot = 0;           /* will be set later */
   b->nweights = nvars;
-  b->weights = nullptr; /* will be set later */
+  b->weights = 0; /* will be set later */
 }
 
 static void mo_block_grevlex4_wts(struct mo_block *b, int nvars)
@@ -99,7 +99,7 @@ static void mo_block_grevlex4_wts(struct mo_block *b, int nvars)
   b->first_exp = 0;            /* will be set later */
   b->first_slot = 0;           /* will be set later */
   b->nweights = nvars;
-  b->weights = nullptr; /* will be set later */
+  b->weights = 0; /* will be set later */
 }
 
 static void mo_block_lex(struct mo_block *b, int nvars)
@@ -110,7 +110,7 @@ static void mo_block_lex(struct mo_block *b, int nvars)
   b->first_exp = 0;  /* will be set later */
   b->first_slot = 0; /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_lex2(struct mo_block *b, int nvars)
@@ -121,7 +121,7 @@ static void mo_block_lex2(struct mo_block *b, int nvars)
   b->first_exp = 0;            /* will be set later */
   b->first_slot = 0;           /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_lex4(struct mo_block *b, int nvars)
@@ -132,7 +132,7 @@ static void mo_block_lex4(struct mo_block *b, int nvars)
   b->first_exp = 0;            /* will be set later */
   b->first_slot = 0;           /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_group_lex(struct mo_block *b, int nvars)
@@ -143,7 +143,7 @@ static void mo_block_group_lex(struct mo_block *b, int nvars)
   b->first_exp = 0;  /* will be set later */
   b->first_slot = 0; /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_group_revlex(struct mo_block *b, int nvars)
@@ -154,7 +154,7 @@ static void mo_block_group_revlex(struct mo_block *b, int nvars)
   b->first_exp = 0;  /* will be set later */
   b->first_slot = 0; /* will be set later */
   b->nweights = 0;
-  b->weights = nullptr;
+  b->weights = 0;
 }
 
 static void mo_block_wt_function(struct mo_block *b, int nvars, deg_t *wts)
@@ -172,7 +172,7 @@ MonomialOrder *monomialOrderMake(const MonomialOrdering *mo)
 {
   MonomialOrder *result;
   int i, j, nv, this_block;
-  deg_t *wts = nullptr;
+  deg_t *wts = NULL;
   /* Determine the number of variables, the number of blocks, and the location
      of the component */
   int nblocks = 0;
@@ -209,7 +209,7 @@ MonomialOrder *monomialOrderMake(const MonomialOrdering *mo)
       struct mon_part_rec_ *t = mo->array[i];
       if (t->type != MO_WEIGHTS)
         {
-          if (t->wts == nullptr)
+          if (t->wts == 0)
             for (j = 0; j < t->nvars; j++) result->degs[nvars++] = 1;
           else
             for (j = 0; j < t->nvars; j++) result->degs[nvars++] = t->wts[j];
@@ -413,7 +413,7 @@ void monomialOrderEncodeFromActualExponents(const MonomialOrder *mo,
                                             monomial result_psums)
 /* Given 'expon', compute the encoded partial sums value */
 {
-  if (mo == nullptr) return;
+  if (mo == 0) return;
   int *tmpexp = static_cast<int *>(alloca((mo->nvars + 1) * sizeof(int)));
   int i, j, nvars, s;
   int *p1;
@@ -549,7 +549,7 @@ void monomialOrderDecodeToActualExponents(const MonomialOrder *mo,
                                           const_monomial psums,
                                           exponents_t expon)
 {
-  if (mo == nullptr) return;
+  if (mo == 0) return;
   int *tmpexp = static_cast<int *>(alloca((mo->nvars + 1) * sizeof(int)));
   int i, j, nvars;
   deg_t *degs = mo->degs;

--- a/M2/Macaulay2/e/interface/aring.cpp
+++ b/M2/Macaulay2/e/interface/aring.cpp
@@ -42,7 +42,7 @@ const Ring /* or null */ *rawARingZZp(unsigned long p)
   if (p <= 1 || p >= 32750)
     {
       ERROR("ZZP: expected a prime number p in range 2 <= p <= 32749");
-      return nullptr;
+      return 0;
     }
   return M2::ConcreteRing<M2::ARingZZp>::create(p);
 }
@@ -58,66 +58,66 @@ static const PolynomialRing * /* or null */ checkGaloisFieldInput(
   // Check that f is monic
   // If any of these fail, then return 0.
   const PolynomialRing *R = f->get_ring()->cast_to_PolynomialRing();
-  if (R == nullptr)
+  if (R == 0)
     {
       ERROR("expected poly ring of the form ZZ/p[x]/(f)");
-      return nullptr;
+      return 0;
     }
   if (R->n_vars() != 1)
     {
       ERROR("expected poly ring of the form ZZ/p[x]/(f)");
-      return nullptr;
+      return 0;
     }
   if (R->n_quotients() != 1)
     {
       ERROR("expected poly ring of the form ZZ/p[x]/(f)");
-      return nullptr;
+      return 0;
     }
   if (R->characteristic() == 0)
     {
       ERROR("expected poly ring of the form ZZ/p[x]/(f)");
-      return nullptr;
+      return 0;
     }
   return R;
 }
 const Ring /* or null */ *rawARingGaloisField1(const RingElement *f)
 {
   const PolynomialRing *R = checkGaloisFieldInput(f);
-  if (R == nullptr) return nullptr;  // error message has already been logged
+  if (R == 0) return 0;  // error message has already been logged
   try
     {
       return M2::ConcreteRing<M2::ARingGFM2>::create(*R, f->get_value());
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 const Ring /* or null */ *rawARingGaloisFieldFlintBig(const RingElement *f)
 {
   const PolynomialRing *R = checkGaloisFieldInput(f);
-  if (R == nullptr) return nullptr;  // error message has already been logged
+  if (R == 0) return 0;  // error message has already been logged
   try
     {
       return M2::ConcreteRing<M2::ARingGFFlintBig>::create(*R, f->get_value());
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
 const Ring /* or null */ *rawARingGaloisFieldFlintZech(const RingElement *f)
 {
   const PolynomialRing *R = checkGaloisFieldInput(f);
-  if (R == nullptr) return nullptr;  // error message has already been logged
+  if (R == 0) return 0;  // error message has already been logged
   try
     {
       return M2::ConcreteRing<M2::ARingGFFlint>::create(*R, f->get_value());
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -138,7 +138,7 @@ const Ring /* or null */ *rawARingGaloisField(int prime, int dimension)
   if (dimension < 0)
     {
       ERROR(" givaroGF/FFPACK: help, dimension is negative ! ");
-      return nullptr;
+      return 0;
     }
   try
     {
@@ -147,7 +147,7 @@ const Ring /* or null */ *rawARingGaloisField(int prime, int dimension)
       if (prime <= 1)
         {
           ERROR("givaroGF/FFPACK: expected a prime number p ");
-          return nullptr;
+          return 0;
         }
 
       //-- NEED_POLYNOMIAL_REPRESENTATION is not usable(namespace problems) and
@@ -168,7 +168,7 @@ const Ring /* or null */ *rawARingGaloisField(int prime, int dimension)
       if (dimension == 1)
         {
           ERROR("maximum modulus = %f\n", M2::ARingZZpFFPACK::getMaxModulus());
-          return nullptr;
+          return 0;
         }
       #if 0
       return M2::ConcreteRing<M2::ARingGFGivaro>::create(prime, dimension);
@@ -182,7 +182,7 @@ const Ring /* or null */ *rawARingGaloisField(int prime, int dimension)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -297,10 +297,10 @@ const Ring /* or null */ *rawARingTower1(const Ring *K, M2_ArrayString names)
     {
       const M2::ConcreteRing<M2::ARingZZpFFPACK> *Kp =
           dynamic_cast<const M2::ConcreteRing<M2::ARingZZpFFPACK> *>(K);
-      if (Kp == nullptr)
+      if (Kp == 0)
         {
           ERROR("expected a base ring ZZ/p");
-          return nullptr;
+          return NULL;
         }
       const M2::ARingZZpFFPACK &A = Kp->ring();
 
@@ -312,7 +312,7 @@ const Ring /* or null */ *rawARingTower1(const Ring *K, M2_ArrayString names)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -323,10 +323,10 @@ const Ring /* or null */ *rawARingTower2(const Ring *R1,
     {
       const M2::ConcreteRing<M2::ARingTower> *K =
           dynamic_cast<const M2::ConcreteRing<M2::ARingTower> *>(R1);
-      if (K == nullptr)
+      if (K == 0)
         {
           ERROR("expected a tower ring");
-          return nullptr;
+          return NULL;
         }
       const M2::ARingTower &A = K->ring();
 
@@ -337,7 +337,7 @@ const Ring /* or null */ *rawARingTower2(const Ring *R1,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -348,10 +348,10 @@ const Ring /* or null */ *rawARingTower3(const Ring *R1,
     {
       const M2::ConcreteRing<M2::ARingTower> *K =
           dynamic_cast<const M2::ConcreteRing<M2::ARingTower> *>(R1);
-      if (K == nullptr)
+      if (K == 0)
         {
           ERROR("expected a tower ring");
-          return nullptr;
+          return NULL;
         }
       const M2::ARingTower &A = K->ring();
 
@@ -364,7 +364,7 @@ const Ring /* or null */ *rawARingTower3(const Ring *R1,
           if (f->get_ring() != R1)
             {
               ERROR("extension element has incorrect base ring");
-              return nullptr;
+              return 0;
             }
           A.from_ring_elem(f1, f->get_value());
           extensions.push_back(f1);
@@ -375,7 +375,7 @@ const Ring /* or null */ *rawARingTower3(const Ring *R1,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return 0;
   }
 }
 

--- a/M2/Macaulay2/e/interface/factory.cpp
+++ b/M2/Macaulay2/e/interface/factory.cpp
@@ -91,13 +91,13 @@ struct enter_factory
   void enter();
   void exit();
 
-  enter_factory() : mode(modeUnknown), Zn(nullptr) { enter(); }
+  enter_factory() : mode(modeUnknown), Zn(NULL) { enter(); }
   enter_factory(const PolynomialRing *P)
       : mode(coeffMode(P)),
         newcharac(mode == modeZn || mode == modeGF
                       ? static_cast<int>(P->characteristic())
                       : 0),
-        Zn(mode == modeZn ? P->getCoefficientRing() : nullptr)
+        Zn(mode == modeZn ? P->getCoefficientRing() : NULL)
   {
     enter();
   }
@@ -419,7 +419,7 @@ static CanonicalForm convertToFactory(const RingElement &g, bool inExtension)
 {
   const Ring *R = g.get_ring();
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected a polynomial ring");
       return 0;
@@ -430,7 +430,7 @@ static CanonicalForm convertToFactory(const RingElement &g, bool inExtension)
   struct enter_factory foo(P);
   if (foo.mode == modeError) return 0;
   CanonicalForm f = 0;
-  for (Nterm *t = g.get_value(); t != nullptr; t = t->next)
+  for (Nterm *t = g.get_value(); t != NULL; t = t->next)
     {
       int coef = 0;
       M->to_varpower(t->monom, vp);
@@ -490,27 +490,27 @@ const RingElement /* or null */ *rawGCDRingElement(const RingElement *f,
                                                    const RingElement *mipo,
                                                    const M2_bool inExtension)
 {
-  const RingElement *ret = nullptr;
+  const RingElement *ret = NULL;
   const PolynomialRing *P = f->get_ring()->cast_to_PolynomialRing();
   const PolynomialRing *P2 = g->get_ring()->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
-      if (f->get_ring()->cast_to_Tower() != nullptr) return towerGCD(f, g);
+      if (f->get_ring()->cast_to_Tower() != 0) return towerGCD(f, g);
       // else we really do have an error:
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   if (P != P2)
     {
       ERROR("encountered different rings");
-      return nullptr;
+      return 0;
     }
   {
     struct enter_factory foo(P);
     if (foo.mode == modeError)
       {
-        algebraicElement_M2 = nullptr;
-        return nullptr;
+        algebraicElement_M2 = NULL;
+        return 0;
       }
     if (foo.mode == modeGF)
       {
@@ -536,8 +536,8 @@ const RingElement /* or null */ *rawGCDRingElement(const RingElement *f,
     ret = convertToM2(P, h);
     if (error())
       {
-        algebraicElement_M2 = nullptr;
-        return nullptr;
+        algebraicElement_M2 = NULL;
+        return NULL;
       }
   }
   if (ret->is_zero()) return ret;
@@ -546,7 +546,7 @@ const RingElement /* or null */ *rawGCDRingElement(const RingElement *f,
   ring_elem b = P->getCoefficients()->invert(a);
   ring_elem r = ret->get_value();
   P->mult_coeff_to(b, r);
-  algebraicElement_M2 = nullptr;
+  algebraicElement_M2 = NULL;
   return RingElement::make_raw(P, r);
 }
 
@@ -560,20 +560,20 @@ const RingElement /* or null */ *rawExtendedGCDRingElement(
   const RingElement *ret;
   const PolynomialRing *P = f->get_ring()->cast_to_PolynomialRing();
   const PolynomialRing *P2 = g->get_ring()->cast_to_PolynomialRing();
-  *A = nullptr;
-  *B = nullptr;
-  if (P == nullptr)
+  *A = NULL;
+  *B = NULL;
+  if (P == 0)
     {
-      if (f->get_ring()->cast_to_Tower() != nullptr)
+      if (f->get_ring()->cast_to_Tower() != 0)
         return towerExtendedGCD(f, g, A, B);
       // else we really do have an error:
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   if (P != P2)
     {
       ERROR("encountered different rings");
-      return nullptr;
+      return 0;
     }
 
   if (f->is_zero())
@@ -591,7 +591,7 @@ const RingElement /* or null */ *rawExtendedGCDRingElement(
     }
 
   struct enter_factory foo(P);
-  if (foo.mode == modeError) return nullptr;
+  if (foo.mode == modeError) return 0;
   if (foo.mode == modeGF)
     {
       set_GF_minimal_poly(P);
@@ -603,22 +603,22 @@ const RingElement /* or null */ *rawExtendedGCDRingElement(
   ret = convertToM2(P, h);
   if (error())
     {
-      algebraicElement_M2 = nullptr;
-      return nullptr;
+      algebraicElement_M2 = NULL;
+      return NULL;
     }
   *A = convertToM2(P, a);
   if (error())
     {
-      algebraicElement_M2 = nullptr;
-      return nullptr;
+      algebraicElement_M2 = NULL;
+      return NULL;
     }
   *B = convertToM2(P, b);
   if (error())
     {
-      algebraicElement_M2 = nullptr;
-      return nullptr;
+      algebraicElement_M2 = NULL;
+      return NULL;
     }
-  algebraicElement_M2 = nullptr;
+  algebraicElement_M2 = NULL;
   return ret;
 }
 
@@ -628,19 +628,19 @@ const RingElement /* or null */ *rawPseudoRemainder(const RingElement *f,
   const bool inExtension = false;
   const PolynomialRing *P = f->get_ring()->cast_to_PolynomialRing();
   const PolynomialRing *P2 = g->get_ring()->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   if (P != P2)
     {
       ERROR("encountered different rings");
-      return nullptr;
+      return 0;
     }
 
   struct enter_factory foo(P);
-  if (foo.mode == modeError) return nullptr;
+  if (foo.mode == modeError) return 0;
   if (foo.mode == modeGF)
     {
       set_GF_minimal_poly(P);
@@ -651,29 +651,29 @@ const RingElement /* or null */ *rawPseudoRemainder(const RingElement *f,
   const RingElement *r = convertToM2(P, h);
   if (error())
     {
-      algebraicElement_M2 = nullptr;
-      return nullptr;
+      algebraicElement_M2 = NULL;
+      return NULL;
     }
-  algebraicElement_M2 = nullptr;
+  algebraicElement_M2 = NULL;
   return r;
 }
 
 void rawFactorBase(const RingElement *g,
                    engine_RawRingElementArrayOrNull *result_factors,
                    M2_arrayintOrNull *result_powers,
-                   const RingElement *mipo = nullptr  // minimal polynomial of
+                   const RingElement *mipo = NULL  // minimal polynomial of
                                                    // generator of field
                                                    // extension, if any;
                                                    // generator is last variable
                    )
 {
-  bool inExtension = mipo != nullptr;
+  bool inExtension = mipo != NULL;
   try
     {
       const PolynomialRing *P = g->get_ring()->cast_to_PolynomialRing();
-      *result_factors = nullptr;
-      *result_powers = nullptr;
-      if (P == nullptr)
+      *result_factors = 0;
+      *result_powers = 0;
+      if (P == 0)
         {
           ERROR("expected polynomial ring");
           return;
@@ -691,7 +691,7 @@ void rawFactorBase(const RingElement *g,
           CanonicalForm h = convertToFactory(*g, notInExtension);
           q = factorize(h, a);
         }
-      else if (mipo != nullptr)
+      else if (mipo != NULL)
         {
           CanonicalForm mipocf = convertToFactory(*mipo, notInExtension);
           Variable a = rootOf(mipocf, 'a');
@@ -709,7 +709,7 @@ void rawFactorBase(const RingElement *g,
           CanonicalForm h = convertToFactory(*g, inExtension);
           // displayCF(P,h);
           q = factorize(h);
-          algebraicElement_M2 = nullptr;
+          algebraicElement_M2 = NULL;
         }
 
       int nfactors = q.length();
@@ -725,8 +725,8 @@ void rawFactorBase(const RingElement *g,
           (*result_factors)->array[next] = convertToM2(P, i.getItem().factor());
           (*result_powers)->array[next++] = i.getItem().exp();
         }
-      algebraicElement_M2 = nullptr;
-      if (error()) *result_factors = nullptr, *result_powers = nullptr;
+      algebraicElement_M2 = NULL;
+      if (error()) *result_factors = NULL, *result_powers = NULL;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -756,19 +756,19 @@ M2_arrayintOrNull rawIdealReorder(const Matrix *M)
     {
       init_seeds();
       const PolynomialRing *P = M->get_ring()->cast_to_PolynomialRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected polynomial ring");
-          return nullptr;
+          return 0;
         }
       const int N = P->n_vars();
 
       struct enter_factory foo(P);
-      if (foo.mode == modeError) return nullptr;
+      if (foo.mode == modeError) return NULL;
       if (foo.mode == modeGF)
         {
           ERROR("not implemented yet");
-          return nullptr;
+          return NULL;
         }
 
       CFList I;
@@ -798,7 +798,7 @@ M2_arrayintOrNull rawIdealReorder(const Matrix *M)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -808,20 +808,20 @@ engine_RawMatrixArrayOrNull rawCharSeries(const Matrix *M)
   try
     {
       const PolynomialRing *P = M->get_ring()->cast_to_PolynomialRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected polynomial ring");
-          return nullptr;
+          return 0;
         }
 
       init_seeds();
 
       struct enter_factory foo(P);
-      if (foo.mode == modeError) return nullptr;
+      if (foo.mode == modeError) return NULL;
       if (foo.mode == modeGF)
         {
           ERROR("not implemented yet");
-          return nullptr;
+          return NULL;
         }
 
       CFList I;
@@ -854,7 +854,7 @@ engine_RawMatrixArrayOrNull rawCharSeries(const Matrix *M)
           for (ListIterator<CanonicalForm> j = u; j.hasItem(); j++)
             {
               result1->array[next1++] = convertToM2(P, j.getItem());
-              if (error()) return nullptr;
+              if (error()) return NULL;
             }
           result->array[next++] =
               IM2_Matrix_make1(M->rows(), u.length(), result1, false);
@@ -864,7 +864,7 @@ engine_RawMatrixArrayOrNull rawCharSeries(const Matrix *M)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 

--- a/M2/Macaulay2/e/interface/freemodule.cpp
+++ b/M2/Macaulay2/e/interface/freemodule.cpp
@@ -29,13 +29,13 @@ const FreeModule /* or null */ *IM2_FreeModule_make(const Ring *R, int rank)
       if (rank < 0)
         {
           ERROR("freemodule rank must be non-negative");
-          return nullptr;
+          return 0;
         }
       return R->make_FreeModule(rank);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -49,13 +49,13 @@ const FreeModule /* or null */ *IM2_FreeModule_make_degs(const Ring *R,
       if (eachdeg == 0)
         {
           ERROR("rawFreeModule: degree rank 0, but sequence of degrees given");
-          return nullptr;
+          return NULL;
         }
       unsigned int rank = degs->len / eachdeg;
       if (rank * eachdeg != degs->len)
         {
           ERROR("inappropriate number of degrees");
-          return nullptr;
+          return 0;
         }
       monomial deg = D->make_one();
       FreeModule *F = R->make_FreeModule();
@@ -68,7 +68,7 @@ const FreeModule /* or null */ *IM2_FreeModule_make_degs(const Ring *R,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -80,7 +80,7 @@ const FreeModule /* or null */ *IM2_FreeModule_make_schreyer(const Matrix *m)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -128,7 +128,7 @@ const FreeModule /* or null */ *IM2_FreeModule_tensor(const FreeModule *F,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -140,7 +140,7 @@ const FreeModule /* or null */ *IM2_FreeModule_dual(const FreeModule *F)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -152,7 +152,7 @@ const FreeModule *IM2_FreeModule_symm(int n, const FreeModule *F)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -164,7 +164,7 @@ const FreeModule *IM2_FreeModule_exterior(int n, const FreeModule *F)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -177,7 +177,7 @@ const FreeModule *IM2_FreeModule_submodule(const FreeModule *F,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -191,7 +191,7 @@ M2_arrayintOrNull rawFreeModuleSelectByDegrees(const FreeModule *F,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 

--- a/M2/Macaulay2/e/interface/groebner.cpp
+++ b/M2/Macaulay2/e/interface/groebner.cpp
@@ -156,11 +156,11 @@ Computation /* or null */ *IM2_GB_set_hilbert_function(Computation *C,
       if (G->get_ring()->get_degree_ring() != h->get_ring())
         {
           ERROR("expected Hilbert function hint to be in correct degree ring");
-          return nullptr;
+          return 0;
         }
-      if (G != nullptr) return G->set_hilbert_function(h);
+      if (G != 0) return G->set_hilbert_function(h);
       ERROR("computation type unknown or not implemented");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -294,7 +294,7 @@ Computation /* or null */ *rawStartComputation(Computation *C)
             }
         }
 
-      return error() ? nullptr : C;
+      return error() ? 0 : C;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -313,9 +313,9 @@ const Matrix /* or null */ *rawGBGetMatrix(Computation *C)
     {
       clear_emit_size();
       GBComputation *G = C->cast_to_GBComputation();
-      if (G != nullptr) return G->get_gb();
+      if (G != 0) return G->get_gb();
       ERROR("computation type unknown or not implemented");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -333,9 +333,9 @@ const Matrix /* or null */ *rawGBMinimalGenerators(Computation *C)
     {
       clear_emit_size();
       GBComputation *G = C->cast_to_GBComputation();
-      if (G != nullptr) return G->get_mingens();
+      if (G != 0) return G->get_mingens();
       ERROR("computation type unknown or not implemented");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -354,9 +354,9 @@ const Matrix /* or null */ *rawGBChangeOfBasis(Computation *C)
     {
       clear_emit_size();
       GBComputation *G = C->cast_to_GBComputation();
-      if (G != nullptr) return G->get_change();
+      if (G != 0) return G->get_change();
       ERROR("computation type unknown or not implemented");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -387,9 +387,9 @@ const Matrix /* or null */ *rawGBGetParallelLeadTerms(Computation *C,
     {
       clear_emit_size();
       GBComputation *G = C->cast_to_GBComputation();
-      if (G != nullptr) return G->get_parallel_lead_terms(w);
+      if (G != 0) return G->get_parallel_lead_terms(w);
       ERROR("computation type unknown or not implemented");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -408,9 +408,9 @@ const Matrix /* or null */ *rawGBSyzygies(Computation *C)
     {
       clear_emit_size();
       GBComputation *G = C->cast_to_GBComputation();
-      if (G != nullptr) return G->get_syzygies();
+      if (G != 0) return G->get_syzygies();
       ERROR("computation type unknown or not implemented");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -425,9 +425,9 @@ const Matrix /* or null */ *rawGBMatrixRemainder(Computation *C,
     {
       clear_emit_size();
       GBComputation *G = C->cast_to_GBComputation();
-      if (G != nullptr) return G->matrix_remainder(m);
+      if (G != 0) return G->matrix_remainder(m);
       ERROR("computation type unknown or not implemented");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -444,7 +444,7 @@ M2_bool IM2_GB_matrix_lift(Computation *C,
     {
       clear_emit_size();
       GBComputation *G = C->cast_to_GBComputation();
-      if (G != nullptr)
+      if (G != 0)
         return G->matrix_lift(m, result_remainder, result_quotient);
       else
         ERROR("computation type unknown or not implemented");
@@ -461,7 +461,7 @@ int IM2_GB_contains(Computation *C, const Matrix *m)
     {
       clear_emit_size();
       GBComputation *G = C->cast_to_GBComputation();
-      if (G != nullptr) return G->contains(m);
+      if (G != 0) return G->contains(m);
       ERROR("computation type unknown or not implemented");
       return -2;
   } catch (const exc::engine_error& e)
@@ -477,9 +477,9 @@ const Matrix /* or null */ *rawResolutionGetMatrix(Computation *C, int level)
     {
       clear_emit_size();
       ResolutionComputation *G = C->cast_to_ResolutionComputation();
-      if (G != nullptr) return G->get_matrix(level);
+      if (G != 0) return G->get_matrix(level);
       ERROR("expected resolution computation type");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -495,9 +495,9 @@ MutableMatrix /* or null */ *rawResolutionGetMatrix2(Computation *C,
     {
       clear_emit_size();
       ResolutionComputation *G = C->cast_to_ResolutionComputation();
-      if (G != nullptr) return G->get_matrix(level, degree);
+      if (G != 0) return G->get_matrix(level, degree);
       ERROR("expected resolution computation type");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -518,9 +518,9 @@ MutableMatrix /* or null */ *rawResolutionGetMutableMatrixB(Computation *C,
     {
       clear_emit_size();
       F4ResComputation *G = dynamic_cast<F4ResComputation *>(C);
-      if (G != nullptr) return G->get_mutable_matrix(R, level);
+      if (G != 0) return G->get_mutable_matrix(R, level);
       ERROR("expected fast nonminimal resolution computation type");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -538,9 +538,9 @@ MutableMatrix /* or null */ *rawResolutionGetMutableMatrix2B(
     {
       clear_emit_size();
       F4ResComputation *G = dynamic_cast<F4ResComputation *>(C);
-      if (G != nullptr) return G->get_mutable_matrix(KK, level, degree);
+      if (G != 0) return G->get_mutable_matrix(KK, level, degree);
       ERROR("expected fast nonminimal resolution computation type");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -554,9 +554,9 @@ const FreeModule /* or null */ *rawResolutionGetFree(Computation *C, int level)
     {
       clear_emit_size();
       ResolutionComputation *G = C->cast_to_ResolutionComputation();
-      if (G != nullptr) return G->get_free(level);
+      if (G != 0) return G->get_free(level);
       ERROR("expected resolution computation type");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
@@ -601,7 +601,7 @@ M2_arrayintOrNull rawResolutionBetti(Computation *C, int type)
   try
     {
       ResolutionComputation *G = C->cast_to_ResolutionComputation();
-      if (G != nullptr) return G->get_betti(type);
+      if (G != 0) return G->get_betti(type);
       ERROR("expected resolution computation type");
       return nullptr;
   } catch (const exc::engine_error& e)
@@ -634,10 +634,10 @@ Matrix /* or null */ *rawSubduction(int numparts, const Matrix *M,
   try
     {
       GBComputation *G = C->cast_to_GBComputation();
-      if (G == nullptr)
+      if (G == 0)
         {
           ERROR("expected a Groebner basis computation");
-          return nullptr;
+          return 0;
         }
       return sagbi::subduct(numparts, M, F, G);
   } catch (const exc::engine_error& e)
@@ -661,16 +661,16 @@ Matrix /* or null */ *rawSubduction1(int numparts,
     {
         GBComputation *gbReductionIdeal = rawGBReductionIdeal->cast_to_GBComputation();
         GBComputation *gbI = rawGBI->cast_to_GBComputation();
-        if ((gbReductionIdeal == nullptr) || (gbI == nullptr))
+        if ((gbReductionIdeal == 0) || (gbI == 0))
         {
             ERROR("expected a Groebner basis computation");
-            return nullptr;
+            return 0;
         }
         return sagbi::subduct1(numparts, rawT, rawS, m, inclusionAmbient, fullSubstitution, substitutionInclusion, gbI, gbReductionIdeal);
     } catch (const exc::engine_error& e)
     {
         ERROR(e.what());
-        return nullptr;
+        return NULL;
     }
 }
 
@@ -680,7 +680,7 @@ void rawDisplayMatrixStream(const Matrix *inputMatrix)
 {
   const Ring *R = inputMatrix->get_ring();
   const PolyRing *P = R->cast_to_PolyRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected a polynomial ring");
       return;
@@ -754,27 +754,27 @@ const Matrix *rawMGB(
     {
       const Ring *R = inputMatrix->get_ring();
       const PolyRing *P = R->cast_to_PolyRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected a polynomial ring");
-          return nullptr;
+          return 0;
         }
       if (nthreads < 0)
         {
           ERROR("mgb: expected a non-negative number of threads");
-          return nullptr;
+          return 0;
         }
       if (P->characteristic() > std::numeric_limits<int>::max())
         {
           ERROR("characteristic is too large for mathic gb computation");
-          return nullptr;
+          return 0;
         }
       if (P->characteristic() == 0)
         {
           ERROR(
               "characteristic for mathic gb computation must be a prime "
               "number");
-          return nullptr;
+          return 0;
         }
       if (not P->getCoefficientRing()->isFinitePrimeField())
         {
@@ -810,7 +810,7 @@ const Matrix *rawMGB(
           ERROR(
               "monomial ordering is not appropriate for Groebner basis "
               "computation");
-          return nullptr;
+          return 0;
         }
       if (!configuration.setMonomialOrder(
               (base_is_revlex
@@ -851,7 +851,7 @@ const Matrix *rawMGB(
       if (callback.wasInterrupted())
         {
           ERROR("computation was interrupted");
-          return nullptr;
+          return 0;
         }
       const Matrix *result = matStream.value();
       // printf("number of callbacks = %lu  result = %lu\n",

--- a/M2/Macaulay2/e/interface/matrix.cpp
+++ b/M2/Macaulay2/e/interface/matrix.cpp
@@ -57,14 +57,14 @@ const RingElement /* or null */ *IM2_Matrix_get_entry(const Matrix *M,
       if (r < 0 || r >= M->n_rows())
         {
           ERROR("matrix row index %d out of range 0 .. %d", r, M->n_rows() - 1);
-          return nullptr;
+          return 0;
         }
       if (c < 0 || c >= M->n_cols())
         {
           ERROR("matrix column index %d out of range 0 .. %d",
                 c,
                 M->n_cols() - 1);
-          return nullptr;
+          return 0;
         }
       ring_elem result;
       result = M->elem(r, c);
@@ -72,7 +72,7 @@ const RingElement /* or null */ *IM2_Matrix_get_entry(const Matrix *M,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -189,7 +189,7 @@ const Matrix /* or null */ *IM2_Matrix_remake1(const FreeModule *target,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -235,7 +235,7 @@ const Matrix /* or null */ *IM2_Matrix_concat(const engine_RawMatrixArray Ms)
       if (n == 0)
         {
           ERROR("matrix concat: expects at least one matrix");
-          return nullptr;
+          return 0;
         }
       const FreeModule *F = Ms->array[0]->rows();
       const Ring *R = F->get_ring();
@@ -247,12 +247,12 @@ const Matrix /* or null */ *IM2_Matrix_concat(const engine_RawMatrixArray Ms)
           if (F->get_ring() != M->get_ring())
             {
               ERROR("matrix concat: different base rings");
-              return nullptr;
+              return 0;
             }
           if (F->rank() != M->n_rows())
             {
               ERROR("matrix concat: row sizes are not equal");
-              return nullptr;
+              return 0;
             }
           for (int j = 0; j < M->n_cols(); j++)
             {
@@ -264,7 +264,7 @@ const Matrix /* or null */ *IM2_Matrix_concat(const engine_RawMatrixArray Ms)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -279,7 +279,7 @@ const Matrix /* or null */ *IM2_Matrix_direct_sum(
       if (n == 0)
         {
           ERROR("matrix direct sum: expects at least one matrix");
-          return nullptr;
+          return 0;
         }
       const Matrix *result = Ms->array[0];
       const Ring *R = result->get_ring();
@@ -287,7 +287,7 @@ const Matrix /* or null */ *IM2_Matrix_direct_sum(
         if (R != Ms->array[i]->get_ring())
           {
             ERROR("matrix direct sum: different base rings");
-            return nullptr;
+            return 0;
           }
       for (unsigned int i = 1; i < n; i++)
         result = result->direct_sum(Ms->array[i]);
@@ -296,7 +296,7 @@ const Matrix /* or null */ *IM2_Matrix_direct_sum(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -308,7 +308,7 @@ const Matrix /* or null */ *IM2_Matrix_tensor(const Matrix *M, const Matrix *N)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -320,7 +320,7 @@ const Matrix /* or null */ *rawModuleTensor(const Matrix *M, const Matrix *N)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -332,7 +332,7 @@ const Matrix /* or null */ *IM2_Matrix_transpose(const Matrix *M)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -346,7 +346,7 @@ const Matrix /* or null */ *IM2_Matrix_reshape(const Matrix *M,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -359,7 +359,7 @@ const Matrix /* or null */ *IM2_Matrix_flip(const FreeModule *F,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -374,7 +374,7 @@ const Matrix /* or null */ *rawWedgeProduct(int p, int q, const FreeModule *F)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -388,7 +388,7 @@ const Matrix /* or null */ *IM2_Matrix_submatrix(const Matrix *M,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -401,7 +401,7 @@ const Matrix /* or null */ *IM2_Matrix_submatrix1(const Matrix *M,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -413,7 +413,7 @@ const Matrix /* or null */ *IM2_Matrix_koszul(int p, const Matrix *M)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -429,13 +429,13 @@ const Matrix /* or null */ *rawKoszulMonomials(int nskew,
       if (M->get_ring() != N->get_ring())
         {
           ERROR("expected same ring");
-          return nullptr;
+          return 0;
         }
       return Matrix::koszul_monomials(nskew, M, N);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -447,7 +447,7 @@ const Matrix /* or null */ *IM2_Matrix_symm(int p, const Matrix *M)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -590,7 +590,7 @@ engine_RawMatrixPairOrNull rawTopCoefficients(const Matrix *M)
   Matrix *coeffs;
   Matrix *monoms;
   coeffs = M->top_coefficients(monoms);
-  if (coeffs == nullptr) return nullptr;
+  if (coeffs == NULL) return NULL;
   engine_RawMatrixPair result = new engine_RawMatrixPair_struct;
   result->a = monoms;
   result->b = coeffs;
@@ -654,7 +654,7 @@ const Matrix /* or null */ *IM2_Matrix_remove_content(const Matrix *M)
 #warning \
     "const Matrix /* or null */ * IM2_Matrix_remove_content(const Matrix *M) -- not implemented yet"
 #endif
-  return nullptr;
+  return NULL;
 }
 
 const Matrix /* or null */ *IM2_Matrix_promote(const FreeModule *newTarget,
@@ -674,14 +674,14 @@ const Matrix /* or null */ *IM2_Matrix_promote(const FreeModule *newTarget,
           else
             {
               ERROR("cannot promote given matrix");
-              return nullptr;
+              return 0;
             }
       mat.compute_column_degrees();
       return mat.to_matrix();
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -703,7 +703,7 @@ const Matrix /* or null */ *IM2_Matrix_lift(int *success_return,
           else
             {
               // ERROR("cannot lift given matrix");
-              return nullptr;
+              return 0;
             }
       mat.compute_column_degrees();
       *success_return = 1;
@@ -711,7 +711,7 @@ const Matrix /* or null */ *IM2_Matrix_lift(int *success_return,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 

--- a/M2/Macaulay2/e/interface/monoid.cpp
+++ b/M2/Macaulay2/e/interface/monoid.cpp
@@ -25,10 +25,10 @@ engine_RawMonoidOrNull IM2_Monoid_make(const MonomialOrdering* mo,
                                        M2_arrayint hefts)
 {
   const PolynomialRing* P = deg_ring->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   return Monoid::create(mo, names, P, degs, hefts);
 }
@@ -67,7 +67,7 @@ static void write_weights(std::vector<int>& grading,
 // vector with nwts '1's.
 {
   for (int i = 0; i < firstvar; i++) grading.push_back(0);
-  if (wts == nullptr)
+  if (wts == 0)
     for (int i = 0; i < nwts; i++) grading.push_back(1);
   else
     for (int i = 0; i < nwts; i++) grading.push_back(wts[i]);
@@ -207,7 +207,7 @@ M2_arrayint rawMonomialOrderingToMatrix(const struct MonomialOrdering* mo)
 {
   bool base;
   std::vector<int> mat;
-  M2_arrayint result = nullptr;
+  M2_arrayint result = 0;
   int component_is_before_row = 0;
   int component_direction = 0;
   if (monomialOrderingToMatrix(

--- a/M2/Macaulay2/e/interface/monomial-ideal.cpp
+++ b/M2/Macaulay2/e/interface/monomial-ideal.cpp
@@ -32,7 +32,7 @@ engine_RawMonomialIdealOrNull IM2_MonomialIdeal_make(const Matrix *m, int n)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -45,7 +45,7 @@ const Matrix /* or null */ *IM2_MonomialIdeal_to_matrix(const MonomialIdeal *I)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -90,7 +90,7 @@ const MonomialIdeal /* or null */ *rawRadicalMonomialIdeal(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -103,7 +103,7 @@ const MonomialIdeal /* or null */ *IM2_MonomialIdeal_intersect(
       if (I->get_ring() != J->get_ring())
         {
           ERROR("expected ideals in the same ring");
-          return nullptr;
+          return 0;
         }
       MonomialIdeal *result = I->intersect(*J);
       intern_monideal(result);
@@ -111,7 +111,7 @@ const MonomialIdeal /* or null */ *IM2_MonomialIdeal_intersect(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -129,7 +129,7 @@ const MonomialIdeal /* or null */ *rawColonMonomialIdeal1(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -142,7 +142,7 @@ const MonomialIdeal /* or null */ *rawColonMonomialIdeal2(
       if (I->get_ring() != J->get_ring())
         {
           ERROR("expected ideals in the same ring");
-          return nullptr;
+          return 0;
         }
       MonomialIdeal *result = I->quotient(*J);
       intern_monideal(result);
@@ -152,7 +152,7 @@ const MonomialIdeal /* or null */ *rawColonMonomialIdeal2(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -168,7 +168,7 @@ const MonomialIdeal /* or null */ *rawSaturateMonomialIdeal1(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -181,7 +181,7 @@ const MonomialIdeal /* or null */ *rawSaturateMonomialIdeal2(
       if (I->get_ring() != J->get_ring())
         {
           ERROR("expected ideals in the same ring");
-          return nullptr;
+          return 0;
         }
       MonomialIdeal *result = I->sat(*J);
       intern_monideal(result);
@@ -189,7 +189,7 @@ const MonomialIdeal /* or null */ *rawSaturateMonomialIdeal2(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -204,7 +204,7 @@ const MonomialIdeal /* or null */ *IM2_MonomialIdeal_borel(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -238,7 +238,7 @@ rawMonomialMinimalPrimes(const MonomialIdeal *I, int codim_limit, int count)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -255,7 +255,7 @@ const MonomialIdeal /* or null */ *rawMaximalIndependentSets(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -271,7 +271,7 @@ const RingElement /* or null */ *IM2_MonomialIdeal_Hilbert(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -296,7 +296,7 @@ class MyIdealConsumer : public Frobby::IdealConsumer, our_new_delete
   ~MyIdealConsumer()
   {
     freemem(exp);
-    J = nullptr;
+    J = 0;
   }
   virtual void consume(mpz_ptr *exponentVector)
   {
@@ -356,10 +356,10 @@ static MonomialIdeal *wrapperFrobbyAlexanderDual(const MonomialIdeal *I,
   if (nv == 0)
     {
       INTERNAL_ERROR("attempting to use frobby with zero variables");
-      return nullptr;
+      return 0;
     }
 
-  mpz_t *topvec = nullptr;
+  mpz_t *topvec = 0;
   if (top->len > 0)
     {
       topvec = newarray(mpz_t, top->len);
@@ -370,7 +370,7 @@ static MonomialIdeal *wrapperFrobbyAlexanderDual(const MonomialIdeal *I,
   MonomialIdeal *result = FrobbyAlexanderDual(I, topvec);
 
   // Clean up
-  if (topvec != nullptr)
+  if (topvec != 0)
     {
       for (int i = 0; i < top->len; i++) mpz_clear(topvec[i]);
       freemem(topvec);
@@ -409,7 +409,7 @@ const MonomialIdeal /* or null */ *rawAlexanderDual(const MonomialIdeal *I,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 

--- a/M2/Macaulay2/e/interface/monomial-ordering.cpp
+++ b/M2/Macaulay2/e/interface/monomial-ordering.cpp
@@ -20,14 +20,14 @@ static struct mon_part_rec_ *mo_make(enum MonomialOrdering_type type,
   result = getmemstructtype(mon_part);
   result->type = type;
   result->nvars = nvars;
-  if (wts != nullptr)
+  if (wts != 0)
     {
       int i;
       result->wts = getmematomicvectortype(int, nvars);
       for (i = 0; i < nvars; i++) result->wts[i] = wts[i];
     }
   else
-    result->wts = nullptr;
+    result->wts = 0;
   return result;
 }
 
@@ -38,7 +38,7 @@ static MonomialOrdering *make_mon_order(int n)
   z->len = n;
   z->_hash = next_hash++;
   int i;
-  for (i = 0; i < n; i++) z->array[i] = nullptr;
+  for (i = 0; i < n; i++) z->array[i] = NULL;
   return z;
 }
 
@@ -53,7 +53,7 @@ static MonomialOrdering *M2_mo_offset(const MonomialOrdering *mo, int offset)
         result->array[i] = mo_make(p->type, p->nvars, p->wts);
       else
         {
-          mon_part q = mo_make(MO_WEIGHTS, offset + p->nvars, nullptr);
+          mon_part q = mo_make(MO_WEIGHTS, offset + p->nvars, NULL);
           q->wts = getmemvectortype(int, q->nvars);
           for (j = 0; j < offset; j++) q->wts[j] = 0;
           for (; j < q->nvars; j++) q->wts[j] = p->wts[j - offset];
@@ -232,7 +232,7 @@ MonomialOrdering *MonomialOrderings::join(
           else
             {
               /* Shift the weights over by nvars_so_far */
-              mon_part q = mo_make(MO_WEIGHTS, nvars_so_far + p->nvars, nullptr);
+              mon_part q = mo_make(MO_WEIGHTS, nvars_so_far + p->nvars, NULL);
               q->wts = getmemvectortype(int, q->nvars);
               for (j = 0; j < nvars_so_far; j++) q->wts[j] = 0;
               for (; j < q->nvars; j++) q->wts[j] = p->wts[j - nvars_so_far];
@@ -358,7 +358,7 @@ std::string MonomialOrderings::toString(const MonomialOrdering *mo)
             o << "UNKNOWN";
             break;
         }
-      if (p->wts != nullptr) { ::toString(o, p->nvars, p->wts); }
+      if (p->wts != NULL) { ::toString(o, p->nvars, p->wts); }
       else if (p_ones)
         {
           ::ones(o, p->nvars);
@@ -439,7 +439,7 @@ M2_arrayint moGetWeightValues(const MonomialOrdering *mo)
 {
   int nvars = rawNumberOfVariables(mo);
   // grab the first weight vector
-  if (mo->len == 0) return nullptr;
+  if (mo->len == 0) return 0;
   if (mo->array[0]->type == MO_WEIGHTS)
     {
       int i;
@@ -449,7 +449,7 @@ M2_arrayint moGetWeightValues(const MonomialOrdering *mo)
       for (; i < nvars; i++) result->array[i] = 0;
       return result;
     }
-  return nullptr;
+  return 0;
 }
 
 int rawNumberOfInvertibleVariables(const MonomialOrdering *mo)
@@ -542,7 +542,7 @@ MonomialOrdering *rawLexMonomialOrdering(int nvars, int packing)
   else
     typ = MO_LEX;
 
-  p = mo_make(typ, nvars, nullptr);
+  p = mo_make(typ, nvars, NULL);
   result = make_mon_order(1);
   result->array[0] = p;
   return result;
@@ -561,7 +561,7 @@ MonomialOrdering /* or null */ *rawGRevLexMonomialOrdering(M2_arrayint degs,
     if (degs->array[i] <= 0)
       {
         ERROR("grevlex: expected all degrees to be positive");
-        return nullptr;
+        return NULL;
       }
     else if (degs->array[i] > 1)
       all_one = 0;
@@ -574,7 +574,7 @@ MonomialOrdering /* or null */ *rawGRevLexMonomialOrdering(M2_arrayint degs,
         typ = MO_GREVLEX4;
       else
         typ = MO_GREVLEX;
-      wts = nullptr;
+      wts = 0;
     }
   else
     {
@@ -595,7 +595,7 @@ MonomialOrdering /* or null */ *rawGRevLexMonomialOrdering(M2_arrayint degs,
 
 MonomialOrdering *rawRevLexMonomialOrdering(int nvars)
 {
-  mon_part p = mo_make(MO_REVLEX, nvars, nullptr);
+  mon_part p = mo_make(MO_REVLEX, nvars, NULL);
   MonomialOrdering *result = make_mon_order(1);
   result->array[0] = p;
   return result;
@@ -610,21 +610,21 @@ MonomialOrdering *rawWeightsMonomialOrdering(M2_arrayint wts)
 }
 MonomialOrdering *rawGroupLexMonomialOrdering(int nvars)
 {
-  mon_part p = mo_make(MO_LAURENT, nvars, nullptr);
+  mon_part p = mo_make(MO_LAURENT, nvars, 0);
   MonomialOrdering *result = make_mon_order(1);
   result->array[0] = p;
   return result;
 }
 MonomialOrdering *rawGroupRevLexMonomialOrdering(int nvars)
 {
-  mon_part p = mo_make(MO_LAURENT_REVLEX, nvars, nullptr);
+  mon_part p = mo_make(MO_LAURENT_REVLEX, nvars, 0);
   MonomialOrdering *result = make_mon_order(1);
   result->array[0] = p;
   return result;
 }
 MonomialOrdering *rawNClexMonomialOrdering(int nvars)
 {
-  mon_part p = mo_make(MO_NC_LEX, nvars, nullptr);
+  mon_part p = mo_make(MO_NC_LEX, nvars, 0);
   MonomialOrdering *result = make_mon_order(1);
   result->array[0] = p;
   return result;
@@ -632,7 +632,7 @@ MonomialOrdering *rawNClexMonomialOrdering(int nvars)
 MonomialOrdering *rawPositionMonomialOrdering(M2_bool up_or_down)
 {
   mon_part p =
-      mo_make((up_or_down ? MO_POSITION_UP : MO_POSITION_DOWN), 0, nullptr);
+      mo_make((up_or_down ? MO_POSITION_UP : MO_POSITION_DOWN), 0, NULL);
   MonomialOrdering *result = make_mon_order(1);
   result->array[0] = p;
   return result;
@@ -671,7 +671,7 @@ MonomialOrdering *rawJoinMonomialOrdering(engine_RawMonomialOrderingArray M)
           else
             {
               /* Shift the weights over by nvars_so_far */
-              mon_part q = mo_make(MO_WEIGHTS, nvars_so_far + p->nvars, nullptr);
+              mon_part q = mo_make(MO_WEIGHTS, nvars_so_far + p->nvars, NULL);
               q->wts = getmemvectortype(int, q->nvars);
               for (j = 0; j < nvars_so_far; j++) q->wts[j] = 0;
               for (; j < q->nvars; j++) q->wts[j] = p->wts[j - nvars_so_far];
@@ -815,7 +815,7 @@ M2_string IM2_MonomialOrdering_to_string(const MonomialOrdering *mo)
             break;
         }
       result = M2_join(result, M2_tostring(s));
-      if (p->wts != nullptr)
+      if (p->wts != NULL)
         result = M2_join(result, intarray_to_string(p->nvars, p->wts));
       else if (p_ones)
         result = M2_join(result, ones_to_string(p->nvars));

--- a/M2/Macaulay2/e/interface/mutable-matrix.cpp
+++ b/M2/Macaulay2/e/interface/mutable-matrix.cpp
@@ -29,7 +29,7 @@ MutableMatrix *IM2_MutableMatrix_identity(const Ring *R,
   if (n < 0)
     {
       ERROR("expected non-negative integer");
-      return nullptr;
+      return 0;
     }
   size_t nrows = static_cast<size_t>(n);
   return internMutableMatrix(MutableMatrix::identity(R, nrows, is_dense));
@@ -181,12 +181,12 @@ IM2_MutableMatrix_get_entry(const MutableMatrix *M, int r, int c)
   if (r < 0 || r >= M->n_rows())
     {
       ERROR("matrix row index %d out of range 0 .. %d", r, M->n_rows() - 1);
-      return nullptr;
+      return 0;
     }
   if (c < 0 || c >= M->n_cols())
     {
       ERROR("matrix column index %d out of range 0 .. %d", c, M->n_cols() - 1);
-      return nullptr;
+      return 0;
     }
   ring_elem result;
   M->get_entry(r, c, result);
@@ -487,7 +487,7 @@ MutableMatrix /* or null */ *rawMutableMatrixTranspose(MutableMatrix *M)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -598,7 +598,7 @@ M2_arrayintOrNull rawLU(const MutableMatrix *A,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -615,7 +615,7 @@ M2_arrayintOrNull rawLUincremental(M2_arrayintOrNull P,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -779,7 +779,7 @@ const RingElement *rawLinAlgDeterminant(MutableMatrix *A)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -788,12 +788,12 @@ MutableMatrix *rawLinAlgInverse(MutableMatrix *A)
   try
     {
       MutableMatrix *B = A->invert();
-      if (B==nullptr) ERROR("matrix not invertible");
+      if (B==0) ERROR("matrix not invertible");
       return internMutableMatrix(B);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -805,7 +805,7 @@ MutableMatrix *rawLinAlgRREF(MutableMatrix *A)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -817,7 +817,7 @@ M2_arrayintOrNull rawLinAlgRankProfile(MutableMatrix *A, M2_bool row_profile)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -829,7 +829,7 @@ MutableMatrix *rawLinAlgNullSpace(MutableMatrix *A)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -841,19 +841,19 @@ MutableMatrix *rawLinAlgSolve(const MutableMatrix *A,
     {
       *success = 1;
       MutableMatrix *result = A->solveLinear(B);
-      if (result != nullptr)
+      if (result != NULL)
         {
           return internMutableMatrix(result);
         }
       else
         {
-          return nullptr;
+          return NULL;
         }
   } catch (const exc::engine_error& e)
     {
       *success = 0;
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -865,19 +865,19 @@ MutableMatrix *rawLinAlgSolveInvertible(const MutableMatrix *A,
     {
       *success = 1;
       MutableMatrix *result = A->solveInvertible(B);
-      if (result != nullptr)
+      if (result != NULL)
         {
           return internMutableMatrix(result);
         }
       else
         {
-          return nullptr;
+          return NULL;
         }
   } catch (const exc::engine_error& e)
     {
       *success = 0;
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -923,7 +923,7 @@ MutableMatrix * /* or null */ rawLinAlgMult(const MutableMatrix *A,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -1030,7 +1030,7 @@ const Matrix /* or null */ *rawMatrixClean(gmp_RR epsilon, const Matrix *M)
       if (M->get_ring()->get_precision() == 0)
         {
           ERROR("expected ring over an RR or CC");
-          return nullptr;
+          return 0;
         }
       return M->clean(epsilon);
   } catch (const exc::engine_error& e)
@@ -1046,7 +1046,7 @@ const RingElement /* or null */ *rawRingElementClean(gmp_RR epsilon,
   if (R->get_precision() == 0)
     {
       ERROR("expected ring over an RR or CC");
-      return nullptr;
+      return 0;
     }
   return RingElement::make_raw(R, R->zeroize_tiny(epsilon, f->get_value()));
 }
@@ -1059,7 +1059,7 @@ MutableMatrix /* or null */ *rawMutableMatrixClean(gmp_RR epsilon,
       if (M->get_ring()->get_precision() == 0)
         {
           ERROR("expected ring over an RR or CC");
-          return nullptr;
+          return 0;
         }
       M->clean(epsilon);
       return M;
@@ -1075,7 +1075,7 @@ static gmp_RRmutable get_norm_start(gmp_RR p, const Ring *R)
   if (R->get_precision() == 0)
     {
       ERROR("expected ring over an RR or CC");
-      return nullptr;
+      return 0;
     }
   gmp_RRmutable norm = getmemstructtype(gmp_RRmutable);
   mpfr_init2(norm, mpfr_get_prec(p));
@@ -1084,7 +1084,7 @@ static gmp_RRmutable get_norm_start(gmp_RR p, const Ring *R)
     {
       ERROR("Lp norm only implemented for p = infinity");
       mpfr_clear(norm);
-      return nullptr;
+      return 0;
     }
   return norm;
 }
@@ -1093,7 +1093,7 @@ gmp_RRorNull rawMatrixNorm(gmp_RR p, const Matrix *M) { return M->norm(p); }
 gmp_RRorNull rawRingElementNorm(gmp_RR p, const RingElement *f)
 {
   gmp_RRmutable norm = get_norm_start(p, f->get_ring());
-  if (!norm) return nullptr;  // error already given.
+  if (!norm) return 0;  // error already given.
   f->get_ring()->increase_maxnorm(norm, f->get_value());
   return moveTo_gmpRR(norm);
 }

--- a/M2/Macaulay2/e/interface/polyroots.cpp
+++ b/M2/Macaulay2/e/interface/polyroots.cpp
@@ -27,7 +27,7 @@ engine_RawRingElementArrayOrNull rawRoots(const RingElement *p,
   const Ring *R = p->get_ring();
   const PolynomialRing *P = R->cast_to_PolynomialRing();
   const Monoid *M = P->getMonoid();
-  if (P == nullptr) {
+  if (P == 0) {
     ERROR("expected a polynomial ring");
     return nullptr;
   }

--- a/M2/Macaulay2/e/interface/random.cpp
+++ b/M2/Macaulay2/e/interface/random.cpp
@@ -55,7 +55,7 @@ gmp_ZZ rawRandomInteger(gmp_ZZ maxN)
 {
   mpz_ptr result = getmemstructtype(mpz_ptr);
   mpz_init(result);
-  if (maxN == nullptr)
+  if (maxN == 0)
     mpz_urandomm(result, state, maxHeight);
   else if (1 != mpz_sgn(maxN))
     {
@@ -73,7 +73,7 @@ gmp_QQ rawRandomQQ(gmp_ZZ height)
 {
   mpq_ptr result = getmemstructtype(mpq_ptr);
   mpq_init(result);
-  if (height == nullptr) height = maxHeight;
+  if (height == 0) height = maxHeight;
   mpz_urandomm(mpq_numref(result), state, height);
   mpz_urandomm(mpq_denref(result), state, height);
   mpz_add_ui(mpq_numref(result), mpq_numref(result), 1);
@@ -86,7 +86,7 @@ void rawSetRandomQQ(mpq_ptr result, gmp_ZZ height)
 /* returns random a/b, where 1 <= b <= height, 1 <= a <= height */
 /* if height is the null pointer, use the default height */
 {
-  if (height == nullptr) height = maxHeight;
+  if (height == 0) height = maxHeight;
   mpz_urandomm(mpq_numref(result), state, height);
   mpz_urandomm(mpq_denref(result), state, height);
   mpz_add_ui(mpq_numref(result), mpq_numref(result), 1);

--- a/M2/Macaulay2/e/interface/ring.cpp
+++ b/M2/Macaulay2/e/interface/ring.cpp
@@ -66,7 +66,7 @@ const Ring /* or null */ *IM2_Ring_ZZp(int p)
   if (p <= 1 || p >= 32750)
     {
       ERROR("ZZP: expected a prime number p in range 2 <= p <= 32749");
-      return nullptr;
+      return 0;
     }
   return Z_mod::create(p);
 }
@@ -83,7 +83,7 @@ const Ring /* or null */ *rawGaloisField(const RingElement *f)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -119,7 +119,7 @@ const Ring /* or null */ *IM2_Ring_polyring(const Ring *K, const Monoid *M)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -138,7 +138,7 @@ const Ring * /* or null */ rawDividedPowerRing(const Ring *K, const Monoid *M)
   }
 #endif
   ERROR("not yet implemented");
-  return nullptr;
+  return 0;
 }
 
 const Ring /* or null */ *IM2_Ring_skew_polyring(const Ring *R,
@@ -147,10 +147,10 @@ const Ring /* or null */ *IM2_Ring_skew_polyring(const Ring *R,
   try
     {
       const PolynomialRing *P = R->cast_to_PolynomialRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected a polynomial ring");
-          return nullptr;
+          return 0;
         }
       SkewPolynomialRing *result = SkewPolynomialRing::create(
           P->getCoefficients(), P->getMonoid(), skewvars);
@@ -159,7 +159,7 @@ const Ring /* or null */ *IM2_Ring_skew_polyring(const Ring *R,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -171,10 +171,10 @@ const Ring /* or null */ *IM2_Ring_weyl_algebra(const Ring *R,
   try
     {
       const PolynomialRing *P = R->cast_to_PolynomialRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected a polynomial ring");
-          return nullptr;
+          return 0;
         }
       WeylAlgebra *result = WeylAlgebra::create(P->getCoefficients(),
                                                 P->getMonoid(),
@@ -186,7 +186,7 @@ const Ring /* or null */ *IM2_Ring_weyl_algebra(const Ring *R,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -196,10 +196,10 @@ const Ring /* or null */ *IM2_Ring_solvable_algebra(const Ring *R,
   try
     {
       const PolynomialRing *P = R->cast_to_PolynomialRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected a polynomial ring");
-          return nullptr;
+          return 0;
         }
       SolvableAlgebra *result = SolvableAlgebra::create(P, Q);
       intern_polyring(result);
@@ -207,7 +207,7 @@ const Ring /* or null */ *IM2_Ring_solvable_algebra(const Ring *R,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -241,7 +241,7 @@ const Ring* /* or null */ rawRingM2FreeAlgebra(const Ring* coefficientRing,
   }
   catch (exc::engine_error& e) {
     ERROR(e.what());
-    return nullptr;
+    return NULL;
   }
 }
 
@@ -294,7 +294,7 @@ const Ring* /* or null */ rawRingM2FreeAlgebraQuotient(const Matrix* GB, int max
   }
   catch (exc::engine_error& e) {
     ERROR(e.what());
-    return nullptr;
+    return NULL;
   }
 }
 
@@ -304,46 +304,46 @@ const Ring /* or null */ *IM2_Ring_frac(const Ring *R)
     {
       if (R == globalZZ) return globalQQ;
       const PolyRingFlat *P = R->cast_to_PolyRingFlat();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected polynomial ring");
-          return nullptr;
+          return 0;
         }
       if (P->getMonoid()->numNonTermOrderVariables() > 0)
         {
           ERROR(
               "cannot currently make fraction field over a polynomial ring "
               "with a non-global monomial order");
-          return nullptr;
+          return 0;
         }
       if (P->getMonoid()->numInvertibleVariables() > 0)
         {
           ERROR(
               "cannot currently make fraction field over a polynomial ring "
               "with Laurent variables, i.e. Inverses=>true set");
-          return nullptr;
+          return 0;
         }
       if (R->get_precision() > 0)
         {
           ERROR("cannot make fraction field over approximate field base");
-          return nullptr;
+          return 0;
         }
-      if (P->getCoefficients()->cast_to_FractionField() != nullptr)
+      if (P->getCoefficients()->cast_to_FractionField() != 0)
         {
           ERROR(
               "fraction fields over other fraction fields not yet implemented");
-          return nullptr;
+          return 0;
         }
-      if (P->getCoefficients()->cast_to_LocalRing() != nullptr)
+      if (P->getCoefficients()->cast_to_LocalRing() != 0)
         {
           ERROR("fraction fields over other local rings not yet implemented");
-          return nullptr;
+          return 0;
         }
       return FractionField::create(P);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -372,7 +372,7 @@ const Ring /* or null */ *IM2_Ring_localization(const Ring *R, Computation *C)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -387,7 +387,7 @@ const Ring /* or null */ *IM2_Ring_quotient(const Ring *R, const Matrix *I)
       if (I->n_rows() != 1)
         {
           ERROR("expected a one row matrix of quotient elements");
-          return nullptr;
+          return 0;
         }
       const PolynomialRing *P = R->cast_to_PolynomialRing();
       if (P != nullptr)
@@ -407,7 +407,7 @@ const Ring /* or null */ *IM2_Ring_quotient(const Ring *R, const Matrix *I)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -421,15 +421,15 @@ const Ring /* or null */ *IM2_Ring_quotient1(const Ring *R, const Ring *B)
     {
       const PolynomialRing *R1 = R->cast_to_PolynomialRing();
       const PolynomialRing *B1 = B->cast_to_PolynomialRing();
-      if (R1 == nullptr || B1 == nullptr)
+      if (R1 == 0 || B1 == 0)
         {
           ERROR("expected a polynomial ring");
-          return nullptr;
+          return 0;
         }
       if (R1->n_quotients() > 0)
         {
           ERROR("encountered quotient polynomial ring");
-          return nullptr;
+          return 0;
         }
       PolynomialRing *result = PolyRingQuotient::create_quotient(R1, B1);
       intern_polyring(result);
@@ -437,7 +437,7 @@ const Ring /* or null */ *IM2_Ring_quotient1(const Ring *R, const Ring *B)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -446,10 +446,10 @@ const Ring /* or null */ *IM2_Ring_schur(const Ring *R)
   try
     {
       const PolynomialRing *P = R->cast_to_PolynomialRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("Schur ring construction: expected a polynomial ring");
-          return nullptr;
+          return 0;
         }
       SchurRing *result = SchurRing::create(P);
       intern_polyring(result);
@@ -457,7 +457,7 @@ const Ring /* or null */ *IM2_Ring_schur(const Ring *R)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -470,7 +470,7 @@ const Ring *rawSchurRing1(const Ring *A)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -483,7 +483,7 @@ const Ring *rawSchurRing2(const Ring *A, int n)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -496,7 +496,7 @@ const Ring *rawSchurSnRing(const Ring *A, int n)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -511,16 +511,16 @@ const Ring /* or null */ *rawTowerRing2(const Ring *R1,
   try
     {
       const Tower *R = R1->cast_to_Tower();
-      if (R == nullptr)
+      if (R == 0)
         {
           ERROR("expected a tower coefficient ring");
-          return nullptr;
+          return 0;
         }
       return Tower::create(R, new_names);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return 0;
   }
 }
 
@@ -530,10 +530,10 @@ const Ring /* or null */ *rawTowerRing3(const Ring *R1,
   try
     {
       const Tower *R = R1->cast_to_Tower();
-      if (R == nullptr)
+      if (R == 0)
         {
           ERROR("expected a tower coefficient ring");
-          return nullptr;
+          return 0;
         }
       VECTOR(ring_elem) extensions;
       for (int i = 0; i < eqns->len; i++)
@@ -542,7 +542,7 @@ const Ring /* or null */ *rawTowerRing3(const Ring *R1,
           if (f->get_ring() != R1)
             {
               ERROR("extension element has incorrect base ring");
-              return nullptr;
+              return 0;
             }
           extensions.push_back(f->get_value());
         }
@@ -550,7 +550,7 @@ const Ring /* or null */ *rawTowerRing3(const Ring *R1,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return 0;
   }
 }
 
@@ -586,10 +586,10 @@ const Ring /* or null */ *rawAmbientRing(const Ring *R)
    engine. */
 {
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   return P->getAmbientRing();
 }
@@ -600,10 +600,10 @@ const Ring /* or null */ *rawDenominatorRing(const Ring *R)
    is returned. This routine is provided only for debugging the engine. */
 {
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   return P->getDenominatorRing();
 }

--- a/M2/Macaulay2/e/interface/ringelement.cpp
+++ b/M2/Macaulay2/e/interface/ringelement.cpp
@@ -64,7 +64,7 @@ const RingElement *IM2_RingElement_from_BigComplex(const Ring *R, gmp_CC z)
   ring_elem f;
   if (R->from_BigComplex(z, f)) return RingElement::make_raw(R, f);
   ERROR("cannot create element of this ring from an element of CC");
-  return nullptr;
+  return 0;
 }
 
 const RingElement *IM2_RingElement_from_BigReal(const Ring *R, gmp_RR z)
@@ -72,7 +72,7 @@ const RingElement *IM2_RingElement_from_BigReal(const Ring *R, gmp_RR z)
   ring_elem f;
   if (R->from_BigReal(z, f)) return RingElement::make_raw(R, f);
   ERROR("cannot create element of this ring from an element of RR");
-  return nullptr;
+  return 0;
 }
 
 const RingElement *IM2_RingElement_from_Interval(const Ring *R, gmp_RRi z)
@@ -80,7 +80,7 @@ const RingElement *IM2_RingElement_from_Interval(const Ring *R, gmp_RRi z)
    ring_elem f;
    if (R->from_Interval(z, f)) return RingElement::make_raw(R, f);
    ERROR("cannot create element of this ring from an element of RRi");
-   return nullptr;
+   return 0;
 }
 
 gmp_ZZorNull IM2_RingElement_to_Integer(const RingElement *a)
@@ -106,7 +106,7 @@ gmp_ZZorNull IM2_RingElement_to_Integer(const RingElement *a)
       return result;
     }
   ERROR("Expected ZZ or ZZ/p as base ring");
-  return nullptr;
+  return 0;
 }
 
 gmp_QQorNull IM2_RingElement_to_rational(const RingElement *a)
@@ -175,7 +175,7 @@ gmp_CCorNull IM2_RingElement_to_BigComplex(const RingElement *a)
 {
   const Ring *R = a->get_ring();
   auto RCCC = dynamic_cast<const M2::ConcreteRing<M2::ARingCCC> *>(R);
-  if (RCCC != nullptr)
+  if (RCCC != 0)
     {
       const M2::ARingCCC::ElementType &b =
           RCCC->ring().from_ring_elem_const(a->get_value());
@@ -183,7 +183,7 @@ gmp_CCorNull IM2_RingElement_to_BigComplex(const RingElement *a)
       return result;
     }
   auto RCC = dynamic_cast<const M2::ConcreteRing<M2::ARingCC> *>(R);
-  if (RCC != nullptr)
+  if (RCC != 0)
     {
       const M2::ARingCC::ElementType &b =
           RCC->ring().from_ring_elem_const(a->get_value());
@@ -191,7 +191,7 @@ gmp_CCorNull IM2_RingElement_to_BigComplex(const RingElement *a)
       return result;
     }
   ERROR("expected an element of CCC");
-  return nullptr;
+  return 0;
 }
 
 #if 0
@@ -235,12 +235,12 @@ const RingElement /* or null */ *IM2_RingElement_make_var(const Ring *R, int v)
   try
     {
       ring_elem a = R->var(v);
-      if (error()) return nullptr;
+      if (error()) return 0;
       return RingElement::make_raw(R, a);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -267,12 +267,12 @@ engine_RawRingElementPair IM2_RingElement_divmod(const RingElement *a,
           ERROR(
               "ring remainder requires both elements to have the same base "
               "ring");
-          return nullptr;
+          return 0;
         }
       ring_elem fquot;
       ring_elem frem =
           R->remainderAndQuotient(a->get_value(), b->get_value(), fquot);
-      if (error()) return nullptr;
+      if (error()) return NULL;
 
       engine_RawRingElementPair result = new engine_RawRingElementPair_struct;
       result->a = RingElement::make_raw(R, fquot);
@@ -281,7 +281,7 @@ engine_RawRingElementPair IM2_RingElement_divmod(const RingElement *a,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -313,11 +313,11 @@ const RingElement *IM2_RingElement_promote(const Ring *S, const RingElement *f)
 
       if (f->promote(S, result)) return result;
       ERROR("cannot promote given ring element");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -335,11 +335,11 @@ const RingElement /* or null */ *IM2_RingElement_lift(int *success_return,
           return result;
         }
       // ERROR("cannot lift given ring element");
-      return nullptr;
+      return 0;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -356,7 +356,7 @@ M2_arrayint IM2_RingElement_multidegree(const RingElement *a)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -369,7 +369,7 @@ const RingElement * /* or null */ rawRingElementAntipode(const RingElement *f)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -385,7 +385,7 @@ gmp_ZZpairOrNull rawWeightRange(M2_arrayint wts, const RingElement *a)
     {
       int lo, hi;
       a->degree_weights(wts, lo, hi);
-      if (error()) return nullptr;
+      if (error()) return 0;
       gmp_ZZpair p = new gmp_ZZpair_struct;
       p->a = newitem(__mpz_struct);
       p->b = newitem(__mpz_struct);
@@ -397,7 +397,7 @@ gmp_ZZpairOrNull rawWeightRange(M2_arrayint wts, const RingElement *a)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -413,7 +413,7 @@ const RingElement /* or null */ *IM2_RingElement_homogenize_to_degree(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -426,7 +426,7 @@ IM2_RingElement_homogenize(const RingElement *a, int v, M2_arrayint wts)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -498,7 +498,7 @@ const RingElement /* or null */ *IM2_RingElement_get_coeff(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -512,7 +512,7 @@ const RingElement /* or null */ *IM2_RingElement_lead_coeff(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -526,7 +526,7 @@ const EngineMonomial /* or null */ *IM2_RingElement_lead_monomial(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -582,10 +582,10 @@ engine_RawRingElementArray rawGetParts(const M2_arrayint wts,
   try
     {
       const PolynomialRing *P = f->get_ring()->cast_to_PolynomialRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected a polynomial");
-          return nullptr;
+          return 0;
         }
       long relems_len;
       ring_elem *relems = P->get_parts(wts, f->get_value(), relems_len);
@@ -599,7 +599,7 @@ engine_RawRingElementArray rawGetParts(const M2_arrayint wts,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -646,7 +646,7 @@ void convolve(const PolyRing *R,
         {
           ring_elem hr;
           Nterm *g = input_relems[j];
-          if (g != nullptr)
+          if (g != 0)
             {
               hr.poly_val =
                   R->mult_by_term(output_relems[i - j], g->coeff, g->monom);
@@ -680,13 +680,13 @@ engine_RawRingElementArrayOrNull rawConvolve(engine_RawRingElementArray H,
       if (len <= 1)
         {
           ERROR("expected ring element array of length at least 2");
-          return nullptr;
+          return 0;
         }
       const PolyRing *P = H->array[1]->get_ring()->cast_to_PolyRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected a polynomial ring");
-          return nullptr;
+          return 0;
         }
       VECTOR(ring_elem) input_relems(len);
       VECTOR(ring_elem) output_relems(len);
@@ -703,7 +703,7 @@ engine_RawRingElementArrayOrNull rawConvolve(engine_RawRingElementArray H,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -722,10 +722,10 @@ const RingElement /* or null */ *rawGetPart(const M2_arrayint wts,
   try
     {
       const PolynomialRing *P = f->get_ring()->cast_to_PolynomialRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected a polynomial");
-          return nullptr;
+          return 0;
         }
       ring_elem g = P->get_part(
           wts, f->get_value(), lobound_given, hibound_given, lobound, hibound);
@@ -733,7 +733,7 @@ const RingElement /* or null */ *rawGetPart(const M2_arrayint wts,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -757,22 +757,22 @@ const RingElement /* or null */ *rawAssociateDivisor(const RingElement *f)
   try
     {
       const PolyRing *P = f->get_ring()->cast_to_PolyRing();
-      if (P == nullptr)
+      if (P == 0)
         {
           ERROR("expected an element of a polynomial ring");
-          return nullptr;
+          return 0;
         }
       if (!P->getCoefficients()->has_associate_divisors())
         {
           ERROR("cannot find preferred associates for this ring");
-          return nullptr;
+          return 0;
         }
       return RingElement::make_raw(
           P->getCoefficients(), P->preferred_associate_divisor(f->get_value()));
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -806,7 +806,7 @@ const RingElement /* or null */ *IM2_RingElement_numerator(const RingElement *a)
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -819,7 +819,7 @@ const RingElement /* or null */ *IM2_RingElement_denominator(
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -830,12 +830,12 @@ const RingElement /* or null */ *IM2_RingElement_fraction(const Ring *R,
   try
     {
       const RingElement *f = a->fraction(R, b);
-      if (error()) return nullptr;
+      if (error()) return NULL;
       return f;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -844,17 +844,17 @@ gmp_ZZorNull rawSchurDimension(const RingElement *f)
   try
     {
       const SchurRing *S = f->get_ring()->cast_to_SchurRing();
-      if (S == nullptr)
+      if (S == 0)
         {
           ERROR("expected a polynomial over a Schur ring");
-          return nullptr;
+          return 0;
         }
       ring_elem result = S->dimension(f->get_value());
       return result.get_mpz();
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -865,22 +865,22 @@ const RingElement /* or null */ *rawSchurSnTensorMult(const RingElement *a,
   try
     {
       const SchurSnRing *R = a->get_ring()->cast_to_SchurSnRing();
-      if (R == nullptr)
+      if (R == 0)
         {
           ERROR("expected a SchurSn ring element");
-          return nullptr;
+          return 0;
         }
       if (R != b->get_ring())
         {
           ERROR("expected SchurSn ring elements");
-          return nullptr;
+          return 0;
         }
       ring_elem result = R->tensor_mult(a->get_value(), b->get_value());
       return RingElement::make_raw(R, result);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -894,20 +894,20 @@ const RingElement /* or null */ *rawSchurFromPartition(const Ring *R,
   try
     {
       const SchurRing2 *S = R->cast_to_SchurRing2();
-      if (S == nullptr)
+      if (S == 0)
         {
           ERROR("expected a Schur ring");
-          return nullptr;
+          return 0;
         }
       // Check that part is a partition, and that the number of parts is <=
       // number allowed
-      if (!S->is_valid_partition(part)) return nullptr;
+      if (!S->is_valid_partition(part)) return 0;
       ring_elem result = S->from_partition(part);
       return RingElement::make_raw(S, result);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 /* Special routines for tower rings */
@@ -917,7 +917,7 @@ int rawDegree(int v, const RingElement *f)
  * tower rings */
 {
   const Tower *R = f->get_ring()->cast_to_Tower();
-  if (R == nullptr) return -1;
+  if (R == 0) return -1;
   return R->degreeInVariable(v, f->get_value());
 }
 
@@ -925,7 +925,7 @@ int rawExtensionDegree(int firstvar, const Ring *R1)
 /* Currently only valid for tower rings.  Others return 0.  */
 {
   const Tower *R = R1->cast_to_Tower();
-  if (R == nullptr) return 0;
+  if (R == 0) return 0;
   if (firstvar < 0)
     {
       ERROR("use rawCharacteristic to find the characteristic");
@@ -937,10 +937,10 @@ int rawExtensionDegree(int firstvar, const Ring *R1)
 const RingElement /* or null */ *rawDiff(int v, const RingElement *f)
 {
   const Tower *R = f->get_ring()->cast_to_Tower();
-  if (R == nullptr)
+  if (R == 0)
     {
       ERROR("not implemented for this ring");
-      return nullptr;
+      return 0;
     }
   return RingElement::make_raw(R, R->differentiate(v, f->get_value()));
 }
@@ -948,10 +948,10 @@ const RingElement /* or null */ *rawDiff(int v, const RingElement *f)
 const RingElement /* or null */ *rawLowerP(const RingElement *f)
 {
   const Tower *R = f->get_ring()->cast_to_Tower();
-  if (R == nullptr)
+  if (R == 0)
     {
       ERROR("not implemented for this ring");
-      return nullptr;
+      return 0;
     }
   return RingElement::make_raw(R, R->lowerP(f->get_value()));
 }
@@ -961,15 +961,15 @@ const RingElement /* or null */ *rawPowerMod(const RingElement *f,
                                              const RingElement *g)
 {
   const Tower *R = f->get_ring()->cast_to_Tower();
-  if (R == nullptr)
+  if (R == 0)
     {
       ERROR("not implemented for this ring");
-      return nullptr;
+      return 0;
     }
   if (g->get_ring() != R)
     {
       ERROR("expected elements in the same ring");
-      return nullptr;
+      return 0;
     }
   return RingElement::make_raw(R,
                                R->power_mod(f->get_value(), n, g->get_value()));

--- a/M2/Macaulay2/e/interface/ringmap.cpp
+++ b/M2/Macaulay2/e/interface/ringmap.cpp
@@ -44,7 +44,7 @@ const RingElement /* or null */ *IM2_RingMap_eval_ringelem(const RingMap *F,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -55,7 +55,7 @@ const Matrix /* or null */ *IM2_RingMap_eval_matrix(const RingMap *F,
   if (newTarget->rank() < M->n_rows())
     {
       ERROR("expected FreeModule of rank at least %d", M->n_rows());
-      return nullptr;
+      return NULL;
     }
   try
     {
@@ -63,7 +63,7 @@ const Matrix /* or null */ *IM2_RingMap_eval_matrix(const RingMap *F,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 
@@ -78,7 +78,7 @@ MutableMatrix /* or null */ *rawRingMapEvalMutableMatrix(const RingMap *F,
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());
-      return nullptr;
+      return NULL;
   }
 }
 

--- a/M2/Macaulay2/e/lapack.cpp
+++ b/M2/Macaulay2/e/lapack.cpp
@@ -305,7 +305,7 @@ M2_arrayintOrNull Lapack::LU(const LMatrixRRR *A, LMatrixRRR *L, LMatrixRRR *U)
   if (info < 0)
     {
       ERROR("argument passed to dgetrf had an illegal value");
-      return nullptr;
+      return 0;
     }
 
   return result;
@@ -403,9 +403,9 @@ bool Lapack::eigenvalues(const LMatrixRRR *A, LMatrixCCC *eigvals)
          &size,
          real,
          imag,
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* left eigenvectors */
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* right eigenvectors */
          workspace,
          &wsize,
@@ -473,7 +473,7 @@ bool Lapack::eigenvectors(const LMatrixRRR *A,
          &size,
          real,
          imag,
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* left eigvecs */
          eigen,
          &size, /* right eigvecs */
@@ -1015,7 +1015,7 @@ M2_arrayintOrNull Lapack::LU(const LMatrixCCC *A, LMatrixCCC *L, LMatrixCCC *U)
     {
       ERROR("argument passed to zgetrf had an illegal value");
       freemem(result);
-      result = nullptr;
+      result = NULL;
     }
   else
     {
@@ -1156,9 +1156,9 @@ bool Lapack::eigenvalues(const LMatrixCCC *A, LMatrixCCC *eigvals)
          copyA,
          &size,
          evals,
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* left eigenvectors */
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* right eigenvectors */
          workspace,
          &wsize,
@@ -1226,7 +1226,7 @@ bool Lapack::eigenvectors(const LMatrixCCC *A,
          copyA,
          &size,
          evals,
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* left eigvecs */
          evecs,
          &size, /* right eigvecs */
@@ -1962,7 +1962,7 @@ M2_arrayintOrNull Lapack::LU(const LMatrixRR *A, LMatrixRR *L, LMatrixRR *U)
   if (info < 0)
     {
       ERROR("argument passed to dgetrf had an illegal value");
-      return nullptr;
+      return 0;
     }
 
   return result;
@@ -2060,9 +2060,9 @@ bool Lapack::eigenvalues(const LMatrixRR *A, LMatrixCC *eigvals)
          &size,
          real,
          imag,
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* left eigenvectors */
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* right eigenvectors */
          workspace,
          &wsize,
@@ -2130,7 +2130,7 @@ bool Lapack::eigenvectors(const LMatrixRR *A,
          &size,
          real,
          imag,
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* left eigvecs */
          eigen,
          &size, /* right eigvecs */
@@ -2895,7 +2895,7 @@ M2_arrayintOrNull Lapack::LU(const LMatrixCC *A, LMatrixCC *L, LMatrixCC *U)
     {
       ERROR("argument passed to zgetrf had an illegal value");
       freemem(result);
-      result = nullptr;
+      result = NULL;
     }
   else
     {
@@ -3036,9 +3036,9 @@ bool Lapack::eigenvalues(const LMatrixCC *A, LMatrixCC *eigvals)
          copyA,
          &size,
          evals,
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* left eigenvectors */
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* right eigenvectors */
          workspace,
          &wsize,
@@ -3106,7 +3106,7 @@ bool Lapack::eigenvectors(const LMatrixCC *A,
          copyA,
          &size,
          evals,
-         static_cast<double *>(nullptr),
+         static_cast<double *>(0),
          &size, /* left eigvecs */
          evecs,
          &size, /* right eigvecs */

--- a/M2/Macaulay2/e/localring.cpp
+++ b/M2/Macaulay2/e/localring.cpp
@@ -80,7 +80,7 @@ void LocalRing::simplify(local_elem *f) const
       x = f->numer;
       const RingElement *a = RingElement::make_raw(mRing, x);
       const RingElement *b = RingElement::make_raw(mRing, y);
-      const RingElement *c = rawGCDRingElement(a, b, nullptr, false);
+      const RingElement *c = rawGCDRingElement(a, b, NULL, false);
 
 #if 0
       // Debugging code
@@ -237,7 +237,7 @@ void LocalRing::lift_up(const Ring *R, const Matrix *m, Matrix *&result) const
         {
           const local_elem * f = ((*i)->coeff).get_local_elem();
           b = RingElement::make_raw(mRing, f->denom);
-          d = rawGCDRingElement(a, b, nullptr, false);
+          d = rawGCDRingElement(a, b, NULL, false);
 #if 0 // FIXME: GCD(8,2)=1 apparently ...
           // see https://github.com/Macaulay2/M2/issues/1958
           drelem(a);
@@ -385,9 +385,9 @@ void LocalRing::lower_content(ring_elem &c, const ring_elem g) const
   const RingElement *g1 = RingElement::make_raw(mRing, gf->numer);
   const RingElement *g2 = RingElement::make_raw(mRing, gf->denom);
 
-  c1 = rawGCDRingElement(c1, g1, nullptr, false);
+  c1 = rawGCDRingElement(c1, g1, NULL, false);
 
-  const RingElement *cc2 = rawGCDRingElement(c2, g2, nullptr, false);
+  const RingElement *cc2 = rawGCDRingElement(c2, g2, NULL, false);
   const RingElement *cc3 = (*c2) * (*g2);
   const RingElement *cc4 = (*cc3) / (*cc2);
 
@@ -739,7 +739,7 @@ extern "C" { // TODO: remove when this function is in e/interface
 Matrix *rawLiftLocalMatrix(const Ring *R, const Matrix *f)
 {
   const LocalRing *L = f->get_ring()->cast_to_LocalRing();
-  if (L == nullptr)
+  if (L == 0)
     {
       ERROR("expected an object over a local ring");
       return nullptr;
@@ -758,7 +758,7 @@ Matrix *rawLiftLocalMatrix(const Ring *R, const Matrix *f)
 M2_bool rawIsLocalUnit(const RingElement *f)
 {
   const LocalRing *L = f->get_ring()->cast_to_LocalRing();
-  if (L == nullptr)
+  if (L == 0)
     {
       ERROR("expected an object over a local ring");
       return false;

--- a/M2/Macaulay2/e/mat-linalg.hpp
+++ b/M2/Macaulay2/e/mat-linalg.hpp
@@ -989,7 +989,7 @@ inline size_t rank(const DMatQQFlint& A)
   // that matrix.
   fmpz_mat_t m1;
   fmpz_mat_init(m1, A.numRows(), A.numColumns());
-  fmpq_mat_get_fmpz_mat_rowwise(m1, nullptr, A.fmpq_mat());
+  fmpq_mat_get_fmpz_mat_rowwise(m1, NULL, A.fmpq_mat());
   // fmpz_mat_print_pretty(m1);
   size_t rk = fmpz_mat_rank(m1);
   fmpz_mat_clear(m1);
@@ -1019,7 +1019,7 @@ inline size_t nullSpace(const DMatQQFlint& A, DMatQQFlint& result_nullspace)
   fmpz_mat_t m2;
   fmpz_mat_init(m1, A.numRows(), A.numColumns());
   fmpz_mat_init(m2, A.numColumns(), A.numColumns());
-  fmpq_mat_get_fmpz_mat_rowwise(m1, nullptr, A.fmpq_mat());
+  fmpq_mat_get_fmpz_mat_rowwise(m1, NULL, A.fmpq_mat());
   // fmpz_mat_print_pretty(m1);
   size_t nullity = fmpz_mat_nullspace(m2, m1);
   // now copy the first 'nullity' columns into result_nullspace

--- a/M2/Macaulay2/e/mat.cpp
+++ b/M2/Macaulay2/e/mat.cpp
@@ -57,7 +57,7 @@ MutableMatrix *MutableMatrix::zero_matrix(const Ring *R,
                                           bool dense)
 {
   MutableMatrix *result = R->makeMutableMatrix(nrows, ncols, dense);
-  if (result != nullptr) return result;
+  if (result != 0) return result;
   // In this case, we just use ring elem arithmetic
   const CoefficientRingR *cR = R->getCoefficientRingR();
   if (dense)

--- a/M2/Macaulay2/e/matrix-con.cpp
+++ b/M2/Macaulay2/e/matrix-con.cpp
@@ -5,17 +5,17 @@
 #include <iostream>
 
 MatrixConstructor::MatrixConstructor()
-    : R(nullptr), rows(nullptr), cols(nullptr), cols_frozen(false), deg(nullptr)
+    : R(0), rows(0), cols(0), cols_frozen(false), deg(0)
 {
 }
 
 MatrixConstructor::MatrixConstructor(const FreeModule *target, int ncols)
-    : R(target->get_ring()), rows(target), cols(nullptr), cols_frozen(false), deg(nullptr)
+    : R(target->get_ring()), rows(target), cols(0), cols_frozen(false), deg(0)
 {
   cols = R->make_FreeModule(ncols);
 
   entries.reserve(ncols);
-  for (int i = 0; i < ncols; i++) entries.push_back(nullptr);
+  for (int i = 0; i < ncols; i++) entries.push_back(0);
 
   deg = R->degree_monoid()->make_one();
 }
@@ -26,9 +26,9 @@ MatrixConstructor::MatrixConstructor(const FreeModule *target,
     : R(target->get_ring()), rows(target), cols(source), cols_frozen(true)
 {
   entries.reserve(source->rank());
-  for (int i = 0; i < source->rank(); i++) entries.push_back(nullptr);
+  for (int i = 0; i < source->rank(); i++) entries.push_back(0);
 
-  deg = (deg0 == nullptr ? R->degree_monoid()->make_one()
+  deg = (deg0 == 0 ? R->degree_monoid()->make_one()
                    : R->degree_monoid()->make_new(deg0));
 }
 
@@ -36,7 +36,7 @@ void MatrixConstructor::append(vec v)
 {
   assert(!cols_frozen);
   monomial d = R->degree_monoid()->make_one();
-  if (v != nullptr) R->vec_multi_degree(rows, v, d);
+  if (v != 0) R->vec_multi_degree(rows, v, d);
   append(v, d);
   R->degree_monoid()->remove(d);
 }
@@ -84,7 +84,7 @@ void MatrixConstructor::compute_column_degree(int i)
     }
   monomial d = R->degree_monoid()->make_one();
   const vec v = entries[i];
-  if (v != nullptr) R->vec_multi_degree(rows, v, d);
+  if (v != 0) R->vec_multi_degree(rows, v, d);
   FreeModule *mutable_cols = const_cast<FreeModule *>(cols);
   mutable_cols->change_degree(i, d);
   R->degree_monoid()->remove(d);

--- a/M2/Macaulay2/e/matrix-con.hpp
+++ b/M2/Macaulay2/e/matrix-con.hpp
@@ -33,7 +33,7 @@ class MatrixConstructor
   MatrixConstructor(const FreeModule *target, int ncols);
   MatrixConstructor(const FreeModule *target,
                     const FreeModule *source,
-                    const_monomial deg = nullptr);
+                    const_monomial deg = 0);
 
   // The copy constructor just does the default thing: copy over all items.
 

--- a/M2/Macaulay2/e/matrix-kbasis.cpp
+++ b/M2/Macaulay2/e/matrix-kbasis.cpp
@@ -106,7 +106,7 @@ class KBasis
   ~KBasis() {}
   void compute();
 
-  Matrix *value() { return (kb_error ? nullptr : mat.to_matrix()); }
+  Matrix *value() { return (kb_error ? 0 : mat.to_matrix()); }
 
  public:
   static Matrix *k_basis(const Matrix *bottom,
@@ -139,7 +139,7 @@ KBasis::KBasis(const Matrix *bottom,
   M = P->getMonoid();
   D = P->get_degree_ring()->getMonoid();
 
-  if (lo_degree == nullptr && hi_degree == nullptr) { computation_type = KB_FULL; }
+  if (lo_degree == 0 && hi_degree == 0) { computation_type = KB_FULL; }
   else if (mHeftVector.size() == 1) { computation_type = KB_SINGLE; }
   else { computation_type = KB_MULTI; }
 
@@ -165,10 +165,10 @@ KBasis::KBasis(const Matrix *bottom,
   kb_exp = newarray_atomic_clear(int, P->n_vars());
   kb_exp_weight = 0;
 
-  if (lo_degree != nullptr)
+  if (lo_degree != NULL)
     kb_target_lo_weight =
         exponents::weight(mHeftVector.size(), lo_degree, mHeftVector);
-  if (hi_degree != nullptr)
+  if (hi_degree != NULL)
     kb_target_hi_weight =
         exponents::weight(mHeftVector.size(), hi_degree, mHeftVector);
 
@@ -184,12 +184,12 @@ KBasis::KBasis(const Matrix *bottom,
   mat = MatrixConstructor(bottom->rows(), 0);
   kb_exp_multidegree = D->make_one();
 
-  if (mHeftVector.size() > 1 && lo_degree != nullptr)
+  if (mHeftVector.size() > 1 && lo_degree != NULL)
     {
       kb_target_multidegree = D->make_one();
       exponents::copy(mHeftVector.size(), lo_degree, kb_target_multidegree);
     }
-  else { kb_target_multidegree = nullptr; }
+  else { kb_target_multidegree = 0; }
 }
 
 void KBasis::insert()
@@ -396,7 +396,7 @@ void KBasis::compute()
       // coeffs
 
       if (kb_monideal->is_one()) continue;
-      if (hi_degree == nullptr)
+      if (hi_degree == NULL)
         {
           // check here that kb_monideal is 0-dimensional
           // (at least for the variables being used):
@@ -475,28 +475,28 @@ Matrix /* or null */ *KBasis::k_basis(const Matrix *bottom,
   //
   // Do some checks first, return 0 if not good.
   const PolynomialRing *P = bottom->get_ring()->cast_to_PolynomialRing();
-  if (P == nullptr) return Matrix::identity(bottom->rows());
+  if (P == 0) return Matrix::identity(bottom->rows());
 
   const PolynomialRing *D = P->get_degree_ring();
-  const int *lo = lo_degree->len > 0 ? lo_degree->array : nullptr;
-  const int *hi = hi_degree->len > 0 ? hi_degree->array : nullptr;
+  const int *lo = lo_degree->len > 0 ? lo_degree->array : 0;
+  const int *hi = hi_degree->len > 0 ? hi_degree->array : 0;
 
   if (heftvec.size() > D->n_vars())
     {
       ERROR("expected heft vector of length <= %d", D->n_vars());
-      return nullptr;
+      return 0;
     }
 
   if (lo && heftvec.size() != lo_degree->len)
     {
       ERROR("expected degrees of length %d", heftvec.size());
-      return nullptr;
+      return 0;
     }
 
   if (hi && heftvec.size() != hi_degree->len)
     {
       ERROR("expected degrees of length %d", heftvec.size());
-      return nullptr;
+      return 0;
     }
 
   // If heftvec.size() is > 1, and both lo and hi are non-null,
@@ -506,7 +506,7 @@ Matrix /* or null */ *KBasis::k_basis(const Matrix *bottom,
       if (lo_degree->array[i] != hi_degree->array[i])
         {
           ERROR("expected degree bounds to be equal");
-          return nullptr;
+          return 0;
         }
 
   KBasis KB(bottom, lo, hi, heftvec, varlist, do_truncation, limit);
@@ -520,15 +520,15 @@ Matrix /* or null */ *KBasis::k_basis(const Matrix *bottom,
           ERROR(
               "basis: computation requires a heft form non-negative on the "
               "degrees of the variables");
-          return nullptr;
+          return 0;
         }
   // This next line will happen if both lo,hi degrees are given, and they are
   // different.  This can only be the singly generated case, and in that case
   // the degrees are in the wrong order, so return with 0 basis.
-  if (lo != nullptr && hi != nullptr && lo[0] > hi[0]) return KB.value();
+  if (lo != NULL && hi != NULL && lo[0] > hi[0]) return KB.value();
 
   KB.compute();
-  if (system_interrupted()) return nullptr;
+  if (system_interrupted()) return 0;
   return KB.value();
 }
 

--- a/M2/Macaulay2/e/matrix-sort.cpp
+++ b/M2/Macaulay2/e/matrix-sort.cpp
@@ -15,8 +15,8 @@ class MatrixSorter
     if (i == j) return 0;
     vec v1 = sort_vecs[i];
     vec v2 = sort_vecs[j];
-    if (v1 == nullptr) return 1;
-    if (v2 == nullptr) return -1;
+    if (v1 == NULL) return 1;
+    if (v2 == NULL) return -1;
     if (deg_ascending != 0)
       {
         int d1 = sort_degs[i];

--- a/M2/Macaulay2/e/matrix-stream.cpp
+++ b/M2/Macaulay2/e/matrix-stream.cpp
@@ -1,7 +1,7 @@
 #include "matrix-stream.hpp"
 
 MatrixStream::MatrixStream(const FreeModule* F)
-    : mFreeModule(F), mMatrixConstructor(F, 0), mValue(nullptr), mCurrentComponent(0)
+    : mFreeModule(F), mMatrixConstructor(F, 0), mValue(0), mCurrentComponent(0)
 {
   mPolyRing = F->get_ring()->cast_to_PolyRing();
   assert(mPolyRing != 0);
@@ -44,8 +44,8 @@ void MatrixStream::appendTermDone(Coefficient coefficient)
   Nterm* t = ring().new_term();
   ring().getMonoid()->from_expvector(mCurrentExponents, t->monom);
   t->coeff = ring().getCoefficients()->from_long(coefficient);
-  t->next = nullptr;
-  if (mLastTerms[mCurrentComponent] == nullptr)
+  t->next = 0;
+  if (mLastTerms[mCurrentComponent] == 0)
     {
       mCurrentColumn[mCurrentComponent] = t;
       mLastTerms[mCurrentComponent] = t;
@@ -67,8 +67,8 @@ void MatrixStream::appendPolynomialDone()
   mMatrixConstructor.append(v);
   for (int i = 0; i < mFreeModule->rank(); i++)
     {
-      mCurrentColumn[i] = nullptr;
-      mLastTerms[i] = nullptr;
+      mCurrentColumn[i] = 0;
+      mLastTerms[i] = 0;
     }
 }
 void MatrixStream::idealDone()

--- a/M2/Macaulay2/e/matrix-symm.cpp
+++ b/M2/Macaulay2/e/matrix-symm.cpp
@@ -9,7 +9,7 @@ class SymmMatrix
     if (m0->n_rows() != 1)
       {
         ERROR("expected one row");
-        return nullptr;
+        return 0;
       }
 
     SymmMatrix s(m0, p);

--- a/M2/Macaulay2/e/matrix.cpp
+++ b/M2/Macaulay2/e/matrix.cpp
@@ -463,7 +463,7 @@ Matrix /* or null */ *Matrix::sub_matrix(M2_arrayint r, M2_arrayint c) const
 {
   const FreeModule *F = rows()->sub_space(r);
   const FreeModule *G = cols()->sub_space(c);
-  if (F == nullptr || G == nullptr) return nullptr;
+  if (F == NULL || G == NULL) return nullptr;
 
   int *minrow = newarray_atomic(int, n_rows());
   int *maxrow = newarray_atomic(int, n_rows());
@@ -484,7 +484,7 @@ Matrix /* or null */ *Matrix::sub_matrix(M2_arrayint r, M2_arrayint c) const
   for (size_t j = 0; j < c->len; j++)
     {
       vec v = elem(c->array[j]);
-      for (; v != nullptr; v = v->next)
+      for (; v != NULL; v = v->next)
         for (int i = minrow[v->comp]; i <= maxrow[v->comp]; i++)
           if (v->comp == r->array[i])
             mat.set_entry(i, j, v->coeff);
@@ -497,7 +497,7 @@ Matrix /* or null */ *Matrix::sub_matrix(M2_arrayint r, M2_arrayint c) const
 Matrix /* or null */ *Matrix::sub_matrix(M2_arrayint c) const
 {
   const FreeModule *G = cols()->sub_space(c);
-  if (G == nullptr) return nullptr;
+  if (G == NULL) return nullptr;
 
   MatrixConstructor mat(rows(), G, degree_shift());
   for (unsigned int i = 0; i < c->len; i++)
@@ -524,7 +524,7 @@ Matrix /* or null */ *Matrix::reshape(const FreeModule *F,
   // EFFICIENCY: might be better to sort columns at end?
   MatrixConstructor mat(F, G, degree_shift());
   for (int c = 0; c < n_cols(); c++)
-    for (vecterm *p = elem(c); p != nullptr; p = p->next)
+    for (vecterm *p = elem(c); p != NULL; p = p->next)
       {
         // Determine new component
         int loc = c * n_rows() + p->comp;
@@ -760,7 +760,7 @@ Matrix *Matrix::tensor(const Matrix *m) const
   if (get_ring() != m->get_ring())
     {
       ERROR("matrix tensor: different base rings");
-      return nullptr;
+      return 0;
     }
 
   const FreeModule *F = rows()->tensor(m->rows());
@@ -1044,7 +1044,7 @@ Matrix *Matrix::divide_by_var(int n, int maxd, int &maxdivided) const
   maxdivided = 0;
   for (int i = 0; i < n_cols(); i++)
     {
-      if (elem(i) != nullptr)
+      if (elem(i) != NULL)
         {
           int lo, hi;
           P->vec_degree_of_var(n, elem(i), lo, hi);
@@ -1202,7 +1202,7 @@ Matrix /* or null */ *Matrix::koszul(const Matrix *r, const Matrix *c)
   const FreeModule *F = r->cols();
 
   const PolynomialRing *P = F->get_ring()->cast_to_PolynomialRing();
-  if (P == nullptr) return nullptr;
+  if (P == NULL) return nullptr;
   const Ring *K = P->getCoefficients();
   const Monoid *M = P->getMonoid();
 
@@ -1413,12 +1413,12 @@ Matrix *Matrix::remove_scalar_multiples() const
   for (int i = 0; i < n_cols(); i++)
     {
       vec f = elem(i);
-      if (f == nullptr) continue;
+      if (f == NULL) continue;
       keep = true;
       for (int j = i + 1; j < n_cols(); j++)
         {
           vec g = elem(j);
-          if (g == nullptr) continue;
+          if (g == NULL) continue;
           if (get_ring()->vec_is_scalar_multiple(f, g))
             {
               keep = false;
@@ -1734,7 +1734,7 @@ Matrix /* or null */ *Matrix::monomials(M2_arrayint vars) const
   MatrixConstructor mat(rows(), 0);
   const void **monoms = exponent_table_to_array(E);
   for (int i = 0; i < nvars; i++) exp[i] = 0;
-  for (int i = 0; monoms[i] != nullptr; i += 2)
+  for (int i = 0; monoms[i] != 0; i += 2)
     {
       const_exponents exp1 = reinterpret_cast<const_exponents>(monoms[i]);
       for (unsigned int j = 0; j < vars->len; j++)
@@ -1784,7 +1784,7 @@ static vec coeffs_of_vec(exponent_table *E,
 #warning "coeffs_of_vec should maybe be in PolynomialRing"
 #endif
 {
-  if (f == nullptr) return nullptr;
+  if (f == NULL) return nullptr;
   const PolynomialRing *P = F->get_ring()->cast_to_PolynomialRing();
   if (P == nullptr) return nullptr;
   const Monoid *M = P->getMonoid();

--- a/M2/Macaulay2/e/matrix.hpp
+++ b/M2/Macaulay2/e/matrix.hpp
@@ -245,14 +245,14 @@ class Matrix : public EngineObject
    public:
     //    iterator(const Matrix *M0, int col0=0) : M(M0), col(col0),
     //    v(M0->elem(col0)) {}
-    iterator(const Matrix *M0) : M(M0), col(-1), v(nullptr) {}
+    iterator(const Matrix *M0) : M(M0), col(-1), v(0) {}
     void set(int newcol)
     {
       col = newcol;
       v = M->elem(col);
     }
     void next() { v = v->next; }
-    bool valid() { return v != nullptr; }
+    bool valid() { return v != 0; }
     int row() { return v->comp; }
     ring_elem entry() { return v->coeff; }
   };

--- a/M2/Macaulay2/e/mem.cpp
+++ b/M2/Macaulay2/e/mem.cpp
@@ -11,12 +11,12 @@ int slab::n_slabs = 0;
 // Array of stashes of 2^n powers.
 // This looks thread unsafe, but is actually thread safe because it is only
 // initialized once when the engine is setup.
-doubling_stash *doubles = nullptr;
+doubling_stash *doubles = NULL;
 
 stash::stash(const char *s, size_t len)
     : name(s),
-      slabs(nullptr),
-      free_list(nullptr),
+      slabs(NULL),
+      free_list(NULL),
       n_allocs(0),
       n_inuse(0),
       highwater(0),
@@ -35,7 +35,7 @@ stash::stash(const char *s, size_t len)
 stash::~stash()
 {
   acquireSpinLock(&list_spinlock);
-  while (slabs != nullptr)
+  while (slabs != NULL)
     {
       slab *p = slabs;
       slabs = slabs->next;
@@ -55,7 +55,7 @@ void stash::chop_slab()
 
   // Time to chop it up.
 
-  char *prev = nullptr;
+  char *prev = NULL;
   char *current = slabs->s;
   for (int i = 0; i < n_per_slab; i++)
     {
@@ -134,7 +134,7 @@ doubling_stash::~doubling_stash()
 {
   for (int i = 0; i < NDOUBLES; i++)
     {
-      if (doubles[i] != nullptr)
+      if (doubles[i] != NULL)
         emit("internal warning -- deleting a double stash");
       freemem(doubles[i]);
     }
@@ -155,7 +155,7 @@ void *doubling_stash::new_elem(size_t size)
 
 void doubling_stash::delete_elem(void *p)
 {
-  if (p == nullptr) return;
+  if (p == NULL) return;
   int *q = (int *)p;
   q--;
   doubles[*q]->delete_elem(q);

--- a/M2/Macaulay2/e/mem.hpp
+++ b/M2/Macaulay2/e/mem.hpp
@@ -40,7 +40,7 @@ class slab : public our_new_delete
   slab *next;
   char s[slab_size];
 
-  slab() : next(nullptr) { n_slabs++; }
+  slab() : next(NULL) { n_slabs++; }
   ~slab() { n_slabs--; }
 };
 
@@ -96,7 +96,7 @@ inline void *stash::new_elem()
   n_allocs++;
   n_inuse++;
   if (n_inuse > highwater) highwater = n_inuse;
-  if (free_list == nullptr)
+  if (free_list == NULL)
     {
       if (n_per_slab == 0)
         {
@@ -117,7 +117,7 @@ inline void *stash::new_elem()
 inline void stash::delete_elem(void *p)
 // Delete the object 'p', placing it on the free list for this stash.
 {
-  if (p == nullptr) return;
+  if (p == NULL) return;
   freemem(p);
   return;
   //  if (trace_bad_deletes)

--- a/M2/Macaulay2/e/monideal-minprimes.cpp
+++ b/M2/Macaulay2/e/monideal-minprimes.cpp
@@ -10,7 +10,7 @@ MinimalPrimes::MinimalPrimes(const MonomialIdeal *const &I)
       mi(I->radical())
 {
   exps = newarray(int *, nvars + 2);
-  for (int i = 0; i <= nvars + 1; i++) exps[i] = nullptr;
+  for (int i = 0; i <= nvars + 1; i++) exps[i] = 0;
 
   primes = new MonomialIdeal(I->get_ring());
   codim_limit = 0;
@@ -19,7 +19,7 @@ MinimalPrimes::MinimalPrimes(const MonomialIdeal *const &I)
 MinimalPrimes::~MinimalPrimes()
 {
   for (int i = 0; i <= nvars + 1; i++)
-    if (exps[i] != nullptr) freemem(exps[i]);
+    if (exps[i] != 0) freemem(exps[i]);
   freemem(exps);
   delete primes;
   delete mi;
@@ -226,7 +226,7 @@ MonomialIdeal *MinimalPrimes::min_primes(int codim_limit0, int minprime_limit0)
   state = do_primes;
   n_minprimes = 0;
 
-  if (exps[0] == nullptr) exps[0] = newarray_atomic_clear(int, nvars);
+  if (exps[0] == 0) exps[0] = newarray_atomic_clear(int, nvars);
 
   while (codim_limit < codim_limit0)
     {
@@ -235,7 +235,7 @@ MonomialIdeal *MinimalPrimes::min_primes(int codim_limit0, int minprime_limit0)
     }
 
   MonomialIdeal *result = primes;
-  primes = nullptr;
+  primes = 0;
   return result;
 }
 
@@ -263,12 +263,12 @@ static int reduce_exp(const int *m, const int *exp)
 void MinimalPrimes::ass_prime_generator(Nmi_node *p, int codim)
 {
   int i = codim + 1;
-  if (exps[i] == nullptr) exps[i] = newarray_atomic(int, nvars);
+  if (exps[i] == 0) exps[i] = newarray_atomic(int, nvars);
   exponents_t exp0 = exps[i];
   for (int j = 0; j < nvars; j++) exp0[j] = exps[codim][j];
   for (;;)
     {
-      if (p == nullptr)
+      if (p == NULL)
         {
           if (state == do_codim)
             {

--- a/M2/Macaulay2/e/monideal.hpp
+++ b/M2/Macaulay2/e/monideal.hpp
@@ -100,7 +100,7 @@ class MonomialIdeal : public EngineObject
   virtual unsigned int computeHashValue() const;
 
  public:
-  MonomialIdeal(const PolynomialRing *RR, stash *mi_stash = nullptr);
+  MonomialIdeal(const PolynomialRing *RR, stash *mi_stash = 0);
   virtual ~MonomialIdeal() { remove_MonomialIdeal(); }
 
   MonomialIdeal(const PolynomialRing *R0,
@@ -120,7 +120,7 @@ class MonomialIdeal : public EngineObject
 
   // Informational
   int size() const { return count / 2; }
-  int topvar() const { return (mi == nullptr ? -1 : mi->var); }
+  int topvar() const { return (mi == NULL ? -1 : mi->var); }
   void text_out(buffer &o) const;
 
   const PolynomialRing *get_ring() const { return R; }
@@ -208,7 +208,7 @@ class MonomialIdeal : public EngineObject
   Iterator end() const { return Iterator(*this, 1); }
   void *next(void *p) const;
   void *prev(void *p) const;
-  int valid(void *p) const { return (p != nullptr); }
+  int valid(void *p) const { return (p != NULL); }
   void debug_out(int disp = 1) const;
   void debug_check() const;
 

--- a/M2/Macaulay2/e/monoid.cpp
+++ b/M2/Macaulay2/e/monoid.cpp
@@ -18,7 +18,7 @@
 #include "polyring.hpp"
 #include "util.hpp"
 
-Monoid *Monoid::trivial_monoid = nullptr;
+Monoid *Monoid::trivial_monoid = 0;
 
 // ONLY to be called by PolyRing::get_trivial_poly_ring()
 void Monoid::set_trivial_monoid_degree_ring(const PolynomialRing *DR)
@@ -38,7 +38,7 @@ Monoid::Monoid()
       degree_monoid_(nullptr),  // will be set later
       mo_(nullptr),
       monorder_(nullptr),
-      overflow(nullptr),
+      overflow(0),
       exp_size(0),
       monomial_size_(0),
       monomial_bound_(0),
@@ -54,7 +54,7 @@ Monoid::Monoid()
 Monoid::~Monoid() {}
 Monoid *Monoid::get_trivial_monoid()
 {
-  if (trivial_monoid == nullptr) trivial_monoid = new Monoid;
+  if (trivial_monoid == 0) trivial_monoid = new Monoid;
 
   return trivial_monoid;
 }
@@ -71,12 +71,12 @@ Monoid *Monoid::create(const MonomialOrdering *mo,
   if (degs->len != nvars * eachdeg)
     {
       ERROR("degree list should be of length %d", nvars * eachdeg);
-      return nullptr;
+      return 0;
     }
   if (nvars != names->len)
     {
       ERROR("expected %d variable names", nvars);
-      return nullptr;
+      return 0;
     }
 
   return new Monoid(mo, names, deg_ring, degs, hefts);
@@ -110,7 +110,7 @@ Monoid::Monoid(const MonomialOrdering *mo,
       degree_monoid_(deg_ring->getMonoid()),
       mo_(mo),
       monorder_(nullptr), // set below
-      overflow(nullptr),
+      overflow(0),
       exp_size(0), // set below
       monomial_size_(0), // set below
       monomial_bound_(0),
@@ -197,9 +197,9 @@ Monoid::Monoid(const MonomialOrdering *mo,
 
 void Monoid::set_degrees()
 {
-  if (degree_monoid_ == nullptr)
+  if (degree_monoid_ == NULL)
     {
-      degree_of_var_.push_back(static_cast<const_monomial>(nullptr));
+      degree_of_var_.push_back(static_cast<const_monomial>(NULL));
       return;
     }
 
@@ -353,7 +353,7 @@ void Monoid::text_out(buffer &o) const
     }
   o << "}";
 
-  if (heftvals_ != nullptr)
+  if (heftvals_ != NULL)
     {
       o << "," << newline << "  Heft => {";
       for (i = 0; i < heftvals_->len; i++)
@@ -364,7 +364,7 @@ void Monoid::text_out(buffer &o) const
       o << "}";
     }
 
-  if (mo_ != nullptr)
+  if (mo_ != 0)
     {
       o << "," << newline << "  ";
       o << IM2_MonomialOrdering_to_string(mo_);
@@ -491,14 +491,14 @@ int Monoid::compare(const_monomial m,
 
 monomial Monoid::make_new(const_monomial d) const
 {
-  if (nvars_ == 0) return nullptr;
+  if (nvars_ == 0) return NULL;
   monomial result = newarray_atomic(int, monomial_size());
   copy(d, result);
   return result;
 }
 monomial Monoid::make_one() const
 {
-  if (nvars_ == 0) return nullptr;
+  if (nvars_ == 0) return NULL;
   monomial result = newarray_atomic(int, monomial_size());
   one(result);
   return result;

--- a/M2/Macaulay2/e/monomial.cpp
+++ b/M2/Macaulay2/e/monomial.cpp
@@ -26,7 +26,7 @@ EngineMonomial::EngineMonomial(M2_arrayint m) { varpower::from_arrayint(m, val);
 EngineMonomial *EngineMonomial::make(int v, int e)
 {
   EngineMonomial *result = new EngineMonomial(v, e);
-  if (error()) return nullptr;
+  if (error()) return 0;
   return result;
 }
 
@@ -35,23 +35,23 @@ EngineMonomial *EngineMonomial::make(M2_arrayint m)
   if ((m->len % 2) != 0)
     {
       ERROR("Monomial expected an even number of elements");
-      return nullptr;
+      return 0;
     }
   for (unsigned int i = 2; i < m->len; i += 2)
     if (m->array[i - 2] <= m->array[i])
       {
         ERROR("Monomial expects variables in descending order");
-        return nullptr;
+        return 0;
       }
   EngineMonomial *result = new EngineMonomial(m);
-  if (error()) return nullptr;
+  if (error()) return 0;
   return result;
 }
 
 EngineMonomial *EngineMonomial::make(const int *vp)
 {
   EngineMonomial *result = new EngineMonomial(vp);
-  if (error()) return nullptr;
+  if (error()) return 0;
   return result;
 }
 
@@ -123,7 +123,7 @@ EngineMonomial *EngineMonomial::operator*(const EngineMonomial &b) const
 {
   EngineMonomial *result = new EngineMonomial;
   varpower::mult(ints(), b.ints(), result->val);
-  if (error()) return nullptr;
+  if (error()) return 0;
   return result;
 }
 
@@ -145,7 +145,7 @@ EngineMonomial *EngineMonomial::power(int n) const
 {
   EngineMonomial *result = new EngineMonomial;
   varpower::power(ints(), n, result->val);
-  if (error()) return nullptr;
+  if (error()) return 0;
   return result;
 }
 

--- a/M2/Macaulay2/e/montable.cpp
+++ b/M2/Macaulay2/e/montable.cpp
@@ -48,13 +48,13 @@ MonomialTable::mon_term *MonomialTable::make_list_head()
   mon_term *t = reinterpret_cast<mon_term *>(mon_term_stash->new_elem());
   t->_next = t->_prev = t;
   t->_val = -1;
-  t->_lead = nullptr;
+  t->_lead = 0;
   return t;
 }
 
 MonomialTable::MonomialTable()
 {
-  _last_match = nullptr;
+  _last_match = NULL;
   _last_match_comp = -1;
 }
 
@@ -67,7 +67,7 @@ MonomialTable *MonomialTable::make(int nvars)
   result->_count = 0;
   /* The first entry is a dummy entry.  Components
      will always start at 1. */
-  result->_head.push_back(nullptr);
+  result->_head.push_back(0);
 
   return result;
 }
@@ -85,7 +85,7 @@ MonomialTable::~MonomialTable()
           tmp->_next->_prev = t;
           mon_term_stash->delete_elem(tmp);
         }
-      _head[i] = nullptr;
+      _head[i] = 0;
     }
   delete mon_term_stash;
   _count = 0;
@@ -132,7 +132,7 @@ int MonomialTable::find_divisor(exponents_t exp, int comp)
 {
   assert(comp >= 1);
   if (comp >= static_cast<int>(_head.size())) return -1;
-  if (comp == _last_match_comp && _last_match != nullptr &&
+  if (comp == _last_match_comp && _last_match != NULL &&
       exponents::divides(_nvars, _last_match->_lead, exp))
     return _last_match->_val;
   unsigned long expmask = ~exponents::mask(_nvars, exp);
@@ -157,10 +157,10 @@ int MonomialTable::find_divisors(int max,
   assert(comp >= 1);
   assert(max != 0);
   if (comp >= static_cast<int>(_head.size())) return 0;
-  if (max == 1 && comp == _last_match_comp && _last_match != nullptr &&
+  if (max == 1 && comp == _last_match_comp && _last_match != NULL &&
       exponents::divides(_nvars, _last_match->_lead, exp))
     {
-      if (result != nullptr) result->push_back(_last_match);
+      if (result != NULL) result->push_back(_last_match);
       return 1;
     }
   mon_term *head = _head[comp];
@@ -179,7 +179,7 @@ int MonomialTable::find_divisors(int max,
             _last_match = t;
             _last_match_comp = comp;
             // move_up(t,head);
-            if (result != nullptr) result->push_back(t);
+            if (result != NULL) result->push_back(t);
             if (max >= 0 && nmatches >= max) break;
           }
       }
@@ -193,7 +193,7 @@ int MonomialTable::find_divisors(int max,
 MonomialTable::mon_term *MonomialTable::find_exact(exponents_t exp,
                                                    int comp) const
 {
-  if (comp >= static_cast<int>(_head.size())) return nullptr;
+  if (comp >= static_cast<int>(_head.size())) return 0;
   mon_term *head = _head[comp];
   mon_term *t;
   int i;
@@ -212,7 +212,7 @@ MonomialTable::mon_term *MonomialTable::find_exact(exponents_t exp,
             }
         if (is_eq) return t;
       }
-  return nullptr;
+  return 0;
 }
 
 void MonomialTable::insert(exponents_t exp, int comp, int id)

--- a/M2/Macaulay2/e/montable.hpp
+++ b/M2/Macaulay2/e/montable.hpp
@@ -67,7 +67,7 @@ class MonomialTable : public our_new_delete
   int find_divisors(int max,
                     exponents_t exp,
                     int comp,
-                    VECTOR(mon_term *) *result = nullptr);
+                    VECTOR(mon_term *) *result = 0);
   /* max: the max number of divisors to find.
      exp: the monomial whose divisors we seek.
      result: an array of mon_term's.

--- a/M2/Macaulay2/e/montableZZ.cpp
+++ b/M2/Macaulay2/e/montableZZ.cpp
@@ -55,7 +55,7 @@ MonomialTableZZ::mon_term *MonomialTableZZ::make_list_head()
   mon_term *t = new mon_term;
   t->_next = t->_prev = t;
   t->_val = -1;
-  t->_lead = nullptr;
+  t->_lead = 0;
   t->_coeff = nullptr;
   return t;
 }
@@ -68,7 +68,7 @@ MonomialTableZZ *MonomialTableZZ::make(int nvars)
   result->_count = 0;
   /* The first entry is a dummy entry.  Components
      will always start at 1. */
-  result->_head.push_back(nullptr);
+  result->_head.push_back(0);
 
   return result;
 }
@@ -173,7 +173,7 @@ int MonomialTableZZ::find_term_divisors(int max,
         if (is_div && mpz_divisible_p(coeff, t->_coeff))
           {
             nmatches++;
-            if (result != nullptr) result->push_back(t);
+            if (result != 0) result->push_back(t);
             if (max >= 0 && nmatches >= max) break;
           }
       }
@@ -183,7 +183,7 @@ int MonomialTableZZ::find_term_divisors(int max,
       o << "find_term_divisors called on ";
       show_mon_term(o, coeff, exp, comp);
       o << " #matches=" << nmatches << newline;
-      if (result != nullptr)
+      if (result != 0)
         for (int i = 0; i < result->size(); i++) show_mon_term(o, (*result)[i]);
       o << newline;
     }
@@ -241,7 +241,7 @@ bool MonomialTableZZ::is_weak_member(mpz_srcptr c, exponents_t exp, int comp) co
 
 bool MonomialTableZZ::is_strong_member(mpz_srcptr c, exponents_t exp, int comp) const
 {
-  return (find_term_divisors(1, c, exp, comp, nullptr) > 0);
+  return (find_term_divisors(1, c, exp, comp, 0) > 0);
 }
 
 int MonomialTableZZ::find_smallest_coeff_divisor(exponents_t exp, int comp) const
@@ -304,7 +304,7 @@ int MonomialTableZZ::find_monomial_divisors(int max,
         if (is_div)
           {
             nmatches++;
-            if (result != nullptr) result->push_back(t);
+            if (result != 0) result->push_back(t);
             if (max >= 0 && nmatches >= max) break;
           }
       }
@@ -315,7 +315,7 @@ int MonomialTableZZ::find_monomial_divisors(int max,
       o << "find_monomial_divisors called on ";
       show_mon_term(o, nullptr, exp, comp);
       o << " #matches=" << nmatches << newline;
-      if (result != nullptr)
+      if (result != 0)
         for (int i = 0; i < result->size(); i++) show_mon_term(o, (*result)[i]);
       o << newline;
     }
@@ -326,7 +326,7 @@ MonomialTableZZ::mon_term *MonomialTableZZ::find_exact(mpz_srcptr coeff,
                                                        exponents_t exp,
                                                        int comp) const
 {
-  if (comp >= static_cast<int>(_head.size())) return nullptr;
+  if (comp >= static_cast<int>(_head.size())) return 0;
   mon_term *head = _head[comp];
   mon_term *t;
   int i;
@@ -345,7 +345,7 @@ MonomialTableZZ::mon_term *MonomialTableZZ::find_exact(mpz_srcptr coeff,
             }
         if (is_eq && !mpz_cmp(coeff, t->_coeff)) return t;
       }
-  return nullptr;
+  return 0;
 }
 
 MonomialTableZZ::mon_term *MonomialTableZZ::find_exact_monomial(
@@ -353,12 +353,12 @@ MonomialTableZZ::mon_term *MonomialTableZZ::find_exact_monomial(
     int comp,
     int first_val) const
 {
-  if (comp >= static_cast<int>(_head.size())) return nullptr;
+  if (comp >= static_cast<int>(_head.size())) return 0;
   mon_term *head = _head[comp];
   mon_term *t;
   int i;
 
-  mon_term *result = nullptr;
+  mon_term *result = 0;
   int neqs = 0;
 
   unsigned long expmask = monomial_mask(_nvars, exp);
@@ -377,7 +377,7 @@ MonomialTableZZ::mon_term *MonomialTableZZ::find_exact_monomial(
               }
           if (is_eq)
             {
-              if (result == nullptr) result = t;
+              if (result == 0) result = t;
               neqs++;
             }
         }

--- a/M2/Macaulay2/e/montableZZ.hpp
+++ b/M2/Macaulay2/e/montableZZ.hpp
@@ -62,7 +62,7 @@ class MonomialTableZZ : public our_new_delete
                          mpz_srcptr coeff,
                          exponents_t exp,
                          int comp,
-                         VECTOR(mon_term *) *result = nullptr) const;
+                         VECTOR(mon_term *) *result = 0) const;
   /* max: the max number of divisors to find.
      exp: the monomial whose divisors we seek.
      result: an array of mon_term's.
@@ -71,7 +71,7 @@ class MonomialTableZZ : public our_new_delete
   int find_monomial_divisors(int max,
                              exponents_t exp,
                              int comp,
-                             VECTOR(mon_term *) *result = nullptr) const;
+                             VECTOR(mon_term *) *result = 0) const;
 
   mon_term *find_exact(mpz_srcptr coeff, exponents_t exp, int comp) const;
   /* If this returns non-NULL, it is valid to grab the 'val' field, and/or to

--- a/M2/Macaulay2/e/mutablecomplex.cpp
+++ b/M2/Macaulay2/e/mutablecomplex.cpp
@@ -33,7 +33,7 @@ size_t MutableComplex::complexity(const iterator &i, const size_t flags) const
   mDifferential[n]->get_entry(u.first, u.second, e);
   // Count terms in the column
   int s = 0;
-  if (mLocalRing == nullptr)
+  if (mLocalRing == 0)
     s = mPolynomialRing->n_terms(e);
   else
     s = mLocalRing->n_terms(e);
@@ -42,7 +42,7 @@ size_t MutableComplex::complexity(const iterator &i, const size_t flags) const
       if (r == u.first) continue;
       mDifferential[n]->get_entry(r, u.second, e);
       if (mRing->is_zero(e)) continue;
-      if (mLocalRing == nullptr)
+      if (mLocalRing == 0)
         s += mPolynomialRing->n_terms(e);
       else
         s += mLocalRing->n_terms(e);
@@ -53,7 +53,7 @@ size_t MutableComplex::complexity(const iterator &i, const size_t flags) const
       if (c == u.second) continue;
       mDifferential[n]->get_entry(u.first, c, e);
       if (mRing->is_zero(e)) continue;
-      if (mLocalRing == nullptr)
+      if (mLocalRing == 0)
         s += mPolynomialRing->n_terms(e);
       else
         s += mLocalRing->n_terms(e);

--- a/M2/Macaulay2/e/mutablecomplex.hpp
+++ b/M2/Macaulay2/e/mutablecomplex.hpp
@@ -20,7 +20,7 @@ class MutableComplex : public MutableEngineObject
   MutableComplex(VECTOR(MutableMatrix *) & D)
       : mRing(D[0]->get_ring()),
         mLocalRing(mRing->cast_to_LocalRing()),
-        mPolynomialRing(mLocalRing == nullptr ? mRing->cast_to_PolynomialRing()
+        mPolynomialRing(mLocalRing == 0 ? mRing->cast_to_PolynomialRing()
                                         : mLocalRing->get_ring()),
         mDifferential(D)
   {

--- a/M2/Macaulay2/e/mutablemat-defs.hpp
+++ b/M2/Macaulay2/e/mutablemat-defs.hpp
@@ -510,7 +510,7 @@ class MutableMat : public MutableMatrix
         {
           ERROR(
               "row index %d out of bounds 0..%d", rows->array[r], n_rows() - 1);
-          return nullptr;
+          return 0;
         }
     for (size_t c = 0; c < cols->len; c++)
       if (cols->array[c] < 0 || cols->array[c] >= n_cols())
@@ -518,7 +518,7 @@ class MutableMat : public MutableMatrix
           ERROR("column index %d out of bounds 0..%d",
                 cols->array[c],
                 n_cols() - 1);
-          return nullptr;
+          return 0;
         }
     MutableMat* result =
         new MutableMat(*this);  // zero matrix, over the same ring
@@ -534,7 +534,7 @@ class MutableMat : public MutableMatrix
           ERROR("column index %d out of bounds 0..%d",
                 cols->array[c],
                 n_cols() - 1);
-          return nullptr;
+          return 0;
         }
     MutableMat* result =
         new MutableMat(*this);  // zero matrix, over the same ring
@@ -546,9 +546,9 @@ class MutableMat : public MutableMatrix
   // promote, lift, eval ////////
   ///////////////////////////////
 
-  virtual MutableMatrix* promote(const Ring* S) const { return nullptr; }
-  virtual MutableMatrix* lift(const Ring* R) const { return nullptr; }
-  virtual MutableMatrix* eval(const RingMap* F) const { return nullptr; }
+  virtual MutableMatrix* promote(const Ring* S) const { return 0; }
+  virtual MutableMatrix* lift(const Ring* R) const { return 0; }
+  virtual MutableMatrix* eval(const RingMap* F) const { return 0; }
   ///////////////////////////////
   // Matrix operations //////////
   ///////////////////////////////

--- a/M2/Macaulay2/e/newdelete.hpp
+++ b/M2/Macaulay2/e/newdelete.hpp
@@ -75,7 +75,7 @@ struct our_new_delete
   {
     TRAPCHK_SIZE(size);
     void *p = getmem(size);
-    if (p == nullptr) outofmem2(size);
+    if (p == NULL) outofmem2(size);
     TRAPCHK(p);
     return p;
   }
@@ -83,7 +83,7 @@ struct our_new_delete
   {
     TRAPCHK_SIZE(size);
     void *p = getmem(size);
-    if (p == nullptr) outofmem2(size);
+    if (p == NULL) outofmem2(size);
     TRAPCHK(p);
     return p;
   }
@@ -91,12 +91,12 @@ struct our_new_delete
   static inline void operator delete(void *obj)
   {
     TRAPCHK(obj);
-    if (obj != nullptr) freemem(obj);
+    if (obj != NULL) freemem(obj);
   }
   static inline void operator delete[](void *obj)
   {
     TRAPCHK(obj);
-    if (obj != nullptr) freemem(obj);
+    if (obj != NULL) freemem(obj);
   }
 
   static inline void *operator new(size_t size, void *existing_memory)
@@ -140,11 +140,11 @@ public:
   our_gc_cleanup();
   virtual ~our_gc_cleanup()
   {
-  if (nullptr == GC_base(this)) return; // Non-heap object.
+  if (0 == GC_base(this)) return; // Non-heap object.
 #ifdef MEMDEBUG
     GC_REGISTER_FINALIZER_IGNORE_SELF(M2_debug_to_outer((void*)this), 0, 0, 0, 0);
 #else
-    GC_REGISTER_FINALIZER_IGNORE_SELF(this,                           nullptr, nullptr, nullptr, nullptr);
+    GC_REGISTER_FINALIZER_IGNORE_SELF(this,                           0, 0, 0, 0);
 #endif
   }
 };
@@ -159,11 +159,11 @@ static inline void cleanup(void* obj, void* displ)
 
 inline our_gc_cleanup::our_gc_cleanup()
 {
-  if (nullptr == GC_base(this)) return; // Non-heap object.
+  if (0 == GC_base(this)) return; // Non-heap object.
 #ifdef MEMDEBUG
   GC_REGISTER_FINALIZER_IGNORE_SELF(M2_debug_to_outer(this), (GC_finalization_proc) cleanup, 0, 0, 0);
 #else
-  GC_REGISTER_FINALIZER_IGNORE_SELF(this,                    (GC_finalization_proc) cleanup, nullptr, nullptr, nullptr);
+  GC_REGISTER_FINALIZER_IGNORE_SELF(this,                    (GC_finalization_proc) cleanup, 0, 0, 0);
 #endif
 }
 

--- a/M2/Macaulay2/e/ntl-interface.cpp
+++ b/M2/Macaulay2/e/ntl-interface.cpp
@@ -82,7 +82,7 @@ bool ntl_LLL(MutableMatrix *M,
 
   if (M2_gbTrace >= 10) printf("LLL: using strategy %d\n", strategy);
   NTL::mat_ZZ *A = mutableMatrix_to_NTL_mat_ZZ(M);
-  NTL::mat_ZZ *V = (U ? mutableMatrix_to_NTL_mat_ZZ(U) : nullptr);
+  NTL::mat_ZZ *V = (U ? mutableMatrix_to_NTL_mat_ZZ(U) : 0);
 
   switch (strategy)
     {

--- a/M2/Macaulay2/e/pfaff.cpp
+++ b/M2/Macaulay2/e/pfaff.cpp
@@ -5,7 +5,7 @@
 #include "interrupted.hpp"
 
 PfaffianComputation::PfaffianComputation(const Matrix *M0, int p0)
-    : R(M0->get_ring()), M(M0), p(p0), done(false), row_set(nullptr)
+    : R(M0->get_ring()), M(M0), p(p0), done(false), row_set(0)
 {
   pfaffs = MatrixConstructor(R->make_FreeModule(1), 0);
   if (p == 0)
@@ -98,7 +98,7 @@ Matrix *Matrix::pfaffians(int p) const
   if (get_ring()->get_precision() > 0)
     {
       ERROR("pfaffian computations over RR or CC not yet implemented");
-      return nullptr;
+      return 0;
     }
   PfaffianComputation d {this, p};
   d.calc();

--- a/M2/Macaulay2/e/poly.cpp
+++ b/M2/Macaulay2/e/poly.cpp
@@ -22,19 +22,19 @@
 
 #define POLY(q) ((q).poly_val)
 
-PolyRing *PolyRing::trivial_poly_ring = nullptr;  // Will be ZZ[]
+PolyRing *PolyRing::trivial_poly_ring = 0;  // Will be ZZ[]
 
 void PolyRing::clear()
 {
   PolynomialRing::clear();
   delete gb_ring_;
-  gb_ring_ = nullptr;
+  gb_ring_ = 0;
 }
 
 PolyRing::~PolyRing() { clear(); }
 const PolyRing *PolyRing::get_trivial_poly_ring()
 {
-  if (trivial_poly_ring == nullptr)
+  if (trivial_poly_ring == 0)
     {
       make_trivial_ZZ_poly_ring();
     }
@@ -53,7 +53,7 @@ const PolyRing *PolyRing::get_trivial_poly_ring()
 
 void PolyRing::make_trivial_ZZ_poly_ring()
 {
-  if (trivial_poly_ring != nullptr) return;
+  if (trivial_poly_ring != 0) return;
 
   //  globalZZ = new RingZZ;
   globalZZ = makeIntegerRing();
@@ -77,10 +77,10 @@ void PolyRing::initialize_poly_ring(const Ring *K,
 {
   initialize_ring(K->characteristic(), deg_ring, M->get_heft_vector());
 
-  initialize_PolynomialRing(K, M, this, this, nullptr);
+  initialize_PolynomialRing(K, M, this, this, NULL);
   poly_size_ = sizeof(Nterm) + sizeof(int) * (M_->monomial_size() - 1);
 
-  gb_ring_ = nullptr;
+  gb_ring_ = 0;
 
   // A polynomial ring is ALWAYS graded (if the coeff vars, if any,
   //   all have degree 0, which is the case with our flattened poly rings
@@ -307,7 +307,7 @@ ring_elem PolyRing::var(int v) const
 int PolyRing::index_of_var(const ring_elem a) const
 {
   Nterm *f = a;
-  if (f == nullptr || f->next != nullptr) return -1;
+  if (f == 0 || f->next != 0) return -1;
   if (!K_->is_equal(f->coeff, K_->from_long(1))) return -1;
   int result = -1;
   exponents_t EXP1 = ALLOCATE_EXPONENTS(exp_size);
@@ -355,7 +355,7 @@ int check_coeff_ring(const Ring *coeffR, const PolyRing *P)
   if (coeffR != P->getCoefficients())
     {
       const PolynomialRing *P0 = coeffR->cast_to_PolynomialRing();
-      if (P0 == nullptr)
+      if (P0 == 0)
         nvars = -1;
       else
         nvars -= P0->n_vars();
@@ -384,7 +384,7 @@ bool PolyRing::promote(const Ring *Rf,
   if (Rf != K_)
     {
       const PolynomialRing *Rf1 = Rf->cast_to_PolynomialRing();
-      if (Rf1 != nullptr)
+      if (Rf1 != 0)
         nvars0 -= Rf1->n_vars();
       else
         return false;
@@ -408,7 +408,7 @@ bool PolyRing::lift(const Ring *Rg, const ring_elem f, ring_elem &result) const
   // We assume that Rg is one of the coefficient rings of 'this'
 
   Nterm *t = f;
-  if (t == nullptr)
+  if (t == 0)
     {
       result = Rg->zero();
       return true;
@@ -418,7 +418,7 @@ bool PolyRing::lift(const Ring *Rg, const ring_elem f, ring_elem &result) const
   if (Rg != K_)
     {
       const PolynomialRing *Rg1 = Rg->cast_to_PolynomialRing();
-      if (Rg1 != nullptr)
+      if (Rg1 != 0)
         nvars0 -= Rg1->n_vars();
       else
         return false;
@@ -435,12 +435,12 @@ bool PolyRing::lift(const Ring *Rg, const ring_elem f, ring_elem &result) const
 ring_elem PolyRing::preferred_associate(ring_elem ff) const
 {
   Nterm *f = ff;
-  if (f == nullptr) return from_long(1);
+  if (f == NULL) return from_long(1);
   ring_elem c = K_->preferred_associate(f->coeff);
   Nterm *t = new_term();
   t->coeff = c;
   M_->one(t->monom);
-  t->next = nullptr;
+  t->next = 0;
   return t;
 }
 
@@ -467,7 +467,7 @@ bool PolyRing::is_unit(const ring_elem f) const
 {
   Nterm *t = f;
   if (begin(f) == end(f)) return false;
-  if (t->next == nullptr && M_->is_one(t->monom) && K_->is_unit(t->coeff))
+  if (t->next == NULL && M_->is_one(t->monom) && K_->is_unit(t->coeff))
     return true;
   return false;
 }
@@ -475,7 +475,7 @@ bool PolyRing::is_unit(const ring_elem f) const
 bool PolyRing::is_zero(const ring_elem f) const
 {
   Nterm *a = f;
-  return a == nullptr;
+  return a == NULL;
 }
 
 bool PolyRing::is_equal(const ring_elem f, const ring_elem g) const
@@ -484,12 +484,12 @@ bool PolyRing::is_equal(const ring_elem f, const ring_elem g) const
   Nterm *b = g;
   for (;; a = a->next, b = b->next)
     {
-      if (a == nullptr)
+      if (a == NULL)
         {
-          if (b == nullptr) return true;
+          if (b == NULL) return true;
           return false;
         }
-      if (b == nullptr) return false;
+      if (b == NULL) return false;
       if (!K_->is_equal(a->coeff, b->coeff)) return false;
       if (nvars_ > 0 && (M_->compare(a->monom, b->monom) != 0)) return false;
     }
@@ -502,12 +502,12 @@ int PolyRing::compare_elems(const ring_elem f, const ring_elem g) const
   Nterm *b = g;
   for (;; a = a->next, b = b->next)
     {
-      if (a == nullptr)
+      if (a == NULL)
         {
-          if (b == nullptr) return 0;
+          if (b == NULL) return 0;
           return -1;
         }
-      if (b == nullptr) return 1;
+      if (b == NULL) return 1;
       if (nvars_ > 0)
         {
           cmp = M_->compare(a->monom, b->monom);
@@ -574,14 +574,14 @@ void PolyRing::degree_weights(const ring_elem f,
                               int &hi) const
 {
   Nterm *t = f;
-  if (t == nullptr)
+  if (t == NULL)
     {
       lo = hi = 0;
       return;
     }
   int e = M_->degree_weights(t->monom, wts);
   lo = hi = e;
-  for (t = t->next; t != nullptr; t = t->next)
+  for (t = t->next; t != NULL; t = t->next)
     {
       e = M_->degree_weights(t->monom, wts);
       if (e > hi)
@@ -609,9 +609,9 @@ ring_elem PolyRing::homogenize(const ring_elem f,
       if (((d - e) % wts->array[v]) != 0)
         {
           // We cannot homogenize, so clean up and exit.
-          result->next = nullptr;
+          result->next = NULL;
           ERROR("homogenization impossible");
-          result = nullptr;
+          result = NULL;
           return result;
         }
       exp[v] += (d - e) / wts->array[v];
@@ -621,7 +621,7 @@ ring_elem PolyRing::homogenize(const ring_elem f,
       result->coeff = K_->copy(a.coeff);
       M_->from_expvector(exp, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   sort(head.next);  // The monomial order, etc. might all have changed.
                     // Some terms might even drop out
   freemem(exp);
@@ -630,8 +630,8 @@ ring_elem PolyRing::homogenize(const ring_elem f,
 
 ring_elem PolyRing::homogenize(const ring_elem f, int v, M2_arrayint wts) const
 {
-  Nterm *result = nullptr;
-  if (POLY(f) == nullptr) return result;
+  Nterm *result = NULL;
+  if (POLY(f) == NULL) return result;
   int lo, hi;
   degree_weights(f, wts, lo, hi);
   assert(wts->array[v] != 0);
@@ -644,9 +644,9 @@ ring_elem PolyRing::copy(const ring_elem f) const
   Nterm *a = f;
   Nterm head;
   Nterm *result = &head;
-  for (; a != nullptr; a = a->next, result = result->next)
+  for (; a != NULL; a = a->next, result = result->next)
     result->next = copy_term(a);
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -654,7 +654,7 @@ void PolyRing::remove(ring_elem &f) const {}
 void PolyRing::internal_negate_to(ring_elem &f) const
 {
   Nterm *v = f;
-  while (v != nullptr)
+  while (v != NULL)
     {
       K_->negate_to(v->coeff);
       v = v->next;
@@ -666,8 +666,8 @@ void PolyRing::internal_add_to(ring_elem &ff, ring_elem &gg) const
   Nterm *f = ff;
   Nterm *g = gg;
   gg = ZERO_RINGELEM;
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == NULL) return;
+  if (f == NULL)
     {
       ff = g;
       return;
@@ -680,7 +680,7 @@ void PolyRing::internal_add_to(ring_elem &ff, ring_elem &gg) const
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               ff = head.next;
@@ -691,7 +691,7 @@ void PolyRing::internal_add_to(ring_elem &ff, ring_elem &gg) const
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               ff = head.next;
@@ -714,13 +714,13 @@ void PolyRing::internal_add_to(ring_elem &ff, ring_elem &gg) const
               result->next = tmf;
               result = result->next;
             }
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               ff = head.next;
               return;
             }
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               ff = head.next;
@@ -747,7 +747,7 @@ ring_elem PolyRing::negate(const ring_elem f) const
       result->coeff = K_->negate(a.coeff);
       M_->copy(a.monom, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -781,15 +781,15 @@ ring_elem PolyRing::mult_by_term(const ring_elem f,
       result->coeff = K_->mult(a.coeff, c);
       M_->mult(m, a.monom, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
 void PolyRing::mult_coeff_to(ring_elem a, ring_elem &f) const
 {
   Nterm *t = f;
-  if (t == nullptr) return;
-  for (; t != nullptr; t = t->next)
+  if (t == NULL) return;
+  for (; t != NULL; t = t->next)
     {
       ring_elem tmp = t->coeff;
       t->coeff = K_->mult(a, tmp);
@@ -799,8 +799,8 @@ void PolyRing::divide_coeff_to(ring_elem &f, ring_elem a) const
 // f is in this, a is in base coefficient ring
 {
   Nterm *t = f;
-  if (t == nullptr) return;
-  for (; t != nullptr; t = t->next)
+  if (t == NULL) return;
+  for (; t != NULL; t = t->next)
     {
       ring_elem tmp = t->coeff;
       t->coeff = K_->divide(tmp, a);
@@ -860,7 +860,7 @@ ring_elem PolyRing::power_direct(const ring_elem ff, int n) const
     ring_elem coef1, coef2, coef3;
 
     Nterm *lead = ff;
-    if (lead == nullptr) return ZERO_RINGELEM;
+    if (lead == NULL) return ZERO_RINGELEM;
 
     rest = lead->next;
     g = from_long(1);
@@ -869,11 +869,11 @@ ring_elem PolyRing::power_direct(const ring_elem ff, int n) const
     Nterm *t = new_term();
     t->coeff = K_->power(lead->coeff, n);
     M_->power(lead->monom, n, t->monom);
-    t->next = nullptr;
+    t->next = NULL;
     //  if (_base_ring != NULL) normal_form(t);  NOT NEEDED
     result = t;
 
-    if (POLY(rest) == nullptr) return result;
+    if (POLY(rest) == 0) return result;
     monomial m = M_->make_one();
 
     mpz_t bin_c;
@@ -930,7 +930,7 @@ ring_elem PolyRing::power(const ring_elem f0, int n) const
 
     while(n)
     {
-      for(Nterm *it=ff, *jt=gg; it!=nullptr; it=it->next, jt=jt->next)
+      for(Nterm *it=ff, *jt=gg; it!=NULL; it=it->next, jt=jt->next)
       {
         jt->coeff = K_->power(it->coeff, pk);
         M_->power(it->monom, pk, jt->monom);
@@ -955,7 +955,7 @@ ring_elem PolyRing::invert(const ring_elem f) const
       ERROR("cannot divide by zero");
       return ZERO_RINGELEM;
     }
-  if (ft->next == nullptr)
+  if (ft->next == NULL)
     {
       if (M_->is_one(ft->monom))
         {
@@ -1004,7 +1004,7 @@ bool PolyRing::imp_attempt_to_cancel_lead_term(ring_elem &f,
   bool result;
   Nterm *t = f;
   Nterm *s = g;
-  if (t == nullptr || s == nullptr) return true;
+  if (t == NULL || s == NULL) return true;
   if (K_->is_field())
     {
       coeff = K_->divide(t->coeff, s->coeff);
@@ -1126,9 +1126,9 @@ void PolyRing::minimal_monomial(ring_elem f, monomial &monom) const
   // This monomial is placed into 'monom'.
 
   Nterm *t = f;
-  if (t == nullptr) return;
+  if (t == NULL) return;
   M_->copy(t->monom, monom);
-  for (t = t->next; t != nullptr; t = t->next) M_->gcd(t->monom, monom, monom);
+  for (t = t->next; t != NULL; t = t->next) M_->gcd(t->monom, monom, monom);
 }
 
 ring_elem PolyRing::remainder(const ring_elem f, const ring_elem g) const
@@ -1301,13 +1301,13 @@ void PolyRing::elem_text_out(buffer &o,
                              bool p_parens) const
 {
   Nterm *t = f;
-  if (t == nullptr)
+  if (t == NULL)
     {
       o << '0';
       return;
     }
 
-  int two_terms = (t->next != nullptr);
+  int two_terms = (t->next != NULL);
 
   int needs_parens = p_parens && two_terms;
   if (needs_parens)
@@ -1317,7 +1317,7 @@ void PolyRing::elem_text_out(buffer &o,
       p_plus = false;
     }
 
-  for (t = f; t != nullptr; t = t->next)
+  for (t = f; t != NULL; t = t->next)
     {
       int isone = M_->is_one(t->monom);
       p_parens = !isone;
@@ -1368,7 +1368,7 @@ ring_elem PolyRing::zeroize_tiny(gmp_RR epsilon, const ring_elem f) const
           M_->copy(a.monom, result->monom);
         }
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 void PolyRing::increase_maxnorm(gmp_RRmutable norm, const ring_elem f) const
@@ -1462,7 +1462,7 @@ Nterm *PolyRing::division_algorithm(Nterm *f, Nterm *g, Nterm *&quot) const
   Nterm *nextterm = new_term();
 
   //  buffer o;
-  while (t != nullptr)
+  while (t != NULL)
     if (M_->divides_partial_order(b->monom, t->monom))
       {
         // o << "t = "; elem_text_out(o,t); o << newline;
@@ -1496,9 +1496,9 @@ Nterm *PolyRing::division_algorithm(Nterm *f, Nterm *g, Nterm *&quot) const
         t = t->next;
       }
 
-  nextterm = nullptr;
-  remt->next = nullptr;
-  divt->next = nullptr;
+  nextterm = NULL;
+  remt->next = NULL;
+  divt->next = NULL;
   quot = divhead.next;
   return remhead.next;
 }
@@ -1515,7 +1515,7 @@ Nterm *PolyRing::division_algorithm(Nterm *f, Nterm *g) const
   Nterm *remt = &remhead;
   ring_elem c;
   monomial m = M_->make_one();
-  while (t != nullptr)
+  while (t != NULL)
     if (M_->divides_partial_order(b->monom, t->monom))
       {
         a = t;
@@ -1535,7 +1535,7 @@ Nterm *PolyRing::division_algorithm(Nterm *f, Nterm *g) const
         t = t->next;
       }
 
-  remt->next = nullptr;
+  remt->next = NULL;
   return remhead.next;
 }
 
@@ -1599,21 +1599,21 @@ Nterm *PolyRing::powerseries_division_algorithm(Nterm *f,
   Nterm *nextterm = new_term();
   long gval = 0, flast = 0;
 
-  if (t != nullptr)
+  if (t != 0)
     {
       Nterm *z = t;
-      for (; z->next != nullptr; z = z->next)
+      for (; z->next != 0; z = z->next)
         ;
 
       flast = M_->first_weight_value(z->monom);
     }
 
-  if (b != nullptr)
+  if (b != 0)
     {
       long gfirst, glast;
       Nterm *z = b;
 
-      if (z->next == nullptr)
+      if (z->next == 0)
         gval = 0;
       else
         {
@@ -1624,7 +1624,7 @@ Nterm *PolyRing::powerseries_division_algorithm(Nterm *f,
               // In this case, we return silently
               throw exc::internal_error("division algorithm for this element is not implemented");
             }
-          for (; z->next != nullptr; z = z->next)
+          for (; z->next != 0; z = z->next)
             ;
           glast = M_->first_weight_value(z->monom);
           gval = gfirst - glast;
@@ -1632,7 +1632,7 @@ Nterm *PolyRing::powerseries_division_algorithm(Nterm *f,
     }
 
   //  buffer o;
-  while (t != nullptr)
+  while (t != NULL)
     {
       long ffirst;
 
@@ -1676,9 +1676,9 @@ Nterm *PolyRing::powerseries_division_algorithm(Nterm *f,
         }
     }
 
-  nextterm = nullptr;
-  remt->next = nullptr;
-  divt->next = nullptr;
+  nextterm = NULL;
+  remt->next = NULL;
+  divt->next = NULL;
   quot = divhead.next;
   return remhead.next;
 }
@@ -1697,7 +1697,7 @@ ring_elem PolyRing::get_logical_coeff(const Ring *coeffR, const Nterm *&f) const
 // the pointer to the first term of f not used (possibly 0).
 // coeffR should be a coefficient ring of 'this'.
 {
-  if (f == nullptr) return coeffR->zero();
+  if (f == 0) return coeffR->zero();
   if (coeffR == K_)
     {
       ring_elem result = f->coeff;
@@ -1709,7 +1709,7 @@ ring_elem PolyRing::get_logical_coeff(const Ring *coeffR, const Nterm *&f) const
   const PolyRing *K = KR->getNumeratorRing();
   Nterm head;
   Nterm *inresult = &head;
-  inresult->next = nullptr;
+  inresult->next = 0;
   exponents_t exp = newarray_atomic(int, n_vars());
   exponents_t exp2 = newarray_atomic(int, n_vars());
   int nvars = n_vars() - K->n_vars();
@@ -1724,11 +1724,11 @@ ring_elem PolyRing::get_logical_coeff(const Ring *coeffR, const Nterm *&f) const
       K->getMonoid()->from_expvector(exp2 + nvars, t->monom);
 
       f = f->next;
-      if (f == nullptr) break;
+      if (f == 0) break;
       M_->to_expvector(f->monom, exp2);
     }
   while (EQ == exponents::lex_compare(nvars, exp, exp2));
-  inresult->next = nullptr;
+  inresult->next = 0;
   return head.next;
 }
 
@@ -1755,12 +1755,12 @@ int PolyRing::n_logical_terms(int nvars0, const ring_elem f) const
   // nvars0 is the number of variables in the outer monoid
   if (nvars0 == n_vars()) return n_terms(f);
   Nterm *t = f;
-  if (t == nullptr) return 0;
+  if (t == 0) return 0;
   exponents_t exp1 = newarray_atomic(int, n_vars());
   exponents_t exp2 = newarray_atomic(int, n_vars());
   M_->to_expvector(t->monom, exp1);
   int result = 1;
-  for (; t != nullptr; t = t->next)
+  for (; t != 0; t = t->next)
     {
       M_->to_expvector(t->monom, exp2);
       if (EQ == exponents::lex_compare(nvars0, exp1, exp2)) continue;
@@ -1784,7 +1784,7 @@ engine_RawArrayPairOrNull PolyRing::list_form(const Ring *coeffR,
   // In the latter case, the last set of variables are part of
   // the coefficients.
   int nvars0 = check_coeff_ring(coeffR, this);
-  if (nvars0 < 0) return nullptr;
+  if (nvars0 < 0) return 0;
   int n = n_logical_terms(nvars0, f);
   engine_RawMonomialArray monoms =
       GETMEM(engine_RawMonomialArray, sizeofarray(monoms, n));
@@ -1835,7 +1835,7 @@ ring_elem *PolyRing::get_parts(const M2_arrayint wts,
   // (3) Sort the array, by increasing weight values.
   // (4) Make an array, copy the elems to it.
 
-  return nullptr;
+  return NULL;
 }
 
 ring_elem PolyRing::get_part(const M2_arrayint wts,
@@ -1860,7 +1860,7 @@ ring_elem PolyRing::get_part(const M2_arrayint wts,
       inresult = inresult->next;
     }
 
-  inresult->next = nullptr;
+  inresult->next = 0;
   freemem(exp);
   return head.next;
 }
@@ -1878,7 +1878,7 @@ ring_elem PolyRing::make_logical_term(const Ring *coeffR,
       M_->from_expvector(exp0, m);
       return make_flat_term(a, m);
     }
-  if (logicalK == nullptr)
+  if (logicalK == 0)
     {
       ERROR("expected actual coefficient ring");
       return from_long(0);
@@ -1898,7 +1898,7 @@ ring_elem PolyRing::make_logical_term(const Ring *coeffR,
       logicalK->getMonoid()->to_expvector(f.monom, exp + nvars0);
       M_->from_expvector(exp, t->monom);
     }
-  inresult->next = nullptr;
+  inresult->next = 0;
   return head.next;
 }
 
@@ -1912,7 +1912,7 @@ ring_elem PolyRing::get_terms(int nvars0,
   if (hi < 0) hi = nterms + hi;
 
   Nterm *t = f;
-  if (t == nullptr) return t;
+  if (t == 0) return t;
   Nterm head;
   Nterm *result = &head;
 
@@ -1920,7 +1920,7 @@ ring_elem PolyRing::get_terms(int nvars0,
   exponents_t exp2 = newarray_atomic(int, n_vars());
   M_->to_expvector(t->monom, exp1);
   int n = 0;
-  while (t != nullptr)
+  while (t != NULL)
     {
       if (n > hi) break;
       if (n >= lo)
@@ -1929,7 +1929,7 @@ ring_elem PolyRing::get_terms(int nvars0,
           result = result->next;
         }
       t = t->next;
-      if (t == nullptr) break;
+      if (t == 0) break;
       M_->to_expvector(t->monom, exp2);
       if (EQ == exponents::lex_compare(nvars0, exp1, exp2)) continue;
       exponents_t temp = exp1;
@@ -1937,7 +1937,7 @@ ring_elem PolyRing::get_terms(int nvars0,
       exp2 = temp;
       n++;
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -1954,14 +1954,14 @@ ring_elem PolyRing::make_flat_term(const ring_elem a, const_monomial m) const
   Nterm *t = new_term();
   t->coeff = K_->copy(a);
   M_->copy(m, t->monom);
-  t->next = nullptr;
+  t->next = NULL;
   return t;
 }
 
 ring_elem PolyRing::lead_flat_coeff(const ring_elem f) const
 {
   Nterm *t = f;
-  if (t == nullptr) return K_->from_long(0);
+  if (t == NULL) return K_->from_long(0);
   return K_->copy(t->coeff);
 }
 
@@ -1985,7 +1985,7 @@ ring_elem PolyRing::get_coeff(const Ring *coeffR,
 
   // Now loop thru f until exponents match up.
   const Nterm *t = f;
-  for (; t != nullptr; t = t->next)
+  for (; t != 0; t = t->next)
     {
       M_->to_expvector(t->monom, exp2);
       if (EQ == exponents::lex_compare(nvars0, exp, exp2)) break;
@@ -2010,7 +2010,7 @@ ring_elem PolyRing::diff(ring_elem a, ring_elem b, int use_coeff) const
             {
               K_->mult_to(d->coeff, s.coeff);
               K_->mult_to(d->coeff, t.coeff);
-              d->next = nullptr;
+              d->next = 0;
               H.add(d);
               d = new_term();
             }
@@ -2066,17 +2066,17 @@ void PolyRing::sort(Nterm *&f) const
   // then add them together.  This allows the same monomial
   // to appear more than once in 'f'.
 
-  if (f == nullptr || f->next == nullptr) return;
-  Nterm *f1 = nullptr;
-  Nterm *f2 = nullptr;
-  while (f != nullptr)
+  if (f == NULL || f->next == NULL) return;
+  Nterm *f1 = NULL;
+  Nterm *f2 = NULL;
+  while (f != NULL)
     {
       Nterm *t = f;
       f = f->next;
       t->next = f1;
       f1 = t;
 
-      if (f == nullptr) break;
+      if (f == NULL) break;
       t = f;
       f = f->next;
       t->next = f2;
@@ -2101,7 +2101,7 @@ bool PolyRing::in_subring(int nslots, const ring_elem a) const
 void PolyRing::degree_of_var(int n, const ring_elem a, int &lo, int &hi) const
 {
   Nterm *t = a;
-  if (t == nullptr)
+  if (t == NULL)
     {
       ERROR("attempting to find degree of a zero element");
       return;
@@ -2109,7 +2109,7 @@ void PolyRing::degree_of_var(int n, const ring_elem a, int &lo, int &hi) const
   exponents_t exp = newarray_atomic(int, n_vars());
   M_->to_expvector(t->monom, exp);
   lo = hi = exp[n];
-  for (t = t->next; t != nullptr; t = t->next)
+  for (t = t->next; t != 0; t = t->next)
     {
       M_->to_expvector(t->monom, exp);
       if (exp[n] < lo)
@@ -2154,13 +2154,13 @@ ring_elem PolyRing::divide_by_var(int n, int d, const ring_elem a) const
       M_->from_expvector(exp, result->monom);
     }
   freemem(exp);
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
 ring_elem PolyRing::divide_by_expvector(const_exponents exp, const ring_elem a) const
 {
-  Nterm *result = nullptr;
+  Nterm *result = 0;
   exponents_t exp0 = newarray_atomic(int, n_vars());
   for (Nterm& t : a)
     {
@@ -2186,37 +2186,37 @@ void PolyRing::lower_content(ring_elem &c, ring_elem g) const
 ring_elem PolyRing::content(ring_elem f) const
 {
   Nterm *t = f;
-  if (t == nullptr) return K_->zero();
+  if (t == 0) return K_->zero();
   ring_elem c = t->coeff;
-  for (t = t->next; t != nullptr; t = t->next) K_->lower_content(c, t->coeff);
+  for (t = t->next; t != 0; t = t->next) K_->lower_content(c, t->coeff);
   return c;
 }
 
 ring_elem PolyRing::content(ring_elem f, ring_elem g) const
 {
   Nterm *t = f;
-  if (t == nullptr) return K_->zero();
+  if (t == 0) return K_->zero();
   ring_elem c = t->coeff;
-  for (t = t->next; t != nullptr; t = t->next) K_->lower_content(c, t->coeff);
-  for (t = g; t != nullptr; t = t->next) K_->lower_content(c, t->coeff);
+  for (t = t->next; t != 0; t = t->next) K_->lower_content(c, t->coeff);
+  for (t = g; t != 0; t = t->next) K_->lower_content(c, t->coeff);
   return c;
 }
 
 ring_elem PolyRing::divide_by_given_content(ring_elem f, ring_elem c) const
 {
   Nterm *a = f;
-  if (a == nullptr) return f;
+  if (a == 0) return f;
 
   Nterm head;
   Nterm *result = &head;
-  for (; a != nullptr; a = a->next)
+  for (; a != NULL; a = a->next)
     {
       result->next = new_term();
       result = result->next;
       result->coeff = K_->divide(a->coeff, c);
       M_->copy(a->monom, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -2226,9 +2226,9 @@ ring_elem PolyRing::divide_by_given_content(ring_elem f, ring_elem c) const
 const PolyRing * /* or null */ isUnivariateOverPrimeField(const Ring *R)
 {
   const PolyRing *P = R->cast_to_PolyRing();
-  if (P == nullptr) return nullptr;
-  if (P->n_vars() != 1) return nullptr;
-  if (P->characteristic() == 0) return nullptr;
+  if (P == 0) return 0;
+  if (P->n_vars() != 1) return 0;
+  if (P->characteristic() == 0) return 0;
   return P;
 }
 
@@ -2248,7 +2248,7 @@ ring_elem PolyRing::fromSmallIntegerCoefficients(
       if (K_->is_zero(c)) continue;
       Nterm *t = new_term();
       t->coeff = c;
-      t->next = nullptr;
+      t->next = NULL;
       M_->from_expvector(exp, t->monom);
       H->add(t);
     }
@@ -2274,7 +2274,7 @@ ring_elem PolyRing::lead_term(int nparts, const ring_elem f) const
       result->coeff = a.coeff;
       M_->copy(a.monom, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -2282,12 +2282,12 @@ const vecterm *PolyRing::vec_locate_lead_term(const FreeModule *F, vec v) const
 // Returns a pointer to the lead vector of v.
 // This works if F has a Schreyer order, or an up/down order.
 {
-  if (v == nullptr) return v;
+  if (v == 0) return v;
   const vecterm *lead = v;
   const SchreyerOrder *S = F->get_schreyer_order();
   if (S)
     {
-      for (vec w = v->next; w != nullptr; w = w->next)
+      for (vec w = v->next; w != 0; w = w->next)
         {
           if (S->schreyer_compare(POLY(lead->coeff)->monom,
                                   lead->comp,
@@ -2300,7 +2300,7 @@ const vecterm *PolyRing::vec_locate_lead_term(const FreeModule *F, vec v) const
     }
   else
     {
-      for (vec w = v->next; w != nullptr; w = w->next)
+      for (vec w = v->next; w != 0; w = w->next)
         {
           if (M_->compare(POLY(lead->coeff)->monom,
                           lead->comp,
@@ -2318,7 +2318,7 @@ vec PolyRing::vec_lead_term(int nparts, const FreeModule *F, vec v) const
 {
   // The first step is to find the lead monomial.
 
-  if (v == nullptr) return nullptr;
+  if (v == 0) return 0;
   const vecterm *lead = vec_locate_lead_term(F, v);
 
   // Now that we have the lead term, use the first n parts of the monomial
@@ -2334,7 +2334,7 @@ vec PolyRing::vec_coefficient_of_var(vec v, int x, int e) const
   exponents_t exp = newarray_atomic(int, n_vars());
   vecterm vec_head;
   vecterm *vec_result = &vec_head;
-  for (vecterm *t = v; t != nullptr; t = t->next)
+  for (vecterm *t = v; t != NULL; t = t->next)
     {
       Nterm head;
       Nterm *result = &head;
@@ -2348,12 +2348,12 @@ vec PolyRing::vec_coefficient_of_var(vec v, int x, int e) const
           result->coeff = f.coeff;
           M_->from_expvector(exp, result->monom);
         }
-      result->next = nullptr;
+      result->next = NULL;
       vec_result->next = make_vec(t->comp, head.next);
       vec_result = vec_result->next;
     }
   freemem(exp);
-  vec_result->next = nullptr;
+  vec_result->next = NULL;
   return vec_head.next;
 }
 
@@ -2368,13 +2368,13 @@ vec PolyRing::vec_top_coefficient(const vec v, int &x, int &e) const
 {
   x = n_vars();
   e = 0;
-  if (v == nullptr)
+  if (v == NULL)
     {
-      return nullptr;
+      return NULL;
     }
 
   exponents_t exp = newarray_atomic(int, n_vars());
-  for (vec t = v; t != nullptr; t = t->next)
+  for (vec t = v; t != 0; t = t->next)
     for (Nterm& f : t->coeff)
       {
         M_->to_expvector(f.monom, exp);
@@ -2446,7 +2446,7 @@ ring_elem PolyRing::vec_get_denominator_QQ(vec f) const
   mpz_t denom;
   mpz_init_set_si(denom, 1);
 
-  for (vec w = f; w != nullptr; w = w->next)
+  for (vec w = f; w != 0; w = w->next)
     determine_common_denominator_QQ(w->coeff, denom);
   ring_elem result = globalZZ->RingZZ::from_int(denom);
   mpz_clear(denom);
@@ -2463,7 +2463,7 @@ gbvector *PolyRing::translate_gbvector_from_ringelem_QQ(ring_elem coeff) const
     {
       // make a gbvector node.
       ring_elem a = globalZZ->RingZZ::from_int(mpq_numref(MPQ_VAL(t.coeff)));
-      gbvector *g = GR->gbvector_term(nullptr, a, t.monom, 0);
+      gbvector *g = GR->gbvector_term(0, a, t.monom, 0);
       inresult->next = g;
       inresult = inresult->next;
     }
@@ -2480,7 +2480,7 @@ gbvector *PolyRing::translate_gbvector_from_ringelem(ring_elem coeff) const
   for (Nterm& t : coeff)
     {
       // make a gbvector node.
-      gbvector *g = GR->gbvector_term(nullptr, t.coeff, t.monom, 0);
+      gbvector *g = GR->gbvector_term(0, t.coeff, t.monom, 0);
       inresult->next = g;
       inresult = inresult->next;
     }
@@ -2492,10 +2492,10 @@ gbvector *PolyRing::translate_gbvector_from_vec_QQ(
     const vec v,
     ring_elem &result_denominator) const
 {
-  if (v == nullptr)
+  if (v == 0)
     {
       result_denominator = globalZZ->one();
-      return nullptr;
+      return 0;
     }
   GBRing *GR = get_gb_ring();
   result_denominator = vec_get_denominator_QQ(v);
@@ -2504,7 +2504,7 @@ gbvector *PolyRing::translate_gbvector_from_vec_QQ(
   gbvector *inresult;
   mpz_t a;
   mpz_init(a);
-  for (vec w = v; w != nullptr; w = w->next)
+  for (vec w = v; w != 0; w = w->next)
     {
       inresult = &head;
       int comp = w->comp + 1;
@@ -2533,12 +2533,12 @@ gbvector *PolyRing::translate_gbvector_from_vec(
   if (getCoefficients() == globalQQ)
     return translate_gbvector_from_vec_QQ(F, v, result_denominator);
   result_denominator = getCoefficients()->one();
-  if (v == nullptr) return nullptr;
+  if (v == 0) return 0;
   GBRing *GR = get_gb_ring();
   gbvectorHeap H(GR, F);
   gbvector head;
   gbvector *inresult;
-  for (vec w = v; w != nullptr; w = w->next)
+  for (vec w = v; w != 0; w = w->next)
     {
       inresult = &head;
       int comp = w->comp + 1;
@@ -2563,13 +2563,13 @@ vec PolyRing::translate_gbvector_to_vec_QQ(const FreeModule *F,
                                            const gbvector *v,
                                            const ring_elem denom) const
 {
-  if (v == nullptr) return nullptr;
+  if (v == 0) return 0;
 
   GBRing *GR = get_gb_ring();
 
   int firstcomp = v->comp;
   int lastcomp = firstcomp;
-  for (const gbvector *t = v->next; t != nullptr; t = t->next)
+  for (const gbvector *t = v->next; t != 0; t = t->next)
     {
       if (firstcomp > t->comp)
         firstcomp = t->comp;
@@ -2581,17 +2581,17 @@ vec PolyRing::translate_gbvector_to_vec_QQ(const FreeModule *F,
   Nterm **vec_last = newarray(Nterm *, lastcomp - firstcomp + 1);
   for (int i = 0; i < lastcomp - firstcomp + 1; i++)
     {
-      vec_comps[i] = nullptr;
-      vec_last[i] = nullptr;
+      vec_comps[i] = 0;
+      vec_last[i] = 0;
     }
 
   // Now make a list of Nterm's, copy gbvectors in (except comps)
-  for (const gbvector *t = v; t != nullptr; t = t->next)
+  for (const gbvector *t = v; t != 0; t = t->next)
     {
       Nterm *s = new_term();
       GR->gbvector_get_lead_monomial(F, t, s->monom);
       s->coeff = globalQQ->fraction(t->coeff, denom);
-      s->next = nullptr;
+      s->next = 0;
       int x = t->comp - firstcomp;
       if (!vec_comps[x])
         {
@@ -2606,7 +2606,7 @@ vec PolyRing::translate_gbvector_to_vec_QQ(const FreeModule *F,
     }
 
   // Now create the vecs
-  vec result = nullptr;
+  vec result = 0;
   for (int x = 0; x < lastcomp - firstcomp + 1; x++)
     if (vec_comps[x])
       {
@@ -2625,7 +2625,7 @@ vec PolyRing::translate_gbvector_to_vec_QQ(const FreeModule *F,
 vec PolyRing::translate_gbvector_to_vec(const FreeModule *F,
                                         const gbvector *v) const
 {
-  if (v == nullptr) return nullptr;
+  if (v == 0) return 0;
 
   if (getCoefficients() == globalQQ)
     return translate_gbvector_to_vec_QQ(F, v, globalZZ->one());
@@ -2633,7 +2633,7 @@ vec PolyRing::translate_gbvector_to_vec(const FreeModule *F,
 
   int firstcomp = v->comp;
   int lastcomp = firstcomp;
-  for (const gbvector *t = v->next; t != nullptr; t = t->next)
+  for (const gbvector *t = v->next; t != 0; t = t->next)
     {
       if (firstcomp > t->comp)
         firstcomp = t->comp;
@@ -2645,17 +2645,17 @@ vec PolyRing::translate_gbvector_to_vec(const FreeModule *F,
   Nterm **vec_last = newarray(Nterm *, lastcomp - firstcomp + 1);
   for (int i = 0; i < lastcomp - firstcomp + 1; i++)
     {
-      vec_comps[i] = nullptr;
-      vec_last[i] = nullptr;
+      vec_comps[i] = 0;
+      vec_last[i] = 0;
     }
 
   // Now make a list of Nterm's, copy gbvectors in (except comps)
-  for (const gbvector *t = v; t != nullptr; t = t->next)
+  for (const gbvector *t = v; t != 0; t = t->next)
     {
       Nterm *s = new_term();
       GR->gbvector_get_lead_monomial(F, t, s->monom);
       s->coeff = t->coeff;
-      s->next = nullptr;
+      s->next = 0;
       int x = t->comp - firstcomp;
       if (!vec_comps[x])
         {
@@ -2670,7 +2670,7 @@ vec PolyRing::translate_gbvector_to_vec(const FreeModule *F,
     }
 
   // Now create the vecs
-  vec result = nullptr;
+  vec result = 0;
   for (int x = 0; x < lastcomp - firstcomp + 1; x++)
     if (vec_comps[x])
       {

--- a/M2/Macaulay2/e/polyquotient.cpp
+++ b/M2/Macaulay2/e/polyquotient.cpp
@@ -125,7 +125,7 @@ bool PolyRingQuotient::lift(const Ring *Rg,
 // f is an element of 'this'.  Rg is the desired ring.
 {
   const PolynomialRing *Rg1 = Rg->cast_to_PolynomialRing();
-  if (Rg == numerR_ || (Rg1 != nullptr && Rg1->getAmbientRing() == numerR_))
+  if (Rg == numerR_ || (Rg1 != 0 && Rg1->getAmbientRing() == numerR_))
     {
       result = f;
       return true;
@@ -139,7 +139,7 @@ bool PolyRingQuotient::promote(const Ring *Rf,
 // f is an element of Rf.  result will be an element in 'this'.
 {
   const PolynomialRing *R1 = Rf->cast_to_PolynomialRing();
-  if (Rf == numerR_ || (R1 != nullptr && numerR_ == R1->getAmbientRing()))
+  if (Rf == numerR_ || (R1 != 0 && numerR_ == R1->getAmbientRing()))
     {
       result = copy(f);
       normal_form(result);

--- a/M2/Macaulay2/e/polyring.cpp
+++ b/M2/Macaulay2/e/polyring.cpp
@@ -41,9 +41,9 @@ void PolynomialRing::initialize_PolynomialRing(const Ring *K,
 
   exp_size = EXPONENT_BYTE_SIZE(nvars_);
 
-  if (K->is_QQ() || (K == globalZZ && denomR != nullptr))
+  if (K->is_QQ() || (K == globalZZ && denomR != 0))
     coeff_type_ = Ring::COEFF_QQ;
-  else if (K == globalZZ && denomR == nullptr)
+  else if (K == globalZZ && denomR == 0)
     coeff_type_ = Ring::COEFF_ZZ;
   else
     coeff_type_ = Ring::COEFF_BASIC;
@@ -59,9 +59,9 @@ void PolynomialRing::initialize_PolynomialRing(const Ring *K,
   if (numeratorR != this)
     {
       // We must set the non-commutative settings ourselves at this time
-      if (numeratorR->cast_to_WeylAlgebra() != nullptr)
+      if (numeratorR->cast_to_WeylAlgebra() != 0)
         is_weyl_ = true;
-      else if (numeratorR->cast_to_SolvableAlgebra() != nullptr)
+      else if (numeratorR->cast_to_SolvableAlgebra() != 0)
         is_solvable_ = true;
       else if (numeratorR->is_skew_commutative())
         {
@@ -71,7 +71,7 @@ void PolynomialRing::initialize_PolynomialRing(const Ring *K,
     }
 
   poly_size_ = 0;  // The callee needs to set this later
-  gb_ring_ = nullptr;    // The callee needs to set this later
+  gb_ring_ = 0;    // The callee needs to set this later
 
   // Also: callee should call setIsGraded, and set oneV, minus_oneV, zeroV
 }
@@ -89,10 +89,10 @@ PolynomialRing *PolynomialRing::create_quotient(const PolynomialRing *R,
   // case (1), (2): PolyRingQuotient
   // case (3): PolyQQ
 
-  PolynomialRing *result = nullptr;
+  PolynomialRing *result = NULL;
   Ring::CoefficientType coeff_type = R->coefficient_type();
 
-  QRingInfo *qrinfo = nullptr;
+  QRingInfo *qrinfo = NULL;
   switch (coeff_type)
     {
       case COEFF_BASIC:
@@ -137,7 +137,7 @@ PolynomialRing *PolynomialRing::create_quotient(const PolynomialRing *R,
   if (M->get_ring() != R)
     {
       ERROR("quotient elements not in the expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   VECTOR(Nterm *) elems;
 

--- a/M2/Macaulay2/e/qring.cpp
+++ b/M2/Macaulay2/e/qring.cpp
@@ -26,7 +26,7 @@ void QRingInfo::destroy(GBRing *GR)
   // remove the gbvector's as they are stashed in gbrings.
   // WARNING: these need to be deleted only if the gbring is non-NULL.
 
-  if (GR == nullptr) return;
+  if (GR == 0) return;
   for (int i = 0; i < quotient_gbvectors.size(); i++)
     GR->gbvector_remove(quotient_gbvectors[i]);
 }
@@ -126,7 +126,7 @@ void QRingInfo_field_basic::normal_form(ring_elem &f) const
   Nterm head;
   Nterm *result = &head;
   Nterm *t = f;
-  while (t != nullptr)
+  while (t != NULL)
     {
       M->to_expvector(t->monom, EXP1);
       Bag *b;
@@ -144,7 +144,7 @@ void QRingInfo_field_basic::normal_form(ring_elem &f) const
           result = result->next;
         }
     }
-  result->next = nullptr;
+  result->next = NULL;
   f = head.next;
 }
 
@@ -157,14 +157,14 @@ void QRingInfo_field_basic::gbvector_normal_form(const FreeModule *F,
   gbvector head;
   gbvector *result = &head;
   gbvector *t = f;
-  while (t != nullptr)
+  while (t != NULL)
     {
       GR->gbvector_get_lead_exponents(F, t, EXP1);
       int x = ringtable->find_divisor(EXP1, 1);
       if (x >= 0)
         {
           const gbvector *r = quotient_gbvector(x);
-          gbvector *zero = nullptr;
+          gbvector *zero = 0;
           GR->gbvector_reduce_lead_term(F, F, zero, t, zero, r, zero);
         }
       else
@@ -174,7 +174,7 @@ void QRingInfo_field_basic::gbvector_normal_form(const FreeModule *F,
           result = result->next;
         }
     }
-  result->next = nullptr;
+  result->next = NULL;
   f = head.next;
 }
 
@@ -219,7 +219,7 @@ void QRingInfo_field_QQ::normal_form(ring_elem &f) const
   Nterm head;
   Nterm *result = &head;
   Nterm *t = f;
-  while (t != nullptr)
+  while (t != NULL)
     {
       M->to_expvector(t->monom, EXP1);
       Bag *b;
@@ -237,7 +237,7 @@ void QRingInfo_field_QQ::normal_form(ring_elem &f) const
           result = result->next;
         }
     }
-  result->next = nullptr;
+  result->next = NULL;
   f = head.next;
 }
 
@@ -249,16 +249,16 @@ void QRingInfo_field_QQ::gbvector_normal_form(const FreeModule *F,
   GBRing *GR = R->get_gb_ring();
   gbvector head;
   gbvector *result = &head;
-  result->next = nullptr;
+  result->next = NULL;
   gbvector *t = f;
-  while (t != nullptr)
+  while (t != NULL)
     {
       GR->gbvector_get_lead_exponents(F, t, EXP1);
       int x = ringtable->find_divisor(EXP1, 1);
       if (x >= 0)
         {
           const gbvector *r = quotient_gbvector(x);
-          gbvector *zero = nullptr;
+          gbvector *zero = 0;
           GR->gbvector_reduce_lead_term(F, F, head.next, t, zero, r, zero);
         }
       else
@@ -266,7 +266,7 @@ void QRingInfo_field_QQ::gbvector_normal_form(const FreeModule *F,
           result->next = t;
           t = t->next;
           result = result->next;
-          result->next = nullptr;
+          result->next = NULL;
         }
     }
   f = head.next;
@@ -282,16 +282,16 @@ void QRingInfo_field_QQ::gbvector_normal_form(const FreeModule *F,
   GBRing *GR = R->get_gb_ring();
   gbvector head;
   gbvector *result = &head;
-  result->next = nullptr;
+  result->next = NULL;
   gbvector *t = f;
-  while (t != nullptr)
+  while (t != NULL)
     {
       GR->gbvector_get_lead_exponents(F, t, EXP1);
       int x = ringtable->find_divisor(EXP1, 1);
       if (x >= 0)
         {
           const gbvector *r = quotient_gbvector(x);
-          gbvector *zero = nullptr;
+          gbvector *zero = 0;
           GR->gbvector_reduce_lead_term(
               F, F, head.next, t, zero, r, zero, use_denom, denom);
         }
@@ -300,7 +300,7 @@ void QRingInfo_field_QQ::gbvector_normal_form(const FreeModule *F,
           result->next = t;
           t = t->next;
           result = result->next;
-          result->next = nullptr;
+          result->next = NULL;
         }
     }
   f = head.next;
@@ -337,7 +337,7 @@ QRingInfo_ZZ::QRingInfo_ZZ(const PolyRing *ambientR,
           appendQuotientElement(f, g);
           exp = newarray_atomic(int, R->n_vars());
 
-          if (f->next == nullptr && R->getMonoid()->is_one(f->monom))
+          if (f->next == 0 && R->getMonoid()->is_one(f->monom))
             {
               is_ZZ_quotient_ = true;
               ZZ_quotient_value_ = f->coeff;
@@ -391,7 +391,7 @@ void QRingInfo_ZZ::normal_form(ring_elem &f) const
   Nterm head;
   Nterm *result = &head;
   Nterm *t = f;
-  while (t != nullptr)
+  while (t != NULL)
     {
       M->to_expvector(t->monom, EXP1);
       int w = ringtableZZ->find_smallest_coeff_divisor(EXP1, 1);
@@ -407,7 +407,7 @@ void QRingInfo_ZZ::normal_form(ring_elem &f) const
       t = t->next;
       result = result->next;
     }
-  result->next = nullptr;
+  result->next = NULL;
   f = head.next;
 }
 
@@ -421,7 +421,7 @@ void QRingInfo_ZZ::gbvector_normal_form(const FreeModule *F, gbvector *&f) const
   gbvector head;
   gbvector *result = &head;
   gbvector *t = f;
-  while (t != nullptr)
+  while (t != NULL)
     {
       GR->gbvector_get_lead_exponents(F, t, EXP1);
       int w = ringtableZZ->find_smallest_coeff_divisor(EXP1, 1);
@@ -431,7 +431,7 @@ void QRingInfo_ZZ::gbvector_normal_form(const FreeModule *F, gbvector *&f) const
           // If the lead monomial reduces away, continue,
           //   else tack the monomial onto the result
           const gbvector *g = quotient_gbvector(w);
-          gbvector *zero = nullptr;
+          gbvector *zero = 0;
           if (GR->gbvector_reduce_lead_term_ZZ(F, F, t, zero, g, zero))
             continue;
         }
@@ -439,7 +439,7 @@ void QRingInfo_ZZ::gbvector_normal_form(const FreeModule *F, gbvector *&f) const
       t = t->next;
       result = result->next;
     }
-  result->next = nullptr;
+  result->next = NULL;
   f = head.next;
 }
 

--- a/M2/Macaulay2/e/qring.hpp
+++ b/M2/Macaulay2/e/qring.hpp
@@ -34,7 +34,7 @@ class QRingInfo : public our_new_delete
   QRingInfo(const PolyRing *R);
 
  public:
-  QRingInfo() : R(nullptr), overZZ_(false), exp_size(0), monom_size(0) {}
+  QRingInfo() : R(0), overZZ_(false), exp_size(0), monom_size(0) {}
   virtual void destroy(GBRing *GR);
   virtual ~QRingInfo();
 
@@ -55,15 +55,15 @@ class QRingInfo : public our_new_delete
     gbvector_normal_form(F, f);
   }
 
-  virtual const MonomialIdeal *get_quotient_monomials() const { return nullptr; }
+  virtual const MonomialIdeal *get_quotient_monomials() const { return 0; }
   // Each bag value is an "Nterm *".
 
-  virtual MonomialTable *get_quotient_MonomialTable() const { return nullptr; }
+  virtual MonomialTable *get_quotient_MonomialTable() const { return 0; }
   // Each id is an index into quotient_ideal_
 
   virtual const MonomialTableZZ *get_quotient_MonomialTableZZ() const
   {
-    return nullptr;
+    return 0;
   }
   // Each id is an index into quotient_ideal_
 };

--- a/M2/Macaulay2/e/reducedgb-ZZ.cpp
+++ b/M2/Macaulay2/e/reducedgb-ZZ.cpp
@@ -8,7 +8,7 @@
 ReducedGB_ZZ::~ReducedGB_ZZ()
 {
   delete T;
-  ringtableZZ = nullptr;
+  ringtableZZ = 0;
 }
 
 ReducedGB_ZZ::ReducedGB_ZZ(GBRing *R0,
@@ -85,7 +85,7 @@ void ReducedGB_ZZ::minimalize(const VECTOR(POLY) & polys0, bool auto_reduced)
 
           if (auto_reduced) remainder(h, false, junk);  // This auto-reduces h.
 
-          if (h.f != nullptr && mpz_sgn(h.f->coeff.get_mpz()) < 0)
+          if (h.f != 0 && mpz_sgn(h.f->coeff.get_mpz()) < 0)
             {
               R->gbvector_mult_by_coeff_to(h.f, globalZZ->minus_one());
               R->gbvector_mult_by_coeff_to(h.fsyz, globalZZ->minus_one());
@@ -133,10 +133,10 @@ enum ReducedGB_ZZ::divisor_type ReducedGB_ZZ::find_divisor(exponents_t exp,
 
 void ReducedGB_ZZ::remainder(POLY &f, bool use_denom, ring_elem &denom)
 {
-  gbvector *zero = nullptr;
+  gbvector *zero = 0;
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
   POLY h = f;
   exponents_t EXP = ALLOCATE_EXPONENTS(R->exponent_byte_size());
   gbvector *r;
@@ -166,7 +166,7 @@ void ReducedGB_ZZ::remainder(POLY &f, bool use_denom, ring_elem &denom)
       frem->next = h.f;
       frem = frem->next;
       h.f = h.f->next;
-      frem->next = nullptr;
+      frem->next = 0;
     }
   h.f = head.next;
   f.f = h.f;
@@ -176,10 +176,10 @@ void ReducedGB_ZZ::remainder(POLY &f, bool use_denom, ring_elem &denom)
 
 void ReducedGB_ZZ::remainder(gbvector *&f, bool use_denom, ring_elem &denom)
 {
-  gbvector *zero = nullptr;
+  gbvector *zero = 0;
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
   gbvector *h = f;
   exponents_t EXP = ALLOCATE_EXPONENTS(R->exponent_byte_size());
 
@@ -218,7 +218,7 @@ void ReducedGB_ZZ::remainder(gbvector *&f, bool use_denom, ring_elem &denom)
       frem->next = h;
       frem = frem->next;
       h = h->next;
-      frem->next = nullptr;
+      frem->next = 0;
     }
   h = head.next;
   f = h;

--- a/M2/Macaulay2/e/reducedgb-field-local.cpp
+++ b/M2/Macaulay2/e/reducedgb-field-local.cpp
@@ -20,7 +20,7 @@ ReducedGB_Field_Local::ReducedGB_Field_Local(GBRing *R0,
       wt(wt0)
 {
   // fprintf(stderr, "creating GB with local order\n");
-  if (wt == nullptr) wt = new GBWeight(F0, nullptr);
+  if (wt == 0) wt = new GBWeight(F0, 0);
   for (int i = 0; i < originalR0->n_quotients(); i++)
     {
       int f_lead_wt;
@@ -30,7 +30,7 @@ ReducedGB_Field_Local::ReducedGB_Field_Local(GBRing *R0,
 
       divisor_info t;
       t.g.f = const_cast<gbvector *>(f);
-      t.g.fsyz = nullptr;
+      t.g.fsyz = 0;
       t.size = R->gbvector_n_terms(f);
       t.alpha = a;
 
@@ -484,11 +484,11 @@ void ReducedGB_Field_Local::remainder(POLY &f, bool use_denom, ring_elem &denom)
       text_out(o);
       emit(o.str());
     }
-  if (f.f == nullptr) return;
+  if (f.f == 0) return;
   T1 = MonomialTable::make(R->n_vars());
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
   POLY h = f;
   exponents_t h_exp = R->exponents_make();
   int h_alpha, g_alpha;
@@ -526,7 +526,7 @@ void ReducedGB_Field_Local::remainder(POLY &f, bool use_denom, ring_elem &denom)
             }
           if (g_alpha > h_alpha)
             {
-              if (head.next != nullptr)
+              if (head.next != 0)
                 {
                   // In this case, we can't reduce the tail without
                   // risking an infinite loop.  So we declare ourselves done
@@ -550,7 +550,7 @@ void ReducedGB_Field_Local::remainder(POLY &f, bool use_denom, ring_elem &denom)
           frem->next = h.f;
           frem = frem->next;
           h.f = h.f->next;
-          frem->next = nullptr;
+          frem->next = 0;
         }
     }
 
@@ -564,16 +564,16 @@ void ReducedGB_Field_Local::remainder(gbvector *&f,
                                       bool use_denom,
                                       ring_elem &denom)
 {
-  if (f == nullptr) return;
+  if (f == 0) return;
 
   T1 = MonomialTable::make(R->n_vars());
-  gbvector *zero = nullptr;
+  gbvector *zero = 0;
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
   POLY h;
   h.f = f;
-  h.fsyz = nullptr;
+  h.fsyz = NULL;
   exponents_t h_exp = R->exponents_make();
   int h_alpha, g_alpha;
   int h_deg = wt->gbvector_weight(f);
@@ -610,7 +610,7 @@ void ReducedGB_Field_Local::remainder(gbvector *&f,
             }
           if (g_alpha > h_alpha)
             {
-              if (head.next != nullptr)
+              if (head.next != 0)
                 {
                   // In this case, we can't reduce the tail without
                   // risking an infinite loop.  So we declare ourselves done
@@ -633,7 +633,7 @@ void ReducedGB_Field_Local::remainder(gbvector *&f,
           frem->next = h.f;
           frem = frem->next;
           h.f = h.f->next;
-          frem->next = nullptr;
+          frem->next = 0;
         }
     }
 

--- a/M2/Macaulay2/e/reducedgb-field.cpp
+++ b/M2/Macaulay2/e/reducedgb-field.cpp
@@ -8,7 +8,7 @@
 ReducedGB_Field::~ReducedGB_Field()
 {
   delete T;
-  Rideal = nullptr;
+  Rideal = 0;
 }
 
 void ReducedGB_Field::set_gb(VECTOR(POLY) & polys0) {}
@@ -101,7 +101,7 @@ void ReducedGB_Field::remainder(POLY &f, bool use_denom, ring_elem &denom)
 {
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
   POLY h = f;
   exponents_t EXP = ALLOCATE_EXPONENTS(R->exponent_byte_size());
   while (!R->gbvector_is_zero(h.f))
@@ -109,11 +109,11 @@ void ReducedGB_Field::remainder(POLY &f, bool use_denom, ring_elem &denom)
       R->gbvector_get_lead_exponents(F, h.f, EXP);
       int x = h.f->comp;
       Bag *b;
-      if (Rideal != nullptr && Rideal->search_expvector(EXP, b))
+      if (Rideal != 0 && Rideal->search_expvector(EXP, b))
         {
           const gbvector *g = originalR->quotient_gbvector(b->basis_elem());
           R->gbvector_reduce_lead_term(
-              F, Fsyz, head.next, h.f, h.fsyz, g, nullptr, use_denom, denom);
+              F, Fsyz, head.next, h.f, h.fsyz, g, 0, use_denom, denom);
         }
       else
         {
@@ -136,7 +136,7 @@ void ReducedGB_Field::remainder(POLY &f, bool use_denom, ring_elem &denom)
               frem->next = h.f;
               frem = frem->next;
               h.f = h.f->next;
-              frem->next = nullptr;
+              frem->next = 0;
             }
         }
     }
@@ -150,10 +150,10 @@ void ReducedGB_Field::remainder(POLY &f, bool use_denom, ring_elem &denom)
 
 void ReducedGB_Field::remainder(gbvector *&f, bool use_denom, ring_elem &denom)
 {
-  gbvector *zero = nullptr;
+  gbvector *zero = 0;
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
   gbvector *h = f;
   exponents_t EXP = ALLOCATE_EXPONENTS(R->exponent_byte_size());
   while (!R->gbvector_is_zero(h))
@@ -161,7 +161,7 @@ void ReducedGB_Field::remainder(gbvector *&f, bool use_denom, ring_elem &denom)
       R->gbvector_get_lead_exponents(F, h, EXP);
       int x = h->comp;
       Bag *b;
-      if (Rideal != nullptr && Rideal->search_expvector(EXP, b))
+      if (Rideal != 0 && Rideal->search_expvector(EXP, b))
         {
           const gbvector *g = originalR->quotient_gbvector(b->basis_elem());
           R->gbvector_reduce_lead_term(
@@ -175,7 +175,7 @@ void ReducedGB_Field::remainder(gbvector *&f, bool use_denom, ring_elem &denom)
               frem->next = h;
               frem = frem->next;
               h = h->next;
-              frem->next = nullptr;
+              frem->next = 0;
             }
           else
             {

--- a/M2/Macaulay2/e/reducedgb-marked.cpp
+++ b/M2/Macaulay2/e/reducedgb-marked.cpp
@@ -40,7 +40,7 @@ struct MarkedGB_sorter
 MarkedGB::MarkedGB(const PolynomialRing *originalR0,
                    const FreeModule *F0,
                    const FreeModule *Fsyz0)
-    : ReducedGB(originalR0->get_gb_ring(), originalR0, F0, Fsyz0), T(nullptr)
+    : ReducedGB(originalR0->get_gb_ring(), originalR0, F0, Fsyz0), T(0)
 {
   T = MonomialTable::make(R->n_vars());
 }
@@ -69,8 +69,8 @@ void MarkedGB::add_marked_elems(const VECTOR(gbvector *) & leadterms0,
       h.f = R->gbvector_copy(f);
       h.fsyz = R->gbvector_copy(polys0[i].fsyz);
 
-      gbvector *iinf = nullptr;
-      for (gbvector *t = h.f; t != nullptr; t = t->next)
+      gbvector *iinf = 0;
+      for (gbvector *t = h.f; t != 0; t = t->next)
         if (inf->comp == t->comp && EQ == M->compare(inf->monom, t->monom))
           {
             iinf = t;
@@ -120,7 +120,7 @@ void MarkedGB::marked_remainder(POLY &f,
 {
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
   POLY h = f;
   exponents_t EXP = ALLOCATE_EXPONENTS(R->exponent_byte_size());
 
@@ -150,7 +150,7 @@ void MarkedGB::marked_remainder(POLY &f,
       frem->next = h.f;
       frem = frem->next;
       h.f = h.f->next;
-      frem->next = nullptr;
+      frem->next = 0;
     }
 
   h.f = head.next;
@@ -162,16 +162,16 @@ void MarkedGB::marked_remainder(POLY &f,
 
 void MarkedGB::remainder(POLY &f, bool use_denom, ring_elem &denom)
 {
-  marked_remainder(f, use_denom, denom, nullptr);
+  marked_remainder(f, use_denom, denom, NULL);
 }
 
 void MarkedGB::remainder(gbvector *&f, bool use_denom, ring_elem &denom)
 {
   //  return geo_remainder(f,use_denom,denom);
-  gbvector *zero = nullptr;
+  gbvector *zero = 0;
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
   gbvector *h = f;
   exponents_t EXP = ALLOCATE_EXPONENTS(R->exponent_byte_size());
 
@@ -185,7 +185,7 @@ void MarkedGB::remainder(gbvector *&f, bool use_denom, ring_elem &denom)
           frem->next = h;
           frem = frem->next;
           h = h->next;
-          frem->next = nullptr;
+          frem->next = 0;
         }
       else
         {
@@ -211,7 +211,7 @@ void MarkedGB::geo_remainder(gbvector *&f, bool use_denom, ring_elem &denom)
 {
   gbvector head;
   gbvector *frem = &head;
-  frem->next = nullptr;
+  frem->next = 0;
 
   gbvectorHeap fb(R, F);
   gbvectorHeap zero(R, Fsyz);
@@ -219,7 +219,7 @@ void MarkedGB::geo_remainder(gbvector *&f, bool use_denom, ring_elem &denom)
 
   const gbvector *lead;
   exponents_t EXP = ALLOCATE_EXPONENTS(R->exponent_byte_size());
-  while ((lead = fb.get_lead_term()) != nullptr)
+  while ((lead = fb.get_lead_term()) != NULL)
     {
       R->gbvector_get_lead_exponents(F, lead, EXP);
       int x = lead->comp;
@@ -228,13 +228,13 @@ void MarkedGB::geo_remainder(gbvector *&f, bool use_denom, ring_elem &denom)
         {
           frem->next = fb.remove_lead_term();
           frem = frem->next;
-          frem->next = nullptr;
+          frem->next = 0;
         }
       else
         {
           POLY g = polys[w];
           R->reduce_marked_lead_term_heap(
-              F, Fsyz, lead, EXP, head.next, fb, zero, leadterms[w], g.f, nullptr);
+              F, Fsyz, lead, EXP, head.next, fb, zero, leadterms[w], g.f, 0);
         }
     }
   f = head.next;
@@ -246,7 +246,7 @@ const Matrix /* or null */ *MarkedGB::get_initial(int nparts)
   if (nparts > 0)
     {
       ERROR("Cannot determine given initial monomials");
-      return nullptr;
+      return 0;
     }
   MatrixConstructor mat(F, 0);
   for (int i = 0; i < polys.size(); i++)

--- a/M2/Macaulay2/e/reducedgb.cpp
+++ b/M2/Macaulay2/e/reducedgb.cpp
@@ -67,7 +67,7 @@ const Matrix /* or null */ *ReducedGB::get_mingens()
 #ifdef DEVELOPMENT
 #warning "mingens?"
 #endif
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *ReducedGB::get_syzygies()
@@ -75,7 +75,7 @@ const Matrix /* or null */ *ReducedGB::get_syzygies()
 #ifdef DEVELOPMENT
 #warning "syzygies?"
 #endif
-  return nullptr;
+  return 0;
 }
 
 const Matrix /* or null */ *ReducedGB::get_change()
@@ -129,13 +129,13 @@ const Matrix /* or null */ *ReducedGB::matrix_remainder(const Matrix *m)
   if (m->get_ring() != originalR)
     {
       ERROR("expected matrix over the same ring");
-      return nullptr;
+      return 0;
     }
 
   if (m->n_rows() != F->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      return nullptr;
+      return 0;
     }
 
   MatrixConstructor red(m->rows(), m->cols(), m->degree_shift());
@@ -160,20 +160,20 @@ M2_bool ReducedGB::matrix_lift(const Matrix *m,
   if (m->get_ring() != originalR)
     {
       ERROR("expected matrix over the same ring");
-      *result_remainder = nullptr;
-      *result_quotient = nullptr;
+      *result_remainder = 0;
+      *result_quotient = 0;
       return false;
     }
   if (m->n_rows() != F->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      *result_remainder = nullptr;
-      *result_quotient = nullptr;
+      *result_remainder = 0;
+      *result_quotient = 0;
       return false;
     }
 
   MatrixConstructor mat_remainder(m->rows(), m->cols(), m->degree_shift());
-  MatrixConstructor mat_quotient(Fsyz, m->cols(), nullptr);
+  MatrixConstructor mat_quotient(Fsyz, m->cols(), 0);
 
 #ifdef DEVELOPMENT
 #warning "K should be the denominator ring?"
@@ -188,7 +188,7 @@ M2_bool ReducedGB::matrix_lift(const Matrix *m,
       g.fsyz = R->gbvector_zero();
 
       remainder(g, true, denom);
-      if (g.f != nullptr) all_zeroes = false;
+      if (g.f != 0) all_zeroes = false;
 
       vec fv = originalR->translate_gbvector_to_vec_denom(F, g.f, denom);
       K->negate_to(denom);
@@ -221,7 +221,7 @@ int ReducedGB::contains(const Matrix *m)
 
       remainder(g, false, denom);
 
-      if (g != nullptr)
+      if (g != NULL)
         {
           R->gbvector_remove(g);
           return i;

--- a/M2/Macaulay2/e/reducedgb.hpp
+++ b/M2/Macaulay2/e/reducedgb.hpp
@@ -43,7 +43,7 @@ class ReducedGB : public GBComputation
   static ReducedGB *create(const PolynomialRing *originalR0,
                            const FreeModule *F0,
                            const FreeModule *Fsyz0,
-                           const GBWeight *wt0 = nullptr);
+                           const GBWeight *wt0 = 0);
 
   virtual GBComputation *cast_to_GBComputation() { return this; }
   virtual void start_computation() {}

--- a/M2/Macaulay2/e/relem.cpp
+++ b/M2/Macaulay2/e/relem.cpp
@@ -49,7 +49,7 @@ RingElement *RingElement::invert() const
   if (is_zero())
     {
       ERROR("ring division: attempt to divide by zero");
-      return nullptr;
+      return 0;
     }
   return new RingElement(R, R->invert(val));
 }
@@ -59,10 +59,10 @@ RingElement /* or null */ *RingElement::operator+(const RingElement &b) const
   if (R != b.get_ring())
     {
       ERROR("ring addition requires both elements to have the same base ring");
-      return nullptr;
+      return 0;
     }
   ring_elem result = R->add(get_value(), b.get_value());
-  if (error()) return nullptr;
+  if (error()) return 0;
   return new RingElement(R, result);
 }
 
@@ -72,10 +72,10 @@ RingElement /* or null */ *RingElement::operator-(const RingElement &b) const
     {
       ERROR(
           "ring subtraction requires both elements to have the same base ring");
-      return nullptr;
+      return 0;
     }
   ring_elem result = R->subtract(get_value(), b.get_value());
-  if (error()) return nullptr;
+  if (error()) return 0;
   return new RingElement(R, result);
 }
 
@@ -86,10 +86,10 @@ RingElement /* or null */ *RingElement::operator*(const RingElement &b) const
       ERROR(
           "ring multiplication requires both elements to have the same base "
           "ring");
-      return nullptr;
+      return 0;
     }
   ring_elem result = R->mult(get_value(), b.get_value());
-  if (error()) return nullptr;
+  if (error()) return 0;
   return new RingElement(R, result);
 }
 
@@ -107,15 +107,15 @@ RingElement /* or null */ *RingElement::operator/(const RingElement &b) const
   if (R != b.get_ring())
     {
       ERROR("ring division requires both elements to have the same base ring");
-      return nullptr;
+      return 0;
     }
   if (b.is_zero())
     {
       ERROR("ring division: attempt to divide by zero");
-      return nullptr;
+      return 0;
     }
   ring_elem result = R->divide(get_value(), b.get_value());
-  if (error()) return nullptr;
+  if (error()) return 0;
   return new RingElement(R, result);
 }
 
@@ -123,14 +123,14 @@ RingElement /* or null */ *RingElement::power(int n) const
 {
   // n negative is handled.
   ring_elem f = R->power(val, n);
-  if (error()) return nullptr;
+  if (error()) return 0;
   return new RingElement(R, f);
 }
 
 RingElement /* or null */ *RingElement::power(mpz_srcptr n) const
 {
   ring_elem f = R->power(val, n);
-  if (error()) return nullptr;
+  if (error()) return 0;
   return new RingElement(R, f);
 }
 
@@ -186,10 +186,10 @@ RingElement /* or null */ *RingElement::get_coeff(const Ring *coeffR,
                                                   const EngineMonomial *m) const
 {
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   return new RingElement(coeffR, P->get_coeff(coeffR, get_value(), m->ints()));
 }
@@ -253,7 +253,7 @@ void RingElement::degree_weights(M2_arrayint wts, int &lo, int &hi) const
       ERROR("zero element has no degree");
       return;
     }
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected polynomial ring");
       return;
@@ -266,7 +266,7 @@ M2_arrayint RingElement::multi_degree() const
   if (is_zero())
     {
       ERROR("the zero element has no degree");
-      return nullptr;
+      return 0;
     }
 
   int *mon = newarray_atomic(int, R->degree_monoid()->monomial_size());
@@ -280,58 +280,58 @@ M2_arrayint RingElement::multi_degree() const
 RingElement *RingElement::homogenize(int v, M2_arrayint wts) const
 {
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   if (v < 0 || v >= P->n_vars())
     {
       ERROR("homogenization: improper ring variable");
-      return nullptr;
+      return 0;
     }
-  if (wts == nullptr || wts->len != static_cast<unsigned int>(P->n_vars()))
+  if (wts == NULL || wts->len != static_cast<unsigned int>(P->n_vars()))
     {
       ERROR("homogenization: improper weight function");
-      return nullptr;
+      return 0;
     }
   if (wts->array[v] == 0)
     {
       ERROR("homogenization: variable weight is zero");
-      return nullptr;
+      return 0;
     }
 
   RingElement *result = new RingElement(P, P->homogenize(val, v, wts));
-  if (error()) return nullptr;
+  if (error()) return 0;
   return result;
 }
 
 RingElement *RingElement::homogenize(int v, int deg, M2_arrayint wts) const
 {
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   if (v < 0 || v >= P->n_vars())
     {
       ERROR("homogenization: improper ring variable");
-      return nullptr;
+      return 0;
     }
-  if (wts == nullptr || wts->len != static_cast<unsigned int>(P->n_vars()))
+  if (wts == NULL || wts->len != static_cast<unsigned int>(P->n_vars()))
     {
       ERROR("homogenization: improper weight function");
-      return nullptr;
+      return 0;
     }
   if (wts->array[v] == 0)
     {
       ERROR("homogenization: variable weight is zero");
-      return nullptr;
+      return 0;
     }
 
   RingElement *result = new RingElement(R, P->homogenize(val, v, deg, wts));
-  if (error()) return nullptr;
+  if (error()) return 0;
   return result;
 }
 
@@ -370,7 +370,7 @@ bool RingElement::lift(const Ring *S, const RingElement *&result) const
 const RingElement /* or null */ *RingElement::content() const
 {
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  const Ring *targetR = (P == nullptr ? R : P->getCoefficients());
+  const Ring *targetR = (P == 0 ? R : P->getCoefficients());
 
   return new RingElement(targetR, R->content(val));
 }
@@ -456,7 +456,7 @@ bool RingElement::getSmallIntegerCoefficients(
 {
   const PolynomialRing *R = get_ring()->cast_to_PolynomialRing();
   const Ring *K = R->getCoefficientRing();
-  if (R == nullptr || R->n_vars() != 1)
+  if (R == 0 || R->n_vars() != 1)
     {
       throw exc::engine_error(
           "Expected a polynomial in a univariate polynomial ring");
@@ -495,7 +495,7 @@ bool RingElement::getSmallIntegerCoefficients(
 M2_arrayintOrNull RingElement::getSmallIntegerCoefficients() const
 {
   std::vector<long> coeffs;
-  if (!getSmallIntegerCoefficients(coeffs)) return nullptr;
+  if (!getSmallIntegerCoefficients(coeffs)) return 0;
   return stdvector_to_M2_arrayint(coeffs);
 }
 

--- a/M2/Macaulay2/e/res-a0-poly.cpp
+++ b/M2/Macaulay2/e/res-a0-poly.cpp
@@ -28,7 +28,7 @@ int res2_poly::compare(const res2term *a, const res2term *b) const
 res2term *res2_poly::new_term() const
 {
   res2term *result = reinterpret_cast<res2term *>(resterm_stash->new_elem());
-  result->next = nullptr;
+  result->next = NULL;
   return result;
 }
 res2term *res2_poly::new_term(ring_elem c, const int *m, res2_pair *x) const
@@ -45,7 +45,7 @@ res2term *res2_poly::mult_by_monomial(const res2term *f, const int *m) const
 {
   res2term head;
   res2term *result = &head;
-  for (const res2term *tm = f; tm != nullptr; tm = tm->next)
+  for (const res2term *tm = f; tm != NULL; tm = tm->next)
     {
       result->next = new_term();
       result = result->next;
@@ -53,7 +53,7 @@ res2term *res2_poly::mult_by_monomial(const res2term *f, const int *m) const
       result->coeff = K->copy(tm->coeff);
       M->mult(tm->monom, m, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -62,7 +62,7 @@ res2term *res2_poly::mult_by_coefficient(const res2term *f,
 {
   res2term head;
   res2term *result = &head;
-  for (const res2term *tm = f; tm != nullptr; tm = tm->next)
+  for (const res2term *tm = f; tm != NULL; tm = tm->next)
     {
       result->next = new_term();
       result = result->next;
@@ -70,7 +70,7 @@ res2term *res2_poly::mult_by_coefficient(const res2term *f,
       result->coeff = K->mult(c, tm->coeff);
       M->copy(tm->monom, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -78,7 +78,7 @@ res2term *res2_poly::copy(const res2term *f) const
 {
   res2term head;
   res2term *result = &head;
-  for (const res2term *tm = f; tm != nullptr; tm = tm->next)
+  for (const res2term *tm = f; tm != NULL; tm = tm->next)
     {
       result->next = new_term();
       result = result->next;
@@ -86,12 +86,12 @@ res2term *res2_poly::copy(const res2term *f) const
       result->coeff = K->copy(tm->coeff);
       M->copy(tm->monom, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 void res2_poly::remove(res2term *&f) const
 {
-  while (f != nullptr)
+  while (f != NULL)
     {
       res2term *tmp = f;
       f = f->next;
@@ -106,7 +106,7 @@ res2term *res2_poly::mult_by_term(const res2term *f,
 {
   res2term head;
   res2term *result = &head;
-  for (const res2term *tm = f; tm != nullptr; tm = tm->next)
+  for (const res2term *tm = f; tm != NULL; tm = tm->next)
     {
       result->next = new_term();
       result = result->next;
@@ -114,7 +114,7 @@ res2term *res2_poly::mult_by_term(const res2term *f,
       result->coeff = K->mult(c, tm->coeff);
       M->mult(tm->monom, m, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 res2term *res2_poly::ring_mult_by_term(const ring_elem f,
@@ -132,16 +132,16 @@ res2term *res2_poly::ring_mult_by_term(const ring_elem f,
       result->coeff = K->mult(c, tm.coeff);
       M->mult(tm.monom, m, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
 void res2_poly::make_monic(res2term *&f) const
 {
-  if (f == nullptr) return;
+  if (f == NULL) return;
   ring_elem c_inv = K->invert(f->coeff);
 
-  for (res2term *tm = f; tm != nullptr; tm = tm->next)
+  for (res2term *tm = f; tm != NULL; tm = tm->next)
     K->mult_to(tm->coeff, c_inv);
 
   K->remove(c_inv);
@@ -149,11 +149,11 @@ void res2_poly::make_monic(res2term *&f) const
 
 void res2_poly::add_to(res2term *&f, res2term *&g) const
 {
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == NULL) return;
+  if (f == NULL)
     {
       f = g;
-      g = nullptr;
+      g = NULL;
       return;
     }
   res2term head;
@@ -164,7 +164,7 @@ void res2_poly::add_to(res2term *&f, res2term *&g) const
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               f = head.next;
@@ -175,11 +175,11 @@ void res2_poly::add_to(res2term *&f, res2term *&g) const
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               f = head.next;
-              g = nullptr;
+              g = NULL;
               return;
             }
           break;
@@ -197,17 +197,17 @@ void res2_poly::add_to(res2term *&f, res2term *&g) const
               result = result->next;
             }
           resterm_stash->delete_elem(tmg);
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               f = head.next;
               return;
             }
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               f = head.next;
-              g = nullptr;
+              g = NULL;
               return;
             }
           break;
@@ -241,7 +241,7 @@ void res2_poly::ring_subtract_multiple_to(res2term *&f,
 int res2_poly::n_terms(const res2term *f) const
 {
   int result = 0;
-  for (; f != nullptr; f = f->next) result++;
+  for (; f != NULL; f = f->next) result++;
   return result;
 }
 
@@ -253,7 +253,7 @@ void res2_poly::elem_text_out(const res2term *f) const
 }
 void res2_poly::elem_text_out(buffer &o, const res2term *f) const
 {
-  if (f == nullptr)
+  if (f == NULL)
     {
       o << "0";
       return;
@@ -262,7 +262,7 @@ void res2_poly::elem_text_out(buffer &o, const res2term *f) const
   bool p_one = false;
   bool p_parens = true;
   bool p_plus = false;
-  for (const res2term *t = f; t != nullptr; t = t->next)
+  for (const res2term *t = f; t != NULL; t = t->next)
     {
       int isone = M->is_one(t->monom);
       K->elem_text_out(o, t->coeff, p_one, p_plus, p_parens);
@@ -278,7 +278,7 @@ vec res2_poly::to_vector(const res2term *f,
 {
   vecHeap H(F);
   monomial mon = M->make_one();
-  for (const res2term *tm = f; tm != nullptr; tm = tm->next)
+  for (const res2term *tm = f; tm != NULL; tm = tm->next)
     {
       //    int x = (to_minimal ? tm->comp->minimal_me : tm->comp->me);
       int x = tm->comp->me;  // MES: Currently used for non-minimal as well...
@@ -298,7 +298,7 @@ res2term *res2_poly::from_vector(const VECTOR(res2_pair *)& base,
   res2term head;
   res2term *result = &head;
 
-  for (vecterm *w = v; w != nullptr; w = w->next)
+  for (vecterm *w = v; w != NULL; w = w->next)
     for (Nterm& t : w->coeff)
       {
         result->next = new_term();
@@ -308,7 +308,7 @@ res2term *res2_poly::from_vector(const VECTOR(res2_pair *)& base,
         M->copy(t.monom, result->monom);
         M->mult(result->monom, result->comp->syz->monom, result->monom);
       }
-  result->next = nullptr;
+  result->next = NULL;
   // Now we must sort these
   sort(head.next);
   return head.next;
@@ -318,7 +318,7 @@ res2term *res2_poly::strip(const res2term *f) const
 {
   res2term head;
   res2term *result = &head;
-  for (const res2term *tm = f; tm != nullptr; tm = tm->next)
+  for (const res2term *tm = f; tm != NULL; tm = tm->next)
     if (tm->comp->syz_type != SYZ2_NOT_MINIMAL)
       {
         result->next = new_term();
@@ -327,16 +327,16 @@ res2term *res2_poly::strip(const res2term *f) const
         result->coeff = K->copy(tm->coeff);
         M->copy(tm->monom, result->monom);
       }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
 const res2term *res2_poly::component_occurs_in(const res2_pair *x,
                                                const res2term *f) const
 {
-  for (const res2term *tm = f; tm != nullptr; tm = tm->next)
+  for (const res2term *tm = f; tm != NULL; tm = tm->next)
     if (tm->comp == x) return tm;
-  return nullptr;
+  return NULL;
 }
 
 void res2_poly::sort(res2term *&f) const
@@ -345,17 +345,17 @@ void res2_poly::sort(res2term *&f) const
   // then add them together.  This allows the same monomial
   // to appear more than once in 'f'.
 
-  if (f == nullptr || f->next == nullptr) return;
-  res2term *f1 = nullptr;
-  res2term *f2 = nullptr;
-  while (f != nullptr)
+  if (f == NULL || f->next == NULL) return;
+  res2term *f1 = NULL;
+  res2term *f2 = NULL;
+  while (f != NULL)
     {
       res2term *t = f;
       f = f->next;
       t->next = f1;
       f1 = t;
 
-      if (f == nullptr) break;
+      if (f == NULL) break;
       t = f;
       f = f->next;
       t->next = f2;

--- a/M2/Macaulay2/e/res-a0.cpp
+++ b/M2/Macaulay2/e/res-a0.cpp
@@ -14,7 +14,7 @@ using respolyHeap = geobucket<const res2_poly, res2term *>;
 
 bool res2_comp::stop_conditions_ok()
 {
-  if (stop_.length_limit != nullptr && stop_.length_limit->len > 0)
+  if (stop_.length_limit != 0 && stop_.length_limit->len > 0)
     {
     }
 
@@ -27,7 +27,7 @@ int res2_comp::complete_thru_degree() const
   int len = resn.size() - 1;
   for (int lev = 0; lev <= len; lev++)
     {
-      for (res2_pair *p = resn[lev]->pairs; p != nullptr; p = p->next)
+      for (res2_pair *p = resn[lev]->pairs; p != NULL; p = p->next)
         {
           if (p->syz_type != SYZ2_S_PAIR) continue;
           int d = p->degree;
@@ -44,11 +44,11 @@ enum ComputationStatusCode res2_comp::skeleton(int level)
   res2_pair *p;
   if (resn[level]->state != RES_SKELETON) return COMP_COMPUTING;
   // If we are new here, next_pairs will be null, so we should sort
-  if (resn[level]->next_pair == nullptr)
+  if (resn[level]->next_pair == NULL)
     {
       sort_skeleton(resn[level]->pairs);
       int n = 0;
-      for (p = resn[level]->pairs; p != nullptr; p = p->next)
+      for (p = resn[level]->pairs; p != NULL; p = p->next)
         {
           p->me = n++;
           p->pair_num = p->me;
@@ -60,7 +60,7 @@ enum ComputationStatusCode res2_comp::skeleton(int level)
   for (;;)
     {
       p = resn[level]->next_pair;
-      if (p == nullptr) break;
+      if (p == NULL) break;
       resn[level]->next_pair = p->next;
       // The following will only insert pairs of degree > topdegree
       // so this routine may be used to increase the degree bound
@@ -77,8 +77,8 @@ void res2_comp::increase_level(int newmax)
   for (int i = resn.size(); i <= newmax + 2; i++)
     {
       res2_level *p = new res2_level;
-      p->pairs = nullptr;
-      p->next_pair = nullptr;
+      p->pairs = NULL;
+      p->next_pair = NULL;
       p->state = RES_SKELETON;
       p->npairs = 0;
       p->nleft = 0;
@@ -95,7 +95,7 @@ enum ComputationStatusCode res2_comp::do_all_pairs(int level, int degree)
   // and then actually compute the ones in that degree.
   if (level <= 0 || level > length_limit + 1) return COMP_COMPUTING;
   //  if (degree <= 0 || degree > hidegree) return COMP_COMPUTING;
-  if (level < resn.size() && (resn[level]->next_pair == nullptr ||
+  if (level < resn.size() && (resn[level]->next_pair == NULL ||
                                 degree < resn[level]->next_pair->degree))
     return COMP_COMPUTING;
   enum ComputationStatusCode ret = do_all_pairs(level, degree - 1);
@@ -117,7 +117,7 @@ enum ComputationStatusCode res2_comp::do_pairs(int level, int degree)
     {
       p = resn[level]->next_pair;
       int nelems = 0;
-      while (p != nullptr && p->degree == degree)
+      while (p != NULL && p->degree == degree)
         {
           if (p->syz_type == SYZ2_S_PAIR || p->syz_type == SYZ2_MAYBE_MINIMAL)
             nelems++;
@@ -130,7 +130,7 @@ enum ComputationStatusCode res2_comp::do_pairs(int level, int degree)
           emit(o.str());
         }
     }
-  for (p = resn[level]->next_pair; p != nullptr; p = p->next)
+  for (p = resn[level]->next_pair; p != NULL; p = p->next)
     {
       if (p->degree != degree) break;
       resn[level]->next_pair = p->next;
@@ -164,7 +164,7 @@ enum ComputationStatusCode res2_comp::do_pairs_by_level(int level)
           emit(o.str());
         }
     }
-  for (p = resn[level]->next_pair; p != nullptr; p = p->next)
+  for (p = resn[level]->next_pair; p != NULL; p = p->next)
     {
       resn[level]->next_pair = p->next;
       handle_pair_by_level(p);
@@ -182,12 +182,12 @@ enum ComputationStatusCode res2_comp::do_pairs_by_level(int level)
       // to place this information elsewhere.
       int nmonoms = 0;
       int nkilled = 0;
-      for (p = resn[level]->pairs; p != nullptr; p = p->next)
+      for (p = resn[level]->pairs; p != NULL; p = p->next)
         {
           res2term *f = p->syz;
           res2term head;
           res2term *g = &head;
-          for (f = p->syz; f != nullptr; f = f->next)
+          for (f = p->syz; f != NULL; f = f->next)
             {
               if (f->comp->mi->size() > 0)
                 {
@@ -198,7 +198,7 @@ enum ComputationStatusCode res2_comp::do_pairs_by_level(int level)
               else
                 nkilled++;
             }
-          g->next = nullptr;
+          g->next = NULL;
           p->pivot_term = head.next;
         }
       if (M2_gbTrace >= 3)
@@ -222,7 +222,7 @@ enum ComputationStatusCode res2_comp::do_pairs_by_degree(int level, int degree)
     {
       p = resn[level]->next_pair;
       int nelems = 0;
-      while (p != nullptr && p->degree == degree)
+      while (p != NULL && p->degree == degree)
         {
           nelems++;
           p = p->next;
@@ -234,7 +234,7 @@ enum ComputationStatusCode res2_comp::do_pairs_by_degree(int level, int degree)
           emit(o.str());
         }
     }
-  for (p = resn[level]->next_pair; p != nullptr; p = p->next)
+  for (p = resn[level]->next_pair; p != NULL; p = p->next)
     {
       if (p->degree != degree) break;
       resn[level]->next_pair = p->next;
@@ -311,10 +311,10 @@ void res2_comp::start_computation()
       if (resn[level]->state != RES_MONORDER) continue;
       // The sort will use compare_num's from syz->comp->compare_num
       // and will use these numbers to break ties:
-      for (n = 0, p = resn[level]->pairs; p != nullptr; p = p->next, n++)
+      for (n = 0, p = resn[level]->pairs; p != NULL; p = p->next, n++)
         p->compare_num = n;
       sort_monorder(resn[level]->pairs);
-      for (n = 0, p = resn[level]->pairs; p != nullptr; p = p->next, n++)
+      for (n = 0, p = resn[level]->pairs; p != NULL; p = p->next, n++)
         p->compare_num = n;
       sort_reduction(resn[level]->pairs);
       resn[level]->state = RES_REDUCTIONS;
@@ -485,7 +485,7 @@ void res2_comp::initialize(const Matrix *mat,
 
   // Do level 1
   for (auto i = 0; i < generator_matrix->n_cols(); i++)
-    if ((*generator_matrix)[i] != nullptr)
+    if ((*generator_matrix)[i] != NULL)
       {
         res2_pair *p = new_res2_pair(i);  // Makes a generator 'pair'
         insert_pair(p);
@@ -569,7 +569,7 @@ res2_comp::res2_comp(const Matrix *m,
 
 void res2_comp::remove_res2_pair(res2_pair *p)
 {
-  if (p == nullptr) return;
+  if (p == NULL) return;
   R->remove(p->syz);
   delete p->mi;
   freemem(p);
@@ -577,8 +577,8 @@ void res2_comp::remove_res2_pair(res2_pair *p)
 
 void res2_comp::remove_res2_level(res2_level *lev)
 {
-  if (lev == nullptr) return;
-  while (lev->pairs != nullptr)
+  if (lev == NULL) return;
+  while (lev->pairs != NULL)
     {
       res2_pair *p = lev->pairs;
       lev->pairs = p->next;
@@ -605,7 +605,7 @@ res2_pair *res2_comp::new_res2_pair(res2_pair *first,
                                     const int *basemon)
 {
   res2_pair *p = new res2_pair;
-  p->next = nullptr;
+  p->next = NULL;
   p->me = next_component++;
   p->pair_num = p->me;
   p->syz_type = SYZ2_S_PAIR;
@@ -619,7 +619,7 @@ res2_pair *res2_comp::new_res2_pair(res2_pair *first,
 //     p->syz->next = R->new_term(K->from_long(-1), basemon, second);
 #endif
   p->mi = new MonomialIdeal(P, mi_stash);
-  p->pivot_term = nullptr;
+  p->pivot_term = NULL;
 
   return p;
 }
@@ -627,7 +627,7 @@ res2_pair *res2_comp::new_res2_pair(res2_pair *first,
 res2_pair *res2_comp::new_base_res2_pair(int i)
 {
   res2_pair *p = new res2_pair;
-  p->next = nullptr;
+  p->next = NULL;
   p->me = next_component++;
   p->pair_num = p->me;
   p->syz_type = SYZ2_MINIMAL;
@@ -639,14 +639,14 @@ res2_pair *res2_comp::new_base_res2_pair(int i)
   p->syz = R->new_term(K->from_long(1), m, p);  // circular link...
   M->remove(m);
   p->mi = new MonomialIdeal(P, mi_stash);
-  p->pivot_term = nullptr;
+  p->pivot_term = NULL;
   return p;
 }
 
 res2_pair *res2_comp::new_res2_pair(int i)
 {
   res2_pair *p = new res2_pair;
-  p->next = nullptr;
+  p->next = NULL;
   p->me = next_component++;
   p->pair_num = p->me;
   p->syz_type = SYZ2_S_PAIR;
@@ -656,7 +656,7 @@ res2_pair *res2_comp::new_res2_pair(int i)
   p->compare_num = 0;
   p->syz = R->from_vector(base_components, (*generator_matrix)[i]);
   p->mi = new MonomialIdeal(P, mi_stash);
-  p->pivot_term = nullptr;
+  p->pivot_term = NULL;
   return p;
 }
 
@@ -856,8 +856,8 @@ int res2_comp::compare_res2_pairs(res2_pair *f, res2_pair *g) const
 
 res2_pair *res2_comp::merge_res2_pairs(res2_pair *f, res2_pair *g) const
 {
-  if (g == nullptr) return f;
-  if (f == nullptr) return g;
+  if (g == NULL) return f;
+  if (f == NULL) return g;
   res2_pair head;
   res2_pair *result = &head;
   while (1) switch (compare_res2_pairs(f, g))
@@ -867,7 +867,7 @@ res2_pair *res2_comp::merge_res2_pairs(res2_pair *f, res2_pair *g) const
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               return head.next;
@@ -877,7 +877,7 @@ res2_pair *res2_comp::merge_res2_pairs(res2_pair *f, res2_pair *g) const
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               return head.next;
@@ -891,17 +891,17 @@ res2_pair *res2_comp::merge_res2_pairs(res2_pair *f, res2_pair *g) const
 void res2_comp::sort_res2_pairs(res2_pair *&p) const
 {
   // These elements are sorted in ascending 'me' values
-  if (p == nullptr || p->next == nullptr) return;
-  res2_pair *p1 = nullptr;
-  res2_pair *p2 = nullptr;
-  while (p != nullptr)
+  if (p == NULL || p->next == NULL) return;
+  res2_pair *p1 = NULL;
+  res2_pair *p2 = NULL;
+  while (p != NULL)
     {
       res2_pair *tmp = p;
       p = p->next;
       tmp->next = p1;
       p1 = tmp;
 
-      if (p == nullptr) break;
+      if (p == NULL) break;
       tmp = p;
       p = p->next;
       tmp->next = p2;
@@ -983,7 +983,7 @@ void res2_comp::new_pairs(res2_pair *p)
             {
               thisvp.resize(0);
               varpower::var(w, 1, thisvp);
-              Bag *b = new Bag(static_cast<void *>(nullptr), thisvp);
+              Bag *b = new Bag(static_cast<void *>(0), thisvp);
               elems.push_back(b);
             }
         }
@@ -1004,7 +1004,7 @@ void res2_comp::new_pairs(res2_pair *p)
           varpower::quotient(a.monom().data(), vp.data(), thisvp);
           if (varpower::is_equal(a.monom().data(), thisvp.data()))
             continue;
-          Bag *b = new Bag(static_cast<void *>(nullptr), thisvp);
+          Bag *b = new Bag(static_cast<void *>(0), thisvp);
           elems.push_back(b);
         }
     }
@@ -1109,9 +1109,9 @@ int res2_comp::find_divisor(const MonomialIdeal *mi,
 
 res2term *res2_comp::s_pair(res2term *f) const
 {
-  res2term *result = nullptr;
+  res2term *result = NULL;
   monomial si = M->make_one();
-  while (f != nullptr)
+  while (f != NULL)
     {
       M->divide(f->monom, f->comp->syz->monom, si);
       res2term *h = R->mult_by_term(f->comp->syz, f->coeff, si);
@@ -1136,7 +1136,7 @@ res2_pair *res2_comp::reduce(res2term *&f,
   exponents_t REDUCE_exp = ALLOCATE_EXPONENTS(exp_size);
   monomial REDUCE_mon = ALLOCATE_MONOMIAL(monom_size);
 
-  res2term *lastterm = (fsyz->next == nullptr ? fsyz : fsyz->next);
+  res2term *lastterm = (fsyz->next == NULL ? fsyz : fsyz->next);
 
   res2_pair *q;
   ring_elem rg;
@@ -1145,7 +1145,7 @@ res2_pair *res2_comp::reduce(res2term *&f,
   int count = 0;
   if (M2_gbTrace >= 4) emit_wrapped(",");
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       M->divide(f->monom, f->comp->syz->monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
@@ -1184,7 +1184,7 @@ res2_pair *res2_comp::reduce(res2term *&f,
         {
           res2term *tmp = f;
           f = f->next;
-          tmp->next = nullptr;
+          tmp->next = NULL;
           R->remove(tmp);
         }
     }
@@ -1194,7 +1194,7 @@ res2_pair *res2_comp::reduce(res2term *&f,
       o << count;
       emit_wrapped(o.str());
     }
-  return nullptr;
+  return NULL;
 }
 
 res2_pair *res2_comp::reduce2(res2term *&f,
@@ -1211,17 +1211,17 @@ res2_pair *res2_comp::reduce2(res2term *&f,
   exponents_t REDUCE_exp = ALLOCATE_EXPONENTS(exp_size);
   monomial REDUCE_mon = ALLOCATE_MONOMIAL(monom_size);
 
-  res2term *lastterm = (fsyz->next == nullptr ? fsyz : fsyz->next);
+  res2term *lastterm = (fsyz->next == NULL ? fsyz : fsyz->next);
   res2term head;
   res2term *red = &head;
-  res2_pair *result = nullptr;
+  res2_pair *result = NULL;
   res2_pair *q;
   ring_elem rg;
 
   int count = 0;
   if (M2_gbTrace >= 4) emit_wrapped(",");
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       M->divide(f->monom, f->comp->syz->monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
@@ -1238,12 +1238,12 @@ res2_pair *res2_comp::reduce2(res2term *&f,
         {
           if (q->syz_type == SYZ2_S_PAIR || q->syz_type == SYZ2_MAYBE_MINIMAL)
             {
-              if (result == nullptr || auto_reduce >= 2)
+              if (result == NULL || auto_reduce >= 2)
                 {
                   lastterm->next =
                       R->new_term(K->negate(f->coeff), f->monom, q);
                   lastterm = lastterm->next;
-                  if (result == nullptr)
+                  if (result == NULL)
                     {
                       // Only do this for the first non-computed pair
                       pivot = lastterm;
@@ -1292,7 +1292,7 @@ res2_pair *res2_comp::reduce2(res2term *&f,
           f = f->next;
         }
     }
-  red->next = nullptr;
+  red->next = NULL;
   f = head.next;
   if (M2_gbTrace >= 4)
     {
@@ -1318,23 +1318,23 @@ res2_pair *res2_comp::reduce3(res2term *&f,
   exponents_t REDUCE_exp = ALLOCATE_EXPONENTS(exp_size);
   monomial REDUCE_mon = ALLOCATE_MONOMIAL(monom_size);
 
-  res2term *lastterm = (fsyz->next == nullptr ? fsyz : fsyz->next);
+  res2term *lastterm = (fsyz->next == NULL ? fsyz : fsyz->next);
   res2term head;
   res2term *red = &head;
-  res2_pair *result = nullptr;
+  res2_pair *result = NULL;
   res2_pair *q;
   ring_elem rg;
   respolyHeap fb(R);  // No bucket is needed for fsyz, since we
                       // only append elements to the end of fsyz.
   fb.add(f);
-  f = nullptr;
+  f = NULL;
   res2term *lead;
   //  Bag *b;
 
   int count = 0;
   if (M2_gbTrace >= 4) emit_wrapped(",");
 
-  while ((lead = fb.remove_lead_term()) != nullptr)
+  while ((lead = fb.remove_lead_term()) != NULL)
     {
       M->divide(lead->monom, lead->comp->syz->monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
@@ -1357,7 +1357,7 @@ res2_pair *res2_comp::reduce3(res2term *&f,
           // q = (res2_pair *) (b->basis_ptr());
           if (q->syz_type == SYZ2_S_PAIR || q->syz_type == SYZ2_MAYBE_MINIMAL)
             {
-              if (result == nullptr)
+              if (result == NULL)
                 {
                   lastterm->next =
                       R->new_term(K->negate(lead->coeff), lead->monom, q);
@@ -1388,7 +1388,7 @@ res2_pair *res2_comp::reduce3(res2term *&f,
           red = red->next;
         }
     }
-  red->next = nullptr;
+  red->next = NULL;
   f = head.next;
   if (M2_gbTrace >= 4)
     {
@@ -1414,22 +1414,22 @@ res2_pair *res2_comp::reduce4(res2term *&f,
   monomial REDUCE_mon = ALLOCATE_MONOMIAL(monom_size);
 
   res2term *lastterm = fsyz;
-  while (lastterm->next != nullptr) lastterm = lastterm->next;
+  while (lastterm->next != NULL) lastterm = lastterm->next;
 
   res2term head;
   res2term *red = &head;
-  res2_pair *result = nullptr;
+  res2_pair *result = NULL;
   res2_pair *q;
   ring_elem rg;
 
   int count = total_reduce_count;
   if (M2_gbTrace >= 4) emit_wrapped(",");
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       res2term *lead = f;
       f = f->next;
-      lead->next = nullptr;
+      lead->next = NULL;
       M->divide(lead->monom, lead->comp->syz->monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
       if (find_ring_divisor(REDUCE_exp, rg))
@@ -1453,7 +1453,7 @@ res2_pair *res2_comp::reduce4(res2term *&f,
               lastterm->next =
                   R->new_term(K->negate(lead->coeff), lead->monom, q);
               lastterm = lastterm->next;
-              if (result == nullptr && q->syz_type == SYZ2_S_PAIR)
+              if (result == NULL && q->syz_type == SYZ2_S_PAIR)
                 {
                   // Only do this for the first non-computed pair
                   // Question: do we really need to keep this information
@@ -1483,7 +1483,7 @@ res2_pair *res2_comp::reduce4(res2term *&f,
           red = red->next;
         }
     }
-  red->next = nullptr;
+  red->next = NULL;
   f = head.next;
   if (M2_gbTrace >= 4)
     {
@@ -1504,7 +1504,7 @@ res2_pair *res2_comp::reduce_by_level(res2term *&f, res2term *&fsyz)
   exponents_t REDUCE_exp = ALLOCATE_EXPONENTS(exp_size);
   monomial REDUCE_mon = ALLOCATE_MONOMIAL(monom_size);
 
-  res2term *lastterm = (fsyz->next == nullptr ? fsyz : fsyz->next);
+  res2term *lastterm = (fsyz->next == NULL ? fsyz : fsyz->next);
 
   res2_pair *q;
   ring_elem rg;
@@ -1512,7 +1512,7 @@ res2_pair *res2_comp::reduce_by_level(res2term *&f, res2term *&fsyz)
   int count = 0;
   if (M2_gbTrace >= 4) emit_wrapped(",");
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       M->divide(f->monom, f->comp->syz->monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
@@ -1538,7 +1538,7 @@ res2_pair *res2_comp::reduce_by_level(res2term *&f, res2term *&fsyz)
         {
           res2term *tmp = f;
           f = f->next;
-          tmp->next = nullptr;
+          tmp->next = NULL;
           R->remove(tmp);
         }
     }
@@ -1548,7 +1548,7 @@ res2_pair *res2_comp::reduce_by_level(res2term *&f, res2term *&fsyz)
       o << count;
       emit_wrapped(o.str());
     }
-  return nullptr;
+  return NULL;
 }
 
 res2_pair *res2_comp::reduce_heap_by_level(res2term *&f, res2term *&fsyz)
@@ -1557,19 +1557,19 @@ res2_pair *res2_comp::reduce_heap_by_level(res2term *&f, res2term *&fsyz)
   exponents_t REDUCE_exp = ALLOCATE_EXPONENTS(exp_size);
   monomial REDUCE_mon = ALLOCATE_MONOMIAL(monom_size);
 
-  res2term *lastterm = (fsyz->next == nullptr ? fsyz : fsyz->next);
+  res2term *lastterm = (fsyz->next == NULL ? fsyz : fsyz->next);
   res2_pair *q;
   ring_elem rg;
   respolyHeap fb(R);  // No bucket is needed for fsyz, since we
                       // only append elements to the end of fsyz.
   fb.add(f);
-  f = nullptr;
+  f = NULL;
   res2term *lead;
 
   int count = 0;
   if (M2_gbTrace >= 4) emit_wrapped(",");
 
-  while ((lead = fb.remove_lead_term()) != nullptr)
+  while ((lead = fb.remove_lead_term()) != NULL)
     {
       M->divide(lead->monom, lead->comp->syz->monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
@@ -1604,14 +1604,14 @@ res2_pair *res2_comp::reduce_heap_by_level(res2term *&f, res2term *&fsyz)
           R->remove(lead);
         }
     }
-  f = nullptr;
+  f = NULL;
   if (M2_gbTrace >= 4)
     {
       buffer o;
       o << count;
       emit_wrapped(o.str());
     }
-  return nullptr;
+  return NULL;
 }
 
 //////////////////////////////////////////////
@@ -1622,7 +1622,7 @@ void res2_comp::do_auto_reductions(res2_pair *p, auto_reduce_node *au)
 // For each node in 'au', remove the specified multiple of 'p->syz'.
 {
   buffer o;
-  while (au != nullptr)
+  while (au != NULL)
     {
       auto_reduce_node *a = au;
       au = au->next;
@@ -1683,7 +1683,7 @@ void res2_comp::handle_pair(res2_pair *p)
     {
     }
 
-  if (f == nullptr)
+  if (f == NULL)
     {
       // minimal syzygy
       if (p->level == length_limit + 1)
@@ -1714,7 +1714,7 @@ void res2_comp::handle_pair(res2_pair *p)
         {
           do_auto_reductions(
               q, reinterpret_cast<auto_reduce_node *>(q->pivot_term));
-          q->pivot_term = nullptr;
+          q->pivot_term = NULL;
         }
       else if (auto_reduce == 3)
         {
@@ -1748,7 +1748,7 @@ void res2_comp::handle_pair_by_level(res2_pair *p)
   else
     reduce(f, p->syz, p->pivot_term, p);
 
-  if (f == nullptr)
+  if (f == NULL)
     {
       p->syz_type = SYZ2_MINIMAL;
       if (M2_gbTrace >= 2) emit_wrapped("z");
@@ -1787,7 +1787,7 @@ void res2_comp::handle_pair_by_degree(res2_pair *p)
   // In this version of 'reduce', the resulting value of 'f' is irrelevant.
   // And in fact the routine should probably read:
   //  res2_pair *q = reduce4(p->syz, p->pivot_term);
-  if (q == nullptr)
+  if (q == NULL)
     {
       if (p->syz_type != SYZ2_NOT_NEEDED)
         {
@@ -1822,7 +1822,7 @@ M2_arrayint res2_comp::betti_skeleton() const
 
   for (int lev = 0; lev <= len; lev++)
     {
-      for (res2_pair *p = resn[lev]->pairs; p != nullptr; p = p->next)
+      for (res2_pair *p = resn[lev]->pairs; p != NULL; p = p->next)
         {
           int d = p->degree;
           B.entry(d, lev)++;
@@ -1840,7 +1840,7 @@ M2_arrayint res2_comp::betti_remaining() const
   betti_init(lo, hi, len, bettis);
   for (int lev = 0; lev <= len; lev++)
     {
-      for (res2_pair *p = resn[lev]->pairs; p != nullptr; p = p->next)
+      for (res2_pair *p = resn[lev]->pairs; p != NULL; p = p->next)
         {
           if (p->syz_type != SYZ2_S_PAIR) continue;
           int d = p->degree;
@@ -1862,7 +1862,7 @@ M2_arrayint res2_comp::betti_minimal() const
   betti_init(lo, hi, len, bettis);
   for (int lev = 0; lev <= len; lev++)
     {
-      for (res2_pair *p = resn[lev]->pairs; p != nullptr; p = p->next)
+      for (res2_pair *p = resn[lev]->pairs; p != NULL; p = p->next)
         {
           if (p->syz_type != SYZ2_MINIMAL) continue;
           int d = p->degree;
@@ -1883,7 +1883,7 @@ M2_arrayint res2_comp::betti_nmonoms() const
   betti_init(lo, hi, len, bettis);
   for (int lev = 0; lev <= len; lev++)
     {
-      for (res2_pair *p = resn[lev]->pairs; p != nullptr; p = p->next)
+      for (res2_pair *p = resn[lev]->pairs; p != NULL; p = p->next)
         {
           int d = p->degree;
           bettis[lev + (len + 1) * d] += R->n_terms(p->syz);
@@ -1910,10 +1910,10 @@ M2_arrayint res2_comp::get_betti(int type) const
         ERROR(
             "cannot use Minimize=>true unless res(...,FastNonminimal=>true) "
             "was used");
-        return nullptr;
+        return 0;
     }
   ERROR("received unknown betti type");
-  return nullptr;
+  return 0;
 }
 
 void res2_comp::text_out(const res2_pair *p) const
@@ -1927,18 +1927,18 @@ void res2_comp::text_out(buffer &o, const res2_pair *p) const
   res2_pair *a, *b;
 
   a = p->syz->comp;
-  if (p->syz->next == nullptr)
-    b = nullptr;
+  if (p->syz->next == NULL)
+    b = NULL;
   else
     b = p->syz->next->comp;
 
   o << p->me << ' ';
   o << p->level << ' ' << p->degree << ' ';
-  if (a != nullptr)
+  if (a != NULL)
     o << a->me << ' ';
   else
     o << ". ";
-  if (b != nullptr)
+  if (b != NULL)
     o << b->me << ' ';
   else
     o << ". ";
@@ -2024,9 +2024,9 @@ void res2_comp::text_out(buffer &o) const
   if (M2_gbTrace >= 2)
     for (int lev = 0; lev < resn.size(); lev++)
       {
-        if (resn[lev]->pairs == nullptr) continue;
+        if (resn[lev]->pairs == NULL) continue;
         o << "---- level " << lev << " ----" << newline;
-        for (res2_pair *p = resn[lev]->pairs; p != nullptr; p = p->next)
+        for (res2_pair *p = resn[lev]->pairs; p != NULL; p = p->next)
           text_out(o, p);
       }
 }
@@ -2039,7 +2039,7 @@ FreeModule *res2_comp::free_of(int i) const
 
   monomial deg = degree_monoid()->make_one();
   int n = 0;
-  for (res2_pair *p = resn[i]->pairs; p != nullptr; p = p->next)
+  for (res2_pair *p = resn[i]->pairs; p != NULL; p = p->next)
     {
       multi_degree(p, deg);
       result->append_schreyer(deg, p->syz->monom, p->compare_num);
@@ -2057,7 +2057,7 @@ FreeModule *res2_comp::minimal_free_of(int i) const
 
   monomial deg = degree_monoid()->make_one();
   int n = 0;
-  for (res2_pair *p = resn[i]->pairs; p != nullptr; p = p->next)
+  for (res2_pair *p = resn[i]->pairs; p != NULL; p = p->next)
     if (p->syz_type == SYZ2_MINIMAL)
       {
         multi_degree(p, deg);
@@ -2072,12 +2072,12 @@ Matrix *res2_comp::make(int level) const
 {
   const FreeModule *F = free_of(level - 1);
   const FreeModule *G = free_of(level);
-  MatrixConstructor result(F, G, nullptr);
+  MatrixConstructor result(F, G, NULL);
   //  Matrix *result = new Matrix(free_of(level-1), free_of(level));
 
   int n = 0;
   if (G->rank() == 0) return result.to_matrix();
-  for (res2_pair *p = resn[level]->pairs; p != nullptr; p = p->next)
+  for (res2_pair *p = resn[level]->pairs; p != NULL; p = p->next)
     result.set_column(n++, R->to_vector(p->syz, F));
   return result.to_matrix();
 }
@@ -2099,7 +2099,7 @@ void res2_comp::reduce_minimal(int x,
     {
       res2_pair *p = elems[i];
       if (p->syz_type == SYZ2_NOT_MINIMAL)
-        while ((tm = R->component_occurs_in(p->pivot_term->comp, f)) != nullptr)
+        while ((tm = R->component_occurs_in(p->pivot_term->comp, f)) != NULL)
           {
             // Subtract the proper multiple to f.  f = ... + c m e_y + ...
             // and                                 p = ... + d n e_y
@@ -2108,7 +2108,7 @@ void res2_comp::reduce_minimal(int x,
                 K->divide(tm->coeff, p->pivot_term->coeff);  // exact division
             // MES: is the following line actually needed?
             M->divide(tm->monom, p->pivot_term->monom, MINIMAL_mon);
-            if (stripped[p->me] == nullptr) stripped[p->me] = R->strip(p->syz);
+            if (stripped[p->me] == NULL) stripped[p->me] = R->strip(p->syz);
             R->subtract_multiple_to(f, c, MINIMAL_mon, stripped[p->me]);
           }
     }
@@ -2118,7 +2118,7 @@ Matrix *res2_comp::make_minimal(int i) const
 {
   const FreeModule *F = minimal_free_of(i - 1);
   const FreeModule *G = minimal_free_of(i);
-  MatrixConstructor result(F, G, nullptr);
+  MatrixConstructor result(F, G, NULL);
   if (i <= 0 || i >= resn.size() - 1) return result.to_matrix();
   if (do_by_level > 0) return make(i);
 
@@ -2126,11 +2126,11 @@ Matrix *res2_comp::make_minimal(int i) const
   VECTOR(res2term *) stripped;
 
   int n = 0;
-  for (res2_pair *p = resn[i]->pairs; p != nullptr; p = p->next)
+  for (res2_pair *p = resn[i]->pairs; p != NULL; p = p->next)
     {
       p->me = n++;
       elems.push_back(p);
-      stripped.push_back(static_cast<res2term *>(nullptr));
+      stripped.push_back(static_cast<res2term *>(NULL));
     }
 
   int thisx = 0;
@@ -2139,7 +2139,7 @@ Matrix *res2_comp::make_minimal(int i) const
       res2_pair *p = elems[x];
       if (p->syz_type == SYZ2_MINIMAL)
         {
-          if (stripped[p->me] == nullptr)
+          if (stripped[p->me] == NULL)
             {
               stripped[p->me] = R->strip(p->syz);
               reduce_minimal(x, stripped[p->me], elems, stripped);

--- a/M2/Macaulay2/e/res-a0.hpp
+++ b/M2/Macaulay2/e/res-a0.hpp
@@ -79,7 +79,7 @@ struct res2_level : public our_new_delete
   int nthrown;  // Number of pairs (that would be in this list)
                 // that were thrown out, because of the hard_degree_limit.
 
-  res2_level() : pairs(nullptr), npairs(0), nleft(0), nminimal(0) {}
+  res2_level() : pairs(NULL), npairs(0), nleft(0), nminimal(0) {}
 };
 
 /**

--- a/M2/Macaulay2/e/res-a1-poly.cpp
+++ b/M2/Macaulay2/e/res-a1-poly.cpp
@@ -28,7 +28,7 @@ inline int res_poly::compare(const resterm *a, const resterm *b) const
 resterm *res_poly::new_term() const
 {
   resterm *result = reinterpret_cast<resterm *>(resterm_stash->new_elem());
-  result->next = nullptr;
+  result->next = NULL;
   return result;
 }
 resterm *res_poly::new_term(ring_elem c, const int *m, res_pair *x) const
@@ -45,7 +45,7 @@ resterm *res_poly::mult_by_monomial(const resterm *f, const int *m) const
 {
   resterm head;
   resterm *result = &head;
-  for (const resterm *tm = f; tm != nullptr; tm = tm->next)
+  for (const resterm *tm = f; tm != NULL; tm = tm->next)
     {
       result->next = new_term();
       result = result->next;
@@ -53,7 +53,7 @@ resterm *res_poly::mult_by_monomial(const resterm *f, const int *m) const
       result->coeff = K->copy(tm->coeff);
       M->mult(tm->monom, m, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -61,7 +61,7 @@ resterm *res_poly::copy(const resterm *f) const
 {
   resterm head;
   resterm *result = &head;
-  for (const resterm *tm = f; tm != nullptr; tm = tm->next)
+  for (const resterm *tm = f; tm != NULL; tm = tm->next)
     {
       result->next = new_term();
       result = result->next;
@@ -69,12 +69,12 @@ resterm *res_poly::copy(const resterm *f) const
       result->coeff = K->copy(tm->coeff);
       M->copy(tm->monom, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 void res_poly::remove(resterm *&f) const
 {
-  while (f != nullptr)
+  while (f != NULL)
     {
       resterm *tmp = f;
       f = f->next;
@@ -89,7 +89,7 @@ resterm *res_poly::mult_by_term(const resterm *f,
 {
   resterm head;
   resterm *result = &head;
-  for (const resterm *tm = f; tm != nullptr; tm = tm->next)
+  for (const resterm *tm = f; tm != NULL; tm = tm->next)
     {
       result->next = new_term();
       result = result->next;
@@ -97,7 +97,7 @@ resterm *res_poly::mult_by_term(const resterm *f,
       result->coeff = K->mult(c, tm->coeff);
       M->mult(tm->monom, m, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 resterm *res_poly::ring_mult_by_term(const ring_elem f,
@@ -115,27 +115,27 @@ resterm *res_poly::ring_mult_by_term(const ring_elem f,
       result->coeff = K->mult(c, tm.coeff);
       M->mult(tm.monom, m, result->monom);
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
 void res_poly::make_monic(resterm *&f) const
 {
-  if (f == nullptr) return;
+  if (f == NULL) return;
   ring_elem c_inv = K->invert(f->coeff);
 
-  for (resterm *tm = f; tm != nullptr; tm = tm->next) K->mult_to(tm->coeff, c_inv);
+  for (resterm *tm = f; tm != NULL; tm = tm->next) K->mult_to(tm->coeff, c_inv);
 
   K->remove(c_inv);
 }
 
 void res_poly::add_to(resterm *&f, resterm *&g) const
 {
-  if (g == nullptr) return;
-  if (f == nullptr)
+  if (g == NULL) return;
+  if (f == NULL)
     {
       f = g;
-      g = nullptr;
+      g = NULL;
       return;
     }
   resterm head;
@@ -146,7 +146,7 @@ void res_poly::add_to(resterm *&f, resterm *&g) const
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               f = head.next;
@@ -157,11 +157,11 @@ void res_poly::add_to(resterm *&f, resterm *&g) const
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               f = head.next;
-              g = nullptr;
+              g = NULL;
               return;
             }
           break;
@@ -179,17 +179,17 @@ void res_poly::add_to(resterm *&f, resterm *&g) const
               result = result->next;
             }
           resterm_stash->delete_elem(tmg);
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               f = head.next;
               return;
             }
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               f = head.next;
-              g = nullptr;
+              g = NULL;
               return;
             }
           break;
@@ -223,7 +223,7 @@ void res_poly::ring_subtract_multiple_to(resterm *&f,
 int res_poly::n_terms(const resterm *f) const
 {
   int result = 0;
-  for (; f != nullptr; f = f->next) result++;
+  for (; f != NULL; f = f->next) result++;
   return result;
 }
 
@@ -235,7 +235,7 @@ void res_poly::elem_text_out(const resterm *f) const
 }
 void res_poly::elem_text_out(buffer &o, const resterm *f) const
 {
-  if (f == nullptr)
+  if (f == NULL)
     {
       o << "0";
       return;
@@ -244,7 +244,7 @@ void res_poly::elem_text_out(buffer &o, const resterm *f) const
   bool p_one = false;
   bool p_parens = true;
   bool p_plus = false;
-  for (const resterm *t = f; t != nullptr; t = t->next)
+  for (const resterm *t = f; t != NULL; t = t->next)
     {
       int isone = M->is_one(t->monom);
       K->elem_text_out(o, t->coeff, p_one, p_parens, p_plus);
@@ -260,7 +260,7 @@ vec res_poly::to_vector(const resterm *f,
 {
   vecHeap H(F);
   monomial mon = M->make_one();
-  for (const resterm *tm = f; tm != nullptr; tm = tm->next)
+  for (const resterm *tm = f; tm != NULL; tm = tm->next)
     {
       //    int x = (to_minimal ? tm->comp->minimal_me : tm->comp->me);
       int x =
@@ -280,7 +280,7 @@ resterm *res_poly::from_vector(const VECTOR(res_pair *)& base, const vec v) cons
 {
   resterm head;
   resterm *result = &head;
-  for (vecterm *w = v; w != nullptr; w = w->next)
+  for (vecterm *w = v; w != NULL; w = w->next)
     for (Nterm& t : w->coeff)
       {
         result->next = new_term();
@@ -290,7 +290,7 @@ resterm *res_poly::from_vector(const VECTOR(res_pair *)& base, const vec v) cons
         M->copy(t.monom, result->monom);
         M->mult(result->monom, result->comp->base_monom, result->monom);
       }
-  result->next = nullptr;
+  result->next = NULL;
   // Now we must sort these
   sort(head.next);
   return head.next;
@@ -300,7 +300,7 @@ resterm *res_poly::strip(const resterm *f) const
 {
   resterm head;
   resterm *result = &head;
-  for (const resterm *tm = f; tm != nullptr; tm = tm->next)
+  for (const resterm *tm = f; tm != NULL; tm = tm->next)
     if (tm->comp->syz_type != SYZ_NOT_MINIMAL)
       {
         result->next = new_term();
@@ -309,16 +309,16 @@ resterm *res_poly::strip(const resterm *f) const
         result->coeff = K->copy(tm->coeff);
         M->copy(tm->monom, result->monom);
       }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
 const resterm *res_poly::component_occurs_in(const res_pair *x,
                                              const resterm *f) const
 {
-  for (const resterm *tm = f; tm != nullptr; tm = tm->next)
+  for (const resterm *tm = f; tm != NULL; tm = tm->next)
     if (tm->comp == x) return tm;
-  return nullptr;
+  return NULL;
 }
 
 void res_poly::sort(resterm *&f) const
@@ -327,17 +327,17 @@ void res_poly::sort(resterm *&f) const
   // then add them together.  This allows the same monomial
   // to appear more than once in 'f'.
 
-  if (f == nullptr || f->next == nullptr) return;
-  resterm *f1 = nullptr;
-  resterm *f2 = nullptr;
-  while (f != nullptr)
+  if (f == NULL || f->next == NULL) return;
+  resterm *f1 = NULL;
+  resterm *f2 = NULL;
+  while (f != NULL)
     {
       resterm *t = f;
       f = f->next;
       t->next = f1;
       f1 = t;
 
-      if (f == nullptr) break;
+      if (f == NULL) break;
       t = f;
       f = f->next;
       t->next = f2;

--- a/M2/Macaulay2/e/res-a1.cpp
+++ b/M2/Macaulay2/e/res-a1.cpp
@@ -63,7 +63,7 @@ void res_comp::initialize(const Matrix *mat, int LengthLimit, int /*strategy*/)
                          // here.
       p->compare_num = i;
 
-      if (S == nullptr)
+      if (S == 0)
         p->base_monom = M->make_one();
       else
         p->base_monom = M->make_new(S->base_monom(i));
@@ -87,7 +87,7 @@ void res_comp::initialize(const Matrix *mat, int LengthLimit, int /*strategy*/)
   nminimal = 0;
 
   for (i = 0; i < mat->n_cols(); i++)
-    if ((*mat)[i] != nullptr)
+    if ((*mat)[i] != NULL)
       {
         res_pair *p = new_res_pair(i);  // Makes a generator 'pair'
         int d = mat->cols()->primary_degree(i);
@@ -136,7 +136,7 @@ res_comp::~res_comp()
 
 void res_comp::remove_res_pair(res_pair *p)
 {
-  if (p == nullptr) return;
+  if (p == NULL) return;
   delete p->mi;
   R->remove(p->syz);
   R->remove(p->stripped_syz);
@@ -146,8 +146,8 @@ void res_comp::remove_res_pair(res_pair *p)
 
 void res_comp::remove_res_degree(res_degree *p)
 {
-  if (p == nullptr) return;
-  while (p->first != nullptr)
+  if (p == NULL) return;
+  while (p->first != NULL)
     {
       res_pair *tmp = p->first;
       p->first = tmp->next;
@@ -158,7 +158,7 @@ void res_comp::remove_res_degree(res_degree *p)
 
 void res_comp::remove_res_level(res_level *lev)
 {
-  if (lev == nullptr) return;
+  if (lev == NULL) return;
   int i;
   for (i = 0; i < lev->bin.size(); i++)
     {
@@ -200,10 +200,10 @@ res_degree *res_comp::make_degree_set(int level, int deg)
 res_degree *res_comp::get_degree_set(int level, int d) const
 // find (level,d) pair set, where 'd' is the slanted degree
 {
-  if (level < 0 || level >= resn.size()) return nullptr;
+  if (level < 0 || level >= resn.size()) return NULL;
   res_level *lev = resn[level];
   d -= lodegree;
-  if (d < 0 || d >= lev->bin.size()) return nullptr;
+  if (d < 0 || d >= lev->bin.size()) return NULL;
   return lev->bin[d];
 }
 
@@ -212,18 +212,18 @@ res_pair *res_comp::new_res_pair()
   res_pair *result = reinterpret_cast<res_pair *>(res_pair_stash->new_elem());
   result->me = 0;
   result->compare_num = 0;
-  result->base_monom = nullptr;
-  result->next = nullptr;
-  result->first = nullptr;
-  result->second = nullptr;
-  result->base_comp = nullptr;
+  result->base_monom = NULL;
+  result->next = NULL;
+  result->first = NULL;
+  result->second = NULL;
+  result->base_comp = NULL;
   result->syz_type = 0;
-  result->mi2 = nullptr;
-  result->next_mi = nullptr;
-  result->syz = nullptr;
+  result->mi2 = NULL;
+  result->next_mi = NULL;
+  result->syz = NULL;
   result->minimal_me = 0;
-  result->pivot_term = nullptr;
-  result->stripped_syz = nullptr;
+  result->pivot_term = NULL;
+  result->stripped_syz = NULL;
   return result;
 }
 
@@ -403,8 +403,8 @@ int res_comp::compare_res_pairs(res_pair *f, res_pair *g) const
 
 res_pair *res_comp::merge_res_pairs(res_pair *f, res_pair *g) const
 {
-  if (g == nullptr) return f;
-  if (f == nullptr) return g;
+  if (g == NULL) return f;
+  if (f == NULL) return g;
   res_pair head;
   res_pair *result = &head;
   while (1) switch (compare_res_pairs(f, g))
@@ -414,7 +414,7 @@ res_pair *res_comp::merge_res_pairs(res_pair *f, res_pair *g) const
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               return head.next;
@@ -424,7 +424,7 @@ res_pair *res_comp::merge_res_pairs(res_pair *f, res_pair *g) const
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               return head.next;
@@ -438,17 +438,17 @@ res_pair *res_comp::merge_res_pairs(res_pair *f, res_pair *g) const
 void res_comp::sort_res_pairs(res_pair *&p) const
 {
   // These elements are sorted in ascending 'me' values
-  if (p == nullptr || p->next == nullptr) return;
-  res_pair *p1 = nullptr;
-  res_pair *p2 = nullptr;
-  while (p != nullptr)
+  if (p == NULL || p->next == NULL) return;
+  res_pair *p1 = NULL;
+  res_pair *p2 = NULL;
+  while (p != NULL)
     {
       res_pair *tmp = p;
       p = p->next;
       tmp->next = p1;
       p1 = tmp;
 
-      if (p == nullptr) break;
+      if (p == NULL) break;
       tmp = p;
       p = p->next;
       tmp->next = p2;
@@ -469,9 +469,9 @@ int res_comp::sort_value(res_pair *p, const std::vector<int> sort_order) const
 
 void res_comp::sort_gens(res_degree *mypairs)
 {
-  if (mypairs == nullptr) return;
+  if (mypairs == NULL) return;
   res_pair *p = mypairs->next_gen;
-  if (p == nullptr || p->next == nullptr) return;
+  if (p == NULL || p->next == NULL) return;
   //  for (res_pair *q = p; q!=NULL; q=q->next)
   //    q->compare_num = sort_value(q, s_pair_order); // MES: to be written
 
@@ -481,10 +481,10 @@ void res_comp::sort_gens(res_degree *mypairs)
 void res_comp::sort_pairs(int level, int deg)
 {
   res_degree *mypairs = get_degree_set(level, deg);
-  if (mypairs == nullptr) return;
+  if (mypairs == NULL) return;
   if (mypairs->is_sorted) return;
   res_pair *p = mypairs->first;
-  if (p != nullptr && p->next != nullptr) sort_res_pairs(mypairs->first);
+  if (p != NULL && p->next != NULL) sort_res_pairs(mypairs->first);
 
   mypairs->next_pair = mypairs->first;
   mypairs->next_new_pair = mypairs->first;
@@ -510,8 +510,8 @@ int res_comp::compare_compares(res_pair *f, res_pair *g) const
 
 res_pair *res_comp::merge_compares(res_pair *f, res_pair *g) const
 {
-  if (g == nullptr) return f;
-  if (f == nullptr) return g;
+  if (g == NULL) return f;
+  if (f == NULL) return g;
   res_pair head;
   res_pair *result = &head;
   while (1) switch (compare_compares(f, g))
@@ -520,7 +520,7 @@ res_pair *res_comp::merge_compares(res_pair *f, res_pair *g) const
           result->next_compare = g;
           result = result->next_compare;
           g = g->next_compare;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next_compare = f;
               return head.next_compare;
@@ -530,7 +530,7 @@ res_pair *res_comp::merge_compares(res_pair *f, res_pair *g) const
           result->next_compare = f;
           result = result->next_compare;
           f = f->next_compare;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next_compare = g;
               return head.next_compare;
@@ -544,17 +544,17 @@ res_pair *res_comp::merge_compares(res_pair *f, res_pair *g) const
 void res_comp::sort_compares(res_pair *&p) const
 {
   // These elements are sorted in ascending 'me' values
-  if (p == nullptr || p->next_compare == nullptr) return;
-  res_pair *p1 = nullptr;
-  res_pair *p2 = nullptr;
-  while (p != nullptr)
+  if (p == NULL || p->next_compare == NULL) return;
+  res_pair *p1 = NULL;
+  res_pair *p2 = NULL;
+  while (p != NULL)
     {
       res_pair *tmp = p;
       p = p->next_compare;
       tmp->next_compare = p1;
       p1 = tmp;
 
-      if (p == nullptr) break;
+      if (p == NULL) break;
       tmp = p;
       p = p->next_compare;
       tmp->next_compare = p2;
@@ -582,11 +582,11 @@ void res_comp::set_compare_nums(int level, int deg)
   // order.
 
   res_degree *mypairs = get_degree_set(level, deg);
-  if (mypairs == nullptr) return;
+  if (mypairs == NULL) return;
 
   res_pair *p;
   res_pair *compare_num_list = mypairs->first;
-  for (p = mypairs->first; p != nullptr; p = p->next)
+  for (p = mypairs->first; p != NULL; p = p->next)
     {
       p->next_compare = p->next;
       p->me = next_me_number++;
@@ -596,7 +596,7 @@ void res_comp::set_compare_nums(int level, int deg)
       merge_compares(resn[level]->compare_num_list, compare_num_list);
 
   int next = 0;
-  for (p = resn[level]->compare_num_list; p != nullptr; p = p->next_compare)
+  for (p = resn[level]->compare_num_list; p != NULL; p = p->next_compare)
     p->compare_num = next++;
 }
 //////////////////////////////////////////////
@@ -642,7 +642,7 @@ void res_comp::new_pairs(res_pair *p)
             {
               thisvp.resize(0);
               varpower::var(w, 1, thisvp);
-              Bag *b = new Bag(static_cast<void *>(nullptr), thisvp);
+              Bag *b = new Bag(static_cast<void *>(0), thisvp);
               elems.push_back(b);
             }
         }
@@ -663,7 +663,7 @@ void res_comp::new_pairs(res_pair *p)
           varpower::quotient(a.monom().data(), vp.data(), thisvp);
           if (varpower::is_equal(a.monom().data(), thisvp.data()))
             continue;
-          Bag *b = new Bag(static_cast<void *>(nullptr), thisvp);
+          Bag *b = new Bag(static_cast<void *>(0), thisvp);
           elems.push_back(b);
         }
     }
@@ -729,7 +729,7 @@ resterm *res_comp::s_pair(res_pair *p) const
   M->divide(p->base_monom, p->first->base_monom, si);
   resterm *result = R->mult_by_monomial(p->first->syz, si);
   ring_elem one = K->from_long(1);
-  if (p->second != nullptr)
+  if (p->second != NULL)
     {
       p->syz->next = R->new_term(K->from_long(-1), p->base_monom, p->second);
       M->divide(p->base_monom, p->second->base_monom, si);
@@ -750,13 +750,13 @@ res_pair *res_comp::reduce(resterm *&f, resterm *&fsyz, resterm *&pivot)
   exponents_t REDUCE_exp = ALLOCATE_EXPONENTS(exp_size);
   monomial REDUCE_mon = ALLOCATE_MONOMIAL(monom_size);
 
-  resterm *lastterm = (fsyz->next == nullptr ? fsyz : fsyz->next);
+  resterm *lastterm = (fsyz->next == NULL ? fsyz : fsyz->next);
 
   res_pair *q;
   ring_elem rg;
   Bag *b;
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       M->divide(f->monom, f->comp->base_monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
@@ -787,7 +787,7 @@ res_pair *res_comp::reduce(resterm *&f, resterm *&fsyz, resterm *&pivot)
           return q;
         }
     }
-  return nullptr;
+  return NULL;
 }
 
 // MES: Uugh.... This should not be a separate routine....?
@@ -800,13 +800,13 @@ res_pair *res_comp::reduce_level_one(resterm *&f,
   exponents_t REDUCE_exp = ALLOCATE_EXPONENTS(exp_size);
   monomial REDUCE_mon = ALLOCATE_MONOMIAL(monom_size);
 
-  resterm *lastterm = (fsyz->next == nullptr ? fsyz : fsyz->next);
+  resterm *lastterm = (fsyz->next == NULL ? fsyz : fsyz->next);
 
   res_pair *q;
   ring_elem rg;
   Bag *b;
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       M->divide(f->monom, f->comp->base_monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
@@ -838,7 +838,7 @@ res_pair *res_comp::reduce_level_one(resterm *&f,
           return q;
         }
     }
-  return nullptr;
+  return NULL;
 }
 
 void res_comp::reduce_gen(resterm *&f) const
@@ -850,7 +850,7 @@ void res_comp::reduce_gen(resterm *&f) const
   ring_elem rg;
   Bag *b;
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       M->divide(f->monom, f->comp->base_monom, REDUCE_mon);
       M->to_expvector(REDUCE_mon, REDUCE_exp);
@@ -878,7 +878,7 @@ void res_comp::reduce_gen(resterm *&f) const
 
 bool res_comp::stop_conditions_ok()
 {
-  if (stop_.length_limit != nullptr && stop_.length_limit->len > 0)
+  if (stop_.length_limit != 0 && stop_.length_limit->len > 0)
     {
       if (length_limit < stop_.length_limit->array[0])
         {
@@ -972,9 +972,9 @@ enum ComputationStatusCode res_comp::gens(int deg)
   // preconditions: reductions(2,deg), gens(deg-1)
   res_pair *p;
   res_degree *mypairs = get_degree_set(1, deg);
-  if (mypairs != nullptr)
+  if (mypairs != NULL)
     {
-      while ((p = mypairs->next_gen) != nullptr)
+      while ((p = mypairs->next_gen) != NULL)
         {
           mypairs->next_gen = p->next;
           handle_gen(p);  // Consumes 'p'
@@ -1009,9 +1009,9 @@ enum ComputationStatusCode res_comp::pairs(int level, int deg)
   res_pair *p;
   sort_pairs(level, deg);
   res_degree *mypairs = get_degree_set(level, deg);
-  if (mypairs != nullptr)
+  if (mypairs != NULL)
     {
-      while ((p = mypairs->next_new_pair) != nullptr)
+      while ((p = mypairs->next_new_pair) != NULL)
         {
           mypairs->next_new_pair = p->next;
           new_pairs(p);
@@ -1032,8 +1032,8 @@ enum ComputationStatusCode res_comp::reductions(int level, int deg)
     }
   sort_pairs(level, deg);
   res_degree *mypairs = get_degree_set(level, deg);
-  if (mypairs != nullptr)
-    while ((p = mypairs->next_pair) != nullptr)
+  if (mypairs != NULL)
+    while ((p = mypairs->next_pair) != NULL)
       {
         mypairs->next_pair = p->next;
         handle_pair(p);
@@ -1053,12 +1053,12 @@ enum ComputationStatusCode res_comp::reductions(int level, int deg)
 void res_comp::handle_gen(res_pair *p)
 {
   reduce_gen(p->syz);
-  if (p->syz != nullptr)
+  if (p->syz != NULL)
     {
       R->make_monic(p->syz);
       M->copy(p->syz->monom, p->base_monom);
       p->first = p->syz->comp;
-      p->second = nullptr;
+      p->second = NULL;
       p->syz_type = SYZ_MINIMAL;
       p->base_comp = p->syz->comp->base_comp;  // MES: added 7/11/97
       insert_res_pair(1, p);
@@ -1083,7 +1083,7 @@ void res_comp::handle_pair(res_pair *p)
   else
     q = reduce(f, p->syz, p->pivot_term);
 
-  if (f == nullptr)
+  if (f == NULL)
     {
       // minimal syzygy
       p->syz_type = SYZ_MINIMAL;
@@ -1135,17 +1135,17 @@ void res_comp::handle_pair(res_pair *p)
 int res_comp::n_pairs(int lev, int d) const
 {
   res_degree *p = get_degree_set(lev, d);
-  if (p == nullptr) return 0;
+  if (p == NULL) return 0;
   return p->npairs;
 }
 
 int res_comp::n_left(int lev, int d) const
 {
   res_degree *p = get_degree_set(lev, d);
-  if (p == nullptr) return 0;
+  if (p == NULL) return 0;
 
   int result = 0;
-  for (res_pair *q = p->first; q != nullptr; q = q->next)
+  for (res_pair *q = p->first; q != NULL; q = q->next)
     if (q->syz_type == SYZ_S_PAIR || q->syz_type == SYZ_GEN) result++;
 
   return result;
@@ -1154,9 +1154,9 @@ int res_comp::n_left(int lev, int d) const
 int res_comp::n_minimal(int lev, int d) const
 {
   res_degree *p = get_degree_set(lev, d);
-  if (p == nullptr) return 0;
+  if (p == NULL) return 0;
   int result = 0;
-  for (res_pair *q = p->first; q != nullptr; q = q->next)
+  for (res_pair *q = p->first; q != NULL; q = q->next)
     if (q->syz_type == SYZ_MINIMAL) result++;
 
   return result;
@@ -1165,9 +1165,9 @@ int res_comp::n_minimal(int lev, int d) const
 int res_comp::n_monoms(int lev, int d) const
 {
   res_degree *p = get_degree_set(lev, d);
-  if (p == nullptr) return 0;
+  if (p == NULL) return 0;
   int result = 0;
-  for (res_pair *q = p->first; q != nullptr; q = q->next)
+  for (res_pair *q = p->first; q != NULL; q = q->next)
     result += R->n_terms(q->syz);
 
   return result;
@@ -1207,7 +1207,7 @@ M2_arrayint res_comp::get_betti(int type) const
               ERROR(
                   "cannot use Minimize=>true unless "
                   "res(...,FastNonminimal=>true) was used");
-              return nullptr;
+              return 0;
             default:
               val = -1;
               break;
@@ -1229,11 +1229,11 @@ void res_comp::text_out(buffer &o, const res_pair *p) const
   res_pair *a = p->first;
   res_pair *b = p->second;  // possibly NULL
   o << p->me << ' ';
-  if (a != nullptr)
+  if (a != NULL)
     o << a->me << ' ';
   else
     o << ". ";
-  if (b != nullptr)
+  if (b != NULL)
     o << b->me << ' ';
   else
     o << ". ";
@@ -1327,8 +1327,8 @@ void res_comp::text_out(buffer &o) const
         for (int i = 0; i < resn[lev]->bin.size(); i++)
           {
             res_degree *mypairs = resn[lev]->bin[i];
-            if (mypairs == nullptr) continue;
-            for (res_pair *p = mypairs->first; p != nullptr; p = p->next)
+            if (mypairs == NULL) continue;
+            for (res_pair *p = mypairs->first; p != NULL; p = p->next)
               {
                 o.put(i, 4);
                 o << ' ';
@@ -1349,7 +1349,7 @@ const FreeModule *res_comp::free_of(int i) const
   for (int j = 0; j < lev->bin.size(); j++)
     {
       res_degree *mypairs = lev->bin[j];
-      for (res_pair *p = mypairs->first; p != nullptr; p = p->next)
+      for (res_pair *p = mypairs->first; p != NULL; p = p->next)
         {
           multi_degree(p, deg);
           result->append_schreyer(deg, p->base_monom, p->compare_num);
@@ -1372,7 +1372,7 @@ const FreeModule *res_comp::minimal_free_of(int i) const
   for (int j = 0; j < lev->bin.size(); j++)
     {
       res_degree *mypairs = lev->bin[j];
-      for (res_pair *p = mypairs->first; p != nullptr; p = p->next)
+      for (res_pair *p = mypairs->first; p != NULL; p = p->next)
         if (p->syz_type == SYZ_MINIMAL)
           {
             multi_degree(p, deg);
@@ -1389,15 +1389,15 @@ Matrix *res_comp::make(int level) const
 {
   const FreeModule *F = free_of(level - 1);
   const FreeModule *G = free_of(level);
-  MatrixConstructor result(F, G, nullptr);
+  MatrixConstructor result(F, G, NULL);
 
   int n = 0;
-  if (G == nullptr) return result.to_matrix();
+  if (G == 0) return result.to_matrix();
   res_level *lev = resn[level];
   for (int j = 0; j < lev->bin.size(); j++)
     {
       res_degree *mypairs = lev->bin[j];
-      for (res_pair *p = mypairs->first; p != nullptr; p = p->next)
+      for (res_pair *p = mypairs->first; p != NULL; p = p->next)
         result.set_column(n++, R->to_vector(p->syz, F));
     }
   return result.to_matrix();
@@ -1420,7 +1420,7 @@ void res_comp::reduce_minimal(int x,
     {
       res_pair *p = elems[i];
       if (p->syz_type == SYZ_NOT_MINIMAL)
-        while ((tm = R->component_occurs_in(p->pivot_term->comp, f)) != nullptr)
+        while ((tm = R->component_occurs_in(p->pivot_term->comp, f)) != NULL)
           {
             // Subtract the proper multiple to f.  f = ... + c m e_y + ...
             // and                                 p = ... + d n e_y
@@ -1429,7 +1429,7 @@ void res_comp::reduce_minimal(int x,
                 K->divide(tm->coeff, p->pivot_term->coeff);  // exact division
             // MES: is the following line actually needed?
             M->divide(tm->monom, p->pivot_term->monom, MINIMAL_mon);
-            if (p->stripped_syz == nullptr) p->stripped_syz = R->strip(p->syz);
+            if (p->stripped_syz == NULL) p->stripped_syz = R->strip(p->syz);
             R->subtract_multiple_to(f, c, MINIMAL_mon, p->stripped_syz);
           }
     }
@@ -1439,13 +1439,13 @@ Matrix *res_comp::make_minimal(int i) const
 {
   const FreeModule *F = minimal_free_of(i - 1);
   const FreeModule *G = minimal_free_of(i);
-  MatrixConstructor result(F, G, nullptr);
+  MatrixConstructor result(F, G, NULL);
   if (i < 0 || i > length_limit) return result.to_matrix();
   VECTOR(res_pair *) elems;
 
   res_level *lev = resn[i];
   for (int j = 0; j < lev->bin.size(); j++)
-    for (res_pair *p = lev->bin[j]->first; p != nullptr; p = p->next)
+    for (res_pair *p = lev->bin[j]->first; p != NULL; p = p->next)
       elems.push_back(p);
 
   int thisx = 0;
@@ -1454,7 +1454,7 @@ Matrix *res_comp::make_minimal(int i) const
       res_pair *p = elems[x];
       if (p->syz_type == SYZ_MINIMAL)
         {
-          if (p->stripped_syz == nullptr)
+          if (p->stripped_syz == NULL)
             {
               p->stripped_syz = R->strip(p->syz);
               reduce_minimal(x, p->stripped_syz, elems);
@@ -1473,7 +1473,7 @@ Matrix *res_comp::make_minimal(int i) const
 void res_comp::skeleton_init(VECTOR(res_pair *)& reslevel)
 {
   // Do level 0
-  res_pair *pp = nullptr;
+  res_pair *pp = NULL;
   for (auto p = base_components.rbegin(); p != base_components.rend(); ++p)
     {
       (*p)->next = pp;
@@ -1482,9 +1482,9 @@ void res_comp::skeleton_init(VECTOR(res_pair *)& reslevel)
   reslevel.push_back(pp);
 
   // Do level 1
-  pp = nullptr;
+  pp = NULL;
   for (auto i = 0; i < generator_matrix->n_cols(); i++)
-    if ((*generator_matrix)[i] != nullptr)
+    if ((*generator_matrix)[i] != NULL)
       {
         res_pair *p = new_res_pair(i);  // Makes a generator 'pair'
         p->next = pp;
@@ -1529,7 +1529,7 @@ void res_comp::skeleton_pairs(res_pair *&result, res_pair *p)
             {
               thisvp.resize(0);
               varpower::var(w, 1, thisvp);
-              Bag *b = new Bag(static_cast<void *>(nullptr), thisvp);
+              Bag *b = new Bag(static_cast<void *>(0), thisvp);
               elems.push_back(b);
             }
         }
@@ -1550,7 +1550,7 @@ void res_comp::skeleton_pairs(res_pair *&result, res_pair *p)
           varpower::quotient(a.monom().data(), vp.data(), thisvp);
           if (varpower::is_equal(a.monom().data(), thisvp.data()))
             continue;
-          Bag *b = new Bag(static_cast<void *>(nullptr), thisvp);
+          Bag *b = new Bag(static_cast<void *>(0), thisvp);
           elems.push_back(b);
         }
     }
@@ -1595,7 +1595,7 @@ int res_comp::skeleton_maxdegree(const VECTOR(res_pair *)& reslevel)
   int result = lodegree;
   for (int level = 0; level < reslevel.size(); level++)
     {
-      for (res_pair *p = reslevel[level]; p != nullptr; p = p->next)
+      for (res_pair *p = reslevel[level]; p != NULL; p = p->next)
         {
           int d = degree(p);
           if (d - level > result) result = d - level;
@@ -1613,7 +1613,7 @@ void res_comp::skeleton_stats(const VECTOR(res_pair *)& reslevel)
   int *bettis = newarray_atomic_clear(int, (maxlevel + 1) * (maxdegree + 1));
   for (level = 0; level < reslevel.size(); level++)
     {
-      for (res_pair *p = reslevel[level]; p != nullptr; p = p->next)
+      for (res_pair *p = reslevel[level]; p != NULL; p = p->next)
         {
           int d = degree(p);
           d -= level;
@@ -1644,7 +1644,7 @@ void res_comp::skeleton_stats(const VECTOR(res_pair *)& reslevel)
   for (level = 0; level <= maxlevel; level++)
     {
       o << "---- level " << level << " ----" << newline;
-      for (res_pair *p = reslevel[level]; p != nullptr; p = p->next)
+      for (res_pair *p = reslevel[level]; p != NULL; p = p->next)
         {
           int d = degree(p);
           o.put(d, 4);
@@ -1672,7 +1672,7 @@ void res_comp::skeleton(int strategy)
     {
       // Sort the pairs in the current level:
       res_pair *pp = reslevel[level];
-      if (pp == nullptr) break;
+      if (pp == NULL) break;
 
       compare_type = strategy;
       sort_res_pairs(pp);
@@ -1681,9 +1681,9 @@ void res_comp::skeleton(int strategy)
 
       // Now compute the pairs at the next level
       res_pair head, *ptrhead;
-      head.next = nullptr;
+      head.next = NULL;
       ptrhead = &head;
-      for (res_pair *p = pp; p != nullptr; p = p->next) skeleton_pairs(ptrhead, p);
+      for (res_pair *p = pp; p != NULL; p = p->next) skeleton_pairs(ptrhead, p);
       reslevel.push_back(head.next);
     }
 

--- a/M2/Macaulay2/e/res-a1.hpp
+++ b/M2/Macaulay2/e/res-a1.hpp
@@ -35,10 +35,10 @@ class res_degree : public our_new_delete
 
  public:
   res_degree()
-      : first(nullptr),
-        next_new_pair(nullptr),
-        next_pair(nullptr),
-        next_gen(nullptr),
+      : first(NULL),
+        next_new_pair(NULL),
+        next_pair(NULL),
+        next_gen(NULL),
         is_sorted(0),
         npairs(0),
         nleft(0),
@@ -64,7 +64,7 @@ class res_level : public our_new_delete
   int nminimal;
 
  public:
-  res_level() : compare_num_list(nullptr), npairs(0), nleft(0), nminimal(0) {}
+  res_level() : compare_num_list(NULL), npairs(0), nleft(0), nminimal(0) {}
 };
 
 /**

--- a/M2/Macaulay2/e/res-a2-gb.cpp
+++ b/M2/Macaulay2/e/res-a2-gb.cpp
@@ -19,7 +19,7 @@ void gb2_comp::setup(FreeModule *FFsyz,
   level = lev;
   int i;
   originalR = FFsyz->get_ring()->cast_to_PolynomialRing();
-  if (originalR == nullptr)
+  if (originalR == NULL)
     {
       ERROR("internal error - ring is not a polynomial ring");
       assert(0);
@@ -33,7 +33,7 @@ void gb2_comp::setup(FreeModule *FFsyz,
   F = const_cast<FreeModule *>(ggens->output_free_module());
 
   gens = ggens;
-  syz = nullptr;
+  syz = NULL;
 
   Fsyz = const_cast<FreeModule *>(FFsyz);
 
@@ -54,7 +54,7 @@ void gb2_comp::setup(FreeModule *FFsyz,
   // We index into this using gbvector components (which are one greater than
   // the
   // FreeModule components
-  monideals.push_back(nullptr);
+  monideals.push_back(0);
   for (i = 0; i < F->rank(); i++)
     {
       monideal_pair *p = new monideal_pair(originalR, mi_stash);
@@ -85,18 +85,18 @@ gb2_comp::gb2_comp(FreeModule *Fsyz0,
 void gb2_comp::set_output(gb_node *p)
 {
   syz = p;
-  use_hilb = (strategy_flags & STRATEGY_USE_HILB) && (syz != nullptr);
+  use_hilb = (strategy_flags & STRATEGY_USE_HILB) && (syz != NULL);
 }
 void gb2_comp::remove_pair(s_pair *&p)
 {
-  p->f = nullptr;  // these are not used in res-a2-gb algorithm except for temp space
-  p->fsyz = nullptr;  // ditto
-  p->first = nullptr;
-  p->second = nullptr;
-  p->next = nullptr;
+  p->f = 0;  // these are not used in res-a2-gb algorithm except for temp space
+  p->fsyz = 0;  // ditto
+  p->first = NULL;
+  p->second = NULL;
+  p->next = NULL;
   M->remove(p->lcm);
   freemem(p);
-  p = nullptr;
+  p = NULL;
 }
 
 gb2_comp::~gb2_comp()
@@ -108,7 +108,7 @@ gb2_comp::~gb2_comp()
       GR->gbvector_remove(g->f);
       GR->gbvector_remove(g->fsyz);
     }
-  these_pairs = nullptr;
+  these_pairs = 0;
 }
 
 //////////////////////////////////////////////
@@ -118,14 +118,14 @@ gb2_comp::~gb2_comp()
 s_pair *gb2_comp::new_ring_pair(gb_elem *p, const int *lcm)
 {
   s_pair *result = new s_pair;
-  result->next = nullptr;
+  result->next = NULL;
   result->syz_type = SPAIR_RING;
   result->degree = M->primary_degree(lcm) + F->primary_degree(p->f->comp - 1);
   result->compare_num = 0;
   result->first = p;
-  result->second = nullptr;
-  result->f = nullptr;
-  result->fsyz = nullptr;
+  result->second = NULL;
+  result->f = NULL;
+  result->fsyz = NULL;
 
   result->lcm = M->make_new(lcm);
   return result;
@@ -135,14 +135,14 @@ s_pair *gb2_comp::new_s_pair(gb_elem *p, gb_elem *q, const int *lcm)
 {
   // p and q should have 'f' field defined.
   s_pair *result = new s_pair;
-  result->next = nullptr;
+  result->next = NULL;
   result->syz_type = SPAIR_PAIR;
   result->degree = M->primary_degree(lcm) + F->primary_degree(p->f->comp - 1);
   result->compare_num = 0;
   result->first = p;
   result->second = q;
-  result->f = nullptr;
-  result->fsyz = nullptr;
+  result->f = NULL;
+  result->fsyz = NULL;
 
   result->lcm = M->make_new(lcm);
   return result;
@@ -310,7 +310,7 @@ void gb2_comp::find_pairs(gb_elem *p)
 
 void gb2_comp::compute_s_pair(s_pair *p)
 {
-  if (p->f == nullptr)
+  if (p->f == NULL)
     {
       monomial s = M->make_one();
       GR->gbvector_get_lead_monomial(F, p->first->f, s);
@@ -320,7 +320,7 @@ void gb2_comp::compute_s_pair(s_pair *p)
           F, Fsyz, GR->one(), s, p->first->f, p->first->fsyz, p->f, p->fsyz);
       if (p->syz_type == SPAIR_PAIR)
         GR->gbvector_reduce_lead_term(
-            F, Fsyz, nullptr, p->f, p->fsyz, p->second->f, p->second->fsyz);
+            F, Fsyz, 0, p->f, p->fsyz, p->second->f, p->second->fsyz);
       M->remove(s);
     }
 }
@@ -334,7 +334,7 @@ void gb2_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
     }
   gbvector head;
   gbvector *result = &head;
-  result->next = nullptr;
+  result->next = 0;
 
   exponents_t div_totalexp = newarray_atomic(int, M->n_vars());
   int count = 0;
@@ -345,7 +345,7 @@ void gb2_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
       GR->gbvector_text_out(o, F, f);
       emit_line(o.str());
     }
-  while (f != nullptr)
+  while (f != NULL)
     {
       Bag *b;
       GR->gbvector_get_lead_exponents(F, f, div_totalexp);
@@ -354,7 +354,7 @@ void gb2_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
                                                                 b))
         {
           const gbvector *g = originalR->quotient_gbvector(b->basis_elem());
-          GR->gbvector_reduce_lead_term(F, Fsyz, head.next, f, fsyz, g, nullptr);
+          GR->gbvector_reduce_lead_term(F, Fsyz, head.next, f, fsyz, g, 0);
           count++;
         }
       else if (monideals[f->comp]->mi_search->search_expvector(div_totalexp, b))
@@ -380,7 +380,7 @@ void gb2_comp::gb_reduce(gbvector *&f, gbvector *&fsyz)
           result->next = f;
           f = f->next;
           result = result->next;
-          result->next = nullptr;
+          result->next = 0;
         }
     }
 
@@ -398,7 +398,7 @@ void gb2_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
 {
   gbvector head;
   gbvector *result = &head;
-  result->next = nullptr;
+  result->next = 0;
 
   exponents_t div_totalexp = newarray_atomic(int, M->n_vars());
   int count = 0;
@@ -408,7 +408,7 @@ void gb2_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
   fb.add(f);
   fsyzb.add(fsyz);
   const gbvector *lead;
-  while ((lead = fb.get_lead_term()) != nullptr)
+  while ((lead = fb.get_lead_term()) != NULL)
     {
       Bag *b;
       GR->gbvector_get_lead_exponents(F, lead, div_totalexp);
@@ -425,7 +425,7 @@ void gb2_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
                                     fb,
                                     fsyzb,
                                     g,
-                                    nullptr);
+                                    0);
           count++;
         }
       else if (monideals[lead->comp]->mi_search->search_expvector(div_totalexp,
@@ -440,7 +440,7 @@ void gb2_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
         {
           result->next = fb.remove_lead_term();
           result = result->next;
-          result->next = nullptr;
+          result->next = 0;
         }
     }
 
@@ -459,7 +459,7 @@ void gb2_comp::gb_geo_reduce(gbvector *&f, gbvector *&fsyz)
 void gb2_comp::reduce(gbvector *&f, gbvector *&fsyz) { gb_reduce(f, fsyz); }
 void gb2_comp::flush_pairs()
 {
-  while (these_pairs != nullptr)
+  while (these_pairs != NULL)
     {
       n_pairs_hilb++;
       s_pair *p = these_pairs;
@@ -485,7 +485,7 @@ void gb2_comp::schreyer_append(gbvector *f)
 void gb2_comp::gb_insert(gbvector *f, gbvector *fsyz, int ismin)
 {
   monomial f_m = M->make_one();
-  gbvector *bull = nullptr;
+  gbvector *bull = NULL;
   gb_elem *p = new gb_elem(f, fsyz, ismin);
 
   if (orig_syz < 0 && ismin)
@@ -536,7 +536,7 @@ int gb2_comp::get_pairs()
   for (;;)
     {
       s_pair *p = spairs->remove();
-      if (p == nullptr) break;
+      if (p == NULL) break;
       if (p->degree != this_degree)
         {
           spairs->put_back(p);
@@ -548,7 +548,7 @@ int gb2_comp::get_pairs()
       n++;
     }
 
-  slast->next = nullptr;
+  slast->next = NULL;
   these_pairs = head.next;
   total_pairs.push_back(this_degree);
   total_pairs.push_back(n);
@@ -561,7 +561,7 @@ bool gb2_comp::s_pair_step()
 // dispatch the result.  Return true.
 {
   if (use_hilb && n_gb_syz == 0) flush_pairs();
-  if (these_pairs == nullptr) return false;  // Done
+  if (these_pairs == NULL) return false;  // Done
   s_pair *p = these_pairs;
   these_pairs = these_pairs->next;
 
@@ -570,19 +570,19 @@ bool gb2_comp::s_pair_step()
 
   gbvector *f = p->f;
   gbvector *fsyz = p->fsyz;
-  p->f = nullptr;
-  p->fsyz = nullptr;
+  p->f = NULL;
+  p->fsyz = NULL;
   remove_pair(p);
 
   gb_reduce(f, fsyz);
-  if (f != nullptr)
+  if (f != NULL)
     {
       gb_insert(f, fsyz, 0);
       n_gb_syz--;
       n_pairs_gb++;
       if (M2_gbTrace >= 3) emit_wrapped("m");
     }
-  else if (fsyz != nullptr && syz != nullptr)
+  else if (fsyz != NULL && syz != NULL)
     {
       if (syz->receive_generator(fsyz, n_syz++, GR->one()))
         {
@@ -598,7 +598,7 @@ bool gb2_comp::s_pair_step()
     }
   else
     {
-      if (fsyz != nullptr) GR->gbvector_remove(fsyz);
+      if (fsyz != NULL) GR->gbvector_remove(fsyz);
       n_pairs_zero++;
       if (M2_gbTrace >= 3) emit_wrapped("o");
     }
@@ -622,16 +622,16 @@ bool gb2_comp::receive_generator(gbvector *f, int n, const ring_elem denom)
       monideals.push_back(p);
     }
 
-  gbvector *fsyz = nullptr;
+  gbvector *fsyz = NULL;
   if (orig_syz >= 0)
     {
       if (orig_syz > n)
         fsyz = GR->gbvector_term(
             Fsyz, denom, n + 1);  // Note the change in component number
       gb_reduce(f, fsyz);
-      if (f == nullptr)
+      if (f == NULL)
         {
-          if (fsyz != nullptr && syz != nullptr)
+          if (fsyz != NULL && syz != NULL)
             syz->receive_generator(fsyz, n_syz++, GR->one());
         }
       else
@@ -644,8 +644,8 @@ bool gb2_comp::receive_generator(gbvector *f, int n, const ring_elem denom)
     {
       gb_reduce(f, fsyz);
       GR->gbvector_remove(fsyz);
-      GR->gbvector_remove_content(f, nullptr);
-      if (f != nullptr)
+      GR->gbvector_remove_content(f, NULL);
+      if (f != NULL)
         {
           // schreyer_append(f);
           isgen = true;
@@ -653,7 +653,7 @@ bool gb2_comp::receive_generator(gbvector *f, int n, const ring_elem denom)
           // The fsyz part will be set at the end of the degree,
           // after sorting takes place, and after auto-reduction in
           // this degree.
-          gb_insert(f, nullptr, 1);
+          gb_insert(f, NULL, 1);
         }
     }
   return isgen;
@@ -707,18 +707,18 @@ enum ComputationStatusCode gb2_comp::calc_gb(int deg)
           RingElement *hsyz;
           const PolynomialRing *DR = originalR->get_degree_ring();
           RingElement *h = RingElement::make_raw(DR, DR->zero());
-          if (syz != nullptr)
+          if (syz != NULL)
             {
               hsyz = syz->hilbertNumerator();
-              if (hsyz == nullptr) return COMP_INTERRUPTED;
+              if (hsyz == 0) return COMP_INTERRUPTED;
               //              o1 << "hsyz = "; hsyz->text_out(o);
               h = (*h) + (*hsyz);
             }
           RingElement *hf1 = hilbertNumerator();
-          if (hf1 == nullptr) return COMP_INTERRUPTED;
+          if (hf1 == 0) return COMP_INTERRUPTED;
           h = (*h) + (*hf1);
           RingElement *hF = hilb_comp::hilbertNumerator(F);
-          if (hF == nullptr) return COMP_INTERRUPTED;
+          if (hF == 0) return COMP_INTERRUPTED;
           h = (*h) - (*hF);
 
 #if 0
@@ -832,10 +832,10 @@ Matrix *gb2_comp::make_lead_term_matrix()
     {
       gb_elem *g = gb[i];
       gbvector *f = g->f;
-      if (f == nullptr) continue;
+      if (f == 0) continue;
       // Only grab the lead term, which should be non-null
       gbvector *fnext = f->next;
-      f->next = nullptr;
+      f->next = 0;
       vec v = originalR->translate_gbvector_to_vec(F, f);
       f->next = fnext;
       result.set_column(i, v);
@@ -854,7 +854,7 @@ RingElement /* or null */ *gb2_comp::hilbertNumerator()
   hf = hilb_comp::hilbertNumerator(hf_matrix);
 
   // hf is NULL if the computation was interrupted
-  if (hf == nullptr) return nullptr;
+  if (hf == 0) return 0;
 
   hf_numgens_F = F->rank();
   hf_numgens_gb = n_gb;
@@ -865,7 +865,7 @@ RingElement /* or null */ *gb2_comp::hilbertNumerator()
 //--- Obtaining matrices as output -------
 Matrix *gb2_comp::min_gens_matrix()
 {
-  MatrixConstructor mat(F, Fsyz, nullptr);
+  MatrixConstructor mat(F, Fsyz, 0);
   int j = 0;
   for (int i = 0; i < gb.size(); i++)
     if (gb[i]->is_min)
@@ -916,14 +916,14 @@ void gb2_comp::debug_out(s_pair *q) const
 }
 void gb2_comp::debug_out(buffer &o, s_pair *q) const
 {
-  if (q == nullptr) return;
+  if (q == NULL) return;
   o << "(" << q->compare_num << " ";
-  if (q->first != nullptr)
+  if (q->first != NULL)
     o << q->first->me;
   else
     o << ".";
   o << " ";
-  if (q->second != nullptr)
+  if (q->second != NULL)
     o << q->second->me;
   else
     o << ".";

--- a/M2/Macaulay2/e/res-a2.cpp
+++ b/M2/Macaulay2/e/res-a2.cpp
@@ -8,7 +8,7 @@
 extern ring_elem hilb(const Matrix &M, const Ring *RR);
 
 gb_emitter::gb_emitter(const Matrix *m)
-    : gens(m), g(nullptr), n_left(m->n_cols()), n_i(0)
+    : gens(m), g(NULL), n_left(m->n_cols()), n_i(0)
 {
   originalR = m->get_ring()->cast_to_PolynomialRing();
   assert(originalR != 0);
@@ -22,7 +22,7 @@ gb_emitter::~gb_emitter() { freemem(these); }
 RingElement *gb_emitter::hilbertNumerator()
 {
   assert(0);  // This routine should NEVER be called
-  return nullptr;
+  return 0;
 }
 enum ComputationStatusCode gb_emitter::calc_gb(int degree)
 {
@@ -36,7 +36,7 @@ enum ComputationStatusCode gb_emitter::calc_gb(int degree)
     {
       if (system_interrupted()) return COMP_INTERRUPTED;
       if (n_i >= n_gens) return COMP_DONE;
-      if (g != nullptr)
+      if (g != NULL)
         {
           ring_elem denom;
           gbvector *v = originalR->translate_gbvector_from_vec(
@@ -80,7 +80,7 @@ void gbres_comp::setup(const Matrix *m, int length, int origsyz, int strategy)
 {
   int i;
   originalR = m->get_ring()->cast_to_PolynomialRing();
-  if (originalR == nullptr) assert(0);
+  if (originalR == NULL) assert(0);
   GR = originalR->get_gb_ring();
   mi_stash = new stash("res mi nodes", sizeof(Nmi_node));
 
@@ -101,7 +101,7 @@ void gbres_comp::setup(const Matrix *m, int length, int origsyz, int strategy)
       const int *mon;
       for (i = 0; i < origsyz; i++)
         {
-          if ((*m)[i] == nullptr)
+          if ((*m)[i] == NULL)
             mon = one;
           else
             {
@@ -126,7 +126,7 @@ void gbres_comp::setup(const Matrix *m, int length, int origsyz, int strategy)
   if (n_nodes == 2)
     {
       // Don't compute syzygies at all.
-      nodes[1]->set_output(nullptr);
+      nodes[1]->set_output(NULL);
     }
   else if (n_nodes >= 3)
     {
@@ -144,7 +144,7 @@ void gbres_comp::setup(const Matrix *m, int length, int origsyz, int strategy)
       FreeModule *F = originalR->make_Schreyer_FreeModule();
       nodes[n_nodes - 1] = new gb2_comp(
           F, mi_stash, nodes[n_nodes - 2], deg++, 0, n_nodes - 1, strategy);
-      nodes[n_nodes - 1]->set_output(nullptr);
+      nodes[n_nodes - 1]->set_output(NULL);
     }
   strategy_flags = strategy;
 }
@@ -169,7 +169,7 @@ gbres_comp::~gbres_comp()
 {
   for (int i = 0; i < n_nodes; i++)
     {
-      nodes[i]->set_output(nullptr);
+      nodes[i]->set_output(NULL);
       delete nodes[i];
     }
 
@@ -180,7 +180,7 @@ gbres_comp::~gbres_comp()
 
 bool gbres_comp::stop_conditions_ok()
 {
-  if (stop_.length_limit != nullptr && stop_.length_limit->len > 0)
+  if (stop_.length_limit != 0 && stop_.length_limit->len > 0)
     {
       ERROR("cannot change length of resolution using this algorithm");
       return false;
@@ -242,10 +242,10 @@ Matrix *gbres_comp::reduce(const Matrix *m, Matrix *&lift)
   if (m->n_rows() != F->rank())
     {
       ERROR("expected matrices to have same number of rows");
-      return nullptr;
+      return 0;
     }
   MatrixConstructor mat_red(m->rows(), m->cols(), m->degree_shift());
-  MatrixConstructor mat_lift(nodes[1]->output_free_module(), m->cols(), nullptr);
+  MatrixConstructor mat_lift(nodes[1]->output_free_module(), m->cols(), 0);
 
   for (int i = 0; i < m->n_cols(); i++)
     {
@@ -383,11 +383,11 @@ M2_arrayint gbres_comp::get_betti(int type) const
       ERROR(
           "cannot use Minimize=>true unless res(...,FastNonminimal=>true) was "
           "used");
-      return nullptr;
+      return 0;
     }
 
   ERROR("received unsupported betti type for this algorithm");
-  return nullptr;
+  return 0;
 }
 
 // Local Variables:

--- a/M2/Macaulay2/e/res-a2.hpp
+++ b/M2/Macaulay2/e/res-a2.hpp
@@ -98,10 +98,10 @@ class gb_emitter : public gb_node
   virtual int n_gb_elems() const { return 0; }
   virtual const FreeModule *output_free_module() const { return gens->rows(); }
   virtual Matrix *get_matrix() { return const_cast<Matrix *>(gens); }
-  virtual Matrix *min_gens_matrix() { return nullptr; }
-  virtual Matrix *initial_matrix(int) { return nullptr; }
-  virtual Matrix *gb_matrix() { return nullptr; }
-  virtual Matrix *change_matrix() { return nullptr; }
+  virtual Matrix *min_gens_matrix() { return 0; }
+  virtual Matrix *initial_matrix(int) { return 0; }
+  virtual Matrix *gb_matrix() { return 0; }
+  virtual Matrix *change_matrix() { return 0; }
   virtual void text_out(buffer &o) const;
   virtual void stats() const;
 };

--- a/M2/Macaulay2/e/ring-vecs.cpp
+++ b/M2/Macaulay2/e/ring-vecs.cpp
@@ -19,9 +19,9 @@ void Ring::remove_vec_node(vec n) const
 
 vec Ring::make_vec(int r, ring_elem a) const
 {
-  if (is_zero(a)) return nullptr;
+  if (is_zero(a)) return NULL;
   vec result = new_vec();
-  result->next = nullptr;
+  result->next = 0;
   result->comp = r;
   result->coeff = a;
   return result;
@@ -29,10 +29,10 @@ vec Ring::make_vec(int r, ring_elem a) const
 
 vec Ring::make_vec_from_array(int len, Nterm **array) const
 {
-  vec result = nullptr;
+  vec result = 0;
   for (int i = 0; i < len; i++)
     {
-      if (array[i] != nullptr)
+      if (array[i] != 0)
         {
           vec v = make_vec(i, array[i]);
           v->next = result;
@@ -52,7 +52,7 @@ vec Ring::copy_vec(const vecterm *v) const
 {
   vecterm head;
   vec result = &head;
-  for (const vecterm *p = v; p != nullptr; p = p->next)
+  for (const vecterm *p = v; p != 0; p = p->next)
     {
       vec w = new_vec();
       result->next = w;
@@ -60,13 +60,13 @@ vec Ring::copy_vec(const vecterm *v) const
       w->comp = p->comp;
       w->coeff = p->coeff;  // copy is not done
     }
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
 void Ring::remove_vec(vec v) const
 {
-  while (v != nullptr)
+  while (v != 0)
     {
       vec tmp = v;
       v = v->next;
@@ -82,12 +82,12 @@ bool Ring::is_equal(const vecterm *a, const vecterm *b) const
 {
   for (;; a = a->next, b = b->next)
     {
-      if (a == nullptr)
+      if (a == NULL)
         {
-          if (b == nullptr) return true;
+          if (b == NULL) return true;
           return false;
         }
-      if (b == nullptr) return false;
+      if (b == NULL) return false;
       if (a->comp != b->comp) return false;
       if (!this->is_equal(a->coeff, b->coeff)) return false;
     }
@@ -97,12 +97,12 @@ int Ring::compare_vecs(vec v, vec w) const
 {
   for (;; v = v->next, w = w->next)
     {
-      if (v == nullptr)
+      if (v == NULL)
         {
-          if (w == nullptr) return 0;
+          if (w == NULL) return 0;
           return -1;
         }
-      if (w == nullptr) return 1;
+      if (w == NULL) return 1;
       int cmp = v->comp - w->comp;
       if (cmp > 0) return cmp;
       if (cmp < 0) return cmp;
@@ -114,7 +114,7 @@ int Ring::compare_vecs(vec v, vec w) const
 
 bool Ring::get_entry(const vecterm *v, int r, ring_elem &result) const
 {
-  for (const vecterm *p = v; p != nullptr; p = p->next)
+  for (const vecterm *p = v; p != 0; p = p->next)
     if (p->comp < r)
       break;
     else if (p->comp == r)
@@ -127,7 +127,7 @@ bool Ring::get_entry(const vecterm *v, int r, ring_elem &result) const
 
 ring_elem Ring::get_entry(vec v, int r) const
 {
-  while (v != nullptr)
+  while (v != NULL)
     {
       if (v->comp == r) return v->coeff;
       if (v->comp < r) return from_long(0);
@@ -139,7 +139,7 @@ ring_elem Ring::get_entry(vec v, int r) const
 int Ring::n_nonzero_terms(const vecterm *v) const
 {
   int result = 0;
-  for (; v != nullptr; v = v->next) result++;
+  for (; v != NULL; v = v->next) result++;
   return result;
 }
 
@@ -147,12 +147,12 @@ vec Ring::negate_vec(vec v) const
 {
   vecterm result;
   vecterm *b = &result;
-  for (vecterm *a = v; a != nullptr; a = a->next)
+  for (vecterm *a = v; a != NULL; a = a->next)
     {
       b->next = make_vec(a->comp, negate(a->coeff));
       b = b->next;
     }
-  b->next = nullptr;
+  b->next = NULL;
   return result.next;
 }
 
@@ -181,10 +181,10 @@ vec Ring::mult_vec(int n, vec v) const
 
 vec Ring::mult_vec(const ring_elem f, const vec w) const
 {
-  if (is_zero(f)) return nullptr;
+  if (is_zero(f)) return NULL;
   vecterm head;
   vec result = &head;
-  for (vec v = w; v != nullptr; v = v->next)
+  for (vec v = w; v != 0; v = v->next)
     {
       ring_elem a = mult(f, v->coeff);
       if (!is_zero(a))
@@ -194,16 +194,16 @@ vec Ring::mult_vec(const ring_elem f, const vec w) const
           result = t;
         }
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
 vec Ring::rightmult_vec(const vec w, const ring_elem f) const
 {
-  if (is_zero(f)) return nullptr;
+  if (is_zero(f)) return NULL;
   vecterm head;
   vec result = &head;
-  for (vec v = w; v != nullptr; v = v->next)
+  for (vec v = w; v != 0; v = v->next)
     {
       ring_elem a = mult(v->coeff, f);
       if (!is_zero(a))
@@ -213,13 +213,13 @@ vec Ring::rightmult_vec(const vec w, const ring_elem f) const
           result = t;
         }
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
 vec Ring::sub_vector(const vecterm *v, M2_arrayint r) const
 {
-  if (v == nullptr) return nullptr;
+  if (v == 0) return 0;
   // Largest component which occurs in v occurs first.
   VECTOR(int) trans(v->comp + 1);
   for (int i = 0; i < v->comp; i++) trans.push_back(-1);
@@ -229,16 +229,16 @@ vec Ring::sub_vector(const vecterm *v, M2_arrayint r) const
 
   vecterm head;
   vecterm *result = &head;
-  for (; v != nullptr; v = v->next)
+  for (; v != NULL; v = v->next)
     if (trans[v->comp] != -1)
       {
         result->next = new_vec();
         result = result->next;
-        result->next = nullptr;
+        result->next = 0;
         result->coeff = v->coeff;
         result->comp = trans[v->comp];
       }
-  result->next = nullptr;
+  result->next = NULL;
   result = head.next;
 
   vec_sort(result);
@@ -249,7 +249,7 @@ vec Ring::component_shift(int n, vec v) const
 {
   vecterm head;
   vec result = &head;
-  for (const vecterm *p = v; p != nullptr; p = p->next)
+  for (const vecterm *p = v; p != 0; p = p->next)
     {
       vec w = new_vec();
       result->next = w;
@@ -257,7 +257,7 @@ vec Ring::component_shift(int n, vec v) const
       w->comp = p->comp + n;
       w->coeff = p->coeff;  // copy is not done
     }
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
@@ -266,7 +266,7 @@ vec Ring::tensor_shift(int n, int m, vec v) const
   vecterm head;
   vecterm *result = &head;
 
-  for (; v != nullptr; v = v->next)
+  for (; v != NULL; v = v->next)
     {
       vec w = new_vec();
       result->next = w;
@@ -274,14 +274,14 @@ vec Ring::tensor_shift(int n, int m, vec v) const
       w->comp = n * v->comp + m;
       w->coeff = v->coeff;  // copy is not done
     }
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
 vec Ring::tensor(const FreeModule *F, vec v, const FreeModule *G, vec w) const
 {
   vecHeap H(F);
-  for (; v != nullptr; v = v->next)
+  for (; v != NULL; v = v->next)
     {
       vec w1 = component_shift(v->comp * G->rank(), w);
       mult_vec_to(w1, v->coeff, false);
@@ -296,14 +296,14 @@ void Ring::vec_text_out(buffer &o,
                         bool p_plus,
                         bool p_parens) const
 {
-  if (v == nullptr)
+  if (v == NULL)
     {
       o << "0";
       return;
     }
 
   p_one = false;
-  for (const vecterm *t = v; t != nullptr; t = t->next)
+  for (const vecterm *t = v; t != NULL; t = t->next)
     {
       this->elem_text_out(o, t->coeff, p_one, p_plus, p_parens);
       o << "<" << t->comp << ">";
@@ -319,7 +319,7 @@ vec Ring::vec_eval(const RingMap *map, const FreeModule *F, const vec v) const
   vecterm head;
   vec result = &head;
 
-  for (vec t = v; t != nullptr; t = t->next)
+  for (vec t = v; t != 0; t = t->next)
     {
       ring_elem a = eval(map, t->coeff, 0);  // a is now in the target ring
       if (!targetRing->is_zero(a))
@@ -328,7 +328,7 @@ vec Ring::vec_eval(const RingMap *map, const FreeModule *F, const vec v) const
           result = result->next;
         }
     }
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
@@ -336,7 +336,7 @@ vec Ring::vec_zeroize_tiny(gmp_RR epsilon, const vec v) const
 {
   vecterm head;
   vec result = &head;
-  for (const vecterm *p = v; p != nullptr; p = p->next)
+  for (const vecterm *p = v; p != 0; p = p->next)
     {
       ring_elem a = zeroize_tiny(epsilon, p->coeff);
       if (!is_zero(a))
@@ -348,7 +348,7 @@ vec Ring::vec_zeroize_tiny(gmp_RR epsilon, const vec v) const
           w->coeff = a;
         }
     }
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
@@ -357,7 +357,7 @@ void Ring::vec_increase_maxnorm(gmp_RRmutable norm, const vec v) const
 // replace norm.
 // Default for rings not over RRR or CCC is to do nothing.
 {
-  for (const vecterm *p = v; p != nullptr; p = p->next)
+  for (const vecterm *p = v; p != 0; p = p->next)
     increase_maxnorm(norm, p->coeff);
 }
 ///////////////////////////////////////
@@ -369,13 +369,13 @@ void Ring::mult_vec_to(vec &v, const ring_elem r, bool opposite_mult) const
   if (this->is_zero(r))
     {
       remove_vec(v);
-      v = nullptr;
+      v = 0;
       return;
     }
   vecterm head;
   head.next = v;
   vec p = &head;
-  while (p->next != nullptr)
+  while (p->next != 0)
     {
       // old version: this->mult_to(p->next->coeff, a);
       ring_elem c;
@@ -400,7 +400,7 @@ void Ring::mult_row(vec &v, const ring_elem r, int i, bool opposite_mult) const
 {
   vecterm head;
   head.next = v;
-  for (vec p = &head; p->next != nullptr; p = p->next)
+  for (vec p = &head; p->next != 0; p = p->next)
     if (p->next->comp < i)
       break;
     else if (p->next->comp == i)
@@ -430,8 +430,8 @@ vec Ring::mult_vec_matrix(const Matrix *m, vec v, bool opposite_mult) const
   // result = 0
   // for each non-zero term f e[component] of the vector v
   //    result += f M[v]
-  vec result = nullptr;
-  for (; v != nullptr; v = v->next)
+  vec result = NULL;
+  for (; v != NULL; v = v->next)
     {
       vec w = this->copy_vec(m->elem(v->comp));
       mult_vec_to(w, v->coeff, !opposite_mult);
@@ -445,12 +445,12 @@ void Ring::divide_vec_to(vec &v, const ring_elem a) const
   if (this->is_zero(a))
     {
       remove_vec(v);
-      v = nullptr;
+      v = 0;
     }
   vecterm head;
   head.next = v;
   vec p = &head;
-  while (p->next != nullptr)
+  while (p->next != 0)
     {
       // old version: this->mult_to(p->next->coeff, a);
       ring_elem c =
@@ -472,7 +472,7 @@ void Ring::divide_row(vec &v, int r, const ring_elem a) const
 {
   vecterm head;
   head.next = v;
-  for (vec p = &head; p->next != nullptr; p = p->next)
+  for (vec p = &head; p->next != 0; p = p->next)
     if (p->next->comp < r)
       break;
     else if (p->next->comp == r)
@@ -493,7 +493,7 @@ void Ring::divide_row(vec &v, int r, const ring_elem a) const
 void Ring::negate_vec_to(vec &v) const
 {
   vec w = v;
-  while (w != nullptr)
+  while (w != NULL)
     {
       negate_to(w->coeff);
       w = w->next;
@@ -508,11 +508,11 @@ void Ring::subtract_vec_to(vec &v, vec &w) const
 
 void Ring::add_vec_to(vec &v, vec &w) const
 {
-  if (w == nullptr) return;
-  if (v == nullptr)
+  if (w == NULL) return;
+  if (v == NULL)
     {
       v = w;
-      w = nullptr;
+      w = NULL;
       return;
     }
   vecterm head;
@@ -523,7 +523,7 @@ void Ring::add_vec_to(vec &v, vec &w) const
         result->next = w;
         result = result->next;
         w = w->next;
-        if (w == nullptr)
+        if (w == NULL)
           {
             result->next = v;
             v = head.next;
@@ -535,11 +535,11 @@ void Ring::add_vec_to(vec &v, vec &w) const
         result->next = v;
         result = result->next;
         v = v->next;
-        if (v == nullptr)
+        if (v == NULL)
           {
             result->next = w;
             v = head.next;
-            w = nullptr;
+            w = NULL;
             return;
           }
       }
@@ -560,17 +560,17 @@ void Ring::add_vec_to(vec &v, vec &w) const
             result = result->next;
           }
         remove_vec_node(tmw);
-        if (w == nullptr)
+        if (w == NULL)
           {
             result->next = v;
             v = head.next;
             return;
           }
-        if (v == nullptr)
+        if (v == NULL)
           {
             result->next = w;
             v = head.next;
-            w = nullptr;
+            w = NULL;
             return;
           }
       }
@@ -581,8 +581,8 @@ ring_elem Ring::dot_product(const vecterm *v, const vecterm *w) const
   ring_elem result = this->from_long(0);
   while (true)
     {
-      if (v == nullptr) return result;
-      if (w == nullptr) return result;
+      if (v == 0) return result;
+      if (w == 0) return result;
       if (v->comp > w->comp)
         v = v->next;
       else if (v->comp < w->comp)
@@ -603,10 +603,10 @@ void Ring::set_entry(vec &v, int r, ring_elem a) const
   bool iszero = this->is_zero(a);
   vecterm head;
   head.next = v;
-  for (p = &head; p->next != nullptr; p = p->next)
+  for (p = &head; p->next != 0; p = p->next)
     if (p->next->comp <= r) break;
 
-  if (p->next == nullptr || p->next->comp < r)
+  if (p->next == 0 || p->next->comp < r)
     {
       if (iszero) return;
       vec w = new_vec();
@@ -638,17 +638,17 @@ void Ring::vec_sort(vecterm *&f) const
   // then add them together.  This allows the same monomial
   // to appear more than once in 'f'.
 
-  if (f == nullptr || f->next == nullptr) return;
-  vecterm *f1 = nullptr;
-  vecterm *f2 = nullptr;
-  while (f != nullptr)
+  if (f == NULL || f->next == NULL) return;
+  vecterm *f1 = NULL;
+  vecterm *f2 = NULL;
+  while (f != NULL)
     {
       vecterm *t = f;
       f = f->next;
       t->next = f1;
       f1 = t;
 
-      if (f == nullptr) break;
+      if (f == NULL) break;
       t = f;
       f = f->next;
       t->next = f2;
@@ -664,16 +664,16 @@ void Ring::vec_sort(vecterm *&f) const
 vec Ring::vec_lead_term(int nparts, const FreeModule *F, vec v) const
 {
   // May be over-ridden by subclasses.  In particular, by polynomial classes.
-  if (v == nullptr) return nullptr;
+  if (v == 0) return 0;
   return make_vec(v->comp, v->coeff);
 }
 
 vec Ring::vec_diff(vec v, int rankFw, vec w, int use_coeff) const
 // rankFw is the rank of the free module corresponding to w.
 {
-  vec result = nullptr;
-  for (; v != nullptr; v = v->next)
-    for (vecterm *p = w; p != nullptr; p = p->next)
+  vec result = NULL;
+  for (; v != NULL; v = v->next)
+    for (vecterm *p = w; p != NULL; p = p->next)
       {
         ring_elem a = diff(v->coeff, p->coeff, use_coeff);
         if (is_zero(a))
@@ -694,22 +694,22 @@ vec Ring::vec_diff(vec v, int rankFw, vec w, int use_coeff) const
 int Ring::vec_in_subring(int nslots, const vec v) const
 {
   const PolynomialRing *PR = cast_to_PolynomialRing();
-  if (PR == nullptr || v == nullptr) return true;
+  if (PR == 0 || v == NULL) return true;
   const Monoid *M = PR->getMonoid();
-  for (vec w = v; w != nullptr; w = w->next)
+  for (vec w = v; w != NULL; w = w->next)
     if (!M->in_subring(nslots, PR->lead_flat_monomial(w->coeff))) return false;
   return true;
 }
 
 void Ring::vec_degree_of_var(int n, const vec v, int &lo, int &hi) const
 {
-  if (v == nullptr)
+  if (v == NULL)
     {
       ERROR("attempting to find degree of zero vector");
       return;
     }
   degree_of_var(n, v->coeff, lo, hi);
-  for (vec w = v->next; w != nullptr; w = w->next)
+  for (vec w = v->next; w != 0; w = w->next)
     {
       int lo1, hi1;
       degree_of_var(n, w->coeff, lo1, hi1);
@@ -722,7 +722,7 @@ vec Ring::vec_divide_by_var(int n, int d, const vec v) const
 {
   vecterm head;
   vecterm *result = &head;
-  for (vec w = v; w != nullptr; w = w->next)
+  for (vec w = v; w != 0; w = w->next)
     {
       ring_elem a = divide_by_var(n, d, w->coeff);
       if (!is_zero(a))
@@ -732,7 +732,7 @@ vec Ring::vec_divide_by_var(int n, int d, const vec v) const
           result = t;
         }
     }
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
@@ -740,7 +740,7 @@ vec Ring::vec_divide_by_expvector(const_exponents exp, const vec v) const
 {
   vecterm head;
   vecterm *result = &head;
-  for (vec w = v; w != nullptr; w = w->next)
+  for (vec w = v; w != 0; w = w->next)
     {
       ring_elem a = divide_by_expvector(exp, w->coeff);
       if (!is_zero(a))
@@ -750,7 +750,7 @@ vec Ring::vec_divide_by_expvector(const_exponents exp, const vec v) const
           result = t;
         }
     }
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
@@ -765,12 +765,12 @@ bool Ring::vec_multi_degree(const FreeModule *F, const vec f, monomial degf) con
 {
   monomial degv;
   degree_monoid()->one(degf);
-  if (f == nullptr) return true;
+  if (f == NULL) return true;
   bool result = multi_degree(f->coeff, degf);
   degree_monoid()->mult(degf, F->degree(f->comp), degf);
   degv = degree_monoid()->make_one();
 
-  for (vec v = f->next; v != nullptr; v = v->next)
+  for (vec v = f->next; v != 0; v = v->next)
     {
       bool ishom = multi_degree(v->coeff, degv);
       result = result && ishom;
@@ -789,14 +789,14 @@ bool Ring::vec_multi_degree(const FreeModule *F, const vec f, monomial degf) con
 bool Ring::vec_is_homogeneous(const FreeModule *F, const vec f) const
 {
   if (!this->is_graded()) return false;
-  if (f == nullptr) return true;
+  if (f == NULL) return true;
   monomial d = degree_monoid()->make_one();
   monomial e = degree_monoid()->make_one();
   bool result = multi_degree(f->coeff, d);
   if (result)
     {
       degree_monoid()->mult(d, F->degree(f->comp), d);
-      for (vecterm *t = f->next; (t != nullptr) && result; t = t->next)
+      for (vecterm *t = f->next; (t != NULL) && result; t = t->next)
         {
           bool ishom = multi_degree(t->coeff, e);
           result = result && ishom;
@@ -819,7 +819,7 @@ void Ring::vec_degree_weights(const FreeModule *F,
                               int &hi) const
 {
   vecterm *t = f;
-  if (t == nullptr)
+  if (t == NULL)
     {
       lo = hi = 0;
       return;
@@ -827,7 +827,7 @@ void Ring::vec_degree_weights(const FreeModule *F,
   degree_weights(t->coeff, wts, lo, hi);
   lo += F->primary_degree(t->comp);
   hi += F->primary_degree(t->comp);
-  for (t = t->next; t != nullptr; t = t->next)
+  for (t = t->next; t != NULL; t = t->next)
     {
       int lo1, hi1;
       degree_weights(t->coeff, wts, lo1, hi1);
@@ -850,7 +850,7 @@ vec Ring::vec_homogenize(const FreeModule *F,
   assert(wts->array[v] != 0);
   // If an error occurs, then return 0, and set ERROR
 
-  for (vec w = f; w != nullptr; w = w->next)
+  for (vec w = f; w != 0; w = w->next)
     {
       int e = F->primary_degree(w->comp);
       ring_elem a = homogenize(w->coeff, v, d - e, wts);
@@ -860,7 +860,7 @@ vec Ring::vec_homogenize(const FreeModule *F,
           result = result->next;
         }
     }
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
@@ -869,8 +869,8 @@ vec Ring::vec_homogenize(const FreeModule *F,
                          int v,
                          M2_arrayint wts) const
 {
-  vecterm *result = nullptr;
-  if (f == nullptr) return result;
+  vecterm *result = NULL;
+  if (f == NULL) return result;
   int lo, hi;
   vec_degree_weights(F, f, wts, lo, hi);
   assert(wts->array[v] != 0);
@@ -893,7 +893,7 @@ bool static check_nterm_multiples(const PolyRing *R,
   Nterm *g;
   const Monoid *M = R->getMonoid();
   const Ring *K = R->getCoefficients();
-  for (f = f1, g = g1; f != nullptr && g != nullptr; f = f->next, g = g->next)
+  for (f = f1, g = g1; f != 0 && g != 0; f = f->next, g = g->next)
     {
       if (M->compare(f->monom, g->monom) != 0) return false;
       ring_elem c1 = K->mult(c, g->coeff);
@@ -901,7 +901,7 @@ bool static check_nterm_multiples(const PolyRing *R,
       int isequal = K->is_equal(c1, d1);
       if (!isequal) return false;
     }
-  if (f == nullptr && g == nullptr) return true;
+  if (f == NULL && g == NULL) return true;
   return false;
 }
 
@@ -909,10 +909,10 @@ bool Ring::vec_is_scalar_multiple(vec f, vec g) const
 // is df = cg, some scalars c,d?
 // These scalars are over the very bottom base field/ZZ.
 {
-  if (f == nullptr) return true;
-  if (g == nullptr) return true;
+  if (f == NULL) return true;
+  if (g == NULL) return true;
   const PolynomialRing *PR = cast_to_PolynomialRing();
-  if (PR == nullptr) return true;
+  if (PR == 0) return true;
   const PolyRing *PR1 = PR->getNumeratorRing();
 #ifdef DEVELOPMENT
 #warning "use numerator only"
@@ -923,27 +923,27 @@ bool Ring::vec_is_scalar_multiple(vec f, vec g) const
   ring_elem c = f1->coeff;
   ring_elem d = g1->coeff;
   vec p, q;
-  for (p = f, q = g; p != nullptr && q != nullptr; p = p->next, q = q->next)
+  for (p = f, q = g; p != NULL && q != NULL; p = p->next, q = q->next)
     {
       if (p->comp != q->comp) return 0;
       if (!check_nterm_multiples(PR1, p->coeff, q->coeff, c, d)) return false;
     }
-  if (q == nullptr && p == nullptr) return true;
+  if (q == NULL && p == NULL) return true;
   return false;
 }
 
 vec Ring::vec_remove_monomial_factors(vec f, bool make_squarefree_only) const
 {
   const PolynomialRing *PR = cast_to_PolynomialRing();
-  if (PR == nullptr) return copy_vec(f);
-  if (f == nullptr) return nullptr;
+  if (PR == 0) return copy_vec(f);
+  if (f == 0) return 0;
 
   exponents_t exp = newarray_atomic(int, PR->n_vars());
 
   Nterm *t = f->coeff;
   PR->getMonoid()->to_expvector(t->monom, exp);  // Get the process started
 
-  for (vec a = f; a != nullptr; a = a->next) monomial_divisor(a->coeff, exp);
+  for (vec a = f; a != NULL; a = a->next) monomial_divisor(a->coeff, exp);
 
   if (make_squarefree_only)
     // Now divide each term by exp[i]-1, if exp[i] >= 2
@@ -958,18 +958,18 @@ vec Ring::vec_remove_monomial_factors(vec f, bool make_squarefree_only) const
 
 ring_elem Ring::vec_content(vec f) const
 {
-  if (f == nullptr) return zero();
+  if (f == 0) return zero();
   ring_elem c = content(f->coeff);
-  for (vec t = f->next; t != nullptr; t = t->next) lower_content(c, t->coeff);
+  for (vec t = f->next; t != 0; t = t->next) lower_content(c, t->coeff);
   return c;
 }
 
 vec Ring::vec_divide_by_given_content(vec f, ring_elem c) const
 {
-  if (f == nullptr) return nullptr;
+  if (f == 0) return 0;
   vecterm head;
   vec result = &head;
-  for (const vecterm *p = f; p != nullptr; p = p->next)
+  for (const vecterm *p = f; p != 0; p = p->next)
     {
       vec w = new_vec();
       result->next = w;
@@ -977,13 +977,13 @@ vec Ring::vec_divide_by_given_content(vec f, ring_elem c) const
       w->comp = p->comp;
       w->coeff = divide_by_given_content(p->coeff, c);
     }
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
 vec Ring::vec_divide_by_content(vec f) const
 {
-  if (f == nullptr) return nullptr;
+  if (f == 0) return 0;
   ring_elem c = vec_content(f);
   return vec_divide_by_given_content(f, c);
 }
@@ -991,8 +991,8 @@ vec Ring::vec_divide_by_content(vec f) const
 ring_elem Ring::vec_split_off_content(vec f, vec &result) const
 {
   ring_elem c = vec_content(f);
-  if (f == nullptr)
-    result = nullptr;
+  if (f == 0)
+    result = 0;
   else
     result = vec_divide_by_given_content(f, c);
   return c;

--- a/M2/Macaulay2/e/ring.hpp
+++ b/M2/Macaulay2/e/ring.hpp
@@ -94,8 +94,8 @@ class Ring : public MutableEngineObject
   ring_elem minus_oneV;
 
   void initialize_ring(long charac,
-                       const PolynomialRing *DR = nullptr,
-                       const M2_arrayint heft_vec = nullptr);
+                       const PolynomialRing *DR = 0,
+                       const M2_arrayint heft_vec = 0);
   Ring()
       : mCharacteristic(0),
         degree_ring(nullptr),
@@ -198,26 +198,26 @@ class Ring : public MutableEngineObject
   ///////////////////////////////////
   // Casting up the ring hierarchy //
   ///////////////////////////////////
-  virtual const RingZZ *cast_to_RingZZ() const { return nullptr; }
-  virtual RingZZ *cast_to_RingZZ() { return nullptr; }
-  virtual const Z_mod *cast_to_Z_mod() const { return nullptr; }
-  virtual Z_mod *cast_to_Z_mod() { return nullptr; }
-  virtual const GF *cast_to_GF() const { return nullptr; }
-  virtual GF *cast_to_GF() { return nullptr; }
-  virtual const Tower *cast_to_Tower() const { return nullptr; }
-  virtual Tower *cast_to_Tower() { return nullptr; }
-  virtual const PolynomialRing *cast_to_PolynomialRing() const { return nullptr; }
-  virtual PolynomialRing *cast_to_PolynomialRing() { return nullptr; }
-  virtual const PolyRing *cast_to_PolyRing() const { return nullptr; }
-  virtual PolyRing *cast_to_PolyRing() { return nullptr; }
-  virtual const PolyQQ *cast_to_PolyQQ() const { return nullptr; }
-  virtual PolyQQ *cast_to_PolyQQ() { return nullptr; }
-  virtual const PolyRingFlat *cast_to_PolyRingFlat() const { return nullptr; }
-  virtual PolyRingFlat *cast_to_PolyRingFlat() { return nullptr; }
-  virtual const FractionField *cast_to_FractionField() const { return nullptr; }
-  virtual FractionField *cast_to_FractionField() { return nullptr; }
-  virtual const LocalRing *cast_to_LocalRing() const { return nullptr; }
-  virtual LocalRing *cast_to_LocalRing() { return nullptr; }
+  virtual const RingZZ *cast_to_RingZZ() const { return 0; }
+  virtual RingZZ *cast_to_RingZZ() { return 0; }
+  virtual const Z_mod *cast_to_Z_mod() const { return 0; }
+  virtual Z_mod *cast_to_Z_mod() { return 0; }
+  virtual const GF *cast_to_GF() const { return 0; }
+  virtual GF *cast_to_GF() { return 0; }
+  virtual const Tower *cast_to_Tower() const { return 0; }
+  virtual Tower *cast_to_Tower() { return 0; }
+  virtual const PolynomialRing *cast_to_PolynomialRing() const { return 0; }
+  virtual PolynomialRing *cast_to_PolynomialRing() { return 0; }
+  virtual const PolyRing *cast_to_PolyRing() const { return 0; }
+  virtual PolyRing *cast_to_PolyRing() { return 0; }
+  virtual const PolyQQ *cast_to_PolyQQ() const { return 0; }
+  virtual PolyQQ *cast_to_PolyQQ() { return 0; }
+  virtual const PolyRingFlat *cast_to_PolyRingFlat() const { return 0; }
+  virtual PolyRingFlat *cast_to_PolyRingFlat() { return 0; }
+  virtual const FractionField *cast_to_FractionField() const { return 0; }
+  virtual FractionField *cast_to_FractionField() { return 0; }
+  virtual const LocalRing *cast_to_LocalRing() const { return 0; }
+  virtual LocalRing *cast_to_LocalRing() { return 0; }
 
   virtual const M2FreeAlgebra *cast_to_M2FreeAlgebra() const { return nullptr; }
   virtual M2FreeAlgebra *cast_to_M2FreeAlgebra() { return nullptr; }
@@ -238,40 +238,40 @@ class Ring : public MutableEngineObject
     return nullptr;
   }
 
-  virtual const SchurRing *cast_to_SchurRing() const { return nullptr; }
-  virtual SchurRing *cast_to_SchurRing() { return nullptr; }
-  virtual const SchurRing2 *cast_to_SchurRing2() const { return nullptr; }
-  virtual SchurRing2 *cast_to_SchurRing2() { return nullptr; }
-  virtual const SchurSnRing *cast_to_SchurSnRing() const { return nullptr; }
-  virtual SchurSnRing *cast_to_SchurSnRing() { return nullptr; }
+  virtual const SchurRing *cast_to_SchurRing() const { return 0; }
+  virtual SchurRing *cast_to_SchurRing() { return 0; }
+  virtual const SchurRing2 *cast_to_SchurRing2() const { return 0; }
+  virtual SchurRing2 *cast_to_SchurRing2() { return 0; }
+  virtual const SchurSnRing *cast_to_SchurSnRing() const { return 0; }
+  virtual SchurSnRing *cast_to_SchurSnRing() { return 0; }
   virtual const SkewPolynomialRing *cast_to_SkewPolynomialRing() const
   {
-    return nullptr;
+    return 0;
   }
-  virtual SkewPolynomialRing *cast_to_SkewPolynomialRing() { return nullptr; }
-  virtual const SolvableAlgebra *cast_to_SolvableAlgebra() const { return nullptr; }
-  virtual SolvableAlgebra *cast_to_SolvableAlgebra() { return nullptr; }
-  virtual const WeylAlgebra *cast_to_WeylAlgebra() const { return nullptr; }
-  virtual RRR *cast_to_RRR() { return nullptr; }
-  virtual const RRR *cast_to_RRR() const { return nullptr; }
-  virtual RRi *cast_to_RRi() { return nullptr; }
-  virtual const RRi *cast_to_RRi() const { return nullptr; }
-  virtual CCC *cast_to_CCC() { return nullptr; }
-  virtual const CCC *cast_to_CCC() const { return nullptr; }
+  virtual SkewPolynomialRing *cast_to_SkewPolynomialRing() { return 0; }
+  virtual const SolvableAlgebra *cast_to_SolvableAlgebra() const { return 0; }
+  virtual SolvableAlgebra *cast_to_SolvableAlgebra() { return 0; }
+  virtual const WeylAlgebra *cast_to_WeylAlgebra() const { return 0; }
+  virtual RRR *cast_to_RRR() { return 0; }
+  virtual const RRR *cast_to_RRR() const { return 0; }
+  virtual RRi *cast_to_RRi() { return 0; }
+  virtual const RRi *cast_to_RRi() const { return 0; }
+  virtual CCC *cast_to_CCC() { return 0; }
+  virtual const CCC *cast_to_CCC() const { return 0; }
   // Galois Field routines.  These three routines only return non-NULL values
   // if this was created as a Galois field, isom to A = kk[b]/(f(b)), kk = prime
   // field of char p.
 
   // Returns NULL if not a GF.  Returns f(b) in the ring kk[b].  (Variable name
   // might be different)
-  virtual const RingElement *getMinimalPolynomial() const { return nullptr; }
+  virtual const RingElement *getMinimalPolynomial() const { return 0; }
   // Returns NULL if not a GF.  Returns an element of 'this', whose powers give
   // all non-zero elements
   // of the field.
   virtual const RingElement *getGenerator() const
   {
     ERROR("not implemented for this ring");
-    return nullptr;
+    return 0;
   }
 
   // For some finite fields, if a = (getGenerator())^r, return r.
@@ -290,14 +290,14 @@ class Ring : public MutableEngineObject
   // for that call.
   virtual const RingElement *getRepresentation(const ring_elem &a) const
   {
-    return nullptr;
+    return 0;
   }
 
   virtual MutableMatrix *makeMutableMatrix(size_t nrows,
                                            size_t ncols,
                                            bool dense) const
   {
-    return nullptr;
+    return 0;
   }
 
   virtual FreeModule *make_FreeModule() const;

--- a/M2/Macaulay2/e/ringmap.cpp
+++ b/M2/Macaulay2/e/ringmap.cpp
@@ -9,9 +9,9 @@
 #include <iostream>
 RingMap::RingMap(const Matrix *m) : R(m->get_ring())
 {
-  M = nullptr;
+  M = 0;
   P = R->cast_to_PolynomialRing();
-  if (P != nullptr)
+  if (P != 0)
     {
       M = P->getMonoid();
       K = P->getCoefficientRing();
@@ -35,14 +35,14 @@ RingMap::RingMap(const Matrix *m) : R(m->get_ring())
       _elem[i].monom_is_one = true;
       _elem[i].bigelem_is_one = true;
       _elem[i].coeff = ZERO_RINGELEM;
-      _elem[i].monom = nullptr;
+      _elem[i].monom = NULL;
 
       ring_elem f = m->elem(0, i);  // This does a copy.
       _elem[i].bigelem = f;
 
       if (R->is_zero(f))
         _elem[i].is_zero = true;
-      else if (P == nullptr)
+      else if (P == 0)
         {
           // Not a polynomial ring, so put everything into coeff
           if (!K->is_equal(f, one))
@@ -58,7 +58,7 @@ RingMap::RingMap(const Matrix *m) : R(m->get_ring())
 #warning "also handle fraction rings"
 #endif
           Nterm *t = f;
-          if (t->next == nullptr)
+          if (t->next == NULL)
             {
               // This is a single term
               if (!K->is_equal(t->coeff, one))
@@ -94,8 +94,8 @@ RingMap::~RingMap()
       R->remove(_elem[i].bigelem);
     }
   freemem(_elem);
-  K = nullptr;
-  M = nullptr;
+  K = NULL;
+  M = NULL;
 }
 
 unsigned int RingMap::computeHashValue() const
@@ -156,11 +156,11 @@ ring_elem RingMap::eval_term(const Ring *sourceK,  // source coeff ring
   ring_elem result = sourceK->eval(this, a, first_var + nvars_in_source);
   if (R->is_zero(result)) return result;
 
-  monomial result_monom = nullptr;
-  monomial temp_monom = nullptr;
+  monomial result_monom = NULL;
+  monomial temp_monom = NULL;
   ring_elem result_coeff = K->from_long(1);
 
-  if (P != nullptr)
+  if (P != 0)
     {
       result_monom = M->make_one();
       temp_monom = M->make_one();
@@ -216,7 +216,7 @@ ring_elem RingMap::eval_term(const Ring *sourceK,  // source coeff ring
               if (R->is_zero(result)) break;
             }
         }
-      if (P != nullptr)
+      if (P != 0)
         {
           ring_elem temp = P->make_flat_term(result_coeff, result_monom);
           K->remove(result_coeff);

--- a/M2/Macaulay2/e/sagbi.cpp
+++ b/M2/Macaulay2/e/sagbi.cpp
@@ -15,11 +15,11 @@ ring_elem sagbi::subduct(int numslots,
   Nterm *result = &head;
   MatrixConstructor mat(R->make_FreeModule(1), 1);
 
-  while (f != nullptr)
+  while (f != NULL)
     {
       Nterm *g = f;
       f = f->next;
-      g->next = nullptr;
+      g->next = NULL;
 
       mat.set_entry(0, 0, g);
       Matrix *m = mat.to_matrix();
@@ -45,7 +45,7 @@ ring_elem sagbi::subduct(int numslots,
         }
     }
 
-  result->next = nullptr;
+  result->next = NULL;
   return head.next;
 }
 
@@ -53,10 +53,10 @@ Matrix *sagbi::subduct(int numparts, const Matrix *m, const RingMap *phi, GBComp
 {
   MatrixConstructor result(m->rows(), m->cols());
   const PolyRing *R = m->get_ring()->cast_to_PolyRing();
-  if (R == nullptr)
+  if (R == 0)
     {
       ERROR("expected polynomial ring");
-      return nullptr;
+      return 0;
     }
   int nslots = R->getMonoid()->n_slots(numparts);
   for (int i = 0; i < m->n_cols(); i++)
@@ -84,7 +84,7 @@ ring_elem sagbi::subduct1(int numslots,
     MatrixConstructor matS(S->make_FreeModule(1), 1);
     bool breakFlag = false;
     
-    while ((f != nullptr) && (breakFlag == false))
+    while ((f != NULL) && (breakFlag == false))
     {
         // tensorRingg = S#"inclusionAmbient" liftg
         // tesnorRingg = gInT
@@ -92,12 +92,12 @@ ring_elem sagbi::subduct1(int numslots,
 
         // This might be the wrong way to deal with this issue.
         // I don't know what to do, however.
-        if(gInT != nullptr)
+        if(gInT != NULL)
           {
               // tensorRingLTg = leadTerm tensorRingg
               // tensorRingLTg = LTgInT
               Nterm *LTgInT = gInT;
-              LTgInT->next = nullptr;
+              LTgInT->next = NULL;
         
             // h = tensorRingLTg % (inAIdeal)
             // h = h1
@@ -110,7 +110,7 @@ ring_elem sagbi::subduct1(int numslots,
 
             ring_elem projectionh = T->eval(substitutionInclusion,h1,0);
             
-            if(projectionh != nullptr)
+            if(projectionh != NULL)
             {
                 // hSub = (S#"fullSubstitution" h) % I
                 ring_elem hInS = T->eval(fullSubstitution,h1,0);
@@ -147,10 +147,10 @@ Matrix *sagbi::subduct1(int numparts,
     MatrixConstructor result(m->rows(), m->cols());
     const PolyRing *T = rawT->cast_to_PolyRing();
     const PolyRing *S = rawS->cast_to_PolyRing();
-    if ((T == nullptr) || (S == nullptr))
+    if ((T == 0) || (S == 0))
     {
         ERROR("expected polynomial ring");
-        return nullptr;
+        return 0;
     }
     int nslots = T->getMonoid()->n_slots(numparts);
     for (int i = 0; i < m->n_cols(); i++)

--- a/M2/Macaulay2/e/schorder.cpp
+++ b/M2/Macaulay2/e/schorder.cpp
@@ -32,7 +32,7 @@ SchreyerOrder *SchreyerOrder::create(const Matrix *m)
   const Ring *R = m->get_ring();
   const SchreyerOrder *S = m->rows()->get_schreyer_order();
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  if (P == nullptr)
+  if (P == 0)
     {
       throw exc::engine_error("expected polynomial ring");
     }
@@ -46,7 +46,7 @@ SchreyerOrder *SchreyerOrder::create(const Matrix *m)
   for (i = 0; i < rk; i++)
     {
       vec v = (*m)[i];
-      if (v == nullptr || S == nullptr)
+      if (v == NULL || S == NULL)
         tiebreaks[i] = i;
       else
         tiebreaks[i] = i + rk * S->compare_num(v->comp);
@@ -57,9 +57,9 @@ SchreyerOrder *SchreyerOrder::create(const Matrix *m)
   for (i = 0; i < rk; i++)
     {
       vec v = (*m)[i];
-      if (v == nullptr)
+      if (v == NULL)
         M->one(base);
-      else if (S == nullptr)
+      else if (S == NULL)
         M->copy(P->lead_flat_monomial(v->coeff), base);
       else
         {
@@ -98,7 +98,7 @@ SchreyerOrder *SchreyerOrder::create(const GBMatrix *m)
   for (i = 0; i < rk; i++)
     {
       gbvector *v = m->elems[i];
-      if (v == nullptr || S == nullptr)
+      if (v == NULL || S == NULL)
         tiebreaks[i] = i;
       else
         tiebreaks[i] = i + rk * S->compare_num(v->comp - 1);
@@ -109,7 +109,7 @@ SchreyerOrder *SchreyerOrder::create(const GBMatrix *m)
   for (i = 0; i < rk; i++)
     {
       gbvector *v = m->elems[i];
-      if (v == nullptr)
+      if (v == NULL)
         M->one(base);
       else  // if (S == NULL)
         M->copy(v->monom, base);
@@ -134,7 +134,7 @@ bool SchreyerOrder::is_equal(const SchreyerOrder *G) const
 // A schreyer order is never equal to a non-Schreyer order, even
 // if the monomials are all ones.
 {
-  if (G == nullptr) return false;
+  if (G == NULL) return false;
   for (int i = 0; i < rank(); i++)
     {
       if (compare_num(i) != G->compare_num(i)) return false;
@@ -156,7 +156,7 @@ SchreyerOrder *SchreyerOrder::sub_space(int n) const
   if (n < 0 || n > rank())
     {
       ERROR("sub schreyer order: index out of bounds");
-      return nullptr;
+      return NULL;
     }
   SchreyerOrder *result = new SchreyerOrder(M);
   for (int i = 0; i < n; i++) result->append(compare_num(i), base_monom(i));
@@ -176,7 +176,7 @@ SchreyerOrder *SchreyerOrder::sub_space(M2_arrayint a) const
       {
         ERROR("schreyer order subspace: index out of bounds");
         freemem(result);
-        return nullptr;
+        return NULL;
       }
   return result;
 }
@@ -281,15 +281,15 @@ struct SchreyerOrder_symm
       : S(S0),
         n(n0),
         M(S0->getMonoid()),
-        symm1_result(nullptr),
-        symm1_base(nullptr),
+        symm1_result(0),
+        symm1_base(0),
         symm1_next(0)
   {
   }
 
   SchreyerOrder *value()
   {
-    if (symm1_result == nullptr)
+    if (symm1_result == 0)
       {
         symm1_result = SchreyerOrder::create(M);
         if (n >= 0)

--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-computation.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-computation.cpp
@@ -35,7 +35,7 @@ ResolutionComputation* createF4Res(const Matrix* groebnerBasisMatrix,
   // null is returned.
   const PolynomialRing* origR =
       groebnerBasisMatrix->get_ring()->cast_to_PolynomialRing();
-  if (origR == nullptr)
+  if (origR == 0)
     {
       ERROR("expected polynomial ring");
       return nullptr;
@@ -78,7 +78,7 @@ ResolutionComputation* createF4Res(const Matrix* groebnerBasisMatrix,
 
   const Ring* K = origR->getCoefficients();
   ResGausser* KK = ResGausser::newResGausser(K);
-  if (KK == nullptr)
+  if (KK == 0)
     {
       ERROR(
           "cannot use res(...,FastNonminimal=>true) with this type of "

--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
@@ -216,7 +216,7 @@ void ResF4toM2Interface::from_M2_vec(const ResPolyRing& R,
   std::vector<res_monomial_word> monoms(n * R.monoid().max_monomial_size());
   n = 0;
   res_monomial_word* nextmonom = monoms.data();
-  for (gbvector* t = f; t != nullptr; t = t->next)
+  for (gbvector* t = f; t != 0; t = t->next)
     {
       R.resGausser().from_ring_elem(
           coeffs, t->coeff, f->coeff);  // note: f->coeff is assumed to be 1 for
@@ -250,8 +250,8 @@ vec ResF4toM2Interface::to_M2_vec(const ResPolyRing& R,
   Nterm** last = newarray(Nterm*, F->rank());
   for (int i = 0; i < F->rank(); i++)
     {
-      comps[i] = nullptr;
-      last[i] = nullptr;
+      comps[i] = 0;
+      last[i] = 0;
     }
 
   int* exp = new int[M->n_vars()];
@@ -266,8 +266,8 @@ vec ResF4toM2Interface::to_M2_vec(const ResPolyRing& R,
       ring_elem a =
           R.resGausser().to_ring_elem(origR->getCoefficientRing(), f.coeffs, i);
       Nterm* g = origR->make_flat_term(a, m1);
-      g->next = nullptr;
-      if (last[comp] == nullptr)
+      g->next = 0;
+      if (last[comp] == 0)
         {
           comps[comp] = g;
           last[comp] = g;
@@ -278,15 +278,15 @@ vec ResF4toM2Interface::to_M2_vec(const ResPolyRing& R,
           last[comp] = g;
         }
     }
-  vec result = nullptr;
+  vec result = 0;
   for (int i = 0; i < F->rank(); i++)
     {
-      if (comps[i] != nullptr)
+      if (comps[i] != 0)
         {
           vec v = origR->make_vec(i, comps[i]);
           origR->add_vec_to(result, v);
-          comps[i] = nullptr;
-          last[i] = nullptr;
+          comps[i] = 0;
+          last[i] = 0;
         }
     }
 
@@ -441,8 +441,8 @@ MutableMatrix* ResF4toM2Interface::to_M2_MutableMatrix(SchreyerFrame& C,
           ring_elem a = C.gausser().to_ring_elem(K, f.coeffs, i);
           Nterm* g = RP->make_flat_term(a, m1);
           if (g == nullptr) continue;
-          g->next = nullptr;
-          if (last[comp] == nullptr)
+          g->next = 0;
+          if (last[comp] == 0)
             {
               comps[comp] = g;
               last[comp] = g;
@@ -857,7 +857,7 @@ M2_arrayint rawMinimalBetti(Computation* C,
   try
     {
       F4ResComputation* G = dynamic_cast<F4ResComputation*>(C);
-      if (G != nullptr)
+      if (G != 0)
         return G->minimal_betti(slanted_degree_limit,
                                 length_limit);  // Computes it if needed
       ERROR("expected resolution computed via res(...,FastNonminimal=>true)");

--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-monlookup.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-monlookup.cpp
@@ -23,9 +23,9 @@ ResF4MonomialLookupTableT<Key>::new_mi_node(varpower_word v,
   mi_node *p = reinterpret_cast<mi_node *>(mi_stash->new_elem());
   p->var = v;
   p->exp = e;
-  p->left = nullptr;
-  p->right = nullptr;
-  p->header = nullptr;
+  p->left = NULL;
+  p->right = NULL;
+  p->header = NULL;
   p->tag = mi_node::node;
   p->val.down = d;
   return p;
@@ -40,9 +40,9 @@ ResF4MonomialLookupTableT<Key>::new_mi_node(varpower_word v,
   mi_node *p = reinterpret_cast<mi_node *>(mi_stash->new_elem());
   p->var = v;
   p->exp = e;
-  p->left = nullptr;
-  p->right = nullptr;
-  p->header = nullptr;
+  p->left = NULL;
+  p->right = NULL;
+  p->header = NULL;
   p->tag = mi_node::leaf;
   p->val.key = k;
   return p;
@@ -51,7 +51,7 @@ ResF4MonomialLookupTableT<Key>::new_mi_node(varpower_word v,
 template <typename Key>
 void ResF4MonomialLookupTableT<Key>::delete_mi_node(mi_node *p)
 {
-  if (p == nullptr) return;
+  if (p == 0) return;
   if (p->right != p->header) delete_mi_node(p->right);
   if (p->tag == mi_node::node)
     {
@@ -66,7 +66,7 @@ ResF4MonomialLookupTableT<Key>::ResF4MonomialLookupTableT(int nvars,
 {
   count = 0;
   mi_stash = mi_stash0;
-  if (mi_stash == nullptr)
+  if (mi_stash == 0)
     {
       count = 1;
       mi_stash = new stash("mi_node", sizeof(mi_node));
@@ -92,7 +92,7 @@ void ResF4MonomialLookupTableT<Key>::insert1(mi_node *&top,
                                              Key k)
 {
   count += 2;
-  mi_node **p = &top, *up = nullptr;
+  mi_node **p = &top, *up = NULL;
   bool one_element = true;
 
   for (index_res_varpower_monomial i = b; i.valid();)
@@ -101,7 +101,7 @@ void ResF4MonomialLookupTableT<Key>::insert1(mi_node *&top,
       varpower_word insert_var = i.var();
       varpower_word insert_exp;
 
-      if (*p == nullptr)
+      if (*p == NULL)
         {
           // make a new header node
           *p = new_mi_node(insert_var, 0, up);
@@ -173,7 +173,7 @@ bool ResF4MonomialLookupTableT<Key>::find_one_divisor1(
     Key &result_k) const
 // mi is the top: where to start looking
 {
-  if (mi == nullptr) return false;
+  if (mi == NULL) return false;
 
   mi_node *p = mi;
 
@@ -183,13 +183,13 @@ bool ResF4MonomialLookupTableT<Key>::find_one_divisor1(
 
       if (p == p->header)
         {
-          if ((p = p->down()) == nullptr) return false;
+          if ((p = p->down()) == NULL) return false;
           continue;
         }
 
       if (p->exp > exp[p->var])
         {
-          if ((p = p->header->down()) == nullptr) return false;
+          if ((p = p->header->down()) == NULL) return false;
           continue;
         }
 
@@ -217,13 +217,13 @@ void ResF4MonomialLookupTableT<Key>::find_all_divisors1(
 
       if (p == p->header)
         {
-          if ((p = p->down()) == nullptr) return;
+          if ((p = p->down()) == NULL) return;
           continue;
         }
 
       if (p->exp > exp[p->var])
         {
-          if ((p = p->header->down()) == nullptr) return;
+          if ((p = p->header->down()) == NULL) return;
           continue;
         }
 
@@ -281,7 +281,7 @@ bool ResF4MonomialLookupTableT<Key>::find_one_divisor_vp(
 {
   if (comp >= mis.size()) return false;
   mi_node *mi = mis[comp];
-  if (mi == nullptr) return false;
+  if (mi == NULL) return false;
 
   ResF4MonomialLookupTableT *me = const_cast<ResF4MonomialLookupTableT *>(this);
   me->update_expvector(static_cast<int>(mi->var), m);
@@ -298,7 +298,7 @@ void ResF4MonomialLookupTableT<Key>::find_all_divisors_vp(
 {
   if (comp >= mis.size()) return;
   mi_node *mi = mis[comp];
-  if (mi == nullptr) return;
+  if (mi == NULL) return;
 
   ResF4MonomialLookupTableT *me = const_cast<ResF4MonomialLookupTableT *>(this);
   me->update_expvector(static_cast<int>(mi->var), m);
@@ -316,7 +316,7 @@ bool ResF4MonomialLookupTableT<Key>::find_one_divisor_packed(
   auto comp = M->get_component(m);
   if (comp >= mis.size()) return false;
   mi_node *mi = mis[comp];
-  if (mi == nullptr) return false;
+  if (mi == NULL) return false;
   M->to_expvector(m, exp0, comp);
   return find_one_divisor1(mi, exp0, result_k);
 }
@@ -330,7 +330,7 @@ void ResF4MonomialLookupTableT<Key>::find_all_divisors_packed(
   auto comp = M->get_component(m);
   if (comp >= mis.size()) return;
   mi_node *mi = mis[comp];
-  if (mi == nullptr) return;
+  if (mi == NULL) return;
   M->to_expvector(m, exp0, comp);
   find_all_divisors1(mi, exp0, result_k);
 }
@@ -343,7 +343,7 @@ void ResF4MonomialLookupTableT<Key>::insert_minimal_vp(
 {
   if (comp >= mis.size())
     {
-      for (long j = comp - mis.size(); j >= 0; j--) mis.push_back(nullptr);
+      for (long j = comp - mis.size(); j >= 0; j--) mis.push_back(0);
     }
   insert1(mis[comp], m, k);
 }
@@ -365,7 +365,7 @@ template <typename Key>
 typename ResF4MonomialLookupTableT<Key>::mi_node *
 ResF4MonomialLookupTableT<Key>::next(mi_node *p) const
 {
-  while (p != nullptr)
+  while (p != NULL)
     {
       p = p->left;
       if (p->tag == mi_node::leaf)
@@ -373,14 +373,14 @@ ResF4MonomialLookupTableT<Key>::next(mi_node *p) const
       else
         p = p->down();
     }
-  return nullptr;
+  return NULL;
 }
 
 template <typename Key>
 typename ResF4MonomialLookupTableT<Key>::mi_node *
 ResF4MonomialLookupTableT<Key>::prev(mi_node *p) const
 {
-  while (p != nullptr)
+  while (p != NULL)
     {
       p = p->right;
       if (p->tag == mi_node::leaf)
@@ -388,7 +388,7 @@ ResF4MonomialLookupTableT<Key>::prev(mi_node *p) const
       else
         p = p->down();
     }
-  return nullptr;
+  return NULL;
 }
 
 static int nlists = 0;
@@ -453,7 +453,7 @@ void ResF4MonomialLookupTableT<Key>::debug_out(int disp) const
   for (typename VECTOR(mi_node *)::const_iterator i = mis.begin();
        i != mis.end();
        i++)
-    if (*i != nullptr) do_tree(*i, 0, 0, disp);
+    if (*i != NULL) do_tree(*i, 0, 0, disp);
   buffer o;
   o << "list nodes     = " << nlists << newline;
   o << "internal nodes = " << nnodes << newline;
@@ -475,7 +475,7 @@ int ResF4MonomialLookupTableT<Key>::debug_check(mi_node *const p,
   // First check the node 'p' itself
   assert(p != NULL);
   assert(p->var >= 0);
-  if (up != nullptr) assert(p->var < up->var);
+  if (up != NULL) assert(p->var < up->var);
   assert(p->header == p);
   assert(p->tag == mi_node::node);
   assert(p->down() == up);
@@ -514,7 +514,7 @@ void ResF4MonomialLookupTableT<Key>::debug_check() const
        i != mis.end();
        i++)
     {
-      if (*i != nullptr) nfound += debug_check(*i, nullptr);
+      if (*i != NULL) nfound += debug_check(*i, NULL);
     }
   assert(count / 2 == nfound);
 }
@@ -529,7 +529,7 @@ void ResF4MonomialLookupTableT<Key>::text_out(buffer &o) const
        i != mis.end();
        i++)
     {
-      for (mi_node *p = *i; p != nullptr; p = next(p))
+      for (mi_node *p = *i; p != NULL; p = next(p))
         {
           if ((++a) % 15 == 0) o << newline;
           o << p->key() << "  ";
@@ -547,8 +547,8 @@ void minimalize_res_varpower_monomials(const VECTOR(res_varpower_monomial) &
     {
       res_varpower_word d = res_varpower_monomials::simple_degree(elems[j]);
       if (d >= bins.size())
-        for (int i = INTSIZE(bins); i <= d; i++) bins.push_back(nullptr);
-      if (bins[d] == nullptr) bins[d] = new VECTOR(int);
+        for (int i = INTSIZE(bins); i <= d; i++) bins.push_back(NULL);
+      if (bins[d] == NULL) bins[d] = new VECTOR(int);
       bins[d]->push_back(j);
     }
 
@@ -556,7 +556,7 @@ void minimalize_res_varpower_monomials(const VECTOR(res_varpower_monomial) &
   ResF4MonomialLookupTableT<int> M(
       10, mi_stash);  // The 10 is simply a suggested start value
   for (int i = 0; i < bins.size(); i++)
-    if (bins[i] != nullptr)
+    if (bins[i] != NULL)
       {
         for (VECTOR(int)::iterator j = bins[i]->begin(); j != bins[i]->end();
              j++)

--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-monlookup.hpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-monlookup.hpp
@@ -77,7 +77,7 @@ class ResF4MonomialLookupTableT : public our_new_delete
   void insert1(mi_node *&p, const_varpower_monomial m, Key k);
 
  public:
-  ResF4MonomialLookupTableT(int nvars, stash *mi_stash = nullptr);
+  ResF4MonomialLookupTableT(int nvars, stash *mi_stash = 0);
   ~ResF4MonomialLookupTableT();
 
   //  // Should we write these two routines?
@@ -135,7 +135,7 @@ class ResF4MonomialLookupTableT : public our_new_delete
 void minimalize_res_varpower_monomials(const VECTOR(res_varpower_monomial) &
                                            elems,
                                        VECTOR(int) & result_minimals,
-                                       stash *mi_stash = nullptr);
+                                       stash *mi_stash = 0);
 
 #endif
 

--- a/M2/Macaulay2/e/schreyer-resolution/res-schreyer-frame.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-schreyer-frame.cpp
@@ -401,7 +401,7 @@ M2_arrayint SchreyerFrame::getBetti(int type)
   if (type == 5) return mComputationStatus.getBetti();
 
   ERROR("betti display not implemented yet");
-  return nullptr;
+  return 0;
 }
 
 void SchreyerFrame::endLevel()

--- a/M2/Macaulay2/e/schur.cpp
+++ b/M2/Macaulay2/e/schur.cpp
@@ -11,8 +11,8 @@ void tableau::initialize(int nvars)
   dim = nvars;
   maxwt = SCHUR_MAX_WT;
   wt = 0;
-  lambda = nullptr;
-  p = nullptr;
+  lambda = 0;
+  p = 0;
   xloc = newarray_atomic(int, SCHUR_MAX_WT + 1);
   yloc = newarray_atomic(int, SCHUR_MAX_WT + 1);
 }
@@ -78,7 +78,7 @@ bool SchurRing::initialize_schur()
   _SMfilled.initialize(n_vars());
   _SMcurrent = 0;
   _SMfinalwt = 0;
-  _SMresult = nullptr;
+  _SMresult = 0;
 
   _SMtab.p = newarray_atomic_clear(int, nvars_ + 1);
   return true;
@@ -88,7 +88,7 @@ SchurRing *SchurRing::create(const PolynomialRing *R)
 {
   SchurRing *result = new SchurRing;
   result->initialize_poly_ring(R->getCoefficients(), R->getMonoid());
-  if (!result->initialize_schur()) return nullptr;
+  if (!result->initialize_schur()) return 0;
   // No GBRing
   return result;
 }
@@ -96,13 +96,13 @@ SchurRing *SchurRing::create(const PolynomialRing *R)
 SchurRing *SchurRing::create(const Ring *A, int n)
 {
   ERROR("not implemented yet");
-  return nullptr;
+  return 0;
 }
 
 SchurRing *SchurRing::createInfinite(const Ring *A)
 {
   ERROR("not implemented yet");
-  return nullptr;
+  return 0;
 }
 
 void SchurRing::text_out(buffer &o) const
@@ -220,10 +220,10 @@ Nterm *SchurRing::skew_schur(int *lambda, int *p)
   _SMtab.resize(_SMfinalwt);
   _SMfilled.resize(_SMfinalwt);
   _SMfilled.fill(lambda, p);
-  _SMresult = nullptr;
+  _SMresult = NULL;
   SM();
   ring_elem result = _SMresult;
-  _SMresult = nullptr;
+  _SMresult = NULL;
   return result;
 }
 

--- a/M2/Macaulay2/e/schur2.cpp
+++ b/M2/Macaulay2/e/schur2.cpp
@@ -443,7 +443,7 @@ bool SchurRing2::promote(const Ring *Rf,
   else
     {
       const SchurRing2 *Sf = Rf->cast_to_SchurRing2();
-      if (Sf != nullptr)
+      if (Sf != 0)
         {
           if (coefficientRing == Sf->getCoefficientRing())
             {
@@ -473,7 +473,7 @@ bool SchurRing2::lift(const Ring *Rg,
   else
     {
       const SchurRing2 *Sg = Rg->cast_to_SchurRing2();
-      if (Sg != nullptr)
+      if (Sg != 0)
         {
           if (coefficientRing == Sg->getCoefficientRing())
             {
@@ -678,7 +678,7 @@ engine_RawArrayPairOrNull SchurRing2::list_form(const Ring *coeffR,
   if (coeffR != coefficientRing)
     {
       ERROR("expected coefficient ring of Schur ring");
-      return nullptr;
+      return 0;
     }
   const schur_poly *f1 = f.get_schur_poly();
   int n = static_cast<int>(f1->size());  // this is here because the lengths of

--- a/M2/Macaulay2/e/skew.cpp
+++ b/M2/Macaulay2/e/skew.cpp
@@ -3,12 +3,12 @@
 #include "monoid.hpp"
 
 SkewMultiplication::SkewMultiplication()
-    : _n_vars(0), _n_skew(0), _skew_list(nullptr), _skew_exp(nullptr), skew_byte_size(0)
+    : _n_vars(0), _n_skew(0), _skew_list(0), _skew_exp(0), skew_byte_size(0)
 {
 }
 
 SkewMultiplication::SkewMultiplication(int nvars, int nskew, int *skew_list)
-    : _n_vars(nvars), _n_skew(nskew), _skew_list(skew_list), _skew_exp(nullptr)
+    : _n_vars(nvars), _n_skew(nskew), _skew_list(skew_list), _skew_exp(0)
 {
   _skew_exp = newarray_atomic_clear(bool, nvars);
   for (int v = 0; v < nskew; v++) _skew_exp[skew_list[v]] = true;

--- a/M2/Macaulay2/e/skewpoly.cpp
+++ b/M2/Macaulay2/e/skewpoly.cpp
@@ -19,7 +19,7 @@ SkewPolynomialRing *SkewPolynomialRing::create(const Ring *K,
   SkewPolynomialRing *result = new SkewPolynomialRing;
 
   result->initialize_poly_ring(K, M);
-  if (!result->initialize_skew(skewvars)) return nullptr;
+  if (!result->initialize_skew(skewvars)) return 0;
   result->gb_ring_ = GBRing::create_SkewPolynomialRing(K, M, result->skew_);
   return result;
 }
@@ -54,13 +54,13 @@ ring_elem SkewPolynomialRing::antipode(const ring_elem f) const
       int mod4 = deg % 4;
       int sign = sign4[mod4];
       Nterm *t = new_term();
-      t->next = nullptr;
+      t->next = 0;
       t->coeff = (sign == 1 ? s.coeff : K_->negate(s.coeff));
       M_->copy(s.monom, t->monom);
       inresult->next = t;
       inresult = inresult->next;
     }
-  inresult->next = nullptr;
+  inresult->next = 0;
   return head.next;
 }
 
@@ -83,7 +83,7 @@ ring_elem SkewPolynomialRing::mult_by_term(const ring_elem f,
       if (sign == 0) continue;
 
       Nterm *t = new_term();
-      t->next = nullptr;
+      t->next = 0;
       t->coeff = K_->mult(c, s.coeff);
       if (sign < 0) K_->negate_to(t->coeff);
 
@@ -91,7 +91,7 @@ ring_elem SkewPolynomialRing::mult_by_term(const ring_elem f,
       inresult->next = t;
       inresult = inresult->next;
     }
-  inresult->next = nullptr;
+  inresult->next = 0;
   return head.next;
 }
 

--- a/M2/Macaulay2/e/solvable.cpp
+++ b/M2/Macaulay2/e/solvable.cpp
@@ -20,7 +20,7 @@ SolvableAlgebra *SolvableAlgebra::create(const Ring *K,
   SolvableAlgebra *result = new SolvableAlgebra;
 
   result->initialize_poly_ring(K, M);
-  if (!result->initialize_solvable(Q)) return nullptr;
+  if (!result->initialize_solvable(Q)) return 0;
   result->gb_ring_ = GBRing::create_SolvableAlgebra(K, M, result);
   return result;
 }

--- a/M2/Macaulay2/e/spair.cpp
+++ b/M2/Macaulay2/e/spair.cpp
@@ -23,7 +23,7 @@ s_pair_heap::s_pair_heap(const Monoid *MM) : M(MM), top_of_heap(-1), nelems(0)
   int i;
   for (i = 0; i < NHEAP; i++)
     {
-      heap[i] = nullptr;
+      heap[i] = NULL;
       n_in_heap[i] = 0;
     }
 }
@@ -36,7 +36,7 @@ s_pair *s_pair_heap::grab_remaining_pairs()
     if (heap[i])
       {
         inresult->next = heap[i];
-        while (inresult->next != nullptr) inresult = inresult->next;
+        while (inresult->next != 0) inresult = inresult->next;
       }
   return head.next;
 }
@@ -78,7 +78,7 @@ int s_pair_heap::compare(s_pair *f, s_pair *g) const
         if (cmp != 0)
           return cmp;  // MES: changed cmp to -cmp, to try out different order
                        // 2/21/00.
-        if (f->first == nullptr || g->first == nullptr) return 0;
+        if (f->first == NULL || g->first == NULL) return 0;
         cmp = f->first->me - g->first->me;
         if (cmp > 0) return 1;
         if (cmp < 0) return -1;
@@ -88,19 +88,19 @@ int s_pair_heap::compare(s_pair *f, s_pair *g) const
         if (cmp != 0)
           return -cmp;  // MES: changed cmp to -cmp, to try out different order
                         // 2/21/00.
-        if (f->first == nullptr || g->first == nullptr) return 0;
+        if (f->first == NULL || g->first == NULL) return 0;
         cmp = f->first->me - g->first->me;
         if (cmp > 0) return 1;
         if (cmp < 0) return -1;
         break;
       case 2:
-        if (f->first != nullptr && g->first != nullptr)
+        if (f->first != NULL && g->first != NULL)
           {
             cmp = f->first->me - g->first->me;
             if (cmp < 0) return -1;
             if (cmp > 0) return 1;
           }
-        if (f->second != nullptr && g->second != nullptr)
+        if (f->second != NULL && g->second != NULL)
           {
             cmp = f->second->me - g->second->me;
             if (cmp < 0) return -1;
@@ -108,7 +108,7 @@ int s_pair_heap::compare(s_pair *f, s_pair *g) const
           }
         cmp = M->compare(f->lcm, g->lcm);
         if (cmp != 0) return cmp;
-        if (f->first == nullptr || g->first == nullptr) return 0;
+        if (f->first == NULL || g->first == NULL) return 0;
         cmp = f->first->me - g->first->me;
         if (cmp > 0) return 1;
         if (cmp < 0) return -1;
@@ -123,8 +123,8 @@ int s_pair_heap::compare(s_pair *f, s_pair *g) const
 s_pair *s_pair_heap::merge(s_pair *f, s_pair *g) const
 {
   // Sort in ascending degree order, then ascending monomial order
-  if (g == nullptr) return f;
-  if (f == nullptr) return g;
+  if (g == NULL) return f;
+  if (f == NULL) return g;
   s_pair head;
   s_pair *result = &head;
   while (1) switch (compare(f, g))
@@ -133,7 +133,7 @@ s_pair *s_pair_heap::merge(s_pair *f, s_pair *g) const
           result->next = g;
           result = result->next;
           g = g->next;
-          if (g == nullptr)
+          if (g == NULL)
             {
               result->next = f;
               return head.next;
@@ -144,7 +144,7 @@ s_pair *s_pair_heap::merge(s_pair *f, s_pair *g) const
           result->next = f;
           result = result->next;
           f = f->next;
-          if (f == nullptr)
+          if (f == NULL)
             {
               result->next = g;
               return head.next;
@@ -155,17 +155,17 @@ s_pair *s_pair_heap::merge(s_pair *f, s_pair *g) const
 
 void s_pair_heap::sort_list(s_pair *&p) const
 {
-  if (p == nullptr || p->next == nullptr) return;
-  s_pair *p1 = nullptr;
-  s_pair *p2 = nullptr;
-  while (p != nullptr)
+  if (p == NULL || p->next == NULL) return;
+  s_pair *p1 = NULL;
+  s_pair *p2 = NULL;
+  while (p != NULL)
     {
       s_pair *tmp = p;
       p = p->next;
       tmp->next = p1;
       p1 = tmp;
 
-      if (p == nullptr) break;
+      if (p == NULL) break;
       tmp = p;
       p = p->next;
       tmp->next = p2;
@@ -181,7 +181,7 @@ void s_pair_heap::insert(s_pair *&p)
 {
   heap[0] = merge(p, heap[0]);
   n_in_heap[0]++;
-  p = nullptr;
+  p = NULL;
   int i = 0;
   while (n_in_heap[i] >= spair_heap_size[i])
     {
@@ -195,7 +195,7 @@ void s_pair_heap::insert(s_pair *&p)
         }
       heap[i] = merge(heap[i - 1], heap[i]);
       n_in_heap[i] += n_in_heap[i - 1];
-      heap[i - 1] = nullptr;
+      heap[i - 1] = NULL;
       n_in_heap[i - 1] = 0;
     }
   if (i > top_of_heap) top_of_heap = i;
@@ -209,13 +209,13 @@ void s_pair_heap::insert(s_pair *p, int len)
   heap[i] = merge(p, heap[i]);
   n_in_heap[i] += len;
   //  std::cerr << "n_in_heap[" << i << "]=" << n_in_heap[i] << std::endl;
-  p = nullptr;
+  p = NULL;
   while (n_in_heap[i] >= spair_heap_size[i])
     {
       i++;
       heap[i] = merge(heap[i - 1], heap[i]);
       n_in_heap[i] += n_in_heap[i - 1];
-      heap[i - 1] = nullptr;
+      heap[i - 1] = NULL;
       n_in_heap[i - 1] = 0;
     }
   if (i > top_of_heap) top_of_heap = i;
@@ -225,7 +225,7 @@ void s_pair_heap::insert(s_pair *p, int len)
 s_pair *s_pair_heap::remove()
 {
   // Find a non-zero element
-  if (nelems == 0) return nullptr;
+  if (nelems == 0) return NULL;
   int i, first;
   for (first = 0; first <= top_of_heap; first++)
     if (n_in_heap[first] > 0) break;
@@ -234,7 +234,7 @@ s_pair *s_pair_heap::remove()
   // Now find the smallest one
   for (i = first + 1; i <= top_of_heap; i++)
     {
-      if (heap[i] == nullptr) continue;
+      if (heap[i] == NULL) continue;
       int cmp = compare(smallest, heap[i]);
       if (cmp > 0)
         {
@@ -245,7 +245,7 @@ s_pair *s_pair_heap::remove()
 
   // Now remove this element and return it:
   heap[first] = smallest->next;
-  smallest->next = nullptr;
+  smallest->next = NULL;
   nelems--;
 
   n_in_heap[first]--;
@@ -263,7 +263,7 @@ s_pair *s_pair_heap::remove()
 void s_pair_heap::put_back(s_pair *&p)
 {
   insert(p);
-  p = nullptr;
+  p = NULL;
 }
 
 void s_pair_heap::stats() const {}

--- a/M2/Macaulay2/e/spair.hpp
+++ b/M2/Macaulay2/e/spair.hpp
@@ -20,23 +20,23 @@ struct gb_elem : public our_new_delete
   int me;
 
   gb_elem()
-      : next(nullptr),
-        next_min(nullptr),
-        pair_list(nullptr),
-        f(nullptr),
-        fsyz(nullptr),
-        lead_exp(nullptr),
+      : next(NULL),
+        next_min(NULL),
+        pair_list(NULL),
+        f(NULL),
+        fsyz(NULL),
+        lead_exp(NULL),
         is_min(0),
         me(0)
   {
   }
   gb_elem(gbvector *f0, gbvector *fsyz0, int is_min0)
-      : next(nullptr),
-        next_min(nullptr),
-        pair_list(nullptr),
+      : next(NULL),
+        next_min(NULL),
+        pair_list(NULL),
         f(f0),
         fsyz(fsyz0),
-        lead_exp(nullptr),
+        lead_exp(NULL),
         is_min(is_min0),
         me(0)
   {

--- a/M2/Macaulay2/e/tower.cpp
+++ b/M2/Macaulay2/e/tower.cpp
@@ -26,7 +26,7 @@ bool Tower::initialize(long charac0,
   // Translate extensions to poly's
   if (extensions.size() == 0)
     {
-      D = DRing::create(charac0, nvars, nullptr);
+      D = DRing::create(charac0, nvars, 0);
     }
   else
     {
@@ -47,20 +47,20 @@ Tower *Tower::create(int charac, M2_ArrayString names)
 {
   Tower *result = new Tower;
   VECTOR(ring_elem) extensions;
-  if (!result->initialize(charac, names, extensions)) return nullptr;
+  if (!result->initialize(charac, names, extensions)) return 0;
   return result;
 }
 
 Tower *Tower::create(const Tower *R, M2_ArrayString new_names)
 {
   // TODO: write
-  return nullptr;
+  return 0;
 }
 
 Tower *Tower::create(const Tower *R, VECTOR(ring_elem) & extensions)
 {
   Tower *result = new Tower;
-  if (!result->initialize(R->characteristic(), R->names, extensions)) return nullptr;
+  if (!result->initialize(R->characteristic(), R->names, extensions)) return 0;
   return result;
 }
 
@@ -296,7 +296,7 @@ class TowerEvaluator : public DPolyTraverser
     target = map->get_ring();
     H = target->make_SumCollector();
     const PolynomialRing *P = target->cast_to_PolynomialRing();
-    K = (P == nullptr ? target : P->getCoefficients());
+    K = (P == 0 ? target : P->getCoefficients());
   }
 
   virtual ~TowerEvaluator() { delete H; }
@@ -367,7 +367,7 @@ int Tower::degreeInVariable(int whichvar, const ring_elem f) const
 ring_elem Tower::differentiate(int whichvar, const ring_elem f) const
 {
   TowerPolynomial f1 = TOWER_POLYNOMIAL_VAL(f);
-  TowerPolynomial h = nullptr;
+  TowerPolynomial h = 0;
   D->diff(whichvar, h, f1);
   return TOWER_RINGELEM(h);
 }
@@ -384,7 +384,7 @@ ring_elem Tower::power_mod(const ring_elem f,
 {
   TowerPolynomial f1 = TOWER_POLYNOMIAL_VAL(f);
   TowerPolynomial g1 = TOWER_POLYNOMIAL_VAL(g);
-  TowerPolynomial h = nullptr;
+  TowerPolynomial h = 0;
   D->power_mod(h, f1, n, g1);
   return TOWER_RINGELEM(h);
 }
@@ -392,7 +392,7 @@ ring_elem Tower::power_mod(const ring_elem f,
 ring_elem Tower::lowerP(const ring_elem f) const
 {
   TowerPolynomial f1 = TOWER_POLYNOMIAL_VAL(f);
-  TowerPolynomial h = nullptr;
+  TowerPolynomial h = 0;
   D->lowerP(h, f1);
   return TOWER_RINGELEM(h);
 }
@@ -407,7 +407,7 @@ const RingElement *towerGCD(const RingElement *F, const RingElement *G)
 {
   const Tower *R = F->get_ring()->cast_to_Tower();
   const Tower *S = G->get_ring()->cast_to_Tower();
-  if (R == nullptr || R != S)
+  if (R == 0 || R != S)
     {
       ERROR("encountered different rings");
     }
@@ -423,7 +423,7 @@ const RingElement *towerExtendedGCD(const RingElement *F,
 {
   const Tower *R = F->get_ring()->cast_to_Tower();
   const Tower *S = G->get_ring()->cast_to_Tower();
-  if (R == nullptr || R != S)
+  if (R == 0 || R != S)
     {
       ERROR("encountered different rings");
     }
@@ -448,7 +448,7 @@ ring_elem Tower::translate(const PolynomialRing *R, ring_elem fR) const
   const Monoid *M = R->getMonoid();
   const Ring *K = R->getCoefficients();
   int nvars = R->n_vars();
-  TowerPolynomial result = nullptr;
+  TowerPolynomial result = 0;
   exponents_t exp = new int[nvars];
   for (Nterm& t : fR)
     {
@@ -512,17 +512,17 @@ const RingElement *rawTowerTranslatePoly(const Ring *newRing,
   // be the same.
   const PolynomialRing *P = F->get_ring()->cast_to_PolynomialRing();
   const Tower *T = newRing->cast_to_Tower();
-  if (P != nullptr && T != nullptr)
+  if (P != 0 && T != 0)
     {
       if (P->n_vars() != T->n_vars())
         {
           ERROR("expected rings with the same number of variables");
-          return nullptr;
+          return 0;
         }
       if (P->characteristic() != T->characteristic())
         {
           ERROR("expected rings with the same characteristic");
-          return nullptr;
+          return 0;
         }
       ring_elem a = T->translate(P, F->get_value());
       return RingElement::make_raw(T, a);
@@ -537,7 +537,7 @@ const RingElement *rawTowerTranslatePoly(const Ring *newRing,
     }
 #endif
   ERROR("expected an element of a TowerRing or a PolynomialRing");
-  return nullptr;
+  return 0;
 }
 
 // Local Variables:

--- a/M2/Macaulay2/e/util/fixCompileCommandsJSON.sh
+++ b/M2/Macaulay2/e/util/fixCompileCommandsJSON.sh
@@ -1,5 +1,0 @@
-#! /bin/zsh
-# This script should be ran in the M2 directory as ./Macaulay2/e/util/fixCompileCommandsJSON.sh
-sed 's;-Xclang;;' /Users/frank/Macaulay2/M2-frank/M2/BUILD/frank/builds.tmp/cmake-appleclang/compile_commands.json > temp.json
-sed 's;-Xpreprocessor -fopenmp /opt/homebrew/opt/libomp/lib/libomp.dylib;;' temp.json > compile_commands.json
-rm temp.json

--- a/M2/Macaulay2/e/util/nullptrFix.sh
+++ b/M2/Macaulay2/e/util/nullptrFix.sh
@@ -1,7 +1,0 @@
-#! /bin/zsh
-# Use this shell script in the e directory as ./util/nullPtrFix.sh
-# This script fixes any uses of 0 or NULL for null pointers and replaces it with nullptr
-for x in **/*.cpp(N) **/*.hpp(N); do
-   echo $x
-   /opt/homebrew/opt/llvm@16/bin/clang-tidy -p ../.. --checks="-*,modernize-use-nullptr" --fix $x
-done

--- a/M2/Macaulay2/e/weylalg.cpp
+++ b/M2/Macaulay2/e/weylalg.cpp
@@ -105,7 +105,7 @@ WeylAlgebra *WeylAlgebra::create(const Ring *K,
   WeylAlgebra *result = new WeylAlgebra;
 
   result->initialize_poly_ring(K, M);
-  if (!result->initialize_weyl(derivs, comms, homog_var)) return nullptr;
+  if (!result->initialize_weyl(derivs, comms, homog_var)) return 0;
 #ifdef DEVELOPMENT
 #warning "hack for ZZ and QQ coeffs in Weyl algebra: clean it up?"
 #endif
@@ -169,12 +169,12 @@ void WeylAlgebra::text_out(buffer &o) const
 /////////////////
 int WeylAlgebra::binomtop = 15;
 int WeylAlgebra::diffcoeffstop = 10;
-int **WeylAlgebra::binomtable = nullptr;
-int **WeylAlgebra::diffcoeffstable = nullptr;
+int **WeylAlgebra::binomtable = 0;
+int **WeylAlgebra::diffcoeffstable = 0;
 
 void WeylAlgebra::initialize1()
 {
-  if (binomtable == nullptr)
+  if (binomtable == 0)
     {
       int i, j;
 
@@ -351,7 +351,7 @@ Nterm *WeylAlgebra::weyl_diff(const ring_elem c,
   // monoid.
 
   Nterm head;
-  head.next = nullptr;
+  head.next = 0;
   Nterm *result = &head;
 
   int i;
@@ -413,7 +413,7 @@ Nterm *WeylAlgebra::weyl_diff(const ring_elem c,
     }
   freemem(exp);
   freemem(result_exp);
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 
@@ -473,7 +473,7 @@ gbvector *WeylAlgebra::gbvector_weyl_diff(
   // monoid.
 
   gbvector head;
-  head.next = nullptr;
+  head.next = 0;
   gbvector *result = &head;
 
   int i;
@@ -498,7 +498,7 @@ gbvector *WeylAlgebra::gbvector_weyl_diff(
         deriv_exp[_commutative[i]] = derivatives[i];
       }
 
-  for (const gbvector *t = g; t != nullptr; t = t->next)
+  for (const gbvector *t = g; t != 0; t = t->next)
     {
       // This first part checks whether the x-part of t->monom is divisible by
       // 'derivatives'.  If so, true is returned, and the resulting monomial is
@@ -534,7 +534,7 @@ gbvector *WeylAlgebra::gbvector_weyl_diff(
     }
   freemem(exp);
   freemem(result_exp);
-  result->next = nullptr;
+  result->next = 0;
   return head.next;
 }
 


### PR DESCRIPTION
…tory."

This commit caused problems with another branch (feature/monoids) where it proved difficult to clean up and remove conflicts with these changes.  Instead, we will rerun the clang-tidy code that created 2886 later, after that code is merged in.
