### PR TITLE
Attempted fix for bug in quotient for matrices over finite field.

### DIFF
--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -354,9 +354,11 @@ addHook((quotient, Matrix, Matrix), Strategy => Default, (opts, f, g) -> (
        and numRows g === numColumns g
        and isFreeModule source g and isFreeModule source f
        then return solve(g,f);	   	     	       	    
+     local retVal;
      if isQuotientOf(ZZ,ring target f)
        and isFreeModule source g and isFreeModule source f
-       then return solve(g,f);
+       then retVal = solve(g,f);
+     if retVal =!= null then return retVal;
      if M.?generators then (
 	  M = cokernel presentation M;	    -- this doesn't change the cover
 	  );

--- a/M2/Macaulay2/tests/normal/quotient.m2
+++ b/M2/Macaulay2/tests/normal/quotient.m2
@@ -1,0 +1,16 @@
+M = matrix {{1},{0}}
+N = matrix {{0},{1}}
+assert(M // N == 0)
+
+M = sub(matrix {{1},{0}}, QQ)
+N = sub(matrix {{0},{1}}, QQ)
+assert(M // N == 0)
+
+M = sub(matrix {{1},{0}}, ZZ/32003)
+N = sub(matrix {{0},{1}}, ZZ/32003)
+assert(M // N == 0)
+
+K = GF(32003^2)
+M = sub(matrix {{1},{0}}, K)
+N = sub(matrix {{0},{1}}, K)
+assert(M // N == 0)


### PR DESCRIPTION
This is an attempted fix for #603.

Feel free to suggest alternative solutions, but at this point if solve return non-null, then that value is returned, otherwise the hook for quotient continues as usual.  This results in "throwing away" the work from solve if a solution is not found(which arises from a call to rawLinAlgSolve of a mutable dense matrix), which may be undesirable.