### PR TITLE
Update various GitHub actions to v4 for node.js 20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/package-review.yml
+++ b/.github/workflows/package-review.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ github.event.inputs.package }}@${{ github.event.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run examples and tests
         uses: Macaulay2/M2/.github/actions/package-review@master
@@ -25,7 +25,7 @@ jobs:
           package: ${{ github.event.inputs.package }}
 
       - name: Upload errors
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: ${{ github.event.inputs.package }}-errors

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -59,7 +59,7 @@ jobs:
             os: macos-12
             compiler: default
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
 # ----------------------
 #   Install missing tools and libraries for macOS
@@ -112,7 +112,7 @@ jobs:
           # Necessary for clang to find the right libomp
           echo "LIBRARY_PATH=`llvm-config --libdir`" >> $GITHUB_ENV
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: matrix.build-system == 'cmake'
         id: restore-cache
         with:
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: ${{ matrix.build-system }}-${{ matrix.os }}-${{ matrix.compiler }}-logs
            path: |
@@ -245,7 +245,7 @@ jobs:
 
       - name: Upload Macaulay2 package for Ubuntu (x86_64)
         if: matrix.build-system == 'cmake' && runner.os == 'Linux' && matrix.compiler == 'clang-15' && success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Macaulay2-${{ env.GIT_COMMIT }}-ubuntu-x86_64
           path: |


### PR DESCRIPTION
This should fix the warnings we're getting on GitHub builds:

> Node.js 16 actions are deprecated. Please update the following actions
> to use Node.js 20: actions/checkout@v3, actions/cache@v3,
> actions/upload-artifact@v3. For more information see:
> https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.