### PR TITLE
Remove --enable-syntax-highlighting configure option

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -231,13 +231,6 @@ fi
 
 AC_SUBST(DOCUMENTATION)
 
-dnl deprecated in 1.22
-dnl TODO: remove this completely after 1.22 is released
-AC_ARG_ENABLE([syntax-highlighting],
-    [AS_HELP_STRING([--enable-syntax-highlighting],
-	[this option is deprecated; syntax highlight is always enabled.])],
-    [AC_MSG_WARN([the --enable-syntax-highlighting option is deprecated; syntax highlighting is always enabled.])])
-
 AC_CANONICAL_HOST()
 AC_SUBST(ARCH,$build_cpu)
 AC_DEFINE_UNQUOTED(ARCH,"$ARCH",[machine hardware type])


### PR DESCRIPTION
It was deprecated in version 1.22 and there was a note to remove it afterwards, so now we're removing it!