### PR TITLE
Use assert(Expression) in check(80, "Complexes")

### DIFF
--- a/M2/Macaulay2/packages/Complexes/FreeResolutionTests.m2
+++ b/M2/Macaulay2/packages/Complexes/FreeResolutionTests.m2
@@ -722,13 +722,13 @@ TEST ///
   assert isWellDefined C
 
   (usedtime2, C2) = toSequence timing freeResolution(I, Strategy => Nonminimal)
-  assert(usedtime2 < usedtime1/10)
+  assert BinaryOperation(symbol <, usedtime2, usedtime1/10)
 
   (usedtime3, C3) = toSequence timing freeResolution I
-  assert(usedtime3 >  5*usedtime2)
+  assert BinaryOperation(symbol >, usedtime3, 5*usedtime2)
 
   (usedtime4, C4) = toSequence timing freeResolution(I, Strategy => Engine)
-  assert(usedtime4 < usedtime3/2)
+  assert BinaryOperation(symbol <, usedtime4, usedtime3/2)
 
   freeResolution(I, Strategy => 0) -- not recomputing
   freeResolution(I, Strategy => 1) -- not recomputing


### PR DESCRIPTION
This will provide more useful logs when these timing tests fail.

For example, this test recently failed on a [PPA build](https://launchpadlibrarian.net/723824347/buildlog_ubuntu-mantic-armhf.macaulay2_1.23.0.1+git202404081743-0ppa202404050321~ubuntu23.10.1_BUILDING.txt.gz):

```m2
Complexes/FreeResolutionTests.m2:710:1-738:1 error:
 -- 
 --                  1      4      10      11      5      1
 -- o9 = (.0009146, R  <-- R  <-- R   <-- R   <-- R  <-- R )
 --                                                       
 --                 0      1      2       3       4      5
 -- 
 -- o9 : Sequence
 -- 
 -- i10 :   assert(usedtime3 >  5*usedtime2)
 -- stdio:20:3:(3): error: assertion failed
 -- 
../m2/debugging.m2:18:6:(1):[9]: error: test(s) #80 of package Complexes failed.
```

We know that `usedtime3` is 0.0009146 (the first element of the previous output line), but we're not sure what it was being compared to.

