### PR TITLE
Fixes to "Ways to use" list for documentation nodes containing a backslash

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -297,7 +297,7 @@ info TOH := x -> (
 
 net TO  := x -> (
      if class x#0 === DocumentTag
-     then concatenate( "\"", format x#0, "\"", if x#?1 then x#1)
+     then concatenate(formatNoEscaping format x#0, if x#?1 then x#1)
      else horizontalJoin( "\"", net x#0, "\"", if x#?1 then x#1)
      )
 net TO2 := x -> format x#1

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -45,6 +45,12 @@ seeAbout := (f, i) -> (
 --   the last member is the corresponding hypertext entry in the UL list
 -----------------------------------------------------------------------------
 
+-- we want quotes around elements of the "Ways to use" list so that
+-- "* String" works when running "help" inside Macaulay2, but we don't
+-- need the quotes otherwise
+MaybeQuotedTT = new IntermediateMarkUpType of TT
+net MaybeQuotedTT := x -> formatNoEscaping x#0
+
 counter := 0
 next := () -> counter = counter + 1
 optTO := key -> (
@@ -54,11 +60,11 @@ optTO := key -> (
     if currentHelpTag.?Key and instance(currentHelpTag.Key, Sequence) and currentHelpTag =!= ptag then return;
     if isUndocumented tag then return;
     if isSecondaryTag tag then (
-	-- this is to avoid doubling "\" in documentation for symbol \ and symbol \\
-	ref := if match("\\\\", fkey) then concatenate("/// ", fkey, " ///") else format fkey;
 	-- TODO: figure out how to align the lists using padding
 	-- ref = pad(ref, printWidth // 4);
-	(format ptag, fkey, next(), fixup if currentHelpTag === ptag then TT ref else SPAN {TT ref, " -- see ", TOH{ptag}}))
+	(format ptag, fkey, next(), fixup (
+		if currentHelpTag === ptag then MaybeQuotedTT fkey
+		else SPAN {MaybeQuotedTT fkey, " -- see ", TOH{ptag}})))
     -- need an alternative here for secondary tags such as (export,Symbol)
     else (fkey, fkey, next(), TOH{tag}))
 -- this isn't different yet, work on it!

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -375,6 +375,11 @@ format String   := String => x -> format' x
 format Sequence := String => s -> format' s
 protect symbol format
 
+-- use /// around strings w/ backslashes
+formatNoEscaping = x -> (
+    if match("\\\\", x) then concatenate("/// ", x, " ///")
+    else format x)
+
 toString = method(Dispatch => Thing, TypicalValue => String)
 toString Thing := simpleToString			    -- if all else fails...
 toString String := identity


### PR DESCRIPTION
As pointed out by @pzinn in Zulip, documentation nodes with backslashes contain a lot of forward slashes under the "Ways to use" list, e.g., from https://www.macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/__bs.html:

![image](https://github.com/Macaulay2/M2/assets/1992248/8169eda0-0522-441b-b436-711e4d866b24)

This makes sense when running `help` inside Macaulay2 in Emacs, since `* String` is a shortcut for `help`, and so you can easily jump to another documentation node by pressing <kbd>Return</kbd> on a particular line.  And when a string contains a backslash, we should use `///` to delimit it to avoid needing to escape the backslashes.  But it doesn't make much sense outside of Emacs.

One other issue I noticed when playing around with this is that we weren't consistently using `///` to delimit strings containing backslashes:

```m2
i1 : help symbol \

o1 = \ -- a binary operator
     **********************

     Ways to use symbol \ :
     ======================

       * "Command \ Set"
       * "Function \ Set"
       * /// Function \ Ideal /// -- see "Ideal / Function" -- apply a function
         to generators of an ideal
       * /// Command \ String /// -- see "VisibleList / Function" -- apply a
         function to elements of a list
...
```

So in particular, when pressing <kbd>Return</kbd> on the `* "Command \ Set"` line, we get the following since the `\` is unescaped:

```m2
i2 :        * "Command \ Set"
stdio:2:10:(0): error: unknown escape sequence: \ 
```

Similarly, running `help symbol \\` and pressing return on `* "Matrix \\ Number"` line actually gives us the `Matrix \ Number` documentation since the first backslash is escaping the second.

This PR fixes these two issues.  In particular:

* Don't use quotes in the "Ways to use" list for the html (or info) documention.
* Use `///` consistently in the "Ways to use" list when viewing the documentation using `help`.

So afterwards, we have the following:

![image](https://github.com/Macaulay2/M2/assets/1992248/bdd4db8e-c937-48a6-b634-f5fafae523e3)

```m2
i1 : help symbol \

o1 = \ -- a binary operator
     **********************

     Ways to use symbol \ :
     ======================

       * /// Command \ Set ///
       * /// Function \ Set ///
       * /// Function \ Ideal /// -- see "Ideal / Function" -- apply a function to generators of an ideal
       * /// Command \ String /// -- see "VisibleList / Function" -- apply a function to elements of a list
 ...
```
