### PR TITLE
Add one-argument hilbertFunction method that returns a function

### DIFF
--- a/M2/Macaulay2/m2/hilbert.m2
+++ b/M2/Macaulay2/m2/hilbert.m2
@@ -381,3 +381,7 @@ addHook((hilbertFunction, List, Module), Strategy => Default, (L, M) -> (
     f := hilbertSeries(M, Order => 1 + sum(h, L, times));
     U := monoid ring f;
     coefficient(U_L, f)))
+
+hilbertFunction Ring   :=
+hilbertFunction Ideal  :=
+hilbertFunction Module := M -> d -> hilbertFunction(d, M)

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/hilbertFunction-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/hilbertFunction-doc.m2
@@ -15,6 +15,9 @@ doc ///
     (hilbertFunction,ZZ,ProjectiveVariety)
     (hilbertFunction,List,CoherentSheaf)
     (hilbertFunction,ZZ,CoherentSheaf)
+    (hilbertFunction,Ring)
+    (hilbertFunction,Module)
+    (hilbertFunction,Ideal)
   Headline
     the Hilbert function
   Usage
@@ -64,6 +67,15 @@ doc ///
       hilbertFunction({2,2}, I)
       S = R/I;
       basis({2,2},S)
+    Text
+      If @SAMP "d"@ is not given, then a function is returned that will accept
+      different values of @SAMP "d"@.
+    Example
+      R = QQ[a..d];
+      I = monomialCurveIdeal(R, {1,2,3});
+      h = hilbertFunction I
+      h 1
+      h 2
   Caveat
     It can be much faster to compute a basis for the desired degree,
     because hilbertFunction works by expanding the Hilbert series to a

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/hilbertFunction-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/hilbertFunction-doc.m2
@@ -2,71 +2,83 @@
 
 undocumented {}
 
-document { 
-     Key => {hilbertFunction,
-	  (hilbertFunction,List,Ring),(hilbertFunction,ZZ,Ring),
-	  (hilbertFunction,List,Module),(hilbertFunction,ZZ,Module),
-	  (hilbertFunction,List,Ideal),(hilbertFunction,ZZ,Ideal),
-	  (hilbertFunction,List,ProjectiveVariety),(hilbertFunction,ZZ,ProjectiveVariety),
-	  (hilbertFunction,List,CoherentSheaf),(hilbertFunction,ZZ,CoherentSheaf)
-	  },
-     Headline => "the Hilbert function",
-     Usage => "hilbertFunction(d,X)",
-     Inputs => {
-	  "d" => {"an integer (or a list of integers) specifying a degree (or multidegree)"},
-	  "M" => {"a ring, module, ideal, coherent sheaf, or projective variety"}
-	  },
-     Outputs => {
-	  ZZ => {"the dimension of the degree ", TT "d", " part of ", TT "M", ".  For an
-	       ideal, the corresponding quotient ring is used.
-	       For a projective varieties and coherent sheaves, the functionality is not yet implemented."}
-	  },
-     PARA {
-     	  "In the following example, compare the rank of the source of the basis map to the number provided by ", TO "hilbertFunction", "."
-	  },
-     EXAMPLE lines ///
-     R = QQ[x,y,z, Degrees=>{3:{1,1}}];
-     hilbertFunction({3,3}, R)
-     basis({3,3},R)
-     ///,     
-     "The standard meaning of subscripts on functions permits a simpler syntax to be used.",
-     EXAMPLE lines ///
-     hilbertFunction_{3,3} R
-     ///,
-     "Here is a singly graded example.",
-     EXAMPLE lines ///
-     R = QQ[x,y,z];,
-     hilbertFunction({3}, R)
-     hilbertFunction(3, R)
-     ///,
-     "Here is an example with a module.",
-     EXAMPLE lines ///
-     R = QQ[a..d, Degrees=>{4:{1,1}}];
-     M = coker matrix {{a,c,d},{c,b,d}}
-     hilbertFunction({2,2}, M)
-     B = basis({2,2},M)
-     numgens source B
-     ///,
-     "Here is an example with an ideal.",
-     EXAMPLE lines ///
-     R = QQ[a..f, Degrees=>{6:{1,1}}];
-     I = ideal (a*b, c*d, e*f);
-     hilbertFunction({2,2}, I)
-     S = R/I;
-     basis({2,2},S)
-     ///,
-     Caveat => {
-	  "It can be much faster to compute a basis for the desired degree, because hilbertFunction works by
-	  expanding the Hilbert series to a sufficiently high order, thus, in effect, computing many values of the
-	  Hilbert function simultaneously.  If several values of the Hilbert function are desired, it is best
-	  to compute the ones of higher degree first, so the expansion will be done to sufficiently high order
-	  at the first attempt, and thus be done just once."
-	  },
--* no longer true:
-     Caveat => {
-     	  "This requires a homogeneous module to compute properly, but
-	  will output something if run on a module which is not homogeneous."
-	  },
-*-
-     SeeAlso => {degreesRing, reduceHilbert, poincare, poincareN, hilbertSeries, hilbertPolynomial, numgens, (symbol _, Function, Thing)}
-     }
+doc ///
+  Key
+    hilbertFunction
+    (hilbertFunction,List,Ring)
+    (hilbertFunction,ZZ,Ring)
+    (hilbertFunction,List,Module)
+    (hilbertFunction,ZZ,Module)
+    (hilbertFunction,List,Ideal)
+    (hilbertFunction,ZZ,Ideal)
+    (hilbertFunction,List,ProjectiveVariety)
+    (hilbertFunction,ZZ,ProjectiveVariety)
+    (hilbertFunction,List,CoherentSheaf)
+    (hilbertFunction,ZZ,CoherentSheaf)
+  Headline
+    the Hilbert function
+  Usage
+    hilbertFunction(d,X)
+  Inputs
+    d:{ZZ,List} -- of integers
+      specifying a degree (or multidegree)
+    M:{Ring,Module,Ideal,CoherentSheaf,ProjectiveVariety}
+  Outputs
+    :ZZ
+      the dimension of the degree @SAMP "d"@ part of @SAMP "M"@.  For an
+      ideal, the corresponding quotient ring is used.
+      For a projective varieties and coherent sheaves, the
+      functionality is not yet implemented.
+  Description
+    Text
+      In the following example, compare the rank of the source of the basis map
+      to the number provided by @SAMP "hilbertFunction"@.
+    Example
+      R = QQ[x,y,z, Degrees=>{3:{1,1}}];
+      hilbertFunction({3,3}, R)
+      basis({3,3},R)
+    Text
+      The standard meaning of subscripts on functions permits a simpler syntax
+      to be used.
+    Example
+      hilbertFunction_{3,3} R
+    Text
+      Here is a singly graded example.
+    Example
+      R = QQ[x,y,z];
+      hilbertFunction({3}, R)
+      hilbertFunction(3, R)
+    Text
+      Here is an example with a module.
+    Example
+      R = QQ[a..d, Degrees=>{4:{1,1}}];
+      M = coker matrix {{a,c,d},{c,b,d}}
+      hilbertFunction({2,2}, M)
+      B = basis({2,2},M)
+      numgens source B
+    Text
+      Here is an example with an ideal.
+    Example
+      R = QQ[a..f, Degrees=>{6:{1,1}}];
+      I = ideal (a*b, c*d, e*f);
+      hilbertFunction({2,2}, I)
+      S = R/I;
+      basis({2,2},S)
+  Caveat
+    It can be much faster to compute a basis for the desired degree,
+    because hilbertFunction works by expanding the Hilbert series to a
+    sufficiently high order, thus, in effect, computing many values of
+    the Hilbert function simultaneously.  If several values of the
+    Hilbert function are desired, it is best to compute the ones of
+    higher degree first, so the expansion will be done to sufficiently
+    high order at the first attempt, and thus be done just once.
+  SeeAlso
+    degreesRing
+    reduceHilbert
+    poincare
+    poincareN
+    hilbertSeries
+    hilbertPolynomial
+    numgens
+    (symbol _, Function, Thing)
+///

--- a/M2/Macaulay2/tests/normal/hilbertFunction.m2
+++ b/M2/Macaulay2/tests/normal/hilbertFunction.m2
@@ -7,11 +7,18 @@ assert(hilbertFunction(3, I) == 4)
 peek I.cache
 assert(hilbertFunction(2, I) == 4)
 
+h = hilbertFunction I
+assert(h 2 == 4)
+assert(h 3 == 4)
+
 --
 
 R = ZZ/101[a..d]
 assert( hilbertFunction(3,R) === 20 )
 assert( hilbertFunction(10,R) === 286 )
+h = hilbertFunction R
+assert(h 3 == 20)
+assert(h 10 == 286)
 
 --
 


### PR DESCRIPTION
We add `hilbertFunction(Module)` (and `hilbertFunction(Ideal)`/`hilbertFunction(Ring)`) that returns a ~~memoized~~ function that takes an integer (or list) as an argument.

For example:

```m2
i1 : R = QQ[x,y,z,w];

i2 : I = monomialCurveIdeal(R, {1,2,3})

             2                    2
o2 = ideal (z  - y*w, y*z - x*w, y  - x*z)

o2 : Ideal of R

i3 : h = hilbertFunction I

o3 = h

o3 : FunctionClosure

i4 : apply(10, h)

o4 = {1, 4, 7, 10, 13, 16, 19, 22, 25, 28}

o4 : List
```