### PR TITLE
Use Debian codename for ISSUE_RELEASE if no version number

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -96,6 +96,9 @@ then if test -f /usr/bin/sw_vers
      elif test -f /usr/bin/lsb_release
      then ISSUE_FLAVOR=`lsb_release -s --id`
           ISSUE_RELEASE=`lsb_release -s --release`
+	  if test $ISSUE_RELEASE = n/a
+	  then ISSUE_RELEASE=`lsb_release -s --codename`
+	  fi
      elif test -f /etc/os-release
      then ISSUE_FLAVOR=`. /etc/os-release ; echo $ID`
           ISSUE_RELEASE=`. /etc/os-release ; echo $VERSION_ID`


### PR DESCRIPTION
This is an issue in Debian testing and unstable, where `lsb_release -s --release` returns the uninformative "n/a".  This causes an extra problem because we end up with a little "a" subdirectory under `usr-dist` during build.

So for example, now we get "Debian-trixie" as the issue.