### PR TITLE
A few updates to branch/tag information in INSTALL

### DIFF
--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -61,6 +61,11 @@ source code:
     git submodule sync
     git submodule update
 
+To obtain the latest, but potentially unstable, changes to the Macaulay2 source
+code, switch to the "development" branch:
+
+    git checkout development
+
 ---------
 Libraries
 ---------

--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -33,11 +33,13 @@ command, assuming you have installed "git" on your machine:
     git clone https://github.com/Macaulay2/M2
 
 A directory called M2, which you can move or rename, will be created, and this
-INSTALL file is in the subdirectory "M2" of it.  The "release" tags tend to
-be more stable, and if you compile from one of those, you'll have the same
-functionality as those who download our binary releases.  So, after cloning,
-you can switch to the tag containing version 1.6, for example, with the
-following command:
+INSTALL file is in the subdirectory "M2" of it.  By default, the "master" branch
+of the M2 repository will be checked out.
+
+The "release" tags tend to be more stable, and if you compile from one of
+those, you'll have the same functionality as those who download our binary
+releases.  So, after cloning, you can switch to the tag containing version 1.6,
+for example, with the following command:
 
     git checkout release-1.6
 
@@ -46,6 +48,10 @@ Instead of release-1.6 you should, of course, use the most recent one.
 The following command shows the list of release tags:
 
     git tag | grep release
+
+However, if some time has passed since the most recent release and your system
+has newer versions of some of Macaulay2's dependencies than were available at
+the time of the release, you may have more success building the "master" branch.
 
 The following commands, run from the top level of this source tree (the parent
 of the directory this file is in) will download the latest changes to the

--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -33,19 +33,19 @@ command, assuming you have installed "git" on your machine:
     git clone https://github.com/Macaulay2/M2
 
 A directory called M2, which you can move or rename, will be created, and this
-INSTALL file is in the subdirectory "M2" of it.  The "release" branches tend to
+INSTALL file is in the subdirectory "M2" of it.  The "release" tags tend to
 be more stable, and if you compile from one of those, you'll have the same
 functionality as those who download our binary releases.  So, after cloning,
-you can switch to the branch containing version 1.6, for example, with the
+you can switch to the tag containing version 1.6, for example, with the
 following command:
 
     git checkout release-1.6
 
 Instead of release-1.6 you should, of course, use the most recent one.
 
-The following command shows the list of release branches:
+The following command shows the list of release tags:
 
-    git branch -a | grep origin/release
+    git tag | grep release
 
 The following commands, run from the top level of this source tree (the parent
 of the directory this file is in) will download the latest changes to the


### PR DESCRIPTION
In response to https://github.com/Macaulay2/M2/issues/3009#issuecomment-1958230775, we add some clarification regarding building the `master` and `development` branches v. the most recent `release-*` tag.

(Since this PR only touches `INSTALL` and doesn't affect the build, the CI tests are skipped.)