### PR TITLE
add Vector AfterNoPrint

### DIFF
--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -93,7 +93,7 @@ moduleAbbrv = (M, abbrv) -> (
     then getAttribute(M, ReverseDictionary)
     else abbrv)
 
-Vector#AfterPrint = v -> moduleAbbrv(module v, Vector)
+Vector#AfterPrint = Vector#AfterNoPrint = v -> moduleAbbrv(module v, Vector)
 
 ring Vector := v -> ring class v
 module Vector := v -> target v#0


### PR DESCRIPTION
recently we've aligned `Vector`'s output with `Matrix`'s output. This PR simply fixes a discrepancy, which is that matrices have an `AfterNoPrint` (their type description is printed even if the matrix itself isn't), but vectors don't -- now they do.