### PR TITLE
Improve error message for toExternalString(Function)

### DIFF
--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -41,10 +41,9 @@ net Command := toString Command := toExternalString Command := f -> (
      )
 
 toExternalString Function := f -> (
-     if hasAttribute(f,ReverseDictionary) then return toString getAttribute(f,ReverseDictionary);
-     t := locate f;
-     if t === null then error "can't convert anonymous function to external string"
-     else error("can't convert anonymous function (",toString t,") to external string")
+     if hasAttribute(f,ReverseDictionary)
+     then toString getAttribute(f,ReverseDictionary)
+     else error("can't convert anonymous function ",net f," to external string")
      )
 
 net Function := toString Function := f -> (


### PR DESCRIPTION
When passed an anonymous function with no global name, it prints the location of the function, but enclosed in parentheses.  The Emacs regular expression thinks that the parentheses are part of the filename, so compilation mode fails to jump to the right place and a file dialog opens.

So we call `net(Function)` to enclose it in the usual Emacs-friendly `-*Function[...]*-`.  We also drop the call the `locate`, since `net` will do that for us.

### Before

```m2
i4 : toExternalString oo
stdio:2:1:(3): error: can't convert anonymous function (foo.m2:1:2-1:5) to external string
```

### After
```m2
i4 : toExternalString oo
stdio:2:1:(3): error: can't convert anonymous function -*Function[foo.m2:1:2-1:5]*- to external string
```

(Note that it's still broken for functions defined in `stdio`, but that's an Emacs issue.)