### PR TITLE
Revert "reduce" changes in #3013

### DIFF
--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -119,7 +119,7 @@ Matrix == RingElement := (m,f) -> m - f == 0		    -- slow!
 Matrix == ZZ := (m,i) -> if i === 0 then rawIsZero m.RawMatrix else m - i == 0
 
 Matrix + Matrix := Matrix => (
-     (f,g) -> map(target f, source f, reduce(target f, raw f + raw g))
+     (f,g) -> map(target f, source f, f.RawMatrix + g.RawMatrix)
      ) @@ toSameRing
 Matrix + RingElement := (f,r) -> if r == 0 then f else f + r*id_(target f)
 RingElement + Matrix := (r,f) -> if r == 0 then f else r*id_(target f) + f
@@ -127,7 +127,7 @@ Number + Matrix := (i,f) -> if i === 0 then f else i*id_(target f) + f
 Matrix + Number := (f,i) -> if i === 0 then f else f + i*id_(target f)
 
 Matrix - Matrix := Matrix => (
-     (f,g) -> map(target f, source f, reduce(target f, raw f - raw g))
+     (f,g) -> map(target f, source f, f.RawMatrix - g.RawMatrix)
      ) @@ toSameRing
 Matrix - RingElement := (f,r) -> if r == 0 then f else f - r*id_(target f)
 RingElement - Matrix := (r,f) -> if r == 0 then -f else r*id_(target f) - f
@@ -138,7 +138,7 @@ Matrix - Number := (f,i) -> if i === 0 then f else f - i*id_(target f)
      symbol ring => ring f,
      symbol source => source f,
      symbol target => target f,
-     symbol RawMatrix => reduce(target f, -raw f),
+     symbol RawMatrix => - f.RawMatrix,
      symbol cache => new CacheTable
      }
 

--- a/M2/Macaulay2/tests/normal/matrix.m2
+++ b/M2/Macaulay2/tests/normal/matrix.m2
@@ -357,13 +357,6 @@ assert Equation(1 + ii || A, matrix {{1 + ii, 0}, {0, 1 + ii}, {1, 2}, {2, 3}})
 assert Equation(x || A, map(R^4, R^{{-1}, {-1}},
 	matrix {{x, 0}, {0, x}, {1, 2}, {2, 3}}))
 
--- issue #3012
-M = comodule ideal 2
-A = map(M, ZZ^1, {{1}})
-assert Equation(A + A, 0)
-assert Equation(A - A, 0)
-assert Equation(A, -A)
-
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test matrix.out"
 -- End:


### PR DESCRIPTION
This restores the matrix addition/subtraction/negation behavior so we don't get the huge slowdowns reported in #3035.