### PR TITLE
Raise division by zero errors for integer/polynomial division

### DIFF
--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -8,6 +8,8 @@ export times0():Expr := oneE;
 export plus1(e:Expr) : Expr := e;
 times1 := plus1;
 
+export DivisionByZero():Expr := buildErrorPacket("division by zero");
+
 export (lhs:Expr) + (rhs:Expr) : Expr := (
      when lhs
      is x:ZZcell do (
@@ -368,11 +370,11 @@ export (lhs:Expr) / (rhs:Expr) : Expr := (
 	  when rhs
 	  is y:ZZcell do (					    -- # typical value: symbol /, ZZ, ZZ, ZZ
 	       if y.v === 0
-	       then buildErrorPacket("division by zero")
+	       then DivisionByZero()
 	       else toExpr(x.v / y.v))
      	  is y:QQcell do (					    -- # typical value: symbol /, ZZ, QQ, QQ
 	       if y.v === 0
-	       then buildErrorPacket("division by zero")
+	       then DivisionByZero()
 	       else toExpr(x.v / y.v))
      	  is y:RRcell do (					    -- # typical value: symbol /, ZZ, RR, RR
 	       toExpr(toRR(x.v,precision(y.v)) / y.v))
@@ -385,17 +387,17 @@ export (lhs:Expr) / (rhs:Expr) : Expr := (
 	  when rhs
 	  is y:ZZcell do (					    -- # typical value: symbol /, QQ, ZZ, QQ
 	       if y.v === 0
-	       then buildErrorPacket("division by zero")
+	       then DivisionByZero()
 	       else toExpr(x.v / y.v))
      	  is y:QQcell do (					    -- # typical value: symbol /, QQ, QQ, QQ
 	       if y.v === 0
-	       then buildErrorPacket("division by zero")
+	       then DivisionByZero()
 	       else toExpr(x.v / y.v))
      	  is y:RRcell do (					    -- # typical value: symbol /, QQ, RR, RR
 	       toExpr(toRR(x.v,precision(y.v)) / y.v))
           is y:RRicell do (toExpr(x.v / y.v))   -- # typical value: symbol /, QQ, RRi, RRi
      	  is y:CCcell do (					    -- # typical value: symbol /, QQ, CC, CC
-	       if y.v === 0 then buildErrorPacket("division by zero") else
+	       if y.v === 0 then DivisionByZero() else
 	       toExpr(toRR(x.v,precision(y.v.re)) / y.v))
 	  is Error do rhs
 	  else binarymethod(lhs,rhs,DivideS))
@@ -403,11 +405,11 @@ export (lhs:Expr) / (rhs:Expr) : Expr := (
 	  when rhs
 	  is y:ZZcell do (					    -- # typical value: symbol /, RR, ZZ, RR
 	       if y.v === 0
-	       then buildErrorPacket("division by zero")
+	       then DivisionByZero()
 	       else toExpr(x.v / y.v))
      	  is y:QQcell do (					    -- # typical value: symbol /, RR, QQ, RR
 	       if y.v === 0
-	       then buildErrorPacket("division by zero")
+	       then DivisionByZero()
 	       else toExpr(x.v / y.v))
      	  is y:RRcell do (					    -- # typical value: symbol /, RR, RR, RR
 	       toExpr(x.v / y.v))
@@ -420,11 +422,11 @@ export (lhs:Expr) / (rhs:Expr) : Expr := (
       when rhs
 	       is y:ZZcell do (                     -- # typical value: symbol /, RRi, ZZ, RRi
 	         if y.v === 0
-	         then buildErrorPacket("division by zero")
+	         then DivisionByZero()
 	         else toExpr(x.v / y.v))
            is y:QQcell do (                      -- # typical value: symbol /, RRi, QQ, RRi
 	         if y.v === 0
-	         then buildErrorPacket("division by zero")
+	         then DivisionByZero()
 	         else toExpr(x.v / y.v))
            is y:RRcell do (toExpr(x.v / y.v))    -- # typical value: symbol /, RRi, RR, RRi
            is y:RRicell do (toExpr(x.v / y.v))   -- # typical value: symbol /, RRi, RRi, RRi
@@ -434,12 +436,12 @@ export (lhs:Expr) / (rhs:Expr) : Expr := (
 	  when rhs
 	  is y:ZZcell do (					    -- # typical value: symbol /, CC, ZZ, CC
 	       if y.v === 0
-	       then buildErrorPacket("division by zero")
+	       then DivisionByZero()
 	       else toExpr(x.v / toRR(y.v,precision(x.v.re)))
 	       )
      	  is y:QQcell do (					    -- # typical value: symbol /, CC, QQ, CC
 	       if y.v === 0
-	       then buildErrorPacket("division by zero")
+	       then DivisionByZero()
 	       else toExpr(x.v / toRR(y.v,precision(x.v.re)))
 	       )
      	  is y:RRcell do (					    -- # typical value: symbol /, CC, RR, CC
@@ -591,7 +593,7 @@ export (lhs:Expr) ^ (rhs:Expr) : Expr := (
 		    if int(y.v%ushort(2)) == 0
 		    then oneE
 		    else minusoneE)
-	       else if isZero(x.v) then buildErrorPacket("division by zero")
+	       else if isZero(x.v) then DivisionByZero()
 	       else (
 		    ex := - y.v;
 		    if !isLong(ex)
@@ -603,7 +605,7 @@ export (lhs:Expr) ^ (rhs:Expr) : Expr := (
 		    	 else toExpr(newQQCanonical(     oneZZ, den)))))
 	  is y:QQcell do (
 	       if isZero(x.v) && isNegative(y.v)
-	       then return buildErrorPacket("division by zero");
+	       then return DivisionByZero();
 	       d := denominator(y.v);
 	       if d === 1 then (
 		    if isNegative(y.v) then toExpr(oneZZ/x.v^(-numerator(y.v)))
@@ -636,14 +638,14 @@ export (lhs:Expr) ^ (rhs:Expr) : Expr := (
 	  when rhs
 	  is y:ZZcell do (
 	       if isZero(x.v) && isNegative(y.v)
-	       then return buildErrorPacket("division by zero");
+	       then return DivisionByZero();
 	       if isLong(y.v) 
 	       then toExpr(x.v^y.v)
 	       else buildErrorPacket("expected exponent to be a small integer")
 	       )
 	  is y:QQcell do (
 	       if isZero(x.v) && isNegative(y.v)
-	       then return buildErrorPacket("division by zero");
+	       then return DivisionByZero();
 	       d := denominator(y.v);
 	       if d === 1 then (
 		    if isLong(numerator(y.v))

--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -474,7 +474,7 @@ export (lhs:Expr) // (rhs:Expr) : Expr := (
 	  when rhs
 	  is y:ZZcell do (					    -- # typical value: symbol //, ZZ, ZZ, ZZ
 	       if y.v === 0
-	       then zeroE
+	       then DivisionByZero()
 	       else toExpr(x.v//y.v)
 	       )
      	  is Error do rhs

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -128,7 +128,7 @@ integermod(e:Expr):Expr := (
      if length(a) == 2 then 
      when a.0 is x:ZZcell do 
      when a.1 is y:ZZcell do 
-     if y.v === 0 then a.0
+     if y.v === 0 then DivisionByZero()
      else toExpr(x.v % y.v)
      else WrongArgZZ(2)
      else WrongArgZZ(1)

--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -6,6 +6,7 @@ use engine;
 use common;
 use hashtables;
 use struct;
+use actors;
 
 header "// TODO: break apart this file so each piece includes only one:
 #include <interface/aring.h>
@@ -1174,7 +1175,7 @@ export rawDivMod(e:Expr):Expr := (
      else WrongArg(2,"a raw ring element")
      is x:ZZcell do
      when a.1 is y:ZZcell do (
-	 if isZero(y.v) then return seq(zeroE, Expr(x));
+	 if isZero(y.v) then return DivisionByZero();
 	 q := newZZmutable();
 	 r := newZZmutable();
 	 if isPositive(y.v)

--- a/M2/Macaulay2/e/poly.cpp
+++ b/M2/Macaulay2/e/poly.cpp
@@ -1134,7 +1134,6 @@ ring_elem PolyRing::remainder(const ring_elem f, const ring_elem g) const
 {
   ring_elem quot;
   ring_elem rem;
-  if (is_zero(g)) throw exc::internal_error("cannot use division algorithm dividing by zero");
   rem = remainderAndQuotient(f, g, quot);
   return rem;
 }
@@ -1143,7 +1142,6 @@ ring_elem PolyRing::quotient(const ring_elem f, const ring_elem g) const
 {
   ring_elem quot;
   ring_elem rem;
-  if (is_zero(g)) throw exc::internal_error("cannot use division algorithm dividing by zero");
   rem = remainderAndQuotient(f, g, quot);
   return quot;
 }
@@ -1157,6 +1155,7 @@ ring_elem PolyRing::remainderAndQuotient(const ring_elem f,
       throw exc::engine_error(
           "polynomial division not yet implemented for RR or CC coefficients");
     }
+  if (is_zero(g)) throw exc::internal_error("cannot use division algorithm dividing by zero");
   Nterm *q, *r;
   ring_elem rem;
   if (is_zero(f))

--- a/M2/Macaulay2/tests/normal/division.m2
+++ b/M2/Macaulay2/tests/normal/division.m2
@@ -205,7 +205,6 @@ assert( (quotientRemainder(1-u^3,1-u)) === (1+u+u^2,0_R) )
 -- quotientRemainder(ZZ, ZZ)
   assert Equation(quotientRemainder(5710, 56), (101, 54))
   assert Equation(quotientRemainder(5710, -56), (-101, 54))
-  assert Equation(quotientRemainder(5710, 0), (0, 5710))
 
 end--
 generateAssertions ///


### PR DESCRIPTION
Currently, we sometimes raise an error and sometimes don't when dividing by zero in integer or polynomial division:

```m2
i1 : 1 // 0

o1 = 0

i2 : 1 % 0

o2 = 1

i3 : quotientRemainder(1, 0)

o3 = (0, 1)

o3 : Sequence

i4 : R = ZZ[x]

o4 = R

o4 : PolynomialRing

i5 : 1_R // 0_R
stdio:5:5:(3): error: cannot use division algorithm dividing by zero

i6 : 1_R % 0_R
stdio:6:5:(3): error: cannot use division algorithm dividing by zero

i7 : quotientRemainder(1_R, 0_R)

o7 = (0, 1)

o7 : Sequence
```

I propose that for consistency, we *always* raise an error. 

```m2
i1 : 1 // 0
stdio:1:3:(3): error: division by zero

i2 : 1 % 0
stdio:2:3:(3): error: division by zero

i3 : quotientRemainder(1, 0)
stdio:3:1:(3): error: division by zero

i4 : R = ZZ[x]

o4 = R

o4 : PolynomialRing

i5 : 1_R // 0_R
stdio:5:5:(3): error: cannot use division algorithm dividing by zero

i6 : 1_R % 0_R
stdio:6:5:(3): error: cannot use division algorithm dividing by zero

i7 : quotientRemainder(1_R, 0_R)
stdio:7:1:(3): error: cannot use division algorithm dividing by zero
```
