### PR TITLE
Restore previous memory allocation behavior of GMP integers in ForeignFunctions package

### DIFF
--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -216,7 +216,9 @@ ffiIntegerType(e:Expr):Expr := (
 	if length(a) == 2 then (
 	    when a.0
 	    is n:ZZcell do (
-		if isZero(n.v)
+		if !isInt(n)
+		then WrongArgSmallInteger(1)
+		else if isZero(n.v)
 		then toExpr(Ccode(voidPointer, "&ffi_type_pointer"))
 		else when a.1
 		is signed:Boolean do (
@@ -260,7 +262,9 @@ ffiIntegerAddress(e:Expr):Expr := (
 	    is x:ZZcell do (
 		when a.1
 		is y:ZZcell do (
-		    if isZero(y.v) then (
+		    if !isInt(y)
+		    then WrongArgSmallInteger(2)
+		    else if isZero(y.v) then (
 			z := copy(x.v);
 			ptr := getMem(pointerSize);
 			Ccode(void, "*(mpz_srcptr *)", ptr, " = ", z);
@@ -320,7 +324,9 @@ ffiIntegerValue(e:Expr):Expr := (
 	    is x:pointerCell do (
 		when a.1
 		is y:ZZcell do (
-		    if isZero(y.v)
+		    if !isInt(y)
+		    then WrongArgSmallInteger(2)
+		    else if isZero(y.v)
 		    then toExpr(moveToZZ(Ccode(ZZmutable, "*(mpz_ptr*)", x.v)))
 		    else when a.2
 		    is signed:Boolean do (
@@ -363,6 +369,7 @@ setupfun("ffiIntegerValue", ffiIntegerValue);
 ffiRealType(e:Expr):Expr := (
     when e
     is n:ZZcell do (
+	if !isInt(n) then return WrongArgSmallInteger();
 	bits := toInt(n);
 	if bits == 0 then toExpr(Ccode(voidPointer, "&ffi_type_pointer"))
 	else if bits == 32 then toExpr(Ccode(voidPointer, "&ffi_type_float"))
@@ -383,6 +390,7 @@ ffiRealAddress(e:Expr):Expr := (
 	    is x:RRcell do (
 		when a.1
 		is y:ZZcell do (
+		    if !isInt(y) then return WrongArgSmallInteger();
 		    bits := toInt(y);
 		    if bits == 0 then (
 			z := copy(x.v);
@@ -419,6 +427,7 @@ ffiRealValue(e:Expr):Expr := (
 	    is x:pointerCell do (
 		when a.1
 		is y:ZZcell do (
+		    if !isInt(y) then return WrongArgSmallInteger();
 		    bits := toInt(y);
 		    if bits == 0
 		    then toExpr(moveToRR(Ccode(RRmutable, "*(mpfr_ptr*)", x.v)))

--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -396,9 +396,14 @@ ffiRealAddress(e:Expr):Expr := (
 		    if !isInt(y) then return WrongArgSmallInteger();
 		    bits := toInt(y);
 		    if bits == 0 then (
-			z := copy(x.v);
+			z := newRRmutable(precision(x.v));
+			Ccode(void, "mpfr_set(", z, ", ", x.v, ", MPFR_RNDN)");
 			ptr := getMem(pointerSize);
-			Ccode(void, "*(mpfr_srcptr *)", ptr, " = ", z);
+			Ccode(void, "*(mpfr_ptr *)", ptr, " = ", z);
+			-- TODO: we get segfaults during garbage collection
+			-- if the following is uncommented
+			-- Ccode(void, "GC_REGISTER_FINALIZER(", ptr, ", ",
+			--  "(GC_finalization_proc)mpfr_clear, ", z, ", 0, 0)");
 			toExpr(ptr))
 		    else if bits == 32 || bits == 64 then (
 			ptr := getMemAtomic(bits / 8);

--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -265,9 +265,12 @@ ffiIntegerAddress(e:Expr):Expr := (
 		    if !isInt(y)
 		    then WrongArgSmallInteger(2)
 		    else if isZero(y.v) then (
-			z := copy(x.v);
+			z := newZZmutable();
+			set(z, x.v);
 			ptr := getMem(pointerSize);
-			Ccode(void, "*(mpz_srcptr *)", ptr, " = ", z);
+			Ccode(void, "*(mpz_ptr *)", ptr, " = ", z);
+			Ccode(void, "GC_REGISTER_FINALIZER(", ptr, ", ",
+			    "(GC_finalization_proc)mpz_clear, ", z, ", 0, 0)");
 			toExpr(ptr))
 		    else when a.2
 		    is signed:Boolean do (

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -203,7 +203,7 @@ clear(x:RRimutable) ::= Ccode( void, "mpfi_clear(",  x, ")" );
 
 clear(z:CCmutable):void := ( clear(z.re); clear(z.im); );
 
-export copy(z:ZZ):ZZ := (
+export moveToZZ(z:ZZmutable):ZZ := (
      y := GCmalloc(ZZmutable);
      Ccode(void, "
 	  int s = z->_mp_size, ss = s>=0 ? s : -s;
@@ -212,14 +212,13 @@ export copy(z:ZZ):ZZ := (
 	  ",y,"->_mp_alloc = ss, ",y,"->_mp_size = s, ",y,"->_mp_d = p;
 	  ");
      Ccode(ZZ,y));
-export moveToZZ(z:ZZmutable):ZZ := copy(Ccode(ZZ, z));
 
 export moveToZZandclear(z:ZZmutable):ZZ := (
      w := moveToZZ(z);
      clear(z);
      w);
 
-export copy(z:RR):RR := (
+export moveToRR(z:RRmutable):RR := (
      y := GCmalloc(RRmutable);
      Ccode(void, "
   	  int limb_size = (",z,"->_mpfr_prec - 1) / GMP_NUMB_BITS + 1;
@@ -232,7 +231,6 @@ export copy(z:RR):RR := (
 	  ");
     Ccode(RR,y)
    );
-export moveToRR(z:RRmutable):RR := copy(Ccode(RR, z));
 
 export moveToRRi(z:RRimutable):RRi := (
     y := GCmalloc(RRimutable);


### PR DESCRIPTION
In #3124, I switched the memory allocation of `mpzT` objects (GMP integers) in the `ForeignFunctions` package from GMP's own `mpz_init` (with a call to `mpz_clear` when finalizing the pointer) to the one we use for `ZZ` at top level that uses GC to allocate memory.  This caused Macaulay2 to crash when calling certain GMP functions using the foreign function interface.

In particular, the examples were failing in Ubuntu 18.04 using GMP 6.1 (before lazy allocation was added in GMP 6.2).  Even using GMP 6.2, we'd get these same crashes using large enough integers to trigger memory allocation.

In this PR, we restore the previous behavior of using `mpz_init`.   We also make a few other related changes:

* Check that some of the `ZZ`'s that we call `toInt` on really fit inside an `int`.
* Remove a couple functions from `gmp.d` that were created for [#3124](https://github.com/Macaulay2/M2/pull/3124) that are no longer used.
* Make the corresponding change for allocation of `mpfrT` objects (MPFR reals).  Until I figure out what's going on, the finalization code is commented out because otherwise we get segfaults during garbage collection.

Closes: #3128