### PR TITLE
Make infoLevel (used for debugging hooks) thread local

### DIFF
--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -610,7 +610,6 @@ popInfoLevel  := (n, s) -> (infoLevel = infoLevel - n; s)
 
 -- This function is mainly used by runHooks, printing a line like this:
  -- (quotient,Ideal,Ideal) with Strategy => Monomial from -*Function[../../Macaulay2/packages/Saturation.m2:196:30-205:82]*-
--- TODO: the filenames are not emacs clickable, perhaps M2-mode should be improved
 debugInfo = (func, key, strategy, infoLevel) -> if debugLevel > infoLevel then printerr(
     toString key, if strategy =!= null then (" with Strategy => ", toString strategy), " from ", toString func)
 

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -602,8 +602,10 @@ addHook(MutableHashTable, Thing, Function) := opts -> (store, key, hook) -> (
     store.HookAlgorithms#alg = hook)
 
 -- tracking debugInfo
-infoLevel     := -1
-pushInfoLevel :=  n     -> (infoLevel = infoLevel + n; n)
+threadVariable infoLevel
+pushInfoLevel :=  n -> (
+    if infoLevel === null then infoLevel = -1;
+    infoLevel = infoLevel + n; n)
 popInfoLevel  := (n, s) -> (infoLevel = infoLevel - n; s)
 
 -- This function is mainly used by runHooks, printing a line like this:


### PR DESCRIPTION
@DaveBarton and I fixed this little bug we noticed at AIM a few months ago.  There's a global variable, `infoLevel`, that is used to keep track of the depth when running hooks.  It's used to print some debugging info depending on the value of `debugLevel`.  If `infoLevel` is bigger than `debugLevel`, then we print a message telling us which hook we're running.  Here's a simple example:

```m2
i1 : foo = method();

i2 : addHook((foo, ZZ), n -> bar n);

i3 : foo ZZ := n -> runHooks((foo, ZZ), n);

i4 : bar = method();

i5 : addHook((bar, ZZ), n -> baz n);

i6 : bar ZZ := n -> runHooks((bar, ZZ), n);

i7 : baz = method();

i8 : addHook((baz, ZZ), n -> qux n);

i9 : baz ZZ := n -> runHooks((baz, ZZ), n);

i10 : qux = method();

i11 : addHook((qux, ZZ), identity);

i12 : qux ZZ := n -> runHooks((qux, ZZ), n);

i13 : for i to 4 do (
          debugLevel = i;
          print("* using debugLevel = " | toString i | ":");
          foo 3)
* using debugLevel = 0:
* using debugLevel = 1:
 -- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28]
* using debugLevel = 2:
 -- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28]
 -- (bar,ZZ) with Strategy => 0 from FunctionClosure[stdio:5:21-5:28]
* using debugLevel = 3:
 -- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28]
 -- (bar,ZZ) with Strategy => 0 from FunctionClosure[stdio:5:21-5:28]
 -- (baz,ZZ) with Strategy => 0 from FunctionClosure[stdio:8:21-8:28]
* using debugLevel = 4:
 -- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28]
 -- (bar,ZZ) with Strategy => 0 from FunctionClosure[stdio:5:21-5:28]
 -- (baz,ZZ) with Strategy => 0 from FunctionClosure[stdio:8:21-8:28]
 -- (qux,ZZ) with Strategy => 0 from identity
```

But we run into problems when running parallel code that uses hooks, as we have multiple threads modifying `infoLevel` at the same time.  Also, `debugLevel` is thread local, and so we're not comparing `infoLevel` with its global value anyway.  This can lead to strange behavior like printing these messages even when we don't want to, and ultimately even crashes:

```m2
i14 : allowableThreads = maxAllowableThreads

o14 = 12

i15 : debugLevel = 0

o15 = 0

i16 : for i to 999 do schedule(() -> foo 3)

i17 :  -- (baz,ZZ) -- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28]
 -- (baz,ZZ) -- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28]  -- (baz,ZZ) -- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28] -- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28]

-- (foo,ZZ) with Strategy => 0 from FunctionClosure[stdio:2:21-2:28]

internal error: beginning of line marker not within buffer
internal error: beginning of line marker not within buffer
internal error: beginning of line marker not within buffer
Aborted (core dumped)

Process M2 exited abnormally with code 134
```
So we make `infoLevel` thread local using the `threadVariable` keyword.  Note that it's initialized to `null` in each new thread, so we first check if it's `null` and then set it to the initial value of -1 if it is.

### After
```m2
i14 : for i to 999 do schedule(() -> foo 3)

i15 :
```

(Note that we still often get `error: interrupted` running this code, but I think that's another issue...)

We also ~~remove the unused return value of the `pushInfoLevel` function and~~ remove a `TODO` comment that was fixed in https://github.com/Macaulay2/M2-emacs/pull/39.
