### PR TITLE
Remove unncessary hash counter increments

### DIFF
--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -257,6 +257,7 @@ makenew(classs:HashTable,parent:HashTable):Expr := (
 		    break;
 		    );
 	       if p == mutableHashTableClass then (
+		    o.hash = nextHash();
 		    break;
 		    );
 	       if p == cacheTableClass then (

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1873,7 +1873,7 @@ foreach s in syms do storeInHashTable(
 storeE = nullE;
 syms = SymbolSequence();
 
-export fileDictionaries := newHashTable(mutableHashTableClass,nothingClass);
+export fileDictionaries := newHashTableWithHash(mutableHashTableClass,nothingClass);
 setupconst("fileDictionaries",Expr(fileDictionaries));
 
 export newStaticLocalDictionaryClosure(filename:string):DictionaryClosure := (

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -2,7 +2,7 @@
 -- put bindings to variables before the forward references, for safety
 use hashtables;
 use convertr;
-export globalAssignmentHooks := newHashTable(mutableHashTableClass,nothingClass);
+export globalAssignmentHooks := newHashTableWithHash(mutableHashTableClass,nothingClass);
 setupconst("globalAssignmentHooks",Expr(globalAssignmentHooks));
 export evalSequenceHadError := false;
 export evalSequenceErrorMessage := nullE;

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -164,11 +164,15 @@ export newHashTable(Class:HashTable,parent:HashTable):HashTable := (
 	  -- we start with four empty buckets.  It is important for the 
 	  -- enlarge/shrink code in hashtable.dd that the number of buckets
 	  -- (here four) is a power of two
-	  Class,parent,0,nextHash(),
+	  Class,parent,0,0,
 	  true,				  -- mutable by default; careful: other routines depend on this
 	  false,
 	  uninitializedSpinLock
 	  ); init(ht.mutex); ht);
+export newHashTableWithHash(Class:HashTable,parent:HashTable):HashTable := (
+       ht:=newHashTable(Class,parent);
+       ht.hash=nextHash();
+       ht);
 
 export newCompiledFunction(fn:fun):CompiledFunction := (
     cf := CompiledFunction(fn, 0);
@@ -244,14 +248,14 @@ export thingClass := (
           true,false, uninitializedSpinLock);
 	  init(ht.mutex); ht);
 
-export hashTableClass := newHashTable(thingClass,thingClass);
-export mutableHashTableClass := newHashTable(thingClass,hashTableClass);
-export typeClass := newHashTable(mutableHashTableClass,mutableHashTableClass);
+export hashTableClass := newHashTableWithHash(thingClass,thingClass);
+export mutableHashTableClass := newHashTableWithHash(thingClass,hashTableClass);
+export typeClass := newHashTableWithHash(mutableHashTableClass,mutableHashTableClass);
        thingClass.Class = typeClass;
        typeClass.Class = typeClass;
        mutableHashTableClass.Class = typeClass;
        hashTableClass.Class = typeClass;
-       newtypeof(parent:HashTable):HashTable := newHashTable(typeClass,parent);
+       newtypeof(parent:HashTable):HashTable := newHashTableWithHash(typeClass,parent);
        newbasictype():HashTable := newtypeof(thingClass);
 export cacheTableClass := newtypeof(mutableHashTableClass);
 export basicListClass := newbasictype();
@@ -294,13 +298,13 @@ export ringElementClass := newtypeof(basicListClass);
 export numberClass := newtypeof(thingClass);
 export inexactNumberClass := newtypeof(numberClass);
 
-       newnumbertype():HashTable := newHashTable(ringClass,numberClass);
+       newnumbertype():HashTable := newHashTableWithHash(ringClass,numberClass);
 export ZZClass := newnumbertype();
 export QQClass := newnumbertype();
 
 export ringFamilyClass := newtypeof(typeClass);
 export inexactNumberTypeClass := newtypeof(ringFamilyClass);
-       newbignumbertype():HashTable := newHashTable(inexactNumberTypeClass,inexactNumberClass);
+       newbignumbertype():HashTable := newHashTableWithHash(inexactNumberTypeClass,inexactNumberClass);
 export RRClass := newbignumbertype();
 export CCClass := newbignumbertype();
 

--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -373,7 +373,7 @@ ernary(n:int):string := (
      else if n == 1 then "unary"
      else tostring(n)+"-ary");
 
-export typicalValues := newHashTable(mutableHashTableClass,nothingClass);
+export typicalValues := newHashTableWithHash(mutableHashTableClass,nothingClass);
 messx := "expected method to be a function or TYPE => function'";
 installIt(numtypes:int,assgnmt:bool,h:HashTable,key:Expr,value:Expr):Expr := (
      when value
@@ -399,7 +399,7 @@ installIt(numtypes:int,assgnmt:bool,h:HashTable,key:Expr,value:Expr):Expr := (
      else buildErrorPacket(messx));
 -----------------------------------------------------------------------------
 -- nullary methods
-export NullaryMethods := newHashTable(mutableHashTableClass,nothingClass);
+export NullaryMethods := newHashTableWithHash(mutableHashTableClass,nothingClass);
 setupconst("nullaryMethods",Expr(NullaryMethods));
 export lookup(e:Expr):Expr := (
      r := lookup1(NullaryMethods,Expr(Sequence(e)));

--- a/M2/Macaulay2/d/sets.dd
+++ b/M2/Macaulay2/d/sets.dd
@@ -2,7 +2,7 @@
 use hashtables;
 use evaluate;
 
-newtypeof(parent:HashTable):HashTable := newHashTable(typeClass,parent);
+newtypeof(parent:HashTable):HashTable := newHashTableWithHash(typeClass,parent);
 export VirtualTally := newtypeof(hashTableClass);
 setupconst("VirtualTally",Expr(VirtualTally));
 export Tally := newtypeof(VirtualTally);


### PR DESCRIPTION
Right now every call to `newHashTable` will increase the hash counter, even if it is not needed -- say if the hash table is unmutable or a cache. This causes massive inflation of the hash counter, leading to the dreaded `hash code serial number counter overflow`. The simple fix in this PR empirically divides by 4 the hash counter increase in examples.