### PR TITLE
Fix SubalgebraBases documentation typos

### DIFF
--- a/M2/Macaulay2/packages/SubalgebraBases/Old-SubalgebraBases/Archive/oldDocumentation.m2
+++ b/M2/Macaulay2/packages/SubalgebraBases/Old-SubalgebraBases/Archive/oldDocumentation.m2
@@ -131,7 +131,7 @@ doc ///
 	  maps p_9 to t_1^2*t_2
         Text
 	  
-	        @TT "p_0"@, ..., @TT "p_9"@ are the variables of what is refered to in the code as the @TT "tensorRing"@,
+	        @TT "p_0"@, ..., @TT "p_9"@ are the variables of what is referred to in the code as the @TT "tensorRing"@,
             which has two types of variables: The variables corresponding to the variables in the @TO "ambient"@ ring (@TT "p_0"@,...,@TT "p_2"@ in this example) and the variables corresponding to the generators of the @TO "Subring"@ (@TT "p_3"@,...,@TT "p_9"@ in this example).
 	  
 	        The function @TO "moduleToSubringIdeal"@ converts the toric syzygy module from our example (which is returned by @TO "toricSyz"@ in the form of a matrix) to an ideal

--- a/M2/Macaulay2/packages/SubalgebraBases/documentation.m2
+++ b/M2/Macaulay2/packages/SubalgebraBases/documentation.m2
@@ -968,7 +968,7 @@ doc ///
             may be performed.    When the flag is set
             to @TT "false"@, the function being called only uses the results
             of prior computations, if they have been stored.    When previous
-            computations have not been peformed, the function usually returns
+            computations have not been performed, the function usually returns
             @TT "null"@.
 
             When the flag is set to @TT "true"@, additional computations will
@@ -1006,7 +1006,7 @@ doc ///
             @ofClass Subring@).
 
             If the flag is set to @TT "false"@,
-            then the check is aplied to the subalgebra generators of $SB$.
+            then the check is applied to the subalgebra generators of $SB$.
             If the flag is set to @TT "true"@,
             then the check is applied to the generators of the subring of $SB$.
     SeeAlso
@@ -1580,7 +1580,7 @@ doc ///
             An instance of a @TT "Subring"@ is constructed with the function @TO "subring"@.
             For many uses, it is suggested to use a @ TT "Subring"@,
             as the computation objects (@TO "SAGBIBasis"@)
-            are handeled behind the scenes, and
+            are handled behind the scenes, and
             the user experience
             is more streamlined.
 
@@ -1641,7 +1641,7 @@ doc ///
             This function serves as the canonical constructor for the @TO "Subring"@ type.
             For many uses, it is suggested to use @ ofClass Subring@,
             as the computation objects (@TO "SAGBIBasis"@)
-            are handeled behind the scenes, and
+            are handled behind the scenes, and
             the user experience
             is more streamlined.
         Example
@@ -1838,7 +1838,7 @@ doc ///
             picking up a computation where it left off.
             For many uses, it is superior to use @ ofClass Subring@,
             as the computation @TT "SAGBIBases"@
-            are handeled behind the scenes, and
+            are handled behind the scenes, and
             the user experience
             is more streamlined.
             To create @ ofClass SAGBIBasis @, use the function @TO "sagbiBasis"@.
@@ -2186,7 +2186,7 @@ doc ///
             unused option
     Outputs
         result:String
-            a desciption of the status of a subalgebra basis computation
+            a description of the status of a subalgebra basis computation
     Description
         Text
             Returns a string with a human readable description


### PR DESCRIPTION
When #3073 was opened, it was originally targeting the `master` branch, and so the `codespell` checks were never run since they're only run on PR's to the `development` branch:

https://github.com/Macaulay2/M2/blob/776fd94fa0060f047234ac837464962d3581609f/.github/workflows/lint.yml#L4

But now that it's been merged, other PR's will fail (like #3079) due to some typos.  This PR fixes those typos.

(Why is `master` the default branch when we want everyone to submit to `development`?)