### PR TITLE
Typos plus encoding

### DIFF
--- a/M2/Macaulay2/packages/AdjunctionForSurfaces.m2
+++ b/M2/Macaulay2/packages/AdjunctionForSurfaces.m2
@@ -406,7 +406,7 @@ doc ///
           {r_1,...,r_s} of multiplicities 
   Outputs
      H: Matrix
-        a 1xn matrix whose entreis are a bases of L(d;r_1p_1,...,r_sp_s)      
+        a 1xn matrix whose entries are a bases of L(d;r_1p_1,...,r_sp_s)      
   Description
      Text
        The function chooses randomly s point p_i in P2 and computes the 
@@ -648,7 +648,7 @@ doc ///
 	to get a rational parametrization. However, one can always parametrize X in terms of the final
 	surface in the adjunction process.
 	
-	The nummerical data are collected in a list with an entry 
+	The numerical data are collected in a list with an entry 
 	
 	(n,d,pi)= (dim Pn_i, degree X_i, sectional genus of X_i)
 	

--- a/M2/Macaulay2/packages/AssociativeAlgebras/doc.m2
+++ b/M2/Macaulay2/packages/AssociativeAlgebras/doc.m2
@@ -1480,7 +1480,7 @@ doc ///
      n : ZZ
      Strategy => String
        either "F4Parallel", "F4", or "Naive".  Default for finite prime fields with
-       a homogeneous ideal is "F4Parallel", and otherwise deault is "Naive", which
+       a homogeneous ideal is "F4Parallel", and otherwise default is "Naive", which
        uses a standard Buchberger-like algorithm
    Outputs
      Igb : Matrix

--- a/M2/Macaulay2/packages/BernsteinSato/DOC/localCohom.m2
+++ b/M2/Macaulay2/packages/BernsteinSato/DOC/localCohom.m2
@@ -8,7 +8,7 @@ document {
        UL {
             {BOLD "LocStrategy => null", 
                  " -- used only for ", TT "localCohom(...Ideal...)", 
-                 ", localizations are done by straigthforward computation of 
+                 ", localizations are done by straightforward computation of 
                  annihilators and b-polynomials as described in [1]."},
             {BOLD "LocStrategy => OaTaWa", 
                  " -- localizations are done following Oaku-Takayama-Walther method [2]."},

--- a/M2/Macaulay2/packages/EngineTests/Res.f4.m2
+++ b/M2/Macaulay2/packages/EngineTests/Res.f4.m2
@@ -20,7 +20,7 @@
 --          todo list of degree,level includes multi-degrees: maybe?  (heftdeg, multidegree, level).
 -- 2. Allow inhomogeneous input
 -- 3. Allow modules to be input (several related tests below failing)
---   how: 2,3 are closeely related: need better monomial order support.
+--   how: 2,3 are closely related: need better monomial order support.
 --   TODO:
 --      (a) try using the monomial order in input matrix.
 --      (b) sorting a set of monomials at a specific level:

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -218,7 +218,7 @@ document {
 			 character tables, decompositions, and other methods for characters.
 			 The GradedCharacter type has been removed, and the Character type
 			 has been modified to accommodate both homological and internal
-			 grading in a simplied format." 
+			 grading in a simplified format." 
                 	 }
 		     }
 		 },

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc12.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc12.m2
@@ -339,7 +339,7 @@ document {
      ///,
      "The following operators can be applied to expressions: ", TO "SPACE", ", ", TO "*", ", ", TO "**", ", ", TO "+", ", ", TO "-", ", ", 
      TO "/", ", ", TO "==", ", ", TO "^", ", and ", TO "_", ".  They are contagious, in the sense that when applied to an expression and a non-expression,
-     the non-expression will be converted to an expression and the operator will be applied.  Only the most trivial algebraic simplications are applied.",
+     the non-expression will be converted to an expression and the operator will be applied.  Only the most trivial algebraic simplifications are applied.",
      EXAMPLE lines ///
      	  d + e
 	  d + 4

--- a/M2/Macaulay2/packages/MatchingFields.m2
+++ b/M2/Macaulay2/packages/MatchingFields.m2
@@ -180,7 +180,7 @@ grMatchingField(ZZ, ZZ, List) := (Lk , Ln, L) -> (
 	}
     )
 
--- Constructor for parital Flag Matching Fields
+-- Constructor for partial Flag Matching Fields
 flMatchingField = method(
     TypicalValue => FlMatchingField
     )
@@ -1905,7 +1905,7 @@ doc ///
 	  Given a matching field $\Lambda$ for the Grassmannian Gr$(k,n)$, the matching field 
 	  polytope $P(\Lambda)$ is simply the convex hull of the exponent
 	  vectors of the image of Pluecker variables under the monomial map of 
-	  $\Lambda$. The polytope natrually lives in the space
+	  $\Lambda$. The polytope naturally lives in the space
 	  $\RR^{k \times n}$.
 	Example
 	  L2 = diagonalMatchingField(2, 4)

--- a/M2/Macaulay2/packages/NonminimalComplexes.m2
+++ b/M2/Macaulay2/packages/NonminimalComplexes.m2
@@ -41,7 +41,7 @@ export {
 debug Core
 
 -*
--- The following shuold be where?
+-- The following should be where?
 newChainComplexMap = method()
 newChainComplexMap(ChainComplex, ChainComplex, HashTable) := (tar,src,maps) -> (
      f := new ChainComplexMap;

--- a/M2/Macaulay2/packages/PhylogeneticTrees.m2
+++ b/M2/Macaulay2/packages/PhylogeneticTrees.m2
@@ -2558,7 +2558,7 @@ TEST ///
 -- We test the function toricSecantDim by computing the 
 -- dimension of a second secant of the CFN model
 -- which is known to be non-defective.
--- We also verify that the dimenson of the secant for the
+-- We also verify that the dimension of the secant for the
 -- CFN model for a 4-leaf tree is no larger than the ambient dimension. 
 
 A = phyloToricAMatrix(6, {{0,1},{2,3},{4,5}},CFNmodel);

--- a/M2/Macaulay2/packages/PlaneCurveLinearSeries.m2
+++ b/M2/Macaulay2/packages/PlaneCurveLinearSeries.m2
@@ -266,7 +266,7 @@ projectiveImage(List, Ring) := Matrix => o -> (D0List, C) ->(
 
 
 projectiveImage Matrix := Ring => o -> M -> (
- -- in this case M is a 1-m matrix respresenting a
+ -- in this case M is a 1-m matrix representing a
  --linear series.
     R := ring M;
     kk := coefficientRing R;

--- a/M2/Macaulay2/packages/SubalgebraBases/Old-SubalgebraBases/Archive/oldDocumentation.m2
+++ b/M2/Macaulay2/packages/SubalgebraBases/Old-SubalgebraBases/Archive/oldDocumentation.m2
@@ -456,7 +456,7 @@ doc ///
      (makePresRing, Subring)
      [makePresRing, VarBaseName]
    Headline
-     Contstructs an instance of the PresRing type
+     Constructs an instance of the PresRing type
    Usage
      result = makePresRing(gndR, gensMat)
      result = makePresRing(gndR, gensList)

--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -422,7 +422,7 @@ Description
   Text
     Topcom assumes that the points do not lie on a hyperplane.  If they do, and the hyperplane is not
     through the origin (and they span that entire affine hyperplane), then give {\tt Homogenize => false} as an option.
-    This is essentially equivalent to considering the point configuration as a vector comfiguration.
+    This is essentially equivalent to considering the point configuration as a vector configuration.
     
     For example, the following three points lie on the hyperplane $x_0 + x_1 + x_2 = 2$.
   Example

--- a/M2/Macaulay2/packages/Valuations.m2
+++ b/M2/Macaulay2/packages/Valuations.m2
@@ -538,7 +538,7 @@ doc ///
             the lowest term valuation
      Description
        Text
-           This function construst a valuation which returns the exponent vector of the
+           This function builds a valuation which returns the exponent vector of the
            lead term of a polynomial with respect to the ring's term order.
            The valuation returns vectors in an @TT "ordered $\\QQ$-module"@,
            which respects the monomial order of the

--- a/M2/Macaulay2/packages/Visualize/fonts/LICENSE
+++ b/M2/Macaulay2/packages/Visualize/fonts/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2004 by MAGENTA Ltd. All Rights Reserved.
+Copyright Â© 2004 by MAGENTA Ltd. All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated documentation files (the "Font Software"), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
just some typos found using codespell, and fix a bad "copyright" sign, not encoded correctly