### PR TITLE
Set thread mode to synchronized during thread test

### DIFF
--- a/M2/Macaulay2/tests/normal/threads.m2
+++ b/M2/Macaulay2/tests/normal/threads.m2
@@ -28,6 +28,7 @@ assert( {0,1,2} == taskResult \ r )
 assert( aaa === null )
 
 -- check whether storing into a mutable hash table is thread safe
+setIOSynchronized()
 n = 32
 h = new MutableHashTable from apply(n, j -> j => null)
 r = apply(3, i -> schedule (() -> (


### PR DESCRIPTION
Otherwise M2 may crash with "beginning of line marker not within buffer" error.

I've never seen this particular bug before, but one of the PPA builds failed and I was able to reproduce it locally.  It's probably my fault -- maybe the switch to std::atomic?

This is what was happening:

```m2
i28 : load "~/M2/M2/Macaulay2/tests/normal/threads.m2"
../../Macaulay2/tests/normal/threads.m2:2:36:(3):[1]: error: interrupted
../../Macaulay2/tests/normal/threads.m2:2:22:(3): --back trace--
../../Macaulay2/m2/reals.m2:247:30:(1):[4]: error: interrupted
Tally{0 => 15}
Tally{0 => 15}
../../Macaulay2/m2/methods.m2:154:80:(1):[3]: --back trace--
../../Macaulay2/tests/normal/threads.m2:36:29:(3):[1]: --back trace--
../../Macaulay2/tests/normal/threads.m2:35:21:(3): --back trace--
internal error: beginning of line marker not within buffer
```
I'm pretty sure that multiple threads were trying to write to `stdio` or `stderr` at the same time.  I'm not clear why this is happening, but we can fix the crash by calling `setIOSynchronized`.

