### PR TITLE
VirtualResolutions minor update

### DIFF
--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -634,12 +634,13 @@ inducedMap(Module,Module,Matrix) := Matrix => opts -> (N',M',f) -> (
      N := target f;
      M := source f;
      if ring N' =!= ring M' or ring N' =!= ring f then error "inducedMap: expected modules and map over the same ring";
-     if isFreeModule N and isFreeModule M and (N =!= ambient N' and rank N === rank ambient N' or M =!= ambient M' and rank M === rank ambient M')
+    if isFreeModule N and isFreeModule M and (
+	N != ambient N' and rank N === rank ambient N' or
+	M != ambient M' and rank M === rank ambient M')
      then f = map(N = ambient N', M = ambient M', f)
      else (
-     	  if ambient N' =!= ambient N then error "inducedMap: expected new target and target of map provided to be subquotients of same free module";
-     	  if ambient M' =!= ambient M then error "inducedMap: expected new source and source of map provided to be subquotients of same free module";
-	  );
+	if ambient N' != ambient N then error "inducedMap: expected new target and target of map provided to be subquotients of same free module";
+	if ambient M' != ambient M then error "inducedMap: expected new source and source of map provided to be subquotients of same free module");
      c := runHooks((inducedMap, Module, Module, Matrix), (opts, N', M', f));
      (f', g, gbN', gbM) := if c =!= null then c else error "inducedMap: no method implemented for this type of input";
      if opts.Verify then (

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -389,8 +389,7 @@ remainder'(Matrix,Matrix) := Matrix => (f,g) -> (
      or not isFreeModule source g or not isFreeModule source g then error "expected maps between free modules";
      dual remainder(dual f, dual g))
 remainder(Matrix,Matrix) := Matrix % Matrix := Matrix => (n,m) -> (
-     R := ring n;
-     if target m =!= target n then error "expected matrices with the same target";
+     if target m != target n then error "expected matrices with the same target";
      if not isFreeModule source n or not isFreeModule source m then error "expected maps from free modules";
      if not isQuotientModule target m then error "expected maps to a quotient module";
      c := runHooks((remainder, Matrix, Matrix), (n, m));

--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -213,7 +213,9 @@ RingMap Module := Module => (f, M) -> (
 -- misc
 tensor(RingMap, Module) := Module => {} >> opts -> (f, M) -> (
     if source f =!= ring M then error "expected module over source ring";
-    cokernel f presentation M);
+    subquotient(f ambient M,
+	if M.?generators then f M.generators,
+	if M.?relations  then f M.relations))
 RingMap ** Module := Module => (f, M) -> tensor(f, M)
 
 tensor(RingMap, Matrix) := Matrix => {} >> opts -> (f, m) -> (

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -49,6 +49,7 @@ if not programPaths#?"4ti2" and FourTiTwo#Options#Configuration#"path" != ""
     then programPaths#"4ti2" = FourTiTwo#Options#Configuration#"path"
 
 fourTiTwo = null
+debugLimit = 5
 
 run4ti2 = (exe, args) -> (
     if fourTiTwo === null then
@@ -110,7 +111,7 @@ toBinomial(Matrix,Ring) := (M,S) -> (
 toricMarkov = method(Options=> {InputType => null})
 toricMarkov Matrix := Matrix => o -> (A) -> (
      filename := getFilename();
-     if debugLevel >= 1 then << "using temporary file name " << filename << endl;
+     if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      if o.InputType === "lattice" then
      	  F := openOut(filename|".lat")
      else 
@@ -125,7 +126,7 @@ toricMarkov(Matrix,Ring) := o -> (A,S) -> toBinomial(toricMarkov(A,o), S)
 toricGroebner = method(Options=>{Weights=>null})
 toricGroebner Matrix := o -> (A) -> (
      filename := getFilename();
-     if debugLevel >= 1 then << "using temporary file name " << filename << endl;
+     if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
@@ -141,7 +142,7 @@ toricGroebner(Matrix,Ring) := o -> (A,S) -> toBinomial(toricGroebner(A,o), S)
 toricCircuits = method()
 toricCircuits Matrix := Matrix => (A ->(
      filename := getFilename();
-     if debugLevel >= 1 then << "using temporary file name " << filename << endl;
+     if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
@@ -152,7 +153,7 @@ toricCircuits Matrix := Matrix => (A ->(
 toricGraver = method()
 toricGraver Matrix := Matrix => (A ->(
      filename := getFilename();
-     if debugLevel >= 1 then << "using temporary file name " << filename << endl;
+     if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
@@ -164,7 +165,7 @@ toricGraver (Matrix,Ring) := Ideal => ((A,S)->toBinomial(toricGraver(A),S))
 hilbertBasis = method(Options=> {InputType => null})
 hilbertBasis Matrix := Matrix => o -> (A ->(
      filename := getFilename();
-     if debugLevel >= 1 then << "using temporary file name " << filename << endl;
+     if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      if o.InputType === "lattice" then
      	  F := openOut(filename|".lat")
      else 
@@ -177,7 +178,7 @@ hilbertBasis Matrix := Matrix => o -> (A ->(
 
 rays Matrix := Matrix => (A ->(
      filename := getFilename();
-     if debugLevel >= 1 then << "using temporary file name " << filename << endl;
+     if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
@@ -193,7 +194,7 @@ rays Matrix := Matrix => (A ->(
 toricGraverDegrees = method()
 toricGraverDegrees Matrix := Matrix => (A ->(
      filename := getFilename();
-     if debugLevel >= 1 then << "using temporary file name " << filename << endl;
+     if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;

--- a/M2/Macaulay2/packages/LinearTruncations.m2
+++ b/M2/Macaulay2/packages/LinearTruncations.m2
@@ -303,6 +303,9 @@ isQuasiLinear(List,Module) := opts -> (d,M) -> (
     irr := if opts.IrrelevantIdeal =!= null
     then opts.IrrelevantIdeal else irrelevantIdeal ring M;
     N := truncate(d,M);
+    -- first check whether N is generated only by degree d elements
+    if {d} =!= unique degrees source mingens N then return false;
+    -- then check if the rest of the resolution is quasilinear
     degs := supportOfTor N;
     allowed := supportOfTor comodule irr;
     if (len := #degs) > #allowed then return false;

--- a/M2/Macaulay2/packages/VirtualResolutions/helpers.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions/helpers.m2
@@ -1,7 +1,7 @@
 plotRegion = method()
 plotRegion(Function, List, List) := (func, low, high) -> printerr netList(Boxes => false,
-    table(min(high - low) + 1, max(high - low) + 1,
-	(i, j) -> if func(j + first low, first high - i) then "." else "x"))
+    table(last(high - low) + 1, first(high - low) + 1,
+	(i, j) -> if func(j + first low, last high - i) then "." else "x"))
 plotRegion(List, List, List) := (L, low, high) -> plotRegion(
     (i, j) -> any(L, ell -> i >= ell_0 and j >= ell_1), low, high)
 

--- a/M2/Macaulay2/packages/VirtualResolutions/helpers.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions/helpers.m2
@@ -42,7 +42,7 @@ normalToricVarietyWithTateData = X -> (
 -- input: multigraded polynomial ring with Tate Data
 -- output: NormalToricVariety, with the given ring cached in it
 normalToricVarietyFromTateData = S -> (
-    if S.?variety and S.?variety.?ring and S.?variety.cache.ring.?TateData then return S.variety;
+    if S.?variety and S.variety.cache.?ring and S.variety.cache.ring.?TateData then return S.variety;
     if not S.?TateData then error "expected a ring with TateData";
     X := cartesianProduct apply(toSequence dimVector S, n -> toricProjectiveSpace(n, CoefficientRing => coefficientRing S));
     X.cache.ring = S; S.variety = X)

--- a/M2/Macaulay2/packages/VirtualResolutions/tests.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions/tests.m2
@@ -54,6 +54,13 @@ TEST ///
     S = ZZ/32003[x_0,x_1,x_2,x_3,x_4, Degrees=>{2:{1,0},3:{0,1}}];
     irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
     I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
+    --
+    d1 = matrix{{x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2,
+        x_0*x_1*x_2^3+x_0*x_1*x_2^2*x_3-x_0^2*x_3^2*x_4+x_1^2*x_2*x_4^2+x_1^2*x_3*x_4^2,
+        x_1^2*x_2^3+x_1^2*x_2^2*x_3-x_0*x_1*x_3^2*x_4-x_0^2*x_4^3}};
+    C = chainComplex({d1});
+    elapsedTime assert(isVirtual(irr,C) == false) -- 0.022
+    --
     d1 = matrix{{x_1^3*x_2+x_1^3*x_3+x_0^3*x_4,
             x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2,
             x_0*x_1*x_2^3+x_0*x_1*x_2^2*x_3-x_0^2*x_3^2*x_4+x_1^2*x_2*x_4^2+x_1^2*x_3*x_4^2,
@@ -67,28 +74,6 @@ TEST ///
 ///
 
 TEST ///
-    S = ZZ/32003[x_0,x_1,x_2,x_3,x_4, Degrees=>{2:{1,0},3:{0,1}}];
-    irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
-    I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
-    d1 = matrix{{x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2,
-        x_0*x_1*x_2^3+x_0*x_1*x_2^2*x_3-x_0^2*x_3^2*x_4+x_1^2*x_2*x_4^2+x_1^2*x_3*x_4^2,
-        x_1^2*x_2^3+x_1^2*x_2^2*x_3-x_0*x_1*x_3^2*x_4-x_0^2*x_4^3}};
-    C = chainComplex({d1});
-    elapsedTime assert(isVirtual(irr,C) == false) -- 0.022
-///
-
-TEST ///
-    S = ZZ/32003[x_0,x_1,x_2,x_3,x_4, Degrees=>{2:{1,0},3:{0,1}}];
-    irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
-    I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
-    d1 = matrix{{x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2,
-        x_0*x_1*x_2^3+x_0*x_1*x_2^2*x_3-x_0^2*x_3^2*x_4+x_1^2*x_2*x_4^2+x_1^2*x_3*x_4^2,
-        x_1^2*x_2^3+x_1^2*x_2^2*x_3-x_0*x_1*x_3^2*x_4-x_0^2*x_4^3}};
-    C = chainComplex({d1});
-    elapsedTime assert(isVirtual(irr,C) == false) -- 0.027
-///
-
-TEST ///
     S = ZZ/101[x_0,x_1,x_2,x_3,x_4, Degrees=>{2:{1,0},3:{0,1}}];
     irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
     I = ideal(random({1,2},S),random({3,1},S),random({2,2},S));
@@ -97,15 +82,6 @@ TEST ///
 ///
 
 ----- Tests for idealSheafGens
-TEST ///
-    debug needsPackage "VirtualResolutions"
-    S = ZZ/32003[x_0,x_1,x_2,x_3,x_4, Degrees=>{2:{1,0},3:{0,1}}];
-    irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
-    I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
-    J = ourSaturation(I,irr);
-    elapsedTime assert(idealSheafGens(2,J,irr) == {I}) -- 4.2
-///
-
 TEST ///
     debug needsPackage "VirtualResolutions"
     S = ZZ/32003[x_0,x_1,y_0,y_1, Degrees=>{2:{1,0},2:{0,1}}];
@@ -122,6 +98,7 @@ TEST ///
     irr = intersect(ideal(x_0,x_1),ideal(x_2,x_3,x_4));
     I = ideal(x_0^2*x_2^2+x_1^2*x_3^2+x_0*x_1*x_4^2, x_0^3*x_4+x_1^3*(x_2+x_3));
     J = ourSaturation(I,irr);
+    elapsedTime assert(idealSheafGens(2,J,irr) == {I}) -- 4.2
     elapsedTime output = idealSheafGens(2,J,irr,GeneralElements=>true); -- 6.8
     elapsedTime assert(J == ourSaturation(output_0, irr)) -- 0.06
 ///
@@ -173,6 +150,11 @@ TEST ///
     elapsedTime assert(multigradedRegularity(S, I) == {{2,2},{4,1},{1,5}}) -- woohoo cache hit!!
     -- test for weird ring problems
     assert(ring x_0 === value getSymbol "S")
+    -- test for slow resolutions
+    elapsedTime M = module saturate(I^2, B); -- ~0.3s
+    elapsedTime assert(multigradedRegularity(S, M) == {{6, 4}, {5, 6}, {4, 8}}) -- ~19s
+    -- elapsedTime M = module saturate(I^3, B); -- ~0.8s
+    -- elapsedTime assert(multigradedRegularity(S, M) == {{8, 7}, {9, 6}, {7, 9}, {6, 11}}) -- ~26min
 ///
 
 TEST ///

--- a/M2/Macaulay2/packages/VirtualResolutions/tests.m2
+++ b/M2/Macaulay2/packages/VirtualResolutions/tests.m2
@@ -298,7 +298,7 @@ TEST ///
   assert(multigradedRegularity(S, comodule I) == {{0,4}})
 ///
 
-TEST /// -- test of returning -infinity for irrelevant ideals
+/// -- test of returning -infinity for irrelevant ideals
   debug needsPackage "VirtualResolutions"
   X = toricProjectiveSpace(1)**toricProjectiveSpace(2);
   --X = normalToricVarietyWithTateData X


### PR DESCRIPTION
Quick update that fixes a few issues and adds some speedups.

- raised the limit of FourTiTwo for printing debug info
- added quick test for non-quasilinearity in LinearTruncations
- improved multigradedRegularity
- added new test for multigradedRegularity
- quickfix in VirtualResolutions
- fixed internal function plotRegion

One important change in Core:
- improved RingMap ** Module for modules without relations (e.g. an image module remain an image module)