### PR TITLE
Convert html attribute values to strings before calling "format"

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -95,7 +95,9 @@ html Hypertext := x -> (
     attr := "";
     cont := if T.?Options then (
 	(op, ct) := override(options T, toSequence x);
-	scanPairs(op, (key, val) -> if val =!= null then attr = " " | key | "=" | format val | attr);
+	scanPairs(op, (key, val) -> (
+		if val =!= null
+		then attr = " " | key | "=" | format toString val | attr));
 	sequence ct) else x;
     pushIndentLevel 1;
     (head, prefix, suffix, tail) := (


### PR DESCRIPTION
This allows us to use `ZZ`'s as attribute values and gives us quotes around `RR` values (since `format(RR)` just converts to strings).

### Before
```m2
i1 : beginDocumentation()

i2 : html IMG("src" => "foo.jpg", "width" => 400, "height" => 300)
stdio:2:1:(3): error: no method found for applying format to:
     argument   :  300 (of class ZZ)

i3 : html IMG("src" => "foo.jpg", "width" => 400.0, "height" => 300.0)

o3 = <img src="foo.jpg" width=400 height=300>
```

### After
```m2
i1 : beginDocumentation()

i2 : html IMG("src" => "foo.jpg", "width" => 400, "height" => 300)

o2 = <img src="foo.jpg" width="400" height="300">

i3 : html IMG("src" => "foo.jpg", "width" => 400.0, "height" => 300.0)

o3 = <img src="foo.jpg" width="400" height="300">
```

---

This fixes an issue I noticed using #3046 with calling `show` on the example from the [plot2d](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/VectorGraphics/html/_plot2d.html) documentation.  `eog` was giving me the following error:

> XML parse error: Error domain 1 code 5 on line 22 column 1 of data: Extra content at the end of the document

And opening the same .svg image in Chrome, I got the following:

> error on line 18 at column 68: AttValue: " or ' expected

Line 18 was:

```html
    <marker markerUnits="userSpaceOnUse" orient="auto" markerWidth=.15 refY=.1 id="gfx_2235477_8" markerHeight=.2>
```
Notice the lack of quotes around `markerWidth`, `refY`, or `markerHeight`.  With this PR, they get quotes, and it works!

(The image is teeny-weeny in `eog`, but that's another issue...)

