### PR TITLE
Quick fix for case when polynomial is only the leading term

### DIFF
--- a/M2/Macaulay2/packages/RealRoots.m2
+++ b/M2/Macaulay2/packages/RealRoots.m2
@@ -2,6 +2,7 @@
 newPackage(
     "RealRoots",
     Version=>"0.1",
+    --updates/corrections to realRootIsolation by Corin Lee (cel34@bath.ac.uk) 16/02/2024
     Date=>"Oct 9, 2020",
     Authors=>{
      	{Name=>"Jordy Lopez Garcia",
@@ -398,7 +399,7 @@ realRootIsolation (RingElement,A) := List => (f,r)->(
 	
 	--bound for real roots
 	C := (listForm ((f-leadTerm(f))/leadCoefficient(f)))/last; --make the polynomial monic, and obtain list of coefficients of non-lead monomials.
-    	M := min(1+max(apply(C,abs)),max(1,sum(C,abs))); --obtains Cauchy or Lagrange bound.
+    	M := min(1+max(0,max(apply(C,abs))),max(1,sum(C,abs))); --obtains Cauchy or Lagrange bound (setting M = 1 if the polynomial is only a single term)
 	
 	L := {{-M,M}};
 	midp := 0;


### PR DESCRIPTION
Quick catch for the case when tested polynomial is a single term (equal to a*x^n). Did not account for the fact that max({})=-infinity, which would occur when f=leadTerm(f), causing the bisection step to fail. When this happens, the root(s) of f would be 0, so M is set to 1.