### PR TITLE
Use GMP functions for nextPrime and binomial

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -2150,6 +2150,13 @@ scan(e:Expr):Expr := (
 	  else WrongNumArgs(2))
      else WrongNumArgs(2));
 setupfun("scan",scan);
+
+nextPrime(e:Expr):Expr := (
+     when e
+     is x:ZZcell do toExpr(nextPrime(x.v - oneZZ))
+     else WrongArgZZ());
+setupfun("nextPrime0", nextPrime);
+
 gcd(x:Expr,y:Expr):Expr := (
      when x
      is a:ZZcell do (

--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -2167,6 +2167,25 @@ gcd(x:Expr,y:Expr):Expr := (
 gcdfun(e:Expr):Expr := accumulate(plus0,plus1,gcd,e);
 setupfun("gcd0",gcdfun);
 
+binomial(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is n:ZZcell do (
+		when a.1
+		is k:ZZcell do (
+		    if isNegative(k.v)
+		    then zeroE
+		    else if !isULong(k)
+		    then WrongArgSmallUInteger(2)
+		    else toExpr(binomial(n.v, toULong(k))))
+		else WrongArgZZ(2))
+	    else WrongArgZZ(1))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+setupfun("binomial0", binomial);
+
 sequencefun(e:Expr):Expr := (
      when e
      is a:Sequence do e

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -473,6 +473,12 @@ fmod(y:ZZ, z:ulong) ::= Ccode( ulong, "mpz_fdiv_ui(", y, ",", z, ")" );
 export (x:ZZ) % (y:ulong) : ulong := fmod(x,y);
 
 export (x:ZZ) % (y:ushort) : ushort := ushort(x % ulong(y));
+
+export nextPrime(x:ZZ):ZZ := (
+     w := newZZmutable();
+     Ccode(void, "mpz_nextprime(", w, ", ", x, ")");
+     moveToZZandclear(w));
+
 gcd(x:ZZmutable, y:ZZ, z:ZZ) ::= Ccode( void, "mpz_gcd(", x, ",", y, ",", z, ")" );
 
 export gcd(x:ZZ,y:ZZ):ZZ := (

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -2470,6 +2470,11 @@ export factorial(x:ulong):ZZ := (
      Ccode( void, "mpz_fac_ui(", w, ",", x, ")" );
      moveToZZandclear(w));
 
+export binomial(n:ZZ, k:ulong):ZZ := (
+     w := newZZmutable();
+     Ccode(void, "mpz_bin_ui(", w, ", ", n, ", ", k, ")");
+     moveToZZandclear(w));
+
 export log1p(x:RR):RR := (
      z := newRRmutable(precision0(x));
      Ccode( void, "mpfr_log1p(", z, ",", x, ", MPFR_RNDN)" );

--- a/M2/Macaulay2/m2/powers.m2
+++ b/M2/Macaulay2/m2/powers.m2
@@ -3,6 +3,8 @@
 needs "methods.m2"
 needs "remember.m2"
 
+binomial(ZZ, ZZ) := ZZ => binomial0
+
 binomial(Number,   Number) := binomial(Number,   Constant) :=
 binomial(Constant, Number) := binomial(Constant, Constant) := ZZ => memoize (
      (n,i) -> (
@@ -14,9 +16,7 @@ binomial(Constant, Number) := binomial(Constant, Constant) := ZZ => memoize (
 	  else if i === 0 then 1
      	  else if n > 0 then (
      	       if i > n then 0
-	       else if instance(n, ZZ) and instance(i, ZZ)
-		    then n! // (i! * (n-i)!)
-		    else n! / (i! * (n-i)!)
+	       else n! / (i! * (n-i)!)
 	       )
 	  else if n === 0 then 0
      	  else (-1)^i * binomial(-n+i-1,i)

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -312,14 +312,7 @@ getNonUnit = R -> if R.?Engine and R.Engine then (
 
 -- nextPrime and getPrimeWithRootOfUnity, written by Frank Schreyer.
 nextPrime=method(TypicalValue=>ZZ)
-nextPrime Number := n -> (
-   n0 := ceiling n;
-   if n0 <= 2 then return 2;
-   if even n0 then n0=n0+1;
-   while not isPrime n0 do n0=n0+2;
-   n0
-   )
-
+nextPrime Number := nextPrime0 @@ ceiling
 
 getPrimeWithRootOfUnity = method(Options=>{Range=>(10^4,3*10^4)})
 getPrimeWithRootOfUnity(ZZ,ZZ) := opt-> (n,r1) -> (

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/binomial-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/binomial-doc.m2
@@ -8,6 +8,7 @@ doc ///
     (binomial, Constant, Number)
     (binomial, Constant, Constant)
     (binomial, RingElement, ZZ)
+    (binomial, ZZ, ZZ)
   Headline
     binomial coefficient
   Usage


### PR DESCRIPTION
## Use GMP's `mpz_nextprime` for `nextPrime`.

We subtract 1 from the input first, since GMP returns the next prime even when the input is prime, e.g., 3 -> 5, but we want 3 -> 3 to match the existing behavior.

This improves the speed considerably for large integers.

### Before
```m2
i1 : elapsedTime nextPrime 2^1000
 -- 1.79048 seconds elapsed

o1 = 107150860718626732094842504906000181056140481170553360744375038837035105112
     493612249319837881569585812759467291755314682518714528569231404359845775746
     985748039345677748242309854210746050623711418779541821530464749835819412673
     987675591655439460770629145711964776865421676604298316526243868372056680696
     73
```

### After
```m2
i1 : elapsedTime nextPrime 2^1000
 -- 0.0214186 seconds elapsed

o1 = 107150860718626732094842504906000181056140481170553360744375038837035105112
     493612249319837881569585812759467291755314682518714528569231404359845775746
     985748039345677748242309854210746050623711418779541821530464749835819412673
     987675591655439460770629145711964776865421676604298316526243868372056680696
     73
```