### PR TITLE
Header updates for flint 3

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -135,7 +135,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release -DBUILD_NATIVE=OFF \
             -DCMAKE_PREFIX_PATH="`brew --prefix`;`brew --prefix libffi`" \
             -DCMAKE_INSTALL_PREFIX=/usr \
-            -DWITH_PYTHON=ON \
+            -DWITH_PYTHON=OFF \
             --debug-trycompile
 
       - name: Build libraries using Ninja
@@ -167,7 +167,7 @@ jobs:
           export CPPFLAGS="-I`brew --prefix`/include -I`brew --prefix libomp`/include"
           export  LDFLAGS="-L`brew --prefix`/lib -L`brew --prefix libomp`/lib \
             -L/Library/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
-          ../../configure --enable-download --with-python --with-system-gc
+          ../../configure --enable-download --without-python --with-system-gc
 
       - name: Build Macaulay2 using Make
         if: matrix.build-system == 'autotools'

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,8 +16,8 @@
 [submodule "M2/submodules/mpir"]
 	path = M2/submodules/mpir
 	url = https://github.com/Macaulay2/mpir.git
-[submodule "M2/submodules/flint2"]
-	path = M2/submodules/flint2
+[submodule "M2/submodules/flint"]
+	path = M2/submodules/flint
 	url = https://github.com/Macaulay2/flint2.git
 [submodule "M2/submodules/frobby"]
 	path = M2/submodules/frobby

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -201,7 +201,7 @@ setupconst("version", Expr(toHashTable(Sequence(
 	"),
    "ntl version" => Ccode(constcharstar,"NTL_VERSION"),
    "frobby version" => Ccode(constcharstar,"frobby_version"),
-   "flint version" => Ccode(constcharstar,"flint_version"),
+   "flint version" => Ccode(constcharstar,"FLINT_VERSION"),
    "scscp version" => Ccode(constcharstar,"
 	 #ifdef HAVE_SCSCP
 	   stringize(SCSCP_VERSION_MAJOR) \".\" stringize(SCSCP_VERSION_MINOR) \".\" stringize(SCSCP_VERSION_PATCH)

--- a/M2/Macaulay2/e/aring-gf-flint-big.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint-big.hpp
@@ -10,15 +10,16 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/fq_nmod.h>
-#include <flint/flint.h>
+#include <flint/flint.h>       // for flint_free, flint_rand_t, fmpz_t
+#include <flint/fmpz.h>        // for fmpz_clear_readonly, fmpz_init_set_...
+#include <flint/fq_nmod.h>     // for fq_nmod_init2, fq_nmod_clear, fq_nm...
+#include <flint/nmod_poly.h>   // for nmod_poly_degree, nmod_poly_get_coe...
 #pragma GCC diagnostic pop
 
 #include "aring.hpp"
 #include "buffer.hpp"
 #include "ringelem.hpp"
 #include "exceptions.hpp" // for exc::division_by_zero_error
-#include <iostream>
 
 class PolynomialRing;
 class RingElement;

--- a/M2/Macaulay2/e/aring-gf-flint.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint.hpp
@@ -10,8 +10,11 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/fq_zech.h>
-#include <flint/flint.h>
+#include <flint/flint.h>      // for flint_rand_t, fmpz_t, ulong
+#include <flint/fmpz.h>       // for fmpz_clear_readonly, fmpz_init_set_...
+#include <flint/fq_nmod.h>    // for fq_nmod_clear, fq_nmod_init, fq_nmod_c...
+#include <flint/fq_zech.h>    // for fq_zech_clear, fq_zech_ctx_clear, fq_z...
+#include <flint/nmod_poly.h>  // for nmod_poly_set_coeff_ui, nmod_poly_clear
 #pragma GCC diagnostic pop
 
 #include "interface/random.h"

--- a/M2/Macaulay2/e/aring-qq-flint.hpp
+++ b/M2/Macaulay2/e/aring-qq-flint.hpp
@@ -10,8 +10,9 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-//#include <flint/arith.h>
-#include <flint/fmpq.h>
+#include <flint/flint.h>  // for fmpq_denref, fmpq_numref, fmpq, flin...
+#include <flint/fmpq.h>   // for fmpq_init, fmpq_set, fmpq_set_mpq
+#include <flint/fmpz.h>   // for fmpz_get_ui, fmpz_cmp_si, fmpz_is_one
 #pragma GCC diagnostic pop
 
 #include "aring.hpp"

--- a/M2/Macaulay2/e/aring-zz-flint.hpp
+++ b/M2/Macaulay2/e/aring-zz-flint.hpp
@@ -16,7 +16,8 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/arith.h>
+#include <flint/flint.h>  // for flint_rand_t, fmpz, fmpz_t
+#include <flint/fmpz.h>   // for fmpz_set_si, fmpz_pow_ui, fmpz_set_mpz
 #pragma GCC diagnostic pop
 
 namespace M2 {

--- a/M2/Macaulay2/e/aring-zzp-flint.hpp
+++ b/M2/Macaulay2/e/aring-zzp-flint.hpp
@@ -16,8 +16,9 @@ class RingMap;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include "flint/arith.h"
-#include "flint/nmod_vec.h"
+#include <flint/flint.h>  // for fmpz_t, nmod_t, flint_rand_t
+#include <flint/fmpz.h>   // for fmpz_clear, fmpz_fdiv_ui, fmpz_init
+#include <flint/nmod.h>   // for nmod_neg, nmod_add, nmod_div, nmod_mul
 #pragma GCC diagnostic pop
 
 namespace M2 {

--- a/M2/Macaulay2/e/aring-zzp-flint.hpp
+++ b/M2/Macaulay2/e/aring-zzp-flint.hpp
@@ -18,7 +18,9 @@ class RingMap;
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <flint/flint.h>  // for fmpz_t, nmod_t, flint_rand_t
 #include <flint/fmpz.h>   // for fmpz_clear, fmpz_fdiv_ui, fmpz_init
-#include <flint/nmod.h>   // for nmod_neg, nmod_add, nmod_div, nmod_mul
+#ifdef HAVE_FLINT_NMOD_H
+  #include <flint/nmod.h>   // for nmod_neg, nmod_add, nmod_div, nmod_mul
+#endif
 #pragma GCC diagnostic pop
 
 namespace M2 {

--- a/M2/Macaulay2/e/dmat-gf-flint-big.hpp
+++ b/M2/Macaulay2/e/dmat-gf-flint-big.hpp
@@ -3,17 +3,16 @@
 #ifndef _dmat_gf_flint_big_hpp_
 #define _dmat_gf_flint_big_hpp_
 
+#include <utility>                 // for swap
+#include "aring-gf-flint-big.hpp"  // for ARingGFFlintBig
+
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/arith.h>
-#include <flint/nmod_mat.h>
-#include <flint/fmpq_mat.h>
-#include <flint/fq_nmod_mat.h>
+#include <flint/fq_nmod_mat.h>  // for fq_nmod_mat_t, fq_nmod_mat_entry, ...
 #pragma GCC diagnostic pop
-#include "aring-gf-flint-big.hpp"
 
 template <typename ACoeffRing>
 class DMat;

--- a/M2/Macaulay2/e/dmat-gf-flint.hpp
+++ b/M2/Macaulay2/e/dmat-gf-flint.hpp
@@ -3,19 +3,17 @@
 #ifndef _dmat_gf_flint__hpp_
 #define _dmat_gf_flint__hpp_
 
+#include <utility>                // for swap
+#include "aring-gf-flint.hpp"     // for ARingGFFlint
+
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/arith.h>
-#include <flint/nmod_mat.h>
-#include <flint/fmpq_mat.h>
-#include <flint/fq_nmod_mat.h>
-#include <flint/fq_zech_mat.h>
+#include <flint/fq_nmod_mat.h>  // for fq_zech_mat_entry, fq_zech_mat_clear
+#include <flint/fq_zech_mat.h>  // for fq_zech_mat_t
 #pragma GCC diagnostic pop
-
-#include "aring-gf-flint.hpp"
 
 template <typename ACoeffRing>
 class DMat;

--- a/M2/Macaulay2/e/dmat-lu-inplace.hpp
+++ b/M2/Macaulay2/e/dmat-lu-inplace.hpp
@@ -9,7 +9,12 @@
 
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
-#include <flint/perm.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <flint/fq_nmod_mat.h>  // for fq_nmod_mat_lu, fq_zech_mat_lu
+#include <flint/perm.h>         // for _perm_parity
+#pragma GCC diagnostic pop
 
 template <typename RT>
 class LUUtil

--- a/M2/Macaulay2/e/dmat-lu-zzp-flint.hpp
+++ b/M2/Macaulay2/e/dmat-lu-zzp-flint.hpp
@@ -1,5 +1,13 @@
 // This file should only be included once, by what?
 
+// The following needs to be included before any flint files are included.
+#include <M2/gc-include.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <flint/nmod_mat.h>  // for nmod_mat_lu, nmod_mat_rank, nmod_mat_det
+#pragma GCC diagnostic pop
+
 //////////////////////
 // ZZpFlint //////////
 //////////////////////

--- a/M2/Macaulay2/e/dmat-qq-flint.hpp
+++ b/M2/Macaulay2/e/dmat-qq-flint.hpp
@@ -3,17 +3,17 @@
 #ifndef _dmat_qq_flint_hpp_
 #define _dmat_qq_flint_hpp_
 
+#include <assert.h>            // for assert
+#include <utility>             // for swap
+#include "aring-qq-flint.hpp"  // for ARingQQFlint
+
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/arith.h>
-#include <flint/nmod_mat.h>
-#include <flint/fmpq_mat.h>
+#include <flint/fmpq_mat.h>  // for fmpq_mat_t, fmpq_mat_entry, fmpq_mat_init, fmpq_ma...
 #pragma GCC diagnostic pop
-
-#include "aring-qq-flint.hpp"
 
 template <typename ACoeffRing>
 class DMat;

--- a/M2/Macaulay2/e/dmat-zz-flint.hpp
+++ b/M2/Macaulay2/e/dmat-zz-flint.hpp
@@ -3,17 +3,17 @@
 #ifndef _dmat_zz_flint_hpp_
 #define _dmat_zz_flint_hpp_
 
+#include <assert.h>            // for assert
+#include <utility>             // for swap
+#include "aring-zz-flint.hpp"  // for ARingZZ
+
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/arith.h>
-#include <flint/nmod_mat.h>
-#include <flint/fmpq_mat.h>
+#include <flint/fmpz_mat.h>  // for fmpz_mat_t, fmpz_mat_entry, fmpz_mat_clear, fmpz_m...
 #pragma GCC diagnostic pop
-
-#include "aring-zz-flint.hpp"
 
 template <typename ACoeffRing>
 class DMat;

--- a/M2/Macaulay2/e/dmat-zzp-flint.hpp
+++ b/M2/Macaulay2/e/dmat-zzp-flint.hpp
@@ -3,17 +3,16 @@
 #ifndef _dmat_zzp_flint_hpp_
 #define _dmat_zzp_flint_hpp_
 
+#include <utility>              // for swap
+#include "aring-zzp-flint.hpp"  // for ARingZZpFlint
+
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/arith.h>
-#include <flint/nmod_mat.h>
-#include <flint/fmpq_mat.h>
+#include <flint/nmod_mat.h>  // for nmod_mat_t, nmod_mat_clear, nmod_mat_init, nmod_m...
 #pragma GCC diagnostic pop
-
-#include "aring-zzp-flint.hpp"
 
 template <typename ACoeffRing>
 class DMat;

--- a/M2/Macaulay2/e/interface/flint.cpp
+++ b/M2/Macaulay2/e/interface/flint.cpp
@@ -4,10 +4,13 @@
 #include <iostream>
 #include <vector>
 
+// The following needs to be included before any flint files are included.
+#include <M2/gc-include.h>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/arith.h>
-#include <flint/fmpz.h>
+#include <flint/fmpz.h>          // for fmpz_t, fmpz, fmpz_clear, fmpz_init...
+#include <flint/fmpz_factor.h>   // for fmpz_factor, fmpz_factor_clear, fmpz...
 #pragma GCC diagnostic pop
 
 #include "error.h"

--- a/M2/Macaulay2/e/interface/ring.cpp
+++ b/M2/Macaulay2/e/interface/ring.cpp
@@ -40,7 +40,8 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/fq_nmod.h>
+#include <flint/fmpz.h>     // for fmpz_t, fmpz_init, fmpz_set_si
+#include <flint/fq_nmod.h>  // for _fq_nmod_ctx_init_conway, fq_nm...
 #pragma GCC diagnostic pop
 
 unsigned int rawRingHash(const Ring *R) { return R->hash(); }

--- a/M2/Macaulay2/e/mat-linalg.hpp
+++ b/M2/Macaulay2/e/mat-linalg.hpp
@@ -57,7 +57,12 @@ typedef DMat<M2::ARingCC> DMatCC;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-#include <flint/fmpz_mat.h>
+#include <flint/flint.h>        // for fmpq_numref, fmpz_t
+#include <flint/fmpq_mat.h>     // for fmpq_mat_mul, fmpq_mat_add
+#include <flint/fmpz.h>         // for fmpz_is_pm1, fmpz_clear, fmpz...
+#include <flint/fmpz_mat.h>     // for fmpz_mat_t, fmpz_mat_mul, fmpz_mat_clear
+#include <flint/fq_nmod_mat.h>  // for fq_nmod_mat_mul, fq_zech_mat_mul
+#include <flint/nmod_mat.h>     // for nmod_mat_mul, nmod_mat_add
 #pragma GCC diagnostic pop
 
 #include <iostream>

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -396,9 +396,9 @@ _ADD_COMPONENT_DEPENDENCY(libraries ntl mp NTL_FOUND)
 
 # https://github.com/Macaulay2/flint2
 ExternalProject_Add(build-flint
-  PREFIX            libraries/flint2
-  SOURCE_DIR        ${CMAKE_SOURCE_DIR}/submodules/flint2
-  BINARY_DIR        libraries/flint2/build
+  PREFIX            libraries/flint
+  SOURCE_DIR        ${CMAKE_SOURCE_DIR}/submodules/flint
+  BINARY_DIR        libraries/flint/build
   CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${M2_HOST_PREFIX}
                     -DCMAKE_SYSTEM_PREFIX_PATH=${M2_HOST_PREFIX}
                     -DCMAKE_MODULE_PATH=${CMAKE_SOURCE_DIR}/cmake
@@ -410,14 +410,10 @@ ExternalProject_Add(build-flint
                     -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                     -DIPO_SUPPORTED=OFF # TODO: because of clang; see https://github.com/wbhart/flint2/issues/644
                     -DWITH_NTL=ON
-                    -DWITH_MPIR=${USING_MPIR}
-                    # TODO: force SIMD flags off for distribution
-                    #-DHAS_FLAG_MPOPCNT
-                    #-DHAS_FLAG_UNROLL_LOOPS
   INSTALL_COMMAND   ${CMAKE_COMMAND} --install . ${strip_setting}
-          COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/flint2
-          COMMAND   ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/submodules/flint2/README ${M2_INSTALL_LICENSESDIR}/flint2
-          COMMAND   ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/submodules/flint2/LICENSE ${M2_INSTALL_LICENSESDIR}/flint2
+          COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/flint
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/submodules/flint/README.md ${M2_INSTALL_LICENSESDIR}/flint
+          COMMAND   ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/submodules/flint/LICENSE ${M2_INSTALL_LICENSESDIR}/flint
   TEST_COMMAND      ${CMAKE_COMMAND} . -DBUILD_TESTING=ON
        COMMAND      ${CMAKE_COMMAND} --build .
        COMMAND      ${CMAKE_COMMAND} --build . --target test

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -343,6 +343,7 @@ ExternalProject_Add(build-ntl
   SOURCE_DIR        libraries/ntl/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
+  PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/ntl/patch-11.5.1
   CONFIGURE_COMMAND cd src && ${CONFIGURE} PREFIX=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
                       TUNE=generic
@@ -431,12 +432,13 @@ _ADD_COMPONENT_DEPENDENCY(libraries flint "mp;mpfr;ntl" FLINT_FOUND)
 # https://service.mathematik.uni-kl.de/ftp/pub/Math/Singular/Factory/
 # TODO: what is ftmpl_inst.o?
 ExternalProject_Add(build-factory
-  URL               https://faculty.math.illinois.edu/Macaulay2/Downloads/OtherSourceCode/factory-4.2.1.tar.gz
-  URL_HASH          SHA256=3a3135d8d9e89bca512b22c8858f3e03f44b15629df6f0309ce4f7ddedd09a15
+  URL               https://www.singular.uni-kl.de/ftp/pub/Math/Factory/factory-4.3.0.tar.gz
+  URL_HASH          SHA256=f1e25b566a8c06d0e98b9795741c6d12b5a34c5c0c61c078d9346d8bbc82f09f
   PREFIX            libraries/factory
   SOURCE_DIR        libraries/factory/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
+  PATCH_COMMAND     patch --batch < ${CMAKE_SOURCE_DIR}/libraries/factory/patch-4.3.0...dcca183
   CONFIGURE_COMMAND autoreconf -vif &&
                     ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -350,6 +350,13 @@ else()
   unset(FACTORY_STREAMIO CACHE)
 endif()
 
+if(FLINT_FOUND)
+  set(CMAKE_REQUIRED_INCLUDES "${FLINT_INCLUDE_DIR}")
+  check_include_files(flint/nmod.h HAVE_FLINT_NMOD_H)
+else()
+  unset(HAVE_FLINT_NMOD_H CACHE)
+endif()
+
 if(FROBBY_FOUND)
   set(CMAKE_REQUIRED_INCLUDES "${FROBBY_INCLUDE_DIR};${MP_INCLUDE_DIRS}")
   # whether frobby has constants::version <0.9.4 or frobby_version >=0.9.4

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -329,6 +329,9 @@ if(CHECK_LIBRARY_COMPATIBILITY)
   unset(LIBRARY_COMPATIBILITY CACHE)
 endif()
 
+unset(CMAKE_REQUIRED_LIBRARIES)
+unset(CMAKE_REQUIRED_INCLUDES)
+
 ###############################################################################
 ## Set four library related definitions
 

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1002,6 +1002,7 @@ then AC_LANG(C)
 	  fi,
 	  AC_MSG_RESULT([no])
 	  BUILD_flint=yes)
+      AC_CHECK_HEADERS([flint/nmod.h]) dnl only present in flint >= 2.9.0
 fi
 if test $BUILD_flint = yes
 then BUILTLIBS="-lflint $BUILTLIBS -lm"

--- a/M2/include/M2/config.h.cmake
+++ b/M2/include/M2/config.h.cmake
@@ -54,6 +54,9 @@
 /* whether factory was built with --enable-streamio */
 #cmakedefine FACTORY_STREAMIO 1
 
+/* whether we have the flint header file nmod.h */
+#cmakedefine HAVE_FLINT_NMOD_H 1
+
 /* whether frobby has frobby_version >=0.9.4 or constants::version <0.9.4 */
 #cmakedefine HAVE_FROBBY_VERSION 1
 

--- a/M2/libraries/factory/patch-4.3.0...dcca183
+++ b/M2/libraries/factory/patch-4.3.0...dcca183
@@ -1,0 +1,406 @@
+diff --git a/factory/COPYING b/factory/COPYING
+index 142252eefc..6f77e94bf2 100644
+--- a/factory/COPYING
++++ b/factory/COPYING
+@@ -7,7 +7,7 @@
+ 
+   Authors: G.-M. Greuel, R. Stobbe, J. Schmidt, M. Lee,
+                     G. Pfister, H. Schoenemann
+-                        Copyright (C) 1991-2022
++                        Copyright (C) 1991-2023
+ 
+   Characteristic sets and factorization over algebraic function fields:
+                    Michael Messollen <mmessollen@web.de>
+diff --git a/factory/FLINTconvert.cc b/factory/FLINTconvert.cc
+index d103d3f36d..0ff904bd7c 100644
+--- a/factory/FLINTconvert.cc
++++ b/factory/FLINTconvert.cc
+@@ -62,6 +62,7 @@ extern "C"
+ #endif
+ #if ( __FLINT_RELEASE >= 20503)
+ #include <flint/fmpq_mpoly.h>
++#include <flint/fmpz_mod.h>
+ 
+ // planed, but not yet in FLINT:
+ #if (__FLINT_RELEASE < 20700)
+@@ -1006,7 +1007,7 @@ CanonicalForm gcdFlintMP_QQ(const CanonicalForm& F, const CanonicalForm& G)
+ #if __FLINT_RELEASE >= 20700
+ CFFList
+ convertFLINTFq_nmod_mpoly_factor2FacCFFList (
+-                   fq_nmod_mpoly_factor_t fac, 
++                   fq_nmod_mpoly_factor_t fac,
+                    const fq_nmod_mpoly_ctx_t& ctx,
+                    const int N,
+                    const fq_nmod_ctx_t& fq_ctx,
+diff --git a/factory/FLINTconvert.h b/factory/FLINTconvert.h
+index bed483b973..ec5a56c309 100644
+--- a/factory/FLINTconvert.h
++++ b/factory/FLINTconvert.h
+@@ -45,6 +45,7 @@ extern "C"
+ #endif
+ #if ( __FLINT_RELEASE >= 20700)
+ #include <flint/fq_nmod_mpoly_factor.h>
++#include <flint/fmpz_mod.h>
+ #endif
+ #endif
+ 
+@@ -316,7 +317,7 @@ CanonicalForm convFlintMPFactoryP(fmpz_mpoly_t f, fmpz_mpoly_ctx_t ctx, int N);
+ #endif // FLINT 2.5.3
+ #if __FLINT_RELEASE >= 20700
+ CanonicalForm
+-convertFq_nmod_mpoly_t2FacCF (const fq_nmod_mpoly_t poly,    ///< [in] 
++convertFq_nmod_mpoly_t2FacCF (const fq_nmod_mpoly_t poly,    ///< [in]
+                               const fq_nmod_mpoly_ctx_t& ctx,///< [in] context
+                               const int N,                   ///< [in] #vars
+                               const fq_nmod_ctx_t& fq_ctx,   ///< [in] fq context
+diff --git a/factory/Makefile.am b/factory/Makefile.am
+index 4e9cec762c..bc6da8e73c 100644
+--- a/factory/Makefile.am
++++ b/factory/Makefile.am
+@@ -111,7 +111,6 @@ nodist_libfactory_la_SOURCES = factory.h factoryconf.h
+ 
+ # factory header files
+ factory_headers = \
+-		si_log2.h \
+ 		cf_assert.h \
+ 		canonicalform.h \
+ 		cf_algorithm.h \
+diff --git a/factory/NTLconvert.cc b/factory/NTLconvert.cc
+index 6dec6be892..eedb70b673 100644
+--- a/factory/NTLconvert.cc
++++ b/factory/NTLconvert.cc
+@@ -43,7 +43,7 @@
+ void out_cf(const char *s1,const CanonicalForm &f,const char *s2);
+ 
+ 
+-VAR long fac_NTL_char = -1;         // the current characterstic for NTL calls
++VAR long fac_NTL_char = -1;         // the current characteristic for NTL calls
+                                 // -1: undefined
+ #ifdef NTL_CLIENT               // in <NTL/tools.h>: using of name space NTL
+ NTL_CLIENT
+diff --git a/factory/README b/factory/README
+index 440791c146..5cd8082063 100644
+--- a/factory/README
++++ b/factory/README
+@@ -204,7 +204,7 @@ example applications for Factory.
+ =================================
+ Algorithms for manipulation of polynomial ideals via the characteristic set
+ methods (e.g., calculating the characteristic set and the irreducible
+-characteristic series) are now incorpareted into factory.
++characteristic series) are now incorporated into factory.
+ If you want to learn about characteristic sets, the next is a good point
+ to start with:
+     Dongming Wang:
+diff --git a/factory/cfModGcd.cc b/factory/cfModGcd.cc
+index 435a663368..12cff69391 100644
+--- a/factory/cfModGcd.cc
++++ b/factory/cfModGcd.cc
+@@ -22,6 +22,7 @@
+ 
+ #include "config.h"
+ 
++#include <math.h>
+ 
+ #include "cf_assert.h"
+ #include "debug.h"
+diff --git a/factory/cfModResultant.cc b/factory/cfModResultant.cc
+index 601a15394a..c1060b6125 100644
+--- a/factory/cfModResultant.cc
++++ b/factory/cfModResultant.cc
+@@ -13,6 +13,7 @@
+ 
+ #include "config.h"
+ 
++#include <math.h>
+ 
+ #include "cf_assert.h"
+ #include "timing.h"
+diff --git a/factory/cf_factor.cc b/factory/cf_factor.cc
+index 6b240994bb..0e937c5d63 100644
+--- a/factory/cf_factor.cc
++++ b/factory/cf_factor.cc
+@@ -47,6 +47,10 @@
+ #include <flint/nmod_mpoly_factor.h>
+ #include <flint/fmpq_mpoly_factor.h>
+ #include <flint/fq_nmod_mpoly_factor.h>
++#include <flint/nmod_poly_factor.h>
++#include <flint/fmpz_poly_factor.h>
++#include <flint/fmpz_mpoly_factor.h>
++#include <flint/fq_nmod_poly_factor.h>
+ #endif
+ #endif
+ 
+diff --git a/factory/cf_map_ext.cc b/factory/cf_map_ext.cc
+index e735a9a870..2b0388fc91 100644
+--- a/factory/cf_map_ext.cc
++++ b/factory/cf_map_ext.cc
+@@ -30,6 +30,7 @@
+ 
+ #ifdef HAVE_FLINT
+ #include "FLINTconvert.h"
++#include <flint/fq_nmod_poly_factor.h>
+ #endif
+ 
+ // cyclotomoic polys:
+diff --git a/factory/cf_ops.cc b/factory/cf_ops.cc
+index a9513938d8..28b76ac19f 100644
+--- a/factory/cf_ops.cc
++++ b/factory/cf_ops.cc
+@@ -394,7 +394,7 @@ getVars ( const CanonicalForm & f )
+       if ( i > 0 ) i--;
+    }
+ ~~~~~~~~~~~~~~~~~~~~~
+- * Then apply( f, diff ) is differentation of f with respect to the
++ * Then apply( f, diff ) is differentiation of f with respect to the
+  * main variable of f.
+  *
+ **/
+diff --git a/factory/cf_roots.cc b/factory/cf_roots.cc
+index fb627ce609..b57038263b 100644
+--- a/factory/cf_roots.cc
++++ b/factory/cf_roots.cc
+@@ -18,6 +18,7 @@
+ 
+ #ifdef HAVE_FLINT
+ #include "FLINTconvert.h"
++#include "flint/nmod_poly_factor.h"
+ #endif
+ 
+ #include "cf_roots.h"
+diff --git a/factory/cf_switches.cc b/factory/cf_switches.cc
+index d9a36a52d7..f3a3c6d80a 100644
+--- a/factory/cf_switches.cc
++++ b/factory/cf_switches.cc
+@@ -40,7 +40,7 @@ CFSwitches::CFSwitches ()
+ #ifdef HAVE_FLINT
+   On(SW_USE_FL_GCD_P);
+   On(SW_USE_FL_GCD_0);
+-#if (__FLINT_RELEASE >= 20700)  
++#if (__FLINT_RELEASE >= 20700)
+   On(SW_USE_FL_FAC_P);
+ #endif
+ #endif
+diff --git a/factory/configure.ac b/factory/configure.ac
+index dd5ab8d242..72d5b426bd 100644
+--- a/factory/configure.ac
++++ b/factory/configure.ac
+@@ -12,11 +12,11 @@ dnl #
+ #
+ # - initialisation.
+ #
+-AC_INIT([factory], [4.3.0])
++AC_INIT([factory], [4.3.2])
+ AC_CONFIG_SRCDIR(canonicalform.cc)
+ AC_CONFIG_MACRO_DIR([m4])
+ AC_CONFIG_AUX_DIR([.])
+-AC_CONFIG_HEADER([_config.h])
++AC_CONFIG_HEADERS([_config.h])
+ 
+ AM_INIT_AUTOMAKE([-Wall foreign subdir-objects]) # -Wno-extra-portability -Werror silent-rules
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+diff --git a/factory/facAbsBiFact.cc b/factory/facAbsBiFact.cc
+index 32ce096023..717e76ed99 100644
+--- a/factory/facAbsBiFact.cc
++++ b/factory/facAbsBiFact.cc
+@@ -23,6 +23,7 @@
+ #include "cf_algorithm.h"
+ #ifdef HAVE_FLINT
+ #include "FLINTconvert.h"
++#include "flint/nmod_poly_factor.h"
+ #include <flint/fmpz_poly_factor.h>
+ #endif
+ #ifdef HAVE_NTL
+diff --git a/factory/facBivar.cc b/factory/facBivar.cc
+index 43b065a171..bd088958e9 100644
+--- a/factory/facBivar.cc
++++ b/factory/facBivar.cc
+@@ -329,7 +329,7 @@ CFList biFactorize (const CanonicalForm& F, const Variable& v)
+   int subCheck1= substituteCheck (A, x);
+   int subCheck2= substituteCheck (A, y);
+   buf= swapvar (A,x,y);
+-  int evaluation, evaluation2, bufEvaluation= 0, bufEvaluation2= 0;
++  int evaluation, evaluation2=0, bufEvaluation= 0, bufEvaluation2= 0;
+   for (int i= 0; i < factorNums; i++)
+   {
+     bufAeval= A;
+diff --git a/factory/facFqBivar.cc b/factory/facFqBivar.cc
+index 0d4429c530..7d3ae84385 100644
+--- a/factory/facFqBivar.cc
++++ b/factory/facFqBivar.cc
+@@ -19,6 +19,7 @@
+ 
+ #include "config.h"
+ 
++#include <math.h>
+ 
+ #include "cf_assert.h"
+ #include "cf_util.h"
+@@ -43,6 +44,8 @@
+ 
+ #ifdef HAVE_FLINT
+ #include "FLINTconvert.h"
++#include "flint/nmod_poly_factor.h"
++#include "flint/fq_nmod_poly_factor.h"
+ #endif
+ 
+ TIMING_DEFINE_PRINT(fac_fq_uni_factorizer)
+@@ -173,7 +176,7 @@ uniFactorizer (const CanonicalForm& A, const Variable& alpha, const bool& GF)
+     setCharacteristic (getCharacteristic());
+     Variable beta= rootOf (mipo.mapinto());
+     CanonicalForm buf= GF2FalphaRep (A, beta);
+-#ifdef HAVE_NTL    
++#ifdef HAVE_NTL
+     if (getCharacteristic() > 2)
+ #else
+     if (getCharacteristic() > 0)
+@@ -222,7 +225,7 @@ uniFactorizer (const CanonicalForm& A, const Variable& alpha, const bool& GF)
+                                                          x, beta);
+ #endif
+     }
+-#ifdef HAVE_NTL    
++#ifdef HAVE_NTL
+     else
+     {
+       GF2X NTLMipo= convertFacCF2NTLGF2X (mipo.mapinto());
+@@ -234,7 +237,7 @@ uniFactorizer (const CanonicalForm& A, const Variable& alpha, const bool& GF)
+       factorsA= convertNTLvec_pair_GF2EX_long2FacCFFList (NTLFactorsA, multi,
+                                                            x, beta);
+     }
+-#endif    
++#endif
+     setCharacteristic (getCharacteristic(), k, cGFName);
+     for (CFFListIterator i= factorsA; i.hasItem(); i++)
+     {
+@@ -246,7 +249,7 @@ uniFactorizer (const CanonicalForm& A, const Variable& alpha, const bool& GF)
+   }
+   else if (alpha.level() != 1)
+   {
+-#ifdef HAVE_NTL  
++#ifdef HAVE_NTL
+     if (getCharacteristic() > 2)
+ #else
+     if (getCharacteristic() > 0)
+@@ -307,14 +310,14 @@ uniFactorizer (const CanonicalForm& A, const Variable& alpha, const bool& GF)
+       factorsA= convertNTLvec_pair_GF2EX_long2FacCFFList (NTLFactorsA, multi,
+                                                            x, alpha);
+     }
+-#endif    
++#endif
+   }
+   else
+   {
+ #ifdef HAVE_FLINT
+ #ifdef HAVE_NTL
+     if (degree (A) < 300)
+-#endif    
++#endif
+     {
+       nmod_poly_t FLINTA;
+       convertFacCF2nmod_poly_t (FLINTA, A);
+@@ -1501,7 +1504,7 @@ long isReduced (const nmod_mat_t M)
+   return 1;
+ }
+ #endif
+-  
++
+ #ifdef HAVE_NTL
+ long isReduced (const mat_zz_pE& M)
+ {
+diff --git a/factory/facFqBivarUtil.cc b/factory/facFqBivarUtil.cc
+index c2bf04fe04..8cc7675ada 100644
+--- a/factory/facFqBivarUtil.cc
++++ b/factory/facFqBivarUtil.cc
+@@ -229,7 +229,7 @@ void appendTestMapDown (CFList& factors, const CanonicalForm& f,
+   CanonicalForm delta= info.getDelta();
+   CanonicalForm gamma= info.getGamma();
+   CanonicalForm g= f;
+-  int degMipoBeta;
++  int degMipoBeta=0;
+   if (!k && beta.level() == 1)
+     degMipoBeta= 1;
+   else if (!k && beta.level() != 1)
+diff --git a/factory/facFqFactorize.cc b/factory/facFqFactorize.cc
+index 6b35b64094..6cb91fd532 100644
+--- a/factory/facFqFactorize.cc
++++ b/factory/facFqFactorize.cc
+@@ -18,6 +18,7 @@
+ 
+ #include "config.h"
+ 
++#include <math.h>
+ 
+ #include "cf_assert.h"
+ #include "debug.h"
+diff --git a/factory/facMul.cc b/factory/facMul.cc
+index 1b734f701d..08d09ccdf8 100644
+--- a/factory/facMul.cc
++++ b/factory/facMul.cc
+@@ -22,6 +22,7 @@
+ 
+ #include "config.h"
+ 
++#include <math.h>
+ 
+ #include "canonicalform.h"
+ #include "facMul.h"
+@@ -37,6 +38,10 @@
+ 
+ #ifdef HAVE_FLINT
+ #include "FLINTconvert.h"
++#include "flint/fq_nmod_vec.h"
++#if __FLINT_RELEASE >= 20503
++#include "flint/fmpz_mod.h"
++#endif
+ #endif
+ 
+ // univariate polys
+diff --git a/factory/fac_util.cc b/factory/fac_util.cc
+index c9a5c0675a..f6bfac2766 100644
+--- a/factory/fac_util.cc
++++ b/factory/fac_util.cc
+@@ -177,7 +177,7 @@ CanonicalForm
+ prod ( const CFArray & a )
+ {
+     return prod( a, a.min(), a.max() );
+-}   
++}
+ 
+ void
+ extgcd ( const CanonicalForm & a, const CanonicalForm & b, CanonicalForm & S, CanonicalForm & T, const modpk & pk )
+diff --git a/factory/int_poly.cc b/factory/int_poly.cc
+index 9bf191b23b..195d137033 100644
+--- a/factory/int_poly.cc
++++ b/factory/int_poly.cc
+@@ -999,21 +999,23 @@ InternalPoly::comparesame ( InternalCF * acoeff )
+         termList cursor1 = firstTerm;
+         termList cursor2 = apoly->firstTerm;
+         for ( ; cursor1 && cursor2; cursor1 = cursor1->next, cursor2 = cursor2->next )
++        {
+             // we test on inequality of coefficients at this
+             // point instead of testing on "less than" at the
+             // last `else' in the enclosed `if' statement since a
+-            // test on inequaltiy in general is cheaper
+-            if ( (cursor1->exp != cursor2->exp) || (cursor1->coeff != cursor2->coeff) )
+-            {
+-                if ( cursor1->exp > cursor2->exp )
+-                    return 1;
+-                else  if ( cursor1->exp < cursor2->exp )
+-                    return -1;
+-                else  if ( cursor1->coeff > cursor2->coeff )
++            // test on inequality in general is cheaper
++            if ( cursor1->exp > cursor2->exp )
++                return 1;
++            else  if ( cursor1->exp < cursor2->exp )
++                return -1;
++            if ( (cursor1->coeff != cursor2->coeff) )
++            {
++                if ( cursor1->coeff > cursor2->coeff )
+                     return 1;
+                 else
+                     return -1;
+-             }
++            }
++        }
+         // check trailing terms
+         if ( cursor1 == cursor2 )
+             return 0;

--- a/M2/libraries/ntl/patch-11.5.1
+++ b/M2/libraries/ntl/patch-11.5.1
@@ -1,0 +1,12 @@
+diff -ur a/src/mfile b/src/mfile
+--- a/src/mfile
++++ b/src/mfile
+@@ -358,7 +358,7 @@ setup2:
+ 
+ setup3:
+ 	$(LINK) $(GMP_OPT_INCDIR) -o gen_gmp_aux gen_gmp_aux.cpp $(GMP_OPT_LIBDIR) $(GMP_OPT_LIB) $(LDLIBS)
+-	./gen_gmp_aux > ../include/NTL/gmp_aux.h 
++	LD_LIBRARY_PATH=$(GMP_LIBDIR) ./gen_gmp_aux > ../include/NTL/gmp_aux.h 
+ 	$(LINK) $(GF2X_OPT_INCDIR) -o gf2x_version_1_2_or_later_required gf2x_version_1_2_or_later_required.cpp $(GF2X_OPT_LIBDIR) $(GF2X_OPT_LIB) $(LDLIBS) 
+ 
+ # setup4 runs the wizard


### PR DESCRIPTION
- updated flint submodule to v3.0.0
- bumped minimum flint version to 2.8.5
- corrected inclusion of flint headers for v3.0.0
- switched to FLINT_VERSION instead of flint_version
- renamed flint2 submodule to flint
- bumped factory to 4.3.0 and patched ntl and factory

Closes #2972
