### PR TITLE
Add importFrom and exportFrom methods accepting a single string

### DIFF
--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -434,10 +434,14 @@ symbolFrom = (pkgname, name) -> value (getpkg pkgname)#"private dictionary"#name
 importFrom = method()
 importFrom(String,  List) := (P, x) -> importFrom(getpkg P, x)
 importFrom(Package, List) := (P, x) -> apply(nonnull x, s -> if not currentPackage#"private dictionary"#?s then currentPackage#"private dictionary"#s = P#"private dictionary"#s)
+importFrom(String,  String) :=
+importFrom(Package, String) := (P, x) -> importFrom(P, {x})
 
 exportFrom = method()
 exportFrom(String,  List) := (P, x) -> exportFrom(getpkg P, x)
 exportFrom(Package, List) := (P, x) -> export \\ toString \ importFrom(P, x)
+exportFrom(String,  String) :=
+exportFrom(Package, String) := (P, x) -> exportFrom(P, {x})
 
 ---------------------------------------------------------------------
 -- Here is where Core officially becomes a package

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -1,8 +1,8 @@
 newPackage(
     "JSON",
     Headline => "JSON encoding and decoding",
-    Version => "0.1",
-    Date => "August 31, 2022",
+    Version => "0.2",
+    Date => "December 13, 2023",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
@@ -10,6 +10,20 @@ newPackage(
     Keywords => {"System"},
     PackageImports => {"Parsing"},
     AuxiliaryFiles => true)
+
+---------------
+-- ChangeLog --
+---------------
+
+-*
+
+0.2 (2023-12-13, M2 1.23)
+* use single-string version of exportFrom
+
+0.1 (2022-08-31, M2 1.21)
+* initial release
+
+*-
 
 export {
     "toJSON",

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -19,7 +19,7 @@ export {
     "ValueSeparator"
     }
 
-exportFrom_Parsing {"nil"}
+exportFrom_Parsing "nil"
 
 ----------------------------------------------------------------
 -- parser based on https://datatracker.ietf.org/doc/html/rfc8259

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/export-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/export-doc.m2
@@ -74,6 +74,8 @@ Node
      exportFrom
     (exportFrom, Package, List)
     (exportFrom, String,  List)
+    (exportFrom, Package, String)
+    (exportFrom, String,  String)
   Headline
     export symbols from a package's private dictionary
   Usage
@@ -81,7 +83,7 @@ Node
   Inputs
     pkg:{Package,String}
       the package containing the symbols
-    :List
+    :{String, List}
       of strings, corresponding to the symbols to export
   Consequences
     Item
@@ -102,6 +104,8 @@ Node
      importFrom
     (importFrom, Package, List)
     (importFrom, String,  List)
+    (importFrom, Package, String)
+    (importFrom, String,  String)
   Headline
     import symbols to the current private dictionary
   Usage
@@ -109,7 +113,7 @@ Node
   Inputs
     pkg:{Package,String}
       the package containing the private symbols
-    :List
+    :{String, List}
       of strings, corresponding to the private @TO2 {Symbol, "symbols"}@ to export from the package
   Outputs
     :List

--- a/M2/Macaulay2/tests/normal/hashtables.m2
+++ b/M2/Macaulay2/tests/normal/hashtables.m2
@@ -1,4 +1,4 @@
-importFrom_Core {"BinaryPowerMethod"}
+importFrom_Core "BinaryPowerMethod"
 plus' = (x,y) -> ( z := x+y ; if z == 0 then continue ; z )
 Poly = new Type of HashTable
 assert( (one = new Poly from {1 => 1}) === new Poly from {1 => 1} )

--- a/M2/Macaulay2/tests/normal/hilbert.m2
+++ b/M2/Macaulay2/tests/normal/hilbert.m2
@@ -76,7 +76,7 @@ scan(3, n -> (
 		    assert( r == s)))))))
 
 --
-importFrom_Core {"truncateSeries"}
+importFrom_Core "truncateSeries"
 R = QQ[x,y, DegreeRank => 2]
 assert(truncateSeries(5, {1,1}, Divide{1_R,Product{Power{1-x,1}}}) == x^4+x^3+x^2+x+1)
 assert(truncateSeries(5, {1,1}, Divide{1_R,Product{Power{1+x,1}}}) == x^4-x^3+x^2-x+1)


### PR DESCRIPTION
I can't count the number of times that I've forgotten that you need a list for `importFrom` and `exportFrom`, so we add new versions that accept just a string:

```m2
i1 : importFrom_Core "concatCols"

o1 = {concatCols}

o1 : List

i2 : concatCols apply(3, i -> random(ZZ^2, ZZ^2))

o2 = | 9 6 6 7 7 1 |
     | 9 9 6 3 7 2 |

              2       6
o2 : Matrix ZZ  <-- ZZ
```