### PR TITLE
Respect value of SuppressErrors for Booth Math & Python errors

### DIFF
--- a/M2/Macaulay2/d/boostmath.dd
+++ b/M2/Macaulay2/d/boostmath.dd
@@ -24,7 +24,8 @@ header "#include <iostream>
 	boost::multiprecision::detail::digits2_2_10(prec));              \\
     return gmp_toRR(boost::math::f(__VA_ARGS__).backend().data(), prec); \\
   } catch (const std::exception& e) {                                    \\
-    std::cout << e.what() << std::endl;                                  \\
+      if (!(*((char*)TS_Get_Local(stdiop_SuppressErrors_id))))           \\
+        std::cout << e.what() << std::endl;                              \\
     return nullptr;                                                      \\
   }";
 

--- a/M2/Macaulay2/d/python.d
+++ b/M2/Macaulay2/d/python.d
@@ -13,7 +13,7 @@ import ErrOccurred():int;
 buildPythonErrorPacket():Expr := (
     e := ErrOccurred();
     if e == 1 then (
-	Ccode(void, "PyErr_Print()");
+	if !SuppressErrors then Ccode(void, "PyErr_Print()");
 	buildErrorPacket("python error"))
     else if e == -1 then StopIterationE
     else nullE);


### PR DESCRIPTION
`try` should suppress error output, but it was only partially suppressed for Boost Math and Python calls.  This PR fixes that.

### Before
```m2
i1 : try inverseErf(-1)
Error in function boost::math::erf_inv<N5boost14multiprecision6numberINS0_8backends18mpfr_float_backendILj0ELNS0_20mpfr_allocation_typeE1EEELNS0_26expression_template_optionE1EEE>(N5boost14multiprecision6numberINS0_8backends18mpfr_float_backendILj0ELNS0_20mpfr_allocation_typeE1EEELNS0_26expression_template_optionE1EEE, N5boost14multiprecision6numberINS0_8backends18mpfr_float_backendILj0ELNS0_20mpfr_allocation_typeE1EEELNS0_26expression_template_optionE1EEE): Overflow Error

i2 : needsPackage "Python"; try pythonValue "1/0"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ZeroDivisionError: division by zero
```

### After
```m2
i1 : try inverseErf(-1)

i2 : needsPackage "Python"; try pythonValue "1/0"

i4 : 
```
