### PR TITLE
Add exportFrom(String, List)

### DIFF
--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -436,6 +436,7 @@ importFrom(String,  List) := (P, x) -> importFrom(getpkg P, x)
 importFrom(Package, List) := (P, x) -> apply(nonnull x, s -> if not currentPackage#"private dictionary"#?s then currentPackage#"private dictionary"#s = P#"private dictionary"#s)
 
 exportFrom = method()
+exportFrom(String,  List) := (P, x) -> exportFrom(getpkg P, x)
 exportFrom(Package, List) := (P, x) -> export \\ toString \ importFrom(P, x)
 
 ---------------------------------------------------------------------

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/export-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/export-doc.m2
@@ -73,12 +73,13 @@ Node
   Key
      exportFrom
     (exportFrom, Package, List)
+    (exportFrom, String,  List)
   Headline
     export symbols from a package's private dictionary
   Usage
     exportFrom(pkg, {"symbol1", "symbol2"})
   Inputs
-    pkg:Package
+    pkg:{Package,String}
       the package containing the symbols
     :List
       of strings, corresponding to the symbols to export


### PR DESCRIPTION
This way it matches `importFrom`. 

### Before

```m2
i1 : importFrom("Core", {"concatRows"})

o1 = {concatRows}

o1 : List

i2 : exportFrom("Core", {"concatCols"})
stdio:2:1:(3): error: no method found for applying exportFrom to:
     argument 1 :  "Core" (of class String)
     argument 2 :  {concatCols} (of class List)
```

### After

```m2
i1 : importFrom("Core", {"concatRows"})

o1 = {concatRows}

o1 : List

i2 : exportFrom("Core", {"concatCols"})

o2 = {concatCols}

o2 : List
```