### PR TITLE
Check for division by zero in ZZ^QQ, QQ^ZZ, and QQ^QQ

### DIFF
--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -602,6 +602,8 @@ export (lhs:Expr) ^ (rhs:Expr) : Expr := (
 		    	 then toExpr(newQQCanonical(minusoneZZ,-den))
 		    	 else toExpr(newQQCanonical(     oneZZ, den)))))
 	  is y:QQcell do (
+	       if isZero(x.v) && isNegative(y.v)
+	       then return buildErrorPacket("division by zero");
 	       d := denominator(y.v);
 	       if d === 1 then toExpr(x.v^numerator(y.v))
 	       else if isNegative(x.v)
@@ -631,11 +633,15 @@ export (lhs:Expr) ^ (rhs:Expr) : Expr := (
      is x:QQcell do (
 	  when rhs
 	  is y:ZZcell do (
+	       if isZero(x.v) && isNegative(y.v)
+	       then return buildErrorPacket("division by zero");
 	       if isLong(y.v) 
 	       then toExpr(x.v^y.v)
 	       else buildErrorPacket("expected exponent to be a small integer")
 	       )
 	  is y:QQcell do (
+	       if isZero(x.v) && isNegative(y.v)
+	       then return buildErrorPacket("division by zero");
 	       d := denominator(y.v);
 	       if d === 1 then (
 		    if isLong(numerator(y.v))

--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -605,7 +605,9 @@ export (lhs:Expr) ^ (rhs:Expr) : Expr := (
 	       if isZero(x.v) && isNegative(y.v)
 	       then return buildErrorPacket("division by zero");
 	       d := denominator(y.v);
-	       if d === 1 then toExpr(x.v^numerator(y.v))
+	       if d === 1 then (
+		    if isNegative(y.v) then toExpr(oneZZ/x.v^(-numerator(y.v)))
+		    else toExpr(x.v^numerator(y.v)))
 	       else if isNegative(x.v)
 	       then if isOdd(d) then (
 		    if isOdd(numerator(y.v))

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -638,8 +638,10 @@ export denominatorRef(x:QQmutable) ::= Ccode( ZZmutable, "mpq_denref(",  x, ")")
 
 export hash(x:QQ):int := hash(numeratorRef(x))+1299841*hash(denominatorRef(x));
 
+isZero0    (x:QQ):bool :=  0 == Ccode(int, "mpq_sgn(",x,")");
 isNegative0(x:QQ):bool := -1 == Ccode(int, "mpq_sgn(",x,")");
 
+export isZero    (x:QQ):bool := isZero0(x);
 export isNegative(x:QQ):bool := isNegative0(x);
 
 export newQQCanonical(i:ZZ,j:ZZ):QQ := (

--- a/M2/Macaulay2/tests/normal/division.m2
+++ b/M2/Macaulay2/tests/normal/division.m2
@@ -129,6 +129,9 @@ assert( (quotientRemainder(1-u^3,1-u)) === (1+u+u^2,0_R) )
   assert((-2)^(-3) == -1/8)
   assert((-17)^(-1) == -1/17)
 
+  -- fixed in #2982
+  assert(2^(-1_QQ) == 1/2)
+
 -- git issue 2177, 2178 FIXED
   K=frac(QQ[t]) 
   R=K[y,x, MonomialOrder=>GLex]; 


### PR DESCRIPTION
Now we get division by zero errors instead of crashes:

```m2
i1 : (0_QQ)^(-1)
stdio:1:7:(3): error: division by zero

i2 : 0^(-1_QQ)
stdio:2:2:(3): error: division by zero

i3 : (0_QQ)^(-1_QQ)
stdio:3:7:(3): error: division by zero
```

Closes: #2981