### PR TITLE
Fix for #2954 and alternative way to give values to memoized function

### DIFF
--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -691,17 +691,6 @@ info = method(Dispatch => Thing, TypicalValue => String)
 
 show = method()
 
--- values of functions by lookup
-lookupfuns = new MutableHashTable
-storefuns = new MutableHashTable
-lookupfuns#toString = x -> f -> if hasAttribute(x,PrintNames) then getAttribute(x,PrintNames) else f x
-storefuns #toString = (x,e) -> (
-     if not instance(e,String) then error "expected a string";
-     setAttribute(x,PrintNames,e))
-Function Thing = (f,x,e) -> (
-     if not storefuns#?f then error("no method for storing values of function ", toString f);
-     storefuns#f (x,e))
-
 -- registerFinalizer
 registerFinalizer' = registerFinalizer
 registerFinalizer = method()

--- a/M2/Macaulay2/m2/remember.m2
+++ b/M2/Macaulay2/m2/remember.m2
@@ -4,17 +4,6 @@ needs "methods.m2"
 
 memoize = method()
 
-memoize Function := f -> (
-     values := new MutableHashTable;
-     x -> (
-	  -- This code is common to any function that has been memoized.
-	  if not values#?x then values#x = f(x) else values#x
-	  )
-     )
-codeHelper#(functionBody(memoize identity)) = g -> { 
-     ("-- function f:", value (first localDictionaries g)#"f")
-     }
-
 memoize(Function,List) := (f,initialValues) -> (
      values := new MutableHashTable from initialValues;
      x -> (
@@ -22,19 +11,22 @@ memoize(Function,List) := (f,initialValues) -> (
 	  if not values#?x then values#x = f(x) else values#x
 	  )
      )
-codeHelper#(functionBody(memoize(identity,{}))) = g -> {
-     ("-- function f:", value (first localDictionaries g)#"f") ,
-     ("-- initialValues:", value (first localDictionaries g)#"initialValues") 
-     }
+memoize Function := f -> memoize(f,{})
 
--- all memoized functions share the same function body (they differ only in the values of the local variables f, values, and x),
+-- all memoized functions share the same function body
+-- (they differ only in the values of the local variables f, values, initivalValues and x)
 -- so here we create one to use for checking.  The function "sin" could be any function.
 memoizedFunctionBody := functionBody memoize sin
+
+codeHelper#memoizedFunctionBody = g -> {
+     ("-- function f:", value (first localDictionaries g)#"f")
+     }
+
 
 memoizeValues = f -> (
      if not instance(f,Function) then error "expected a function";
      if functionBody f =!= memoizedFunctionBody then error "expected a memoized function";
-     values := (frame f)#1;
+     values := (frame f)#2;
      assert instance(values, MutableHashTable);
      values
      )
@@ -42,9 +34,25 @@ memoizeValues = f -> (
 memoizeClear = f -> (
      if not instance(f,Function) then error "expected a function";
      if functionBody f =!= memoizedFunctionBody then error "expected a memoized function";
-     assert instance((frame f)#1, MutableHashTable);
-     (frame f)#1 = new MutableHashTable;
+     assert instance((frame f)#2, MutableHashTable);
+     (frame f)#2 = new MutableHashTable;
      )
+
+-- values of functions by lookup
+lookupfuns = new MutableHashTable
+storefuns = new MutableHashTable
+lookupfuns#toString = x -> f -> if hasAttribute(x,PrintNames) then getAttribute(x,PrintNames) else f x
+storefuns #toString = (x,e) -> (
+     if not instance(e,String) then error "expected a string";
+     setAttribute(x,PrintNames,e))
+Function Thing = (f,x,e) -> if functionBody f === memoizedFunctionBody then (
+    values := (frame f)#2;
+    assert instance(values, MutableHashTable);
+    values#x=e
+    ) else (
+    if not storefuns#?f then error("no method for storing values of function ", f);
+    storefuns#f (x,e)
+)
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
@@ -708,6 +708,15 @@ document {
 	  be provided for the argument ", TT "x", "."
 	  },
      PARA{
+	  "Alternatively, values can be provided after defining the memoized function
+	  using the syntax ", TT "f x = v", ". A slightly more efficient implementation of the above would be"
+	  },
+     EXAMPLE lines ///
+     fib = memoize( n -> fib(n-1) + fib(n-2) )
+     fib 0 = fib 1 = 1;
+     fib 28
+     ///,
+     PARA{
 	  "The function ", TT "memoize", " operates by constructing
 	  a ", TO "MutableHashTable", ", in which the arguments are used
 	  as keys for accessing the return value of the function.  This mutable hash table


### PR DESCRIPTION
- fix for #2954: now all memoized functions have the same function body. I ended up removing `initialValues` from the `codeHelper` since they appear in the list of symbols anyway.
- I also implemented the suggestion in the comments of #2954 to give values to a memoized function after defining it and added an example in the doc.