### PR TITLE
Fix typo in compareExchange docs (z is stored in x, not y)

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_atomic.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_atomic.m2
@@ -237,7 +237,7 @@ doc ///
   Description
     Text
       The values of @VAR "x"@ and @VAR "y"@ are compared.  If they agree,
-      then @TO true@ is returned and the value of @VAR "y"@ is stored in
+      then @TO true@ is returned and the value of @VAR "z"@ is stored in
       @VAR "x"@.  Otherwise, @TO false@ is returned.  This operation occurs
       atomically and is thread safe.
     Example


### PR DESCRIPTION
Thanks to @pzinn for catching this!

@DanGrayson -- would it be possible to include this small fix in the release?