### PR TITLE
Store document tag filename relative to package source directory & fix locate(DocumentTag)

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -654,7 +654,8 @@ document List := opts -> args -> (
 	    storeRawDocumentation(tag2, new HashTable from {
 		    PrimaryTag => tag, -- tag must be primary
 		    symbol DocumentTag => tag2,
-		    "filename" => currentFileName,
+		    "filename" => relativizeFilename(
+			currentPackage#"source directory", currentFileName),
 		    "linenum" => currentRowNumber()
 		    })));
     -- Check BaseFunction
@@ -673,7 +674,8 @@ document List := opts -> args -> (
     if #out > 0 then o.Outputs = out else remove(o, Outputs);
     if #ino > 0 then o.Options = ino else remove(o, Options);
     -- Set the location of the documentation
-    o#"filename" = currentFileName;
+    o#"filename" = relativizeFilename(
+	currentPackage#"source directory", currentFileName);
     o#"linenum"  = currentRowNumber();
     currentDocumentTag = null;
     storeRawDocumentation(tag, new HashTable from o))
@@ -689,7 +691,8 @@ undocumented Thing := key -> if key =!= null then (
     storeRawDocumentation(tag, new HashTable from {
 	    symbol DocumentTag => tag,
 	    "undocumented"     => true,
-	    "filename"         => currentFileName,
+	    "filename"         => relativizeFilename(
+		currentPackage#"source directory", currentFileName),
 	    "linenum"          => currentRowNumber()
 	    }))
 

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -316,7 +316,9 @@ storeRawDocumentation := (tag, rawdoc) -> (
     fkey := format tag;
     if currentPackage#rawKey#?fkey and signalDocumentationError tag then (
 	newloc := toString new FilePosition from (
-	    minimizeFilename rawdoc#"filename", rawdoc#"linenum", 0);
+	    minimizeFilename(
+		currentPackage#"source directory" | rawdoc#"filename"),
+ 	    rawdoc#"linenum", 0);
 	rawdoc = currentPackage#rawKey#fkey;
 	oldloc := toString locate rawdoc.DocumentTag;
 	printerr("error: documentation already provided for ", format tag);
@@ -392,7 +394,9 @@ hasDocumentation = key -> null =!= fetchAnyRawDocumentation makeDocumentTag(key,
 -- TODO: is it possible to expand to (filename, start,startcol, stop,stopcol, pos,poscol)?
 locate DocumentTag := tag -> new FilePosition from (
     if (rawdoc := fetchAnyRawDocumentation tag) =!= null
-    then (minimizeFilename rawdoc#"filename", rawdoc#"linenum",0)
+    then (
+	minimizeFilename((package tag)#"source directory" | rawdoc#"filename"),
+	rawdoc#"linenum", 0)
     else (currentFileName, currentRowNumber(), currentColumnNumber()))
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Currently, the `filename` key for each tag in the documentation database stores the filename of the documentation source relative to whichever directory we were in when calling `installPackage`.  This filename is then used by `locate(DocumentTag)` to tell us where the documentation source is located.  But the probability that we are in the same directory as we were when the package was installed is small.

Also, in the autotools build, we run `installPackage` inside a temporary directory, but in the cmake build, we just run it in the `packages` directory, so the filenames stored in the documentation databases are different depending on the build system.  (I think based on reading the code -- I haven't actually tested a cmake build to verify this.)

So we standardize the filename stored in the documentation database by making it relative to the package source directory.  We then prepend the package source directory to this when calling `locate`.

### Before

For example, let's say I run the following in the `packages` directory:

```m2
i1 : installPackage "JSON"
 -- making example results for "JSON"                                        -- 0.806262 seconds elapsed
 -- making example results for "fromJSON"                                    -- 0.823951 seconds elapsed
 -- making example results for "toJSON"                                      -- 0.837141 seconds elapsed
 -- warning: found 3 documentation node(s) not listed as a subnode
 -- warning: missing node: nil cited by nil
 -- warning: 1 warning(s) occurred in documentation for package JSON

o1 = JSON

o1 : Package

i2 : locate makeDocumentTag "JSON"

o2 = JSON.m2:198:0

o2 : FilePosition
```

So far, so good.  But now let's exit Macaulay2, `cd` to the home directory, and then fire `M2` back up:

```m2
i1 : needsPackage "JSON"

o1 = JSON

o1 : Package

i2 : locate makeDocumentTag "JSON"

o2 = JSON.m2:198:0

o2 : FilePosition
```

We get the same output, even though `JSON.m2` is not in the home directory.  Also, we won't be able to jump to the file in Emacs.

### After

Now, after doing the same thing, we get the correct output after `cd`'ing to the home directory:

```m2
i2 : locate makeDocumentTag JSON

o2 = .Macaulay2/local/share/Macaulay2/JSON.m2:198:0

o2 : FilePosition
```