### PR TITLE
Include modules assigned to global variables in Matrix#AfterPrint

### DIFF
--- a/M2/Macaulay2/m2/chaincomplexes.m2
+++ b/M2/Macaulay2/m2/chaincomplexes.m2
@@ -124,7 +124,8 @@ net ChainComplex := C -> (
      else (
 	  a := s#0;
 	  b := s#-1;
-	  horizontalJoin between(" <-- ", apply(a .. b,i -> stack (net C_i," ",net i)))))
+	  horizontalJoin between(" <-- ", apply(a .. b,i ->
+		  stack (net moduleAbbrv(C_i, C_i)," ",net i)))))
 
 texMath ChainComplex := C -> (
      complete C;

--- a/M2/Macaulay2/m2/chaincomplexes.m2
+++ b/M2/Macaulay2/m2/chaincomplexes.m2
@@ -133,7 +133,7 @@ texMath ChainComplex := C -> (
      if # s === 0 then "0" else
      concatenate apply(s,i->(
 	     if i>s#0 then "\\,\\xleftarrow{" | texMath short C.dd_i | "}\\,",
-	     texUnder(texMath C_i,i)
+	     texUnder(texMath moduleAbbrv(C_i, C_i),i)
 	     ))
       )
 

--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -1282,7 +1282,7 @@ toString'(Function, MapExpression) := (fmt,x) -> toString'(fmt,new FunctionAppli
 lineOnTop := (s) -> concatenate(width s : "-") || s
 net MapExpression := x-> if #x>2 then horizontalJoin(net x#0, " <--",
 		    lineOnTop net x#2,
-		    "-- ", net x#1) else net x#0 | " <--- " | net x#1
+		    "-- ", net x#1) else net x#0 | " <-- " | net x#1
 texMath MapExpression := x -> texMath x#0 | "\\," | (if #x>2 then "\\xleftarrow{" | texMath x#2 | "}" else "\\longleftarrow ") | "\\," | texMath x#1
 expressionValue MapExpression := x -> map toSequence apply(x,expressionValue)
 

--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -397,10 +397,12 @@ Number ** RingElement :=
 RingElement ** Number := 
 RingElement ** RingElement := (r,s) -> matrix {{r}} ** matrix {{s}}
 
--- Matrix#AfterPrint = Matrix#AfterNoPrint = f -> (class f, " ", new MapExpression from {target f,source f})
 Matrix#AfterPrint = Matrix#AfterNoPrint = f -> (
     class f,
-    if isFreeModule target f and isFreeModule source f then  (" ", new MapExpression from {target f,source f})
+    (
+	(tar, src) := apply((target f, source f), M -> moduleAbbrv(M, null));
+	if tar =!= null and src =!= null
+	then (" ", new MapExpression from expression \ {tar, src}))
     )
 
 -- precedence Matrix := x -> precedence symbol x

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -82,6 +82,14 @@ toExternalString Vector :=
 toString Vector := v -> toString expression v
 texMath Vector := v -> texMath expression v
 --html Vector := v -> html expression v
+
+-- helper for Matrix#AfterPrint
+moduleAbbrv = (M, abbrv) -> (
+    if isFreeModule M then M
+    else if hasAttribute(M, ReverseDictionary)
+    then getAttribute(M, ReverseDictionary)
+    else abbrv)
+
 ring Vector := v -> ring class v
 module Vector := v -> target v#0
 leadTerm Vector := v -> new class v from leadTerm v#0

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -83,12 +83,14 @@ toString Vector := v -> toString expression v
 texMath Vector := v -> texMath expression v
 --html Vector := v -> html expression v
 
--- helper for Matrix#AfterPrint
+-- helper for Matrix#AfterPrint and Vector#AfterPrint
 moduleAbbrv = (M, abbrv) -> (
     if isFreeModule M then M
     else if hasAttribute(M, ReverseDictionary)
     then getAttribute(M, ReverseDictionary)
     else abbrv)
+
+Vector#AfterPrint = v -> moduleAbbrv(module v, Vector)
 
 ring Vector := v -> ring class v
 module Vector := v -> target v#0

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -409,6 +409,7 @@ Complex#id = (C) -> (
     result
     )
 
+importFrom(Core, {"moduleAbbrv"})
 net Complex := C -> (
      (lo,hi) := C.concentration;
      if lo > hi then 
@@ -419,7 +420,7 @@ net Complex := C -> (
      else
          horizontalJoin between(" <-- ", 
              for i from lo to hi list
-                 stack (net C_i, " ", net i))
+                 stack (net moduleAbbrv(C_i, C_i), " ", net i))
      )
 
 texUnder := (x,y) -> "\\underset{\\vphantom{\\Bigg|}"|y|"}{"|x|"}"

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -456,12 +456,12 @@ texMath Complex := String => C -> (
     else (
         concatenate for i from lo to hi list (
             if i === lo then 
-                texUnder(texMath C_i,i) 
+                texUnder(texMath moduleAbbrv(C_i, C_i),i) 
             else (
                 "\\,\\xleftarrow{\\scriptsize " 
                 | texMatrixShort dd^C_i 
                 | "}\\," 
-                | texUnder(texMath C_i,i)
+                | texUnder(texMath moduleAbbrv(C_i, C_i),i)
                 )
             )
         )

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview_modules.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview_modules.m2
@@ -458,9 +458,10 @@ document {
      "Notice that as is usual in Macaulay2, the target comes before the source.",
      PARA{},
      "Macaulay2 doesn't display the source and target, unless they are both free
-     modules.  Use ", TO target, " and ", TO source, " to get them.  The ",
-     TO matrix, " routine recovers the matrix of free modules between the
-     generators of the source and target.",
+     modules or have been assigned to global variables.  Use ", TO target,
+     " and ", TO source, " to get them.  The ", TO matrix,
+     " routine recovers the matrix of free modules between the generators of the
+     source and target.",
      EXAMPLE {
 	  "source F",
 	  "target F == R^1",

--- a/M2/Macaulay2/tests/ComputationsBook/completeIntersections/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/completeIntersections/test.out.expected
@@ -12,8 +12,8 @@ i3 : U = matrix {{w,x},{y,z}}
 o3 = | w x |
      | y z |
 
-             2       2
-o3 : Matrix A  <--- A
+             2      2
+o3 : Matrix A  <-- A
 
 i4 : C = chainComplex U
 
@@ -60,8 +60,8 @@ i10 : V = s_0
 o10 = {1} | z  -x |
       {1} | -y w  |
 
-              2       2
-o10 : Matrix A  <--- A
+              2      2
+o10 : Matrix A  <-- A
 
 i11 : A = QQ[x,y,z];
 
@@ -94,8 +94,8 @@ i19 : C = res L;
 
 i20 : U = C.dd_1;
 
-              9       9
-o20 : Matrix A  <--- A
+              9      9
+o20 : Matrix A  <-- A
 
 i21 : print U
 {4} | x2 0  -2yz+5z2 0     y2-5/2yz yz-5/2z2 -5/2yz   0        0      |
@@ -112,8 +112,8 @@ i22 : s = nullhomotopy (-f * id_C);
 
 i23 : V = s_0;
 
-              9       9
-o23 : Matrix A  <--- A
+              9      9
+o23 : Matrix A  <-- A
 
 i24 : print V
 {6} | -x  0  0   -3y2 -2yz+5z2 0         -2y2+5yz 0         0         |
@@ -153,13 +153,13 @@ i28 : time (U,V) = matrixFactorization(B^1/m^3);
 
 i29 : U;
 
-              15       15
-o29 : Matrix A   <--- A
+              15      15
+o29 : Matrix A   <-- A
 
 i30 : V;
 
-              15       15
-o30 : Matrix A   <--- A
+              15      15
+o30 : Matrix A   <-- A
 
 i31 : F.dd_3 - F.dd_5 == 0
 
@@ -287,8 +287,8 @@ o60 = {2, 2}  | X_1 |
       {0, -1} | x   |
       {0, -1} | y   |
 
-              4       1
-o60 : Matrix S  <--- S
+              4      1
+o60 : Matrix S  <-- S
 
 i61 : trim J
 
@@ -451,8 +451,8 @@ o72 = | -28x2-31xy-24y2-4xz-49yz-19z2  -44x2y-4xy2-49y3+30x2z-51xyz+51y2z+23xz2-
       | 47x2-6xy-49y2+9xz+47yz-25z2    16x2y-9xy2-31y3+34x2z-2xyz-16y2z-23xz2+14yz2+50z3   |
       | -36x2-44xy-18y2+11xz-18yz+21z2 -36x2y+28xy2-21y3-x2z-8xyz+6y2z+37xz2+27yz2+43z3    |
 
-              3       2
-o72 : Matrix B  <--- B
+              3      2
+o72 : Matrix B  <-- B
 
 i73 : f_{1}
 
@@ -460,13 +460,13 @@ o73 = | -44x2y-4xy2-49y3+30x2z-51xyz+51y2z+23xz2-19yz2+42z3 |
       | 16x2y-9xy2-31y3+34x2z-2xyz-16y2z-23xz2+14yz2+50z3   |
       | -36x2y+28xy2-21y3-x2z-8xyz+6y2z+37xz2+27yz2+43z3    |
 
-              3       1
-o73 : Matrix B  <--- B
+              3      1
+o73 : Matrix B  <-- B
 
 i74 : M = cokernel f;
 
 i75 : time P = Ext(M,B^1/(x,y,z));
-     -- used 0.196473 seconds
+     -- used 0.332459 seconds
 
 i76 : S = ring P;
 
@@ -479,8 +479,8 @@ o77 = {2, 3}  | X_1 |
       {0, -1} | y   |
       {0, -1} | z   |
 
-              6       1
-o77 : Matrix S  <--- S
+              6      1
+o77 : Matrix S  <-- S
 
 i78 : R = K[X_1..X_3,Degrees => {{-2,-3},{-2,-4},{-2,-5}}];
 
@@ -489,7 +489,7 @@ i79 : phi = map(R,S,{X_1,X_2,X_3,0,0,0})
 o79 = map (R, S, {X , X , X , 0, 0, 0})
                    1   2   3
 
-o79 : RingMap R <--- S
+o79 : RingMap R <-- S
 
 i80 : P = prune (phi ** P);
 
@@ -499,8 +499,8 @@ o81 = {2, 3} | X_1 |
       {2, 4} | X_2 |
       {2, 5} | X_3 |
 
-              3       1
-o81 : Matrix R  <--- R
+              3      1
+o81 : Matrix R  <-- R
 
 i82 : evenPart P
 
@@ -733,7 +733,7 @@ i109 : psi = map(K,B)
 
 o109 = map (K, B, {0, 0, 0})
 
-o109 : RingMap K <--- B
+o109 : RingMap K <-- B
 
 i110 : apply(10, i -> rank (psi ** Ext^i(M,coker vars B)))
 

--- a/M2/Macaulay2/tests/ComputationsBook/constructions/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/constructions/test.out.expected
@@ -311,8 +311,8 @@ i32 : time b=randomModule2ForDeg17CY(8,R);
      -- Trial n. 759, k=8
      -- used 12.3878 seconds
 
-              3       16
-o32 : Matrix R  <--- R
+              3      16
+o32 : Matrix R  <-- R
 
 i33 : betti res coker b
 
@@ -343,8 +343,8 @@ o37 = true
 
 i38 : n=finalTest#1;
 
-              16       16
-o38 : Matrix R   <--- R
+              16      16
+o38 : Matrix R   <-- R
 
 i39 : betti (nn=syz n)
 
@@ -358,13 +358,13 @@ o39 : BettiTally
 
 i40 : n2t=transpose submatrix(nn,{0..15},{3});
 
-              1       16
-o40 : Matrix R  <--- R
+              1      16
+o40 : Matrix R  <-- R
 
 i41 : b2:=syz b;
 
-              16       36
-o41 : Matrix R   <--- R
+              16      36
+o41 : Matrix R   <-- R
 
 i42 : j:=ideal mingens ideal flatten(n2t*b2);
 

--- a/M2/Macaulay2/tests/ComputationsBook/d-modules/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/d-modules/test.out.expected
@@ -147,29 +147,29 @@ i23 : ann2 = relations Dlocalize(R,f)
 
 o23 = | wDz-zDw wDy-yDw zDy-yDz wDx-xDw zDx-xDz yDx-xDy -xDx-yDy-zDz-wDw-4 |
 
-              1       7
-o23 : Matrix D  <--- D
+              1      7
+o23 : Matrix D  <-- D
 
 i24 : F = matrix{{f}}
 
 o24 = | x2+y2+z2+w2 |
 
-              1       1
-o24 : Matrix D  <--- D
+              1      1
+o24 : Matrix D  <-- D
 
 i25 : ann1 = gens gb modulo(F,ann2)
 
 o25 = {2} | wDz-zDw wDy-yDw zDy-yDz Dx^2+Dy^2+Dz^2+Dw^2 wDx-xDw zDx-xDz yDx-xDy xDx+yDy+zDz+wDw+2 x2Dw+y2Dw+z2Dw+w2Dw+2w x2Dz+y2Dz+z2Dz+zwDw+2z x2Dy+y2Dy+yzDz+ywDw+2y |
 
-              1       11
-o25 : Matrix D  <--- D
+              1      11
+o25 : Matrix D  <-- D
 
 i26 : gens gb((ideal ann2) + (ideal F))
 
 o26 = | w z y x |
 
-              1       4
-o26 : Matrix D  <--- D
+              1      4
+o26 : Matrix D  <-- D
 
 i27 : D = QQ[x,y,z,Dx,Dy,Dz, WeylAlgebra => {x=>Dx, y=>Dy, z=>Dz}];
 
@@ -278,8 +278,8 @@ i45 : JH3gb=gens gb JH3
 
 o45 = | w z uDu+vDv+3 xDu+yDv yDy+vDv+3 xDy+uDv uDx+vDy yDx+vDu xDx-vDv v2 uv yv u2 yu+xv xu y2 xy x2 xvDv+2x vDyDu-vDxDv-2Dx |
 
-              1       20
-o45 : Matrix D  <--- D
+              1      20
+o45 : Matrix D  <-- D
 
 i46 : testmTorsion = method();
 
@@ -343,8 +343,8 @@ i60 : IH3gb=gens gb IH3
 
 o60 = | 1 |
 
-              1       1
-o60 : Matrix D  <--- D
+              1      1
+o60 : Matrix D  <-- D
 
 i61 : findSocle = method();
 

--- a/M2/Macaulay2/tests/ComputationsBook/exterior-algebra/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/exterior-algebra/test.out.expected
@@ -23,8 +23,8 @@ i5 : M=coker matrix{{x_0^2, x_1^2}};
 
 i6 : m=presentation truncate(regularity M,M);
 
-             4       8
-o6 : Matrix S  <--- S
+             4      8
+o6 : Matrix S  <-- S
 
 i7 : symExt(m,E)
 
@@ -33,8 +33,8 @@ o7 = {-1} | e_2 0   0   0   |
      {-1} | e_0 0   e_2 0   |
      {-1} | 0   e_0 e_1 e_2 |
 
-             4       4
-o7 : Matrix E  <--- E
+             4      4
+o7 : Matrix E  <-- E
 
 i8 : bgg = (i,M,E) ->(
           S :=ring(M);
@@ -56,8 +56,8 @@ o10 = {-2} | e_1 e_0 0   |
       {-2} | e_2 0   e_0 |
       {-2} | 0   e_2 e_1 |
 
-              3       3
-o10 : Matrix E  <--- E
+              3      3
+o10 : Matrix E  <-- E
 
 i11 : tateResolution = (m,E,loDeg,hiDeg)->(
            M := coker m;
@@ -73,8 +73,8 @@ i11 : tateResolution = (m,E,loDeg,hiDeg)->(
 
 i12 : m = matrix{{x_0,x_1}};
 
-              1       2
-o12 : Matrix S  <--- S
+              1      2
+o12 : Matrix S  <-- S
 
 i13 : regularity coker m
 
@@ -101,8 +101,8 @@ i16 : T.dd_1
 
 o16 = {-4} | e_2 |
 
-              1       1
-o16 : Matrix E  <--- E
+              1      1
+o16 : Matrix E  <-- E
 
 i17 : sheafCohomology = (m,E,loDeg,hiDeg)->(
            T := tateResolution(m,E,loDeg,hiDeg);
@@ -118,8 +118,8 @@ i19 : E=ZZ/32003[e_0..e_3,SkewCommutative=>true];
 
 i20 : m=koszul(3,vars S);
 
-              6       4
-o20 : Matrix S  <--- S
+              6      4
+o20 : Matrix S  <-- S
 
 i21 : regularity coker m
 
@@ -166,8 +166,8 @@ o28 = {1} | -x_1 -x_2 0    |
       {1} | x_0  0    -x_2 |
       {1} | 0    x_0  x_1  |
 
-              3       3
-o28 : Matrix S  <--- S
+              3      3
+o28 : Matrix S  <-- S
 
 i29 : alpha = map(U ++ U, S^{-1}, transpose{{0,-1,0,1,0,0}});
 
@@ -204,15 +204,15 @@ o36 = {1} | -x_1 -x_2 0    -x_3 0    0    |
       {1} | 0    x_0  x_1  0    0    -x_3 |
       {1} | 0    0    0    x_0  x_1  x_2  |
 
-              4       6
-o36 : Matrix S  <--- S
+              4      6
+o36 : Matrix S  <-- S
 
 i37 : sortedBasis(2,E)
 
 o37 = | e_0e_1 e_0e_2 e_1e_2 e_0e_3 e_1e_3 e_2e_3 |
 
-              1       6
-o37 : Matrix E  <--- E
+              1      6
+o37 : Matrix E  <-- E
 
 i38 : beilinson1=(e,dege,i,S)->(
            E := ring e;
@@ -237,8 +237,8 @@ o39 = {-3} | 0  |
       {-3} | -1 |
       {-3} | 0  |
 
-              4       1
-o39 : Matrix S  <--- S
+              4      1
+o39 : Matrix S  <-- S
 
 i40 : beilinson1(e_1,1,2,S)
 
@@ -249,15 +249,15 @@ o40 = {-2} | 0 0 0 0  |
       {-2} | 0 0 0 0  |
       {-2} | 0 0 0 -1 |
 
-              6       4
-o40 : Matrix S  <--- S
+              6      4
+o40 : Matrix S  <-- S
 
 i41 : beilinson1(e_1,1,1,S)
 
 o41 = | x_0 0 -x_2 0 -x_3 0 |
 
-              1       6
-o41 : Matrix S  <--- S
+              1      6
+o41 : Matrix S  <-- S
 
 i42 : U = (i,S) -> (
            if i < 0 or i >= numgens S then S^0
@@ -285,16 +285,16 @@ i46 : alphad = map(E^1,E^{-1,-1},{{e_1,e_2}})
 
 o46 = | e_1 e_2 |
 
-              1       2
-o46 : Matrix E  <--- E
+              1      2
+o46 : Matrix E  <-- E
 
 i47 : alpha = map(E^{-1,-1},E^{-2},{{e_1},{e_2}})
 
 o47 = {1} | e_1 |
       {1} | e_2 |
 
-              2       1
-o47 : Matrix E  <--- E
+              2      1
+o47 : Matrix E  <-- E
 
 i48 : alphad=beilinson(alphad,S);
 
@@ -323,16 +323,16 @@ i54 : beta=map(E^1,E^{-2,-1},{{e_0*e_2+e_1*e_3,-e_4}})
 
 o54 = | e_0e_2+e_1e_3 -e_4 |
 
-              1       2
-o54 : Matrix E  <--- E
+              1      2
+o54 : Matrix E  <-- E
 
 i55 : alpha=map(E^{-2,-1},E^{-3},{{e_4},{e_0*e_2+e_1*e_3}})
 
 o55 = {2} | e_4           |
       {1} | e_0e_2+e_1e_3 |
 
-              2       1
-o55 : Matrix E  <--- E
+              2      1
+o55 : Matrix E  <-- E
 
 i56 : beta=beilinson(beta,S);
 
@@ -355,8 +355,8 @@ o59 : BettiTally
 
 i60 : foursect = random(S^4, S^10) * presentation G;
 
-              4       9
-o60 : Matrix S  <--- S
+              4      9
+o60 : Matrix S  <-- S
 
 i61 : IX = trim minors(4,foursect);
 
@@ -378,8 +378,8 @@ i65 : alphad = matrix{{e_4*e_1, e_2*e_3},{e_0*e_2, e_3*e_4},
                       {e_1*e_3, e_4*e_0},{e_2*e_4, e_0*e_1},
                       {e_3*e_0, e_1*e_2}};
 
-              5       2
-o65 : Matrix E  <--- E
+              5      2
+o65 : Matrix E  <-- E
 
 i66 : alphad=map(E^5,E^{-2,-2},alphad)
 
@@ -389,16 +389,16 @@ o66 = | -e_1e_4 e_2e_3  |
       | e_2e_4  e_0e_1  |
       | -e_0e_3 e_1e_2  |
 
-              5       2
-o66 : Matrix E  <--- E
+              5      2
+o66 : Matrix E  <-- E
 
 i67 : alpha=syz alphad
 
 o67 = {2} | e_0e_1  e_2e_3 e_0e_4 e_1e_2 -e_3e_4 |
       {2} | -e_2e_4 e_1e_4 e_1e_3 e_0e_3 e_0e_2  |
 
-              2       5
-o67 : Matrix E  <--- E
+              2      5
+o67 : Matrix E  <-- E
 
 i68 : alphad=beilinson(alphad,S);
 
@@ -442,13 +442,13 @@ i74 : -- presentation FHM has the basis elements in the reverse order now
 
 o74 = | 5576 4983 5586 -2697 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 |
 
-              1       19
-o74 : Matrix S  <--- S
+              1      19
+o74 : Matrix S  <-- S
 
 i75 : mapcone = sect || transpose presentation FHM;
 
-              36       19
-o75 : Matrix S   <--- S
+              36      19
+o75 : Matrix S   <-- S
 
 i76 : fmapcone = res coker mapcone;
 

--- a/M2/Macaulay2/tests/ComputationsBook/geometry/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/geometry/test.out.expected
@@ -22,7 +22,7 @@ i4 : cubicMap = map(ringP1,ringP3,{s^3, s^2*t, s*t^2, t^3})
                             3   2      2   3
 o4 = map (ringP1, ringP3, {s , s t, s*t , t })
 
-o4 : RingMap ringP1 <--- ringP3
+o4 : RingMap ringP1 <-- ringP3
 
 i5 : idealCubic = kernel cubicMap
 
@@ -45,8 +45,8 @@ i7 : M = matrix{{x_0,x_1,x_2},{x_1,x_2,x_3}}
 o7 = | x_0 x_1 x_2 |
      | x_1 x_2 x_3 |
 
-                  2            3
-o7 : Matrix ringP3  <--- ringP3
+                  2           3
+o7 : Matrix ringP3  <-- ringP3
 
 i8 : idealCubic3 = minors(2, M)
 
@@ -72,8 +72,8 @@ i12 : gens idealCubic
 
 o12 = | x_2^2-x_1x_3 x_1x_2-x_0x_3 x_1^2-x_0x_2 |
 
-                   1            3
-o12 : Matrix ringP3  <--- ringP3
+                   1           3
+o12 : Matrix ringP3  <-- ringP3
 
 i13 : 0 == (gens idealCubic)%(gens idealCubic3)
 
@@ -87,8 +87,8 @@ i15 : f = vars ringP3
 
 o15 = | x_0 x_1 x_2 x_3 |
 
-                   1            4
-o15 : Matrix ringP3  <--- ringP3
+                   1           4
+o15 : Matrix ringP3  <-- ringP3
 
 i16 : OmegaP3 = kernel f
 
@@ -107,8 +107,8 @@ o17 = {1} | -x_1 0    -x_2 0    0    -x_3 |
       {1} | 0    x_1  x_0  -x_3 0    0    |
       {1} | 0    0    0    x_2  x_1  x_0  |
 
-                   4            6
-o17 : Matrix ringP3  <--- ringP3
+                   4           6
+o17 : Matrix ringP3  <-- ringP3
 
 i18 : OmegaP3=image g
 
@@ -129,8 +129,8 @@ o19 = {2} | x_2  0    0    x_3  |
       {2} | 0    -x_2 0    x_0  |
       {2} | 0    0    -x_2 -x_1 |
 
-                   6            4
-o19 : Matrix ringP3  <--- ringP3
+                   6           4
+o19 : Matrix ringP3  <-- ringP3
 
 i20 : G = res coker f
 
@@ -183,8 +183,8 @@ o22 = {1} | -x_1 -x_2 0    -x_3 0    0    |
       {1} | 0    x_0  x_1  0    0    -x_3 |
       {1} | 0    0    0    x_0  x_1  x_2  |
 
-                   4            6
-o22 : Matrix ringP3  <--- ringP3
+                   4           6
+o22 : Matrix ringP3  <-- ringP3
 
 i23 : degrees source G.dd_2
 
@@ -211,8 +211,8 @@ i26 : m = matrix{{x_0^3, x_1^2, x_2,x_3},{x_1^3,x_2^2,x_3,0}}
 o26 = | x_0^3 x_1^2 x_2 x_3 |
       | x_1^3 x_2^2 x_3 0   |
 
-                   2            4
-o26 : Matrix ringP3  <--- ringP3
+                   2           4
+o26 : Matrix ringP3  <-- ringP3
 
 i27 : I = minors(2,m)
 
@@ -268,8 +268,8 @@ o32 = {1} | 0    -x_3 -x_2 |
       {1} | 2x_2 x_1  -x_0 |
       {1} | -x_1 -x_0 0    |
 
-                   4            3
-o32 : Matrix ringP3  <--- ringP3
+                   4           3
+o32 : Matrix ringP3  <-- ringP3
 
 i33 : delta2 = delta1 // (gens OmegaP3res)
 
@@ -283,8 +283,8 @@ o33 = {2} | 0  1  0  |
       {2} | -1 0  0  |
       {2} | 0  -1 0  |
 
-                   9            3
-o33 : Matrix ringP3  <--- ringP3
+                   9           3
+o33 : Matrix ringP3  <-- ringP3
 
 i34 : delta = map(OmegaP3res, module idealCubic, delta2)
 
@@ -657,13 +657,14 @@ i86 : g = homomorphism dualModule_{0}
 
 o86 = | x_0+15871x_5 5836x_4 x_2-2813x_5 |
 
-o86 : Matrix
+o86 : Matrix OS <-- L
 
 i87 : toP2 = g*basis(0,L)
 
 o87 = | x_0+15871x_5 5836x_4 x_2-2813x_5 |
 
-o87 : Matrix
+                          3
+o87 : Matrix OS <-- ringP5
 
 i88 : ringXcan = ringP5/idealXcan
 

--- a/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/test.out.expected
@@ -374,8 +374,8 @@ i51 : A = matrix{{1,1,1,1,1},{1,2,4,5,6}}
 o51 = | 1 1 1 1 1 |
       | 1 2 4 5 6 |
 
-               2        5
-o51 : Matrix ZZ  <--- ZZ
+               2       5
+o51 : Matrix ZZ  <-- ZZ
 
 i52 : w1 = {1,1,1,1,1};
 
@@ -386,44 +386,44 @@ i54 : b1 = transpose matrix{{3,9}}
 o54 = | 3 |
       | 9 |
 
-               2        1
-o54 : Matrix ZZ  <--- ZZ
+               2       1
+o54 : Matrix ZZ  <-- ZZ
 
 i55 : b2 = transpose matrix{{5,16}}
 
 o55 = | 5  |
       | 16 |
 
-               2        1
-o55 : Matrix ZZ  <--- ZZ
+               2       1
+o55 : Matrix ZZ  <-- ZZ
 
 i56 : IP(A, w1, b1)
 
 o56 = | 1 1 0 0 1 |
 
-               1        5
-o56 : Matrix ZZ  <--- ZZ
+               1       5
+o56 : Matrix ZZ  <-- ZZ
 
 i57 : IP(A, w2, b1)
 
 o57 = | 1 0 2 0 0 |
 
-               1        5
-o57 : Matrix ZZ  <--- ZZ
+               1       5
+o57 : Matrix ZZ  <-- ZZ
 
 i58 : IP(A, w1, b2)
 
 o58 = | 2 1 0 0 2 |
 
-               1        5
-o58 : Matrix ZZ  <--- ZZ
+               1       5
+o58 : Matrix ZZ  <-- ZZ
 
 i59 : IP(A, w2, b2)
 
 o59 = | 0 2 3 0 0 |
 
-               1        5
-o59 : Matrix ZZ  <--- ZZ
+               1       5
+o59 : Matrix ZZ  <-- ZZ
 
 i60 : S = QQ[a,b,c,d];
 
@@ -584,8 +584,8 @@ o86 = | x_0 x_1 x_2 |
       | x_1 x_2 x_3 |
       | x_2 x_3 x_4 |
 
-              3       3
-o86 : Matrix S  <--- S
+              3      3
+o86 : Matrix S  <-- S
 
 i87 : rationalQuartic = minors(2, m);
 
@@ -711,8 +711,8 @@ o101 = | 1 1 1 1 1 1 1 |
        | 0 2 0 0 0 1 0 |
        | 2 2 0 2 1 1 1 |
 
-                4        7
-o101 : Matrix ZZ  <--- ZZ
+                4       7
+o101 : Matrix ZZ  <-- ZZ
 
 i102 : IA = toricIdeal(A, {1,1,1,1,1,1,1})
 
@@ -736,7 +736,7 @@ o104 = true
 
 i105 : StoS = map(S, S, {x_1, x_2, x_3, x_3 - x_4, x_5, x_6, x_7});
 
-o105 : RingMap S <--- S
+o105 : RingMap S <-- S
 
 i106 : J = StoS IA
 
@@ -762,8 +762,8 @@ i109 : A = matrix{{2,0,0,1,0,0,2,1,1,3,2,2,2,3,3,3},
                   {0,2,0,0,1,0,1,2,1,2,3,2,3,2,3,3},
                   {0,0,2,0,0,1,1,1,2,2,2,3,3,3,2,3}};
 
-                3        16
-o109 : Matrix ZZ  <--- ZZ
+                3       16
+o109 : Matrix ZZ  <-- ZZ
 
 i110 : D = A^{0}+A^{1}+A^{2} || A
 
@@ -772,8 +772,8 @@ o110 = | 2 2 2 1 1 1 4 4 4 7 7 7 8 8 8 9 |
        | 0 2 0 0 1 0 1 2 1 2 3 2 3 2 3 3 |
        | 0 0 2 0 0 1 1 1 2 2 2 3 3 3 2 3 |
 
-                4        16
-o110 : Matrix ZZ  <--- ZZ
+                4       16
+o110 : Matrix ZZ  <-- ZZ
 
 i111 : D = entries transpose D;
 

--- a/M2/Macaulay2/tests/ComputationsBook/preface/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/preface/test.out.expected
@@ -28,15 +28,15 @@ i5 : b = vars R
 
 o5 = | x y z |
 
-             1       3
-o5 : Matrix R  <--- R
+             1      3
+o5 : Matrix R  <-- R
 
 i6 : c = matrix {{x^2,y^2,z^2}}
 
 o6 = | x2 y2 z2 |
 
-             1       3
-o6 : Matrix R  <--- R
+             1      3
+o6 : Matrix R  <-- R
 
 i7 : M = coker b
 

--- a/M2/Macaulay2/tests/ComputationsBook/programming/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/programming/test.out.expected
@@ -320,8 +320,8 @@ i64 : vars R
 
 o64 = | x y z |
 
-              1       3
-o64 : Matrix R  <--- R
+              1      3
+o64 : Matrix R  <-- R
 
 i65 : toString vars R
 

--- a/M2/Macaulay2/tests/ComputationsBook/schemes/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/schemes/test.out.expected
@@ -32,8 +32,8 @@ o8 = | 0 1 0 |
      | 0 0 1 |
      | 0 0 0 |
 
-             3       3
-o8 : Matrix S  <--- S
+             3      3
+o8 : Matrix S  <-- S
 
 i9 : G = genericMatrix(S, y_0, 3, 3)
 
@@ -41,8 +41,8 @@ o9 = | y_0 y_3 y_6 |
      | y_1 y_4 y_7 |
      | y_2 y_5 y_8 |
 
-             3       3
-o9 : Matrix S  <--- S
+             3      3
+o9 : Matrix S  <-- S
 
 i10 : classicalAdjoint = (G) -> (
            n := degree target G;
@@ -53,15 +53,15 @@ i10 : classicalAdjoint = (G) -> (
 
 i11 : num = G * N3 * classicalAdjoint(G);
 
-              3       3
-o11 : Matrix S  <--- S
+              3      3
+o11 : Matrix S  <-- S
 
 i12 : D = det(G);
 
 i13 : M = genericMatrix(S, a, 3, 3);
 
-              3       3
-o13 : Matrix S  <--- S
+              3      3
+o13 : Matrix S  <-- S
 
 i14 : elimIdeal = minors(1, (D*id_(S^3))*M - num) + ideal(1-D*t);
 
@@ -96,8 +96,8 @@ o21 = {1} | 3x2a+2xyb+y2d+2xzc+yze+z2f |
       {1} | x2b+2xyd+3y2g+xze+2yzh+z2i |
       {1} | x2c+xye+y2h+2xzf+2yzi+3z2j |
 
-              3       1
-o21 : Matrix S  <--- S
+              3      1
+o21 : Matrix S  <-- S
 
 i22 : singularities = ideal(partials) + ideal(F);
 
@@ -119,8 +119,8 @@ o25 = {1} | 3a 2b d  2c e  f  |
       {1} | b  2d 3g e  2h i  |
       {1} | c  e  h  2f 2i 3j |
 
-              3       6
-o25 : Matrix S  <--- S
+              3      6
+o25 : Matrix S  <-- S
 
 i26 : hess = det submatrix(jacobian ideal partials, {0..2}, {0..2});
 
@@ -131,8 +131,8 @@ o27 = {1} | -24c2d+24bce-18ae2-24b2f+72adf               4be2-16bdf-48c2g+144afg
       {1} | 2be2-8bdf-24c2g+72afg+16bch-24aeh-8b2i+24adi 4de2-16d2f-48ceg+48bfg+32cdh-48ah2-16bdi+144agi         -18e2g+24deh-24bh2-24d2i+72bgi                2e3-8def-24cfg-8ceh+24bfh+24cdi-8bei-24ahi-24bdj+216agj -48efg+4e2h+32dfh-16ch2+48cgi-16bhi-48d2j+144bgj        -24f2g+2e2i+16dfi-8chi-8bi2-24dej+72cgj+24bhj |
       {1} | 2ce2-8cdf-8c2h+24afh+16bci-24aei-24b2j+72adj 2e3-8def-24cfg-8ceh+24bfh+24cdi-8bei-24ahi-24bdj+216agj -24efg+2e2h+16dfh-8ch2+24cgi-8bhi-24d2j+72bgj 4e2f-16df2-16cfh+32bfi-48ai2+48cdj-48bej+144ahj         -48f2g+4e2i+32dfi-16chi-16bi2-48dej+144cgj+48bhj        -24f2h+24efi-24ci2-18e2j+72chj                |
 
-              3       6
-o27 : Matrix S  <--- S
+              3      6
+o27 : Matrix S  <-- S
 
 i28 : detDiscr = ideal det (A || B, Strategy=>Cofactor);
 
@@ -346,7 +346,7 @@ i76 : phi = map(PP4, S, matrix{{0_PP4, 0_PP4, 0_PP4}} | vars PP4)
 
 o76 = map (PP4, S, {0, 0, 0, a, b, c, d, e})
 
-o76 : RingMap PP4 <--- S
+o76 : RingMap PP4 <-- S
 
 i77 : surfaceA = phi ideal selectInSubring(1, gens gb I)
 
@@ -368,7 +368,7 @@ i80 : PP2xPP1 = QQ[x, y, z, u, v];
 
 i81 : embed = map(PP2xPP1, R, 0 | vars PP2xPP1);
 
-o81 : RingMap PP2xPP1 <--- R
+o81 : RingMap PP2xPP1 <-- R
 
 i82 : blowUp = PP2xPP1 / embed(blowUpIdeal);
 
@@ -376,7 +376,7 @@ i83 : PP5 = QQ[A .. F];
 
 i84 : segre = map(blowUp, PP5, matrix{{x*u,y*u,z*u,x*v,y*v,z*v}});
 
-o84 : RingMap blowUp <--- PP5
+o84 : RingMap blowUp <-- PP5
 
 i85 : ker segre
 
@@ -389,7 +389,7 @@ i86 : projection = map(PP4, PP5, matrix{{a, c, d, c, b, e}})
 
 o86 = map (PP4, PP5, {a, c, d, c, b, e})
 
-o86 : RingMap PP4 <--- PP5
+o86 : RingMap PP4 <-- PP5
 
 i87 : surfaceB = trim projection ker segre
 
@@ -407,7 +407,7 @@ o88 : Ideal of PP4
 
 i89 : sigma = map( PP4, PP4, matrix{{d, e, a, c, b}});
 
-o89 : RingMap PP4 <--- PP4
+o89 : RingMap PP4 <-- PP4
 
 i90 : surfaceC = sigma determinantal
 
@@ -437,7 +437,7 @@ i96 : R = QQ[t, u, v, A .. H];
 i97 : phi = map(R, PP3, matrix{{t}} | 
               u*matrix{{A, B, C, D}} + v*matrix{{E, F, G, H}});
 
-o97 : RingMap R <--- PP3
+o97 : RingMap R <-- PP3
 
 i98 : imageFamily = phi Q;
 
@@ -447,15 +447,15 @@ i99 : coeffOfFamily = contract(matrix{{u^2,u*v,v^2}}, gens imageFamily)
 
 o99 = | tA2+tB2+tC2+D2 2tAE+2tBF+2tCG+2DH tE2+tF2+tG2+H2 |
 
-              1       3
-o99 : Matrix R  <--- R
+              1      3
+o99 : Matrix R  <-- R
 
 i100 : S = QQ[t, A..H];
 
 i101 : coeffOfFamily = substitute(coeffOfFamily, S);
 
-               1       3
-o101 : Matrix S  <--- S
+               1      3
+o101 : Matrix S  <-- S
 
 i102 : Sbar = S / (ideal coeffOfFamily);
 
@@ -464,8 +464,8 @@ i103 : psi = matrix{{t}} | exteriorPower(2,
 
 o103 = | t -BE+AF -CE+AG -CF+BG -DE+AH -DF+BH -DG+CH |
 
-                  1          7
-o103 : Matrix Sbar  <--- Sbar
+                  1         7
+o103 : Matrix Sbar  <-- Sbar
 
 i104 : PP5 = QQ[t, a..f];
 
@@ -494,8 +494,8 @@ o107 = {-2} | f2       |
        {-2} | ad-cf    |
        {-2} | a2+b2+c2 |
 
-                 11         1
-o107 : Matrix PP5   <--- PP5
+                 11        1
+o107 : Matrix PP5   <-- PP5
 
 i108 : oneFibre = trim substitute(saturate(fanoOfFamily, t), {t => 1})
 

--- a/M2/Macaulay2/tests/ComputationsBook/solving/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/solving/test.out.expected
@@ -239,18 +239,18 @@ i36 : R = QQ[r, y11, y12, y21, y22];
 
 i37 : P = matrix{{0, y11, y12}};
 
-              1       3
-o37 : Matrix R  <--- R
+              1      3
+o37 : Matrix R  <-- R
 
 i38 : V = matrix{{1, y21, y22}};
 
-              1       3
-o38 : Matrix R  <--- R
+              1      3
+o38 : Matrix R  <-- R
 
 i39 : Points = matrix Points ** R;
 
-              5       3
-o39 : Matrix R  <--- R
+              5      3
+o39 : Matrix R  <-- R
 
 i40 : I = ideal apply(0..4, i -> (
                 X := Points^{i};
@@ -336,8 +336,8 @@ o56 = | 1 s s2 s3  s4   s5   |
       | 0 1 2s 3s2 4s3  5s4  |
       | 0 0 2  6s  12s2 20s3 |
 
-                    3             6
-o56 : Matrix (QQ[s])  <--- (QQ[s])
+                    3            6
+o56 : Matrix (QQ[s])  <-- (QQ[s])
 
 i57 : spSchub = (r, L, P) -> (
            I := ideal apply(subsets(numgens source L, 
@@ -567,8 +567,8 @@ i99 : X = 1 | matrix table(2, n-1, (i,j) -> z_(i,j))
 o99 = | 1 0 z_(0,0) z_(0,1) z_(0,2) |
       | 0 1 z_(1,0) z_(1,1) z_(1,2) |
 
-              2       5
-o99 : Matrix R  <--- R
+              2      5
+o99 : Matrix R  <-- R
 
 i100 : I = ideal (apply(1..(2*n-2), 
                       i -> tanQuad(nSphere(V(), r()), X)));

--- a/M2/Macaulay2/tests/ComputationsBook/toricHilbertScheme/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/toricHilbertScheme/test.out.expected
@@ -14,8 +14,8 @@ o4 = | 1 -2 1  0 0 |
      | 0 5  -6 1 0 |
      | 0 6  -7 0 1 |
 
-              3        5
-o4 : Matrix ZZ  <--- ZZ
+              3       5
+o4 : Matrix ZZ  <-- ZZ
 
 i5 : needsPackage "LLLBases"; 
 
@@ -27,8 +27,8 @@ o6 = | 0  1  2  |
      | -1 -1 2  |
      | 1  1  -1 |
 
-              5        3
-o6 : Matrix ZZ  <--- ZZ
+              5       3
+o6 : Matrix ZZ  <-- ZZ
 
 i7 : B = transpose LLL syz matrix A 
 
@@ -36,8 +36,8 @@ o7 = | 0 1  -1 -1 1  |
      | 1 -1 0  -1 1  |
      | 2 0  -3 2  -1 |
 
-              3        5
-o7 : Matrix ZZ  <--- ZZ
+              3       5
+o7 : Matrix ZZ  <-- ZZ
 
 i8 : toBinomial = (b,R) -> (
           top := 1_R; bottom := 1_R;
@@ -78,8 +78,8 @@ o13 = {-2, -9}  | cd-be    |
       {-5, -28} | ad4-c2e3 |
       {-6, -42} | d6-ce5   |
 
-              8       1
-o13 : Matrix R  <--- R
+              8      1
+o13 : Matrix R  <-- R
 
 i14 : graver = (I) -> (
           R := ring I;
@@ -111,8 +111,8 @@ i15 : Graver = graver I
 
 o15 = | -cd+be -bd+ae -b2+ac -cd2+ae2 -a2d2+c3e -c4+a3e -c4+a2bd -bc3+a3d -ad4+c2e3 -abd3+c3e2 -a2d3+bc2e2 -ab2d2+c4e -a3d2+b2c2e -c5+a2b2e -c5+ab3d -b2c3+a4e -b3c2+a4d -d6+ce5 -bd5+c2e4 -ad5+bce4 -b2d4+c3e3 -a2d4+b2ce3 -b3d3+c4e2 -a3d3+b3ce2 -b4d2+c5e -a4d2+b4ce -c6+ab4e -c6+b5d -b4c2+a5e -b5c+a5d -d7+be6 -ad6+b2e5 -a2d5+b3e4 -a3d4+b4e3 -a4d3+b5e2 -a5d2+b6e -c7+b6e -c7+a5d2 -b6c+a6e -b7+a6d -d8+ae7 -b8+a7e |
 
-              1       42
-o15 : Matrix R  <--- R
+              1      42
+o15 : Matrix R  <-- R
 
 i16 : graverFibers = (Graver) -> (
            ProductIdeal := (I) -> ( trim ideal(
@@ -296,8 +296,8 @@ o34 = | 3  2  2  1  1  1  1  1  1  0  0  0  0  0  0  0  |
       | 1  1  2  1  2  3  0  4  -1 1  2  3  4  5  -1 -6 |
       | 0  0  -1 0  -1 -2 0  -3 1  0  -1 -2 -3 -4 1  5  |
 
-               5        16
-o34 : Matrix ZZ  <--- ZZ
+               5       16
+o34 : Matrix ZZ  <-- ZZ
 
 i35 : primitive := (L) -> (
            n := #L-1; g := L#n;
@@ -341,8 +341,8 @@ o42 : Ideal of R
 
 i43 : Graver22 = graver I22;
 
-              1       15
-o43 : Matrix R  <--- R
+              1      15
+o43 : Matrix R  <-- R
 
 i44 : generateAmonos(Graver22);
 
@@ -414,7 +414,7 @@ i53 : G = removeRedundantVariables JM
 o53 = map (B, B, {z , z z , z z z , z z z  , z , z , z z z  , z z , z z z  , z z , z  , z z , z z z  })
                    1   5 6   1 5 6   5 6 11   5   6   5 6 11   5 6   5 6 11   5 6   11   5 6   5 6 11
 
-o53 : RingMap B <--- B
+o53 : RingMap B <-- B
 
 i54 : ideal gens gb(G JM)
 
@@ -434,7 +434,7 @@ i56 : F = map(CX, ring J, matrix{{a,b,c,d,e}} |
 o56 = map (CX, T, {a, b, c, d, e, z , z z , z z z , z z z  , z , z , z z z  , z z , z z z  , z z , z  , z z , z z z  })
                                    1   5 6   1 5 6   5 6 11   5   6   5 6 11   5 6   5 6 11   5 6   11   5 6   5 6 11
 
-o56 : RingMap CX <--- T
+o56 : RingMap CX <-- T
 
 i57 : J1 = F J
 
@@ -487,7 +487,7 @@ o64 : Ideal of B
 
 i65 : G = removeRedundantVariables JM;
 
-o65 : RingMap B <--- B
+o65 : RingMap B <-- B
 
 i66 : toString ideal gens gb(G JM)
 
@@ -501,7 +501,7 @@ o67 : Ideal of B
 
 i68 : GG = removeRedundantVariables K;
 
-o68 : RingMap B <--- B
+o68 : RingMap B <-- B
 
 i69 : ideal gens gb (GG K)
 
@@ -519,8 +519,8 @@ o71 : Ideal of R
 
 i72 : Graver = graver I;
 
-              1       5
-o72 : Matrix R  <--- R
+              1      5
+o72 : Matrix R  <-- R
 
 i73 : fibers = graverFibers Graver;
 
@@ -549,8 +549,8 @@ i78 : S = QQ[a,b,c,d,z];
 
 i79 : zG = z ** substitute(gens G, S);
 
-              1       22
-o79 : Matrix S  <--- S
+              1      22
+o79 : Matrix S  <-- S
 
 i80 : R = QQ[y_1 .. y_22];
 
@@ -559,7 +559,7 @@ i81 : F = map(S,R,zG)
                    5     5    4 3 5    5 3 4    4 2 2 4    3 4   4    2 6 4    4   4 3    3 3 3 3    2 5 2 3      7   3    4 6 2    3 2 5 2    2 4 4 2      6 3 2    8 2 2    3   7      2 3 6        5 5      7 4      2 2 8      4 7    6 6
 o81 = map (S, R, {a b*c*d z, a b d z, a c d z, a b c d z, a b c*d z, a b d z, a b*c d z, a b c d z, a b c d z, a*b c*d z, a c d z, a b c d z, a b c d z, a*b c d z, b c d z, a b*c d*z, a b c d*z, a*b c d*z, b c d*z, a b c z, a*b c z, b c z})
 
-o81 : RingMap S <--- R
+o81 : RingMap S <-- R
 
 i82 : PA = trim ker F
 
@@ -753,8 +753,8 @@ i94 : H = transpose matrix{
       {3,1,2},
       {3,2,1}};
 
-               3        6
-o94 : Matrix ZZ  <--- ZZ
+               3       6
+o94 : Matrix ZZ  <-- ZZ
 
 i95 : P = polarCone H
 
@@ -786,7 +786,7 @@ i99 : F = removeRedundantVariables I
                    8       4   2
 o99 = map (A, A, {d  + 1, d , d , d, e})
 
-o99 : RingMap A <--- A
+o99 : RingMap A <-- A
 
 i100 : I1 = ideal gens gb(F I)
 

--- a/M2/Macaulay2/tests/ComputationsBook/varieties/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/varieties/test.out.expected
@@ -113,8 +113,8 @@ i22 : basis T
 
 o22 = | 1 x x2 x3 x4 x4y x4yz x4yz2 x4yz3 x4yz4 x4z x4z2 x4z3 x4z4 x3y x3yz x3yz2 x3yz3 x3yz4 x3z x3z2 x3z3 x3z4 x2y x2yz x2yz2 x2yz3 x2yz4 x2z x2z2 x2z3 x2z4 xy xyz xyz2 xyz3 xyz4 xz xz2 xz3 xz4 y y2 y3 y4 y4z y4z2 y4z3 y4z4 y3z y3z2 y3z3 y3z4 y2z y2z2 y2z3 y2z4 yz yz2 yz3 yz4 z z2 z3 z4 |
 
-              1       65
-o22 : Matrix T  <--- T
+              1      65
+o22 : Matrix T  <-- T
 
 i23 : use R;
 
@@ -214,8 +214,8 @@ i35 : G = gens gb ourpoints''
 
 o35 = | x13-1 y-x6 z5+x5+x4-1 |
 
-              1       3
-o35 : Matrix S  <--- S
+              1      3
+o35 : Matrix S  <-- S
 
 i36 : ideal selectInSubring(1,G)
 
@@ -258,8 +258,8 @@ o39 = {-9}  | x3y6   |
       {-15} | x10y5  |
       {-15} | x15    |
 
-              20       1
-o39 : Matrix R   <--- R
+              20      1
+o39 : Matrix R   <-- R
 
 i40 : degree M
 
@@ -275,8 +275,8 @@ i42 : basis S
 
 o42 = | 1 x x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x14y x14yz x14yz2 x14yz3 x14yz4 x14z x14z2 x14z3 x14z4 x13y x13yz x13yz2 x13yz3 x13yz4 x13z x13z2 x13z3 x13z4 x12y x12yz x12yz2 x12yz3 x12yz4 x12z x12z2 x12z3 x12z4 x11y x11yz x11yz2 x11yz3 x11yz4 x11z x11z2 x11z3 x11z4 x10y x10y2 x10y3 x10y3z x10y3z2 x10y3z3 x10y3z4 x10y2z x10y2z2 x10y2z3 x10y2z4 x10yz x10yz2 x10yz3 x10yz4 x10z x10z2 x10z3 x10z4 x9y x9y2 x9y3 x9y3z x9y3z2 x9y3z3 x9y3z4 x9y2z x9y2z2 x9y2z3 x9y2z4 x9yz x9yz2 x9yz3 x9yz4 x9yz5 x9yz6 x9yz7 x9yz8 x9yz9 x9z x9z2 x9z3 x9z4 x9z5 x9z6 x9z7 x9z8 x9z9 x8y x8y2 x8y3 x8y3z x8y3z2 x8y3z3 x8y3z4 x8y2z x8y2z2 x8y2z3 x8y2z4 x8yz x8yz2 x8yz3 x8yz4 x8yz5 x8yz6 x8yz7 x8yz8 x8yz9 x8z x8z2 x8z3 x8z4 x8z5 x8z6 x8z7 x8z8 x8z9 x7y x7y2 x7y3 x7y3z x7y3z2 x7y3z3 x7y3z4 x7y2z x7y2z2 x7y2z3 x7y2z4 x7yz x7yz2 x7yz3 x7yz4 x7yz5 x7yz6 x7yz7 x7yz8 x7yz9 x7z x7z2 x7z3 x7z4 x7z5 x7z6 x7z7 x7z8 x7z9 x6y x6y2 x6y3 x6y4 x6y5 x6y5z x6y5z2 x6y5z3 x6y5z4 x6y4z x6y4z2 x6y4z3 x6y4z4 x6y3z x6y3z2 x6y3z3 x6y3z4 x6y2z x6y2z2 x6y2z3 x6y2z4 x6yz x6yz2 x6yz3 x6yz4 x6yz5 x6yz6 x6yz7 x6yz8 x6yz9 x6z x6z2 x6z3 x6z4 x6z5 x6z6 x6z7 x6z8 x6z9 x5y x5y2 x5y3 x5y4 x5y5 x5y5z x5y5z2 x5y5z3 x5y5z4 x5y4z x5y4z2 x5y4z3 x5y4z4 x5y3z x5y3z2 x5y3z3 x5y3z4 x5y3z5 x5y3z6 x5y3z7 x5y3z8 x5y3z9 x5y2z x5y2z2 x5y2z3 x5y2z4 x5y2z5 x5y2z6 x5y2z7 x5y2z8 x5y2z9 x5yz x5yz2 x5yz3 x5yz4 x5yz5 x5yz6 x5yz7 x5yz8 x5yz9 x5z x5z2 x5z3 x5z4 x5z5 x5z6 x5z7 x5z8 x5z9 x4y x4y2 x4y3 x4y4 x4y5 x4y5z x4y5z2 x4y5z3 x4y5z4 x4y4z x4y4z2 x4y4z3 x4y4z4 x4y3z x4y3z2 x4y3z3 x4y3z4 x4y3z5 x4y3z6 x4y3z7 x4y3z8 x4y3z9 x4y2z x4y2z2 x4y2z3 x4y2z4 x4y2z5 x4y2z6 x4y2z7 x4y2z8 x4y2z9 x4yz x4yz2 x4yz3 x4yz4 x4yz5 x4yz6 x4yz7 x4yz8 x4yz9 x4yz10 x4yz11 x4yz12 x4yz13 x4yz14 x4z x4z2 x4z3 x4z4 x4z5 x4z6 x4z7 x4z8 x4z9 x4z10 x4z11 x4z12 x4z13 x4z14 x3y x3y2 x3y3 x3y4 x3y5 x3y5z x3y5z2 x3y5z3 x3y5z4 x3y4z x3y4z2 x3y4z3 x3y4z4 x3y3z x3y3z2 x3y3z3 x3y3z4 x3y3z5 x3y3z6 x3y3z7 x3y3z8 x3y3z9 x3y2z x3y2z2 x3y2z3 x3y2z4 x3y2z5 x3y2z6 x3y2z7 x3y2z8 x3y2z9 x3yz x3yz2 x3yz3 x3yz4 x3yz5 x3yz6 x3yz7 x3yz8 x3yz9 x3yz10 x3yz11 x3yz12 x3yz13 x3yz14 x3z x3z2 x3z3 x3z4 x3z5 x3z6 x3z7 x3z8 x3z9 x3z10 x3z11 x3z12 x3z13 x3z14 x2y x2y2 x2y3 x2y4 x2y5 x2y6 x2y7 x2y8 x2y8z x2y8z2 x2y8z3 x2y8z4 x2y7z x2y7z2 x2y7z3 x2y7z4 x2y6z x2y6z2 x2y6z3 x2y6z4 x2y5z x2y5z2 x2y5z3 x2y5z4 x2y4z x2y4z2 x2y4z3 x2y4z4 x2y3z x2y3z2 x2y3z3 x2y3z4 x2y3z5 x2y3z6 x2y3z7 x2y3z8 x2y3z9 x2y2z x2y2z2 x2y2z3 x2y2z4 x2y2z5 x2y2z6 x2y2z7 x2y2z8 x2y2z9 x2yz x2yz2 x2yz3 x2yz4 x2yz5 x2yz6 x2yz7 x2yz8 x2yz9 x2yz10 x2yz11 x2yz12 x2yz13 x2yz14 x2z x2z2 x2z3 x2z4 x2z5 x2z6 x2z7 x2z8 x2z9 x2z10 x2z11 x2z12 x2z13 x2z14 xy xy2 xy3 xy4 xy5 xy6 xy7 xy8 xy9 xy10 xy11 xy11z xy11z2 xy11z3 xy11z4 xy10z xy10z2 xy10z3 xy10z4 xy9z xy9z2 xy9z3 xy9z4 xy8z xy8z2 xy8z3 xy8z4 xy7z xy7z2 xy7z3 xy7z4 xy6z xy6z2 xy6z3 xy6z4 xy6z5 xy6z6 xy6z7 xy6z8 xy6z9 xy5z xy5z2 xy5z3 xy5z4 xy5z5 xy5z6 xy5z7 xy5z8 xy5z9 xy4z xy4z2 xy4z3 xy4z4 xy4z5 xy4z6 xy4z7 xy4z8 xy4z9 xy3z xy3z2 xy3z3 xy3z4 xy3z5 xy3z6 xy3z7 xy3z8 xy3z9 xy2z xy2z2 xy2z3 xy2z4 xy2z5 xy2z6 xy2z7 xy2z8 xy2z9 xyz xyz2 xyz3 xyz4 xyz5 xyz6 xyz7 xyz8 xyz9 xyz10 xyz11 xyz12 xyz13 xyz14 xz xz2 xz3 xz4 xz5 xz6 xz7 xz8 xz9 xz10 xz11 xz12 xz13 xz14 y y2 y3 y4 y5 y6 y7 y8 y9 y10 y11 y12 y13 y14 y14z y14z2 y14z3 y14z4 y13z y13z2 y13z3 y13z4 y12z y12z2 y12z3 y12z4 y11z y11z2 y11z3 y11z4 y10z y10z2 y10z3 y10z4 y9z y9z2 y9z3 y9z4 y9z5 y9z6 y9z7 y9z8 y9z9 y8z y8z2 y8z3 y8z4 y8z5 y8z6 y8z7 y8z8 y8z9 y7z y7z2 y7z3 y7z4 y7z5 y7z6 y7z7 y7z8 y7z9 y6z y6z2 y6z3 y6z4 y6z5 y6z6 y6z7 y6z8 y6z9 y5z y5z2 y5z3 y5z4 y5z5 y5z6 y5z7 y5z8 y5z9 y4z y4z2 y4z3 y4z4 y4z5 y4z6 y4z7 y4z8 y4z9 y4z10 y4z11 y4z12 y4z13 y4z14 y3z y3z2 y3z3 y3z4 y3z5 y3z6 y3z7 y3z8 y3z9 y3z10 y3z11 y3z12 y3z13 y3z14 y2z y2z2 y2z3 y2z4 y2z5 y2z6 y2z7 y2z8 y2z9 y2z10 y2z11 y2z12 y2z13 y2z14 yz yz2 yz3 yz4 yz5 yz6 yz7 yz8 yz9 yz10 yz11 yz12 yz13 yz14 z z2 z3 z4 z5 z6 z7 z8 z9 z10 z11 z12 z13 z14 |
 
-              1       690
-o42 : Matrix S  <--- S
+              1      690
+o42 : Matrix S  <-- S
 
 i43 : tally apply(flatten entries basis(S),degree)
 
@@ -307,8 +307,8 @@ i44 : basis(19,S)
 
 o44 = | x14yz4 x9yz9 x4yz14 |
 
-              1       3
-o44 : Matrix S  <--- S
+              1      3
+o44 : Matrix S  <-- S
 
 i45 : (x+y+z)^19
 
@@ -330,8 +330,8 @@ i47 : C.dd_1
 
 o47 = | x3y6 x7y4 x2y9 x2y4z5 x11y2 xy12 x6y2z5 xy7z5 xy2z10 x15 y15 x10z5 y10z5 x5z10 y5z10 z15 |
 
-              1       16
-o47 : Matrix R  <--- R
+              1      16
+o47 : Matrix R  <-- R
 
 i48 : set flatten entries gens M - set flatten entries C.dd_1
 
@@ -359,8 +359,8 @@ o49 = {9}  | -y3 -x4 0   -z5 0   0   0   0   0   0   0   0   0   0   0   0   0  
       {15} | 0   0   0   0   0   0   0   0   0   0   0   0   x   0   0   0   0   0   0   0   0   0   0   0   y5  0   -z5 |
       {15} | 0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   xy2 0   0   0   0   x5  y5  |
 
-              16       27
-o49 : Matrix R   <--- R
+              16      27
+o49 : Matrix R   <-- R
 
 i50 : C.dd_3
 
@@ -392,8 +392,8 @@ o50 = {12} | z5  0   0   0   0   0   0   0   0   0   0   0   |
       {20} | 0   0   0   0   0   0   0   0   0   0   0   y2  |
       {20} | 0   0   0   0   0   0   0   0   x   0   0   0   |
 
-              27       12
-o50 : Matrix R   <--- R
+              27      12
+o50 : Matrix R   <-- R
 
 i51 : A = {{1, 1, 1, 1},
            {1, 5,10,25}}
@@ -430,8 +430,8 @@ i56 : h = basis({25,219}, R)
 
 o56 = | p14n2d2q7 p9n8d2q6 p9n5d6q5 p9n2d10q4 p4n14d2q5 p4n11d6q4 p4n8d10q3 p4n5d14q2 p4n2d18q |
 
-              1       9
-o56 : Matrix R  <--- R
+              1      9
+o56 : Matrix R  <-- R
 
 i57 : rank source h
 
@@ -476,8 +476,8 @@ o61 = {-6}  | p5q-n6     |
       {-2}  | xd-n2      |
       {-2}  | xy-p       |
 
-              18       1
-o61 : Matrix S   <--- S
+              18      1
+o61 : Matrix S   <-- S
 
 i62 : S' = S/I
 

--- a/M2/Macaulay2/tests/normal/capture.m2
+++ b/M2/Macaulay2/tests/normal/capture.m2
@@ -16,8 +16,8 @@ i2 : A = matrix\"1,2,3,4;1,3,6,10;19,7,11,13\" ** oo\n
 o2 = | 1  2 3  4  |
      | 1  3 6  10 |
      | 19 7 11 13 |\n
-             3       4
-o2 : Matrix K  <--- K\n" | ".*", out))
+             3      4
+o2 : Matrix K  <-- K\n" | ".*", out))
 
 -- printing errors
 (err, out) = capture "1/0"


### PR DESCRIPTION
This way, we might be able to see some more information about maps between non-free modules.

### Before
```m2
i1 : R = QQ[x,y,z];

i2 : M = comodule ideal x

o2 = cokernel | x |

                            1
o2 : R-module, quotient of R

i3 : map(M, R^3, {{x, y, z}})

o3 = | 0 y z |

o3 : Matrix
```

What are the source and target?

### After
```m2
i1 : R = QQ[x,y,z];

i2 : M = comodule ideal x

o2 = cokernel | x |

                            1
o2 : R-module, quotient of R

i3 : map(M, R^3, {{x, y, z}})

o3 = | 0 y z |

                    3
o3 : Matrix M <--- R
```