### PR TITLE
Add version switcher to web documentation

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -55,6 +55,8 @@ defaultCharset := () -> META { "http-equiv" => "Content-Type", "content" => "tex
 
 defaultHEAD = title -> HEAD splice { TITLE title, defaultCharset(), defaultStylesheet(), KaTeX(),
     SCRIPT {"src" => getStyleFile "prism.js", ""},
+    SCRIPT {"var current_version = '", version#"VERSION", "';"},
+    SCRIPT {"src" => getStyleFile "version-select.js"},
     LINK {
 	"rel" => "icon", "type" => "image/x-icon",
 	"href" => getStyleFile "icon.gif"}}

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -269,8 +269,12 @@ buttonBar := tag -> DIV {
 	    else if tag === "toc"
 	    then HREF {htmlDirectory | tocFileName, "Table of Contents"}
 	    else TO tag)},
-    prepend("class" => "right",
-	DIV splice between_" | " {
+    DIV join({"class" => "right",
+	    LITERAL ///<form method="get" action="https://www.google.com/search">
+  <input placeholder="Search" type="text" name="q" value="">
+  <input type="hidden" name="q" value="site:macaulay2.com/doc">
+</form>///},
+	splice between_" | " {
 	    nextButton tag,
 	    prevButton tag,
 	    forwardButton tag,

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -240,8 +240,8 @@ BACKWARD  := tag -> if PREV#?tag then BACKWARD0 PREV#tag else if UP#?tag then UP
 topNodeButton  := (htmlDirectory, topFileName)   -> HREF {htmlDirectory | topFileName,   "top" };
 indexButton    := (htmlDirectory, indexFileName) -> HREF {htmlDirectory | indexFileName, "index"};
 tocButton      := (htmlDirectory, tocFileName)   -> HREF {htmlDirectory | tocFileName,   "toc"};
-pkgButton      := TO2 {"packages provided with Macaulay2", "packages"};
-homeButton     := HREF {"http://macaulay2.com/", "Macaulay2 website"};
+pkgButton      := TO2 {"packages provided with Macaulay2", "Packages"};
+homeButton     := HREF {"https://macaulay2.com/", "Macaulay2"};
 
 nextButton     := tag -> if NEXT#?tag then HREF { htmlFilename NEXT#tag, "next" }     else "next"
 prevButton     := tag -> if PREV#?tag then HREF { htmlFilename PREV#tag, "previous" } else "previous"
@@ -250,10 +250,34 @@ backwardButton := tag -> ( b := BACKWARD tag; if b =!= null then HREF { htmlFile
 upButton       := tag -> if   UP#?tag then HREF { htmlFilename   UP#tag, "up" } else "up"
 topButton      := tag -> if tag =!= topDocumentTag then topNodeButton(htmlDirectory, topFileName) else "top"
 
+upAncestors := tag -> reverse(
+    n := 0; prepend(tag, while UP#?tag and n < 20 list (n = n+1; tag = UP#tag)))
+
 -- TODO: revamp this using Bootstrap
-buttonBar := tag -> TABLE { "class" => "buttons", TR { TD { DIV splice between_" | " {
-		nextButton tag, prevButton tag, forwardButton tag, backwardButton tag, upButton tag, topButton tag,
-		indexButton(htmlDirectory, indexFileName), tocButton(htmlDirectory, tocFileName), pkgButton, homeButton}}}}
+buttonBar := tag -> DIV {
+    "id" => "buttons",
+    DIV {
+	homeButton, " ", SPAN {"id" => "version-select-container", ""},
+	" » ", TO2 {"Macaulay2Doc", "Documentation "}, " ",
+	BR {},
+	pkgButton, " » ",
+	SPAN if UP#?tag
+	then between(" > ", apply(upAncestors tag, i -> TO i))
+	else (TO topDocumentTag, " :: ",
+	    if tag === "index"
+	    then HREF {htmlDirectory | indexFileName, "Index"}
+	    else if tag === "toc"
+	    then HREF {htmlDirectory | tocFileName, "Table of Contents"}
+	    else TO tag)},
+    prepend("class" => "right",
+	DIV splice between_" | " {
+	    nextButton tag,
+	    prevButton tag,
+	    forwardButton tag,
+	    backwardButton tag,
+	    upButton tag,
+	    indexButton(htmlDirectory, indexFileName),
+	    tocButton(htmlDirectory, tocFileName)})}
 
 -----------------------------------------------------------------------------
 -- makePackageIndex
@@ -377,9 +401,6 @@ installInfo := (pkg, installPrefix, installLayout, verboseLog) -> (
 -- install HTML documentation for package
 -----------------------------------------------------------------------------
 
-upAncestors := tag -> reverse(
-    n := 0; prepend(tag, while UP#?tag and n < 20 list (n = n+1; tag = UP#tag)))
-
 makeSortedIndex := (nodes, verboseLog) -> (
      numAnchorsMade = 0;
      fn := installPrefix | htmlDirectory | indexFileName;
@@ -388,7 +409,7 @@ makeSortedIndex := (nodes, verboseLog) -> (
      fn << html validate HTML {
 	  defaultHEAD title,
 	  BODY nonnull {
-	       DIV { topNodeButton(htmlDirectory, topFileName), " | ", tocButton(htmlDirectory, tocFileName), " | ", pkgButton, " | ", homeButton },
+	       buttonBar "index",
 	       HR{},
 	       HEADER1 title,
 	       DIV between(LITERAL "&nbsp;&nbsp;&nbsp;",apply(alpha, c -> HREF {"#"|c, c})),
@@ -406,7 +427,7 @@ makeTableOfContents := (pkg, verboseLog) -> (
      fn << html validate HTML {
 	  defaultHEAD title,
 	  BODY {
-	       DIV { topNodeButton(htmlDirectory, topFileName), " | ", indexButton(htmlDirectory, indexFileName), " | ", pkgButton, " | ", homeButton },
+	       buttonBar "toc",
 	       HR{},
 	       HEADER1 title,
 	       toDoc unbag pkg#"table of contents"
@@ -441,9 +462,6 @@ installHTML := (pkg, installPrefix, installLayout, verboseLog, rawDocumentationC
 		defaultHEAD {fkey, commentize headline fkey},
 		BODY {
 		    buttonBar tag,
-		    if UP#?tag
-		    then DIV between(" > ", apply(upAncestors tag, i -> TO i))
-		    else DIV (TO topDocumentTag, " :: ", TO tag),
 		    HR{},
 		    fetchProcessedDocumentation(pkg, fkey)
 		    }

--- a/M2/Macaulay2/packages/Style/doc.css
+++ b/M2/Macaulay2/packages/Style/doc.css
@@ -96,6 +96,10 @@ kbd {
   box-shadow: inset 0 -1px 0;
 }
 
+div#buttons {display: flex;}
+div#buttons div {flex-grow: 1;}
+.right {text-align: right;}
+
 /*
 
  Local Variables:

--- a/M2/Macaulay2/packages/Style/version-select.js
+++ b/M2/Macaulay2/packages/Style/version-select.js
@@ -1,0 +1,25 @@
+if (window.location.protocol != "file:") {
+    fetch("../../../../../../versions.json")
+	.then((response) => response.json())
+	.then((versions) => {
+	    const select = document.createElement("select");
+	    select.setAttribute("id", "version-select");
+	    select.setAttribute("onChange", "switch_version()");
+	    Object.keys(versions).forEach((version) => {
+		const option = document.createElement("option");
+		option.value = versions[version];
+		option.innerHTML = version;
+		select.appendChild(option);
+	    });
+	    select.value = current_version;
+	    const span = document.getElementById("version-select-container");
+	    span.appendChild(select);
+	});
+}
+
+function switch_version() {
+    const new_version = document.getElementById("version-select").value;
+    const re = new RegExp("/Macaulay2(-".concat(current_version, ")?/"));
+    window.location.href = window.location.href.replace(
+	re, "/Macaulay2-".concat(new_version, "/"));
+}

--- a/M2/VERSION-README
+++ b/M2/VERSION-README
@@ -56,6 +56,19 @@ Here is the procedure:
 	      architectures are available downstream
 	 - using the common *.deb file on the web site, update the documentation and
 	   version number there
+	 - add the new version number to the versions.json file on the website
+	      This is a file that should exist on the webserver in the
+	      same directory as the various Macaulay2-X.Y
+	      subdirectories containing the documentation.  It should
+	      contain a JSON object whose elements are key-value pairs
+	      corresponding to all of the Macaulay2 versions that have
+	      documentation available on the website in decreasing
+	      order.  The keys contain how each version will appear in
+	      the dropdown version selection menu, and the values
+	      contain the corresponding version numbers, e.g.,
+	      {"latest release (1.22)": "1.22", "1.21": "1.21", "1.20": "1.20"}
+	      This is used by version-select.js in the Style package
+	      to create the dropdown menu.
        - on the development branch:
 	 - merge the new release branch into development
 	      git checkout development


### PR DESCRIPTION
As discussed at a recent M2internals meeting, we add a dropdown menu to the web documentation so users can navigate easily to the documentation for different versions of Macaulay2.  To check it out in action, see https://webwork.piedmont.edu/M2/Macaulay2/share/doc/Macaulay2/FirstPackage/html/index.html (`FirstPackage` and `Style` documentation only).

Note that the dropdown menu will only appear when served over a webserver (so not when using `viewHelp`, for example).  It assumes the directory structure currently used by the website (i.e., the entire `share` directory is inside a directory of the form `Macaulay2-X.Y`), and relies on the existence of a file `versions.json` in the same directory that contains the various `Macaulay2-X.Y` directories that contains the various version numbers in a JSON array, e.g., `["1.22", "1.21", "1.20"]`.  This is documented in `VERSION-README`.