### PR TITLE
trim PID

### DIFF
--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -251,7 +251,7 @@ trimPID := M -> if M.?relations then (if M.?generators then trimPID image genera
     f := presentation M;
     (g,ch) := smithNormalForm(f, ChangeMatrix => {true, false});
     isunit := r -> r != 0 and degree r === {0};
-    rows := select(min(rank source f,rank target f),i->isunit g_(i,i));
+    rows := select(min(rank source g,rank target g),i->isunit g_(i,i));
     rows = rows | toList(rank target f..<rank target g); -- temporary fix for #3017
     ch = submatrix'(ch,rows,);
     p:=id_(target ch)//ch;

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -204,7 +204,7 @@ addHook((minimalPresentation, Module), (opts, M) -> (
 	       N.cache.pruningMap = map(M,N,id_(target ch) // ch);	    -- yuk, taking an inverse here, gb should give inverse change matrices, or the pruning map should go the other way
 	       break N)))
 
-addHook((minimalPresentation, Module), (opts, M) -> (
+addHook((minimalPresentation, Module), Strategy => "PID", (opts, M) -> (
      	  R := ring M;
 	  if instance(R,PolynomialRing) and numgens R === 1 and isField coefficientRing R and not isHomogeneous M then (
 	       f := presentation M;
@@ -218,6 +218,7 @@ addHook((minimalPresentation, Module), (opts, M) -> (
 	       isunit := r -> r != 0 and degree r === {0};
 	       piv := select(pivots g,ij -> isunit g_ij);
 	       rows := first \ piv;
+    	       rows = rows | toList(rank target f..<rank target g); -- temporary fix for #3017
 	       cols := last \ piv;
 	       (g,ch) = (submatrix'(g,rows,cols),submatrix'(ch,rows,));
 	       (g,ch) = (p' g,p' ch);

--- a/M2/Macaulay2/tests/normal/prune.m2
+++ b/M2/Macaulay2/tests/normal/prune.m2
@@ -57,7 +57,7 @@ assert( target N.cache.pruningMap === M )
 P = prune N						    -- N is already pruned!
 assert( target P.cache.pruningMap === N )
 
--- trim PID
+-- prune PID
 R=QQ[x]
 M = module ideal(3*x^4-x^3+x^2-x-2,3*x^4+2*x^3+6*x+4)
 N = prune M

--- a/M2/Macaulay2/tests/normal/prune.m2
+++ b/M2/Macaulay2/tests/normal/prune.m2
@@ -57,6 +57,14 @@ assert( target N.cache.pruningMap === M )
 P = prune N						    -- N is already pruned!
 assert( target P.cache.pruningMap === N )
 
+-- trim PID
+R=QQ[x]
+M = module ideal(3*x^4-x^3+x^2-x-2,3*x^4+2*x^3+6*x+4)
+N = prune M
+assert(isFreeModule N)
+assert(rank N == 1)
+
+
 -----------------------------------------------------------------------------
 end
 -- Local Variables:

--- a/M2/Macaulay2/tests/normal/trim.m2
+++ b/M2/Macaulay2/tests/normal/trim.m2
@@ -25,6 +25,13 @@ assert (trim(M,Strategy=>Complement) === trim(N,Strategy=>Complement))
 assert (trim P === R^1)
 assert (trim(P,Strategy=>Complement) === R^1)
 
+-- trim PID
+R=QQ[x]
+I = ideal(3*x^4-x^3+x^2-x-2,3*x^4+2*x^3+6*x+4)
+J = trim I
+assert(I == J)
+assert(numgens J == 1)
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test trim.out"
 -- End:

--- a/M2/Macaulay2/tests/normal/trim.m2
+++ b/M2/Macaulay2/tests/normal/trim.m2
@@ -32,7 +32,7 @@ J = trim I
 assert(I == J)
 assert(numgens J == 1)
 I' = ideal(x^3-1, x^2+1)
-J' = trim I
+J' = trim I'
 assert(J'_* == {1})
 
 -- Local Variables:

--- a/M2/Macaulay2/tests/normal/trim.m2
+++ b/M2/Macaulay2/tests/normal/trim.m2
@@ -31,6 +31,9 @@ I = ideal(3*x^4-x^3+x^2-x-2,3*x^4+2*x^3+6*x+4)
 J = trim I
 assert(I == J)
 assert(numgens J == 1)
+I' = ideal(x^3-1, x^2+1)
+J' = trim I
+assert(J'_* == {1})
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test trim.out"


### PR DESCRIPTION
- correct trimming of modules / ideals in PIDs. resolves (at last!) #1273:
```
i1 : R = ZZ/7[t];

i2 : I = ideal(t^3*(t+1), t*(t-1))

             4    3   2
o2 = ideal (t  + t , t  - t)

o2 : Ideal of R

i3 : trim I

o3 = ideal t

o3 : Ideal of R

i4 : R=QQ[x]

o4 = R

o4 : PolynomialRing

i5 : ideal(3*x^4-x^3+x^2-x-2,3*x^4+2*x^3+6*x+4)

              4    3    2            4     3
o5 = ideal (3x  - x  + x  - x - 2, 3x  + 2x  + 6x + 4)

o5 : Ideal of R

i6 : trim oo

               2
o6 = ideal(x + -)
               3

o6 : Ideal of R
```
- several bugs were found in the process. #3017 is *not* fixed in this PR, somebody else needs to take a look at it since a lot is problematic with `smithNormalForm` at the moment.
- instead, a temporary workaround in the `prune` PID strategy was implemented, and similarly for the new `trim` PID strategy.
- tests were added for both `trim` and `prune`.