### PR TITLE
Update M2-emacs submodule after restoration of M2-demo-buffer behavior

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -85,6 +85,20 @@ document {
             LI { "Some computations in the engine (e.g. minimal betti diagrams and Groebner bases over associative algebras), ",
                   "can now take advantage of multiple CPU cores, see ", TO "parallelism in engine computations", "."}
 		    }
+	       },
+	  LI { "emacs updates:",
+	       UL {
+	            LI { "Indentation in the Macaulay2 major mode is now more consistent with other Emacs majors modes.  For example, it now respects ",
+			 "the Electric Indent minor mode.  In particular, it is possible to toggle whether code is automatically indented after pressing ",
+			 KBD "Return", " by running ", SAMP "M-x electric-indent-mode", "." },
+		    LI { "The Macaulay2 Interaction major mode now respects the ", SAMP "comint-use-prompt-regexp", " variable.  This controls how ",
+			 "many lines are sent to Macaulay2 when pressing ", KBD "Return", " after scrolling up to previous input.  If the variable is ",
+			 "set to ", SAMP "t", ", then one line will be sent.  If it is set to ", SAMP "nil", " (the default), then the entire input ",
+			 "field will be sent." },
+		    LI { "The function ", SAMP "M2-send-to-program", " (which is bound to ", KBD "F11", " by default), is now only intended to be ",
+			 "called from the Macaulay2 major mode.  A new function, ", SAMP "M2-send-input-or-get-input-from-demo-buffer", " has been ",
+			 "added (and bound to ", KBD "F11", ") for the Macaulay2 Interaction major mode.  The user experience should remain unchanged." }
+		    }
 	       }
 	  }
      }

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_getting_started.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_getting_started.m2
@@ -979,7 +979,7 @@ document {
      TO "teaching emacs how to find M2", ".",
      PARA{},
      "You may wish to bind the emacs function ", TT "M2-send-to-program", "
-     to a global keystroke for ease of use; this is done automatically for
+     to a global keystroke for ease of use; this is done automatically
      in Macaulay2 buffers.  For example, the following emacs code
      will bind it to the function key ", TT "f11", ".",
      PARA{},

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_getting_started.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_getting_started.m2
@@ -1000,6 +1000,33 @@ document {
      PARA{},
      "Notice that the input prompts are not submitted to Macaulay2.",
      PARA{},
+     "Here is a way to conduct a demo of Macaulay2 in which the code to be
+     submitted is not visible on the screen.  Visit a file called ", 
+     TT "foo.m2", " and paste the following text into it.",
+     PARA{},
+     PRE ///20!
+     4 + 5 * 2^20
+     -- that's all folks!///,
+     PARA{},
+     "Press ", TT "M-f11", " with your cursor in this buffer to designate it as
+     the source for the Macaulay2 commands.  (The notation ", TT "M-f11", " means 
+     that while holding the ", TT "Meta", " key down, you should press the ", TT "f11", " 
+     function key.  The Meta key is the Alt key on some keyboards, or it can be simulated by 
+     pressing Escape (just once) and following that with the key you wanted to press 
+     while the meta key was held down.)  Then position your cursor (and thus the 
+     emacs point) within the line containing ", TT "20!", ".  Now press 
+     ", TT "M-x M2-demo", " to open up a new frame called ", TT "DEMO", "
+     for the ", TT "*M2*", " window with a large font suitable for use with
+     a projector, and with your cursor in that frame, press ", TT "f11", "
+     a few times to conduct the demo.  (If the font or frame is the wrong
+     size, you may have to create a copy of the file ", TT "M2.el", " with
+     a version of the function ", TT "M2-demo", " modified to fit your
+     screen.)",
+     PARA{},
+     "One press of ", TT "f11", " brings the next line of code forward into the
+     ", TT "*M2*", " buffer, and the next press executes it.  Use ", TT "C-x 5 0", " 
+     when you want the demo frame to go away.",
+     PARA{},
      "There is a way to send a region of text to Macaulay2: simply select a region
      of text, making sure the mark is active (as described above) and press ", TT "f11", ".
      Try that on the list below; put it into an emacs buffer, move your cursor to the 


### PR DESCRIPTION
After https://github.com/Macaulay2/M2-emacs/pull/57, <kbd>F11</kbd> now works again in `M2-comint-mode` buffers to grab input from `M2-demo-buffer`.  This PR updates the `M2-emacs` submodule to the most recent commit.

We also update the Emacs documentation, reverting one of the commits in #3133 that removed the mention of this behavior, fixing a typo, and adding the Emacs-related changes to the 1.23 changelog.