### PR TITLE
Fix link to JSAG copy of BettiCharacters package

### DIFF
--- a/M2/Macaulay2/packages/BettiCharacters.m2
+++ b/M2/Macaulay2/packages/BettiCharacters.m2
@@ -33,7 +33,7 @@ newPackage(
 	 "acceptance date" => "2023-05-30",
 	 "published article URI" => "https://msp.org/jsag/2023/13-1/p04.xhtml",
 	 "published article DOI" => "https://doi.org/10.2140/jsag.2023.13.45",
-	 "published code URI" => "https://msp.org/jsag/2023/13-1/jsag-v13-n1-x03-BettiCharacters.m2",
+	 "published code URI" => "https://msp.org/jsag/2023/13-1/jsag-v13-n1-x04-BettiCharacters.m2",
 	 "repository code URI" => "https://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/BettiCharacters.m2",
 	 "release at publication" => "a446af4424af33c06ab97694761a4d5bbc4d535f",
 	 "version at publication" => "2.1",


### PR DESCRIPTION
When I was preparing the 1.23 release, I noticed that the link to the `BettiCharacters` source code on the JSAG webpage was broken.  I was able to find it by playing around with the URL, and I used the link that worked in the `Certification` section.

I reported the broken link to JSAG.  They fixed it, but now the link I used in the package is broken!