### PR TITLE
Include more flint headers last

### DIFF
--- a/M2/Macaulay2/e/interface/aring.cpp
+++ b/M2/Macaulay2/e/interface/aring.cpp
@@ -5,19 +5,21 @@
 #include <vector>
 #include <memory>
 
-#include "aring-gf-flint-big.hpp"
-#include "aring-gf-flint.hpp"
 #include "aring-glue.hpp"
 #include "aring-m2-gf.hpp"
 #include "aring-qq.hpp"
 #include "aring-tower.hpp"
-#include "aring-zz-flint.hpp"
 #include "aring-zzp-ffpack.hpp"
-#include "aring-zzp-flint.hpp"
 #include "aring-zzp.hpp"
 #include "exceptions.hpp"
 #include "polyring.hpp"
 #include "relem.hpp"
+
+// include flint headers last to avoid #1674
+#include "aring-gf-flint-big.hpp"
+#include "aring-gf-flint.hpp"
+#include "aring-zz-flint.hpp"
+#include "aring-zzp-flint.hpp"
 
 const RingQQ *globalQQ;
 


### PR DESCRIPTION
This is a followup to #2985.

A reminder of what was happening:  after the updates to support flint 3 in #2973, we ran into #1674 again, a compile error on some systems (64-bit ARM and a couple others) due to a macro conflict between flint and givaro.  Including the flint headers last fixes the problem.

Rearranging the order of the headers in `aring-translate.hpp` as in #2985 was sufficient to fix the problem for newer systems (like Debian unstable), but we still got compilation errors a bit later (when compiling `interface/aring.cpp`) on slightly older systems (up through Ubuntu 22.04), so we change the order there as well.