### PR TITLE
Add numeric(InfiniteNumber, Constant) method

### DIFF
--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -283,6 +283,7 @@ toString Constant := net Constant := c -> toString c#0
 toExternalString Constant := c -> toString c#0
 numeric Constant := c -> c#1 defaultPrecision
 numeric(ZZ,Constant) := (prec,c) -> c#1 prec
+numeric(InfiniteNumber, Constant) := (prec, c) -> numeric c
 numericInterval Constant := c -> if #c < 3 then interval(0,-1,Precision=>defaultPrecision) else c#2 defaultPrecision
 numericInterval(ZZ,Constant) := (prec,c) -> if #c < 3 then interval(0,-1,Precision=>prec) else c#2 prec
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_arithmetic.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_arithmetic.m2
@@ -5,6 +5,7 @@ document {
       (numeric, ZZ, RRi),
         (numeric, CC), (numeric, ZZ, VisibleList),
 	  (numeric, VisibleList), (numeric, ZZ, Constant), (numeric, Constant),
+	  (numeric, InfiniteNumber, Constant),
      	  (numeric, ZZ, Number), (numeric, Number),
 	  (numeric, ZZ, InfiniteNumber),(numeric, InfiniteNumber)},
      Headline => "convert to floating point",


### PR DESCRIPTION
This gets called if we try to do arithmetic with a `Constant` object and a `RingElement` object (over a coefficient ring with infinite precision), but the method doesn't exist!  We still end up with an error, but it's hopefully more informative.

### Before
```m2
i1 : R = QQ[x]

o1 = R

o1 : PolynomialRing

i2 : pi + 3_R
stdio:2:4:(3): error: no method found for applying numeric to:
     argument 1 :  infinity (of class InfiniteNumber)
     argument 2 :  pi (of class Constant)
```

### After
```m2
i1 : R = QQ[x]

o1 = R

o1 : PolynomialRing

i2 : pi + 3_R
stdio:2:4:(3): error: can't promote number to ring
```
