### PR TITLE
fixed is_equal to ignore Schreyer order on free modules

### DIFF
--- a/M2/Macaulay2/e/freemod.cpp
+++ b/M2/Macaulay2/e/freemod.cpp
@@ -163,8 +163,10 @@ bool FreeModule::is_equal(const FreeModule *F) const
     for (i = 0; i < rank(); i++)
       if (0 != D->compare(degree(i), F->degree(i))) return false;
 
+  /* free modules with same ranks and degrees should be equal
   if (schreyer != nullptr) return schreyer->is_equal(F->schreyer);
   if (F->schreyer != nullptr) return false;
+  */
 
   return true;
 }

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -635,12 +635,12 @@ inducedMap(Module,Module,Matrix) := Matrix => opts -> (N',M',f) -> (
      M := source f;
      if ring N' =!= ring M' or ring N' =!= ring f then error "inducedMap: expected modules and map over the same ring";
     if isFreeModule N and isFreeModule M and (
-	N != ambient N' and rank N === rank ambient N' or
-	M != ambient M' and rank M === rank ambient M')
+	N =!= ambient N' and rank N === rank ambient N' or
+	M =!= ambient M' and rank M === rank ambient M')
      then f = map(N = ambient N', M = ambient M', f)
      else (
-	if ambient N' != ambient N then error "inducedMap: expected new target and target of map provided to be subquotients of same free module";
-	if ambient M' != ambient M then error "inducedMap: expected new source and source of map provided to be subquotients of same free module");
+	if ambient N' =!= ambient N then error "inducedMap: expected new target and target of map provided to be subquotients of same free module";
+	if ambient M' =!= ambient M then error "inducedMap: expected new source and source of map provided to be subquotients of same free module");
      c := runHooks((inducedMap, Module, Module, Matrix), (opts, N', M', f));
      (f', g, gbN', gbM) := if c =!= null then c else error "inducedMap: no method implemented for this type of input";
      if opts.Verify then (

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -389,7 +389,7 @@ remainder'(Matrix,Matrix) := Matrix => (f,g) -> (
      or not isFreeModule source g or not isFreeModule source g then error "expected maps between free modules";
      dual remainder(dual f, dual g))
 remainder(Matrix,Matrix) := Matrix % Matrix := Matrix => (n,m) -> (
-     if target m != target n then error "expected matrices with the same target";
+     if target m =!= target n then error "expected matrices with the same target";
      if not isFreeModule source n or not isFreeModule source m then error "expected maps from free modules";
      if not isQuotientModule target m then error "expected maps to a quotient module";
      c := runHooks((remainder, Matrix, Matrix), (n, m));

--- a/M2/Macaulay2/tests/normal/schorder2.m2
+++ b/M2/Macaulay2/tests/normal/schorder2.m2
@@ -13,9 +13,8 @@ assert(degrees source symmetricPower(2, matrix{{a^2,a*b,b^3}}) ==
 assert(degrees source symmetricPower(3, matrix{{a^2,a*b,b^3}}) ==
      {{6, 0, 0}, {5, 1, 0}, {4, 3, 0}, {4, 2, 0}, {3, 4, 0}, 
       {2, 6, 0}, {3, 3, 0}, {2, 5, 0}, {1, 7, 0}, {0, 9, 0}})
-     
 
-
+--------------------
 R = QQ[a..d]
 f = schreyerOrder vars R
 debug Core
@@ -36,7 +35,6 @@ g = symmetricPower(3,f)
 rawSource raw g
 assert(schreyerOrder source g == diagonalMatrix matrix{(flatten entries g)/leadMonomial})
 
-
 ----- test of schreyer orders with exterior power
 R = QQ[a..d]
 f = schreyerOrder vars R
@@ -51,3 +49,8 @@ raw F2
 F4 = exteriorPower(4,F) 
 schreyerOrder F4
 assert(exteriorPower(5,F) == 0)
+
+----- test of equality of free modules with or without schreyer order
+R = QQ[x,y,z]/(x^2+y^2+z^2)
+M = ambient coker(res coker vars R).dd_2
+assert(M === R^{3:-1})


### PR DESCRIPTION
Also partially reverts changes from 1338599 and 7f1c585.

Closes #3135.