### PR TITLE
Simplified calls to scripted functors

### DIFF
--- a/M2/Macaulay2/m2/Hom.m2
+++ b/M2/Macaulay2/m2/Hom.m2
@@ -8,7 +8,7 @@ needs "matrix1.m2"
 
 Hom = method(Options => {
 	DegreeLimit       => null,
-	MinimalGenerators => false,
+	MinimalGenerators => true,
 	Strategy          => null,
 	})
 

--- a/M2/Macaulay2/m2/ext.m2
+++ b/M2/Macaulay2/m2/ext.m2
@@ -6,22 +6,19 @@ needs "matrix1.m2"
 needs "modules.m2"
 needs "Hom.m2"
 
+-- TODO: should this be fixed for all Ext methods,
+-- or should they each have their own options?
 ExtOptions = new OptionTable from {
     MinimalGenerators => true
      }
 
 Ext = new ScriptedFunctor from {
-    argument => ExtOptions >> opts -> (M, N) -> (
-	       f := lookup(Ext,class M,class N);
-	       if f === null then noMethod(Ext,(M,N),{false,false});
-	(f opts)(M, N)),
     superscript => i -> new ScriptedFunctor from {
-	argument => ExtOptions >> opts -> (M, N) -> (
-		    	      f := lookup(Ext,class i,class M,class N);
-		    	      if f === null then noMethod(Ext,(i,M,N),{false,false,false});
-	     (f opts)(i, M, N))
-	       }
-     }
+	-- Ext^1(F, G)
+	argument => ExtOptions >> opts -> X -> applyMethodWithOpts''(Ext, functorArgs(i, X), opts)
+	},
+    argument => ExtOptions >> opts -> X -> applyMethodWithOpts''(Ext, X, opts)
+    }
 
 -- TODO: Ext^i(R, S) should work as well
 Ext(ZZ, Ring, Ring)   :=

--- a/M2/Macaulay2/m2/gateway.m2
+++ b/M2/Macaulay2/m2/gateway.m2
@@ -27,6 +27,16 @@ applyMethod'' = (F, X) -> (
     key := prepend(F, delete(Option, apply(X, class)));
     applyMethod'(key, toString F, X))
 
+-- TODO: combine for all functors
+applyMethodWithOpts' = (key, desc, X, opts) -> (
+    if (F := lookup key) =!= null then (F opts) X
+    else error("no method for ", desc, " applied to ", X))
+
+applyMethodWithOpts'' = (F, X, opts) -> (
+    -- TODO: write a variation of lookup to do this
+    key := prepend(F, apply(X, class));
+    applyMethodWithOpts'(key, toString F, X, opts))
+
 -----------------------------------------------------------------------------
 -- Functor and ScriptedFunctor type declarations
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/gateway.m2
+++ b/M2/Macaulay2/m2/gateway.m2
@@ -3,6 +3,34 @@
 needs "expressions.m2"
 needs "methods.m2"
 
+-----------------------------------------------------------------------------
+-- helpers for functors
+-----------------------------------------------------------------------------
+
+-- flatten the arguments given to a scripted functor
+functorArgs = method()
+functorArgs(Thing,        Sequence) := (i,    args) -> prepend(i, args)
+functorArgs(Thing, Thing, Sequence) := (i, j, args) -> prepend(i, prepend(j, args))
+functorArgs(Thing, Thing, Thing)    :=
+functorArgs(Thing, Thing)           := identity
+
+applyMethod = (key, X) -> (
+    if (F := lookup key) =!= null then F X else error "no method available") -- expand this error message later
+
+-- TODO: combine these with applyMethod and retire these
+applyMethod' = (key, desc, X) -> (
+    if (F := lookup key) =!= null then F X
+    else error("no method for ", desc, " applied to ", X))
+
+applyMethod'' = (F, X) -> (
+    -- TODO: write a variation of lookup to do this
+    key := prepend(F, delete(Option, apply(X, class)));
+    applyMethod'(key, toString F, X))
+
+-----------------------------------------------------------------------------
+-- Functor and ScriptedFunctor type declarations
+-----------------------------------------------------------------------------
+
 ScriptedFunctor = new Type of MutableHashTable
 ScriptedFunctor.synonym = "scripted functor"
 globalAssignment ScriptedFunctor

--- a/M2/Macaulay2/m2/tor.m2
+++ b/M2/Macaulay2/m2/tor.m2
@@ -4,21 +4,24 @@ needs "gateway.m2" -- for ScriptedFunctor
 needs "matrix1.m2"
 needs "modules.m2"
 
+-- TODO: should this be fixed for all Tor methods,
+-- or should they each have their own options?
 TorOptions = new OptionTable from {
     MinimalGenerators => true
      }
 
-
 Tor = new ScriptedFunctor from {
     subscript => i -> new ScriptedFunctor from {
-	argument => TorOptions >> opts -> (M, N) -> (
-		    	      f := lookup(Tor,class i,class M,class N);
-		if f === null then error "no method available";
-	    (f opts)(i, M, N))
-	       }
-     }
+	-- Tor_i(F, G)
+	argument => TorOptions >> opts -> X -> applyMethodWithOpts''(Tor, functorArgs(i, X), opts)
+	},
+    argument => TorOptions >> opts -> X -> applyMethodWithOpts''(Tor, X, opts)
+    }
 
 -- see packages/Complexes/Tor.m2 for Tor(ZZ, Module, Matrix) and Tor(ZZ, Matrix, Module)
+Tor(ZZ, Module, Matrix) := Matrix => opts -> (i, J, f) -> notImplemented()
+Tor(ZZ, Matrix, Module) := Matrix => opts -> (i, J, f) -> notImplemented()
+
 Tor(ZZ, Ring,  Matrix) :=
 Tor(ZZ, Ideal, Matrix) := opts -> (i,M,f) -> Tor_i(module M, f, opts)
 Tor(ZZ, Matrix, Ring)  :=

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -542,17 +542,17 @@ CoherentSheaf ^** ZZ := (F,n) -> binaryPower(F,n,tensor,() -> OO_(F.variety)^1, 
 -- Sheaf Hom and Ext
 -----------------------------------------------------------------------------
 
+Hom(SheafOfRings, SheafOfRings)  :=
+Hom(SheafOfRings, CoherentSheaf) :=
+Hom(CoherentSheaf, SheafOfRings)  :=
 Hom(CoherentSheaf, CoherentSheaf) := Module => o -> (F, G) -> HH^0(variety F, sheafHom(F, G, o))
-Hom(SheafOfRings,  CoherentSheaf) := Module => o -> (O, G) -> Hom(O^1, G,   o)
-Hom(CoherentSheaf, SheafOfRings)  := Module => o -> (F, O) -> Hom(F,   O^1, o)
-Hom(SheafOfRings,  SheafOfRings)  := Module => o -> (O, R) -> Hom(O^1, R^1, o)
 
 sheafHom = method(TypicalValue => CoherentSheaf, Options => options Hom)
 -- TODO: should this assert that the sheaves are on the same variety?
+sheafHom(SheafOfRings, SheafOfRings)  :=
+sheafHom(SheafOfRings, CoherentSheaf) :=
+sheafHom(CoherentSheaf, SheafOfRings)  :=
 sheafHom(CoherentSheaf, CoherentSheaf) := CoherentSheaf => o -> (F, G) -> sheaf(variety F, Hom(module F, module G, o))
-sheafHom(SheafOfRings,  CoherentSheaf) := CoherentSheaf => o -> (O, G) -> sheafHom(O^1, G,   o)
-sheafHom(CoherentSheaf, SheafOfRings)  := CoherentSheaf => o -> (F, O) -> sheafHom(F,   O^1, o)
-sheafHom(SheafOfRings,  SheafOfRings)  := CoherentSheaf => o -> (O, R) -> sheafHom(O^1, R^1, o)
 
 -- see m2/ext.m2
 ExtOptions = options Ext.argument
@@ -568,13 +568,12 @@ sheafExt = new ScriptedFunctor from {
 	)
     }
 
+sheafExt(ZZ, SheafOfRings, SheafOfRings)  :=
+sheafExt(ZZ, SheafOfRings, CoherentSheaf) :=
+sheafExt(ZZ, CoherentSheaf, SheafOfRings)  :=
 sheafExt(ZZ, CoherentSheaf, CoherentSheaf) := CoherentSheaf => opts -> (
      (n,F,G) -> sheaf_(variety F) Ext^n(module F, module G, opts)
      )
-
-sheafExt(ZZ,SheafOfRings,CoherentSheaf) := Module => (n,O,G) -> sheafExt^n(O^1,G)
-sheafExt(ZZ,CoherentSheaf,SheafOfRings) := Module => (n,F,O) -> sheafExt^n(F,O^1)
-sheafExt(ZZ,SheafOfRings,SheafOfRings) := Module => (n,O,R) -> sheafExt^n(O^1,R^1)
 
 -----------------------------------------------------------------------------
 -- code donated by Greg Smith <ggsmith@math.berkeley.edu>
@@ -585,7 +584,8 @@ sheafExt(ZZ,SheafOfRings,SheafOfRings) := Module => (n,O,R) -> sheafExt^n(O^1,R^
 -- See tests/normal/ext-global.m2 for the examples
 -----------------------------------------------------------------------------
 
-Ext(ZZ,CoherentSheaf,SumOfTwists) := Module => opts -> (m,F,G') -> (
+Ext(ZZ, SheafOfRings,  SumOfTwists) :=
+Ext(ZZ, CoherentSheaf, SumOfTwists) := Module => opts -> (m,F,G') -> (
      -- depends on truncate methods
      needsPackage "Truncations";
      G := G'#0;
@@ -617,16 +617,13 @@ Ext(ZZ,CoherentSheaf,SumOfTwists) := Module => opts -> (m,F,G') -> (
      else if (min degrees E)#0 > e then minimalPresentation E
      else minimalPresentation truncate(e,E))
 
-Ext(ZZ,SheafOfRings,SumOfTwists) := Module => opts -> (m,O,G') -> Ext^m(O^1,G',opts)
-
-Ext(ZZ,CoherentSheaf,CoherentSheaf) := Module => opts -> (n,F,G) -> (
+Ext(ZZ, SheafOfRings, SheafOfRings)  :=
+Ext(ZZ, SheafOfRings, CoherentSheaf) :=
+Ext(ZZ, CoherentSheaf, SheafOfRings)  :=
+Ext(ZZ, CoherentSheaf, CoherentSheaf) := Module => opts -> (n,F,G) -> (
      E := Ext^n(F,G(>=0),opts);
      k := coefficientRing ring E;
      k^(rank source basis(0,E)))
-
-Ext(ZZ,SheafOfRings,CoherentSheaf) := Module => opts -> (n,O,G) -> Ext^n(O^1,G,opts)
-Ext(ZZ,CoherentSheaf,SheafOfRings) := Module => opts -> (n,F,O) -> Ext^n(F,O^1,opts)
-Ext(ZZ,SheafOfRings,SheafOfRings) := Module => opts -> (n,O,R) -> Ext^n(O^1,R^1,opts)
 
 -----------------------------------------------------------------------------
 -- end of code donated by Greg Smith <ggsmith@math.berkeley.edu>

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -573,19 +573,17 @@ sheafExt(ZZ, CoherentSheaf, CoherentSheaf) := CoherentSheaf => options Ext.argum
 
 Ext(ZZ, SheafOfRings,  SumOfTwists) :=
 Ext(ZZ, CoherentSheaf, SumOfTwists) := Module => opts -> (m,F,G') -> (
+    sameVariety(F, G');
+    X := variety F;
+    checkProjective X;
+    checkVariety(X, F);
      -- depends on truncate methods
      needsPackage "Truncations";
      G := G'#0;
      e := G'#1#0;
-     if variety G =!= variety F
-     then error "expected sheaves on the same variety";
-     if not instance(variety G,ProjectiveVariety)
-     then error "expected sheaves on a projective variety";
      M := module F;
      N := module G;
      R := ring M;
-     if not isAffineRing R
-     then error "expected sheaves on a variety over a field";
      local E;
      if dim M === 0 or m < 0 then E = R^0
      else (

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -542,32 +542,25 @@ Hom(CoherentSheaf, SheafOfRings)  :=
 Hom(CoherentSheaf, CoherentSheaf) := Module => o -> (F, G) -> HH^0(variety F, sheafHom(F, G, o))
 
 sheafHom = method(TypicalValue => CoherentSheaf, Options => options Hom)
--- TODO: should this assert that the sheaves are on the same variety?
 sheafHom(SheafOfRings, SheafOfRings)  :=
 sheafHom(SheafOfRings, CoherentSheaf) :=
 sheafHom(CoherentSheaf, SheafOfRings)  :=
-sheafHom(CoherentSheaf, CoherentSheaf) := CoherentSheaf => o -> (F, G) -> sheaf(variety F, Hom(module F, module G, o))
-
--- see m2/ext.m2
-ExtOptions = options Ext.argument
+sheafHom(CoherentSheaf, CoherentSheaf) := CoherentSheaf => o -> (F, G) -> (
+    sameVariety(F, G); sheaf(variety F, Hom(module F, module G, o)))
 
 sheafExt = new ScriptedFunctor from {
-    superscript => (
-	i -> new ScriptedFunctor from {
-	    argument => ExtOptions >> opts -> (M, N) -> (
-		f := lookup(sheafExt,class i,class M,class N);
-		if f === null then error "no method available";
-		(f opts)(i,M,N))
-	    }
-	)
+    superscript => i -> new ScriptedFunctor from {
+	-- sheafExt^1(F, G)
+	argument => X -> applyMethod''(sheafExt, functorArgs(i, X))
+	},
+    argument => X -> applyMethod''(sheafExt, X)
     }
 
 sheafExt(ZZ, SheafOfRings, SheafOfRings)  :=
 sheafExt(ZZ, SheafOfRings, CoherentSheaf) :=
 sheafExt(ZZ, CoherentSheaf, SheafOfRings)  :=
-sheafExt(ZZ, CoherentSheaf, CoherentSheaf) := CoherentSheaf => opts -> (
-     (n,F,G) -> sheaf_(variety F) Ext^n(module F, module G, opts)
-     )
+sheafExt(ZZ, CoherentSheaf, CoherentSheaf) := CoherentSheaf => options Ext.argument >> opts -> (i, F, G) -> (
+    sameVariety(F, G); sheaf(variety F, Ext^i(module F, module G, opts)))
 
 -----------------------------------------------------------------------------
 -- code donated by Greg Smith <ggsmith@math.berkeley.edu>

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -39,16 +39,10 @@ export {
 
 importFrom_Core {
     "getAttribute", "hasAttribute", "ReverseDictionary",
+    "applyMethod", "applyMethod''", "functorArgs",
     "toString'", "expressionValue", "unhold", -- TODO: prune these
     "tryHooks", "cacheHooks",
     }
-
------------------------------------------------------------------------------
--- Utilities to be added to Core
------------------------------------------------------------------------------
-
-applyMethod = (key, X) -> (
-    if (F := lookup key) =!= null then F X else error "no method available") -- expand this error message later
 
 -----------------------------------------------------------------------------
 -- Local utilities

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -464,12 +464,11 @@ cohomology(ZZ, ProjectiveVariety, CoherentSheaf) := Module => opts -> (p, X, F) 
 -- Module of twisted global sections Γ_*(F)
 -----------------------------------------------------------------------------
 
--- TODO: optimize caching here
+-- TODO: optimize caching: if HH^0(F>=b) is cached above, does this need to be cached?
 -- TODO: should F>=0 be hardcoded?
 minimalPresentation CoherentSheaf := prune CoherentSheaf := CoherentSheaf => opts -> F -> (
     cacheHooks(symbol minimalPresentation, F, (minimalPresentation, CoherentSheaf), (opts, F),
-	-- this is the default algorithm
-	(opts, F) -> sheaf(F.variety, minimalPresentation(HH^0 F(>=0), opts))))
+	(opts, F) -> sheaf(F.variety, HH^0 F(>=0)))) -- this is the default algorithm
 
 -----------------------------------------------------------------------------
 -- cotangentSheaf, tangentSheaf, and canonicalBundle
@@ -587,12 +586,13 @@ Ext(ZZ, CoherentSheaf, SumOfTwists) := Module => opts -> (m,F,G') -> (
      local E;
      if dim M === 0 or m < 0 then E = R^0
      else (
-          f := presentation R;
-          S := ring f;
-          n := numgens S -1;
           l := min(dim N, m);
-	  P := resolution(cokernel lift(presentation N,S) ** cokernel f);
+	  P := resolution flattenModule N;
 	  p := length P;
+	  n := dim ring P - 1;
+	  -- global Ext is composition of sheaf Ext and cohomology
+	  -- so we compute it as a Grothendieck spectral sequence
+	  -- in this case, it degenerates
 	  if p < n-l then E = Ext^m(M, N, opts)
 	  else (
 	       a := max apply(n-l..p,j -> (max degrees P_j)#0-j);

--- a/M2/Macaulay2/tests/normal/hom.m2
+++ b/M2/Macaulay2/tests/normal/hom.m2
@@ -268,9 +268,9 @@ fh = Hom(M,f)
 assert (target fh == Hom(M, target f))
 assert (source fh == Hom(M, source f))
 assert( (minimalPresentation Hom(f,M)) ===
-   map(S^1,cokernel map(S^{{ -1},{ -1}},S^{{ -2}},{{ -b}, {a}}),{{a,b}}) )
+    map(S^1,cokernel(map(S^{{-1}, {-1}},S^{{-2}},{{a}, {-b}})),{{b, a}}) )
 assert( (minimalPresentation Hom(f,f)) ===
-     map(S^1,cokernel map(S^{{ -1},{ -1}},S^{{ -2}},{{ -b}, {a}}),{{a,b}}) )
+    map(S^1,cokernel(map(S^{{-1}, {-1}},S^{{-2}},{{a}, {-b}})),{{b, a}}) )
 
 -- bug found by David Treumann:
 


### PR DESCRIPTION
- simplified sheafy Hom and Ext methods
- added helper methods for scripted functors
- added helper methods for scripted functors with options
- updated sheafHom and sheafExt
- simplified global Ext
- updated Ext to use functor helpers
- updated Tor to use functor helpers
- added more details for prune and Ext of sheaves
