### PR TITLE
Add Citation File Format file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+---
+cff-version: 1.2.0
+authors:
+  - family-names: Grayson
+    given-names: Daniel R.
+  - family-names: Stillman
+    given-names: Michael E.
+title: Macaulay2, a software system for research in algebraic geometry
+url: https://macaulay2.com/
+
+# Local Variables:
+# mode: yaml
+# End:


### PR DESCRIPTION
See https://citation-file-format.github.io/.  This adds a "Cite this repository" link to the GitHub page that allows users to quickly copy/paste a BibTeX entry for citing Macaulay2.  (See https://github.com/d-torrance/M2/tree/citation).

I couldn't get it to perfectly replicate the BibTeX entry returned by `cite`, but it's close:

### Using `cite`

```m2
i1 : needsPackage "PackageCitations"

o1 = PackageCitations

o1 : Package

i2 : cite()

o2 = @misc{M2,
       author = {Grayson, Daniel R. and Stillman, Michael E.},
       title = {Macaulay2, a software system for research in algebraic geometry},
       howpublished = {Available at \url{https://macaulay2.com/}}
     }
```

### Pasted from GitHub

```bibtex
@software{Grayson_Macaulay2_a_software,
author = {Grayson, Daniel R. and Stillman, Michael E.},
title = {{Macaulay2, a software system for research in algebraic geometry}},
url = {https://macaulay2.com/}
}
```