### PR TITLE
Use "commentize" in code(TestInput)

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -6,9 +6,9 @@ needs "run.m2"
 -- Local utilities
 -----------------------------------------------------------------------------
 
-sourceFileStamp = (filename, linenum) -> concatenate(
+sourceFileStamp = (filename, linenum) -> toString commentize(
     pos := new FilePosition from (toAbsolutePath filename, linenum, 1);
-    concatenate("--", toString pos, ": location of test code"));
+    toString pos, ": location of test code")
 
 -----------------------------------------------------------------------------
 -- TestInput

--- a/M2/Macaulay2/tests/normal/testing.m2
+++ b/M2/Macaulay2/tests/normal/testing.m2
@@ -10,7 +10,7 @@ assert instance(pkgtest, TestInput)
 assert Equation(toSequence locate pkgtest, (testpkg, 3, 1, 4, 1,,))
 assert Equation(toString pkgtest, testpkg | ":3:1-4:1")
 assert Equation(net pkgtest, "-*TestInput[" | testpkg | ":3:1-4:1]*-")
-expectedCode =  "--" | toAbsolutePath testpkg |
+expectedCode =  " -- " | toAbsolutePath testpkg |
 	":4:1: location of test code" | newline | "assert Equation(1 + 1, 2)"
 assert Equation(code pkgtest, expectedCode)
 assert Equation(code 0, expectedCode)


### PR DESCRIPTION
This makes output more consistent and also fixes clickability in Emacs.  (Previously, Emacs though the `--` was part of the filename.)


### Before

```m2
i1 : code tests(0, "FirstPackage")

o1 = --/usr/share/Macaulay2/FirstPackage.m2:57:1: location of test code

         assert ( firstFunction 2 == "D'oh!" )
```

### After

```m2
i2 : code tests(0, "FirstPackage")

o2 =  -- /home/dtorrance/src/macaulay2/M2/M2/Macaulay2/packages/FirstPackage.m2:57:1: location of test code

         assert ( firstFunction 2 == "D'oh!" )
```