### PR TITLE
Use Debian codename for ISSUE_RELEASE if no version number (cmake)

### DIFF
--- a/M2/cmake/flavor.cmake
+++ b/M2/cmake/flavor.cmake
@@ -26,6 +26,11 @@ if(NOT DEFINED ISSUE)
     execute_process(COMMAND ${LSB_RELEASE} -s --release
       OUTPUT_VARIABLE ISSUE_RELEASE
       ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(ISSUE_RELEASE STREQUAL "n/a")
+      execute_process(COMMAND ${LSB_RELEASE} -s --codename
+       OUTPUT_VARIABLE ISSUE_RELEASE
+       ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
   elseif(OS_RELEASE)
     file(READ ${OS_RELEASE} _os_release)
     string(REGEX MATCH "ID=([A-Za-z ]*)\n"      _ "${_os_release}")


### PR DESCRIPTION
This is the cmake version of #2986.   Thanks to @mahrud for providing the code in https://github.com/Macaulay2/M2/pull/2986#issuecomment-1806937416!