### PR TITLE
Transfer some functionality from Monodromy solver to NAG

### DIFF
--- a/M2/Macaulay2/packages/MonodromySolver/Systems.m2
+++ b/M2/Macaulay2/packages/MonodromySolver/Systems.m2
@@ -75,18 +75,8 @@ flatten GateSystem := GS -> gateSystem(parameters GS | vars GS, gateMatrix GS)
 flatten PolySystem := PS -> sub(PS, first flattenRing ring PS)
 
 -- syntactic sugar for creating instances of GateSystem
-gateSystem (BasicList, BasicList, GateMatrix) := (P, X, F) -> (
-    GM := if numcols F == 1 then F else transpose F;
-    gateSystem(gateMatrix{toList P}, gateMatrix{toList X}, GM)
-    )
 gateSystem (Thing, Thing, Gate) := (X, P, g) -> gateSystem(X, P, gateMatrix{{g}})
 gateSystem (List, Thing) := (X, F) -> gateSystem({}, X, F)
-
--- syntactic sugar for declareVariable \ {symbols}
-vars IndexedVariable := x -> declareVariable x
-vars Symbol := x -> declareVariable x
-vars InputGate := x -> x
-InputGate .. InputGate := (A, B) -> value \ (A.Name .. B.Name)
 
 -- take some functions from the GateMatrix \ GateSystem
 GateMatrix ^ BasicList := (M, inds) -> M^(toList inds)
@@ -105,55 +95,6 @@ computeMixedVolume System := sys -> (
 	);	    
     computeMixedVolume specGS
     )
-
-
--- helper functions for square down
--- orthonormal basis for col(L) using SVD
-ONB = L -> (
-    (S,U,Vt) := SVD L;
-    r := # select(S,s->not areEqual(s,0));
-    U_{0..r-1}
-    )
--- orthonormal basis for subspace of col(L) that is perpendicular to col(M)
-perp = (M, L) -> if areEqual(norm L, 0) then M else (
-    Lortho := ONB L;
-    Lperp := M-Lortho*conjugate transpose Lortho * M;
-    ONB Lperp
-    )
-
--- finding a square subsystem of maximal rank
-rowSelector = method(Options=>{"BlockSize"=>1,Verbose=>false})
-rowSelector (AbstractPoint, AbstractPoint, GateSystem) := o -> (y0, c0, GS) -> (
-    (n, m, N) := (numVariables GS, numParameters GS, numFunctions GS);
-    blockSize := o#"BlockSize";
-    numBlocks := ceiling(N/blockSize);
-    numIters := 0;
-    L := matrix{for i from 1 to n list 0_CC}; -- initial "basis" for row space
-    r := 0;
-    goodRows := {};
-    diffIndices := {};
-    while (r < n and numIters < numBlocks) do (
-    	diffIndices = for j from numIters*blockSize to min((numIters+1)*blockSize, N)-1 list j;
-	if o.Verbose then << "processing rows " << first diffIndices << " thru " << last diffIndices << endl;
-    	newRows := evaluateJacobian(GS^diffIndices, y0, c0);
-    	for j from 0 to numrows newRows - 1 do (
-	    tmp := transpose perp(transpose newRows^{j}, transpose L);
-	    if not areEqual(0, norm tmp) then (
-		if o.Verbose then << "added row " << blockSize*numIters+j << endl;
-	    	if areEqual(norm L^{0}, 0) then L = tmp else L = L || tmp;
-	    	goodRows = append(goodRows, blockSize*numIters+j);
-		);
-    	    );
-    	r = numericalRank L;
-    	numIters = numIters+1;
-	);
-    if o.Verbose then << "the rows selected are " << goodRows << endl;
-    goodRows
-    )
-
-squareDown = method(Options=>{"BlockSize"=>1, Verbose=>false})
-squareDown (AbstractPoint, AbstractPoint, GateSystem) := o -> (y0, c0, F) -> F^(rowSelector(y0, c0, F, "BlockSize" => o#"BlockSize", Verbose=>o.Verbose))
-
 
 newtonHomotopy = method(Options=>{Iterations=>10})
 newtonHomotopy GateSystem := o -> G -> (

--- a/M2/Macaulay2/packages/MonodromySolver/Systems.m2
+++ b/M2/Macaulay2/packages/MonodromySolver/Systems.m2
@@ -78,10 +78,6 @@ flatten PolySystem := PS -> sub(PS, first flattenRing ring PS)
 gateSystem (Thing, Thing, Gate) := (X, P, g) -> gateSystem(X, P, gateMatrix{{g}})
 gateSystem (List, Thing) := (X, F) -> gateSystem({}, X, F)
 
--- take some functions from the GateMatrix \ GateSystem
-GateMatrix ^ BasicList := (M, inds) -> M^(toList inds)
-GateSystem ^ BasicList := (P, inds) -> gateSystem(parameters P, vars P, (gateMatrix P)^inds)
-
 -- routines for mixed volume computation (via gfan)
 computeMixedVolume = method()
 computeMixedVolume List := polys -> value gfanMixedVolume(

--- a/M2/Macaulay2/packages/NAGtypes.m2
+++ b/M2/Macaulay2/packages/NAGtypes.m2
@@ -243,6 +243,9 @@ evaluateHx (ParameterHomotopy,Matrix,Matrix,Number) := (H,parameters,x,t) -> err
 SpecializedParameterHomotopy = new Type of Homotopy
 specialize = method()
 specialize (ParameterHomotopy,Matrix) := (PH, M) -> (
+    if numcols M != 1 then M = transpose M;
+    if numcols M != 1 then error "1-row or 1-column matrix expected"; 
+    if numcols PH.Parameters != numrows M then error "wrong number of parameters";  
     SPH := new SpecializedParameterHomotopy;
     SPH.ParameterHomotopy = PH;
     SPH.Parameters = M;
@@ -286,7 +289,7 @@ undocumented {
 
 undocumented {(toExternalString,Point), (toExternalString,PolySystem),
     unionPointSet,  (unionPointSet,PointSet,PointSet), pointSet, (pointSet,Thing), (areEqual,PointSet,PointSet), PointSet,
-    differencePointSet, (differencePointSet,PointSet,PointSet), specialize, (specialize,ParameterHomotopy,Matrix),
+    differencePointSet, (differencePointSet,PointSet,PointSet), 
     (symbol ==,PointSet,PointSet), (net,PointSet), 
     (symbol +,PointSet,PointSet), (symbol -,PointSet,PointSet),
     }

--- a/M2/Macaulay2/packages/NAGtypes/PolySystem.m2
+++ b/M2/Macaulay2/packages/NAGtypes/PolySystem.m2
@@ -106,13 +106,16 @@ toCCpolynomials (Matrix,InexactField) := (F,C) -> (
     )    
 
 -- evaluate = method()
+
 evaluate (Matrix,AbstractPoint) := (M,p) -> evaluate(M, matrix p)
 evaluate (PolySystem,Matrix) := (P,X) -> evaluate(P.PolyMap,X)
 evaluate (Matrix,Matrix) := (M,X) ->  (
     C := coefficientRing ring M;
+    RX := ring X;
+    commonField := commonRing{1_C, 1_RX};--try promote(1_C, RX) then RX else try promote(1_RX, C) then C else error "common field not found";
     -- work around a sub(CC,QQ) bug!!!
     if instance(ring X, InexactField) then 
-	M = toCCpolynomials(M,C=ring X);   
+	M = toCCpolynomials(M,C=commonField);   
     if numColumns X == 1 then X = transpose X;
     if numRows X == 1 then sub(M,sub(X,C))
     else error "expected a row or a column vector"

--- a/M2/Macaulay2/packages/NAGtypes/doc-NAGtypes.m2
+++ b/M2/Macaulay2/packages/NAGtypes/doc-NAGtypes.m2
@@ -1134,6 +1134,8 @@ doc ///
     Text
       An abstract type that of homotopy that involves parameters.
       Can be specialized to produce @TO SpecializedParameterHomotopy@.
+  SeeAlso
+    specialize
 ///	    
 
 doc ///
@@ -1149,6 +1151,24 @@ doc ///
   Headline
     a collection of parameters
 ///
+
+doc ///
+  Key 
+    (specialize, ParameterHomotopy, Matrix)
+    specialize
+  Headline
+    specialize a parameter homotopy
+  Usage
+    Hp = specialize(H,p)
+  Inputs 
+    H: 
+      homotopy
+    p: 
+      values of parameters 
+  Outputs
+    Hp:SpecializedParameterHomotopy
+      specialized homotopy
+///	    
 
 doc ///
   Key

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry.m2
@@ -388,26 +388,84 @@ randomOrthonormalCols = method() -- return a random m-by-n matrix with orthonorm
 randomOrthonormalCols(ZZ,ZZ) := (m,n) -> 
 if m<n or n<1 then error "wrong input" else (randomUnitaryMatrix m)_(toList(0..n-1))
 
-squareUp = method() -- squares up a polynomial system (presented as a one-column matrix)
-squareUp PolySystem := P -> if P.?SquaredUpSystem then P.SquaredUpSystem else squareUp(P, P.NumberOfVariables)
-squareUp (PolySystem,ZZ) := (P,n) -> (
-    m := P.NumberOfPolys;
-    if m<=n then "overdetermined system expected";
-    C := coefficientRing ring P;
-    M := if class C === ComplexField then sub(randomOrthonormalRows(n,m), C) else random(C^n,C^m);
-    squareUp(P,M)
+-- helper functions for square down:
+-- orthonormal basis for col(L) using SVD
+ONB = L -> (
+    (S,U,Vt) := SVD L;
+    r := # select(S,s->not areEqual(s,0));
+    U_{0..r-1}
     )
-squareUp(PolySystem,Matrix) := (P,M) -> (
-    P.SquareUpMatrix = M;
-    P.SquaredUpSystem = polySystem (sub(M,ring P)*P.PolyMap) -- should work without sub!!!
+-- orthonormal basis for subspace of col(L) that is perpendicular to col(M)
+perp = (M, L) -> if areEqual(norm L, 0) then M else (
+    Lortho := ONB L;
+    Lperp := M-Lortho*conjugate transpose Lortho * M;
+    ONB Lperp
+    )
+-- finding a square subsystem of maximal rank
+rowSelector = method(Options=>{"block size"=>1,"target rank"=>null,Verbose=>false})
+rowSelector (AbstractPoint, AbstractPoint, System) := o -> (y0, c0, GS) -> (
+    (n, m, N) := (numVariables GS, numParameters GS, numFunctions GS);
+    blockSize := o#"block size";
+    numBlocks := ceiling(N/blockSize);
+    numIters := 0;
+    L := matrix{for i from 1 to n list 0_CC}; -- initial "basis" for row space
+    r := 0;
+    goodRows := {};
+    diffIndices := {};
+    while (r < n and numIters < numBlocks) do (
+    	diffIndices = for j from numIters*blockSize to min((numIters+1)*blockSize, N)-1 list j;
+	if o.Verbose then << "processing rows " << first diffIndices << " thru " << last diffIndices << endl;
+    	newRows := evaluateJacobian(GS^diffIndices, y0, c0);
+    	for j from 0 to numrows newRows - 1 do (
+	    tmp := transpose perp(transpose newRows^{j}, transpose L);
+	    if not areEqual(0, norm tmp) then (
+		if o.Verbose then << "added row " << blockSize*numIters+j << endl;
+	    	if areEqual(norm L^{0}, 0) then L = tmp else L = L || tmp;
+	    	goodRows = append(goodRows, blockSize*numIters+j);
+		);
+    	    );
+    	r = numericalRank L;
+    	numIters = numIters+1;
+	);
+    if o.Verbose then << "the rows selected are " << goodRows << endl;
+    goodRows
     )
 
+-- stashes and returns "squared up" subsytem, according to given strategy
+squareUp = method(Options => {Field => null, Strategy => null, "block size"=>1, "target rank" => null, Verbose=>false}) -- squares up a polynomial system (presented as a one-column matrix)
+squareUp System := o -> P -> if P.?SquaredUpSystem then P.SquaredUpSystem else squareUp(P, numVariables P, o)
+squareUp (AbstractPoint, AbstractPoint, GateSystem) := o -> (p0, x0, F) -> (
+    keptRows := rowSelector(p0, x0, F, "block size" => o#"block size", Verbose=>o.Verbose);
+    F.SquaredUpSystem = F^keptRows
+    )
+squareUp (AbstractPoint, GateSystem) := o -> (x0, F) -> squareUp(point{{}}, x0, F, o)
+squareUp (System, ZZ) := o -> (P, n) -> (
+    m := numFunctions P;
+    if m<=n then "expect more equations than second argument";
+    C := if instance(o.Field, Nothing) then (
+	if instance(P, PolySystem) then coefficientRing ring P
+	else default CC
+	) else o.Field;
+    if instance(o.Strategy, Nothing) or o.Strategy == "random matrix" then (
+    	M := if class C === ComplexField then sub(randomOrthonormalRows(n,m), C) else random(C^n,C^m);
+    	squareUp(P,M,o)
+	) 
+    else if o.Strategy == "slack variables" then error "strategy not implemented"
+    else error "strategy not implemented"
+    )
+squareUp(System, Matrix) := o -> (P, M) -> (
+    P.SquareUpMatrix = M;
+    P.SquaredUpSystem = if instance(P, PolySystem) then polySystem (M*P.PolyMap) else gateSystem(parameters P, vars P, M * gateMatrix P)
+    )
+-- todo: squareUp(System, ...) not implemented, override w/ PolySystem and GateSystem
+
+--- is this ever used???
 squareUpMatrix = method()
-squareUpMatrix PolySystem := P -> if P.?SquareUpMatrix then P.SquareUpMatrix else (
+squareUpMatrix System := P -> if P.?SquareUpMatrix then P.SquareUpMatrix else (
     n := P.NumberOfVariables;
     C := coefficientRing ring P;
     map(C^n)
-    ) 
+    )
 
 load "./NumericalAlgebraicGeometry/BSS-certified.m2"
 load "./NumericalAlgebraicGeometry/0-dim-methods.m2"
@@ -578,6 +636,7 @@ installPackage("Style")
 installPackage("NumericalAlgebraicGeometry")
 
 installPackage ("NumericalAlgebraicGeometry", MakeDocumentation=>false)
+restart
 check "NumericalAlgebraicGeometry"
 
 -- Local Variables:

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
@@ -672,7 +672,9 @@ isOn(point {{sqrt 5*ii,sqrt 3}},W)
     }
 
 document {
-    Key => {newton, (newton,PolySystem,Matrix), (newton,PolySystem,AbstractPoint)},
+    Key => {newton, 
+	-*(newton,System,Matrix),*- 
+	(newton,System,AbstractPoint)},
     Headline => "Newton-Raphson method",
     "Performs one step of the Newton-Raphson method.",
     Caveat=>{"Works for a regular square or overdetermined system."}
@@ -1147,12 +1149,14 @@ doc ///
 	It is related to @TO GateHomotopy@. 
 ///
 
+-*
 doc ///
 Key 
   (specialize,GateParameterHomotopy,MutableMatrix)
 Headline
   specialize parameters in a (gate) parameter homotopy 
 ///
+*-
 
 doc ///
 Key

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
@@ -788,7 +788,7 @@ document {
     }
 
 document {
-    Key => {squareUp, (squareUp,PolySystem), (squareUp,PolySystem,ZZ), (squareUp,PolySystem, Matrix), 
+    Key => {squareUp, (squareUp,System), (squareUp,System,ZZ), (squareUp,System, Matrix), 
 	SquaredUpSystem, SquareUpMatrix
 	},
     Headline => "square up a polynomial system",

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
@@ -959,6 +959,7 @@ doc ///
 	(gateSystem,Matrix)
 	(gateSystem,PolySystem)
 	(gateSystem,PolySystem,List)
+	(gateSystem,BasicList,BasicList,GateMatrix)
     Headline
         a constructor for GateSystem
     Usage
@@ -972,6 +973,7 @@ doc ///
     	Text 
             @TO GateMatrix@ {\tt M} is expected to have 1 column.
     	    Matrices {\tt params} and {\tt variables} are expected to have 1 row.
+	    (Later addition: TO DO say something about less restritive syntax.) 
         Example
             variables = declareVariable \ {x,y}
     	    F = gateSystem(matrix{variables}, matrix{{x*y-1},{x^3+y^2-2}})

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
@@ -789,23 +789,49 @@ document {
 
 document {
     Key => {squareUp, (squareUp,System), (squareUp,System,ZZ), (squareUp,System, Matrix), 
-	SquaredUpSystem, SquareUpMatrix
+	SquaredUpSystem, SquareUpMatrix,
+	(squareUp, AbstractPoint, AbstractPoint, GateSystem), 
+	(squareUp, AbstractPoint, GateSystem)  
 	},
     Headline => "square up a polynomial system",
-    Usage => "G = squareUp F\\nG = squareUp(F,M)\\nsquareUp(F,n)",
+    Usage => "G = squareUp F
+    G = squareUp(F,M)
+    G = squareUp(F,n)
+    G = squareUp(x0,F)
+    G = squareUp(p0,x0,F)
+    ",
     Inputs => { 
-	"F"=>PolySystem,
-	"M"=>Matrix=>{" the matrix used to square up the system (by default a random matrix is picked)"},
-	"n"=>ZZ=>{" the number of polynomials to be formed (by default, this equals the number of variables)"}  
+	"F"=>System,
+	"M"=>Matrix=>{" used to square up the system (by default a random matrix is picked)"},
+	"n"=>ZZ=>{" the number of polynomials to be formed (by default, this equals the number of variables)"},
+	"x0"=>Point=>{" used to compute the dimension of the tangent space (approximately)"},
+	"p0"=>Point=>{" parameters specialization (in case of a parametric system)"} 	 
 	},
     Outputs => { "G"=>PolySystem },
-    "Squares up an overdetermined polynomial system. Attaches keys ", 
-    TO SquareUpMatrix, " and ", TO SquaredUpSystem,
-    " to ", TT "F", ".", 
+    PARA {"There are two flavors of this method: both aimed at producing a regular sequence (either global or local)."},
+    PARA {"The first squares up an overdetermined polynomial system (usually assuming that the user is interested in the isolated solutions; i.e., the components of dimension 0) and attaches keys ", 
+    	TO SquareUpMatrix, " and ", TO SquaredUpSystem,
+    	" to ", TT "F", "."}, 
     EXAMPLE lines ///
-    CC[x,y]; F = polySystem {x^2+y^2,x^3+y^3,x^4+y^4}
+    CC[X,Y]; F = polySystem {X^2+Y^2,X^3+Y^3,X^4+Y^4}
     G := squareUp F
     peek F
+    ///,
+    PARA { 
+	"The other computes ", TO "numericalRank", " ", TT "r", 
+	" of the Jacobian of ", TT "F", " and picks out the first ", TT"r", 
+	" polynomials who give the same (approximate) rank at the specified point."   
+	},
+    EXAMPLE ///
+    X = gateMatrix{toList vars(x,y,z)}
+    P = gateMatrix{toList vars(a..d)}
+    F = gateSystem(P,X,gateMatrix{{y^2-x*z},{x^2*y-z^2},{x^3-y*z},{a*x+b*y+c*z+d}})
+    X0 = point{{1,1,1_CC}}
+    P0 = point{{1,1,1,-3_CC}}
+    norm evaluate(F, P0, X0) -- should be small
+    numericalRank evaluateJacobian(F, P0, X0) -- should equal number of variables
+    G = squareUp(P0, X0, F)
+    netList entries gateMatrix G
     ///,
     SeeAlso=>{PolySystem}
     }

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
@@ -273,11 +273,13 @@ gateSystem PolySystem := GateSystem => F -> if F#?GateSystem then F#GateSystem e
   F#GateSystem = gateSystem(F,parameters F)
 gateSystem (PolySystem,List-*of parameters*-) := (F,P) -> ( 
     R := ring F; 
-    if not isSubset(P, gens R) then "some parameters are not among generators of the ring";
-    X := getVarGates R;
-    variables := gateMatrix {X_(positions(gens R, x->not member(x,P)))};  
-    parameters := gateMatrix {X_(positions(gens R, x->member(x,P)))};
-    gateSystem(parameters, variables, gatePolynomial F.PolyMap)
+    (S, R2S) := flattenRing R;
+    params := R2S \ P;
+    if not isSubset(params, gens S) then error"some parameters are not among generators of the ring";
+    X := getVarGates S;
+    variables := gateMatrix {X_(positions(gens S, x->not member(x,params)))};  
+    parameters := gateMatrix {X_(positions(gens S, x->member(x,params)))};
+    gateSystem(parameters, variables, gatePolynomial R2S F.PolyMap)
     ) 
  
 -- !!! a general problem: some methods need PolySystem to be changed to GateSystem

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
@@ -192,6 +192,11 @@ rowSelector (AbstractPoint, AbstractPoint, GateSystem) := o -> (y0, c0, GS) -> (
 squareDown = method(Options=>{"BlockSize"=>1, Verbose=>false})
 squareDown (AbstractPoint, AbstractPoint, GateSystem) := o -> (y0, c0, F) -> F^(rowSelector(y0, c0, F, "BlockSize" => o#"BlockSize", Verbose=>o.Verbose))
 
+-* squareDown --> squareUp: write 
+squareUp(AbstractPoint, AbstractPoint, GateSystem)
+squareUp(AbstractPoint, GateSystem)
+*-
+
 --TEST 
 /// -- package Serialization
 restart
@@ -311,7 +316,7 @@ evaluateH (GateParameterHomotopy,Matrix,Matrix,Number) := (H,parameters,x,t) -> 
 evaluateHt (GateParameterHomotopy,Matrix,Matrix,Number) := (H,parameters,x,t) -> evaluateHt(H.GateHomotopy,parameters||x,t)
 evaluateHx (GateParameterHomotopy,Matrix,Matrix,Number) := (H,parameters,x,t) -> evaluateHx(H.GateHomotopy,parameters||x,t)
 
-specialize (GateParameterHomotopy,MutableMatrix) := (PH, M) -> specialize(PH, mutableMatrix M)
+-*specialize (GateParameterHomotopy,MutableMatrix) := (PH, M) -> specialize(PH, mutableMatrix M)
 specialize (GateParameterHomotopy,MutableMatrix) := (PH, M) -> (                                                                                                         
     if numcols M != 1 then error "1-column matrix expected"; 
     if numcols PH.Parameters != numrows M then error "wrong number of parameters";  
@@ -320,6 +325,7 @@ specialize (GateParameterHomotopy,MutableMatrix) := (PH, M) -> (
     SPH.Parameters = M;                                                                                                                                       
     SPH                                                                                                                                                       
     ) 
+*-
 
 -- !!! replaces makeGateMatrix
 gateSystem PolySystem := GateSystem => F -> if F#?GateSystem then F#GateSystem else 

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
@@ -146,57 +146,6 @@ evaluate(H,p0,x0)
 evaluateJacobian(H,p0,x0)
 ///
 
--- helper functions for square down:
--- orthonormal basis for col(L) using SVD
-ONB = L -> (
-    (S,U,Vt) := SVD L;
-    r := # select(S,s->not areEqual(s,0));
-    U_{0..r-1}
-    )
--- orthonormal basis for subspace of col(L) that is perpendicular to col(M)
-perp = (M, L) -> if areEqual(norm L, 0) then M else (
-    Lortho := ONB L;
-    Lperp := M-Lortho*conjugate transpose Lortho * M;
-    ONB Lperp
-    )
--- finding a square subsystem of maximal rank
-rowSelector = method(Options=>{"BlockSize"=>1,Verbose=>false})
-rowSelector (AbstractPoint, AbstractPoint, GateSystem) := o -> (y0, c0, GS) -> (
-    (n, m, N) := (numVariables GS, numParameters GS, numFunctions GS);
-    blockSize := o#"BlockSize";
-    numBlocks := ceiling(N/blockSize);
-    numIters := 0;
-    L := matrix{for i from 1 to n list 0_CC}; -- initial "basis" for row space
-    r := 0;
-    goodRows := {};
-    diffIndices := {};
-    while (r < n and numIters < numBlocks) do (
-    	diffIndices = for j from numIters*blockSize to min((numIters+1)*blockSize, N)-1 list j;
-	if o.Verbose then << "processing rows " << first diffIndices << " thru " << last diffIndices << endl;
-    	newRows := evaluateJacobian(GS^diffIndices, y0, c0);
-    	for j from 0 to numrows newRows - 1 do (
-	    tmp := transpose perp(transpose newRows^{j}, transpose L);
-	    if not areEqual(0, norm tmp) then (
-		if o.Verbose then << "added row " << blockSize*numIters+j << endl;
-	    	if areEqual(norm L^{0}, 0) then L = tmp else L = L || tmp;
-	    	goodRows = append(goodRows, blockSize*numIters+j);
-		);
-    	    );
-    	r = numericalRank L;
-    	numIters = numIters+1;
-	);
-    if o.Verbose then << "the rows selected are " << goodRows << endl;
-    goodRows
-    )
-
-squareDown = method(Options=>{"BlockSize"=>1, Verbose=>false})
-squareDown (AbstractPoint, AbstractPoint, GateSystem) := o -> (y0, c0, F) -> F^(rowSelector(y0, c0, F, "BlockSize" => o#"BlockSize", Verbose=>o.Verbose))
-
--* squareDown --> squareUp: write 
-squareUp(AbstractPoint, AbstractPoint, GateSystem)
-squareUp(AbstractPoint, GateSystem)
-*-
-
 --TEST 
 /// -- package Serialization
 restart

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
@@ -6,8 +6,7 @@
 
 export{ 
     "GateSystem", "gateSystem", 
-    "GateHomotopy", "GateParameterHomotopy", "gateHomotopy", "segmentHomotopy", "parametricSegmentHomotopy",
-    "squareDown" -- TO DO: merge with squareUp ??? 
+    "GateHomotopy", "GateParameterHomotopy", "gateHomotopy", "segmentHomotopy", "parametricSegmentHomotopy"
     }
 
 debug SLPexpressions

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/systems.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/systems.m2
@@ -52,7 +52,7 @@ rowSelector (AbstractPoint, AbstractPoint, System) := o -> (y0, c0, GS) -> (
     goodRows
     )
 
--- stashes and returns "squared up" subsytem, according to given strategy
+-- stashes and returns "squared up" subsystem, according to given strategy
 squareUp = method(Options => {Field => null, Strategy => null, "block size"=>1, "target rank" => null, Verbose=>false}) -- squares up a polynomial system (presented as a one-column matrix)
 squareUp System := o -> P -> if P.?SquaredUpSystem then P.SquaredUpSystem else squareUp(P, numVariables P, o)
 squareUp (System, ZZ) := o -> (P, n) -> (

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/systems.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/systems.m2
@@ -1,0 +1,140 @@
+------------------------------------------------------
+-- routines for 0-dim solution sets 
+-- not included in other files
+-- (loaded by  ../NumericalAlgebraicGeometry.m2)
+------------------------------------------------------
+
+-- helper functions for "square down":
+
+-- move these to SLPexpressions???
+GateMatrix ^ BasicList := (M, inds) -> M^(toList inds)
+GateSystem ^ BasicList := (P, inds) -> gateSystem(parameters P, vars P, (gateMatrix P)^inds)
+
+-- orthonormal basis for col(L) using SVD
+ONB = L -> (
+    (S,U,Vt) := SVD L;
+    r := # select(S,s->not areEqual(s,0));
+    U_{0..r-1}
+    )
+-- orthonormal basis for subspace of col(L) that is perpendicular to col(M)
+perp = (M, L) -> if areEqual(norm L, 0) then M else (
+    Lortho := ONB L;
+    Lperp := M-Lortho*conjugate transpose Lortho * M;
+    ONB Lperp
+    )
+-- finding a square subsystem of maximal rank
+rowSelector = method(Options=>{"block size"=>1,"target rank"=>null,Verbose=>false})
+rowSelector (AbstractPoint, AbstractPoint, System) := o -> (y0, c0, GS) -> (
+    (n, m, N) := (numVariables GS, numParameters GS, numFunctions GS);
+    blockSize := o#"block size";
+    numBlocks := ceiling(N/blockSize);
+    numIters := 0;
+    L := matrix{for i from 1 to n list 0_CC}; -- initial "basis" for row space
+    r := 0;
+    goodRows := {};
+    diffIndices := {};
+    while (r < n and numIters < numBlocks) do (
+    	diffIndices = for j from numIters*blockSize to min((numIters+1)*blockSize, N)-1 list j;
+	if o.Verbose then << "processing rows " << first diffIndices << " thru " << last diffIndices << endl;
+    	newRows := evaluateJacobian(GS^diffIndices, y0, c0);
+    	for j from 0 to numrows newRows - 1 do (
+	    tmp := transpose perp(transpose newRows^{j}, transpose L);
+	    if not areEqual(0, norm tmp) then (
+		if o.Verbose then << "added row " << blockSize*numIters+j << endl;
+	    	if areEqual(norm L^{0}, 0) then L = tmp else L = L || tmp;
+	    	goodRows = append(goodRows, blockSize*numIters+j);
+		);
+    	    );
+    	r = numericalRank L;
+    	numIters = numIters+1;
+	);
+    if o.Verbose then << "the rows selected are " << goodRows << endl;
+    goodRows
+    )
+
+-- stashes and returns "squared up" subsytem, according to given strategy
+squareUp = method(Options => {Field => null, Strategy => null, "block size"=>1, "target rank" => null, Verbose=>false}) -- squares up a polynomial system (presented as a one-column matrix)
+squareUp System := o -> P -> if P.?SquaredUpSystem then P.SquaredUpSystem else squareUp(P, numVariables P, o)
+squareUp (System, ZZ) := o -> (P, n) -> (
+    m := numFunctions P;
+    if m<=n then "expect more equations than second argument";
+    C := if instance(o.Field, Nothing) then (
+	if instance(P, PolySystem) then coefficientRing ring P
+	else default CC
+	) else o.Field;
+    if instance(o.Strategy, Nothing) or o.Strategy == "random matrix" then (
+    	M := if class C === ComplexField then sub(randomOrthonormalRows(n,m), C) else random(C^n,C^m);
+    	squareUp(P,M,o)
+	) 
+    else if o.Strategy == "slack variables" then error "strategy not implemented"
+    else error "strategy not implemented"
+    )
+squareUp(System, Matrix) := o -> (P, M) -> (
+    P.SquareUpMatrix = M;
+    P.SquaredUpSystem = if instance(P, PolySystem) then polySystem (M*P.PolyMap) else gateSystem(parameters P, vars P, M * gateMatrix P)
+    )
+-- todo: squareUp(System, ...) not implemented, override w/ PolySystem and GateSystem
+
+--- is this ever used???
+squareUpMatrix = method()
+squareUpMatrix System := P -> if P.?SquareUpMatrix then P.SquareUpMatrix else (
+    n := P.NumberOfVariables;
+    C := coefficientRing ring P;
+    map(C^n)
+    )
+
+---------------------------------------------------
+-- below is what was formerly known as "squareDown"
+-- (needs a point for evaluation of the jacobian; uses rowSelector above)
+squareUp (AbstractPoint, AbstractPoint, GateSystem) := o -> (p0, x0, F) -> (
+    keptRows := rowSelector(p0, x0, F, "block size" => o#"block size", Verbose=>o.Verbose);
+    F.SquaredUpSystem = F^keptRows
+    )
+squareUp (AbstractPoint, GateSystem) := o -> (x0, F) -> squareUp(point{{}}, x0, F, o)
+
+TEST ///
+needsPackage "NumericalSchubertCalculus"
+needsPackage "NumericalAlgebraicGeometry"
+-- Schubert calculus on the Grassmannian of m-planes in C^2m
+-- derksen example
+k = 1 -- k=2 (more interesting)
+n = 3 -- n=4 (...)
+m = 2*k
+p = 2*n - m
+assert(m+p == 2*n)
+prob1 = apply(4, i -> apply(k, j -> n-k))
+-- synthesize solution
+prob1Instance = randomSchubertProblemInstance(prob1, m, m+p)
+K0s = last \ prob1Instance
+p0 = fold(apply(K0s, K0 -> matrix{flatten entries K0}), (a,b) -> a|b)
+elapsedTime X0s = solveSchubertProblem(prob1Instance, m, m+p);
+length realPoints apply(X0s, m -> point matrix{flatten entries m})
+X0 = first X0s
+X0 = X0 * (inverse X0^{0..m-1})
+x0 = matrix{flatten entries X0^{m..m+p-1}}
+allMinors = (k, M) -> (
+    (m, n) := (numrows M, numcols M);
+    flatten apply(subsets(m,k), R -> apply(subsets(n,k), C -> det(M_C^R)))
+    )
+-- setup equations
+X = gateMatrix for i from 1 to p list for j from 1 to m list x_(i,j)
+P = gateMatrix{vars flatten flatten for i from 1 to #prob1 list for j from 1 to m+p list for k from 1 to m+p list K_(i,j,k)}
+O = inputGate 1
+Z = inputGate 0
+I = gateMatrix apply(m, i-> apply(m,j->if i==j then O else Z))
+Ks = for i from 1 to #prob1 list matrix for j from 1 to m+p list for k from 1 to m+p list K_(i,j,k)
+elapsedTime rankConstraints = transpose gateMatrix{flatten flatten apply(prob1, Ks, (S, K) -> apply(#S, i -> (
+	j := S#i;
+	M := (I || X) | K_{0..p+i-j}; 
+	allMinors(m+p-j+1, M)
+	)
+    )
+)};
+G = gateSystem(P, matrix{flatten entries X}, rankConstraints)
+norm evaluate(G, p0, x0)
+assert (numericalRank evaluateJacobian(G, p0, x0)==numVariables G)
+GSq = squareUp(point p0, point x0, G)
+assert(numVariables GSq == numFunctions GSq)
+assert(norm evaluate(GSq, p0, x0) < 1e-8)
+/// 
+ 

--- a/M2/Macaulay2/packages/SLPexpressions.m2
+++ b/M2/Macaulay2/packages/SLPexpressions.m2
@@ -121,6 +121,11 @@ declareVariable Symbol :=
 declareVariable IndexedVariable := g -> (g <- inputGate g) 
 declareVariable InputGate := g -> g
 declareVariable Thing := g -> error "defined only for a Symbol or an IndexedVariable" 
+-- syntactic sugar for declareVariable \ {symbols}
+vars IndexedVariable := x -> declareVariable x
+vars Symbol := x -> declareVariable x
+vars InputGate := x -> x
+InputGate .. InputGate := (A, B) -> value \ (A.Name .. B.Name)
 
 undeclareVariable = method()
 undeclareVariable InputGate := g -> 

--- a/M2/Macaulay2/packages/SLPexpressions/doc.m2
+++ b/M2/Macaulay2/packages/SLPexpressions/doc.m2
@@ -627,3 +627,18 @@ doc ///
     SeeAlso
         "compressing circuits"
 ///
+
+doc /// 
+  Key 
+    (symbol .., InputGate, InputGate)
+  Headline 
+    Passing .. to InputGate names (see code). TO DO: expand this.
+///
+
+doc ///
+  Key 
+    "creating variables as objects of type InputGate"
+    (vars, IndexedVariable)
+    (vars, Symbol)
+    (vars, InputGate) 
+///


### PR DESCRIPTION
... and make some improvements.

In collaboration with @timduff35 
* several auxiliary functions moved to a more natural place `NumericalAlgerbaicGeometry`, `SLPexpressions`, ...
* `squareUp` includes a version of `squareDown` (non-exported method in `MonodromySolver` in the past).

One check (related to `bertini`) fails on a Mac (with `bertini` installed, otherwise this check is disabled) --- see #2948 
