### PR TITLE
Enclose filenames with spaces in them in quotes

### DIFF
--- a/M2/Macaulay2/d/stdiop.d
+++ b/M2/Macaulay2/d/stdiop.d
@@ -112,7 +112,13 @@ export verifyMinimizeFilename(filename:string):string := (
 export tostring(w:Position) : string := (
      if w == dummyPosition 
      then "-*dummy position*-"
-     else errfmt(verifyMinimizeFilename(w.filename),int(w.line),int(w.column + 1),int(w.loadDepth)));
+     else (
+	 filename := verifyMinimizeFilename(w.filename);
+	 foreach c in filename do (
+	     if c == ' ' then (
+		 filename = "\"" + filename + "\"";
+		 break));
+	 errfmt(filename ,int(w.line),int(w.column + 1),int(w.loadDepth))));
 export (o:file) << (w:Position) : file := o << tostring(w);
 export (o:BasicFile) << (w:Position) : BasicFile := o << tostring(w);
 threadLocal export SuppressErrors := false;

--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -239,7 +239,8 @@ FilePosition = new Type of BasicList
 FilePosition.synonym = "file position"
 toString FilePosition :=
 net FilePosition := p -> concatenate(
-    p#0,":",toString p#1,":",toString p#2,
+    if match(" ", p#0) then format p#0 else p#0,
+    ":",toString p#1,":",toString p#2,
     if #p>3 then ("-",toString p#3,":",toString p#4),
 --    if #p>5 then (" (",toString p#5,":",toString p#6,")")
     )


### PR DESCRIPTION
This is part of a proposal to fix https://github.com/Macaulay2/M2-emacs/issues/48.  When a filename contains spaces, we enclose it in quotes so that Emacs will realize that the spaces are part of the path and correctly identify it.

Currently, this PR fixes the two places in the the code that are responsible for printing filenames.  It's a draft for now, as there will be an accompanying M2-emacs PR.  If that's merged, then I plan on updating the M2-emacs commit in this PR.

So consider the file `~/tmp/foo bar baz.m2` containing the following code:

```m2
f = x -> 1/x
```

### Before:
```m2
i1 : load "~/tmp/foo bar baz.m2"

i2 : f 0
tmp/foo bar baz.m2:1:11:(3):[1]: error: division by zero
tmp/foo bar baz.m2:1:11:(3):[1]: --entering debugger (type help to see debugger commands)
tmp/foo bar baz.m2:1:9-1:11: --source code:
f = x -> 1/x
```

In particular, Emacs only identifies `baz.m2` as the filename.

### After
```m2
i1 : load "~/tmp/foo bar baz.m2"

i2 : f 0
"tmp/foo bar baz.m2":1:11:(3):[1]: error: division by zero
"tmp/foo bar baz.m2":1:11:(3):[1]: --entering debugger (type help to see debugger commands)
"tmp/foo bar baz.m2":1:9-1:11: --source code:
f = x -> 1/x
```

Once the Emacs regexes are updated to identify the entire quoted string as the filename, then things should work properly.

Cc: @mikestillman 