### PR TITLE
Simplify construction of vectors

### DIFF
--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -117,6 +117,7 @@ lift(Vector,Number) := Vector => o -> (v,S) -> vector (lift(v#0,S))
 
 - Vector := Vector => v -> new class v from {-v#0}
 Number * Vector := RingElement * Vector := Vector => (r,v) -> vector(r * v#0)
+Vector * Number := Vector * RingElement := Vector => (v,r) -> vector(v#0 * r)
 Vector + Vector := Vector => (v,w) -> vector(v#0+w#0)
 Vector - Vector := Vector => (v,w) -> vector(v#0-w#0)
 Vector ** Vector := Vector => (v,w) -> vector(v#0**w#0)

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -115,6 +115,7 @@ lift(Vector,InexactNumber') :=
 lift(Vector,RingElement) :=
 lift(Vector,Number) := Vector => o -> (v,S) -> vector (lift(v#0,S))
 
++ Vector := Vector => identity
 - Vector := Vector => v -> new class v from {-v#0}
 Number * Vector := RingElement * Vector := Vector => (r,v) -> vector(r * v#0)
 Vector * Number := Vector * RingElement := Vector => (v,r) -> vector(v#0 * r)

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -154,6 +154,10 @@ new Module from Sequence := (Module,x) -> (
      	       symbol numgens => rawRank rM
      	       })) x
 
+vector(Module, Matrix) := (M, f) -> vector map(M,,entries f)
+vector(Module, List)   := (M, v) -> vector map(M,,apply(splice v, i -> {i}))
+vector(Module, RingElement) := vector(Module, Number) := (M, x) -> vector(M, {x})
+
 -- TODO: deprecate these
 degreesMonoid Module := GeneralOrderedMonoid => M -> degreesMonoid ring M
 degreesRing Module := PolynomialRing => M -> degreesRing ring M

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -79,6 +79,8 @@ entries Vector := v -> entries ambient v#0 / first
 norm Vector := v -> norm v#0
 expression Vector := v -> VectorExpression apply(flatten entries super v#0,expression)
 net Vector := v -> net expression v
+describe Vector := v -> Describe expression FunctionApplication(
+    vector, (describe module v, describe \ flatten entries matrix v))
 toExternalString Vector :=
 toString Vector := v -> toString expression v
 texMath Vector := v -> texMath expression v

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -68,6 +68,7 @@ vector Matrix := f -> (
      new target f from {f}
     )
 vector List := v -> vector matrix apply(splice v, i -> {i});
+vector RingElement := vector Number := x -> vector {x}
 
 -----------------------------------------------------------------------------
 

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -81,7 +81,7 @@ expression Vector := v -> VectorExpression apply(flatten entries super v#0,expre
 net Vector := v -> net expression v
 describe Vector := v -> Describe expression FunctionApplication(
     vector, (describe module v, describe \ flatten entries matrix v))
-toExternalString Vector :=
+toExternalString Vector := toString @@ describe
 toString Vector := v -> toString expression v
 texMath Vector := v -> texMath expression v
 --html Vector := v -> html expression v

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -45,7 +45,6 @@ undocumented {
     (symbol*,  ZZ, ChainComplexMap),
     (symbol*,  Expression, OneExpression),
     (symbol*,  OneExpression, Expression),
-    (symbol*,  Number, Vector)
     }
 
      
@@ -110,7 +109,10 @@ document {
     (symbol*,  Thing, List),
     (symbol*,  ZZ, ProjectiveHilbertPolynomial),
     (symbol*,  ProjectiveHilbertPolynomial, ZZ),
-    (symbol*,  RingElement, Vector)
+    (symbol*,  RingElement, Vector),
+    (symbol*,  Number, Vector),
+    (symbol*,  Vector, RingElement),
+    (symbol*,  Vector, Number)
 	  },
      Headline => "a binary operator, usually used for multiplication",
      Usage => "x * y",

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -234,6 +234,7 @@ document {
 	  (symbol +, InfiniteNumber, Number),
 	  (symbol +, GradedModuleMap, RingElement),
 	  (symbol +, Number, Matrix),
+	  (symbol +, Vector),
 	  (symbol +, Vector, Vector),
 	  (symbol +, Matrix, RingElement),
 	  (symbol +, RingElement, Matrix),

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_module.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_module.m2
@@ -52,13 +52,63 @@ document {
      PARA{},
      SeeAlso => {"generators","subquotient"}}
 
-document {
-     Key => {vector,(vector,List),(vector,Matrix)},
-     Headline => "make a vector",
-     TT "vector {a,b,c,...}", " -- produces an element of a free module from a list.",
-     PARA{},
-     "The elements a,b,c,... must be elements of the same ring, or be
-     convertible to elements of the same ring."}
+doc ///
+  Key
+    vector
+    (vector, Module, List)
+    (vector, Module, Matrix)
+    (vector, Module, Number)
+    (vector, Module, RingElement)
+    (vector, List)
+    (vector, Matrix)
+    (vector, Number)
+    (vector, RingElement)
+  Headline
+    make a vector
+  Usage
+    vector(M, x)
+    vector x
+  Inputs
+    M:Module
+    x:{List, Matrix, Number, RingElement}
+  Outputs
+    :Vector
+  Description
+    Text
+      For any $R$-module $M$, there exists an isomorphism between
+      $\operatorname{Hom}(R,M)$ and $M$ given by $f\mapsto f(1)$.
+      Therefore, internally all @TO Vector@ objects representing
+      elements of $M$ correspond to matrices with source $R^1$ and
+      target $M$.  A vector may be constructed from such a matrix using
+      @SAMP "vector"@.
+    Example
+      R = QQ[x,y,z]
+      f = matrix {{x}, {y}, {z}}
+      vector f
+    Text
+      Alternatively, $M$ may be specified if it differs from the target
+      of the matrix.
+    Example
+      g = matrix {{1}, {2}, {3}}
+      vector(R^3, g)
+    Text
+      If the matrix would have only one element, then that element may be
+      given instead.  If the module is not provided, then the result will
+      be an element of the free module of rank one of the ring of the given
+      element.
+    Example
+      vector 2
+      vector x
+      vector(R^1, 2)
+    Text
+      Alternatively, a list of elements may be provided.  If the module is
+      not specified, then the vector will be an element of a free module over
+      a ring containing all the elements of the list.
+    Example
+      vector {1, 2, 3}
+      vector {1, x, y}
+      vector(R^3, {1, 2, 3})
+///
 
 document {
      Key => {super,(super, GradedModule),(super, CoherentSheaf),(super, Matrix),(super, Module),(super,Vector)},

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/describe-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/describe-doc.m2
@@ -18,6 +18,7 @@ Node
     (describe, QuotientRing)
     (describe, RingMap)
     (describe, Thing)
+    (describe, Vector)
   Headline
     real description
   Usage

--- a/M2/Macaulay2/packages/Macaulay2Doc/types.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/types.m2
@@ -791,8 +791,8 @@ document {
 
 document {
      Key => Vector,
-     Headline => "the class of all elements of free modules that are handled by the engine",
-     "If ", TT "R", " is a ring handled by the engine, and ", TT "M", " is a free
+     Headline => "the class of all elements of modules that are handled by the engine",
+     "If ", TT "R", " is a ring handled by the engine, and ", TT "M", " is a
      module over ", TT "R", ", then M is a subclass of Vector.",
      PARA{},
      SeeAlso => {"engine", "Module"}}

--- a/M2/Macaulay2/tests/normal/vector.m2
+++ b/M2/Macaulay2/tests/normal/vector.m2
@@ -1,0 +1,25 @@
+-- constructor methods
+assert Equation(vector 1, vector matrix {{1}})
+assert Equation(vector {1, 2, 3}, vector matrix {{1}, {2}, {3}})
+
+R = QQ[x,y,z]
+assert Equation(vector x, vector matrix {{x}})
+assert Equation(vector {x, y, z}, vector matrix {{x}, {y}, {z}})
+
+M = image transpose vars R
+assert Equation(vector(M, 1), vector map(M,, {{1}}))
+
+N = image vars R
+v = vector(N, {1, 2, 3})
+w = vector(N, {4, 5, 6})
+assert Equation(v, vector map(N,, {{1}, {2}, {3}}))
+
+-- module operations
+assert Equation(+v, v)
+assert Equation(v + w, vector(N, {5, 7, 9}))
+assert Equation(-v, vector(N, {-1, -2, -3}))
+assert Equation(v - w, vector(N, {-3, -3, -3}))
+assert Equation(2 * v, vector(N, {2, 4, 6}))
+assert Equation(x * v, vector map(N, R^{-1}, {{x}, {2*x}, {3*x}}))
+assert Equation(v * 2, vector(N, {2, 4, 6}))
+assert Equation(v * x, vector map(N, R^{-1}, {{x}, {2*x}, {3*x}}))


### PR DESCRIPTION
Previously, if we wanted a `Vector` object from some non-free module, we'd need to use `new` and build a matrix:

```m2
i1 : R = QQ[x,y,z,w];

i2 : M = (comodule monomialCurveIdeal(R, {1,2,3}))^3;

i3 : new M from map(M, R^1, {{z^2}, {y*z}, {y^2}})

o3 = | yw |
     | xw |
     | xz |

o3 : cokernel | z2-yw yz-xw y2-xz 0     0     0     0     0     0     |
              | 0     0     0     z2-yw yz-xw y2-xz 0     0     0     |
              | 0     0     0     0     0     0     z2-yw yz-xw y2-xz |
```

This PR gives us an easier way to do this, similar to how `vector(List)` works for free modules:

```m2
i1 : R = QQ[x,y,z,w];

i2 : M = (comodule monomialCurveIdeal(R, {1,2,3}))^3;

i3 : M {z^2, y*z, y^2}

o3 = | yw |
     | xw |
     | xz |

o3 : cokernel | z2-yw yz-xw y2-xz 0     0     0     0     0     0     |
              | 0     0     0     z2-yw yz-xw y2-xz 0     0     0     |
              | 0     0     0     0     0     0     z2-yw yz-xw y2-xz |

```

We also add a few other vector operations (like right scalar multiplication and unary `+`).  Keeping this as a draft for now until I can add unit tests and docs.