### PR TITLE
Raise error simplifying elements of fraction field when gcd fails

### DIFF
--- a/M2/Macaulay2/e/frac.cpp
+++ b/M2/Macaulay2/e/frac.cpp
@@ -116,6 +116,7 @@ void FractionField::simplify(frac_elem *f) const
       const RingElement *a = RingElement::make_raw(R_, x);
       const RingElement *b = RingElement::make_raw(R_, y);
       const RingElement *c = rawGCDRingElement(a, b, nullptr, false);
+      if (!c) return;
 
 #if 0
       // Debugging code


### PR DESCRIPTION
This is a partial fix for #3172 in that it raises an error instead of segfaulting.   When simplifying an element of a fraction field, we first find the gcd of the numerator and denominator.  However, currently we don't check to see if an error was raised in the gcd routine, and if one was, we get a segfault since the "gcd" is a really just a null pointer.

With this patch on @pzinn's branch, we now get the following:

```m2
i1 : Qi  =  toField( QQ[i]/(i^2+1) )

o1 = Qi

o1 : PolynomialRing

i2 : R   = Qi[u,v]

o2 = R

o2 : PolynomialRing

i3 : (u + v) / i
stdio:3:8:(3): error: expected coefficient ring of the form ZZ/n, ZZ, QQ, or GF
```

