### PR TITLE
Consistent vertical alignment in html doc navigation bar

### DIFF
--- a/M2/Macaulay2/packages/Style/doc.css
+++ b/M2/Macaulay2/packages/Style/doc.css
@@ -97,7 +97,7 @@ kbd {
 }
 
 div#buttons {display: flex;}
-div#buttons div {flex-grow: 1;}
+div#buttons div {flex-grow: 1; align-self: flex-end;}
 .right {text-align: right;}
 
 /*


### PR DESCRIPTION
Previously, the two columns were aligned to the top of the container div, but we align them to the bottom for a consistent look.

---

This is in response to https://github.com/Macaulay2/M2/pull/2926#issuecomment-1740347393 -- good catch, @mahrud!

The fix is already live on the website.