### PR TITLE
Simplified finding libffi and its version in CMake

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -102,8 +102,10 @@ jobs:
           echo "CC=${{  matrix.cc  }}" >> $GITHUB_ENV
           echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
           if [[ "${{ runner.os }}" == "Linux" ]]
-          then alias llvm-config="llvm-config-14"
+          then shopt -s expand_aliases
+               alias llvm-config="/usr/bin/llvm-config-14"
                echo "/usr/lib/ccache"                     >> $GITHUB_PATH
+               echo "/home/linuxbrew/.linuxbrew/bin"      >> $GITHUB_PATH
           else echo `brew --prefix ccache`/libexec        >> $GITHUB_PATH
                echo `brew --prefix make  `/libexec/gnubin >> $GITHUB_PATH
                echo `brew --prefix llvm@14`/bin              >> $GITHUB_PATH

--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -169,6 +169,8 @@ target_include_directories(M2-interpreter
     $<INSTALL_INTERFACE:include/Macaulay2>
     $<$<BOOL:${WITH_PYTHON}>:$<BUILD_INTERFACE:${Python3_INCLUDE_DIRS}>>
   PRIVATE
+    # Note: this shouldn't be necessary since FFI::ffi is linked above
+    $<$<BOOL:${WITH_FFI}>:$<BUILD_INTERFACE:${FFI_INCLUDE_DIRS}>>
     ${SQLite3_INCLUDE_DIRS}
   )
 

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -229,7 +229,7 @@ setupconst("version", Expr(toHashTable(Sequence(
        stringize(EIGEN_WORLD_VERSION) \".\"
        stringize(EIGEN_MAJOR_VERSION) \".\"
        stringize(EIGEN_MINOR_VERSION)"),
-   "libffi version" => Ccode(constcharstar, "LIBFFI_VERSION"),
+   "libffi version" => Ccode(constcharstar, "FFI_VERSION"),
    "M2 suffix" => Ccode(constcharstar,"M2SUFFIX"),
    "executable extension" => Ccode(constcharstar,"EXEEXT"),
    "M2 name" => Ccode(constcharstar," \"M2\" M2SUFFIX EXEEXT "),

--- a/M2/cmake/FindFFI.cmake
+++ b/M2/cmake/FindFFI.cmake
@@ -1,81 +1,57 @@
 # Attempts to discover ffi library with a linkable ffi_call function.
+# See https://sourceware.org/libffi/
 #
-# Example usage:
+# This module defines an imported target FFI:ffi when called:
+#  find_package(FFI)
+# FFI_ROOT may be set to define search paths for the ffi library.
 #
-# find_package(FFI)
+# Once done this will define
 #
-# FFI_REQUIRE_INCLUDE may be set to consider ffi found if the includes
-# are present in addition to the library. This is useful to keep off
-# for the imported package on platforms that install the library but
-# not the headers.
-#
-# FFI_LIBRARY_DIR may be set to define search paths for the ffi library.
-#
-# If successful, the following variables will be defined:
-# FFI_FOUND
-# FFI_INCLUDE_DIRS
-# FFI_LIBRARIES
-# HAVE_FFI_CALL
-#
-# HAVE_FFI_H or HAVE_FFI_FFI_H is defined depending on the ffi.h include path.
-#
-# Additionally, the following import target will be defined:
-# FFI::ffi
+#  FFI_FOUND		- system has the FFI library with correct version
+#  FFI_INCLUDE_DIRS	- the FFI include directory
+#  FFI_LIBRARIES	- the FFI library
+#  FFI_VERSION		- FFI version
+#  HAVE_FFI_CALL	- whether ffi_call is linkable
 
-find_path(FFI_INCLUDE_DIRS ffi.h PATHS ${FFI_INCLUDE_DIR})
-if( EXISTS "${FFI_INCLUDE_DIRS}/ffi.h" )
-  set(FFI_HEADER ffi.h CACHE INTERNAL "")
-  set(HAVE_FFI_H 1 CACHE INTERNAL "")
-else()
-  find_path(FFI_INCLUDE_DIRS ffi/ffi.h PATHS ${FFI_INCLUDE_DIR})
-  if( EXISTS "${FFI_INCLUDE_DIRS}/ffi/ffi.h" )
-    set(FFI_HEADER ffi/ffi.h CACHE INTERNAL "")
-    set(HAVE_FFI_FFI_H 1 CACHE INTERNAL "")
+if(NOT FFI_FOUND)
+  # First look for hints through pkg-config
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(FFI QUIET libffi)
   endif()
+  unset(FFI_INCLUDE_DIRS CACHE)
+  unset(FFI_LIBRARIES CACHE)
+
+  # Then find the paths using CMake routines
+  find_path(FFI_INCLUDE_DIRS ffi.h HINTS ${FFI_INCLUDEDIR})
+  find_library(FFI_LIBRARIES ffi   HINTS ${FFI_LIBDIR})
+
+  # Ensure that ffi_call is linkable
+  if(FFI_LIBRARIES)
+    include(CMakePushCheckState)
+    include(CheckCSourceCompiles)
+    cmake_push_check_state()
+    list(APPEND CMAKE_REQUIRED_INCLUDES  "${FFI_INCLUDE_DIRS}")
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "${FFI_LIBRARIES}")
+    check_c_source_compiles([[struct ffi_cif;
+      typedef struct ffi_cif ffi_cif;
+      void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue);
+      int main() { ffi_call(0, 0, 0, 0); }]] HAVE_FFI_CALL)
+    cmake_pop_check_state()
+  endif()
+
+  if(NOT FFI_VERSION)
+    set(FFI_VERSION "version not specified")
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(FFI DEFAULT_MSG FFI_INCLUDE_DIRS FFI_LIBRARIES HAVE_FFI_CALL)
+
+  mark_as_advanced(FFI_LIBRARIES FFI_INCLUDE_DIRS FFI_LIBRARIES HAVE_FFI_CALL)
 endif()
-
-find_library(FFI_LIBRARIES ffi PATHS ${FFI_LIBRARY_DIR})
-
-if(FFI_LIBRARIES)
-  include(CMakePushCheckState)
-  include(CheckCSourceCompiles)
-  cmake_push_check_state()
-  list(APPEND CMAKE_REQUIRED_LIBRARIES ${FFI_LIBRARIES})
-  check_c_source_compiles("
-    struct ffi_cif;
-    typedef struct ffi_cif ffi_cif;
-    void ffi_call(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue);
-    int main() { ffi_call(0, 0, 0, 0); }"
-    HAVE_FFI_CALL)
-  cmake_pop_check_state()
-endif()
-
-unset(required_includes)
-if(FFI_REQUIRE_INCLUDE)
-  set(required_includes FFI_INCLUDE_DIRS)
-endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(FFI
-                                  FOUND_VAR
-                                    FFI_FOUND
-                                  REQUIRED_VARS
-                                    FFI_LIBRARIES
-                                    ${required_includes}
-                                    HAVE_FFI_CALL)
-mark_as_advanced(FFI_LIBRARIES
-                 FFI_INCLUDE_DIRS
-                 HAVE_FFI_CALL
-                 FFI_HEADER
-                 HAVE_FFI_H
-                 HAVE_FFI_FFI_H)
 
 if(FFI_FOUND)
-  if(NOT TARGET FFI::ffi)
-    add_library(FFI::ffi UNKNOWN IMPORTED)
-    set_target_properties(FFI::ffi PROPERTIES IMPORTED_LOCATION "${FFI_LIBRARIES}")
-    if(FFI_INCLUDE_DIRS)
-      set_target_properties(FFI::ffi PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FFI_INCLUDE_DIRS}")
-    endif()
-  endif()
+  add_library(FFI::ffi UNKNOWN IMPORTED)
+  set_target_properties(FFI::ffi PROPERTIES IMPORTED_LOCATION "${FFI_LIBRARIES}")
+  set_target_properties(FFI::ffi PROPERTIES INTERFACE_INCLUDE_DIRSECTORIES "${FFI_INCLUDE_DIRS}")
 endif()

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -81,10 +81,8 @@ endif()
 
 if(WITH_FFI)
   find_package(FFI REQUIRED QUIET)
-  execute_process(COMMAND pkg-config --modversion libffi
-    OUTPUT_VARIABLE LIBFFI_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 else()
-  set(LIBFFI_VERSION "not present")
+  set(FFI_VERSION "not present")
 endif()
 
 ###############################################################################

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -262,12 +262,15 @@ if(VERBOSE)
      Compiler preprocessor options = ${COMPILE_DEFINITIONS}
      Compiler flags    = ${COMPILE_OPTIONS}
      Linker flags      = ${LINK_OPTIONS}\n")
-  message("## CMake path variables
+endif()
+
+message("## CMake path variables
+     CMAKE_PREFIX_PATH
+       ${CMAKE_PREFIX_PATH}
      CMAKE_SYSTEM_PREFIX_PATH
        ${CMAKE_SYSTEM_PREFIX_PATH}
      CMAKE_C_IMPLICIT_LINK_DIRECTORIES
        ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}\n")
-endif()
 
 ###############################################################################
 ## Detect type sizes and existence of symbols, headers, and functions

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1683,12 +1683,12 @@ AS_IF([test x$with_libffi != xno ],
        AC_SEARCH_LIBS([ffi_call], [ffi], [],
 	   [AC_MSG_ERROR([libffi not found or not linkable])])
        AC_CHECK_FUNCS([ffi_get_struct_offsets])
-       LIBFFI_VERSION=$(pkg-config --modversion libffi)],
+       FFI_VERSION=$(pkg-config --modversion libffi)],
       [AC_MSG_RESULT([no])
        AC_MSG_ERROR([install libffi or use --without-libffi option])])],
-    [LIBFFI_VERSION="not present"])
+    [FFI_VERSION="not present"])
 AC_SUBST([LIBFFI], [$with_libffi])
-AC_DEFINE_UNQUOTED([LIBFFI_VERSION], ["$LIBFFI_VERSION"], [libffi version])
+AC_DEFINE_UNQUOTED([FFI_VERSION], ["$FFI_VERSION"], [libffi version])
 
 # after this point we add no more libraries to $LIBS, e.g., with AC_SEARCH_LIBS()
 SAVELIBS=$LIBS

--- a/M2/include/M2/config.h.cmake
+++ b/M2/include/M2/config.h.cmake
@@ -61,7 +61,7 @@
 #cmakedefine HAVE_FFI_GET_STRUCT_OFFSETS 1
 
 /* libffi version */
-#define LIBFFI_VERSION "${LIBFFI_VERSION}"
+#define FFI_VERSION "${FFI_VERSION}"
 
 // TODO: only used in Macaulay2/d/scclib.c. Still needed?
 /* whether getaddrinfo can handle numeric service (port) numbers */


### PR DESCRIPTION
Closes #2965, as an alternative to #2970.

- added linuxbrew path for GitHub Actions
- simplified finding libffi and its version
- added temporary fix for ffi on macOS
- set CMake to always print prefix paths

This is tested on fedora with brew, mac, and gentoo. `FindFFI.cmake` is revised and also the variable `LIBFFI_VERSION` to `FFI_VERSION` is changed everywhere for simplicity.

cc: @d-torrance @dimpase
