### PR TITLE
Parallelization updates

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -68,8 +68,14 @@ int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[]
   while (env[++envc] != NULL) { /* iterate over environ until you hit NULL */ }
 
   GC_INIT();
+  size_t heap_size = GC_get_heap_size(),
+	 min_heap_size = 150'000'000 + getMaxAllowableThreads() * 8'000'000;
+		// each thread is currently started with 8 MB of stack space
+  if (heap_size < min_heap_size)
+    GC_expand_hp(min_heap_size - heap_size);
   GC_call_with_alloc_lock(GC_start_performance_measurement_0, NULL);
     // record total time of (full) gcs for GCstats()
+
   IM2_initialize();
 
 #ifndef NDEBUG

--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -56,6 +56,11 @@ void* interpFunc(ArgCell* vargs);
 void* profFunc(ArgCell* p);
 void* testFunc(ArgCell* p);
 
+static void * GC_start_performance_measurement_0(void *) {
+  GC_start_performance_measurement();
+  return NULL;
+}
+
 int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[])
 {
   /* find the number of environment variables defined */
@@ -63,6 +68,8 @@ int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[]
   while (env[++envc] != NULL) { /* iterate over environ until you hit NULL */ }
 
   GC_INIT();
+  GC_call_with_alloc_lock(GC_start_performance_measurement_0, NULL);
+    // record total time of (full) gcs for GCstats()
   IM2_initialize();
 
 #ifndef NDEBUG

--- a/M2/Macaulay2/c/README
+++ b/M2/Macaulay2/c/README
@@ -289,7 +289,7 @@ Expressions:
 
 	export a := b				export a variable or function (by declaring it in *.sig)
 	import a				import a variable (used mainly in *.sig files)
-	thread a := b				declare a thread local variable
+	threadLocal a := b			declare a thread local variable
 
 	f(x,y)					function application
 	when e 					examine e

--- a/M2/Macaulay2/c/README
+++ b/M2/Macaulay2/c/README
@@ -266,7 +266,7 @@ Expressions:
 	if a then b
 	until a do b
 	while a do b			evaluates b as long as a is true
-	while a list b			produces a list of the values of b, as long as a is true
+	while a list b			produces a list of the values of b, as long as a is true (not implemented!?)
 	foreach a in b do c		
 	foreach a at i in b do c
 	foreach a at i in b by s do c
@@ -330,7 +330,7 @@ Useful functions
 	+	-	*	/	%
 	^^					exclusive or
 	^					power (for doubles)
-	::					nothing
+	::					nothing (not implemented!?)
 
 Operators
 

--- a/M2/Macaulay2/c/README
+++ b/M2/Macaulay2/c/README
@@ -210,7 +210,7 @@ Types:
 
 	Pointer "bar"			a new pointer type, declared as "bar" in the C or C++ code produced
 	atomicPointer "bar"		a new atomic pointer type, declared as "bar" in the C or C++ code produced
-	malloc(T)			returns a pointer of type T pointing to new memory on the heap
+	GCmalloc(T)			returns a pointer of type T pointing to new memory on the heap
 					the number of bytes allocated is sizeof(*((T)0))
 					if T is a pointer type, the memory is cleared by GC_MALLOC
 					if T is an atomic pointer type, the memory is not cleared by GC_MALLOC_ATOMIC

--- a/M2/Macaulay2/c/dictionary.c
+++ b/M2/Macaulay2/c/dictionary.c
@@ -220,7 +220,7 @@ static void psymbol(node s){
      if (s->body.symbol.flags & defined_F) put(" initialized");
      if (s->body.symbol.flags & export_F) put(" export");
      if (s->body.symbol.flags & import_F) put(" import");
-     if (s->body.symbol.flags & threadLocal_F) put(" thread");
+     if (s->body.symbol.flags & threadLocal_F) put(" threadLocal");
      if (s->body.symbol.flags & const_F) put(" const");
      if (s->body.symbol.flags & global_F) put(" global");
      if (s->body.symbol.flags & literal_F) put(" literal");

--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -27,16 +27,23 @@ void system_handleInterruptsSetup(M2_bool handleInterrupts) {
   oursignal(SIGALRM,handleInterrupts ? alarm_handler : SIG_DFL);
 }
 
-static __thread double startTime;
+static double startTime;
 double system_cpuTime(void) {
   struct timespec t;
-  int err = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t);
+  int err = clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &t);
   if (err) return 0; /* silent about error */
   double u = t.tv_sec + t.tv_nsec * 1e-9;
   return u - startTime;
 }
 void system_cpuTime_init(void) {
   startTime = system_cpuTime();
+}
+
+double system_threadTime(void) {
+  struct timespec t;
+  int err = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &t);
+  if (err) return 0; /* silent about error */
+  return t.tv_sec + t.tv_nsec * 1e-9;
 }
 
 void clean_up(void) {

--- a/M2/Macaulay2/d/M2mem.c
+++ b/M2/Macaulay2/d/M2mem.c
@@ -69,7 +69,7 @@ void freememlen(void *s, size_t old) {
 #ifdef MEMDEBUG
      M2_debug_free(s);
 #else     
-     GC_FREE(s);
+     /* GC_FREE(s); */
 #endif
 }
 
@@ -80,7 +80,7 @@ void freemem(void *s) {
 #ifdef MEMDEBUG
      M2_debug_free(s);
 #else     
-     GC_FREE(s);
+     /* GC_FREE(s); */
 #endif
 }
 
@@ -192,7 +192,7 @@ char *getmoremem_atomic (char *s, size_t old, size_t new) {
      size_t min = old<new ? old : new;
      if (p == NULL) outofmem2(new);
      memcpy(p, s, min);
-     GC_FREE(s);
+     /* GC_FREE(s); */
 #    ifndef NDEBUG
      {
        int excess = new - min;

--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -1148,9 +1148,18 @@ lengthFun(rhs:Code):Expr := (
      e := eval(rhs);
      when e
      is Error do e
-     is x:HashTable do toExpr(x.numEntries)
+     is x:HashTable do (
+	  if (x.Mutable) then lockRead(x.mutex);
+	  res := toExpr(x.numEntries);
+	  if (x.Mutable) then unlock(x.mutex);
+	  res)
      is x:Sequence do toExpr(length(x))
-     is dc:DictionaryClosure do toExpr(dc.dictionary.symboltable.numEntries)
+     is dc:DictionaryClosure do (
+	  table := dc.dictionary.symboltable;
+	  lockRead(table.mutex);
+	  res := toExpr(table.numEntries);
+	  unlock(table.mutex);
+	  res)
      is x:List do toExpr(length(x.v))
      is s:stringCell do toExpr(length(s.v))
      is n:Net do toExpr(length(n.body))

--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -68,10 +68,11 @@ setupfun("toList1",toList);
 values(e:Expr):Expr := (
      when e
      is oc:DictionaryClosure do (
-	  o := oc.dictionary;
-	  Expr(list(
-		    new Sequence len o.symboltable.numEntries do
-		    foreach bucket in o.symboltable.buckets do (
+	  o := oc.dictionary.symboltable;
+	  lockRead(o.mutex);
+	  l := Expr(list(
+		    new Sequence len o.numEntries do
+		    foreach bucket in o.buckets do (
 			 p := bucket;
 			 while true do (
 			      when p
@@ -80,24 +81,31 @@ values(e:Expr):Expr := (
 				   provide Expr(SymbolClosure(if sym.thread then threadFrame else oc.frame,sym));
 				   p=q.next;)
 			      else break;
-			      )))))
-     is o:HashTable do (lock(o.mutex); l:= list(
+			      ))));
+	  unlock(o.mutex);
+	  l)
+     is o:HashTable do (
+	if o.Mutable then lockRead(o.mutex);
+	l:= list(
 	  new Sequence len o.numEntries do
 	  foreach bucket in o.table do (
 	       p := bucket;
 	       while p != p.next do (
 		    provide Expr(p.value);
-		    p = p.next; ))); unlock(o.mutex); l)
+		    p = p.next; )));
+	if o.Mutable then unlock(o.mutex);
+	l)
      else WrongArg("a hash table or dictionary"));
 setupfun("values",values);
 
 pairs(e:Expr):Expr := (
      when e
      is oc:DictionaryClosure do (    -- # typical value: pairs, Dictionary, List
-	  o := oc.dictionary;
-	  Expr(list(
-		    new Sequence len o.symboltable.numEntries do (
-			 foreach bucket in o.symboltable.buckets do (
+	  o := oc.dictionary.symboltable;
+	  lockRead(o.mutex);
+	  l := Expr(list(
+		    new Sequence len o.numEntries do (
+			 foreach bucket in o.buckets do (
 			      p := bucket;
 			      while true do (
 				   when p
@@ -108,14 +116,20 @@ pairs(e:Expr):Expr := (
 						  Expr(SymbolClosure(if sym.thread then threadFrame else oc.frame,sym))));
 					p=q.next;)
 				   else break; ));
-			 ))))
-     is o:HashTable do (lock(o.mutex); l:=list(	-- # typical value: pairs, HashTable, List
+			 )));
+	  unlock(o.mutex);
+	  l)
+     is o:HashTable do (
+	if o.Mutable then lockRead(o.mutex);
+	l:=list(	-- # typical value: pairs, HashTable, List
 	  new Sequence len o.numEntries do
 	  foreach bucket in o.table do (
 	       p := bucket;
 	       while p != p.next do (
 		    provide Expr(Sequence(p.key,p.value));
-		    p = p.next; ))); unlock(o.mutex); l )
+		    p = p.next; )));
+	if o.Mutable then unlock(o.mutex);
+	l )
      is o:Sequence do
 	  Expr(new Sequence len length(o) do (
 	    i := 0;

--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -685,6 +685,8 @@ cpuTime(e:Expr):Expr := (
      else WrongNumArgs(0));
 setupfun("cpuTime",cpuTime);
 
+-- TODO: should "timing" return thread and gc times like "time"?
+-- (moved to actors5.d for gc time)
 timefun(a:Code):Expr := (
      v := cpuTime();
      ret := eval(a);
@@ -693,13 +695,6 @@ timefun(a:Code):Expr := (
      is Error do ret
      else list(timeClass,Sequence(toExpr(x-v),ret)));
 setupop(timingS,timefun);
-showtimefun(a:Code):Expr := (
-     v := cpuTime();
-     ret := eval(a);
-     x := cpuTime();
-     stdIO << "     -- used " << x-v << " seconds" << endl;
-     ret);
-setupop(timeS,showtimefun);
 
 exponent(e:Expr):Expr := (
      when e

--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -34,6 +34,7 @@ override(h:HashTable,v:Sequence,numopts:int):Expr := (
 	       when r is Error do return r else nothing;
 	       )
 	  is y:HashTable do (
+	       -- assume y is not Mutable so we don't lock it
 	       foreach bucket in y.table do (
 		    q := bucket;
 		    while q != q.next do (
@@ -65,6 +66,7 @@ override(v:Sequence,numopts:int):Expr := (
 	       when r is Error do return r else nothing;
 	       )
 	  is y:HashTable do (
+	       -- assume y is not Mutable so we don't lock it
 	       foreach bucket in y.table do (
 		    q := bucket;
 		    while q != q.next do (

--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -450,7 +450,7 @@ compareop(lhs:Code,rhs:Code):Expr := (
 unaryQuestionFun(rhs:Code):Expr := unarymethod(rhs,QuestionS);
 setup(QuestionS,unaryQuestionFun,compareop);
 
-whichway := GreaterS;
+threadLocal whichway := GreaterS;
 threadLocal sortlist := emptySequence;
 subsort(l:int,r:int):Expr := (
      b := r+1-l;

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1193,7 +1193,7 @@ instanceof(e:Expr):Expr := (
 setupfun("instance",instanceof);
 
 
-hadseq := false;
+threadLocal hadseq := false;
 deeplen(a:Sequence):int := (
      n := 0;
      foreach x in a do (

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -245,17 +245,25 @@ any(f:Expr,n:int):Expr := (
 	  );
      False);
 any(f:Expr,obj:HashTable):Expr := (
+     v:Expr := False;
+     if obj.Mutable then lockRead(obj.mutex);
      foreach bucket in obj.table do (
 	  p := bucket;
 	  while true do (
 	       if p == p.next then break;
-	       v := applyEEE(f,p.key,p.value);
-	       when v is err:Error do if err.message == breakMessage then return if err.value == dummyExpr then nullE else err.value else return v else nothing;
-	       if v == True then return True;
-	       if v != False then return buildErrorPacket("any: expected true or false");
+	       v = applyEEE(f,p.key,p.value);
+	       if v != False then break;
 	       p = p.next;
-	       ));
-     False);
+	       );
+	  if v != False then break);
+     if obj.Mutable then unlock(obj.mutex);
+     when v
+     is err:Error do return
+	  if err.message == breakMessage then if err.value == dummyExpr then nullE else err.value
+	  else v
+     else nothing;
+     if v != True && v != False then return buildErrorPacket("any: expected true or false");
+     v);
 any(f:Expr,a:Sequence):Expr := (
      foreach x at i in a do (
 	  y := applyEE(f,x);
@@ -301,7 +309,7 @@ any(e:Expr):Expr := (
 setupfun("any",any);
 
 --find(f:Expr,obj:HashTable):Expr := (
---     foreach bucket in obj.table do (
+--     foreach bucket in obj.table do (	-- also must lock
 --	  p := bucket;
 --	  while true do (
 --	       if p == bucketEnd then break;
@@ -1207,8 +1215,8 @@ deeplen(a:Sequence):int := (
 	       );
 	  );
      n);
-deepseq := emptySequence;
-deepindex := 0;
+threadLocal deepseq := emptySequence;
+threadLocal deepindex := 0;
 deepinsert(a:Sequence):int := (
      n := 0;
      foreach x in a do (
@@ -1226,7 +1234,7 @@ deepsplice(a:Sequence):Sequence := (
      hadseq = false;
      newlen := deeplen(a);
      if hadseq then (
-     	  deepseq = new Sequence len deeplen(a) do provide nullE;
+     	  deepseq = new Sequence len newlen do provide nullE;
      	  deepindex = 0;
      	  deepinsert(a);
      	  w := deepseq;

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -245,7 +245,7 @@ any(f:Expr,n:int):Expr := (
 	  );
      False);
 any(f:Expr,obj:HashTable):Expr := (
-     v:Expr := False;
+     v := False;
      if obj.Mutable then lockRead(obj.mutex);
      foreach bucket in obj.table do (
 	  p := bucket;

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -2074,6 +2074,21 @@ GCstats(e:Expr):Expr := (
      else WrongNumArgs(0));
 setupfun("GCstats",GCstats);
 
+showtimefun(a:Code):Expr := (
+     cpuStart := cpuTime();
+     threadStart := threadTime();
+     gcStart := gcTime();
+     ret := eval(a);
+     cpuEnd := cpuTime();
+     threadEnd := threadTime();
+     gcEnd := gcTime();
+     stdError << " -- used "
+	 << cpuEnd - cpuStart << "s (cpu); "
+	 << threadEnd - threadStart << "s (thread); "
+	 << gcEnd - gcStart << "s (gc)" << endl;
+     ret);
+setupop(timeS,showtimefun);
+
 header "
 extern void set_gftable_dir(char *); /* defined in library factory, as patched by us */
 ";

--- a/M2/Macaulay2/d/actors6.dd
+++ b/M2/Macaulay2/d/actors6.dd
@@ -23,20 +23,11 @@ elapsedTimefun(a:Code):Expr := (
 setupop(elapsedTimingS,elapsedTimefun);
 showElapsedTimefun(a:Code):Expr := (
      time3 := Ccode(Chrono, "std::chrono::steady_clock::now()");
-     cpuStart := cpuTime();
-     threadStart := threadTime();
-     gcStart := gcTime();
      ret := eval(a);
      time4 := Ccode(Chrono, "std::chrono::steady_clock::now()");
-     cpuEnd := cpuTime();
-     threadEnd := threadTime();
-     gcEnd := gcTime();
      d := Ccode(uint64_t, "(time4-time3).count()");
      x := double(d)/1000000000.;
-     stdError << " -- " << x << " seconds elapsed; "
-	  << cpuEnd - cpuStart << " process (cpu time); "
-	  << threadEnd - threadStart << " thread; "
-	  << gcEnd - gcStart << " gc (process)" << endl;
+     stdError << " -- " << x << " seconds elapsed" << endl;
      ret);
 setupop(elapsedTimeS,showElapsedTimefun);
 

--- a/M2/Macaulay2/d/actors6.dd
+++ b/M2/Macaulay2/d/actors6.dd
@@ -9,7 +9,7 @@ declarations "
 -- so that means we can write "use actors6;" only in a *.dd file, not in a *.d file.
 -- That's why we are renaming interp.d to interp.dd.  Eventually all *.d files should
 -- be renamed.
-Chrono := Type "std::chrono::steady_clock::time_point" ;    
+Chrono := Type "std::chrono::steady_clock::time_point" ;    -- or use clock_gettime(CLOCK_MONOTONIC, &ts)
 
 elapsedTimefun(a:Code):Expr := (
      time1 := Ccode(Chrono, "std::chrono::steady_clock::now()");
@@ -23,11 +23,20 @@ elapsedTimefun(a:Code):Expr := (
 setupop(elapsedTimingS,elapsedTimefun);
 showElapsedTimefun(a:Code):Expr := (
      time3 := Ccode(Chrono, "std::chrono::steady_clock::now()");
+     cpuStart := cpuTime();
+     threadStart := threadTime();
+     gcStart := gcTime();
      ret := eval(a);
      time4 := Ccode(Chrono, "std::chrono::steady_clock::now()");
+     cpuEnd := cpuTime();
+     threadEnd := threadTime();
+     gcEnd := gcTime();
      d := Ccode(uint64_t, "(time4-time3).count()");
      x := double(d)/1000000000.;
-     stdError << " -- " << x << " seconds elapsed" << endl;
+     stdError << " -- " << x << " seconds elapsed; "
+	  << cpuEnd - cpuStart << " process (cpu time); "
+	  << threadEnd - threadStart << " thread; "
+	  << gcEnd - gcStart << " gc (process)" << endl;
      ret);
 setupop(elapsedTimeS,showElapsedTimefun);
 

--- a/M2/Macaulay2/d/atomic.d
+++ b/M2/Macaulay2/d/atomic.d
@@ -4,6 +4,7 @@ declarations "
   #include \"M2/atomic-field.h\"
   #ifdef __cplusplus
     #include <atomic>
+    using std::atomic_fetch_add;
     using std::atomic_signal_fence;
     using std::memory_order_seq_cst;
   #else
@@ -16,6 +17,8 @@ export load(x:atomicField) ::= Ccode(int, "load_Field(",x,")");
 export test(x:atomicField) ::= (load(x) != 0);
 export store(x:atomicField,y:int) ::= Ccode(void, "store_Field(",x,",",y,")");
 export store(x:atomicField,y:bool) ::= store(x, Ccode(int, y));
+export fetch_add(x:atomicField,y:int) ::= Ccode(int, "atomic_fetch_add(&(",x,").field,",y,")");
+
 export compilerBarrier() ::= Ccode(void,"atomic_signal_fence(memory_order_seq_cst)");
 
 -- Local Variables:

--- a/M2/Macaulay2/d/atomic.d
+++ b/M2/Macaulay2/d/atomic.d
@@ -17,7 +17,8 @@ export load(x:atomicField) ::= Ccode(int, "load_Field(",x,")");
 export test(x:atomicField) ::= (load(x) != 0);
 export store(x:atomicField,y:int) ::= Ccode(void, "store_Field(",x,",",y,")");
 export store(x:atomicField,y:bool) ::= store(x, Ccode(int, y));
-export fetch_add(x:atomicField,y:int) ::= Ccode(int, "atomic_fetch_add(&(",x,").field,",y,")");
+export fetch_add(x:atomicField,y:int) ::=
+    Ccode(int, "atomic_fetch_add(&(",lvalue(x),").field,",y,")");
 
 export compilerBarrier() ::= Ccode(void,"atomic_signal_fence(memory_order_seq_cst)");
 

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -360,7 +360,7 @@ bumpPrecedence();
      --why are these using precSpace and not prec?
      special("symbol",unarysymbol,precSpace,prec);
      special("global",unaryglobal,precSpace,prec);
-     special("threadVariable",unarythread,precSpace,prec);
+     special("threadLocal",unarythread,precSpace,prec);
      special("local",unarylocal,precSpace,prec);
 -----------------------------------------------------------------------------
 export GlobalAssignS := makeProtectedSymbolClosure("GlobalAssignHook");

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -84,8 +84,8 @@ export makeEntry(word:Word,position:Position,dictionary:Dictionary,thread:bool,l
 
 	  if thread then (
 	       -- threadFrame grows whenever an assignment occurs, if needed, so we don't enlarge it now
-	       frameindex = threadFramesize;
-	       threadFramesize = threadFramesize + 1;
+	       frameindex = load(threadFramesize);
+	       fetch_add(threadFramesize, 1);
 	       )
 	  else (
 	       -- this allows the global frame to grow

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -425,7 +425,7 @@ export lookup(word:Word,table:SymbolHashTable):(null or Symbol) := (
      entryList := table.buckets.(
 	  word.hash & (length(table.buckets)-1)
 	  );
-     res:(null or Symbol) := NULL;
+     res := (null or Symbol)(NULL);
      while true do
      when entryList
      is null do break

--- a/M2/Macaulay2/d/buckets.dd
+++ b/M2/Macaulay2/d/buckets.dd
@@ -4,7 +4,8 @@ bucketsfun(e:Expr):Expr := (
      when e
      is dc:DictionaryClosure do (
 	  d := dc.dictionary;
-	  Expr(
+	  lockRead(d.symboltable.mutex);
+	  res := Expr(
 	       list(
 		    new Sequence len length(d.symboltable.buckets) do (
 			 foreach b in d.symboltable.buckets do (
@@ -26,9 +27,13 @@ bucketsfun(e:Expr):Expr := (
 					     c = cell.next;
 					     true)
 					)
-				   do nothing))))))
-     is h:HashTable do list(
-	  new Sequence len length(h.table) do (
+				   do nothing)))));
+	  unlock(d.symboltable.mutex);
+	  res)
+     is h:HashTable do (
+	  if h.Mutable then lockRead(h.mutex);
+	  res := list(
+	    new Sequence len length(h.table) do (
 	       foreach pp in h.table do (
 		    n := 0;
 		    p := pp;
@@ -40,7 +45,9 @@ bucketsfun(e:Expr):Expr := (
 		    s := new Sequence len n do (
 			 provide Expr(Sequence(p.key, p.value));
 			 p = p.next);
-		    provide list(s))))
+		    provide list(s))));
+	  if h.Mutable then unlock(h.mutex);
+	  res)
      else WrongArg("a hash table"));
 setupfun("buckets",bucketsfun);
 

--- a/M2/Macaulay2/d/classes.dd
+++ b/M2/Macaulay2/d/classes.dd
@@ -176,19 +176,10 @@ export Class(e:Expr):HashTable := (
 classfun(e:Expr):Expr := Expr(Class(e));
 setupfun("class",classfun);
 
-export commonAncestor(x:HashTable,y:HashTable):HashTable := (
-     if x == y then return x;
-     t := x;
-     while t != thingClass do ( t.numEntries = - 1 - t.numEntries; t = t.parent; );
-     a := thingClass;
-     t = y;
-     while t != thingClass do (
-	  if t.numEntries < 0 then ( a = t; break; );
-	  t = t.parent;
-     	  );
-     t = x;
-     while t != thingClass do ( t.numEntries = - 1 - t.numEntries; t = t.parent; );
-     a);
+export commonAncestor(x:HashTable,y:HashTable):HashTable :=
+     if ancestor(x,y) then y
+     else if y == thingClass then y	-- shouldn't occur
+     else commonAncestor(x,y.parent)
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d classes.o "

--- a/M2/Macaulay2/d/equality.dd
+++ b/M2/Macaulay2/d/equality.dd
@@ -17,7 +17,7 @@ equal(x:HashTable,y:HashTable):Expr := (
      if x.hash != y.hash then return False;
      if x.Class != y.Class || x.parent != y.parent then return False;
      if x.hash == 0 && x.Class == cacheTableClass then return True; -- cache tables have hash code 0
-     if x.Mutable || y.Mutable then return False;
+     if x.Mutable || y.Mutable then return False;	-- so we don't need to lockRead() after this
      if x.numEntries != y.numEntries || length(x.table) != length(y.table) then return False;
      foreach a at i in x.table do (
 	  p := a;

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -4,8 +4,8 @@ use hashtables;
 use convertr;
 export globalAssignmentHooks := newHashTableWithHash(mutableHashTableClass,nothingClass);
 setupconst("globalAssignmentHooks",Expr(globalAssignmentHooks));
-export evalSequenceHadError := false;
-export evalSequenceErrorMessage := nullE;
+export threadLocal evalSequenceHadError := false;
+export threadLocal evalSequenceErrorMessage := nullE;
 threadLocal errorreturn := nullE;
 --The recycleBin provides essentially a linked list of frames up to size 20 for easy reuse.
 --Questions: Can this lead to excess memory leaks if you create a ton of frames of the same size?

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1692,7 +1692,7 @@ setup(LeftArrowS,assigntofun);
 
 idfun(e:Expr):Expr := e;
 setupfun("identity",idfun);
-scanpairs(f:Expr,obj:HashTable):Expr := (
+scanpairs(f:Expr,obj:HashTable):Expr := (	-- obj is not Mutable
      foreach bucket in obj.table do (
 	  p := bucket;
 	  while true do (
@@ -1716,7 +1716,7 @@ scanpairsfun(e:Expr):Expr := (
 setupfun("scanPairs",scanpairsfun);
 
 mpre():Expr := buildErrorPacket("applyPairs: expected function to return null, a sequence of length 2, or an option x=>y");
-mappairs(f:Expr,o:HashTable):Expr := (
+mappairs(f:Expr,o:HashTable):Expr := (	-- o is not Mutable
      x := newHashTable(o.Class,o.parent);
      x.beingInitialized = true;
      foreach bucket in o.table do (
@@ -1725,7 +1725,7 @@ mappairs(f:Expr,o:HashTable):Expr := (
 	       if p == p.next then break;
 	       v := applyEEE(f,p.key,p.value);
 	       when v 
-	       is Error do return v 
+	       is Error do return v
 	       is Nothing do nothing
 	       is b:List do (
 		    if b.Class != optionClass then return mpre();
@@ -1757,7 +1757,7 @@ mappairsfun(e:Expr):Expr := (
      else      WrongNumArgs(2));
 setupfun("applyPairs",mappairsfun);
 
-export mapkeys(f:Expr,o:HashTable):Expr := (
+export mapkeys(f:Expr,o:HashTable):Expr := (	-- o is not Mutable
      x := newHashTable(o.Class,o.parent);
      x.beingInitialized = true;
      foreach bucket in o.table do (
@@ -1771,7 +1771,7 @@ export mapkeys(f:Expr,o:HashTable):Expr := (
 	       p = p.next;
 	       ));
      Expr(sethash(x,o.Mutable)));
-export mapkeysmerge(f:Expr,o:HashTable,g:Expr):Expr := (
+export mapkeysmerge(f:Expr,o:HashTable,g:Expr):Expr := (	-- o is not Mutable
      x := newHashTable(o.Class,o.parent);
      x.beingInitialized = true;
      foreach bucket in o.table do (
@@ -1811,7 +1811,7 @@ mapkeysfun(e:Expr):Expr := (
      else      WrongNumArgs(2,3));
 setupfun("applyKeys",mapkeysfun);
 
-export mapvalues(f:Expr,o:HashTable):Expr := (
+export mapvalues(f:Expr,o:HashTable):Expr := (	-- o is not Mutable
      x := newHashTable(o.Class,o.parent);
      x.beingInitialized = true;
      hadError := false;
@@ -1860,6 +1860,7 @@ merge(e:Expr):Expr := (
 	       z := copy(x);
 	       z.Mutable = true;
 	       z.beingInitialized = true;
+	       if (y.Mutable) then lockRead(y.mutex);
 	       foreach bucket in y.table do (
 		    q := bucket;
 		    while q != q.next do (
@@ -1867,7 +1868,10 @@ merge(e:Expr):Expr := (
 			 if val != notfoundE then (
 			      t := applyEEE(g,val,q.value);
 			      when t is err:Error do (
-			      	   if err.message != continueMessage then return t else remove(z,q.key);
+			      	   if err.message != continueMessage then (
+					if (y.Mutable) then unlock(y.mutex);
+					return t)
+				   else remove(z,q.key);
 			      	   )
 			      else (
 				   storeInHashTable(z,q.key,q.hash,t);
@@ -1877,6 +1881,7 @@ merge(e:Expr):Expr := (
 			      storeInHashTable(z,q.key,q.hash,q.value);
 			      );
 			 q = q.next));
+	       if (y.Mutable) then unlock(y.mutex);
 	       mut := x.Mutable && y.Mutable;
 	       if x.parent == y.parent then (
 		    z.Class = commonAncestor(x.Class,y.Class);
@@ -1890,6 +1895,7 @@ merge(e:Expr):Expr := (
 	       z := copy(y);
 	       z.Mutable = true;
 	       z.beingInitialized = true;
+	       if (x.Mutable) then lockRead(x.mutex);
 	       foreach bucket in x.table do (
 		    q := bucket;
 		    while q != q.next do (
@@ -1897,7 +1903,10 @@ merge(e:Expr):Expr := (
 			 if val != notfoundE then (
 			      t := applyEEE(g,q.value,val);
 			      when t is err:Error do (
-			      	   if err.message != continueMessage then return t else remove(z,q.key);
+			      	   if err.message != continueMessage then (
+					if (x.Mutable) then unlock(x.mutex);
+					return t)
+				   else remove(z,q.key);
 			      	   )
 			      else (
 				   storeInHashTable(z,q.key,q.hash,t);
@@ -1907,6 +1916,7 @@ merge(e:Expr):Expr := (
 			      storeInHashTable(z,q.key,q.hash,q.value);
 			      );
 			 q = q.next));
+	       if (x.Mutable) then unlock(x.mutex);
 	       mut := x.Mutable && y.Mutable;
 	       if x.parent == y.parent then (
 		    z.Class = commonAncestor(x.Class,y.Class);
@@ -1920,7 +1930,7 @@ merge(e:Expr):Expr := (
 	  else WrongArg(1,"a hash table"))
      else WrongNumArgs(3));
 setupfun("merge",merge);		  -- see objects.d
-combine(f:Expr,g:Expr,h:Expr,x:HashTable,y:HashTable):Expr := (
+combine(f:Expr,g:Expr,h:Expr,x:HashTable,y:HashTable):Expr := (	-- x and y are not Mutable
      z := newHashTable(x.Class,x.parent);
      z.beingInitialized = true;
      foreach pp in x.table do (
@@ -1963,7 +1973,8 @@ combine(f:Expr,g:Expr,h:Expr,x:HashTable,y:HashTable):Expr := (
 		    );
 	       p = p.next));
      sethash(z,x.Mutable | y.Mutable));
-                                
+
+-- x and y are not Mutable:
 twistCombine(f:Expr,tw:Expr,g:Expr,h:Expr,x:HashTable,y:HashTable):Expr := (
      z := newHashTable(x.Class,x.parent);
      z.beingInitialized = true;

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -63,7 +63,9 @@ export globalFrame := Frame(self, 0, globalFramesize, true,
 	  nullE						    -- one value for dummySymbol
 	  ));
 export threadFrameID := 0;
-export threadFramesize := 0;
+header "struct atomic_field expr_threadFramesize;";
+import threadFramesize:atomicField;
+store(threadFramesize, 0);
 export threadLocal threadFrame  := Frame(self, threadFrameID, 0, true, Sequence());
 export enlarge(f:Frame):int := (
      n := f.valuesUsed;
@@ -74,8 +76,8 @@ export enlarge(f:Frame):int := (
 	       while true do provide nullE));
      n);
 export enlargeThreadFrame():Frame := (
-     if threadFramesize > length(threadFrame.values) then (
-	  threadFrame.values = new Sequence len 2 * threadFramesize + 1 do (
+     if load(threadFramesize) > length(threadFrame.values) then (
+	  threadFrame.values = new Sequence len 2 * load(threadFramesize) + 1 do (
 	       foreach value in threadFrame.values do provide value;
 	       while true do provide nullE));
      threadFrame);

--- a/M2/Macaulay2/d/getline.d
+++ b/M2/Macaulay2/d/getline.d
@@ -1,6 +1,6 @@
 --		Copyright 1994-2000 by Daniel R. Grayson
 use tokens;
-tokenbuf := newvarstring(100);
+threadLocal tokenbuf := newvarstring(100);
 export getLine(o:file):StringOrError := (
      ch := 0;
      while (

--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -9,6 +9,8 @@ dummyapplyEEE(g:Expr,e0:Expr,e1:Expr):Expr := g;
 export applyEEEpointer := dummyapplyEEE;
 
 export hash(x:HashTable):int := (
+     lockit := x.Mutable && !x.beingInitialized;
+     if (lockit) then lockRead(x.mutex);
      h := x.parent.hash + x.Class.hash * 231 + 32455;
      foreach bucket in x.table do (
 	  p := bucket;
@@ -17,6 +19,7 @@ export hash(x:HashTable):int := (
 	       h = h + j * j * hash(p.value);
 	       p = p.next;
 	       ));
+     if (lockit) then unlock(x.mutex);
      h);
 export sethash(o:HashTable,Mutable:bool):HashTable := (
      if Mutable 
@@ -41,7 +44,7 @@ mutablefun(e:Expr):Expr := Expr(toExpr(
 setupfun("isMutable",mutablefun);
 
 MutexArray := array(ThreadMutex,49);
-enlarge(o:HashTable):void := (
+enlarge(o:HashTable):void := (	-- caller must first lockWrite() if (! o.beingInitialized)
      oldTable := o.table;
      newlen := 2*length(oldTable);
      mask := newlen - 1;
@@ -55,10 +58,10 @@ enlarge(o:HashTable):void := (
 	       p = p.next;));
      --Note that all operations are done on a new table
      --So simply do a compiler barrier and then swapping the tables becomes atomic
-     compilerBarrier(); 
+     -- compilerBarrier(); 
      o.table = newTable;
      );
-shrink(o:HashTable):void := (
+shrink(o:HashTable):void := (	-- caller must first lockWrite() if (! o.beingInitialized)
      oldTable := o.table;
      newlen := length(oldTable)/2;
      mask := newlen - 1;
@@ -72,7 +75,7 @@ shrink(o:HashTable):void := (
 	       p = p.next;));
      --Note that all operations are done on a new table
      --So simply do a compiler barrier and then swapping the tables becomes atomic
-     compilerBarrier();
+     -- compilerBarrier();
      o.table = newTable;
      );
 export remove(x:HashTable,key:Expr):Expr := (
@@ -80,7 +83,7 @@ export remove(x:HashTable,key:Expr):Expr := (
 	  return buildErrorPacket("attempted to modify an immutable hash table");
 	  );
      h := hash(key);
-     if !x.beingInitialized then lock(x.mutex);
+     if !x.beingInitialized then lockWrite(x.mutex);
      hmod := int(h & (length(x.table)-1));
      p := x.table.hmod;
      prev := p;
@@ -95,15 +98,14 @@ export remove(x:HashTable,key:Expr):Expr := (
 	       && length(x.table) > 4
 	       -- 4 is the length of a new hash table, see tokens.d, newHashTable()
 	       then shrink(x);
-	       if !x.beingInitialized then unlock(x.mutex);
-	       return Expr(x));
+	       break);
 	  prev = p;
 	  p = p.next);
      if !x.beingInitialized then unlock(x.mutex);
      Expr(x));
 export storeInHashTable(x:HashTable,key:Expr,h:int,value:Expr):Expr := (
      if !x.Mutable then return buildErrorPacket("attempted to modify an immutable hash table");
-     if !x.beingInitialized then lock(x.mutex);
+     if !x.beingInitialized then lockWrite(x.mutex);
      hmod := int(h & (length(x.table)-1));
      p := x.table.hmod;
      while p != p.next do (
@@ -118,6 +120,7 @@ export storeInHashTable(x:HashTable,key:Expr,h:int,value:Expr):Expr := (
 	  enlarge(x);
 	  hmod = int(h & (length(x.table)-1));
 	  );
+     -- Old comments:
      -- In the following statement, a new entry is adding by atomically replacing the pointer x.table.hmod.
      -- This will not confuse readers that don't lock the hash table, because once the load x.table.hmod, they
      -- will have a linked list that stays the same, is shortened, or has a value changed, and contains no
@@ -127,7 +130,7 @@ export storeInHashTable(x:HashTable,key:Expr,h:int,value:Expr):Expr := (
      x.table.hmod = KeyValuePair(key,h,value,x.table.hmod);
      --Do not increment numEntries until after new value pair has been inserted to maintain consistency.
      --It is necessary to throw in a compilerBarrier to ensure that there is no memory reordering
-     compilerBarrier();
+     -- compilerBarrier();
      x.numEntries = x.numEntries + 1;
      --Note: x.numEntries may be inconsistent with the number of entries in the table if accessed from another thread
      if !x.beingInitialized then unlock(x.mutex);
@@ -136,7 +139,7 @@ export storeInHashTable(x:HashTable,key:Expr,value:Expr):Expr := storeInHashTabl
 export storeInHashTableNoClobber(x:HashTable,key:Expr,h:int,value:Expr):Expr := (
      -- derived from storeInHashTable above!
      if !x.Mutable then return buildErrorPacket("attempted to modify an immutable hash table");
-     if !x.beingInitialized then lock(x.mutex);
+     if !x.beingInitialized then lockWrite(x.mutex);
      hmod := int(h & (length(x.table)-1));
      p := x.table.hmod;
      while p != p.next do (
@@ -155,14 +158,14 @@ export storeInHashTableNoClobber(x:HashTable,key:Expr,h:int,value:Expr):Expr := 
      x.table.hmod = KeyValuePair(key,h,value,x.table.hmod);
      --Do not increment numEntries until after new value pair has been inserted to maintain consistency.
      --It is necessary to throw in a compilerBarrier to ensure that there is no memory reordering
-     compilerBarrier();
+     -- compilerBarrier();
      x.numEntries = x.numEntries + 1;
      if !x.beingInitialized then unlock(x.mutex);
      value);
 export storeInHashTableNoClobber(x:HashTable,key:Expr,value:Expr):Expr := storeInHashTableNoClobber(x,key,hash(key),value);
 export storeInHashTableMustClobber(x:HashTable,key:Expr,h:int,value:Expr):Expr := (
      if !x.Mutable then return buildErrorPacket("attempted to modify an immutable hash table");
-     if !x.beingInitialized then lock(x.mutex);
+     if !x.beingInitialized then lockWrite(x.mutex);
      hmod := int(h & (length(x.table)-1));
      p := x.table.hmod;
      while p != p.next do (
@@ -184,7 +187,7 @@ export storeInHashTableMustClobber(x:HashTable,key:Expr,value:Expr):Expr := (
 export storeInHashTableWithCollisionHandler(x:HashTable,key:Expr,value:Expr,handler:Expr):Expr := (
      if !x.Mutable then return buildErrorPacket("attempted to modify an immutable hash table");
      h := hash(key);
-     if !x.beingInitialized then lock(x.mutex);
+     if !x.beingInitialized then lockWrite(x.mutex);
      hmod := int(h & (length(x.table)-1));
      p := x.table.hmod;
      while p != p.next do (
@@ -203,7 +206,7 @@ export storeInHashTableWithCollisionHandler(x:HashTable,key:Expr,value:Expr,hand
      x.table.hmod = KeyValuePair(key,h,value,x.table.hmod);
      --Do not increment numEntries until after new value pair has been inserted to maintain consistency.
      --It is necessary to throw in a compilerBarrier to ensure that there is no memory reordering
-     compilerBarrier();
+     -- compilerBarrier();
      x.numEntries = x.numEntries + 1;
      if !x.beingInitialized then unlock(x.mutex);
      value);
@@ -285,19 +288,17 @@ copy(table:array(KeyValuePair)):array(KeyValuePair) := (
 			      newbucket))))));
 export copy(o:HashTable):HashTable := (
      lockit := o.Mutable && !o.beingInitialized;
-     if lockit then lock(o.mutex);
-     x := HashTable( copy(o.table), o.Class, o.parent, o.numEntries, o.hash, o.Mutable, false, uninitializedSpinLock );
-     init(x.mutex);
+     if lockit then lockRead(o.mutex);
+     x := HashTable( copy(o.table), o.Class, o.parent, o.numEntries, o.hash, o.Mutable, false, newThreadRWLock() );
      if lockit then unlock(o.mutex);
      x);
 export copy(o:HashTable,newClass:HashTable,newParent:HashTable,newMutable:bool):HashTable := (
      lockit := o.Mutable && !o.beingInitialized;
-     if lockit then lock(o.mutex);
+     if lockit then lockRead(o.mutex);
      x := HashTable(
 	  if newMutable || o.Mutable then copy(o.table) else o.table,
 	  newClass,
-	  newParent, o.numEntries, 0, newMutable, false, uninitializedSpinLock);
-     init(x.mutex);
+	  newParent, o.numEntries, 0, newMutable, false, newThreadRWLock());
      if newMutable then (
 	  if newClass != cacheTableClass 
 	  then x.hash = nextHash(); -- cache tables are mutable and have hash code 0
@@ -310,40 +311,63 @@ export copy(o:HashTable,newClass:HashTable,newMutable:bool):HashTable := copy(o,
 
 export lookup1(object:HashTable,key:Expr,keyhash:int):Expr := (
      -- warning: can return notfoundE, which should not be given to the user
+     res := notfoundE;
+     lockit := object.Mutable && !object.beingInitialized;
+     if lockit then lockRead(object.mutex);
      keymod := int(keyhash & (length(object.table)-1));
      bucket := object.table.keymod;
      while bucket != bucket.next do (
-	  if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then return bucket.value;
+	  if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then (
+	       res = bucket.value;
+	       break);
 	  bucket = bucket.next;
 	  );
-     notfoundE);
+     if lockit then unlock(object.mutex);
+     res);
 export lookup1(object:HashTable,key:Expr):Expr := lookup1(object,key,hash(key));
 export lookup1force(object:HashTable,key:Expr,keyhash:int):Expr := (
+     lockit := object.Mutable && !object.beingInitialized;
+     if lockit then lockRead(object.mutex);
      keymod := int(keyhash & (length(object.table)-1));
      bucket := object.table.keymod;
      while bucket != bucket.next do (
-	  if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then return bucket.value;
+	  if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then (
+	       res := bucket.value;
+	       if lockit then unlock(object.mutex);
+	       return res);
 	  bucket = bucket.next;
 	  );
+     if lockit then unlock(object.mutex);
      buildErrorPacket("key not found in hash table"));
 export lookup1force(object:HashTable,key:Expr):Expr := lookup1force(object,key,hash(key));
 export lookup1Q(object:HashTable,key:Expr,keyhash:int):bool := (
+     lockit := object.Mutable && !object.beingInitialized;
+     if lockit then lockRead(object.mutex);
      keymod := int(keyhash & (length(object.table)-1));
      bucket := object.table.keymod;
      while bucket != bucket.next do (
-	  if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then return true;
+	  if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then (
+	       if lockit then unlock(object.mutex);
+	       return true);
 	  bucket = bucket.next;
 	  );
+     if lockit then unlock(object.mutex);
      false);
 export lookup1Q(object:HashTable,key:Expr):bool := lookup1Q(object,key,hash(key));
 export lookup(object:HashTable,key:Expr,keyhash:int):Expr := (
      while true do (
+	  lockit := object.Mutable && !object.beingInitialized;
+	  if lockit then lockRead(object.mutex);
      	  keymod := int(keyhash & (length(object.table)-1));
      	  bucket := object.table.keymod;
      	  while bucket != bucket.next do (
-	       if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then return bucket.value;
+	       if bucket.key == key || bucket.hash == keyhash && equal(bucket.key,key)==True then (
+		    res := bucket.value;
+		    if lockit then unlock(object.mutex);
+		    return res);
 	       bucket = bucket.next;
 	       );
+	  if lockit then unlock(object.mutex);
 	  if object == thingClass then break;
 	  object = object.parent;
 	  );
@@ -713,7 +737,8 @@ setupfun("lookup",lookupfun);
 export keys(o:HashTable):Expr := (
      -- This requires length and items.
      -- Thus the hash table needs to not change, so lock it.
-     if !o.beingInitialized then lock(o.mutex);
+     lockit := o.Mutable && !o.beingInitialized;
+     if lockit then lockRead(o.mutex);
      l:= list(
      new Sequence len o.numEntries do
      foreach bucket in o.table do (
@@ -724,10 +749,11 @@ export keys(o:HashTable):Expr := (
 	       )
 	  )
      );
-     if !o.beingInitialized then unlock(o.mutex);
+     if lockit then unlock(o.mutex);
      l);
-export keys(o:Dictionary):Expr := Expr(
-     list(
+export keys(o:Dictionary):Expr := (
+     lockRead(o.symboltable.mutex);
+     l := list(
 	  new Sequence len o.symboltable.numEntries do
 	  foreach bucket in o.symboltable.buckets do (
 	       p := bucket;
@@ -736,18 +762,26 @@ export keys(o:Dictionary):Expr := Expr(
 		    is q:SymbolListCell do (
 			 provide Expr(stringCell(q.word.name));
 			 p=q.next;)
-		    else break;))));
+		    else break;)));
+     unlock(o.symboltable.mutex);
+     l);
 
 export lookup(s:string,table:SymbolHashTable):(null or Symbol) := (
      if table == dummySymbolHashTable then error("dummy table used");
+     lockRead(table.mutex);
      entryList := table.buckets.( hash(s) & (length(table.buckets)-1) );
+     res:(null or Symbol) := NULL;
      while true do
      when entryList
-     is null do return NULL
+     is null do break
      is entryListCell:SymbolListCell do (
 	  if 0 == strcmp(entryListCell.word.name, s)
-	  then return entryListCell.entry;
-	  entryList = entryListCell.next));
+	  then (
+	       res = entryListCell.entry;
+	       break);
+	  entryList = entryListCell.next);
+     unlock(table.mutex);
+     res);
 
 export ArrayIndexOutOfBounds(i:int, n:int):Expr := (
      buildErrorPacket("array index " + tostring(i) + " out of bounds 0 .. " +

--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -770,7 +770,7 @@ export lookup(s:string,table:SymbolHashTable):(null or Symbol) := (
      if table == dummySymbolHashTable then error("dummy table used");
      lockRead(table.mutex);
      entryList := table.buckets.( hash(s) & (length(table.buckets)-1) );
-     res:(null or Symbol) := NULL;
+     res := (null or Symbol)(NULL);
      while true do
      when entryList
      is null do break

--- a/M2/Macaulay2/d/parse.d
+++ b/M2/Macaulay2/d/parse.d
@@ -92,7 +92,7 @@ export SymbolList := null or SymbolListCell;
 export SymbolHashTable := { 
      buckets:array(SymbolList),	 -- length always a power of 2
      numEntries:int,
-     mutex:SpinLock -- Modification mutex: lock before changing
+     mutex:ThreadRWLockPtr
      };
 
 export Dictionary := {
@@ -474,8 +474,8 @@ export HashTable := {+
      numEntries:int,
      hash:int,
      Mutable:bool,
-     beingInitialized:bool,-- if true, no need to lock a mutex while modifying it
-     mutex:SpinLock
+     beingInitialized:bool,-- if true, no need to lock the mutex
+     mutex:ThreadRWLockPtr
      };
 
 --This unfortunately needs to be here as it references Hash Table which needs expr.  

--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -217,6 +217,7 @@ setupfun("taskResult",taskResult);
 setupfun("setIOSynchronized",setIOSynchronized);
 setupfun("setIOUnSynchronized",setIOUnSynchronized);
 setupfun("setIOExclusive",setIOExclusive);
+setupfun("getIOThreadMode", getIOThreadMode);
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d pthread.o "

--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -203,7 +203,9 @@ taskResult(e:Expr):Expr := (
      when e is c:TaskCell do
      if c.body.resultRetrieved then buildErrorPacket("task result already retrieved")
      else if !taskKeepRunning(c.body.task) then buildErrorPacket("task canceled")
-     else if !taskDone(c.body.task) then buildErrorPacket("task not done yet")
+     else if !taskDone(c.body.task) then (
+	  Ccode(voidPointer, "waitOnTask(",c.body.task,")");
+	  taskResult(e))
      else (
 	  r := c.body.returnValue;
 	  c.body.returnValue = nullE;

--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -217,6 +217,15 @@ setupfun("taskResult",taskResult);
 setupfun("setIOSynchronized",setIOSynchronized);
 setupfun("setIOUnSynchronized",setIOUnSynchronized);
 setupfun("setIOExclusive",setIOExclusive);
+
+export getIOThreadMode(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 0
+	then toExpr(getFileThreadMode(stdIO))
+	else WrongNumArgs(0, 1))
+    is f:file do toExpr(getFileThreadMode(f))
+    else WrongArg("a file or ()"));
 setupfun("getIOThreadMode", getIOThreadMode);
 
 -- Local Variables:

--- a/M2/Macaulay2/d/sets.dd
+++ b/M2/Macaulay2/d/sets.dd
@@ -22,6 +22,7 @@ makeSet(e:Expr):Expr := (
      else WrongArg("a visible list"));
 setupfun("set",makeSet);
 
+-- object is beingInitialized:
 modify(object:HashTable,key:Expr,f:function(Expr):Expr,v:Expr):void := (
      keyhash:= hash(key);
      keymod := int(keyhash & (length(object.table)-1));

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -1022,8 +1022,9 @@ export setIOSynchronized(e:Expr):Expr :=(
      is a:Sequence do (
 	  if length(a) == 0
 	  then (setFileThreadState(stdIO,1); setFileThreadState(stdError,1); nullE)
-	  else WrongNumArgs(0))
-     else WrongNumArgs(0)
+	  else WrongNumArgs(0, 1))
+     is f:file do (setFileThreadState(f, 1); nullE)
+     else WrongArg("a file or ()")
 );
 
 export setIOExclusive(e:Expr):Expr :=(
@@ -1031,8 +1032,9 @@ export setIOExclusive(e:Expr):Expr :=(
      is a:Sequence do (
 	  if length(a) == 0
 	  then (setFileThreadState(stdIO,2); setFileThreadState(stdError,2); nullE)
-	  else WrongNumArgs(0))
-     else WrongNumArgs(0)
+	  else WrongNumArgs(0, 1))
+     is f:file do (setFileThreadState(f, 2); nullE)
+     else WrongArg("a file or ()")
 );
 
 export setIOUnSynchronized(e:Expr):Expr :=(
@@ -1040,8 +1042,9 @@ export setIOUnSynchronized(e:Expr):Expr :=(
      is a:Sequence do (
 	  if length(a) == 0
 	  then (setFileThreadState(stdIO,0); setFileThreadState(stdError,0); nullE)
-	  else WrongNumArgs(0))
-     else WrongNumArgs(0)
+	  else WrongNumArgs(0, 1))
+     is f:file do (setFileThreadState(f, 0); nullE)
+     else WrongArg("a file or ()")
 );
 
 export getIOThreadMode(e:Expr):Expr := (

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -5,6 +5,7 @@ use errio;
 use gmp;
 use expr;
 use stdio0;
+use util;
 
 header "#include \"../system/m2fileinterface.h\"
         #include <readline/history.h>";
@@ -91,6 +92,8 @@ export setFileThreadState(o:file, state:int):void :=
 (
 	Ccode(void,"M2File_SetThreadMode(",lvalue(o.cfile),",state)")
 );
+export getFileThreadState(o:file):int := (
+    Ccode(int,"M2File_GetThreadMode(", lvalue(o.cfile), ")"));
 
 export syscallErrorMessage(msg:string):string := msg + " failed: " + syserrmsg();
 export fileErrorMessage(o:file,msg:string):string := (
@@ -1041,6 +1044,14 @@ export setIOUnSynchronized(e:Expr):Expr :=(
      else WrongNumArgs(0)
 );
 
+export getIOThreadMode(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 0
+	then toExpr(getFileThreadState(stdIO))
+	else WrongNumArgs(0, 1))
+    is f:file do toExpr(getFileThreadState(f))
+    else WrongArg("a file or ()"));
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d stdio.o "

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -816,44 +816,6 @@ export isnan(x:double):bool := x!=x;
 
 export tostring(x:bool):string := if x then "true" else "false";
 
-export tostring5(
-     x:double,						-- the number to format
-     s:int,					-- number of significant digits
-     l:int,					   -- max number leading zeroes
-     t:int,				    -- max number extra trailing digits
-     e:string			     -- separator between mantissa and exponent
-     ) : string := (
-     o := newvarstring(25);
-     if isinf(x) then return "infinity";
-     if isnan(x) then return "NotANumber";
-     if x==0. then return "0.";
-     if x<0. then (o << '-'; x=-x);
-     oldx := x;
-     i := 0;
-     if x >= 1. then (
-     	  until x < 10000000000. do ( x = x/10000000000.; i = i + 10 );
-     	  until x < 100000. do ( x = x/100000.; i = i + 5 );
-     	  until x < 100. do ( x = x/100.; i = i + 2 );
-     	  until x < 10. do ( x = x/10.; i = i + 1 );
-	  )
-     else (
-     	  until x >= 1./10000000000. do ( x = x*10000000000.; i = i - 10 );
-     	  until x >= 1./100000. do ( x = x*100000.; i = i - 5 );
-     	  until x >= 1./100. do ( x = x*100.; i = i - 2 );
-     	  until x >= 1. do ( x = x*10.; i = i - 1 );
-	  );
-     -- should rewrite this so the format it chooses is the one that takes the least space, preferring not to use the exponent when it's a tie
-     if i<0 then (
-	  if -i <= l 
-	  then digits(o,oldx,1,s-i-1)
-	  else (digits(o,x,1,s-1); o << e << tostring(i);))
-     else if i+1 > s then (
-	  if i+1-s <= t
-	  then digits(o,x,i+1,0)
-	  else (digits(o,x,1,s-1); o << e << tostring(i);))
-     else digits(o,x,i+1,s-i-1);
-     tostring(o));
-
 export tostringRR(x:double) : string := (
     o := newstring(25);
     Ccode(void, "snprintf((char *)", o, "->array, 25, \"%g\", ", x, ")");

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -415,7 +415,7 @@ simpleflush(o:file):int := (				    -- write the entire buffer to file or enlarg
      endFileOutput(o);
      NOERROR);
 
--- Add a string to foss.outbuffer, flushing if necessary, and updating outbol for flushnets().
+-- Add a string to foss.outbuffer, flushing on overflow, and updating outbol for flushnets().
 simpleout(o:file,x:string):int := (
      foss := getFileFOSS(o);
      i := 0;						    -- bytes of x transferred so far
@@ -439,7 +439,7 @@ simpleout(o:file,x:string):int := (
      releaseFileFOSS(o);
      NOERROR);
 
--- Transfer any foss.nets to outbuffer, flushing as necessary.
+-- Transfer any foss.nets to outbuffer, flushing on overflow.
 flushnets(o:file):int := (
      foss := getFileFOSS(o);
      if foss.hadNet then (

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -5,7 +5,6 @@ use errio;
 use gmp;
 use expr;
 use stdio0;
-use util;
 
 header "#include \"../system/m2fileinterface.h\"
         #include <readline/history.h>";
@@ -1048,15 +1047,6 @@ export setIOUnSynchronized(e:Expr):Expr :=(
      is f:file do (setFileThreadMode(f, 0); nullE)
      else WrongArg("a file or ()")
 );
-
-export getIOThreadMode(e:Expr):Expr := (
-    when e
-    is a:Sequence do (
-	if length(a) == 0
-	then toExpr(getFileThreadMode(stdIO))
-	else WrongNumArgs(0, 1))
-    is f:file do toExpr(getFileThreadMode(f))
-    else WrongArg("a file or ()"));
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d stdio.o "

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -854,7 +854,11 @@ export tostring5(
      else digits(o,x,i+1,s-i-1);
      tostring(o));
 
-export tostringRR(x:double) : string := tostring5(x,6,5,5,"e");
+export tostringRR(x:double) : string := (
+    o := newstring(25);
+    Ccode(void, "snprintf((char *)", o, "->array, 25, \"%g\", ", x, ")");
+    Ccode(void, o, "->len = strlen((char *)", o, "->array)");
+    o);
 
 export (o:file) << (x:double) : file := o << tostringRR(x);
 

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -790,24 +790,6 @@ export (o:file) << (x:uchar) : file := o << int(x);
 export (o:file) << (b:bool) : file := (
      o << if b then "true" else "false");
 
-digits(o:varstring,x:double,a:int,b:int):void := (
-     x = x + 0.5 * pow(10.,double(1-a-b));
-     if x >= 10. then (x = x/10.; a = a+1; b = if b==0 then 0 else b-1);
-     while a > 0 do (
-	  putdigit(o,int(x));
-	  x = 10. * (x - double(int(x)));
-	  a = a-1;
-	  );
-     o << '.';
-     lim := pow(10.,double(-b+1));
-     while b > 0 do (
-	  if x < lim then break;
-	  putdigit(o,int(x));
-	  x = 10. * (x - double(int(x)));
-	  lim = lim * 10.;
-	  b = b-1;
-	  ));
-
 export finite(x:double):bool := x==x && x-x == x-x;
 
 export isinf(x:double):bool := x==x && x-x != x-x;

--- a/M2/Macaulay2/d/stdio0.d
+++ b/M2/Macaulay2/d/stdio0.d
@@ -24,7 +24,7 @@ export fileOutputSyncState :=
 	     	       	        -- The text after this point may be combined with
 				-- subsequently printed nets.
         hadNet:bool,		-- whether a Net is present, in which case the
-	     	       	        -- buffer will be empty
+				-- buffer will be empty (actually just outbol == outindex)
 	nets:NetList,	        -- list of nets, to be printed after the outbuffer
         bytesWritten:int,       -- bytes written so far
 	lastCharOut:int,        -- when outbuffer empty, last character written, or -1 if none

--- a/M2/Macaulay2/d/strings.d
+++ b/M2/Macaulay2/d/strings.d
@@ -54,7 +54,7 @@ export match(s:string,i:int,t:string):bool := (
      n := length(t);
      j := 0;
      while i < m && j < n do if s.i != t.j then return false else (i=i+1; j=j+1);
-     true);
+     j == n);
 export index(s:string,offset:int,sep:string):int := (
      i := offset;
      while i < length(s) do if match(s,i,sep) then return i else i=i+1;

--- a/M2/Macaulay2/d/system.d
+++ b/M2/Macaulay2/d/system.d
@@ -127,6 +127,7 @@ import exec(argv:array(string)):int;	-- beware: this routine calls GC_malloc
 export execstar(argv:charstarstar) ::= Ccode(int,"execvp(",argv,"[0],",argv,")");
 import getenv(s:string):string;
 import cpuTime():double;
+import threadTime():double;
 import strcmp(s:string,t:string):int;
 import strnumcmp(s:string,t:string):int;
 import randomint():int;

--- a/M2/Macaulay2/e/gb-default.cpp
+++ b/M2/Macaulay2/e/gb-default.cpp
@@ -574,9 +574,15 @@ void gbA::spair_text_out(buffer &o, spair *p)
  * S-pair heuristics *****
  *************************/
 
+#if defined(__has_feature) && __has_feature(thread_sanitizer)	// to avoid warnings
+static std::atomic_ulong ncalls(0);
+static std::atomic_ulong nloops(0);
+static std::atomic_ulong nsaved_unneeded(0);
+#else
 static unsigned long ncalls = 0;
 static unsigned long nloops = 0;
 static unsigned long nsaved_unneeded = 0;
+#endif
 bool gbA::pair_not_needed(spair *p, gbelem *m)
 {
   /* Check the criterion: in(m) divides lcm(p).

--- a/M2/Macaulay2/e/gb-default.cpp
+++ b/M2/Macaulay2/e/gb-default.cpp
@@ -574,7 +574,13 @@ void gbA::spair_text_out(buffer &o, spair *p)
  * S-pair heuristics *****
  *************************/
 
-#if defined(__has_feature) && __has_feature(thread_sanitizer)	// to avoid warnings
+#ifdef __has_feature	// a Clang and maybe gcc extension to determine compiler features
+    #if __has_feature(thread_sanitizer)
+	#define __SANITIZE_THREAD__	1	// gcc predefines this instead of __has_feature
+    #endif
+#endif
+
+#if __SANITIZE_THREAD__	// to avoid warnings
 static std::atomic_ulong ncalls(0);
 static std::atomic_ulong nloops(0);
 static std::atomic_ulong nsaved_unneeded(0);

--- a/M2/Macaulay2/e/gb-default.cpp
+++ b/M2/Macaulay2/e/gb-default.cpp
@@ -580,7 +580,7 @@ void gbA::spair_text_out(buffer &o, spair *p)
     #endif
 #endif
 
-#if __SANITIZE_THREAD__	// to avoid warnings
+#if __SANITIZE_THREAD__	// to avoid warnings; these variables are only used for diagnostics
 static std::atomic_ulong ncalls(0);
 static std::atomic_ulong nloops(0);
 static std::atomic_ulong nsaved_unneeded(0);

--- a/M2/Macaulay2/e/mem.cpp
+++ b/M2/Macaulay2/e/mem.cpp
@@ -40,6 +40,7 @@ stash::~stash()
       slab *p = slabs;
       slabs = slabs->next;
       GC_FREE(p);  // this dramatically improves our memory usage
+        // TODO: comment out all GC_FREE()s!?
       // printf("removed %p\n", p);
     }
 }

--- a/M2/Macaulay2/e/text-io.cpp
+++ b/M2/Macaulay2/e/text-io.cpp
@@ -4,9 +4,10 @@
 #include "newdelete.hpp"
 #include <cstdio>
 #include <cstring>
+#include <atomic>
 
 int MAX_LINE_LENGTH = 75;
-int emit_line_len = 0;
+std::atomic_int emit_line_len = 0;
 
 void bignum_text_out(buffer &o, mpz_srcptr a)
 {

--- a/M2/Macaulay2/m2/basictests/W02-threads.m2
+++ b/M2/Macaulay2/m2/basictests/W02-threads.m2
@@ -1,5 +1,5 @@
 assert = x -> if not x then error "assertion failed"
 
 assert( getGlobalSymbol "stopIfError" === symbol stopIfError )
-threadVariable foo
+threadLocal foo
 assert( getGlobalSymbol "foo" === symbol foo )

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1009,6 +1009,8 @@ export {
 	"pad",
 	"pager",
 	"pairs",
+	"parallelApply",
+	"parallelApplyRaw",
 	"parent",
 	"part",
 	"partition",

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1010,7 +1010,6 @@ export {
 	"pager",
 	"pairs",
 	"parallelApply",
-	"parallelApplyRaw",
 	"parent",
 	"part",
 	"partition",

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1214,7 +1214,7 @@ export {
 	"tex",
 	"texMath",
 	"then",
-	"threadVariable",
+	"threadLocal",
 	"throw",
 	"time",
 	"times",
@@ -1297,6 +1297,7 @@ export {
         "numrows" => "numRows",
         "res" => "resolution",
         "sub" => "substitute",
+	"threadVariable" => "threadLocal", -- TODO: eventually remove this?
 	-- unicode synonyms:
 	"ℚ" => "QQ",
 	"ℝ" => "RR",

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -750,6 +750,7 @@ export {
 	"get",
 	"getChangeMatrix",
 	"getGlobalSymbol",
+	"getIOThreadMode",
 	"getNetFile",
 	"getNonUnit",
 	"getPrimeWithRootOfUnity",

--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -14,7 +14,7 @@ recursionLimit = 300
 -- initialize the trivial monoid, see rawMonoid()
 degreesRing 0;
 
-setIOUnSynchronized()					    -- try to avoid deadlocks when running examples
+-- setIOUnSynchronized()					    -- try to avoid deadlocks when running examples
 
 addEndFunction(() -> scan(openFiles(), f -> if isOutputFile f then flush f))
 addEndFunction(() -> path = {})

--- a/M2/Macaulay2/m2/lists.m2
+++ b/M2/Macaulay2/m2/lists.m2
@@ -253,7 +253,8 @@ deepScan   = (L, f) -> (deepApply'(L, f, e -> instance(e, BasicList));) -- not m
 parallelApplyRaw = (L, f) ->
      -- 'reverse's to minimize thread switching in 'taskResult's:
      reverse (taskResult \ reverse apply(L, e -> schedule(f, e)));
-parallelApply = (L, f) -> (	-- (BasicList, Function) -> List
+parallelApply = method()
+parallelApply(BasicList, Function) := (L, f) -> (
      n := #L;
      numThreads := min(n + 1, maxAllowableThreads);
      oldAllowableThreads := allowableThreads;

--- a/M2/Macaulay2/m2/lists.m2
+++ b/M2/Macaulay2/m2/lists.m2
@@ -253,8 +253,9 @@ deepScan   = (L, f) -> (deepApply'(L, f, e -> instance(e, BasicList));) -- not m
 parallelApplyRaw = (L, f) ->
      -- 'reverse's to minimize thread switching in 'taskResult's:
      reverse (taskResult \ reverse apply(L, e -> schedule(f, e)));
-parallelApply = method()
-parallelApply(BasicList, Function) := (L, f) -> (
+parallelApply = method(Options => {Strategy => null})
+parallelApply(BasicList, Function) := o -> (L, f) -> (
+     if o.Strategy === "raw" then return parallelApplyRaw(L, f);
      n := #L;
      numThreads := min(n + 1, maxAllowableThreads);
      oldAllowableThreads := allowableThreads;

--- a/M2/Macaulay2/m2/lists.m2
+++ b/M2/Macaulay2/m2/lists.m2
@@ -250,6 +250,20 @@ deepApply' = (L, f, g) -> flatten if g L then toList apply(L, e -> deepApply'(e,
 deepApply  = (L, f) ->  deepApply'(L, f, e -> instance(e, BasicList))
 deepScan   = (L, f) -> (deepApply'(L, f, e -> instance(e, BasicList));) -- not memory efficient
 
+parallelApplyRaw = (L, f) ->
+     -- 'reverse's to minimize thread switching in 'taskResult's:
+     reverse (taskResult \ reverse apply(L, e -> schedule(f, e)));
+parallelApply = (L, f) -> (	-- (BasicList, Function) -> List
+     n := #L;
+     numThreads := min(n + 1, maxAllowableThreads);
+     oldAllowableThreads := allowableThreads;
+     if allowableThreads < numThreads then allowableThreads = numThreads;
+     numChunks := 3 * numThreads;
+     res := if n <= numChunks then toList parallelApplyRaw(L, f) else
+	  flatten parallelApplyRaw(pack(L, ceiling(n / numChunks)), chunk -> apply(chunk, f));
+     allowableThreads = oldAllowableThreads;
+     res);
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -607,7 +607,7 @@ addHook(MutableHashTable, Thing, Function) := opts -> (store, key, hook) -> (
     store.HookAlgorithms#alg = hook)
 
 -- tracking debugInfo
-threadVariable infoLevel
+threadLocal infoLevel
 pushInfoLevel :=  n -> (
     if infoLevel === null then infoLevel = -1;
     infoLevel = infoLevel + n; n)

--- a/M2/Macaulay2/packages/Complexes/FreeResolutionTests.m2
+++ b/M2/Macaulay2/packages/Complexes/FreeResolutionTests.m2
@@ -201,21 +201,21 @@ TEST ///
   assert(betti C0 == betti C3)
 
   I = ideal I_*
-  (usedtime, C) = toSequence timing freeResolution(I, LengthLimit => 6, Strategy => 0)
+  (usedtime, C) = toSequence elapsedTiming freeResolution(I, LengthLimit => 6, Strategy => 0)
   assert isWellDefined C
   assert(length C == 6)
   
-  (usedtime1, C1) = toSequence timing freeResolution(I, LengthLimit => 6, Strategy => 1) -- no recomputation
+  (usedtime1, C1) = toSequence elapsedTiming freeResolution(I, LengthLimit => 6, Strategy => 1) -- no recomputation
   assert isWellDefined C1
   assert(length C1 == 6)
   assert(usedtime1 < usedtime/5) -- this /5 is a heuristic, just to check that essentially no computation is happening for usedtime1
 
-  (usedtime2, C2) = toSequence timing freeResolution(I, LengthLimit => 7, Strategy => 1)
+  (usedtime2, C2) = toSequence elapsedTiming freeResolution(I, LengthLimit => 7, Strategy => 1)
   assert isWellDefined C2
   assert(length C2 == 7)
   assert(usedtime1 < usedtime2/2)
   
-  (usedtime3, C3) = toSequence timing freeResolution(I, LengthLimit => 5, Strategy => 0) -- does change length, no recomputation
+  (usedtime3, C3) = toSequence elapsedTiming freeResolution(I, LengthLimit => 5, Strategy => 0) -- does change length, no recomputation
   assert isWellDefined C3
   assert(length C3 == 5)
   assert(usedtime3 < usedtime2/2)
@@ -718,16 +718,16 @@ TEST ///
   I = ideal"abc-de2, abd-c2d, ac2-bd2, abcde"
   gbTrace=2
 
-  (usedtime1, C) = toSequence timing freeResolution(I, Strategy => Nonminimal)
+  (usedtime1, C) = toSequence elapsedTiming freeResolution(I, Strategy => Nonminimal)
   assert isWellDefined C
 
-  (usedtime2, C2) = toSequence timing freeResolution(I, Strategy => Nonminimal)
+  (usedtime2, C2) = toSequence elapsedTiming freeResolution(I, Strategy => Nonminimal)
   assert BinaryOperation(symbol <, usedtime2, usedtime1/10)
 
-  (usedtime3, C3) = toSequence timing freeResolution I
+  (usedtime3, C3) = toSequence elapsedTiming freeResolution I
   assert BinaryOperation(symbol >, usedtime3, 5*usedtime2)
 
-  (usedtime4, C4) = toSequence timing freeResolution(I, Strategy => Engine)
+  (usedtime4, C4) = toSequence elapsedTiming freeResolution(I, Strategy => Engine)
   assert BinaryOperation(symbol <, usedtime4, usedtime3/2)
 
   freeResolution(I, Strategy => 0) -- not recomputing

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/cpuTime-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/cpuTime-doc.m2
@@ -18,9 +18,6 @@ doc ///
      for i from 0 to 1000000 do 223131321321*324234324324;
      t2 = cpuTime()
      t2-t1
-  Caveat
-    Under Linux, the cpu time reported is that consumed by the thread, but under MAC OS X,
-    it is that consumed by the process.
   SeeAlso
     "time"
     "timing"

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/parallelism-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/parallelism-doc.m2
@@ -14,7 +14,7 @@ doc ///
        over a finite field.  Also included is (one of the algorithms for) the computation of Groebner
        bases in polynomial rings over finite fields, whether graded or not.
      Text
-       The variable {\tt nummTBBThreads} controls the number of cores used by Macaulay2.
+       The variable {\tt numTBBThreads} controls the number of cores used by Macaulay2.
        The default value (zero) means the system can choose an appropriate number
        of cores (often the maximum available).  Note that the default
        behavior is to use multiple cores.

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview2.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview2.m2
@@ -969,7 +969,7 @@ document {
      "The method installed by the code above is automatically inherited by 
      subclasses of ", TT "X", " and ", TT "Y", ".  Here is a brief
      description of the way this works.  Suppose ", TT "X", " is the 
-     ", TO "parent", " of ", TT "P", " and ", TT "Y", " is the parent of ", TT "X", ".  When 
+     ", TO "parent", " of ", TT "P", " and ", TT "Y", " is the parent of ", TT "Q", ".  When
      a sum ", TT "p+q", " is evaluated where the class of ", TT "p", " is 
      ", TT "P", " and the class of ", TT "q", " is ", TT "Q", ", then the binary
      method for ", TT "P+Q", " is applied, unless there isn't one, in which
@@ -998,7 +998,7 @@ document {
      with",
      PRE "new Z of X from Y := (z,y) -> ...",
      "where ", TT "z", " denotes the new hash table of class ", TT "Z", " and parent
-     ", TT "x", " provided to the routine by the system."
+     ", TT "X", " provided to the routine by the system."
      }
 
 document {

--- a/M2/Macaulay2/packages/Macaulay2Doc/overview3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overview3.m2
@@ -247,13 +247,12 @@ document {
 	  },
      UL {
 	  LI { "GC_INITIAL_HEAP_SIZE -- initial heap size in bytes, or number of gigabytes followed by 'G', similarly for 'M', 'K'" },
-	  LI { "GC_MAXIMUM_HEAP_SIZE -- maximum collected heap size" },
+	  LI { "GC_MAXIMUM_HEAP_SIZE -- optional maximum collected heap size" },
 	  LI { "GC_FREE_SPACE_DIVISOR -- if set to a number D, then
                          we try to make sure that we allocate at least N/D bytes between collections, where N is twice the
                          number of traced bytes, plus the number of untraced bytes, plus a rough estimate of the root set
                          size.  Increasing its value will use less space but more collection time.  Decreasing it will
-                         appreciably decrease collection time at the expense of space.
-			 Macaulay2 sets the initial default value to 12." },
+                         appreciably decrease collection time at the expense of space." },
 	  LI { "GC_PRINT_STATS -- whether to turn on logging" },
 	  LI { "GC_PRINT_VERBOSE_STATS -- whether to turn on even more logging" },
 	  LI { "GC_DUMP_REGULARLY -- whether to generate a debugging dump on startup and during every collection; very verbose" },

--- a/M2/Macaulay2/packages/Macaulay2Doc/system.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/system.m2
@@ -13,10 +13,10 @@ document {
 	  easily extracted, as follows."
 	  },
      EXAMPLE lines ///
-     s#"heap size"
+     s#"heapSize"
      ///,
      PARA {
-	  "The entries whose keys are upper case give the values of environment variables affecting the operation of the 
+	  "Any entries whose keys are all upper case give the values of environment variables affecting the operation of the 
 	  garbage collector that have been specified by the user."
 	  },
      PARA {

--- a/M2/Macaulay2/packages/Macaulay2Doc/system.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/system.m2
@@ -831,7 +831,9 @@ document {
      Headline => "time a computation",
 	Usage => "time e",
      TT "time e", " evaluates ", TT "e", ", prints the amount of cpu time
-     used, and returns the value of ", TT "e", ".",
+     used, and returns the value of ", TT "e", ".  The time used by the
+     the current thread and garbage collection during the evaluation of ", TT "e",
+     " is also shown.",
      EXAMPLE "time 3^30",
      SeeAlso => {"timing", "cpuTime", "elapsedTiming", "elapsedTime"}
      }
@@ -855,9 +857,7 @@ document {
      Headline => "time a computation including time elapsed",
 	Usage => "elapsedTime e",
      TT "elapsedTime e", " evaluates ", TT "e", ", prints the amount of time
-     elapsed, and returns the value of ", TT "e", ". The cpu time used by the Macaulay2
-     process, the current thread, and garbage collection during the evaluation of ", TT "e",
-     " is also shown.",
+     elapsed, and returns the value of ", TT "e", ".",
      EXAMPLE "elapsedTime sleep 1",
      SeeAlso => {"elapsedTiming", "cpuTime", "GCstats",
 	  "parallel programming with threads and tasks",

--- a/M2/Macaulay2/packages/Macaulay2Doc/system.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/system.m2
@@ -857,7 +857,7 @@ document {
      TT "elapsedTime e", " evaluates ", TT "e", ", prints the amount of time
      elapsed, and returns the value of ", TT "e", ". The cpu time used by the Macaulay2
      process, the current thread, and garbage collection during the evaluation of ", TT "e",
-     "is also shown."
+     " is also shown.",
      EXAMPLE "elapsedTime sleep 1",
      SeeAlso => {"elapsedTiming", "cpuTime", "GCstats",
 	  "parallel programming with threads and tasks",

--- a/M2/Macaulay2/packages/Macaulay2Doc/system.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/system.m2
@@ -3,7 +3,9 @@ document {
      Headline => "information about the status of the garbage collector",
      PARA {
 	  "Macaulay2 uses the Hans Boehm ", TO2 {"GC garbage collector", "garbage collector"}, " to reclaim unused memory.  The function ", TT "GCstats", " 
-	  provides information about its status."
+	  provides information about its status, such as the total number of bytes allocated,
+	  the current heap size, the number of garbage collections done, the number of threads
+	  used in each collection, the total cpu time spent in garbage collection, etc."
 	  },
      EXAMPLE lines ///
      s = GCstats()
@@ -850,12 +852,16 @@ document {
      }
 document {
      Key => "elapsedTime",
-     Headline => "time a computation using time elapsed",
+     Headline => "time a computation including time elapsed",
 	Usage => "elapsedTime e",
      TT "elapsedTime e", " evaluates ", TT "e", ", prints the amount of time
-     elapsed, and returns the value of ", TT "e", ".",
+     elapsed, and returns the value of ", TT "e", ". The cpu time used by the Macaulay2
+     process, the current thread, and garbage collection during the evaluation of ", TT "e",
+     "is also shown."
      EXAMPLE "elapsedTime sleep 1",
-     SeeAlso => {"elapsedTiming", "cpuTime"}
+     SeeAlso => {"elapsedTiming", "cpuTime", "GCstats",
+	  "parallel programming with threads and tasks",
+	  "parallelism in engine computations"}
      }
 document {
      Key => Time,

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -404,13 +404,18 @@ Node
   exclusive I/O for the current thread
  Usage
   setIOExclusive()
+  setIOExclusive f
+ Inputs
+  f:File
  Consequences
   Item
-   the current thread becomes the only one permitted to use the files @ TO stdio @ and @ TO stderr @
+   the current thread becomes the only one permitted to use the file @VAR "f"@,
+   or if no file is given, the files @ TO stdio @ and @ TO stderr @.
  SeeAlso
   "parallel programming with threads and tasks"
   setIOUnSynchronized
   setIOSynchronized
+  getIOThreadMode
 Node
  Key
   setIOSynchronized
@@ -418,15 +423,21 @@ Node
   synchronized I/O for threads
  Usage
   setIOSynchronized()
+  setIOSynchronized f
+  getIOThreadMode
+ Inputs
+  f:File
  Consequences
   Item
-   threads are permitted to use the files @ TO stdio @ and @ TO stderr @ to output complete lines only
+   threads are permitted to use the file @VAR "f"@, or if no file is given,
+   @ TO stdio @ and @ TO stderr @, to output complete lines only
  Caveat
    this function is experimental
  SeeAlso
   "parallel programming with threads and tasks"
   setIOUnSynchronized
   setIOExclusive
+  getIOThreadMode
 Node
  Key
   setIOUnSynchronized
@@ -434,11 +445,38 @@ Node
   unsynchronized I/O for threads
  Usage
   setIOUnSynchronized()
+  setIOUnSynchronized f
+  getIOThreadMode
+ Inputs
+  f:File
  Consequences
   Item
-   threads are permitted to use the files @ TO stdio @ and @ TO stderr @ in an unregulated manner
+   threads are permitted to use the file @VAR "f"@, or if no file is given,
+   @ TO stdio @ and @ TO stderr @, in an unregulated manner
  SeeAlso
   "parallel programming with threads and tasks"
+  setIOSynchronized
+  setIOExclusive
+Node
+ Key
+  getIOThreadMode
+ Headline
+  get I/O thread mode
+ Usage
+  getIOThreadMode()
+  getIOThreadMode f
+ Inputs
+  f:File
+ Consequences
+  Item
+   returns the I/O thread mode for the file @VAR "f"@, or if no file is given,
+   @TO stdio@, as an integer:
+   @UL {
+       "0 for unsynchronized",
+       "1 for synchronized",
+       "2 for exclusive"}@
+ SeeAlso
+  setIOUnSynchronized
   setIOSynchronized
   setIOExclusive
 Node

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -123,18 +123,30 @@ Node
  Key
   parallelApply
   (parallelApply, BasicList, Function)
+  [parallelApply, Strategy]
  Headline
-  apply a function to each element, using all cores
+  apply a function to each element in parallel
  Usage
   parallelApply(L,f)
  Inputs
   L:BasicList
   f:Function
+  Strategy => {Nothing, String}
  Outputs
-  :List
-    {\tt toList apply(L,f)}, with the result computed in parallel in chunks
+  :{List, BasicList}
+    If the @TO Strategy@ option is @TO null@, then this behaves like
+    @M2CODE "toList apply(L,f)"@, with the result computed in parallel in
+    chunks using all cores.
+    If it is the string @SAMP "\"raw\""@, then this behaves like
+    @M2CODE "apply(apply(L, e -> schedule(f, e)), taskResult)"@.
  Description
   Text
+    If the option @SAMP "Strategy"@ is given the string @SAMP "\"raw\""@, then
+    a separate task is created for each element of @VAR "L"@. @VAR "L"@ is not
+    split into chunks, @ TO "allowableThreads" @ is used unchanged, and the
+    result has the same class as @VAR "L"@.   Normally the default strategy
+    (@M2CODE "Strategy => null"@) is more efficient.
+
     See @ TO "parallel programming with threads and tasks" @ for more information and an
     important warning about thread safety.
 Node
@@ -482,29 +494,3 @@ Node
   "parallel programming with threads and tasks"
   cancelTask
 ///
-
--- not exported:
--- Node
---  Key
---   parallelApplyRaw
---  Headline
---   apply a function to each element in parallel
---  Usage
---   parallelApplyRaw(L,f)
---  Inputs
---   L:BasicList
---   f:Function
---  Outputs
---   :BasicList
---     {\tt apply(apply(L, e -> schedule(f, e)), taskResult)}
---  Description
---   Text
---     A separate task is created for each element of {\tt L}. {\tt L} is not split into chunks,
---     @ TO "allowableThreads" @ is used unchanged, and the result has the same class as {\tt L}.
---     Normally @ TO parallelApply @ is more efficient.
---
---     See @ TO "parallel programming with threads and tasks" @ for more information and an
---     important warning about thread safety.
---  SeeAlso
---   "parallel programming with threads and tasks"
---   parallelApply

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -122,6 +122,7 @@ Node
 Node
  Key
   parallelApply
+  (parallelApply, BasicList, Function)
  Headline
   apply a function to each element, using all cores
  Usage

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -19,7 +19,7 @@ Node
   setIOExclusive
   setIOSynchronized
   setIOUnSynchronized
-  "threadVariable"
+  "threadLocal"
   "allowableThreads"
   "maxAllowableThreads"
   Task
@@ -242,18 +242,18 @@ Node
    will signal an error.
 Node
  Key
-  "threadVariable"
+  "threadLocal"
  Headline
   create a symbol whose value in one thread is not shared with others
  Usage
-  threadVariable foo
+  threadLocal foo
  Outputs
   :
    a new symbol, whose name is "foo", for example, whose values in each thread will be independent of each other,
    with initial value @ TO null @
  Description
   Example
-   threadVariable x
+   threadLocal x
    x = 1
    t = schedule ( () -> ( x = 2 ; x ) )
    taskResult t

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -93,9 +93,6 @@ Node
 
     Warning: Access to external libraries such as singular, etc., may not
     currently be thread safe.
- SeeAlso
-  "parallelism in engine computations"
-  elapsedTime
 Node
  Key
   (addCancelTask, Task, Task)

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -93,6 +93,9 @@ Node
 
     Warning: Access to external libraries such as singular, etc., may not
     currently be thread safe.
+ SeeAlso
+  "parallelism in engine computations"
+  elapsedTime
 Node
  Key
   (addCancelTask, Task, Task)

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -41,9 +41,9 @@ Node
     including cpu caches; it is like running Macaulay2 on a computer that is running other big
     programs at the same time. We can see this using @ TO "elapsedTime" @.
   Example
-       fib = n -> if n < 2 then n else fib(n-1)+fib(n-2);
-       elapsedTime         apply(1..30, n -> fib(20));
-       elapsedTime parallelApply(1..30, n -> fib(20));
+       L = random toList (1..10000);
+       elapsedTime         apply(1..100, n -> sort L);
+       elapsedTime parallelApply(1..100, n -> sort L);
   Text
     You will have to try it on your examples to see how much they speed up.
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -7,7 +7,6 @@ Node
   "parallel programming with threads and tasks"
  Subnodes
   parallelApply
-  parallelApplyRaw
   createTask
   addCancelTask
   addDependencyTask
@@ -137,30 +136,6 @@ Node
   Text
     See @ TO "parallel programming with threads and tasks" @ for more information and an
     important warning about thread safety.
-Node
- Key
-  parallelApplyRaw
- Headline
-  apply a function to each element in parallel
- Usage
-  parallelApplyRaw(L,f)
- Inputs
-  L:BasicList
-  f:Function
- Outputs
-  :BasicList
-    {\tt apply(apply(L, e -> schedule(f, e)), taskResult)}
- Description
-  Text
-    A separate task is created for each element of {\tt L}. {\tt L} is not split into chunks,
-    @ TO "allowableThreads" @ is used unchanged, and the result has the same class as {\tt L}.
-    Normally @ TO parallelApply @ is more efficient.
-    
-    See @ TO "parallel programming with threads and tasks" @ for more information and an
-    important warning about thread safety.
- SeeAlso
-  "parallel programming with threads and tasks"
-  parallelApply
 Node
  Key
   (addCancelTask, Task, Task)
@@ -506,3 +481,29 @@ Node
   "parallel programming with threads and tasks"
   cancelTask
 ///
+
+-- not exported:
+-- Node
+--  Key
+--   parallelApplyRaw
+--  Headline
+--   apply a function to each element in parallel
+--  Usage
+--   parallelApplyRaw(L,f)
+--  Inputs
+--   L:BasicList
+--   f:Function
+--  Outputs
+--   :BasicList
+--     {\tt apply(apply(L, e -> schedule(f, e)), taskResult)}
+--  Description
+--   Text
+--     A separate task is created for each element of {\tt L}. {\tt L} is not split into chunks,
+--     @ TO "allowableThreads" @ is used unchanged, and the result has the same class as {\tt L}.
+--     Normally @ TO parallelApply @ is more efficient.
+--
+--     See @ TO "parallel programming with threads and tasks" @ for more information and an
+--     important warning about thread safety.
+--  SeeAlso
+--   "parallel programming with threads and tasks"
+--   parallelApply

--- a/M2/Macaulay2/packages/NumericalImplicitization/tests.m2
+++ b/M2/Macaulay2/packages/NumericalImplicitization/tests.m2
@@ -123,6 +123,7 @@ assert((pseudoWitnessSet(F, I, PW.witnessPointPairs, PW.imageSlice)).degree == 6
 ///
 
 TEST /// -- Orthogonal group O(n)
+-- no-capture-flag
 setRandomSeed 0
 n = 4
 R = CC[x_0..x_(n^2-1)]

--- a/M2/Macaulay2/system/m2file.hpp
+++ b/M2/Macaulay2/system/m2file.hpp
@@ -47,11 +47,11 @@ public:
   //exclusive recurse count
   size_t exclusiveRecurseCount;
   //Function to wait for exclusive owner to be current thread.
-  void waitExclusiveThread(size_t exclusiveRecurseCounter);
+  void waitExclusiveThread(size_t exclusiveRecurseDelta);
   //Function to wait for syncOrExclOwner to be released and then acquire it
-  void waitThreadAcquire(size_t recurseCoutner); 
+  void waitThreadAcquire(size_t recurseDelta);
   //Function to release recurseCount and if == 0 set syncOrExclOwner to 0
-  void releaseThreadCount(size_t recurseCounter);
+  void releaseThreadCount(size_t recurseDelta);
   //Set new syncOrExclOwner
   void setOwnerThread(pthread_t newOwner, size_t recurseCounter=0);
 };

--- a/M2/Macaulay2/system/m2file.hpp
+++ b/M2/Macaulay2/system/m2file.hpp
@@ -38,22 +38,22 @@ public:
   //Mutex for guarding map & internals of file
   pthreadMutex m_MapMutex;
   //For exclusive mode, the thread that currently owns io
-  //For sync mode, the thread that currently owns the mutex
-  pthread_t exclusiveOwner;
-  //condition variable for waiting to acquire exclusive ownership
-  pthread_cond_t exclusiveChangeCondition;
-  //number of times exclusiveOwner acquired
+  //For sync mode, the thread that currently owns the mutex (no, actually unsyncState)
+  pthread_t syncOrExclOwner;
+  //condition variable for waiting to acquire ownership
+  pthread_cond_t ownerChangeCondition;
+  //number of times syncOrExclOwner acquired
   size_t  recurseCount;
   //exclusive recurse count
   size_t exclusiveRecurseCount;
-  //Function to wait for exclusiveOwner to be current thread.
-  void waitExclusiveThread(size_t recurseCounter);
-  //Function to wait for exclusiveOwner to be released and then acquire it
-  void waitExclusiveThreadAcquire(size_t recurseCoutner); 
-  //Function to release recurseCount and if == 0 set exclusiveOwner to -1
-  void releaseExclusiveThreadCount(size_t recurseCounter);
-  //Set new exclusiveOwner
-  void setExclusiveOwner(pthread_t newExclusiveOwner, size_t recurseCounter=0);
+  //Function to wait for exclusive owner to be current thread.
+  void waitExclusiveThread(size_t exclusiveRecurseCounter);
+  //Function to wait for syncOrExclOwner to be released and then acquire it
+  void waitThreadAcquire(size_t recurseCoutner); 
+  //Function to release recurseCount and if == 0 set syncOrExclOwner to 0
+  void releaseThreadCount(size_t recurseCounter);
+  //Set new syncOrExclOwner
+  void setOwnerThread(pthread_t newOwner, size_t recurseCounter=0);
 };
 
 #include "m2fileinterface.h"

--- a/M2/Macaulay2/system/supervisor.cpp
+++ b/M2/Macaulay2/system/supervisor.cpp
@@ -16,7 +16,7 @@ const static int maxNumThreads = (numCores < 4) ? 4 : (16 < numCores ? 16 : numC
 // The number of compute-bound threads allowed at any given time should be the number of cores and pseudocores.
 // There may be I/O bound threads, such as the main interpreter thread.  So a good thing to set currentAllowedThreads to is the
 // number of cores plus the expected number of I/O bound threads.
-static int currentAllowedThreads = 2;
+static int currentAllowedThreads = 4;
 
 
 // The thread that the interpreter runs in.

--- a/M2/Macaulay2/system/supervisor.cpp
+++ b/M2/Macaulay2/system/supervisor.cpp
@@ -7,6 +7,8 @@
 #include <iostream>
 #include <chrono>
 #include <thread>
+#include <mutex>
+using std::lock_guard;
 
 // The maximum number of concurrent threads
 const static unsigned int numCores = std::thread::hardware_concurrency();
@@ -16,7 +18,7 @@ const static int maxNumThreads = (numCores < 4) ? 4 : (16 < numCores ? 16 : numC
 // The number of compute-bound threads allowed at any given time should be the number of cores and pseudocores.
 // There may be I/O bound threads, such as the main interpreter thread.  So a good thing to set currentAllowedThreads to is the
 // number of cores plus the expected number of I/O bound threads.
-static int currentAllowedThreads = 4;
+static atomic_int currentAllowedThreads(4);
 
 
 // The thread that the interpreter runs in.
@@ -78,13 +80,10 @@ extern "C" {
   }
   void pushTask(struct ThreadTask* task)
   {
-    threadSupervisor->m_Mutex.lock();
-    task->m_Mutex.lock();
+    lock_guard<pthreadMutex> supLock(threadSupervisor->m_Mutex);
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
     if(task->m_ReadyToRun)
-      {
-	task->m_Mutex.unlock();
 	return;
-      }
     if(task->m_Dependencies.empty())
       {
 	task->m_ReadyToRun=true;
@@ -95,59 +94,65 @@ extern "C" {
 	threadSupervisor->m_WaitingTasks.push_back(task);
       }
     pthread_cond_signal(&threadSupervisor->m_TaskWaitingCondition);
-    task->m_Mutex.unlock();
-    threadSupervisor->m_Mutex.unlock();
   }
 
   void delThread(pthread_t thread)
   {
-    threadSupervisor->m_Mutex.lock();
+    lock_guard<pthreadMutex> supLock(threadSupervisor->m_Mutex);
     gc_map(pthread_t, struct ThreadSupervisorInformation*)::iterator it = threadSupervisor->m_ThreadMap.find(thread);
     if(it!=threadSupervisor->m_ThreadMap.end())
       {
 	threadSupervisor->m_ThreadMap.erase(it);
       }
-    threadSupervisor->m_Mutex.unlock();
   }
   void addCancelTask(struct ThreadTask* task, struct ThreadTask* cancel)
   {
-    task->m_Mutex.lock();
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
     task->m_CancelTasks.insert(cancel);
-    task->m_Mutex.unlock();
   }
   void addStartTask(struct ThreadTask* task, struct ThreadTask* start)
   {
-    task->m_Mutex.lock();
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
     task->m_StartTasks.insert(start);
-    task->m_Mutex.unlock();
   }
   void addDependency(struct ThreadTask* task, struct ThreadTask* dependency)
   {
     dependency->m_Mutex.lock();
     dependency->m_StartTasks.insert(task);
     dependency->m_Mutex.unlock(); 
-    task->m_Mutex.lock();
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
     task->m_Dependencies.insert(dependency);
-    task->m_Mutex.unlock();
   }
   int taskDone(struct ThreadTask* task)
   {
-    return task && task->m_Done;
+    if (! task)	return false;
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
+	// synchronizes-with the task's thread, avoids data races
+    return task->m_Done;
   }
   int taskStarted(struct ThreadTask* task)
   {
-    return task && task->m_Started;
+    if (! task)	return false;
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
+	// synchronizes-with the task's thread, avoids data races
+    return task->m_Started;
   }
   void* taskResult(struct ThreadTask* task)
   {
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
+	// synchronizes-with the task's thread, avoids data races
     return task->m_Result;
   }
   int taskKeepRunning(struct ThreadTask* task)
   {
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
+	// synchronizes-with the task's thread, avoids data races
     return task->m_KeepRunning;
   }
   int taskRunning(struct ThreadTask* task)
   {
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
+	// synchronizes-with the task's thread, avoids data races
     return task->m_Running;
   }
   void taskInterrupt(struct ThreadTask* task)
@@ -170,18 +175,14 @@ extern "C" {
     if(NULL == threadSupervisor)
       threadSupervisor = new (GC) ThreadSupervisor(maxNumThreads);
     assert(threadSupervisor);
-    threadSupervisor->m_Mutex.lock();
+    lock_guard<pthreadMutex> supLock(threadSupervisor->m_Mutex);
     if(threadSupervisor->m_ThreadLocalIdPtrSet.find(refno)!=threadSupervisor->m_ThreadLocalIdPtrSet.end())
-      {
-	threadSupervisor->m_Mutex.unlock();
 	return;
-      }
     threadSupervisor->m_ThreadLocalIdPtrSet.insert(refno);
     int ref = threadSupervisor->m_ThreadLocalIdCounter++;
     if(ref>threadSupervisor->s_MaxThreadLocalIdCounter)
      abort();
     *refno = ref;
-    threadSupervisor->m_Mutex.unlock();
   }
   int getAllowableThreads()
   {
@@ -206,14 +207,13 @@ ThreadTask::ThreadTask(const char* name, ThreadTaskFunctionPtr func, void* userD
 ThreadTask::~ThreadTask() {}
 void* ThreadTask::waitOn()
 {
-  m_Mutex.lock();
+  lock_guard<pthreadMutex> lock(m_Mutex);
   while(!m_Done && m_KeepRunning)
     {
       pthread_cond_wait(&m_FinishCondition,&m_Mutex.m_Mutex);
     }
   assert(m_Done || !m_KeepRunning);
   void* ret = m_Result;
-  m_Mutex.unlock();
   return ret;
 }
 
@@ -277,7 +277,7 @@ void ThreadSupervisor::initialize()
 }
 void ThreadSupervisor::_i_finished(struct ThreadTask* task)
 {
-  m_Mutex.lock();
+  lock_guard<pthreadMutex> supLock(m_Mutex);
   m_RunningTasks.remove(task);
   if(task->m_KeepRunning)
     {
@@ -289,26 +289,17 @@ void ThreadSupervisor::_i_finished(struct ThreadTask* task)
     }
   if(pthread_cond_broadcast(&task->m_FinishCondition))
     abort();  
-  m_Mutex.unlock();
 }
 void ThreadSupervisor::_i_startTask(struct ThreadTask* task, struct ThreadTask* launcher)
 {
-  m_Mutex.lock();
-  task->m_Mutex.lock();
+  lock_guard<pthreadMutex> supLock(m_Mutex);
+  lock_guard<pthreadMutex> lock(task->m_Mutex);
   if(task->m_ReadyToRun)
-    {
-      task->m_Mutex.unlock();
-      m_Mutex.unlock();
       return;
-    }
   if(!task->m_Dependencies.empty())
     {
       if(!launcher)
-	{
-	  task->m_Mutex.unlock();
-	  m_Mutex.unlock();
 	  return;
-	}
       gc_set(struct ThreadTask*)::iterator it = task->m_Dependencies.find(launcher);
       if(it!=task->m_Dependencies.end())
 	{
@@ -316,36 +307,28 @@ void ThreadSupervisor::_i_startTask(struct ThreadTask* task, struct ThreadTask* 
 	  task->m_FinishedDependencies.insert(launcher);
 	}
       if(!task->m_Dependencies.empty())
-	{
-	  task->m_Mutex.unlock();
-	  m_Mutex.unlock();
 	  return;
-	}
     }
   m_WaitingTasks.remove(task);
   task->m_ReadyToRun=true;
   m_ReadyTasks.push_back(task);
   if(pthread_cond_signal(&m_TaskWaitingCondition))
     abort();
-  task->m_Mutex.unlock();
-  m_Mutex.unlock();
 }
 void ThreadSupervisor::_i_cancelTask(struct ThreadTask* task)
 {
-  m_Mutex.lock();
-  task->m_Mutex.lock();
+  lock_guard<pthreadMutex> supLock(m_Mutex);
+  lock_guard<pthreadMutex> lock(task->m_Mutex);
   if(task->m_CurrentThread)
     {
       atomic_store(&task->m_CurrentThread->m_Interrupt->field, 1);
       atomic_store(&task->m_CurrentThread->m_Exception->field, 1);
     }
   task->m_KeepRunning=false;
-  task->m_Mutex.unlock();
-  m_Mutex.unlock();
 }
 struct ThreadTask* ThreadSupervisor::getTask()
 {
-  m_Mutex.lock();
+  lock_guard<pthreadMutex> supLock(m_Mutex);
   while(m_ReadyTasks.empty())
     {
       //This exists in case pthread cond wait returns due to a signal/etc
@@ -358,7 +341,6 @@ struct ThreadTask* ThreadSupervisor::getTask()
   struct ThreadTask* task = m_ReadyTasks.front();
   m_ReadyTasks.pop_front();
   m_RunningTasks.push_back(task);
-  m_Mutex.unlock();
   return task;
 }
 void ThreadTask::run(SupervisorThread* thread)
@@ -376,13 +358,10 @@ void ThreadTask::run(SupervisorThread* thread)
   m_Running=true;
   m_Mutex.unlock();
   m_Result = m_Func(m_UserData);
-  m_Mutex.lock();
+  lock_guard<pthreadMutex> lock(m_Mutex);
   m_Running=false;
   if(!m_KeepRunning)
-    {
-      m_Mutex.unlock();
       return;
-    }
   m_Done = true;
   m_CurrentThread=NULL;
   threadSupervisor->_i_finished(this);
@@ -392,7 +371,6 @@ void ThreadTask::run(SupervisorThread* thread)
   //start stuff
   for(gc_set(ThreadTask*)::iterator it = m_StartTasks.begin(); it!=m_StartTasks.end(); ++it)
     threadSupervisor->_i_startTask(*it,this);
-  m_Mutex.unlock();
 }
 
 SupervisorThread::SupervisorThread(int localThreadId):m_KeepRunning(true),m_LocalThreadId(localThreadId)

--- a/M2/Macaulay2/system/supervisor.hpp
+++ b/M2/Macaulay2/system/supervisor.hpp
@@ -56,10 +56,11 @@ struct ThreadTask
   pthreadMutex m_Mutex;
   ///run task
   void run(SupervisorThread* thread);
-  ///Condition variable for task
+  ///Condition variable for task done or canceled
   pthread_cond_t m_FinishCondition;
   ///Current thread running on
   SupervisorThread* m_CurrentThread;
+  ///Wait until the task is done or canceled
   void* waitOn();
 };
 
@@ -134,8 +135,8 @@ struct ThreadSupervisor
   std::list<ThreadTask*> m_CanceledTasks;
   ///mutex for accessing lists
   pthreadMutex m_Mutex;
-  ///new task waiting
-  pthread_cond_t m_TaskWaitingCondition;
+  ///new task ready to run
+  pthread_cond_t m_TaskReadyToRunCondition;
   ///list of supervisor threads
   std::list<SupervisorThread*> m_Threads;
   ///set of initialized pointers

--- a/M2/Macaulay2/system/supervisorinterface.h
+++ b/M2/Macaulay2/system/supervisorinterface.h
@@ -31,7 +31,7 @@ extern "C" {
   struct ThreadTask;
   extern void setInterpThread();
   extern int tryGlobalInterrupt(), tryGlobalAlarm(), tryGlobalTrace();
-  extern void* waitOnTask(struct ThreadTask* task);
+  extern void* waitOnTask(struct ThreadTask* task);	// wait until done or canceled
   extern void addCancelTask(struct ThreadTask* task, struct ThreadTask* cancel);
   extern void pushTask(struct ThreadTask* task);
   extern void addStartTask(struct ThreadTask* task, struct ThreadTask* start);

--- a/M2/Macaulay2/tests/CMakeLists.txt
+++ b/M2/Macaulay2/tests/CMakeLists.txt
@@ -103,7 +103,7 @@ add_custom_target(M2-tests-ComputationsBook)
 set(CHAPTERS completeIntersections constructions d-modules exterior-algebra geometry
   monomialIdeals preface programming schemes solving toricHilbertScheme varieties)
 
-set(M2_ARGS -q --stop --print-width 0)
+set(M2_ARGS -q --stop --print-width 0 --silent)
 
 foreach(_chapter IN LISTS CHAPTERS)
 
@@ -124,7 +124,7 @@ foreach(_chapter IN LISTS CHAPTERS)
   ###############################################################################
   # we depend on "diff" accepting some options that perhaps only GNU diff does
   add_custom_target(M2-tests-ComputationsBook-${_chapter}
-    COMMAND ${M2} ${M2_ARGS} -e path=${M2_PATH} -e ${M2_TEST_STRING} -e "exit 0" > test.out
+    COMMAND ${M2} ${M2_ARGS} -e path=${M2_PATH} -e ${M2_TEST_STRING} -e "exit 0" > test.out 2>&1
     COMMAND sed -f ${book_patterns} -f ${chapter_patterns} > test.out.trim < test.out
     COMMAND sed -f ${book_patterns} -f ${chapter_patterns} > test.out.expected.trim
       < ${CMAKE_CURRENT_SOURCE_DIR}/${_group}/test.out.expected

--- a/M2/Macaulay2/tests/ComputationsBook/Makefile.chapter.in
+++ b/M2/Macaulay2/tests/ComputationsBook/Makefile.chapter.in
@@ -43,7 +43,7 @@ test.out.expected.trim: $(EXPECTED) $(book_patterns) $(chapter_patterns)
 	@<$< sed -f $(book_patterns) -f $(chapter_patterns) >$@
 
 test.out: test.m2 always
-	@$(LIMIT) $(M2CMD) $(INPUT) $(EXIT) >test.out.tmp
+	@$(LIMIT) $(M2CMD) $(INPUT) $(EXIT) >test.out.tmp 2>&1
 	@mv test.out.tmp test.out
 
 clean:; rm -f *.trim

--- a/M2/Macaulay2/tests/ComputationsBook/constructions/test.out.expected
+++ b/M2/Macaulay2/tests/ComputationsBook/constructions/test.out.expected
@@ -308,8 +308,8 @@ i30 : K=ZZ/13;
 i31 : R=K[x_0..x_6];
 
 i32 : time b=randomModule2ForDeg17CY(8,R);
-     -- Trial n. 759, k=8
      -- used 12.3878 seconds
+     -- Trial n. 759, k=8
 
               3      16
 o32 : Matrix R  <-- R

--- a/M2/Macaulay2/tests/ComputationsBook/patterns
+++ b/M2/Macaulay2/tests/ComputationsBook/patterns
@@ -4,7 +4,7 @@
 # s//\n/
 
 # wipe out execution timing results
-s/-- used [0-9.][0-9.e-]* seconds/-- used XXX seconds/g
+s/-- used [0-9.][0-9.e-]* *s.*/-- used XXX seconds/g
 s/-- [0-9.][0-9.e-]* seconds/-- XXX seconds/g
 
 # Wipe out source code line numbers, which may change.  The format used by "code" may also change.
@@ -36,3 +36,6 @@ s/\$\([[:alpha:]]\)/\1/g
 /^--changing factory characteristic \(back \)\{0,1\}from [0-9][0-9]* to [0-9][0-9]*$/d
 /^--setting factory rational mode \(back \)\{0,1\}on$/d
 /^--setting factory rational mode \(back \)\{0,1\}off$/d
+
+# GC warnings
+/GC Warning:.*/d

--- a/M2/Macaulay2/tests/normal/threads.m2
+++ b/M2/Macaulay2/tests/normal/threads.m2
@@ -43,6 +43,48 @@ print (currentTime()-c)
 -- to come before the files d/*.o on the linker command line.
 assert ( maxAllowableThreads != 0 )
 
+-- thread modes
+restoremode = i -> (
+    if i == 0 then setIOUnSynchronized()
+    else if i == 1 then setIOSynchronized()
+    else if i == 2 then setIOExclusive()
+    else error "unknown thread mode")
+
+origmode = getIOThreadMode()
+
+setIOExclusive()
+setIOUnSynchronized()
+assert Equation(getIOThreadMode(), 0)
+assert Equation(getIOThreadMode stdio, 0)
+assert Equation(getIOThreadMode stderr, 0)
+
+setIOSynchronized()
+assert Equation(getIOThreadMode(), 1)
+assert Equation(getIOThreadMode stdio, 1)
+assert Equation(getIOThreadMode stderr, 1)
+
+setIOExclusive()
+assert Equation(getIOThreadMode(), 2)
+assert Equation(getIOThreadMode stdio, 2)
+assert Equation(getIOThreadMode stderr, 2)
+
+restoremode origmode
+
+fn = temporaryFileName()
+f = fn << "foo" << close
+
+setIOExclusive f
+setIOUnSynchronized f
+assert Equation(getIOThreadMode f, 0)
+
+setIOSynchronized f
+assert Equation(getIOThreadMode f, 1)
+
+setIOExclusive f
+assert Equation(getIOThreadMode f, 2)
+
+removeFile fn
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test threads.out"
 -- End:

--- a/M2/Macaulay2/tests/normal/threads.m2
+++ b/M2/Macaulay2/tests/normal/threads.m2
@@ -11,19 +11,16 @@ assert not isReady t
 
 -- check whether we can get the result of a thread's computation: a function
 t = schedule ( () -> 2+2 )
-while not isReady t do nothing
 assert( 4 === taskResult t )
 
 -- check whether we can get the result of a thread's computation: a function with an argument
 t = schedule ( x -> x+2, 2 )
-while not isReady t do nothing
 assert( 4 === taskResult t )
 
 -- check whether thread local variables have separate values in separate threads
 threadVariable aaa
 assert( aaa === null )
 r = apply(3, i -> schedule (() -> ( aaa = i ; sleep 3 ; aaa )))
-while not all(r,isReady) do sleep 1
 assert( {0,1,2} == taskResult \ r )
 assert( aaa === null )
 

--- a/M2/include/M2/gc-include.h
+++ b/M2/include/M2/gc-include.h
@@ -39,7 +39,7 @@
    * to appear before we include gc.h, in order to take effect
    */
   // #define GC_FREE_SPACE_DIVISOR 12
-  #define GC_INITIAL_HEAP_SIZE 70000000
+  #define GC_INITIAL_HEAP_SIZE 70000000	// may be overridden in e.g. bin/main.cpp
 
   #include <gc/gc.h>
 

--- a/M2/include/M2/gc-include.h
+++ b/M2/include/M2/gc-include.h
@@ -38,7 +38,7 @@
    * these two macros affect the definition of GC_INIT, but have
    * to appear before we include gc.h, in order to take effect
    */
-  #define GC_FREE_SPACE_DIVISOR 12
+  // #define GC_FREE_SPACE_DIVISOR 12
   #define GC_INITIAL_HEAP_SIZE 70000000
 
   #include <gc/gc.h>

--- a/M2/libraries/gc/patch-8.0.4
+++ b/M2/libraries/gc/patch-8.0.4
@@ -16,3 +16,14 @@ diff -ur /Users/dan/src/M2/M2.git/M2/BUILD/dan/builds.tmp/gallium-master/librari
  #include <CoreFoundation/CoreFoundation.h>
  
  /* From "Inside Mac OS X - Mach-O Runtime Architecture" published by Apple
+--- gc-8.0.4/mallocx.c	2024-02-09 21:01:29.914830890 -0500
++++ gc-8.0.4/mallocx.c	2024-02-09 21:01:40.854964129 -0500
+@@ -470,7 +470,7 @@ GC_API void GC_CALL GC_generic_malloc_ma
+ 
+     /* As a last attempt, try allocating a single object.  Note that    */
+     /* this may trigger a collection or expand the heap.                */
+-      op = GC_generic_malloc_inner(lb, k);
++      op = GC_generic_malloc_inner(lb - EXTRA_BYTES, k);
+       if (0 != op) obj_link(op) = 0;
+ 
+   out:


### PR DESCRIPTION
This branch includes a number of improvements to Macaulay2's code related to parallelization, primarily by @DaveBarton.  The work began at the AIM workshop ["Macaulay2: expanded functionality and improved efficiency"](https://aimath.org/pastworkshops/macaulay2efie.html) last fall.

Improvements include:

* Changed initial value of `currentAllowedThreads` from 2 to 4 to 5, added 1 to `maxAllowableThreads`
* Use default `GC_FREE_SPACE_DIVISOR` of 3 not 12, initial heap size 70MB -> 150MB + `maxAllowableThreads` * 8MB
* `elapsedTime`: also show process, thread, gc time.  Also change `cpuTime()` to return process, not thread, time.
* Have `taskResult()` wait for the task to finish
* Added `parallelApply` - make it take `allowableThreads` as an optional parameter!?
* Comment out some `GC_FREE()`s
* Add patch for GC bug fix
* Add `getThreadIOMode` function and improve the existing `setIO*` functions