### PR TITLE
Update Python package to support Python 3.12

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -135,7 +135,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release -DBUILD_NATIVE=OFF \
             -DCMAKE_PREFIX_PATH="`brew --prefix`;`brew --prefix libffi`" \
             -DCMAKE_INSTALL_PREFIX=/usr \
-            -DWITH_PYTHON=OFF \
+            -DWITH_PYTHON=ON \
             --debug-trycompile
 
       - name: Build libraries using Ninja
@@ -167,7 +167,7 @@ jobs:
           export CPPFLAGS="-I`brew --prefix`/include -I`brew --prefix libomp`/include"
           export  LDFLAGS="-L`brew --prefix`/lib -L`brew --prefix libomp`/lib \
             -L/Library/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
-          ../../configure --enable-download --without-python --with-system-gc
+          ../../configure --enable-download --with-python --with-system-gc
 
       - name: Build Macaulay2 using Make
         if: matrix.build-system == 'autotools'

--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -71,10 +71,6 @@ int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[]
 
   system_cpuTime_init();
 
-#ifdef WITH_PYTHON
-  Py_Initialize();
-#endif
-
   abort_jmp.is_set = FALSE;
   interrupt_jmp.is_set = FALSE;
 

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -31,6 +31,16 @@ toExpr(r:pythonObjectOrNull):Expr := (
 	x.hash = h;
 	Expr(x)));
 
+PyInitialize(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 0 then (
+	    Ccode(void, "Py_Initialize()");
+	    nullE)
+	else WrongNumArgs(0))
+    else WrongNumArgs(0));
+setupfun("pythonInitialize", PyInitialize);
+
 import RunSimpleString(s:string):int;
 PyRunSimpleString(e:Expr):Expr := (
      when e is s:stringCell do if 0 == RunSimpleString(s.v) then nullE else buildPythonErrorPacket()

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -165,7 +165,7 @@ setupconst("pythonFalse",
 -- ints --
 ----------
 
-import LongAsZZ(z:ZZmutable, x:pythonObject):ZZmutable;
+import LongAsZZ(z:ZZmutable, x:pythonObject):void;
 PyLongAsLong(e:Expr):Expr :=
     when e
     is x:pythonObjectCell do (
@@ -176,7 +176,8 @@ PyLongAsLong(e:Expr):Expr :=
 	else if overflow == 0 then toExpr(y)
 	else (
 	    z := newZZmutable();
-	    toExpr(moveToZZandclear(LongAsZZ(z, x.v)))))
+	    LongAsZZ(z, x.v);
+	    toExpr(moveToZZandclear(z))))
     is s:SpecialExpr do PyLongAsLong(s.e)
     else WrongArgPythonObject();
 setupfun("pythonLongAsLong",PyLongAsLong);

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -74,6 +74,7 @@ importFrom_Core {
     "pythonDictSetItem",
     "pythonFalse",
     "pythonImportImportModule",
+    "pythonInitialize",
     "pythonListNew",
     "pythonListSetItem",
     "pythonLongAsLong",
@@ -109,6 +110,8 @@ export { "pythonHelp", "context", "Preprocessor", "toPython",
 }
 
 exportMutable { "val", "eval", "valuestring", "stmt", "expr", "dict", "symbols", "stmtexpr"}
+
+pythonInitialize()
 
 pythonHelp = Command (() -> pythonValue ///help()///)
 

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -5,8 +5,8 @@ this does not work unless M2 is compiled --with-python
 pythonPresent := Core#"private dictionary"#?"pythonRunString"
 
 newPackage("Python",
-    Version => "0.5",
-    Date => "May 18, 2023",
+    Version => "0.6",
+    Date => "November 6, 2023",
     Headline => "interface to Python",
     Authors => {
 	{Name => "Daniel R. Grayson",
@@ -26,6 +26,11 @@ newPackage("Python",
 ---------------
 
 -*
+
+0.6 (2023-11-06, M2 1.23)
+* move initialization of python from M2 startup package load time
+* update int <-> ZZ conversion for python 3.12
+* use a constant hash for None
 
 0.5 (2023-05-18, M2 1.22)
 * improvements for displaying python objects in webapp mode


### PR DESCRIPTION
From [gmpy2](https://github.com/aleaxit/gmpy) 2.2.0a1

---

This should fix the compilation errors we're getting with Python 3.12 ([like this one](https://github.com/Macaulay2/M2/actions/runs/6753249299/job/18359521379)).  I've been getting strange segfaults with Python 3.12 in Debian unstable, but I'm curious what happens with the GitHub builds...