### PR TITLE
Fix "describe", "expression", "toString", and "toExternalString" in ForeignFunctions package

### DIFF
--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -546,6 +546,10 @@ net SharedLibrary := net @@ expression
 toString SharedLibrary := toString @@ expression
 texMath SharedLibrary := texMath @@ expression
 
+describe SharedLibrary := lib -> Describe FunctionApplication(
+    openSharedLibrary, lib#1)
+toExternalString SharedLibrary := toExternalFormat @@ describe
+
 -- on apple silicon machines, shared libraries are often in /opt/homebrew/lib,
 -- but this is not in DYLD_LIBRARY_PATH, so we try there if the first call to
 -- dlopen fails

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -2128,3 +2128,30 @@ ptr = getMemory foo
 assert BinaryOperation(symbol ===, value (foo * ptr),
     hashTable{"a" => 5, "b" => numeric pi, "c" => "Hello, world!"})
 ///
+
+TEST ///
+-- describe/toExternalString
+x = int 5
+assert Equation(value value describe x, 5)
+assert Equation(value value toExternalString x, 5)
+x = charstar "foo"
+assert Equation(value value describe x, "foo")
+assert Equation(value value toExternalString x, "foo")
+int3 = 3 * int
+x = int3 {1, 2, 3}
+assert Equation(value value describe x, {1, 2, 3})
+assert Equation(value value toExternalString x, {1, 2, 3})
+x = charstarstar {"foo", "bar", "baz"}
+assert Equation(value value describe x, {"foo", "bar", "baz"})
+assert Equation(value value toExternalString x, {"foo", "bar", "baz"})
+foo = foreignStructType("foo", {"a" => int, "b" => double, "c" => charstar})
+x = foo {"a" => 5, "b" => pi, "c" => "Hello, world!"}
+assert BinaryOperation(symbol ===, value value describe x,
+    hashTable{"a" => 5, "b" => numeric pi, "c" => "Hello, world!"})
+assert BinaryOperation(symbol ===, value value toExternalString x,
+    hashTable{"a" => 5, "b" => numeric pi, "c" => "Hello, world!"})
+
+mpfi = openSharedLibrary "mpfi"
+assert instance(value describe mpfi, SharedLibrary)
+assert instance(value toExternalString mpfi, SharedLibrary)
+///

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -137,8 +137,10 @@ Pointer - ZZ := (ptr, n) -> ptr + -n
 
 ForeignObject = new SelfInitializingType of HashTable
 ForeignObject.synonym = "foreign object"
-net ForeignObject := x -> net value x
-texMath ForeignObject := texMath @@ value
+expression ForeignObject := expression @@ value
+net ForeignObject := net @@ expression
+toString ForeignObject := toString @@ expression
+texMath ForeignObject := texMath @@ expression
 ForeignObject#AfterPrint = x -> (ForeignObject, " of type ", class x)
 
 value ForeignObject := x -> error("no value function exists for ", class x)
@@ -273,7 +275,7 @@ foreignRealType(String, ZZ) := (name, bits) -> (
     T.Address = ffiRealType(bits);
     new T from RR := (T, x) -> new T from {Address => ffiRealAddress(x, bits)};
     value T := x -> ffiRealValue(address x, bits);
-    net T := x -> format(0, value x);
+    expression T := x -> expression format(0, value x);
     T)
 
 float = foreignRealType("float", 32)
@@ -1502,8 +1504,6 @@ doc ///
     (value, voidstar)
     (value, voidstarstar)
     (net, ForeignObject)
-    (net, double)
-    (net, float)
   Headline
     get the value of a foreign object as a Macaulay2 thing
   Usage

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1,7 +1,7 @@
 newPackage("ForeignFunctions",
     Headline => "foreign function interface",
-    Version => "0.2",
-    Date => "May 13, 2023",
+    Version => "0.3",
+    Date => "December 4, 2023",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
@@ -14,6 +14,11 @@ newPackage("ForeignFunctions",
 ---------------
 
 -*
+
+0.3 (2023-12-04, M2 1.23)
+* add subscripted assignment for various pointer types
+* add support for GMP integers
+* add support for describe, expression, toExternalString, and toString
 
 0.2 (2023-05-13, M2 1.22)
 * improvements for displaying foreign objects in webapp mode

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -814,6 +814,7 @@ doc ///
  Key
    ForeignVoidType
    "void"
+   (symbol SPACE, ForeignVoidType, Nothing)
  Headline
    foreign void type
  Description

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -541,7 +541,10 @@ ForeignFunctionPointerType Function := (T, f) -> new T from f
 
 SharedLibrary = new SelfInitializingType of BasicList
 SharedLibrary.synonym = "shared library"
-net SharedLibrary := lib -> lib#1
+expression SharedLibrary := lib -> expression lib#1
+net SharedLibrary := net @@ expression
+toString SharedLibrary := toString @@ expression
+texMath SharedLibrary := texMath @@ expression
 
 -- on apple silicon machines, shared libraries are often in /opt/homebrew/lib,
 -- but this is not in DYLD_LIBRARY_PATH, so we try there if the first call to

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -457,6 +457,7 @@ foreignStructType(String, VisibleList) := (name, x) -> (
     T)
 
 ForeignStructType VisibleList := (T, x) -> new T from x
+ForeignStructType HashTable := (T, x) -> T apply(keys x, k -> k => x#k)
 
 isAtomic ForeignStructType := T -> T.Atomic
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1515,7 +1515,14 @@ doc ///
     (value, uint64)
     (value, voidstar)
     (value, voidstarstar)
+    (describe, ForeignObject)
+    (expression, ForeignObject)
+    (expression, float)
+    (expression, double)
     (net, ForeignObject)
+    (texMath, ForeignObject)
+    (toExternalString, ForeignObject)
+    (toString, ForeignObject)
   Headline
     get the value of a foreign object as a Macaulay2 thing
   Usage
@@ -1559,7 +1566,8 @@ doc ///
       x = mystruct {"a" => 2, "b" => sqrt 2}
       value x
     Text
-      Note that this function is also used by @TT "net(ForeignObject)"@ for
+      Note that this function is also used by @TO describe@, @TO expression@,
+      @TO net@, @TO texMath@, @TO toExternalString@, and @TO toString@ for
       representing foreign objects.
 ///
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1287,13 +1287,14 @@ doc ///
 doc ///
   Key
     (symbol SPACE, ForeignStructType, VisibleList)
+    (symbol SPACE, ForeignStructType, HashTable)
   Headline
     cast a hash table to a foreign struct
   Usage
     T x
   Inputs
     T:ForeignStructType
-    x:VisibleList -- whose elements are options
+    x:{HashTable, VisibleList}
   Outputs
     :ForeignObject
   Description

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -117,7 +117,8 @@ importFrom_Core {
     "ffiStructAddress",
     "ffiUnionType",
     "ffiFunctionPointerAddress",
-    "registerFinalizerForPointer"
+    "registerFinalizerForPointer",
+    "toExternalFormat"
     }
 
 
@@ -142,6 +143,9 @@ net ForeignObject := net @@ expression
 toString ForeignObject := toString @@ expression
 texMath ForeignObject := texMath @@ expression
 ForeignObject#AfterPrint = x -> (ForeignObject, " of type ", class x)
+
+describe ForeignObject := x -> Describe FunctionApplication(class x, value x)
+toExternalString ForeignObject := toExternalFormat @@ describe
 
 value ForeignObject := x -> error("no value function exists for ", class x)
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1671,14 +1671,20 @@ doc ///
 doc ///
   Key
     SharedLibrary
+    (describe, SharedLibrary)
+    (expression, SharedLibrary)
     (net, SharedLibrary)
+    (texMath, SharedLibrary)
+    (toExternalString, SharedLibrary)
+    (toString, SharedLibrary)
   Headline
     a shared library
   Description
     Text
       A shared library that could be used to load foreign functions.  Each
       shared library object consists of a pointer to a handle for the library
-      and a string that is used by @TT "net(SharedLibrary)"@.
+      and a string that is used by @TO describe@, @TO expression@, @TO net@,
+      @TO texMath@, @TO toExternalString@, and @TO toString@.
     Example
       mpfr = openSharedLibrary "mpfr"
       peek mpfr


### PR DESCRIPTION
Previously, `expression` basically worked, but `describe` should have given more information.  And `toString` and `toExternalString`, which now wrap around these, were completely broken.

### Before

```m2
i1 : needsPackage "ForeignFunctions"

o1 = ForeignFunctions

o1 : Package

i2 : describe int 5

o2 = 5

i3 : expression int 5

o3 = 5

o3 : Expression of class Holder

i4 : toString int 5

o4 = new int32 from {Address => 0x7f499a8250e0}

i5 : toExternalString int 5
stdio:5:1:(3): error: can't convert local symbol or invisible global symbol 'Address' to external string
/usr/share/Macaulay2/ForeignFunctions.m2:147:32-147:39: here is the first use of 'Address'
```

### After

```m2
i1 : needsPackage "ForeignFunctions"

o1 = ForeignFunctions

o1 : Package

i2 : describe int 5

o2 = int32 5

i3 : expression int 5

o3 = 5

o3 : Expression of class Holder

i4 : toString int 5

o4 = 5

i5 : toExternalString int 5

o5 = int32 5
```