### PR TITLE
Include flint headers last

### DIFF
--- a/M2/Macaulay2/e/aring-translate.hpp
+++ b/M2/Macaulay2/e/aring-translate.hpp
@@ -13,15 +13,17 @@
 #include "aring-RRR.hpp"
 #include "aring-CCC.hpp"
 #include "aring-zz-gmp.hpp"
-#include "aring-zz-flint.hpp"
 #include "aring-zzp.hpp"
-#include "aring-zzp-flint.hpp"
 #include "aring-zzp-ffpack.hpp"
 #include "aring-qq.hpp"
 #include "aring-m2-gf.hpp"
+#include "aring-tower.hpp"
+
+// include flint headers last to avoid #1674
+#include "aring-zz-flint.hpp"
+#include "aring-zzp-flint.hpp"
 #include "aring-gf-flint-big.hpp"
 #include "aring-gf-flint.hpp"
-#include "aring-tower.hpp"
 
 namespace M2 {
 template <typename RT>


### PR DESCRIPTION
Otherwise we run into an issue on several architectures where flint and givaro (which is used by ffpack) define the same macro, causing build failures.

We ran into #1674 again on [a](https://code.launchpad.net/~profzoom/+archive/ubuntu/macaulay2/+build/26970548/+files/buildlog_ubuntu-jammy-arm64.macaulay2_1.22.0.1+git202311070801-0ppa202310271018~ubuntu22.04.1_BUILDING.txt.gz) [number](https://code.launchpad.net/~profzoom/+archive/ubuntu/macaulay2/+build/26970550/+files/buildlog_ubuntu-jammy-ppc64el.macaulay2_1.22.0.1+git202311070801-0ppa202310271018~ubuntu22.04.1_BUILDING.txt.gz) [of](https://code.launchpad.net/~profzoom/+archive/ubuntu/macaulay2/+build/26970551/+files/buildlog_ubuntu-jammy-s390x.macaulay2_1.22.0.1+git202311070801-0ppa202310271018~ubuntu22.04.1_BUILDING.txt.gz) PPA builds after #2973 was merged.  This patch was tested on a Debian arm64 porterbox.