### PR TITLE
Use memory address instead of counter for hashes of some mutable types

### DIFF
--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -582,16 +582,16 @@ leftshiftfun(e:Expr):Expr := (
 	  else WrongNumArgs(2))
      else WrongNumArgs(2));
 installMethod(Expr(LessLessS),ZZClass,ZZClass,
-     Expr(CompiledFunction(leftshiftfun,nextHash()))
+     Expr(newCompiledFunction(leftshiftfun))
      );
 installMethod(Expr(LessLessS),RRClass,ZZClass,
-     Expr(CompiledFunction(leftshiftfun,nextHash()))
+     Expr(newCompiledFunction(leftshiftfun))
      );
 installMethod(Expr(LessLessS),RRiClass,ZZClass,
-     Expr(CompiledFunction(leftshiftfun,nextHash()))
+     Expr(newCompiledFunction(leftshiftfun))
      );
 installMethod(Expr(LessLessS),CCClass,ZZClass,
-     Expr(CompiledFunction(leftshiftfun,nextHash()))
+     Expr(newCompiledFunction(leftshiftfun))
      );
 
 rightshiftfun(e:Expr):Expr := (
@@ -627,16 +627,16 @@ rightshiftfun(e:Expr):Expr := (
 	  else WrongNumArgs(2))
      else WrongNumArgs(2));
 installMethod(Expr(GreaterGreaterS),ZZClass,ZZClass,
-     Expr(CompiledFunction(rightshiftfun,nextHash()))
+     Expr(newCompiledFunction(rightshiftfun))
      );
 installMethod(Expr(GreaterGreaterS),RRClass,ZZClass,
-     Expr(CompiledFunction(rightshiftfun,nextHash()))
+     Expr(newCompiledFunction(rightshiftfun))
      );
 installMethod(Expr(GreaterGreaterS),RRiClass,ZZClass,
-     Expr(CompiledFunction(rightshiftfun,nextHash()))
+     Expr(newCompiledFunction(rightshiftfun))
      );
 installMethod(Expr(GreaterGreaterS),CCClass,ZZClass,
-     Expr(CompiledFunction(rightshiftfun,nextHash()))
+     Expr(newCompiledFunction(rightshiftfun))
      );
 
 unSingleton(e:Expr):Expr := (

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1646,7 +1646,7 @@ storeGlobalDictionaries(e:Expr):Expr := (			    -- called with (symbol,newvalue)
 storeInHashTable(
      globalAssignmentHooks,
      Expr(SymbolBody(dictionaryPathS)),
-     Expr(CompiledFunction(storeGlobalDictionaries,nextHash())));
+     Expr(newCompiledFunction(storeGlobalDictionaries)));
 
 getcwdfun(e:Expr):Expr := (				    -- this has to be a function, because getcwd may fail
      when e is s:Sequence do
@@ -1864,7 +1864,7 @@ store(e:Expr):Expr := (			    -- called with (symbol,newvalue)
 		    else msg))
 	  else buildErrorPacket(msg))
      else WrongNumArgs(2));
-storeE := Expr(CompiledFunction(store,nextHash()));
+storeE := Expr(newCompiledFunction(store));
 foreach s in syms do storeInHashTable(
      globalAssignmentHooks,
      Expr(SymbolBody(s)),

--- a/M2/Macaulay2/d/common.d
+++ b/M2/Macaulay2/d/common.d
@@ -183,7 +183,7 @@ export setupfun(name:string,fun:unop):Symbol := (
 export setupfun(name:string,value:fun):Symbol := (
      word := makeUniqueWord(name,parseWORD);
      entry := makeSymbol(word,dummyPosition,globalDictionary);
-     globalFrame.values.(entry.frameindex) = Expr(CompiledFunction(value,nextHash()));
+     globalFrame.values.(entry.frameindex) = Expr(newCompiledFunction(value));
      entry.Protected = true;
      entry);
 export setupvar(name:string,value:Expr,thread:bool):Symbol := (

--- a/M2/Macaulay2/d/common.d
+++ b/M2/Macaulay2/d/common.d
@@ -246,20 +246,17 @@ setupfun("hash",hashfun);
 export dbmcheck(ret:int):Expr := (
      if ret == -1 then buildErrorPacket(dbmstrerror())
      else Expr(ZZcell(toInteger(ret))));
-export dbmopenin(filename:string):Expr := (
-     mutable := false;
-     filename = expandFileName(filename);
-     handle := dbmopen(filename,mutable);
-     if handle == -1 
-     then buildErrorPacket(dbmstrerror() + " : " + filename)
-     else Expr(Database(filename,nextHash(),handle,true,mutable)));
-export dbmopenout(filename:string):Expr := (
-     mutable := true;
-     filename = expandFileName(filename);
-     handle := dbmopen(filename,mutable);
-     if handle == -1 
-     then buildErrorPacket(dbmstrerror() + " : " + filename)
-     else Expr(Database(filename,nextHash(),handle,true,mutable)));
+dbmopenhelper(filename:string,is_mutable:bool):Expr := (
+    filename = expandFileName(filename);
+    handle := dbmopen(filename,is_mutable);
+    if handle == -1
+    then buildErrorPacket(dbmstrerror() + " : " + filename)
+    else (
+	db := Database(filename,0,handle,true,is_mutable);
+	db.hash = hashFromAddress(Expr(db));
+	Expr(db)));
+export dbmopenin(filename:string):Expr := dbmopenhelper(filename, false);
+export dbmopenout(filename:string):Expr := dbmopenhelper(filename, true);
 export dbmclose(f:Database):Expr := (
      if !f.isopen then return buildErrorPacket("database already closed");
      dbmclose(f.handle);

--- a/M2/Macaulay2/d/convertr.d
+++ b/M2/Macaulay2/d/convertr.d
@@ -367,9 +367,12 @@ export convert(e:ParseTree):Code := (
 	  else Code(binaryCode(b.Operator.entry.binary,convert(b.lhs),
 	       	    convert(b.rhs),treePosition(e)))
 	  )
-     is a:Arrow do Code(functionCode(
+     is a:Arrow do (
+	  fc := functionCode(
 	       a.Operator,		  -- just for display purposes!
-	       convert(a.rhs),a.desc,nextHash()))
+	       convert(a.rhs),a.desc,0);
+	  fc.hash = hashFromAddress(Expr(fc));
+	  Code(fc))
      is u:Unary do (
 	  if u.Operator.word == CommaW
 	  then Code(sequenceCode(makeCodeSequence(e,CommaW),treePosition(e)))

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1355,7 +1355,10 @@ export evalraw(c:Code):Expr := (
      	       	    else binarymethod(left,b.rhs,AdjacentS))
 	       is Error do left
 	       else binarymethod(left,b.rhs,AdjacentS))
-	  is m:functionCode do return Expr(FunctionClosure(noRecycle(localFrame),m,nextHash()))
+	  is m:functionCode do (
+	       fc := FunctionClosure(noRecycle(localFrame),m,0);
+	       fc.hash = hashFromAddress(Expr(fc));
+	       return Expr(fc))
 	  is r:localMemoryReferenceCode do (
 	       f := localFrame;
 	       nd := r.nestingDepth;

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -32,6 +32,10 @@ export nextHash():int := (
      then Ccode(void, " fprintf(stderr, \" *** hash code serial number counter overflow (too many mutable objects created)\\n\"); abort(); ");
      HashCounter);
 
+-- Knuth, Art of Computer Programming, Section 6.4
+export fibonacciHash(k:int,p:int):int := (
+    Ccode(int, "(2654435769 * ",k,") >> (32 - ",p,")"));
+
 export NULL ::= null();
 
 -- scopes

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -170,6 +170,10 @@ export newHashTable(Class:HashTable,parent:HashTable):HashTable := (
 	  uninitializedSpinLock
 	  ); init(ht.mutex); ht);
 
+export newCompiledFunction(fn:fun):CompiledFunction := (
+    cf := CompiledFunction(fn, 0);
+    cf.hash = hashFromAddress(Expr(cf));
+    cf);
 
 --More dummy declarations
 

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -36,6 +36,9 @@ export nextHash():int := (
 export fibonacciHash(k:int,p:int):int := (
     Ccode(int, "(2654435769 * ",k,") >> (32 - ",p,")"));
 
+-- hash codes for mutable objects that don't use nextHash
+export hashFromAddress(e:Expr):int := fibonacciHash(Ccode(int, "(long)",e), 9);
+
 export NULL ::= null();
 
 -- scopes

--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -444,10 +444,10 @@ export installMethod(meth:Expr,lhs:HashTable,rhs:HashTable,value:Expr):Expr := (
 	  value));
 
 export installMethod(s:SymbolClosure,X:HashTable,f:fun):Expr := (
-     installMethod(Expr(s),X,Expr(CompiledFunction(f,nextHash())))
+     installMethod(Expr(s),X,Expr(newCompiledFunction(f)))
      );
 export installMethod(s:SymbolClosure,X:HashTable,Y:HashTable,f:fun):Expr := (
-     installMethod(Expr(s),X,Y,Expr(CompiledFunction(f,nextHash())))
+     installMethod(Expr(s),X,Y,Expr(newCompiledFunction(f)))
      );
 
 threadLocal Key2 := Sequence(nullE,nullE,nullE);

--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -148,7 +148,7 @@ export rawMonomialIsOne(e:Expr):Expr := (
      else WrongArg(1,"a raw monomial")
      else WrongNumArgs(2)
      else WrongNumArgs(2));
-installMethod(Expr(EqualEqualS), rawMonomialClass,ZZClass, Expr(CompiledFunction(rawMonomialIsOne,nextHash())));
+installMethod(Expr(EqualEqualS), rawMonomialClass,ZZClass, Expr(newCompiledFunction(rawMonomialIsOne)));
 
 rawCompareMonomial(M:RawMonoid,a:RawMonomial,b:RawMonomial):int := Ccode(returns,"
      try { return a->compare(M,*b); }

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -23,11 +23,13 @@ toExpr(r:pythonObjectOrNull):Expr := (
     when r
     is null do buildPythonErrorPacket()
     is po:pythonObject do (
+	x := pythonObjectCell(po, 0);
 	h := int(Ccode(long, "PyObject_Hash(", po, ")"));
 	if h == -1 then ( -- unhashable object (e.g., a list)
 	    Ccode(void, "PyErr_Clear()");
-	    h = nextHash());
-	Expr(pythonObjectCell(po, h))));
+	    h = hashFromAddress(Expr(x)));
+	x.hash = h;
+	Expr(x)));
 
 import RunSimpleString(s:string):int;
 PyRunSimpleString(e:Expr):Expr := (


### PR DESCRIPTION
This is a first draft addressing the points in https://github.com/Macaulay2/M2/issues/2591#issuecomment-1724313002.  I've started with a relatively conservative approach:

* We introduce a new function in the interpreter, `hashFromAddress`, which takes an `Expr` and returns a hash code based on its address in memory.  Since the addresses are all multiples of powers of 2, by themselves, they make awful hash codes with lots of collisions.  So we use Fibonacci hashing to spread them out.
* Every `Expr` type that previously used `nextHash` to determine its hash code but is not one of the input types for `youngest` or `serialNumber` now uses `hashFromAddress`.

### Before

```m2
i1 : hash new Type of BasicList

o1 = 1248871

i2 : hash new Type of BasicList

o2 = 1248879
```

### After

```m2
i1 : hash new Type of BasicList 

o1 = 1186750

i2 : hash new Type of BasicList 

o2 = 1186752
```

## Questions

* Is there a better choice of hashing function?  There are some comments online throwing shade at Fibonacci hashing, but it seems to do pretty well.  For example, it's pretty close to what you would expect if it's equally likely for an element to be sorted into a each bucket:

```m2
i2 : B = buckets set apply(1000, i -> x -> x);

i3 : #B

o3 = 2048

i4 : tally \\ length \ B

o4 = Tally{0 => 1257}
           1 => 597
           2 => 181
           3 => 11
           4 => 2

o4 : Tally

i5 : needsPackage "Probability"; X = binomialDistribution(1000, 1/2048.);

i7 : apply(5, i -> 2048 * density_X i)

o7 = {1256.67, 613.907, 149.803, 24.3451, 2.96435}
```
* The documentation for `youngest` says it only accepts mutable hash tables, but in reality it also accepts files, compiled function closures, and symbols.  Are these necessary?  Should we move these over to `hashFromAddress` as well?
* Should we limit the use of `nextHash` to just `Type` objects, or keep it for all mutable hash tables?
* The `serialNumber` function, which also uses hash codes for some types to determine the age of an object, is only used by the `Serialization` package, which is "still experimental and preliminary".  Do we need this?  Or could we move these over to `hashFromAddress`, too?
