### PR TITLE
Add new "MethodSymbol" class for symbols which are used for methods

### DIFF
--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1873,6 +1873,20 @@ foreach s in syms do storeInHashTable(
 storeE = nullE;
 syms = SymbolSequence();
 
+makeMethodSymbol(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is HashTable do (
+		when a.1
+		is s:stringCell do Expr(makeMethodSymbol(s.v))
+		else WrongArgString(2))
+	    else WrongArg(1, "a hash table"))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+installMethod(NewFromS, methodSymbolClass, stringClass, makeMethodSymbol);
+
 export fileDictionaries := newHashTable(mutableHashTableClass,nothingClass);
 setupconst("fileDictionaries",Expr(fileDictionaries));
 

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1688,7 +1688,7 @@ readonlyfilesS := dummySymbol;
 setupconst("minExponent",toExpr(minExponent));
 setupconst("maxExponent",toExpr(maxExponent));
 
-StandardS := makeProtectedSymbolClosure("Standard");
+StandardS := makeMethodSymbol("Standard");
 export StandardE := Expr(StandardS);
 export topLevelMode := Expr(StandardS);
 topLevelModeS := dummySymbol;

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -133,6 +133,7 @@ makeKeyword(w:Word):SymbolClosure := (
      -- keywords differ from symbols in that their initial value is null
      entry := makeEntry(w,dummyPosition,globalDictionary);
      entry.Protected = true;
+     entry.Class = keywordClass;
      sc := SymbolClosure(globalFrame,entry);
      globalFrame.values.(entry.frameindex) = Expr(sc);
      sc);

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -345,10 +345,10 @@ bumpPrecedence();
      special("threadVariable",unarythread,precSpace,prec);
      special("local",unarylocal,precSpace,prec);
 -----------------------------------------------------------------------------
-export GlobalAssignS := makeProtectedSymbolClosure("GlobalAssignHook");
+export GlobalAssignS := makeMethodSymbol("GlobalAssignHook");
 export GlobalAssignE := Expr(GlobalAssignS);
 
-export GlobalReleaseS := makeProtectedSymbolClosure("GlobalReleaseHook");
+export GlobalReleaseS := makeMethodSymbol("GlobalReleaseHook");
 export GlobalReleaseE := Expr(GlobalReleaseS);
 
 export EqualE := Expr(EqualS);
@@ -361,19 +361,19 @@ export GreaterE := Expr(GreaterS);
 export GreaterEqualE := Expr(GreaterEqualS);
 export incomparableE := Expr(incomparableS);
 
-export NewS := makeProtectedSymbolClosure("NewMethod");
+export NewS := makeMethodSymbol("NewMethod");
 export NewE := Expr(NewS);
 
-export NewOfS := makeProtectedSymbolClosure("NewOfMethod");
+export NewOfS := makeMethodSymbol("NewOfMethod");
 export NewOfE := Expr(NewOfS);
 
-export NewFromS := makeProtectedSymbolClosure("NewFromMethod");
+export NewFromS := makeMethodSymbol("NewFromMethod");
 export NewFromE := Expr(NewFromS);
 
-export NewOfFromS := makeProtectedSymbolClosure("NewOfFromMethod");
+export NewOfFromS := makeMethodSymbol("NewOfFromMethod");
 export NewOfFromE := Expr(NewOfFromS);
 
-export InverseS := makeProtectedSymbolClosure("InverseMethod");
+export InverseS := makeMethodSymbol("InverseMethod");
 export InverseE := Expr(InverseS);
 
 export StopIterationS := makeProtectedSymbolClosure("StopIteration");

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -110,7 +110,8 @@ export makeEntry(word:Word,position:Position,dictionary:Dictionary,thread:bool):
 	       false,				      -- not protected
 	       false,
 	       thread,
-	       nextHash()
+	       nextHash(),
+	       symbolClass
 	       ),
 	  dictionary.symboltable));
 export makeEntry(word:Word,position:Position,dictionary:Dictionary):Symbol := (

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -138,6 +138,11 @@ makeKeyword(w:Word):SymbolClosure := (
      globalFrame.values.(entry.frameindex) = Expr(sc);
      sc);
 export makeProtectedSymbolClosure(s:string):SymbolClosure := makeProtectedSymbolClosure(makeUniqueWord(s,parseWORD));
+export makeMethodSymbol(s:string):SymbolClosure := (
+    sc := makeProtectedSymbolClosure(s);
+    sc.symbol.Class = methodSymbolClass;
+    sc);
+
 -----------------------------------------------------------------------------
 --Counter used for initializing precedence of different things in the parser
 prec := 0;

--- a/M2/Macaulay2/d/classes.dd
+++ b/M2/Macaulay2/d/classes.dd
@@ -61,6 +61,7 @@ setupconst("CompiledFunction",Expr(compiledFunctionClass));
 setupconst("CompiledFunctionClosure",Expr(compiledFunctionClosureClass));
 setupconst("Symbol",Expr(symbolClass));
 setupconst("Keyword",Expr(keywordClass));
+setupconst("MethodSymbol",Expr(methodSymbolClass));
 setupconst("Time",Expr(timeClass));
 setupconst("Option",Expr(optionClass));
 setupconst("OptionTable",Expr(optionTableClass));

--- a/M2/Macaulay2/d/classes.dd
+++ b/M2/Macaulay2/d/classes.dd
@@ -139,7 +139,7 @@ export Class(e:Expr):HashTable := (
      is Sequence do sequenceClass
      is CompiledFunction do compiledFunctionClass
      is CompiledFunctionClosure do compiledFunctionClosureClass
-     is s:SymbolClosure do if s.symbol.word.parse == parseWORD then symbolClass else keywordClass
+     is s:SymbolClosure do s.symbol.Class
      is SymbolBody do symbolBodyClass
      is RRicell do RRiClass
      is RRcell do RRClass

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -325,7 +325,8 @@ export dummySymbol := Symbol(
      false,						    -- not protected, so we can use it in parallelAssignmentFun
      false,
      false,
-     0
+     0,
+     symbolClass
      );
 dummySymbolClosure := SymbolClosure(globalFrame,dummySymbol);
 globalFrame.values.dummySymbolFrameIndex = Expr(dummySymbolClosure);

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -316,6 +316,7 @@ export rawMutableComplexClass := newtypeof(rawObjectClass);	    -- RawMutableCom
 export angleBarListClass := newtypeof(visibleListClass);
 export RRiClass := newbignumbertype();
 export pointerClass := newbasictype();
+export methodSymbolClass := newtypeof(symbolClass);
 -- all new types, dictionaries, and classes go just above this line, if possible, so hash codes don't change gratuitously!
 
 export dummySymbol := Symbol(

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -203,28 +203,9 @@ export emptySequence := Sequence();
 
 export emptySequenceE := Expr(emptySequence);
 
-export dummySymbol := Symbol(
-     Word("-*dummy symbol*-",TCnone,0,newParseinfo()),dummySymbolHash,dummyPosition,
-     dummyUnaryFun,dummyPostfixFun,dummyBinaryFun,
-     Macaulay2Dictionary.frameID,dummySymbolFrameIndex,1,
-     false,						    -- not protected, so we can use it in parallelAssignmentFun
-     false,
-     false,
-     0
-     );
-dummySymbolClosure := SymbolClosure(globalFrame,dummySymbol);
-globalFrame.values.dummySymbolFrameIndex = Expr(dummySymbolClosure);
 export dummyCode := Code(nullCode());
 export NullCode := Code(nullCode());
 export dummyCodeClosure := CodeClosure(dummyFrame,dummyCode);
-export dummyToken   := Token(
-     Word("-*dummy token*-",TCnone,0,newParseinfo()),
-     dummyPosition.filename,
-     dummyPosition.line,
-     dummyPosition.column,
-     dummyPosition.loadDepth,
-     Macaulay2Dictionary,dummySymbol,false);
-
 export parseWORD    := newParseinfo();			    -- parsing functions filled in later
 
 export dummyWord    := Word("-*dummy word*-",TCnone,0,newParseinfo());
@@ -337,6 +318,24 @@ export RRiClass := newbignumbertype();
 export pointerClass := newbasictype();
 -- all new types, dictionaries, and classes go just above this line, if possible, so hash codes don't change gratuitously!
 
+export dummySymbol := Symbol(
+     Word("-*dummy symbol*-",TCnone,0,newParseinfo()),dummySymbolHash,dummyPosition,
+     dummyUnaryFun,dummyPostfixFun,dummyBinaryFun,
+     Macaulay2Dictionary.frameID,dummySymbolFrameIndex,1,
+     false,						    -- not protected, so we can use it in parallelAssignmentFun
+     false,
+     false,
+     0
+     );
+dummySymbolClosure := SymbolClosure(globalFrame,dummySymbol);
+globalFrame.values.dummySymbolFrameIndex = Expr(dummySymbolClosure);
+export dummyToken   := Token(
+     Word("-*dummy token*-",TCnone,0,newParseinfo()),
+     dummyPosition.filename,
+     dummyPosition.line,
+     dummyPosition.column,
+     dummyPosition.loadDepth,
+     Macaulay2Dictionary,dummySymbol,false);
 
 --Error Handling 
 export buildErrorPacket(message:string):Expr := Expr(Error(dummyPosition,message,nullE,false,dummyFrame));

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -25,14 +25,14 @@ update(err:Error,prefix:string,f:Code):Error := (
      else printErrorMessage0(f,prefix + ": --backtrace update-- ")
      );
 previousLineNumber := -1;
-
-BeforeEval := makeProtectedSymbolClosure("BeforeEval");
-AfterEval := makeProtectedSymbolClosure("AfterEval");
-BeforePrint := makeProtectedSymbolClosure("BeforePrint");
-Print := makeProtectedSymbolClosure("Print");
-NoPrint := makeProtectedSymbolClosure("NoPrint");
-AfterPrint := makeProtectedSymbolClosure("AfterPrint");
-AfterNoPrint := makeProtectedSymbolClosure("AfterNoPrint");
+ 
+BeforeEval := makeMethodSymbol("BeforeEval");
+AfterEval := makeMethodSymbol("AfterEval");
+BeforePrint := makeMethodSymbol("BeforePrint");
+Print := makeMethodSymbol("Print");
+NoPrint := makeMethodSymbol("NoPrint");
+AfterPrint := makeMethodSymbol("AfterPrint");
+AfterNoPrint := makeMethodSymbol("AfterNoPrint");
 runmethod(methodname:SymbolClosure,g:Expr):Expr := (
      method := lookup(Class(g),methodname);
      if method == nullE then g else applyEE(method,g)
@@ -297,8 +297,8 @@ readeval(file:TokenFile,returnLastvalue:bool,returnIfError:bool):Expr := (
      setGlobalVariable(fileExitHooks,savefe);
      if lastexiterror != dummyError then Expr(lastexiterror) else ret);
 
-InputPrompt := makeProtectedSymbolClosure("InputPrompt");
-InputContinuationPrompt := makeProtectedSymbolClosure("InputContinuationPrompt");
+InputPrompt := makeMethodSymbol("InputPrompt");
+InputContinuationPrompt := makeMethodSymbol("InputContinuationPrompt");
 
 promptcount := 0;
 topLevelPrompt():string := (

--- a/M2/Macaulay2/d/parse.d
+++ b/M2/Macaulay2/d/parse.d
@@ -85,7 +85,8 @@ export Symbol := {		    -- symbol table entry for a symbol
      Protected:bool,	            -- whether protected against assignment by the user
      flagLookup:bool,		    -- whether to warn when symbol is used
      thread:bool,		    -- whether to use threadFrame instead of globalFrame
-     serialNumber:int		    -- a counter, used to tell the age for the Serialization package
+     serialNumber:int,		    -- a counter, used to tell the age for the Serialization package
+     Class:HashTable
      };
 export SymbolListCell := {word:Word, entry:Symbol, next:SymbolList};
 export SymbolList := null or SymbolListCell;

--- a/M2/Macaulay2/d/texmacs.d
+++ b/M2/Macaulay2/d/texmacs.d
@@ -4,7 +4,7 @@ use getline;
 use util;
 use evaluate;
 
-TeXmacsEvaluate := makeProtectedSymbolClosure("TeXmacsEvaluate");
+TeXmacsEvaluate := makeMethodSymbol("TeXmacsEvaluate");
 
 export topLevelTeXmacs():int := (
      unsetprompt(stdIO);

--- a/M2/Macaulay2/m2/classes.m2
+++ b/M2/Macaulay2/m2/classes.m2
@@ -22,6 +22,7 @@ String.synonym = "string"
 File.synonym = "file"
 Symbol.synonym = "symbol"
 Keyword.synonym = "keyword"
+MethodSymbol.synonym = "method symbol"
 Dictionary.synonym = "dictionary"
 -- Pseudocode.synonym = "pseudocode" -- "a pseudocode" doesn't sound so great
 Task.synonym = "task"

--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -156,6 +156,7 @@ sequenceMethods := (T, F, tallyF) -> nonnull apply(pairs T, (key, func) -> if in
     if isBinaryAssignmentOperator key and tallyF <= tally splice  key     then  key     else -- e.g T#((symbol SPACE, symbol=), T, T)
     if  isUnaryAssignmentOperator key and tallyF <= tally splice (key, T) then (key, T) else -- e.g T#(symbol+, symbol=)
     if instance(key, Keyword)         and tallyF <= tally splice (key, T) then (key, T) else -- e.g T#(symbol #)
+    if instance(key, MethodSymbol)    and tallyF <= tally splice (key, T) then (key, T) else -- e.g T.NewMethod
     if instance(key, Function)        and tallyF <= tally splice (key, T) then (key, T) else -- e.g T#resolution
     if instance(key, Sequence)        and tallyF <= tally         key     then  key)
 

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -285,7 +285,8 @@ fSeq := new HashTable from {
 	    if t#?1 and t#1===Type then "type of ", toString s#2, ")")),
     2 => s -> (
 	t := if methodOptions s#0 =!= null then (methodOptions s#0).Dispatch else {Thing, Thing};
-	(toString s#0, "(",
+	if instance(s#0, MethodSymbol) then (toString s#1, ".", toString s#0)
+	else (toString s#0, "(",
 	    if t===Type or instance(t,List) and t#?0 and t#0===Type then "type of ", toString s#1, ")")),
     1 => s -> (toString s#0, "()"),
     }

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -21,7 +21,7 @@ currentDocumentTag = null
 reservedNodeNames := {"Top", "Table of Contents"}
 
 -- TODO: handle this in methods from code.m2
-methodNames := set {NewFromMethod, NewMethod, NewOfFromMethod, NewOfMethod, id, Ext, Tor}
+methodNames := set {id, Ext, Tor}
 
 -----------------------------------------------------------------------------
 -- Local utilities
@@ -45,9 +45,9 @@ verifyKey Sequence := key -> ( -- e.g., (res, Module) or (symbol **, Module, Mod
     else if #key == 1 and not instance(key#0, Function)
     then error("documentation key ", format toString key, " encountered, but ", format toString key#0, " is not a function")
     else if #key  > 1
-    and not any({Keyword, Command, Function, ScriptedFunctor}, type -> instance(key#0, type)) and not methodNames#?(key#0)
+    and not any({Keyword, Command, Function, ScriptedFunctor, MethodSymbol}, type -> instance(key#0, type)) and not methodNames#?(key#0)
     and not (instance(key#0, Sequence) and 2 == #key#0 and key#0#1 === symbol= and instance(key#0#0, Keyword))
-    then error("documentation key ", format toString key, " encountered, but ", format toString key#0, " is not a function, command, scripted functor, or keyword");
+    then error("documentation key ", format toString key, " encountered, but ", format toString key#0, " is not a function, command, scripted functor, keyword, or method symbol");
     --
     if  isUnaryAssignmentOperator key           -- e.g., ((?, =), Type), or (?, =)
     or isBinaryAssignmentOperator key then true -- e.g., ((?, =), Type, Type)

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -288,6 +288,7 @@ export {
 	"MethodFunctionBinary",
 	"MethodFunctionSingle",
 	"MethodFunctionWithOptions",
+	"MethodSymbol",
 	"MinimalGenerators",
 	"MinimalMatrix",
 	"Minimize",

--- a/M2/Macaulay2/m2/jupyter.m2
+++ b/M2/Macaulay2/m2/jupyter.m2
@@ -2,6 +2,7 @@ needs "monideal.m2"
 needs "expressions.m2"
 needs "reals.m2"
 
+new MethodSymbol from "Jupyter"
 lastprompt := "";
 
 ZZ#{Jupyter,InputPrompt} = lineno -> concatenate(concatenate("[INP]",newline,"[INP]"), lastprompt = concatenate(interpreterDepth:"i", toString lineno, " : "));

--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -153,6 +153,8 @@ embrace = n -> (
      d := depth n;
      horizontalJoin("{"^(h,d), n, "}"^(h,d)))
 
+new MethodSymbol from "Wrap"
+
 VerticalList = new SelfInitializingType of List
 VerticalList.synonym = "vertical list"
 net VerticalList := x -> if #x === 0 then "{}" else embrace stack apply(x,net)

--- a/M2/Macaulay2/m2/robust.m2
+++ b/M2/Macaulay2/m2/robust.m2
@@ -32,6 +32,8 @@ truncNet := (wid,ht,s) -> (
 truncString := (wid,s) -> if wid > 0 and width s > wid then concatenate(substring(s,0,wid-1),"$") else s
 checkNet    := n -> if instance(n, Net   ) then n else error "didn't format correctly"
 checkString := n -> if instance(n, String) then n else error "didn't format correctly"
+
+new MethodSymbol from "Format"
 Nothing.Format = toString
 String.Format = format
 silentRobustNet = (wid,ht,sec,y) -> (
@@ -136,7 +138,7 @@ Thing#{Standard,Print} = x -> (
      save := printWidth;
      if printWidth != 0 then printWidth = printWidth - #oprompt;
      z := robustNet x;
-     wrapper := lookup(global Wrap,class x);
+     wrapper := lookup(Wrap,class x);
      if wrapper =!= null then (
 	  fun := () -> z = wrapper z;
 	  try timelimit(printingTimeLimit, fun)

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -451,6 +451,9 @@ replaced := (arg, x) -> (stderr << "error: command line option " << arg << " has
 notyeterr := arg     -> (stderr << "error: command line option " << arg << " has not been re-implemented yet.";   << endl << endl; usage(); exit 1)
 notyet := arg -> if phase == 1 then (stderr << "warning: command line option " << arg << " has not been re-implemented yet." << endl << flush)
 
+new MethodSymbol from "WebApp"
+new MethodSymbol from "TeXmacs"
+
 action := hashTable {
      "-h" => arg -> (usage(); exit 0),
      "-mpwprompt" => notyeterr,
@@ -482,11 +485,11 @@ action := hashTable {
      "--restarted" => arg -> restarted = true,
      "--texmacs" => arg -> (
 	  if phase == 1 then (
-	       topLevelMode = global TeXmacs;
+	       topLevelMode = TeXmacs;
 	       printWidth = 80;
 	       )
 	  else if phase == 3 then (
-	       topLevelMode = global TeXmacs;
+	       topLevelMode = TeXmacs;
 	       printWidth = 80;
 	       )
 	  else if phase == 4 then (
@@ -501,7 +504,7 @@ action := hashTable {
 	       )
 	  ),
      "--version" => arg -> ( << version#"VERSION" << newline; exit 0; ),
-     "--webapp" => arg -> ( printWidth=0; topLevelMode = global WebApp; )
+     "--webapp" => arg -> ( printWidth=0; topLevelMode = WebApp; )
      };
 
 argno := 1

--- a/M2/Macaulay2/packages/Macaulay2Doc/types.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/types.m2
@@ -451,6 +451,37 @@ document {
      SeeAlso => {"precedence of operators"}
      }
 
+doc ///
+  Key
+    MethodSymbol
+    (NewFromMethod, MethodSymbol, String)
+  Headline
+    the class of all method symbols
+  Usage
+    new MethodSymbol from x
+  Inputs
+    x:String
+  Outputs
+    :MethodSymbol
+  Description
+    Text
+      A method symbol is special type of @TO Symbol@ that is used as a
+      key in a @TO Type@ to store a method.  Note that this is not
+      typical, as the keys for methods created by @TO installMethod@
+      are @TO MethodFunction@ objects or sequences containing such
+      objects.  However, there are some exceptions like @TO NewMethod@
+      and @TO AfterPrint@.
+
+      Methods stored using a method symbol will appear when running
+      @TO methods@ on a type.
+    Example
+      X = new Type of HashTable;
+      new MethodSymbol from "foo"
+      X.foo = () -> 1;
+      X.bar = () -> 2;
+      methods X
+///
+
 document { Key => ImmutableType,
      Headline => "the class of immutable types",
      "All types are implemented as hash tables.  Most types are mutable, so that additional methods for handling their instances can be added

--- a/M2/Macaulay2/tests/normal/methods.m2
+++ b/M2/Macaulay2/tests/normal/methods.m2
@@ -120,3 +120,9 @@ assert ( chainComplex (new X, FOO => 123 ) === (new OptionTable from {FOO => 123
 assert ( chainComplex (new X) === (new OptionTable from {FOO => BAR},new X from {}) )
 chainComplex X := identity
 assert( chainComplex (new X) === new X )
+
+X = new Type of BasicList
+new MethodSymbol from "foo"
+X.foo = () -> 1
+X.bar = () -> 2
+assert(toList methods X === {(foo, X)})


### PR DESCRIPTION
This is (I think) an improved version of #3090.  Rather than have some whitelist of symbols that we allow to appear in the output of `methods`, we add a new subclass of `Symbol`, `MethodSymbol`, and just check the class.  `NewMethod` and friends are all elements of this proposed new class, and package authors can add their own.

Here's a simple example:

```m2
i1 : X = new Type of HashTable;

i2 : new MethodSymbol from "foo";

i3 : X.foo = x -> 1;

i4 : X.bar = x -> 2;

i5 : methods X

o5 = {0 => (foo, X)}

o5 : NumberedVerticalList
```

Here is a list of the symbols that I'm proposing be turned into method symbols:

```m2
    Fixed objects of class MethodSymbol :
     =====================================

       * "AfterEval" -- top level method applied after evaluation
       * "AfterNoPrint" -- top level method applied after not printing
       * "AfterPrint" -- top level method applied after printing
       * "BeforePrint" -- top level method applied before printing results
       * "GlobalAssignHook" -- hook for assignment to global variables
       * "GlobalReleaseHook"
       * "InverseMethod" -- compute reciprocals
       * "Jupyter" -- top level printing method used in the Jupyter kernel
       * "NewFromMethod"
       * "NewMethod"
       * "NewOfFromMethod"
       * "NewOfMethod"
       * "NoPrint" -- top level method for non-printing results
       * "Print" -- top level method for printing results
       * "Standard" -- the standard top level printing method
       * "TeXmacs" -- the TeXmacs top level printing method
       * "WebApp" -- the web app top level printing method
       * "Wrap" -- a key for methods for wrapping printed output
```
This is a draft for now until I write some documentation.

I'm not sure whether the `topLevelMode` symbols like `Standard` and `WebApp` belong on this list or not, since they're always paired up inside a list with something else.  But they are used for defining methods, so I suppose it makes sense even if `methods`  can't currently find them.

Comments welcome!