### PR TITLE
Replace RingElement Array syntax with RingElement Sequence

### DIFF
--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -443,24 +443,24 @@ substitute(Matrix,ZZ) := Matrix => (m,i) -> (
 sub2 = (S,R,v) -> (				   -- S is the target ring or might be null, meaning target ring not known yet
      commonzero := if S === null then 0 else 0_S;  -- the 0 element of the target ring
      local dummy;
-     g := generators R;
      A := R;
-     while try (A = if instance(A,FractionField) then frac coefficientRing A else coefficientRing A; true) else false
-     do g = join(g, generators A);
-     h := new MutableHashTable;
-     for i from 0 to #g-1 do h#(g#i) = if h#?(g#i) then (h#(g#i),i) else 1:i;
-     h = new HashTable from apply(pairs h, (x,i) -> (x,deepSplice i));
-     m := new MutableList from (#g:symbol dummy);
+    -- a list, containing variables of R and its base rings
+    (g, gs) := flatten \ toSequence transpose while A =!= ZZ list {generators A, if A.?generatorSymbols then A.generatorSymbols else {}} do try (
+        A = if instance(A, FractionField) then frac coefficientRing A else coefficientRing A) else break;
+    -- a hash table, consisting of pairs (generator symbol) => (indices)
+    h := new MutableHashTable;
+    -- a list, eventually containing the targets of each generator
+    m := new MutableList from apply(pairs gs, (i, x) -> ( h#x = if h#?x then append(h#x, i) else 1:i; symbol dummy ));
      for opt in v do (
 	  if class opt =!= Option or #opt =!= 2 then error "expected a list of options";
-	  x := opt#0;
+	  x := baseName opt#0;
 	  y := opt#1;
 	  if instance(y, Constant) then y = numeric y;
 	  if not instance(y,RingElement) and not instance(y,Number) then error "expected substitution values to be ring elements or numbers";
 	  if S === null
 	  then try commonzero = commonzero + 0_(ring y) else error "expected substitution values to be in compatible rings"
 	  else try y = promote(y,S) else error "expected to be able to promote value to target ring";
-	  if not h#?x and ((try x=promote(x,R))===null or not h#?x) then error( "expected ", toString x, " to be a generator of ", toString R );
+	  try x_R else error( "expected ", toString x, " to be a generator of ", toString R );
 	  for i in h#x do (
 	       if m#i =!= symbol dummy and m#i =!= y then error "multiple destinations specified for a generator";
 	       m#i = y;
@@ -503,12 +503,19 @@ substitute(Ideal,Option) := (I,v) -> (sub2(,ring I,{v})) I
 substitute(Vector,Option) := (f,v) -> (sub2(,ring f,{v})) f
 substitute(RingElement,Option) := (f,v) -> (sub2(,ring f,{v})) f
 
-RingElement Array := (r,v) -> (
-    R := ring r;
-    n := #generators R;
-    if #v !=n
-    then error("encountered values for ", #v, " variables, but expected ", n)
-    else substitute(r, apply(n, i -> R_i => v#i)))
+-----------------------------------------------------------------------------
+-- Syntactic sugar for polynomial evaluation
+-----------------------------------------------------------------------------
+
+RingElement Array := -- TODO: eventually deprecate this
+RingElement Sequence := (f, v) -> (
+    R := ring f;
+    n := if R.?numallvars then R.numallvars else numgens R;
+    if #v > n
+    then error("encountered values for ", #v, " variables, but expected at most ", n)
+    else substitute(f, apply(#v, i -> R_i => v#i)))
+-- this will make f(a) work as expected
+RingElement Number := RingElement RingElement := (f, n) -> f(1:n)
 
 -----------------------------------------------------------------------------
 -- inverse

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_ringmaps.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_ringmaps.m2
@@ -49,6 +49,7 @@ document {
      Caveat => {"If the rings ", TT "R", " and ", TT "S", " have different degree monoids, then the degrees of the image
         might need to be changed, since Macaulay2 sometimes doesn't have enough information to
 	determine the image degrees of elements of a free module."},
+     SeeAlso => {(symbol SPACE, RingElement, Sequence)}
      }
 
 document { 
@@ -192,8 +193,51 @@ document {
      the corresponding ring homomorphism is well-defined; this may produce
      surprising results, especially if rational coefficients are converted
      to integer coefficients.",
+     Subnodes => TO \ {
+	 (symbol SPACE, RingElement, Sequence)
+	 },
      SeeAlso => {RingMap, hilbertSeries, value, Expression}
      }
+
+undocumented (symbol SPACE, RingElement, Array) -- TODO: eventually deprecate this
+
+doc ///
+Node
+  Key
+    (symbol SPACE, RingElement, Sequence)
+    (symbol SPACE, RingElement, Number)
+    (symbol SPACE, RingElement, RingElement)
+  Headline
+    evaluation of polynomials
+  Usage
+    f(a,b,c)
+  Inputs
+    f:RingElement
+    :Nothing
+      @TT "(a,b,c)"@, a sequence of numbers or ring elements
+  Outputs
+    r:RingElement
+      the result of evaluating @TT "f"@ at the provided values
+  Description
+    Example
+      R = QQ[x,y,z];
+      f = x^3 - y^2 + 999*z;
+      f(10,0,0)
+      f(0,1,0)
+      f(0,0,1)
+      f(10,1,-1)
+      x^3 * f(0,0,1)
+      f(0,0,x+y+z) / 999
+      f(z,y,x)
+      f(x,x,x)
+    Text
+      Note that giving fewer variables results in partial evaluation.
+    Example
+      f(10)
+      f(10,y,z)
+  SeeAlso
+    (symbol SPACE, RingMap, RingElement)
+///
 
 -- document {
 --      Key => NonLinear,

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_rings.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_rings.m2
@@ -152,20 +152,6 @@ document {
      SeeAlso => "polynomial rings"}
 
 document {
-     Key => (symbol SPACE, RingElement, Array),
-     Headline => "substitution of variables",
-     Usage => "f[a,b,c]",
-     Inputs => { "f", Nothing => { TT "[a,b,c]", ", an array of ring elements" } },
-     Outputs => {
-	  "r" => { "the result of replacing the variables in ", TT "f", " by the ring elements provided in brackets." } } ,
-     EXAMPLE {
-	  "R = QQ[x,y];",
-	  "f = x^3 + 99*y;",
-	  "f[1000,3]"
-	  }
-     }
-
-document {
     Key => IndexedVariable,
     Headline => "the class of all indexed variables",
     "Indexed variables provide the possibility of producing

--- a/M2/Macaulay2/tests/normal/subst8.m2
+++ b/M2/Macaulay2/tests/normal/subst8.m2
@@ -36,3 +36,7 @@ assert( (sub(f, {T_0 => S_0})) === w_2*x^3+w_1*x^2+x );
 K = frac((ZZ/32749)[a..c]/c)
 S = K[s]
 substitute(s^2, { s => -s - 1 })
+---
+needsPackage "AssociativeAlgebras"
+R = QQ<|e_0..e_2,t|>
+sub(t, {t => 1})

--- a/M2/Macaulay2/tests/normal/subst8.m2
+++ b/M2/Macaulay2/tests/normal/subst8.m2
@@ -1,0 +1,38 @@
+R = QQ[x,y,z];
+f = x^3 - y^2 + 999*z;
+assert( (f()) === f );
+assert( (f(10,0,0)) === 1000/1 );
+assert( (f(0,1,0)) === -1/1 );
+assert( (f(0,0,1)) === 999/1 );
+assert( (f(10,1,-1)) === 0/1 );
+assert( (x^3 * f(0,0,1)) === 999*x^3 );
+assert( (f(0,0,x+y+z) / 999) === x+y+z );
+assert( (f(z,y,x)) === z^3-y^2+999*x );
+assert( (f(x,x,x)) === x^3-x^2+999*x );
+assert( (f(10)) === -y^2+999*z+1000 );
+assert( (f(10,y,z)) === -y^2+999*z+1000 );
+--
+B = QQ[b]; A = B[a];
+f = a + 10*b;
+assert( (f()) === f );
+assert( (f(1,2)) === 21/1 );
+assert( (f(1)) === 10*b+1 );
+C = A/(a^2+b^2)
+g = sub(f, C);
+assert( (g()) === g );
+assert( (g(10*a)) === 10*a+10*b );
+assert( (g(10*a^2,b^2)) == 0 );
+--
+R = ZZ[]
+f = 4_R
+assert( (f()) === 4 );
+--
+W = ZZ[w_1..w_2]
+S = W[x..y]
+T = W[t]
+f = w_2*t^3+w_1*t^2+t
+assert( (sub(f, {T_0 => S_0})) === w_2*x^3+w_1*x^2+x );
+--
+K = frac((ZZ/32749)[a..c]/c)
+S = K[s]
+substitute(s^2, { s => -s - 1 })


### PR DESCRIPTION
Closes #2943 and closes #2944.

I wanted to fully remove `f[a,b,c]` notation, but would rather not spend hours fixing rare uses of it in random examples and tests. Ideally eventually it should be deprecated.

cc: @pzinn @d-torrance 