### PR TITLE
Add support for "code" inside stdio 

### DIFF
--- a/M2/Macaulay2/d/M2.d
+++ b/M2/Macaulay2/d/M2.d
@@ -43,22 +43,17 @@ export makearrayint(n:int):arrayint := Ccode(returns, "
   GC_CHECK_CLOBBER(z);
   return z; /* Note that getmem_atomic returns zeroed memory */
 ");
-export tocharstar(s:string):charstar := Ccode(returns, "
-  char *p = getmem_atomic(s->len + 1);
-  memcpy(p,s->array,s->len);
-  p[s->len] = 0;
+export tocharstarn(s:string, n:int):charstar := Ccode(returns, "
+  char *p = getmem_atomic(", n + 1, ");
+  memcpy(p,s->array,", n, ");
+  p[", n, "] = 0;
   GC_CHECK_CLOBBER(p);
   return p;
 ");
-export tocharstarOrNull(s:string):charstarOrNull := Ccode(returns, "
-  char *p;
-  if (s->len == 0) return NULL;
-  p = getmem_atomic(s->len + 1);
-  memcpy(p,s->array,s->len);
-  p[s->len] = 0;
-  GC_CHECK_CLOBBER(p);
-  return p;
-");
+export tocharstar(s:string):charstar := tocharstarn(s, length(s));
+export tocharstarOrNull(s:string):charstarOrNull := (
+    if length(s) == 0 then charstarOrNull(null())
+    else charstarOrNull(tocharstar(s)));
 export tostringn(s:charstar,n:int):string := Ccode(returns, "
   M2_string p = (M2_string)getmem_atomic(sizeofarray(p,n));
   p->len = n;

--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -147,7 +147,7 @@ static int read_via_readline(char *buf,int len,char *prompt) {
     if (p == NULL) return 0;	/* EOF */
     i = 0;
     plen = strlen(p);
-    if (*p) add_history(p);
+    add_history(p);
   }
   r = plen - i;
   if (r > len) r = len;

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -19,7 +19,8 @@ header "// required for toString routines
 #include <interface/random.h>               // for system_randomint
 #include <interface/ring.h>                 // for IM2_Ring_to_string
 #include <interface/ringelement.h>          // for IM2_RingElement_to_string
-#include <interface/ringmap.h>              // for IM2_RingMap_to_string";
+#include <interface/ringmap.h>              // for IM2_RingMap_to_string
+#include <readline/history.h>               // for history_get";
 
 internalName(s:string):string := (
      -- was "$" + s in 0.9.2
@@ -1670,6 +1671,18 @@ locate(e:Expr):Expr := (
      else WrongArg("a function, symbol, sequence, or null"));
 setupfun("locate", locate).Protected = false; -- will be overloaded in m2/methods.m2
 
+historyGet(e:Expr):Expr := (
+    when e
+    is n:ZZcell do (
+	if !isInt(n) then WrongArgSmallInteger()
+	else (
+	    entry := Ccode(voidPointer, "history_get(", toInt(n), ")");
+	    if entry == nullPointer()
+	    then buildErrorPacket("no history entry with that offset")
+	    else toExpr(tostring(Ccode(charstar, "((HIST_ENTRY *)", entry,
+			")->line")))))
+    else WrongArgZZ());
+setupfun("historyGet", historyGet);
 
 powermod(e:Expr):Expr := (
      when e is s:Sequence do

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -6,7 +6,9 @@ use gmp;
 use expr;
 use stdio0;
 
-header "#include \"../system/m2fileinterface.h\"";
+header "#include \"../system/m2fileinterface.h\"
+        #include <readline/history.h>";
+
 --provide a constant representation of default buffer size for a file
 --this must be set the same as the bufsize in stdio0.d
 bufsize ::= 4 * 1024;
@@ -715,7 +717,12 @@ export filbuf(o:file):int := (
 	       r = (
 		    if o.infd == NOFD 
 		    then 0 -- take care of "string files" made by stringTokenFile in interp.d
-		    else read(o.infd,o.inbuffer,n,o.insize)));
+		    else (
+			ret := read(o.infd,o.inbuffer,n,o.insize);
+			if ret > 0 && o == stdIO then (
+			    buf := tocharstarn(o.inbuffer, ret - 1);
+			    Ccode(void, "add_history(", buf, ")"));
+			ret)));
 	  if r == ERROR then (
 	       fileErrorMessage(o,"read");
 	       return r;

--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -41,11 +41,15 @@ code = method(Dispatch => Thing)
 code Nothing    := identity
 code FilePosition := x -> (
     filename := x#0; start := x#1; stop := x#3;
-     if filename =!= "stdio" then (
+     (
 	  wp := set characters " \t\r);";
 	  file := (
 	       if match("startup.m2.in$", filename) then startupString
 	       else if filename === "currentString" then currentString
+	       else if filename === "stdio" then (
+		    start = 1;
+		    stop = x#3 - x#1 + 1;
+		    toString stack apply(x#1..x#3, historyGet))
 	       else (
 		    if not fileExists filename then error ("couldn't find file ", filename);
 		    get filename

--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -45,7 +45,10 @@ code FilePosition := x -> (
 	  wp := set characters " \t\r);";
 	  file := (
 	       if match("startup.m2.in$", filename) then startupString
-	       else if filename === "currentString" then currentString
+	       else if filename === "currentString" then (
+		    if currentString === null
+		    then error "code no longer available"
+		    else currentString)
 	       else if filename === "stdio" then (
 		    start = 1;
 		    stop = x#3 - x#1 + 1;


### PR DESCRIPTION
Currently `code` won't work for functions defined on the standard input:

```m2
i1 : f = x -> x^2

o1 = f

o1 : FunctionClosure

i2 : code f

o2 = 
```

This proposal uses readline's history to get it to work:

```m2
i1 : f = x -> x^2

o1 = f

o1 : FunctionClosure

i2 : code f

o2 = stdio:1:6-1:11: --source code:
     f = x -> x^2
```

However, there's been some discussion (#825) of removing readline in favor of editline, so I'm not sure if we want to do this or not.  Also, the default in Emacs is to call Macaulay2 with `--no-readline`, and this doesn't work then.   So I'm opening this is a draft for now for discussion.