### PR TITLE
Disable thread safety for Boost if no atomic ints or std::mutex

### DIFF
--- a/M2/Macaulay2/d/boostmath.dd
+++ b/M2/Macaulay2/d/boostmath.dd
@@ -2,6 +2,13 @@ use util;
 use common;
 
 header "#include <iostream>
+  #include <boost/config.hpp>
+  #include <boost/math/tools/atomic.hpp>
+  #if defined(BOOST_HAS_THREADS) && \\
+     (defined(BOOST_NO_CXX11_HDR_MUTEX) || defined(BOOST_MATH_NO_ATOMIC_INT))
+  #define BOOST_MATH_BERNOULLI_UNTHREADED
+  #endif
+
   #include <boost/multiprecision/mpfr.hpp>
   #include <boost/math/special_functions/beta.hpp>
   #include <boost/math/special_functions/erf.hpp>


### PR DESCRIPTION
This fixes a build error that was occurring during the armel build of the Debian package during the transition to Boost 1.83.

    /usr/include/boost/math/special_functions/detail/bernoulli_details.hpp:389:31: error: static assertion failed: Unsupported configuration: your platform appears to have either no atomic integers, or no std::mutex.  If you are happy with thread-unsafe code, then you may define BOOST_MATH_BERNOULLI_UNTHREADED to suppress this error.
      389 |       static_assert(sizeof(T) == 1, "Unsupported configuration: your platform appears to have either no atomic integers, or no std::mutex.  If you are happy with thread-unsafe code, then you may define BOOST_MATH_BERNOULLI_UNTHREADED to suppress this error.");
          |                     ~~~~~~~~~~^~~~
    compilation terminated due to -Wfatal-errors.

See https://buildd.debian.org/status/fetch.php?pkg=macaulay2&arch=armel&ver=1.22%2Bds-4%2Bb1&stamp=1702971525&raw=0