### PR TITLE
Use typical values when documenting assignment methods

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -493,16 +493,17 @@ getSignature Sequence := x -> (
     else (
 	-- putting something like OO in the key indicates a fake dispatch
 	x' := select(drop(toList x, 1), T -> not ancestor(Nothing, T));
-	if instance(x#0, Sequence)
-	and #x#0 === 2 and x#0#1 === symbol=
-	or  #x   === 2 and x#0   === symbol<-
-	then ( x' | { Thing }, { Thing } )	   -- it's an assignment method
+	-- assignment methods
+	-- TODO: should we worry about the possibility of the input
+	-- and output types being different?
+	if (instance(x#0, Sequence) and #x#0 === 2 and x#0#1 === symbol=
+	    or #x === 2 and x#0 === symbol<-
+	    or isMember(x#0, augmentedAssignmentOperators))
+	then (append(x', typicalValue x), {typicalValue x})
 	-- for "new T from x", T is already known, so we just care about x
 	else if x#0 === NewFromMethod
-	then ( {x#2}         , { typicalValue x } )
-	else if isMember(x#0, augmentedAssignmentOperators)
-	then (append(x', typicalValue x), {typicalValue x})
-	else ( x'            , { typicalValue x } )))
+	then ( {x#2} , { typicalValue x } )
+	else (  x'   , { typicalValue x } )))
 
 isOption := opt -> instance(opt, Option) and #opt == 2 and instance(opt#0, Symbol);
 

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -234,7 +234,6 @@ fSeq := new HashTable from splice {
     (3, class, Keyword ) => s -> (toString s#1, " ", toString s#0, " ", toString s#2), -- infix operator
     (3, class, Symbol  ) => s -> (toString s#1, " ", toString s#0, " ", toString s#2), -- infix operator
     -- infix assignment operator (really a ternary operator!)
-    (3, class, Sequence) => s -> (toString s#1, " ", toString s#0#0, " ", toString s#2, " ", toString s#0#1, " Thing"),
     (2, class, Keyword ) => s -> (toString s#0, " ", toString s#1), -- prefix operator
     (2, class, Sequence) => s -> (
 	op := s#0#0;
@@ -249,6 +248,10 @@ fSeq := new HashTable from splice {
     (2, symbol _*      ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol ~       ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol !       ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
+
+    -- assignment methods
+    (3, class, Sequence) => s -> (toString s#1, " ", toString s#0#0, " ",
+	toString s#2, " ", toString s#0#1, " ", toString typicalValue s),
     apply(augmentedAssignmentOperators, op -> (2, op) => s ->
 	(toString s#1, " ", toString op, " ", toString typicalValue(op, s#1))),
 

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -235,12 +235,6 @@ fSeq := new HashTable from splice {
     (3, class, Symbol  ) => s -> (toString s#1, " ", toString s#0, " ", toString s#2), -- infix operator
     -- infix assignment operator (really a ternary operator!)
     (2, class, Keyword ) => s -> (toString s#0, " ", toString s#1), -- prefix operator
-    (2, class, Sequence) => s -> (
-	op := s#0#0;
-	if prefix#?op
-	then (toString op, " ", toString s#1, " ", toString s#0#1, " Thing")
-	else (toString s#1, " ", toString op, " ", toString s#0#1, " Thing")),
-
     (3, symbol SPACE   ) => s -> (toString s#1, " ", toString s#2),
     (2, symbol <-      ) => s -> (toString s#1, " <- Thing"),       -- assignment statement with left hand side evaluated
     (2, symbol (*)     ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
@@ -252,6 +246,13 @@ fSeq := new HashTable from splice {
     -- assignment methods
     (3, class, Sequence) => s -> (toString s#1, " ", toString s#0#0, " ",
 	toString s#2, " ", toString s#0#1, " ", toString typicalValue s),
+    (2, class, Sequence) => s -> (
+	op := s#0#0;
+	if prefix#?op
+	then (toString op, " ", toString s#1, " ", toString s#0#1, " ",
+	    toString typicalValue s)
+	else (toString s#1, " ", toString op, " ", toString s#0#1, " ",
+	    toString typicalValue s)),
     apply(augmentedAssignmentOperators, op -> (2, op) => s ->
 	(toString s#1, " ", toString op, " ", toString typicalValue(op, s#1))),
 

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -236,7 +236,6 @@ fSeq := new HashTable from splice {
     -- infix assignment operator (really a ternary operator!)
     (2, class, Keyword ) => s -> (toString s#0, " ", toString s#1), -- prefix operator
     (3, symbol SPACE   ) => s -> (toString s#1, " ", toString s#2),
-    (2, symbol <-      ) => s -> (toString s#1, " <- Thing"),       -- assignment statement with left hand side evaluated
     (2, symbol (*)     ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol ^*      ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol _*      ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
@@ -253,6 +252,8 @@ fSeq := new HashTable from splice {
 	    toString typicalValue s)
 	else (toString s#1, " ", toString op, " ", toString s#0#1, " ",
 	    toString typicalValue s)),
+    (2, symbol <-      ) => s -> (toString s#1, " <- ",
+	toString typicalValue s),
     apply(augmentedAssignmentOperators, op -> (2, op) => s ->
 	(toString s#1, " ", toString op, " ", toString typicalValue(op, s#1))),
 

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -255,7 +255,7 @@ fSeq := new HashTable from splice {
     (2, symbol <-      ) => s -> (toString s#1, " <- ",
 	toString typicalValue s),
     apply(augmentedAssignmentOperators, op -> (2, op) => s ->
-	(toString s#1, " ", toString op, " ", toString typicalValue(op, s#1))),
+	(toString s#1, " ", toString op, " ", toString typicalValue s)),
 
     -- ScriptedFunctors
     (4, class, ScriptedFunctor, ZZ) => s -> (

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -714,7 +714,7 @@ registerFinalizer(Thing, String) := registerFinalizer'
 -- augmented assignment -- syntactic sugar for installing methods
 -- e.g., "T += f" is equivalent to "installMethod(symbol +=, T, f)"
 scan(augmentedAssignmentOperators, op ->
-    installMethod(op, Type, (T, f) -> installMethod(op, T, f)))
+    installMethod(op, Type, Function => (T, f) -> installMethod(op, T, f)))
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "


### PR DESCRIPTION
One of the changes in #3093 was to use the typical values when creating document tags for augmented assignment.  This is so `makeDocumentTag (symbol +=, AtomicInt)` would give us `Macaulay2Doc :: AtomicInt += ZZ` instead of `Macaulay2Doc :: AtomicInt += Thing`.

We propose that this should also be the case for the other assignment methods using `=` and `<-`.  This shouldn't change any existing document tags since no assignment methods currently set typical values (` (set methods symbol = + set methods symbol <-) * set keys typicalValues` is empty), and the default typical value is `Thing`.

### Before
```m2
i1 : X = new Type of BasicList;

i2 : X + X = X => (x, y, e) -> new X from {};

i3 : makeDocumentTag ((symbol +, symbol =), X, X)

o3 = User :: X + X = Thing

o3 : DocumentTag
```

### After
```m2
i1 : X = new Type of BasicList;

i2 : X + X = X => (x, y, e) -> new X from {};

i3 : makeDocumentTag ((symbol +, symbol =), X, X)

o3 = User :: X + X = X

o3 : DocumentTag
```

We also use typical values for processing the input and output types of the `Usage` section of the documentation for assignment methods and install typical values for the various augmented assignment methods for `Type`.