### PR TITLE
Save position when running commandInterpreter

### DIFF
--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -267,7 +267,9 @@ readeval3(file:TokenFile,printout:bool,dc:DictionaryClosure,returnLastvalue:bool
       savepf := currentPosFile;
 	setGlobalVariable(currentFileName,toExpr(file.posFile.file.filename));
 	setGlobalVariable(currentFileDirectory,toExpr(dirname(file.posFile.file.filename)));
-        currentPosFile = file.posFile;
+	if currentPosFile.file == stdIO && file.posFile.file == stdIO
+	then file.posFile = currentPosFile
+	else currentPosFile = file.posFile;
 	ret := readeval4(file,printout,dc.dictionary,returnLastvalue,stopIfBreakReturnContinue,returnIfError);
       setGlobalVariable(currentFileDirectory,savecd);
       setGlobalVariable(currentFileName,savecf);


### PR DESCRIPTION
This is a followup to #3028.  I noticed that `code` stopped working for functions defined in `stdio` after I'd been in and out of the debugger.  This is because every time `commandInterpreter` is called, we reset the position in `stdio` to the beginning:
https://github.com/Macaulay2/M2/blob/86d6c70f8746e6b13d95c53ad20d880e0d60a8dc/M2/Macaulay2/d/stdiop.d#L175-L179

We change it so that if we're loading `stdio` from `stdio`, we save the current position.

### Before
```m2
i1 : commandInterpreter()

ii2 : f = x -> x^2

oo2 = f

oo2 : FunctionClosure

ii3 : locate f -- we want it to be on line 2

oo3 = stdio:1:6-1:11

oo3 : FilePosition

ii4 : code f -- broken!

oo4 = stdio:1:6-1:11: --source code:
      commandInterpreter()
```

### After
```m2
i1 : commandInterpreter()

ii2 : f = x -> x^2

oo2 = f

oo2 : FunctionClosure

ii3 : locate f

oo3 = stdio:2:6-2:11

oo3 : FilePosition

ii4 : code f

oo4 = stdio:2:6-2:11: --source code:
      f = x -> x^2
```