### PR TITLE
Add MPFR support to ForeignFunctions package

### DIFF
--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -261,9 +261,9 @@ ffiIntegerAddress(e:Expr):Expr := (
 		when a.1
 		is y:ZZcell do (
 		    if isZero(y.v) then (
-			z := moveToZZ(Ccode(ZZmutable, x.v));
+			z := copy(x.v);
 			ptr := getMem(pointerSize);
-			Ccode(void, "*(void **)", ptr, " = ", z);
+			Ccode(void, "*(mpz_srcptr *)", ptr, " = ", z);
 			toExpr(ptr))
 		    else when a.2
 		    is signed:Boolean do (
@@ -385,9 +385,9 @@ ffiRealAddress(e:Expr):Expr := (
 		is y:ZZcell do (
 		    bits := toInt(y);
 		    if bits == 0 then (
-			z := moveToRR(Ccode(RRmutable, x.v));
+			z := copy(x.v);
 			ptr := getMem(pointerSize);
-			Ccode(void, "*(void **)", ptr, " = ", z);
+			Ccode(void, "*(mpfr_srcptr *)", ptr, " = ", z);
 			toExpr(ptr))
 		    else if bits == 32 || bits == 64 then (
 			ptr := getMemAtomic(bits / 8);

--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -347,11 +347,14 @@ setupfun("ffiIntegerValue", ffiIntegerValue);
 -- real types --
 ----------------
 
+-- returns pointer to ffi_type object for given real number type
+-- input: n:ZZ (0 = mpfr_t, 32 = float, 64 = double)
 ffiRealType(e:Expr):Expr := (
     when e
     is n:ZZcell do (
 	bits := toInt(n);
-	if bits == 32 then toExpr(Ccode(voidPointer, "&ffi_type_float"))
+	if bits == 0 then toExpr(Ccode(voidPointer, "&ffi_type_pointer"))
+	else if bits == 32 then toExpr(Ccode(voidPointer, "&ffi_type_float"))
 	else if bits == 64 then toExpr(Ccode(voidPointer, "&ffi_type_double"))
 	else buildErrorPacket("expected 32 or 64 bits"))
     else WrongArgZZ());

--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -393,6 +393,10 @@ ffiRealAddress(e:Expr):Expr := (
     else WrongNumArgs(2));
 setupfun("ffiRealAddress", ffiRealAddress);
 
+-- returns value (as RR) of real number object given its address
+-- inputs: (x:Pointer, y:ZZ)
+-- x = pointer to real number object
+-- y = type (0 = mpfr_t, 32 = float, 64 = double)
 ffiRealValue(e:Expr):Expr := (
     when e
     is a:Sequence do (
@@ -402,11 +406,13 @@ ffiRealValue(e:Expr):Expr := (
 		when a.1
 		is y:ZZcell do (
 		    bits := toInt(y);
-		    if bits == 32
+		    if bits == 0
+		    then toExpr(moveToRR(Ccode(RRmutable, "*(mpfr_ptr*)", x.v)))
+		    else if bits == 32
 		    then toExpr(Ccode(float, "*(float *)", x.v))
 		    else if bits == 64
 		    then toExpr(Ccode(double, "*(double *)", x.v))
-		    else buildErrorPacket("expected 32 or 64 bits"))
+		    else buildErrorPacket("expected 0, 32, or 64"))
 		else WrongArgZZ(2))
 	    else WrongArgPointer(1))
 	else WrongNumArgs(2))

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -203,7 +203,7 @@ clear(x:RRimutable) ::= Ccode( void, "mpfi_clear(",  x, ")" );
 
 clear(z:CCmutable):void := ( clear(z.re); clear(z.im); );
 
-export moveToZZ(z:ZZmutable):ZZ := (
+export copy(z:ZZ):ZZ := (
      y := GCmalloc(ZZmutable);
      Ccode(void, "
 	  int s = z->_mp_size, ss = s>=0 ? s : -s;
@@ -212,6 +212,7 @@ export moveToZZ(z:ZZmutable):ZZ := (
 	  ",y,"->_mp_alloc = ss, ",y,"->_mp_size = s, ",y,"->_mp_d = p;
 	  ");
      Ccode(ZZ,y));
+export moveToZZ(z:ZZmutable):ZZ := copy(Ccode(ZZ, z));
 
 export moveToZZandclear(z:ZZmutable):ZZ := (
      w := moveToZZ(z);

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -219,7 +219,7 @@ export moveToZZandclear(z:ZZmutable):ZZ := (
      clear(z);
      w);
 
-export moveToRR(z:RRmutable):RR := (
+export copy(z:RR):RR := (
      y := GCmalloc(RRmutable);
      Ccode(void, "
   	  int limb_size = (",z,"->_mpfr_prec - 1) / GMP_NUMB_BITS + 1;
@@ -232,6 +232,7 @@ export moveToRR(z:RRmutable):RR := (
 	  ");
     Ccode(RR,y)
    );
+export moveToRR(z:RRmutable):RR := copy(Ccode(RR, z));
 
 export moveToRRi(z:RRimutable):RRi := (
     y := GCmalloc(RRimutable);

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -259,12 +259,7 @@ if version#"pointer size" == 4 then (
     ) else (
     long = int64;
     ulong = uint64)
-
-mpzT = new ForeignIntegerType;
-mpzT.Name = "mpz_t";
-mpzT.Address = ffiPointerType
-new mpzT from ZZ := (T, n) -> new T from {Address => ffiIntegerAddress n}
-value mpzT := ffiIntegerValue @@ address
+mpzT = foreignIntegerType("mpz_t", 0, true)
 
 ForeignIntegerType Number :=
 ForeignIntegerType Constant := (T, x) -> new T from truncate x

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1,7 +1,7 @@
 newPackage("ForeignFunctions",
     Headline => "foreign function interface",
     Version => "0.3",
-    Date => "January 28, 2023",
+    Date => "February 8, 2024",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
@@ -15,9 +15,9 @@ newPackage("ForeignFunctions",
 
 -*
 
-0.3 (2024-01-28, M2 1.23)
+0.3 (2024-02-08, M2 1.23)
 * add subscripted assignment for various pointer types
-* add support for GMP integers
+* add support for GMP integers and MPFR reals
 * add support for describe, expression, toExternalString, and toString
 * use null coalescing operator
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -77,6 +77,7 @@ export {
     "mpzT",
     "float",
     "double",
+    "mpfrT",
     "voidstar",
     "charstar",
     "voidstarstar",
@@ -289,12 +290,13 @@ foreignRealType(String, ZZ) := (name, bits) -> (
 
 float = foreignRealType("float", 32)
 double = foreignRealType("double", 64)
+mpfrT = foreignRealType("mpfr_t", 0)
 
 ForeignRealType Number :=
 ForeignRealType Constant := (T, x) -> new T from realPart numeric x
 ForeignRealType RRi := (T, x) -> T toRR x
 
-isAtomic ForeignRealType := T -> true
+isAtomic ForeignRealType := T -> if T === mpfrT then false else true
 
 --------------------------
 -- foreign pointer type --

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -1959,6 +1959,7 @@ assert Equation(value mpzT 10^100, 10^100)
 -- real types
 assert Equation(value float 3.14159, 3.14159p24)
 assert Equation(value double 3.14159, 3.14159p53)
+assert Equation(value mpfrT 3.14159p100, 3.14159p100)
 
 -- pointer types
 ptr = address int 3

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -956,6 +956,29 @@ doc ///
 
 doc ///
   Key
+    mpfrT
+    (NewFromMethod, mpfrT, RR)
+    (value, mpfrT)
+  Headline
+    MPFR multiple-precision floating-point type
+  Description
+    Text
+      Macaulay2's native @TO RR@ real number type wraps around @TT
+      "mpfr_t"@ from @HREF{"https://mpfr.org/", "MPFR"}@.  This type
+      (which is an instance of @TO ForeignRealType@) allows for
+      conversion between Macaulay2 reals and MPFR reals without loss
+      of precision.
+    Example
+      mpfrT numeric(100, pi)
+      value oo
+      mpfrAdd = foreignFunction("mpfr_add", void, {mpfrT, mpfrT, mpfrT, int})
+      x = mpfrT 0p100
+      mpfrAdd(x, numeric(100, pi), exp 1p100, 0)
+      x
+///
+
+doc ///
+  Key
     (symbol SPACE, ForeignRealType, Number)
     (symbol SPACE, ForeignRealType, Constant)
     (symbol SPACE, ForeignRealType, RRi)


### PR DESCRIPTION
For example:

```m2
i1 : needsPackage "ForeignFunctions";

i2 : mpfrAdd = foreignFunction("mpfr_add", void, {mpfrT, mpfrT, mpfrT, int})

o2 = mpfr_add

o2 : ForeignFunction

i3 : x = mpfrT 0p100

o3 = 0

o3 : ForeignObject of type mpfr_t

i4 : mpfrAdd(x, numeric(100, pi), exp 1p100, 0)

i5 : x

o5 = 5.85987448204883847382293085463

o5 : ForeignObject of type mpfr_t

i6 : value oo

o6 = 5.85987448204883847382293085463

o6 : RR (of precision 100)