### PR TITLE
Use correct package source directory in locate(DocumentTag)

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -397,7 +397,8 @@ hasDocumentation = key -> null =!= fetchAnyRawDocumentation makeDocumentTag(key,
 locate DocumentTag := tag -> new FilePosition from (
     if (rawdoc := fetchAnyRawDocumentation tag) =!= null
     then (
-	minimizeFilename((package tag)#"source directory" | rawdoc#"filename"),
+	minimizeFilename((package rawdoc.DocumentTag)#"source directory" |
+	    rawdoc#"filename"),
 	rawdoc#"linenum", 0)
     else (currentFileName, currentRowNumber(), currentColumnNumber()))
 


### PR DESCRIPTION
We used the original `DocumentTag` object to detect the package, but this is often `User`, which likely has the wrong source directory. Instead, we get the package information from the hash table returned by `fetchAnyRawDocumentation`.

### Before
```m2
i1 : makeDocumentTag "operators"

o1 = User :: operators

o1 : DocumentTag

i2 : locate oo

o2 = /usr/share/Macaulay2/Core/Macaulay2Doc/ov_language.m2:1153:0

o2 : FilePosition
```

That `Core` shouldn't be there!

### After

```m2
i1 : makeDocumentTag "operators"

o1 = User :: operators

o1 : DocumentTag

i2 : locate oo

o2 = M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2:1153:0

o2 : FilePosition
```