### PR TITLE
Don't build autotools during GitHub workflow

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -110,6 +110,7 @@ jobs:
                echo `brew --prefix make  `/libexec/gnubin >> $GITHUB_PATH
                echo `brew --prefix llvm`/bin              >> $GITHUB_PATH
                PATH=`brew --prefix llvm`/bin:$PATH
+               echo `brew --prefix libtool`/libexec/gnubin >> $GITHUB_PATH
           fi
           # Necessary for clang to find the right libomp
           echo "LIBRARY_PATH=`llvm-config --libdir`" >> $GITHUB_ENV

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -161,7 +161,6 @@ jobs:
       - name: Configure Macaulay2 using Autotools
         if: matrix.build-system == 'autotools'
         run: |
-          make -C ../.. get-libtool get-automake get-autoconf
           make -C ../.. all
           export PYVERSION=`python3 -c "from sys import version_info; \
             print(f'{version_info.major}.{version_info.minor}')"`


### PR DESCRIPTION
autoconf, automake, and libtool are already available on the system, so there's no need to build them from scratch.

The one wrinkle is that on macOS, `/usr/bin/libtool` isn't GNU libtool, but if we add the correct directory to the `PATH` environment variable as outlined on the [brew libtool page](https://formulae.brew.sh/formula/libtool), then we're all set.