### PR TITLE
Add iterator support for "take" with list as 2nd argument

### DIFF
--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1133,7 +1133,7 @@ take(e:Expr):Expr := (
 	      is n:ZZcell do (
 		  if !isInt(n) then return WrongArgSmallInteger(2);
 		  m := toInt(n);
-		  if m < 0 then return WrongArg(2, "a positive integer");
+		  if m < 0 then return WrongArg(2, "a nonnegative integer");
 		  if m == 0 then return Expr(emptyList);
 		  r := new Sequence len m do provide nullE;
 		  j := 0;

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1129,31 +1129,58 @@ take(e:Expr):Expr := (
 	      if nextfunc == nullE
 	      then return buildErrorPacket(
 		  "no method for applying next to iterator");
+	      start := 0;
+	      stop := 0;
 	      when args.1
 	      is n:ZZcell do (
 		  if !isInt(n) then return WrongArgSmallInteger(2);
-		  m := toInt(n);
-		  if m < 0 then return WrongArg(2, "a nonnegative integer");
-		  if m == 0 then return Expr(emptyList);
-		  r := new Sequence len m do provide nullE;
-		  j := 0;
-		  y := nullE;
-		  while (
-		      y = applyEE(nextfunc, iter);
-		      when y
-		      is Error do return returnFromFunction(y)
-		      else nothing;
-		      y != StopIterationE)
-		  do (
-		      r.j = y;
-		      j = j + 1;
-		      if j == m then break);
-		  Expr(list(
-			  if j == 0 then emptySequence
-			  else if j == m then r
-			  else new Sequence len j do (
-			      foreach x in r do provide x))))
-	      else WrongArgZZ(2)))
+		  stop = toInt(n);
+		  if stop < 0 then return WrongArg(2, "a nonnegative integer");
+		  if stop == 0 then return list())
+	      is x:List do (
+		  ok := true;
+		  if length(x.v) == 2 then (
+		      when x.v.0
+		      is a:ZZcell do (
+			  when x.v.1
+			  is b:ZZcell do (
+			      if !isInt(a) || !isInt(b)
+			      then ok = false
+			      else (
+				  start = toInt(a);
+				  stop = toInt(b) + 1))
+			  else ok = false)
+		      else ok = false)
+		  else ok = false;
+		  if !ok
+		  then return WrongArg(2, "a list of two small integers"))
+	      else return WrongArg(2, "an integer or list of integers");
+	      if stop < start then return list();
+	      j := 0;
+	      y := nullE;
+	      while (j < start && y != StopIterationE)
+	      do (
+		  y = applyEE(nextfunc, iter);
+		  when y
+		  is Error do return returnFromFunction(y)
+		  else nothing;
+		  j = j + 1);
+	      r := new Sequence len stop - start do provide nullE;
+	      while (
+		  y = applyEE(nextfunc, iter);
+		  when y
+		  is Error do return returnFromFunction(y)
+		  else nothing;
+		  y != StopIterationE)
+	      do (
+		  r.(j - start) = y;
+		  j = j + 1;
+		  if j == stop then break);
+	      list(
+		      if j < start then emptySequence
+		      else if j == stop then r
+		      else new Sequence len j - start do (
+			  foreach x in r do provide x))))
      else WrongNumArgs(2)
      else WrongNumArgs(2));
 setupfun("take",take);

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -69,7 +69,7 @@ concatenate Nothing := concatenate String := concatenate Symbol := concatenate Z
 deepSplice BasicList := BasicList => deepSplice
 drop(BasicList,ZZ) := drop(BasicList,List) := BasicList => drop
 take(BasicList,ZZ) := take(BasicList,List) := BasicList => take
-take(Thing,ZZ) := List => take
+take(Thing,ZZ) := take(Thing,List) := List => take
 get File := get String := String => get
 getc File := String => getc
 getenv String := String => getenv

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/take-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/take-doc.m2
@@ -7,6 +7,7 @@ doc ///
   (take, BasicList, ZZ)
   (take, BasicList, List)
   (take, Thing, ZZ)
+  (take, Thing, List)
  Headline
   Take some elements from a list or sequence.
  Usage
@@ -44,6 +45,7 @@ doc ///
   Example
    take("Hello, world!", 5)
    take("Hello, world!", 20)
+   take("Hello, world!", {7, 11})
  SeeAlso
   drop
   select

--- a/M2/Macaulay2/tests/normal/iterators.m2
+++ b/M2/Macaulay2/tests/normal/iterators.m2
@@ -37,6 +37,7 @@ assert Equation(fold(plus, next i, i), 77)
 assert Equation(take(P, 0), {})
 assert Equation(take(P, 5), {2, 3, 5, 7, 11})
 assert Equation(take(P, 20), {2, 3, 5, 7, 11, 13, 17, 19})
+assert Equation(take(P, {2, 5}), {5, 7, 11, 13})
 
 assert Equation(toList iterator {1, 2, 3}, {1, 2, 3})
 assert Equation(toList iterator (1, 2, 3), {1, 2, 3})


### PR DESCRIPTION
Currently, `take(x, i)` works when `x` is a non-list iterable object and `i` is an integer, e.g.:

```m2
i1 : take("Hello, world!", 5)

o1 = {H, e, l, l, o}

o1 : List

i2 : take(iterator(1..10), 5)

o2 = {1, 2, 3, 4, 5}

o2 : List
```

However, `take(x, {j, k})` only works when `x` is a basic list:

```m2
i1 : take(1..10, {3, 7})

o1 = (4, 5, 6, 7, 8)

o1 : Sequence

i2 : take("Hello, world!", {3, 7})
stdio:2:1:(3): error: expected argument 2 to be an integer

i3 : take(iterator(1..10), {3, 7})
stdio:3:1:(3): error: expected argument 2 to be an integer
```

This PR adds support for `take(x, {j, k})` when `x` is any iterable object:

```m2
i1 : take("Hello, world!", {3, 7})

o1 = {l, o, ,,  , w}

o1 : List

i2 : take(iterator(1..10), {3, 7})

o2 = {4, 5, 6, 7, 8}

o2 : List
```