### PR TITLE
Check for division by zero in lcm

### DIFF
--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -49,7 +49,10 @@ gcdCoefficients(RingElement,RingElement) := (f,g) -> (	    -- ??
 
 lcm(ZZ,RingElement) := (r,s) -> lcm(promote(abs r,ring s),s)
 lcm(RingElement,ZZ) := (r,s) -> lcm(promote(abs s,ring r),r)
-lcm(RingElement,RingElement) := (f,g) -> f * (g // gcd(f,g))
+lcm(RingElement,RingElement) := (f,g) -> (
+    d := gcd(f, g);
+    if d == 0 then d
+    else f * (g // d))
 
 -----------------------------------------------------------------------------
 

--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -58,10 +58,16 @@ abs ZZ := abs RR := abs RRi := abs CC := abs QQ := abs0
 abs Constant := abs @@ numeric
 
 lcm = method(Binary => true)
-lcm(ZZ,ZZ) := (f,g) -> abs f * (abs g // gcd(f,g))
-lcm(ZZ,QQ) := (f,g) -> abs f * (abs g / gcd(f,g))
-lcm(QQ,ZZ) := (f,g) -> abs f * (abs g / gcd(f,g))
-lcm(QQ,QQ) := (f,g) -> abs f * (abs g / gcd(f,g))
+lcm(ZZ,ZZ) := (f,g) -> (
+    d := gcd(f, g);
+    if d == 0 then 0
+    else abs f * (abs g // d))
+lcm(ZZ,QQ) :=
+lcm(QQ,ZZ) :=
+lcm(QQ,QQ) := (f,g) -> (
+    d := gcd(f, g);
+    if d == 0 then 0_QQ
+    else abs f * (abs g / d))
 
 odd  = x -> 1 === x%2
 even = x -> 0 === x%2

--- a/M2/Macaulay2/tests/normal/gcd.m2
+++ b/M2/Macaulay2/tests/normal/gcd.m2
@@ -4,11 +4,14 @@ assert( gcd(1000:2) == 2 )
 assert( gcd splice(1000:2,3) == 1 )
 assert( lcm(2,3,5,7) == 210 )
 assert( lcm(1000:2) == 2 )
+assert( lcm(0, 0) == 0 )
+assert( lcm(0/1, 0/1) == 0 )
 
 R = ZZ/32003[x,y]
 f = (x+y)^3*(x-y^2)
 g = (x+y)^2*(x^3-x*y+y^3)^4
 assert ( gcd(f,g) == (x+y)^2 )
+assert ( lcm(0_R, 0_R) == 0 )
 
 GF 729[x, y, z]
 assert( gcd((x^5+y^3+a+1)*(y-1),(x^5+y^3+a+1)*(z+1)) == x^5+y^3+a+1 )


### PR DESCRIPTION
This way we get lcm(0, 0) = 0 for all cases, as expected.


### Before
```m2
i1 : lcm(0, 0)

o1 = 0

i2 : lcm(0/1, 0/1)
stdio:3:1:(3): error: division by zero

i3 : R = QQ[x]; lcm(0_R, 0_R)
stdio:4:12:(3): error: cannot use division algorithm dividing by zero
```

### After
```m2
i1 : lcm(0, 0)

o1 = 0

i2 : lcm(0/1, 0/1)

o2 = 0

o2 : QQ

i3 : R = QQ[x]; lcm(0_R, 0_R)

o4 = 0

o4 : R
```

Closes: #3061