### PR TITLE
Show unary methods installed using symbols using "methods"

### DIFF
--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -152,12 +152,23 @@ thingMethods := (T, F) -> nonnull apply(pairs T, (key, func) -> if instance(func
     if isUnaryAssignmentOperator key and isMember(F,        key) then (key, T) else -- unary assignment method, e.g symbol=
     if instance(key, Sequence)       and isMember(F, splice key) then  key)
 
+-- unary methods that are installed using a symbol as a key
+symbolMethods = set {
+    AfterEval,
+    AfterNoPrint,
+    AfterPrint,
+    Format,
+    InverseMethod,
+    NewMethod,
+    Wrap}
+
 sequenceMethods := (T, F, tallyF) -> nonnull apply(pairs T, (key, func) -> if instance(func, Function) then
     if isBinaryAssignmentOperator key and tallyF <= tally splice  key     then  key     else -- e.g T#((symbol SPACE, symbol=), T, T)
     if  isUnaryAssignmentOperator key and tallyF <= tally splice (key, T) then (key, T) else -- e.g T#(symbol+, symbol=)
     if instance(key, Keyword)         and tallyF <= tally splice (key, T) then (key, T) else -- e.g T#(symbol #)
     if instance(key, Function)        and tallyF <= tally splice (key, T) then (key, T) else -- e.g T#resolution
-    if instance(key, Sequence)        and tallyF <= tally         key     then  key)
+    if instance(key, Sequence)        and tallyF <= tally         key     then  key     else
+    if isMember(key, symbolMethods)   and tallyF <= tally splice (key, T) then (key, T))
 
 methods = method(Dispatch => Thing, TypicalValue => NumberedVerticalList)
 methods Manipulator := M -> methods class M

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -21,7 +21,8 @@ currentDocumentTag = null
 reservedNodeNames := {"Top", "Table of Contents"}
 
 -- TODO: handle this in methods from code.m2
-methodNames := set {NewFromMethod, NewMethod, NewOfFromMethod, NewOfMethod, id, Ext, Tor}
+methodNames := set {
+    NewFromMethod, NewOfFromMethod, NewOfMethod, id, Ext, Tor} + symbolMethods
 
 -----------------------------------------------------------------------------
 -- Local utilities


### PR DESCRIPTION
I noticed the following unusual behavior:

```m2
i1 : methods NewMethod

o1 = {0 => (NewMethod, ChainComplex)}

o1 : NumberedVerticalList
```

It seems like we should be able to go the other direction and find `NewMethod` in the list of methods for `ChainComplex`:

```m2
i2 : methods ChainComplex

o2 = {0 => ((_, =), ChainComplex, ZZ)                                      }
     {1 => (**, ChainComplex, ChainComplex)                                }
     {2 => (**, ChainComplex, ChainComplexMap)                             }
     .
     .
     .
     {37 => (minimalPresentation, ChainComplex)                            }
     {38 => (net, ChainComplex)                                            }
     {39 => (NewFromMethod, ChainComplex, Resolution)                      }
     {40 => (poincare, ChainComplex)                                       }
     {41 => (poincareN, ChainComplex)                                      }
     .
     .
     .
```

It's not there!  It turns out that unary methods that are stored in types using keys that are non-keyword symbols were being skipped.  Now there are lots of symbols that we do want to skip (like `synonym` and `texMath`), but there a few that probably should be listed.

We whitelist a specific list (`AfterEval`, `AfterNoPrint`, `AfterPrint`, `Format`, `InverseMethod`, `NewMethod`, `Wrap`).  Did I miss any?

### After

```m2
i1 : methods ChainComplex

o1 = {0 => ((_, =), ChainComplex, ZZ)                                      }
     {1 => (**, ChainComplex, ChainComplex)                                }
     {2 => (**, ChainComplex, ChainComplexMap)                             }
     .
     .
     .
     {37 => (minimalPresentation, ChainComplex)                            }
     {38 => (net, ChainComplex)                                            }
     {39 => (NewFromMethod, ChainComplex, Resolution)                      }
     {40 => (NewMethod, ChainComplex)                                      }
     {41 => (poincare, ChainComplex)                                       }
     {42 => (poincareN, ChainComplex)                                      }
     .
     .
     .
```