### PR TITLE
fix #2950 + minor texMath

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -854,22 +854,24 @@ readE(f:file):Expr := (
      is e:errmsg do buildErrorPacket(e.message)
      is s:stringCell do Expr(s));
 
+readIO(msg:string):Expr := (
+     readprompt = msg;
+     oldprompt := stdIO.prompt;
+     stdIO.prompt = readpromptfun;
+     r := getLine(stdIO);
+     stdIO.prompt = oldprompt;
+     when r
+     is e:errmsg do buildErrorPacket(e.message)
+     is s:stringCell do Expr(s)
+);
+
 readfun(e:Expr):Expr := (
      when e
      is f:file do readE(f)
-     is p:stringCell do (
-	  readprompt = p.v;
-	  oldprompt := stdIO.prompt;
-	  stdIO.prompt = readpromptfun;
-	  r := getLine(stdIO);
-	  stdIO.prompt = oldprompt;
-	  when r
-	  is e:errmsg do buildErrorPacket(e.message)
-	  is s:stringCell do Expr(s)
-	  )
+     is p:stringCell do readIO(p.v)
      is s:Sequence do (
 	  if length(s) == 0
-	  then readE(stdIO)
+	  then readIO("")
 	  else if length(s) == 2
 	  then (
 	       when s.0

--- a/M2/Macaulay2/m2/betti.m2
+++ b/M2/Macaulay2/m2/betti.m2
@@ -83,11 +83,11 @@ rawBettiTally = v -> (
     minrow := min fi;
     maxrow := max fi;
     v = table(toList (minrow .. maxrow), toList (mincol .. maxcol), (i,j) -> if v#?(i,j) then v#(i,j) else 0);
-    leftside := splice {"", "total:", apply(minrow .. maxrow, i -> toString i | ":")};
+    leftside := splice {, "total:", apply(minrow .. maxrow, i -> hold i : "")};
     totals := apply(transpose v, sum);
     v = prepend(totals,v);
-    v = applyTable(v, bt -> if bt === 0 then "." else toString bt);
-    v = prepend(toString \ toList (mincol .. maxcol), v);
+    v = applyTable(v, bt -> if bt === 0 then symbol . else bt);
+    v = prepend(toList (mincol .. maxcol), v);
     v = apply(leftside,v,prepend);
     v)
 
@@ -106,7 +106,7 @@ rawMultigradedBettiTally = B -> (
 		m := n * R_d;
 		if H#?key then H#key = H#key + m else H#key = m;
 		) else (
-		s := toString n | ":" | toString d;
+		s := hold n : d;
 		if H#?i then H#i = H#i | {s} else H#i = {s};
 		);
 	    ));
@@ -115,30 +115,34 @@ rawMultigradedBettiTally = B -> (
 	T := table(toList (0 .. length rows - 1), toList (0 .. length cols - 1),
 	    (i,j) -> if H#?(rows#i,cols#j) then H#(rows#i,cols#j) else 0);
 	-- Making the table
-	xAxis := toString \ cols;
-	yAxis := (i -> toString i | ":") \ rows;
-	T = applyTable(T, n -> if n === 0 then "." else toString raw n);
+	xAxis := cols;
+	yAxis := (i -> hold i:"") \ rows;
+--	T = applyTable(T, n -> if n === 0 then symbol . else raw n);
+	T = applyTable(T, n -> if n === 0 then symbol . else n);
 	T = prepend(xAxis, T);
-	T = apply(prepend("", yAxis), T, prepend);
+	T = apply(prepend(, yAxis), T, prepend);
 	) else (
 	T = table(max((keys H)/(j -> #H#j)), sort keys H,
-	    (i,k) -> if i < #H#k then H#k#i else null);
-	T = prepend(toString \ sort keys H, T);
+	    (i,k) -> if i < #H#k then H#k#i);
+	T = prepend(sort keys H, T);
 	);
     T)
 
+toStringn := x -> if x===null then "" else toString x
 net            BettiTally := B -> netList(rawBettiTally B,            Alignment => Right, HorizontalSpace => 1, BaseRow => 1, Boxes => false)
-net MultigradedBettiTally := B -> netList(rawMultigradedBettiTally B, Alignment => Right, HorizontalSpace => 1, BaseRow => 1, Boxes => false)
+net MultigradedBettiTally := B -> netList(applyTable(rawMultigradedBettiTally B,toStringn), Alignment => Right, HorizontalSpace => 1, BaseRow => 1, Boxes => false)
+
+texMathn := x -> if x===null then "" else texMath x
 
 texMath BettiTally := v -> (
     v = rawBettiTally v;
-    v = join({prepend(2, drop(v#0, 1)), prepend("\\text{total:}\n  ", drop(v#1, 1))}, drop(v, 2));
-    v = between("\\\\\n", apply(v, row -> concatenate between(" & ", row)));
+--    v = join({prepend("  ", drop(v#0, 1)), prepend("\\text{total:}\n  ", drop(v#1, 1))}, drop(v, 2));
+    v = between("\\\\\n", apply(v, row -> concatenate between(" & ", apply(row,texMathn))));
     concatenate("\\begin{matrix}", newline, v, newline, "\\end{matrix}"))
 texMath MultigradedBettiTally := v -> (
     v = rawMultigradedBettiTally v;
-    v = if compactMatrixForm then prepend(prepend(2, drop(v#0, 1)), drop(v, 1)) else v;
-    v = between("\\\\\n", apply(v, row -> concatenate between(" & ", row)));
+    v = if compactMatrixForm then prepend(prepend(, drop(v#0, 1)), drop(v, 1)) else v;
+    v = between("\\\\\n", apply(v, row -> concatenate between(" & ", apply(row,texMathn))));
     concatenate("\\begin{matrix}", newline, v, newline, "\\end{matrix}"))
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/betti.m2
+++ b/M2/Macaulay2/m2/betti.m2
@@ -83,7 +83,7 @@ rawBettiTally = v -> (
     minrow := min fi;
     maxrow := max fi;
     v = table(toList (minrow .. maxrow), toList (mincol .. maxcol), (i,j) -> if v#?(i,j) then v#(i,j) else 0);
-    leftside := splice {, "total:", apply(minrow .. maxrow, i -> hold i : "")};
+    leftside := splice {, "total:", apply(minrow .. maxrow, i -> RowExpression{ i, symbol :} )};
     totals := apply(transpose v, sum);
     v = prepend(totals,v);
     v = applyTable(v, bt -> if bt === 0 then symbol . else bt);
@@ -116,7 +116,7 @@ rawMultigradedBettiTally = B -> (
 	    (i,j) -> if H#?(rows#i,cols#j) then H#(rows#i,cols#j) else 0);
 	-- Making the table
 	xAxis := cols;
-	yAxis := (i -> hold i:"") \ rows;
+	yAxis := (i -> RowExpression{ i, symbol :}) \ rows;
 --	T = applyTable(T, n -> if n === 0 then symbol . else raw n);
 	T = applyTable(T, n -> if n === 0 then symbol . else n);
 	T = prepend(xAxis, T);
@@ -132,7 +132,10 @@ toStringn := x -> if x===null then "" else toString x
 net            BettiTally := B -> netList(rawBettiTally B,            Alignment => Right, HorizontalSpace => 1, BaseRow => 1, Boxes => false)
 net MultigradedBettiTally := B -> netList(applyTable(rawMultigradedBettiTally B,toStringn), Alignment => Right, HorizontalSpace => 1, BaseRow => 1, Boxes => false)
 
-texMathn := x -> if x===null then "" else texMath x
+texMathn := method()
+texMathn Nothing := x -> ""
+texMathn String := s -> "\\text{"|s|"}" -- minor variation, no tt
+texMathn Thing := texMath
 
 texMath BettiTally := v -> (
     v = rawBettiTally v;

--- a/M2/Macaulay2/m2/betti.m2
+++ b/M2/Macaulay2/m2/betti.m2
@@ -94,7 +94,7 @@ rawBettiTally = v -> (
 rawMultigradedBettiTally = B -> (
     if keys B == {} then return 0;
     N := max apply(pairs B, (key, n) -> ((i,d,h) := key; length d));
-    R := ZZ[vars(0..N-1), MonomialOrder => Lex, Inverses => true];
+    R := ZZ(monoid[vars(0..N-1), MonomialOrder => Lex, Inverses => true]);
     H := new MutableHashTable;
     (rows, cols) := ({}, {});
     scan(pairs B,

--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -450,6 +450,8 @@ scan(assocList, opClass -> (
 	    installMethod(opClass#operator,opClass#unit,opClass,(x,y) -> y);
 	    )
 ))
+ZeroExpression * Expression := (x,y) -> x
+Expression * ZeroExpression := (x,y) -> y
        - ZeroExpression     := identity
 	   - Minus          := x -> expression x#0
            - Expression     := x -> new Minus from {x}
@@ -587,8 +589,8 @@ toString'(Function, Table) := (fmt,m) -> concatenate(
 -- TODO: move this to latex.m2
 keywordTexMath = new HashTable from { -- both unary and binary keywords
     symbol |- => "\\vdash ",
-    symbol .. => "\\,{.}{.}\\, ",
-    symbol ..< => "\\,{.}{.}{<}\\, ",
+    symbol .. => "\\,{.}{.}\\,",
+    symbol ..< => "\\,{.}{.}{<}\\,",
     symbol <= => "\\le ",
     symbol >= => "\\ge ",
     symbol => => "\\Rightarrow ",
@@ -606,9 +608,9 @@ keywordTexMath = new HashTable from { -- both unary and binary keywords
     symbol >> => "\\gg ",
     symbol ~ => "\\sim ",
     symbol ^** => "{}^{\\otimes}", -- temporary solution to KaTeX issue https://github.com/KaTeX/KaTeX/issues/3576
-    symbol _ => "\\_ ",
-    symbol { => "\\{ ",
-    symbol } => "\\} ",
+    symbol _ => "\\_",
+    symbol { => "\\{",
+    symbol } => "\\}",
     symbol \ => "\\backslash ",
     symbol \\ => "\\backslash\\backslash ",
     symbol # => "\\#",
@@ -1082,21 +1084,15 @@ html Product := v -> (
      )
 *-
 
-texMath Power := v -> if v#1 === 1 or v#1 === ONE then texMath v#0 else (
+texMathSuperscript := v -> (
     p := precedence v;
     x := texMath v#0;
     y := texMath v#1;
-    if precedence v#0 <  p then x = "\\left(" | x | "\\right)";
+    if precedence v#0 < p or class v#0 === Superscript or class v#0 === Power then x = "\\left(" | x | "\\right)"; -- precedence of double superscript
     concatenate(x,"^{",y,"}") -- no braces around x
-    )
-
-texMath Superscript := v -> if v#1 === moduleZERO then "0" else (
-    p := precedence v;
-    x := texMath v#0;
-    y := texMath v#1;
-    if precedence v#0 <  p then x = "\\left(" | x | "\\right)";
-    concatenate(x,"^{",y,"}") -- no braces around x
-    )
+)
+texMath Power := v -> if v#1 === 1 or v#1 === ONE then texMath v#0 else texMathSuperscript v
+texMath Superscript := v -> if v#1 === moduleZERO then "0" else texMathSuperscript v
 
 texMath Subscript := v -> (
      p := precedence v;
@@ -1146,6 +1142,7 @@ texMath SparseMonomialVectorExpression := v -> (
      )
 
 texMath Table := m -> (
+    if any(m, x-> not instance(x,VisibleList)) then m = apply(m, x -> {x});
     if m#?0 then concatenate(
 	"\\begin{array}{", #m#0: "c", "}", newline,
 	between(///\\/// | newline, apply(toList m, row -> between("&",apply(row,texMath)))),

--- a/M2/Macaulay2/m2/latex.m2
+++ b/M2/Macaulay2/m2/latex.m2
@@ -89,8 +89,8 @@ texMath Symbol := x -> if keywordTexMath#?x then keywordTexMath#x else texVariab
 
 -----------------------------------------------------------------------------
 
-tex     Nothing :=
-texMath Nothing := x -> ""
+tex     Nothing := tex @@ toString
+texMath Nothing := texMath @@ toString
 
 tex     Thing := x -> concatenate("$", texMath x, "$")
 texMath Thing := x -> texMath net x -- if we're desperate (in particular, for raw objects)

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/betti-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/betti-doc.m2
@@ -142,10 +142,10 @@ Node
     Example
       R = QQ[a,b,c,d, Degrees => {{1,0},{2,1},{0,1},{-2,1}}];
       heft R
-      b = betti res coker vars R
-      betti(b, Weights => {1,0})
-      betti(b, Weights => {0,1})
-      multigraded b
+      B = betti res coker vars R
+      betti(B, Weights => {1,0})
+      betti(B, Weights => {0,1})
+      multigraded B
   Synopsis
     Heading
       Betti table of a Groebner basis


### PR DESCRIPTION
I fixed #2950, though I'm still not sure whether `compactMatrixForm` is used appropriately, as mentioned in the comments.
I also threw in a bunch of small fixes, including an expression bug I introduced when removing `NonAssociativeProduct` (try `expression 0 * x`) and a double superscript bug.