### PR TITLE
Updates for getting/setting thread modes

### DIFF
--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -217,6 +217,7 @@ setupfun("taskResult",taskResult);
 setupfun("setIOSynchronized",setIOSynchronized);
 setupfun("setIOUnSynchronized",setIOUnSynchronized);
 setupfun("setIOExclusive",setIOExclusive);
+setupfun("getIOThreadMode", getIOThreadMode);
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d pthread.o "

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -1022,8 +1022,9 @@ export setIOSynchronized(e:Expr):Expr :=(
      is a:Sequence do (
 	  if length(a) == 0
 	  then (setFileThreadState(stdIO,1); setFileThreadState(stdError,1); nullE)
-	  else WrongNumArgs(0))
-     else WrongNumArgs(0)
+	  else WrongNumArgs(0, 1))
+     is f:file do (setFileThreadState(f, 1); nullE)
+     else WrongArg("a file or ()")
 );
 
 export setIOExclusive(e:Expr):Expr :=(
@@ -1031,8 +1032,9 @@ export setIOExclusive(e:Expr):Expr :=(
      is a:Sequence do (
 	  if length(a) == 0
 	  then (setFileThreadState(stdIO,2); setFileThreadState(stdError,2); nullE)
-	  else WrongNumArgs(0))
-     else WrongNumArgs(0)
+	  else WrongNumArgs(0, 1))
+     is f:file do (setFileThreadState(f, 2); nullE)
+     else WrongArg("a file or ()")
 );
 
 export setIOUnSynchronized(e:Expr):Expr :=(
@@ -1040,8 +1042,9 @@ export setIOUnSynchronized(e:Expr):Expr :=(
      is a:Sequence do (
 	  if length(a) == 0
 	  then (setFileThreadState(stdIO,0); setFileThreadState(stdError,0); nullE)
-	  else WrongNumArgs(0))
-     else WrongNumArgs(0)
+	  else WrongNumArgs(0, 1))
+     is f:file do (setFileThreadState(f, 0); nullE)
+     else WrongArg("a file or ()")
 );
 
 export getIOThreadMode(e:Expr):Expr := (

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -5,6 +5,7 @@ use errio;
 use gmp;
 use expr;
 use stdio0;
+use util;
 
 header "#include \"../system/m2fileinterface.h\"
         #include <readline/history.h>";
@@ -91,6 +92,8 @@ export setFileThreadState(o:file, state:int):void :=
 (
 	Ccode(void,"M2File_SetThreadMode(",lvalue(o.cfile),",state)")
 );
+export getFileThreadMode(o:file):int := (
+    Ccode(int,"M2File_GetThreadMode(", lvalue(o.cfile), ")"));
 
 export syscallErrorMessage(msg:string):string := msg + " failed: " + syserrmsg();
 export fileErrorMessage(o:file,msg:string):string := (
@@ -1041,6 +1044,14 @@ export setIOUnSynchronized(e:Expr):Expr :=(
      else WrongNumArgs(0)
 );
 
+export getIOThreadMode(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 0
+	then toExpr(getFileThreadMode(stdIO))
+	else WrongNumArgs(0, 1))
+    is f:file do toExpr(getFileThreadMode(f))
+    else WrongArg("a file or ()"));
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d stdio.o "

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -728,6 +728,7 @@ export {
 	"get",
 	"getChangeMatrix",
 	"getGlobalSymbol",
+	"getIOThreadMode",
 	"getNetFile",
 	"getNonUnit",
 	"getPrimeWithRootOfUnity",

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -343,13 +343,18 @@ Node
   exclusive I/O for the current thread
  Usage
   setIOExclusive()
+  setIOExclusive f
+ Inputs
+  f:File
  Consequences
   Item
-   the current thread becomes the only one permitted to use the files @ TO stdio @ and @ TO stderr @
+   the current thread becomes the only one permitted to use the file @VAR "f"@,
+   or if no file is given, the files @ TO stdio @ and @ TO stderr @.
  SeeAlso
   "parallel programming with threads and tasks"
   setIOUnSynchronized
   setIOSynchronized
+  getIOThreadMode
 Node
  Key
   setIOSynchronized
@@ -357,15 +362,21 @@ Node
   synchronized I/O for threads
  Usage
   setIOSynchronized()
+  setIOSynchronized f
+  getIOThreadMode
+ Inputs
+  f:File
  Consequences
   Item
-   threads are permitted to use the files @ TO stdio @ and @ TO stderr @ to output complete lines only
+   threads are permitted to use the file @VAR "f"@, or if no file is given,
+   @ TO stdio @ and @ TO stderr @, to output complete lines only
  Caveat
    this function is experimental
  SeeAlso
   "parallel programming with threads and tasks"
   setIOUnSynchronized
   setIOExclusive
+  getIOThreadMode
 Node
  Key
   setIOUnSynchronized
@@ -373,11 +384,38 @@ Node
   unsynchronized I/O for threads
  Usage
   setIOUnSynchronized()
+  setIOUnSynchronized f
+  getIOThreadMode
+ Inputs
+  f:File
  Consequences
   Item
-   threads are permitted to use the files @ TO stdio @ and @ TO stderr @ in an unregulated manner
+   threads are permitted to use the file @VAR "f"@, or if no file is given,
+   @ TO stdio @ and @ TO stderr @, in an unregulated manner
  SeeAlso
   "parallel programming with threads and tasks"
+  setIOSynchronized
+  setIOExclusive
+Node
+ Key
+  getIOThreadMode
+ Headline
+  get I/O thread mode
+ Usage
+  getIOThreadMode()
+  getIOThreadMode f
+ Inputs
+  f:File
+ Consequences
+  Item
+   returns the I/O thread mode for the file @VAR "f"@, or if no file is given,
+   @TO stdio@, as an integer:
+   @UL {
+       "0 for unsynchronized",
+       "1 for synchronized",
+       "2 for exclusive"}@
+ SeeAlso
+  setIOUnSynchronized
   setIOSynchronized
   setIOExclusive
 Node

--- a/M2/Macaulay2/tests/normal/threads.m2
+++ b/M2/Macaulay2/tests/normal/threads.m2
@@ -45,6 +45,48 @@ print (currentTime()-c)
 -- to come before the files d/*.o on the linker command line.
 assert ( maxAllowableThreads != 0 )
 
+-- thread modes
+restoremode = i -> (
+    if i == 0 then setIOUnSynchronized()
+    else if i == 1 then setIOSynchronized()
+    else if i == 2 then setIOExclusive()
+    else error "unknown thread mode")
+
+origmode = getIOThreadMode()
+
+setIOExclusive()
+setIOUnSynchronized()
+assert Equation(getIOThreadMode(), 0)
+assert Equation(getIOThreadMode stdio, 0)
+assert Equation(getIOThreadMode stderr, 0)
+
+setIOSynchronized()
+assert Equation(getIOThreadMode(), 1)
+assert Equation(getIOThreadMode stdio, 1)
+assert Equation(getIOThreadMode stderr, 1)
+
+setIOExclusive()
+assert Equation(getIOThreadMode(), 2)
+assert Equation(getIOThreadMode stdio, 2)
+assert Equation(getIOThreadMode stderr, 2)
+
+restoremode origmode
+
+fn = temporaryFileName()
+f = fn << "foo" << close
+
+setIOExclusive f
+setIOUnSynchronized f
+assert Equation(getIOThreadMode f, 0)
+
+setIOSynchronized f
+assert Equation(getIOThreadMode f, 1)
+
+setIOExclusive f
+assert Equation(getIOThreadMode f, 2)
+
+removeFile fn
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test threads.out"
 -- End:


### PR DESCRIPTION
This is based on a parallelization branch that @DaveBarton, @mikestillman, and I are working on.

There are three little-known functions, [setIOUnSynchronized](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_set__I__O__Un__Synchronized.html), [setIOSynchronized](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_set__I__O__Synchronized.html), and [setIOExclusive](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_set__I__O__Exclusive.html), that control how different threads write to files. 

This PR adds two features:
* Previously, these functions only set the I/O thread mode for `stdio` and `stderr`.  They now can set it for any file.
* Previously, there was no way of checking the current I/O thread mode at top level.  A new function, `getIOThreadMode`, has been added that returns the thread mode as an integer (0, 1, or 2 for unsynchronized, synchronized, or exclusive, respectively) for `stdio` (if no argument) or a given file.