### PR TITLE
Varieties: determinant, canonicalBundle, isProjective, and better caching

### DIFF
--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -641,6 +641,10 @@ runHooks(MutableHashTable, Thing, Thing) := true >> opts -> (store, key, args) -
     error("unrecognized Strategy => '", toString alg, "' for ", toString key, newline,
 	"  available strategies are: ", demark_", " \\ toExternalString \ new List from store.HookPriority))
 
+-- helper for hookifying methods
+-- runs the hooks, if none succeed, runs the default algorithm f
+tryHooks = (key, args, f) -> if (c := runHooks(key, args)) =!= null then c else f args
+
 -- and keys
 protect QuotientRingHook
 
@@ -677,6 +681,11 @@ codeHelper#(functionBody (cacheValue null) null) = g -> {
 codeHelper#(functionBody (stashValue null) null) = g -> {
      ("-- function f:", value (first localDictionaries g)#"f")
      }
+
+-- helper for hookifying and caching methods
+-- if a cached value isn't found on X, runs the hooks, if none succeed, runs the default algorithm f
+-- TODO: simplify usage
+cacheHooks = (ckey, X, mkey, args, f) -> ((cacheValue ckey) (X -> tryHooks(mkey, args, f))) X
 
 -----------------------------------------------------------------------------
 -- hypertext conversion

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -90,7 +90,6 @@ document {
     (symbol*,  RingElement, MutableMatrix),
     (symbol*,  Ring, MonomialIdeal),
     (symbol*,  MonomialIdeal, Module),
-    (symbol*,  AffineVariety, AffineVariety),
     (symbol*,  MonomialIdeal, MonomialIdeal),
     (symbol*,  RingElement, Ideal),
     (symbol*,  Matrix, Vector),

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/hilbertFunction-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/hilbertFunction-doc.m2
@@ -11,10 +11,6 @@ doc ///
     (hilbertFunction,ZZ,Module)
     (hilbertFunction,List,Ideal)
     (hilbertFunction,ZZ,Ideal)
-    (hilbertFunction,List,ProjectiveVariety)
-    (hilbertFunction,ZZ,ProjectiveVariety)
-    (hilbertFunction,List,CoherentSheaf)
-    (hilbertFunction,ZZ,CoherentSheaf)
     (hilbertFunction,Ring)
     (hilbertFunction,Module)
     (hilbertFunction,Ideal)
@@ -25,13 +21,11 @@ doc ///
   Inputs
     d:{ZZ,List} -- of integers
       specifying a degree (or multidegree)
-    M:{Ring,Module,Ideal,CoherentSheaf,ProjectiveVariety}
+    M:{Ring,Ideal,Module}
   Outputs
     :ZZ
       the dimension of the degree @SAMP "d"@ part of @SAMP "M"@.  For an
       ideal, the corresponding quotient ring is used.
-      For a projective varieties and coherent sheaves, the
-      functionality is not yet implemented.
   Description
     Text
       In the following example, compare the rank of the source of the basis map

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/hilbertSeries-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/hilbertSeries-doc.m2
@@ -2,8 +2,6 @@
 --- author(s): L.Gold
 --- note:
 
-undocumented {(hilbertSeries,CoherentSheaf)}
-
 document { 
      Key => hilbertSeries,
      Headline => "compute the Hilbert series",
@@ -71,26 +69,6 @@ document {
 	  "poincare M"
 	  }
      }
-
--- NOTE: listed as undocumented above.
--- document { 
---      Key => (hilbertSeries,CoherentSheaf),
---      Headline => "compute the Hilbert series of a coherent sheaf",
---      Usage => "hilbertSeries M",
---      Inputs => {
--- 	  "M"
--- 	  },
---      Outputs => {
--- 	  Divide => "the Hilbert series" },
---      "We compute the ", TO2 (hilbertSeries, "Hilbert series"), " of a
---      coherent sheaf.",
---      EXAMPLE {
--- 	  "V = Proj(ZZ/101[x_0..x_2]);",
--- 	  "M = sheaf(image matrix {{x_0^3+x_1^3+x_2^3}})",
---       	  "s = hilbertSeries M",
---       	  "numerator s"
--- 	  }
---      }
 
 document { 
      Key => {(hilbertSeries, Ideal)},
@@ -162,30 +140,6 @@ document {
      }
 }
 
-document { 
-     Key => (hilbertSeries,ProjectiveVariety),
-     Headline => "compute the Hilbert series of a projective variety",
-     Usage => "hilbertSeries V",
-     Inputs => {
-	  "V" =>  ProjectiveVariety
-	  },
-     Outputs => {
-	  Divide =>   "the Hilbert series" },
-     "We compute the ", TO2 (hilbertSeries, "Hilbert series"), " of a
-     projective variety, that is, the Hilbert series of the
-     homogeneous coordinate ring of ", TT "V", ". The saturation of
-     the ideal may need to be computed.",
-     PARA {
-	  "This method is not implemented yet."
-	  }
--* temporarily disabled
-     EXAMPLE {
-	  "V = Proj(QQ[x,y])",
-	  "s = hilbertSeries V",
-	  "numerator s"
-	  }
-*-
-     }
 document { 
      Key => [hilbertSeries, Order],
      Headline => "display the truncated power series expansion",

--- a/M2/Macaulay2/packages/NormalToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties.m2
@@ -56,7 +56,6 @@ export {
     "isFano", 
     "isFibration",
     "isNef",  
-    "isProjective",
     "isProper", 
     "isQQCartier", 
     "kleinschmidt",

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
@@ -484,7 +484,6 @@ isComplete NormalToricVariety := Boolean => (
 	)
     )
 
-isProjective = method ()
 isProjective NormalToricVariety := Boolean => (
     cacheValue symbol isProjective) (
     X -> (

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricVarietiesDocumentation.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricVarietiesDocumentation.m2
@@ -1799,7 +1799,6 @@ doc ///
 doc ///
     Key 
         (isProjective, NormalToricVariety)
-        isProjective	
     Headline 
         whether a toric variety is projective
     Usage 

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -40,6 +40,7 @@ export {
 importFrom_Core {
     "getAttribute", "hasAttribute", "ReverseDictionary",
     "toString'", "expressionValue", "unhold", -- TODO: prune these
+    "tryHooks", "cacheHooks",
     }
 
 -----------------------------------------------------------------------------
@@ -247,9 +248,11 @@ super   CoherentSheaf := CoherentSheaf => F -> sheaf(F.variety, super   F.module
 ambient CoherentSheaf := CoherentSheaf => F -> sheaf(F.variety, ambient F.module)
 cover   CoherentSheaf := CoherentSheaf => F -> sheaf(F.variety, cover   F.module)
 
+-- TODO: do all need to be hookified? Perhaps prefixing
+-- the variety to the key, like 'euler(X, F)', would be better.
 degree  CoherentSheaf := F -> degree  module F
 degrees CoherentSheaf := F -> degrees module F
-euler   CoherentSheaf := F -> euler   module F
+euler   CoherentSheaf := F -> tryHooks((euler, CoherentSheaf), F, euler @@ module)
 eulers  CoherentSheaf := F -> eulers  module F
 genus   CoherentSheaf := F -> genus   module F
 genera  CoherentSheaf := F -> genera  module F
@@ -469,8 +472,10 @@ cohomology(ZZ, ProjectiveVariety, CoherentSheaf) := Module => opts -> (p, X, F) 
 
 -- TODO: optimize caching here
 -- TODO: should F>=0 be hardcoded?
-minimalPresentation CoherentSheaf := prune CoherentSheaf := CoherentSheaf => opts -> (cacheValue symbol minimalPresentation) (
-    F -> sheaf(F.variety, minimalPresentation(HH^0 F(>=0), opts)))
+minimalPresentation CoherentSheaf := prune CoherentSheaf := CoherentSheaf => opts -> F -> (
+    cacheHooks(symbol minimalPresentation, F, (minimalPresentation, CoherentSheaf), (opts, F),
+	-- this is the default algorithm
+	(opts, F) -> sheaf(F.variety, minimalPresentation(HH^0 F(>=0), opts))))
 
 -----------------------------------------------------------------------------
 -- cotangentSheaf, tangentSheaf, and canonicalBundle

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -138,11 +138,11 @@ ambient     AffineVariety :=     AffineVariety => X -> Spec ambient ring X
 ambient ProjectiveVariety := ProjectiveVariety => X -> Proj ambient ring X
 
 -- arithmetic ops
--- TODO: uncomment the projective ones when Proj works with multigraded rings
--- TODO: use ** instead of * to match NormalToricVarieties, etc.
-AffineVariety     *      AffineVariety :=     AffineVariety => (X, Y) -> Spec(ring X ** ring Y)
---ProjectiveVariety *  ProjectiveVariety := ProjectiveVariety => (X, Y) -> Proj(ring X ** ring Y)
-AffineVariety     ** Ring              :=     AffineVariety => (X, R) -> X * Spec R
+-- TODO: document
+AffineVariety     **     AffineVariety :=     AffineVariety => (X, Y) -> Spec(ring X ** ring Y)
+AffineVariety     ** Ring              :=     AffineVariety => (X, R) -> X ** Spec R
+-- TODO: uncomment when Proj works with multigraded rings
+--ProjectiveVariety ** ProjectiveVariety := ProjectiveVariety => (X, Y) -> Proj(ring X ** ring Y)
 --ProjectiveVariety ** Ring              := ProjectiveVariety => (X, R) -> X ** Proj R
 
 -- property checks

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -397,7 +397,6 @@ twistedGlobalSectionsModule = (F, bound) -> (
 -- cohomology
 -----------------------------------------------------------------------------
 -- TODO: add hooks for X not finite type over k?
--- TODO: improve caching until HH^0 F(>=0) is cached
 
 -- HH^p(X, OO_X)
 cohomology(ZZ,          SheafOfRings) := Module => opts -> (p,    O) -> cohomology(p, variety O, O^1, opts)
@@ -408,6 +407,8 @@ cohomology(ZZ,                    SumOfTwists) := Module => opts -> (p,    S) ->
 cohomology(ZZ, ProjectiveVariety, SumOfTwists) := Module => opts -> (p, X, S) -> (
     checkVariety(X, S);
     (F, b) := (S#0, S#1#0);
+    if not F.cache.?HH    then F.cache.HH = new MutableHashTable;
+    if F.cache.HH#?(p, b) then F.cache.HH#(p, b) else F.cache.HH#(p, b) =
     if p == 0 then twistedGlobalSectionsModule(F, b) else HH^(p+1)(module F, Degree => b))
 
 -- HH^p(X, F)
@@ -417,6 +418,8 @@ cohomology(ZZ,     AffineVariety, CoherentSheaf) := Module => opts -> (p, X, F) 
     if p == 0 then module F else (ring F)^0)
 cohomology(ZZ, ProjectiveVariety, CoherentSheaf) := Module => opts -> (p, X, F) -> (
     checkVariety(X, F);
+    if not F.cache.?HH then F.cache.HH = new MutableHashTable;
+    if F.cache.HH#?p   then return F.cache.HH#p;
     -- TODO: only need basis(0, G) in the end, is this too much computation?
     G := if p == 0 then twistedGlobalSectionsModule(F, 0) -- HH^0 F(>=0)
     else (
@@ -431,7 +434,7 @@ cohomology(ZZ, ProjectiveVariety, CoherentSheaf) := Module => opts -> (p, X, F) 
 	-- TODO: check that X is proper (or at least finite type)
 	Ext^(n-p)(M, w));
     k := coefficientRing ring F;
-    k^(rank source basis(0, G)))
+    F.cache.HH#p = k^(rank source basis(0, G)))
 
 -----------------------------------------------------------------------------
 -- Module of twisted global sections Γ_*(F)

--- a/M2/Macaulay2/packages/Varieties/tests.m2
+++ b/M2/Macaulay2/packages/Varieties/tests.m2
@@ -1,3 +1,18 @@
+TEST /// -- twisted global section module
+  ringP3 = ZZ/101[x_0..x_3]
+  ringP1 = ZZ/101[s,t]
+  cubicMap = map(ringP1, ringP3, {s^3, s^2*t, s*t^2, t^3})
+  idealCubic = kernel cubicMap
+  Cubic = Proj(ringP3/idealCubic)
+  Omega = cotangentSheaf Cubic
+  -- certain changes in the code for twisted global sections
+  -- (e.g. omitting MinimalGenerators => true in calling Hom)
+  -- add random coefficients in the presentation of Omega.
+  assert(module Omega(1) === coker matrix(ring Cubic, {{-x_3, -x_2, -x_1}, {x_2, x_1, x_0}}))
+///
+
+end
+
 -- multigraded Proj
 restart
 needsPackage "VirtualResolutions"


### PR DESCRIPTION
- added commentary for sheaf cohomology
- added commentary for twistedGlobalSectionsModule
- added caching for sheaf cohomology
- added determinant CoherentSheaf and canonicalBundle ProjectiveVariety
- added isProjective and projectivity assertions
- added test for twisted global sections
- hookified a few methods for CoherentSheaves
- removed duplicated code from NormalToricVarieties
- switched to AffineVariety ** AffineVariety (rather than *)
