### PR TITLE
Prepend rootURI to filenames in viewHelp before calling show(URL)

### DIFF
--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -440,7 +440,7 @@ viewHelp = method(Dispatch => Thing)
 viewHelp String := key -> viewHelp makeDocumentTag key
 viewHelp Thing  := key -> (
     if key === () then (
-        if fileExists frontpage then show URL { frontpage }
+        if fileExists frontpage then show URL(rootURI | frontpage)
 	-- TODO: generate this on-demand
         else error("missing documentation index: ", frontpage, ". Run makePackageIndex() or start M2 without -q"))
     else viewHelp makeDocumentTag key)
@@ -448,7 +448,7 @@ viewHelp DocumentTag := tag -> (
     rawdoc := fetchAnyRawDocumentation tag;
     if ( tag' := getOption(rawdoc, symbol DocumentTag) ) =!= null
     and fileExists( docpage := concatenate htmlFilename tag' )
-    then show URL { docpage } else show help tag)
+    then show URL(rootURI | docpage) else show help tag)
 viewHelp ZZ := i -> seeAbout(viewHelp, i)
 
 viewHelp = new Command from viewHelp


### PR DESCRIPTION
This is for consistency with other calls to `show(URL)`, e.g., `show(Hypertext)` and `show(TEX)`.