### PR TITLE
Only include boost/math/tools/atomic.hpp if we have it

### DIFF
--- a/M2/Macaulay2/d/boostmath.dd
+++ b/M2/Macaulay2/d/boostmath.dd
@@ -3,7 +3,9 @@ use common;
 
 header "#include <iostream>
   #include <boost/config.hpp>
-  #include <boost/math/tools/atomic.hpp>
+  #ifdef HAVE_BOOST_MATH_TOOLS_ATOMIC_HPP
+    #include <boost/math/tools/atomic.hpp>
+  #endif
   #if defined(BOOST_HAS_THREADS) && \\
      (defined(BOOST_NO_CXX11_HDR_MUTEX) || defined(BOOST_MATH_NO_ATOMIC_INT))
   #define BOOST_MATH_BERNOULLI_UNTHREADED

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -52,6 +52,9 @@ else()
   #fallback to header only mode
   set(Boost_stacktrace_header_only YES)
 endif()
+set(CMAKE_REQUIRED_INCLUDES "${Boost_INCLUDE_DIR}")
+check_include_files(boost/math/tools/atomic.hpp
+  HAVE_BOOST_MATH_TOOLS_ATOMIC_HPP)
 
 # TODO: replace gdbm, see https://github.com/Macaulay2/M2/issues/594
 find_package(GDBM	REQUIRED QUIET) # See FindGDBM.cmake

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1380,7 +1380,8 @@ fi
 AX_BOOST_REGEX
 LIBS="$LIBS $BOOST_REGEX_LIB"
 
-AC_CHECK_HEADERS([boost/math/special_functions.hpp], [],
+AC_CHECK_HEADERS([boost/math/special_functions.hpp],
+    [AC_CHECK_HEADERS([boost/math/tools/atomic.hpp])],
     [AC_MSG_ERROR([Boost Math Toolkit not available])])
 AC_SEARCH_LIBS([ldexpq], [quadmath])
 


### PR DESCRIPTION
This is a followup to #3043.  By adding support for newer versions of Boost, I broke support for older versions!  For example, on Ubuntu 18.04, with boost 1.65, we get the following:

```c
boostmath.dd:6:12: fatal error: boost/math/tools/atomic.hpp: No such file or directory
   #include <boost/math/tools/atomic.hpp>
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

([Full build log](https://launchpadlibrarian.net/704157228/buildlog_ubuntu-bionic-amd64.macaulay2_1.22.0.1+git202312192158-0ppa202312161637~ubuntu18.04.1_BUILDING.txt.gz))

So we check for the existence of the header and only include it if we can.