### PR TITLE
Add show(GraphicsObject)

### DIFF
--- a/M2/Macaulay2/packages/VectorGraphics.m2
+++ b/M2/Macaulay2/packages/VectorGraphics.m2
@@ -1781,6 +1781,19 @@ multidoc ///
     needsPackage "Graphs";
     R=QQ[x,y]; b=flatten entries basis(0,3,R)
     digraph select(b**b,a->a#1 % a#0 == 0 and first degree a#1 == first degree a#0 +1)
+ Node
+  Key
+   (show, GraphicsObject)
+  Headline
+   view a graphics object
+  Usage
+   show g
+  Inputs
+   g:GraphicsObject
+  Description
+   Text
+    View a graphics object (as an .svg file) using the default system image
+    viewer.
 ///
 undocumented {
     Contents, TextContent, RefPoint, Specular, Radius, Point1, Point2, PointList, Mesh, FontSize, RadiusX, RadiusY, Frame,

--- a/M2/Macaulay2/packages/VectorGraphics.m2
+++ b/M2/Macaulay2/packages/VectorGraphics.m2
@@ -750,6 +750,10 @@ new SVG from GraphicsObject := (S,g) -> (
 
 hypertext GraphicsObject := g -> SVG g
 html GraphicsObject := html @@ hypertext
+show GraphicsObject := g -> (
+    file := temporaryFileName() | ".svg";
+    file << html g << close;
+    show URL("file://" | file))
 
 -- tex output
 tikzscale := 1; -- not thread-safe


### PR DESCRIPTION
This allows viewing of graphics from the `VectorGraphics` package outside of the webapp.  The object is written to an .svg file and then opened using `show(URL)`.  

So for example, consider the following code:

```m2
i1 : needsPackage "VectorGraphics"

o1 = VectorGraphics

o1 : Package

i2 : show GraphicsText {TextContent => "Hello, world!", "fill" => "red", FontSize => 50}
```

This results in the system's default image viewer (`eog` on my system) opening up the following image:
![image](https://github.com/Macaulay2/M2/assets/1992248/6c9e9150-8d20-4f49-95fb-0f53dfc3a103)

This is one piece of a bigger project I'm working on to view graphics in Emacs inside the buffer, but it needs some more work.  This part is ready, though!

cc: @pzinn
