### PR TITLE
fix regex of isAbsolutePath etc

### DIFF
--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -144,10 +144,10 @@ if firstTime then (
      re = re | "|\\$";					    -- $www.uiuc.edu:80
      re = re | "|!";					    -- !date
      re = re | "|~";					    -- ~user/foo/bar
-     isAbsolutePathRegexp := "^(" | re | ")";		    -- whether the path will work from any directory and get to the same file
+     isAbsolutePathRegexp := "\\`(" | re | ")";             -- whether the path will work from any directory and get to the same file
      re = re | "|\\./";					    -- ./foo/bar
      re = re | "|\\.\\./";				    -- ../foo/bar
-     isStablePathRegexp   := "^(" | re | ")";               -- whether we should search only in the current directory (or current file directory)
+     isStablePathRegexp   := "\\`(" | re | ")";             -- whether we should search only in the current directory (or current file directory)
      -- whether to search the path for an executable, based on execvp(3)
      isFixedExecPath = filename -> match("/", filename);
      isAbsolutePath = filename -> match(isAbsolutePathRegexp, filename);


### PR DESCRIPTION
the regex of `isAbsolutePath` used `^` to signify the start of the string. since our regex is multiline it actually matched the start of every line, which created subtle bugs, e.g., the `src` field of an `IMG` being improperly tagged as absolute path when it's a `data/image` which happens to have a line starting with a `/`. I replaced ^ with \\` which matches the start of the string only.