### PR TITLE
Implement a workaround for incompatability between libc++ and mpreal

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -45,9 +45,9 @@ jobs:
         include:
           - build-system: cmake
             os: ubuntu-22.04
-            compiler: clang-14
-            cxx: clang++-14
-            cc: clang-14
+            compiler: clang-15
+            cxx: clang++-15
+            cc: clang-15
           # This build tests Clang rather than AppleClang (keep)
           - build-system: cmake
             os: macos-12
@@ -73,7 +73,7 @@ jobs:
         run: |
           brew config
           brew tap macaulay2/tap
-          brew install automake boost tbb ccache ctags llvm@14 make ninja yasm libffi
+          brew install automake boost tbb ccache ctags llvm make ninja yasm libffi
           brew install --only-dependencies macaulay2/tap/M2
 
 # ----------------------
@@ -85,13 +85,13 @@ jobs:
         run: |
           sudo add-apt-repository -y -n ppa:macaulay2/macaulay2
           sudo apt-get update
-          sudo apt-get install -y -q --no-install-recommends clang-14 gfortran libtool-bin ninja-build yasm ccache
+          sudo apt-get install -y -q --no-install-recommends clang-15 gfortran libtool-bin ninja-build yasm ccache
           sudo apt-get install -y -q --no-install-recommends libatomic-ops-dev libboost-stacktrace-dev \
                   libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev liblapack-dev libxml2-dev \
                   libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libmpfi-dev libntl-dev gfan \
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
                   libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 normaliz coinor-csdp \
-                  nauty lrslib polymake phcpack w3c-markup-validator libtbb-dev qepcad libomp-14-dev
+                  nauty lrslib polymake phcpack w3c-markup-validator libtbb-dev qepcad libomp-15-dev
 
 # ----------------------
 #   Steps common to all build variants
@@ -103,13 +103,13 @@ jobs:
           echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
           if [[ "${{ runner.os }}" == "Linux" ]]
           then shopt -s expand_aliases
-               alias llvm-config="/usr/bin/llvm-config-14"
+               alias llvm-config="/usr/bin/llvm-config-15"
                echo "/usr/lib/ccache"                     >> $GITHUB_PATH
                echo "/home/linuxbrew/.linuxbrew/bin"      >> $GITHUB_PATH
           else echo `brew --prefix ccache`/libexec        >> $GITHUB_PATH
                echo `brew --prefix make  `/libexec/gnubin >> $GITHUB_PATH
-               echo `brew --prefix llvm@14`/bin              >> $GITHUB_PATH
-               PATH=`brew --prefix llvm@14`/bin:$PATH
+               echo `brew --prefix llvm`/bin              >> $GITHUB_PATH
+               PATH=`brew --prefix llvm`/bin:$PATH
           fi
           # Necessary for clang to find the right libomp
           echo "LIBRARY_PATH=`llvm-config --libdir`" >> $GITHUB_ENV
@@ -147,7 +147,7 @@ jobs:
         if: matrix.build-system == 'cmake'
         run: |
           cmake --build . --target M2-core M2-emacs install-packages
-          if [[ "${{ runner.os }}" == "Linux" ]] && [[ "${{ matrix.compiler }}" == "clang-14" ]]; then
+          if [[ "${{ runner.os }}" == "Linux" ]] && [[ "${{ matrix.compiler }}" == "clang-15" ]]; then
               sudo apt-get install -y -q --no-install-recommends dpkg-dev
               echo "GIT_COMMIT=`git describe --dirty --always --match HEAD`" >> $GITHUB_ENV
               cpack -G DEB
@@ -179,7 +179,7 @@ jobs:
 # ----------------------
 
       - name: Run Tests using CTest
-        if: matrix.build-system == 'cmake' && runner.os == 'Linux' && matrix.compiler == 'clang-14'
+        if: matrix.build-system == 'cmake' && runner.os == 'Linux' && matrix.compiler == 'clang-15'
         run: |
           set -xe
           ./M2 -q --check 1 -e 'exit 0'
@@ -247,7 +247,7 @@ jobs:
              M2/BUILD/build/Macaulay2/tests/*/*.errors
 
       - name: Upload Macaulay2 package for Ubuntu (x86_64)
-        if: matrix.build-system == 'cmake' && runner.os == 'Linux' && matrix.compiler == 'clang-14' && success()
+        if: matrix.build-system == 'cmake' && runner.os == 'Linux' && matrix.compiler == 'clang-15' && success()
         uses: actions/upload-artifact@v3
         with:
           name: Macaulay2-${{ env.GIT_COMMIT }}-ubuntu-x86_64

--- a/M2/Macaulay2/e/eigen.cpp
+++ b/M2/Macaulay2/e/eigen.cpp
@@ -29,6 +29,41 @@ using MatrixXmpRR = Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic>;
 using MatrixXmpCC = Eigen::Matrix<std::complex<double>,Eigen::Dynamic,Eigen::Dynamic>;
 #endif
 
+#ifdef _LIBCPP_VERSION
+/* workaround incompatibility between libc++'s implementation of complex and
+ * mpreal
+ */
+namespace eigen_mpfr {
+inline Real abs(const Complex &x) { return hypot(x.real(), x.imag()); }
+inline Complex sqrt(const Complex &x)
+{
+  Real a = abs(x);
+  const Real &xr = x.real();
+  const Real &xi = x.imag();
+  if (xi >= 0) { return Complex(sqrt((a + xr) / 2), sqrt((a - xr) / 2)); }
+  else { return Complex(sqrt((a + xr) / 2), -sqrt((a - xr) / 2)); }
+}
+inline std::complex<Real> operator/(const Complex &lhs, const Complex &rhs)
+{
+  Real a = abs(rhs);
+  const Real &lhsr = lhs.real();
+  const Real &lhsi = lhs.imag();
+  const Real &rhsr = rhs.real();
+  const Real &rhsi = rhs.imag();
+  return Complex((lhsr * rhsr + lhsi * rhsi) / a,
+                 (lhsi * rhsr - lhsr * rhsi) / a);
+}
+inline std::complex<Real> operator*(const Complex &lhs, const Complex &rhs)
+{
+  const Real &lhsr = lhs.real();
+  const Real &lhsi = lhs.imag();
+  const Real &rhsr = rhs.real();
+  const Real &rhsi = rhs.imag();
+  return Complex(lhsr * rhsr - lhsi * rhsi, lhsi * rhsr + lhsr * rhsi);
+}
+};  // namespace eigen_mpfr
+#endif
+
 namespace EigenM2 {
 
 #ifdef NO_LAPACK  

--- a/M2/Macaulay2/e/eigen.cpp
+++ b/M2/Macaulay2/e/eigen.cpp
@@ -43,7 +43,7 @@ inline Complex sqrt(const Complex &x)
   if (xi >= 0) { return Complex(sqrt((a + xr) / 2), sqrt((a - xr) / 2)); }
   else { return Complex(sqrt((a + xr) / 2), -sqrt((a - xr) / 2)); }
 }
-inline std::complex<Real> operator/(const Complex &lhs, const Complex &rhs)
+inline Complex operator/(const Complex &lhs, const Complex &rhs)
 {
   const Real &lhsr = lhs.real();
   const Real &lhsi = lhs.imag();
@@ -53,7 +53,7 @@ inline std::complex<Real> operator/(const Complex &lhs, const Complex &rhs)
   return Complex((lhsr * rhsr + lhsi * rhsi) / normrhs,
                  (lhsi * rhsr - lhsr * rhsi) / normrhs);
 }
-inline std::complex<Real> operator*(const Complex &lhs, const Complex &rhs)
+inline Complex operator*(const Complex &lhs, const Complex &rhs)
 {
   const Real &lhsr = lhs.real();
   const Real &lhsi = lhs.imag();

--- a/M2/Macaulay2/e/eigen.cpp
+++ b/M2/Macaulay2/e/eigen.cpp
@@ -45,13 +45,13 @@ inline Complex sqrt(const Complex &x)
 }
 inline std::complex<Real> operator/(const Complex &lhs, const Complex &rhs)
 {
-  Real a = abs(rhs);
   const Real &lhsr = lhs.real();
   const Real &lhsi = lhs.imag();
   const Real &rhsr = rhs.real();
   const Real &rhsi = rhs.imag();
-  return Complex((lhsr * rhsr + lhsi * rhsi) / a,
-                 (lhsi * rhsr - lhsr * rhsi) / a);
+  Real normrhs = rhsr*rhsr+rhsi*rhsi;
+  return Complex((lhsr * rhsr + lhsi * rhsi) / normrhs,
+                 (lhsi * rhsr - lhsr * rhsi) / normrhs);
 }
 inline std::complex<Real> operator*(const Complex &lhs, const Complex &rhs)
 {


### PR DESCRIPTION
This implements versions of various functions for `complex<Real>` to work around incompatibility between libc++ and mpreal. This should fix #2860. I've tested that it compiles on linux with clang and libc++, but I'd appreciate someone on an affected Mac testing it as well.

I still need to make sure that all of these handle `NaN` and `inf` correctly, and I suspect they currently don't.

Also, these are the naive algorithms for these operations, so I might have to go and figure out what libc++ does and see if it's worth copying.