### PR TITLE
Use "standalone" class instead of "article" in showTex

### DIFF
--- a/M2/Macaulay2/m2/latex.m2
+++ b/M2/Macaulay2/m2/latex.m2
@@ -237,7 +237,7 @@ tex MENU := x -> tex drop(redoMENU x, 1)
 -----------------------------------------------------------------------------
 
 -- TODO: incorporate this with packages/Style/M2book.tex.in
-TeXclass := "\\documentclass{article}"
+TeXclass := "\\documentclass{standalone}"
 TeXpackages := {"amsmath", "amssymb"}
 TeXtemplate := src -> concatenate( TeXclass,                newline,
     apply(TeXpackages, pkg -> "\\usepackage{" | pkg | "}"), newline,


### PR DESCRIPTION
This way, the size of the document will match the size of the object we're viewing.

For example, consider the following code:

```m2
i1 : R = QQ[x,y,z,w]

o1 = R

o1 : PolynomialRing

i2 : showTex res monomialCurveIdeal(R, {1, 2, 3})
+ cd /tmp/M2-720210-0/0/
+ pdflatex -interaction=batchmode show
This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023/Debian) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
```

### Before
![image](https://github.com/Macaulay2/M2/assets/1992248/3131e900-15ab-43df-9b88-be709ba47ca9)

### After
![image](https://github.com/Macaulay2/M2/assets/1992248/2fff3267-7139-4e87-b193-059b5e30ad65)
