### PR TITLE
frac of iterated ring

### DIFF
--- a/M2/Macaulay2/m2/enginering.m2
+++ b/M2/Macaulay2/m2/enginering.m2
@@ -284,11 +284,13 @@ coefficientRing FractionField := F -> coefficientRing last F.baseRings
 -- freduce := (f) -> (numerator f)/(denominator f)
 
 factoryAlmostGood = R -> (
-     k := coefficientRing R;
-     k === QQ or
-     k === ZZ or
-     instance(k,QuotientRing) and ambient k === ZZ and isPrime char k or
-     instance(k,GaloisField))
+    if instance(R,QuotientRing) then factoryAlmostGood ambient R
+    else if instance(R,PolynomialRing) then factoryAlmostGood coefficientRing R
+    else (R === QQ or
+     R === ZZ or
+     instance(R,GaloisField)
+     )
+ )
 factoryGood = R -> factoryAlmostGood R and not (options R).Inverses
 
 frac EngineRing := R -> if isField R then R else if R.?frac then R.frac else (


### PR DESCRIPTION
This is an attempt to relax the requirements to create the fraction field of a ring. This is now allowed:
```
i1 : R=QQ[u]

o1 = R

o1 : PolynomialRing

i2 : S=R[v]

o2 = S

o2 : PolynomialRing

i3 : u/v

     u
o3 = -
     v

o3 : frac S
```
Not everything will work out of the box; as pointed out in #3172, this will not work:
```
i1 : Qi  =  toField( QQ[i]/(i^2+1) )

o1 = Qi

o1 : PolynomialRing

i2 : R   = Qi[u,v]

o2 = R

o2 : PolynomialRing

i3 : (u+v)/i
stdio:3:5:(3): error: expected coefficient ring of the form ZZ/n, ZZ, QQ, or GF
```
though at least it won't crash M2 thanks to #3173. I have no simple fix that doesn't involve ugly hacks so will leave this for now. (removing `toField` fixes the problem).

Another issue is promotion between various rings, but I'll create a separate issue (if this PR tests OK) to discuss this.
