### PR TITLE
Certify packages published in JSAG volume 14

### DIFF
--- a/.codespell_ignore
+++ b/.codespell_ignore
@@ -12,6 +12,7 @@ bloks
 braket
 bu
 comon
+conet
 coo
 damon
 debugg

--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -269,3 +269,4 @@ PlaneCurveLinearSeries
 Valuations
 SchurVeronese
 VNumber
+TropicalToric

--- a/M2/Macaulay2/packages/CotangentSchubert.m2
+++ b/M2/Macaulay2/packages/CotangentSchubert.m2
@@ -11,7 +11,20 @@ newPackage(
     PackageImports => {"VectorGraphics"},
     AuxiliaryFiles => true,
     DebuggingMode => false,
-    Configuration => { "Factor" => false, "PuzzleSize" => 7 }
+    Configuration => { "Factor" => false, "PuzzleSize" => 7 },
+    Certification => {
+	"journal name" => "Journal of Software for Algebra and Geometry",
+	"journal URI" => "https://msp.org/jsag/",
+	"article title" => "The CotangentSchubert Macaulay2 package",
+	"acceptance date" => "2024-02-06",
+	"published article URI" => "https://msp.org/jsag/2024/14-1/p09.xhtml",
+	"published code URI" => "https://msp.org/jsag/2024/14-1/jsag-v14-n1-x09-CotangentSchubert.m2",
+	"repository code URI" => "http://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/CotangentSchubert.m2",
+	"release at publication" => "6a750d5611ff9685a31e1eb4e176bb71b6842a58",
+	"version at publication" => "0.63",
+	"volume number" => "14",
+	"volume URI" => "https://msp.org/jsag/2024/14-1/"
+	}
     )
 
 if (options CotangentSchubert).Configuration#"Factor" then needsPackage "Factor" else factor PolynomialRing := opts -> identity;

--- a/M2/Macaulay2/packages/GeometricDecomposability.m2
+++ b/M2/Macaulay2/packages/GeometricDecomposability.m2
@@ -18,7 +18,20 @@ newPackage(
                 }
                 },
         Keywords => {"Commutative Algebra"},
-        PackageImports => {"Depth", "PrimaryDecomposition"}
+        PackageImports => {"Depth", "PrimaryDecomposition"},
+	Certification => {
+	    "journal name" => "Journal of Software for Algebra and Geometry",
+	    "journal URI" => "https://msp.org/jsag/",
+	    "article title" => "The GeometricDecomposability package for Macaulay2",
+	    "acceptance date" => "2024-01-23",
+	    "published article URI" => "https://msp.org/jsag/2024/14-1/p06.xhtml",
+	    "published code URI" => "https://msp.org/jsag/2024/14-1/jsag-v14-n1-x06-GeometricDecomposability.m2",
+	    "repository code URI" => "http://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/GeometricDecomposability.m2",
+	    "release at publication" => "d29b1075986232868a6460344ad708dbddbdd29b",
+	    "version at publication" => "1.2",
+	    "volume number" => "14",
+	    "volume URI" => "https://msp.org/jsag/2024/14-1/"
+	    }
         )
 
 export {

--- a/M2/Macaulay2/packages/InvariantRing.m2
+++ b/M2/Macaulay2/packages/InvariantRing.m2
@@ -40,17 +40,17 @@ newPackage(
         Headline => "invariants of group actions",
 	Keywords => {"Representation Theory", "Group Theory"},
 	Certification => {
-	     "journal name" => "The Journal of Software for Algebra and Geometry",
-	     "journal URI" => "http://j-sag.org/",
-	     "article title" => "Computing the invariant ring of a finite group",
-	     "acceptance date" => "2013-05-16",
-	     "published article URI" => "http://j-sag.org/Volume5/jsag-3-2013.pdf",
-	     "published code URI" => "http://j-sag.org/Volume5/InvariantRing.m2",
+	     "journal name" => "Journal of Software for Algebra and Geometry",
+	     "journal URI" => "https://msp.org/jsag/",
+	     "article title" => "The InvariantRing package for Macaulay2",
+	     "acceptance date" => "2023-09-14",
+	     "published article URI" => "https://msp.org/jsag/2024/14-1/p02.xhtml",
+	     "published code URI" => "https://msp.org/jsag/2024/14-1/jsag-v14-n1-x02-InvariantRing.m2",
 	     "repository code URI" => "http://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/InvariantRing.m2",
-	     "release at publication" => "68f41d641fadb0a1054023432eb60177f1d7cbd9",
-	     "version at publication" => "1.1.0",
-	     "volume number" => "5",
-	     "volume URI" => "http://j-sag.org/Volume5/"
+	     "release at publication" => "d708862d93052a37b7f9ff1e584a9b57d1cb7870",
+	     "version at publication" => "2.0",
+	     "volume number" => "14",
+	     "volume URI" => "https://msp.org/jsag/2024/14-1/"
 	     },
 	AuxiliaryFiles => true,
         DebuggingMode => false

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -5,7 +5,7 @@ star := IMG { "src" => replace("PKG","Style",currentLayout#"package") | "GoldSta
 document {
      Key => "changes to Macaulay2, by version",
      Subnodes => {
---	  TO "changes made for the next release",
+	  TO "changes made for the next release",
 	  TO "changes, 1.23",
 	  TO "changes, 1.22",
 	  TO "changes, 1.21",
@@ -38,6 +38,28 @@ document {
 	  TO "list of obsolete functions"
 	  }
      }
+
+document {
+    Key => "changes made for the next release",
+    UL {
+	LI { "packages that have been published and certified:",
+	    UL {
+		LI { star, " ", TO "CotangentSchubert::CotangentSchubert", ", a package by Paul Zinn-Justin for Cotangent Schubert calculus, has been published." },
+		LI { star, " ", TO "GeometricDecomposability::GeometricDecomposability", ", a package by Mike Cummings and Adam Van Tuyl to check whether ideals are geometrically vertex decomposable, has been published." },
+		LI { star, " ", TO "InvariantRing::InvariantRing", ", a package by Luigi Ferraro, Federico Galetto, Francesca Gandini, Hang Huang, Thomas Hawes, Matthew Mastroeni, and Xianglong Ni for invariants of group actions, has been published." },
+		LI { star, " ", TO "MultiplicitySequence::MultiplicitySequence", ", a package by Justin Chen, Youngsu Kim, and Jonathan Montaño for computing the multiplicity sequence of an ideal, has been published." },
+		LI { star, " ", TO "Probability::Probability", ", a package by Doug Torrance for basic probability functions, has been published." },
+		LI { star, " ", TO "TropicalToric::TropicalToric", ", a package by Alessio Borzì on tropical methods for toric intersection theory, has been published." }
+		}
+	    },
+	LI { "new packages:",
+	    UL {
+		LI { TO "TropicalToric::TropicalToric", ", a package by Alessio Borzì on tropical methods for toric intersection theory, has been added." },
+		LI { TO "VNumber::VNumber", ", a package by Antonino Ficarra and Emanuele Sgroi to compute v-number of homogeneous ideals and v-function of monomial ideals, has been added." }
+		}
+	    }
+	}
+    }
 
 document {
      Key => "changes, 1.23",

--- a/M2/Macaulay2/packages/MultiplicitySequence.m2
+++ b/M2/Macaulay2/packages/MultiplicitySequence.m2
@@ -24,7 +24,20 @@ newPackage(
         "Normaliz",
         "PrimaryDecomposition",
         "MinimalPrimes"
-    }
+    },
+    Certification => {
+	"journal name" => "Journal of Software for Algebra and Geometry",
+	"journal URI" => "https://msp.org/jsag/",
+	"article title" => "Computing multiplicity sequences",
+	"acceptance date" => "2023-10-31",
+	"published article URI" => "https://msp.org/jsag/2024/14-1/p03.xhtml",
+	"published code URI" => "https://msp.org/jsag/2024/14-1/jsag-v14-n1-x03-MultiplicitySequence.m2",
+	"repository code URI" => "http://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/MultiplicitySequence.m2",
+	"release at publication" => "6a750d5611ff9685a31e1eb4e176bb71b6842a58",
+	"version at publication" => "0.7",
+	"volume number" => "14",
+	"volume URI" => "https://msp.org/jsag/2024/14-1/"
+	}
 )
 
 export {

--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -24,7 +24,21 @@ newPackage("Probability",
 	    Name     => "Doug Torrance",
 	    Email    => "dtorrance@piedmont.edu",
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
-    Keywords => {"Algebraic Statistics"})
+    Keywords => {"Algebraic Statistics"},
+    Certification => {
+	"journal name" => "Journal of Software for Algebra and Geometry",
+	"journal URI" => "https://msp.org/jsag/",
+	"article title" => "The Probability package for Macaulay2",
+	"acceptance date" => "2024-01-23",
+	"published article URI" => "https://msp.org/jsag/2024/14-1/p07.xhtml",
+	"published code URI" => "https://msp.org/jsag/2024/14-1/jsag-v14-n1-x07-Probability.m2",
+	"repository code URI" => "http://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/Probability.m2",
+	"release at publication" => "fe3f536ed3c90d114452e31a24fc3a935a3b9ca3",
+	"version at publication" => "0.3",
+	"volume number" => "14",
+	"volume URI" => "https://msp.org/jsag/2024/14-1/"
+	}
+    )
 
 ---------------
 -- ChangeLog --

--- a/M2/Macaulay2/packages/TropicalToric.m2
+++ b/M2/Macaulay2/packages/TropicalToric.m2
@@ -23,7 +23,20 @@ newPackage(
 	AuxiliaryFiles => true,
 	CacheExampleOutput => true,
   OptionalComponentsPresent => true,
-  UseCachedExampleOutput => true
+  UseCachedExampleOutput => true,
+  Certification => {
+      "journal name" => "Journal of Software for Algebra and Geometry",
+      "journal URI" => "https://msp.org/jsag/",
+      "article title" => "Tropical computations for toric intersection theory in Macaulay2",
+      "acceptance date" => "2023-09-14",
+      "published article URI" => "https://msp.org/jsag/2024/14-1/p04.xhtml",
+      "published code URI" => "https://msp.org/jsag/2024/14-1/jsag-v14-n1-x04-TropicalToric.zip",
+      "repository code URI" => "http://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/TropicalToric.m2",
+      "release at publication" => "9ef0931eee637fc1fd9f377b35e91f4c14309a7c",
+      "version at publication" => "1.0",
+      "volume number" => "14",
+      "volume URI" => "https://msp.org/jsag/2024/14-1/"
+      }
 )
 
 export{

--- a/M2/Macaulay2/packages/TropicalToric.m2
+++ b/M2/Macaulay2/packages/TropicalToric.m2
@@ -1,0 +1,85 @@
+newPackage(
+  "TropicalToric",
+	Version => "1.0",
+	Date => "May 2022",
+	Authors => {
+   		{
+        Name => "Alessio Borzì",
+        Email => "Alessio.Borzi@warwick.ac.uk",
+        HomePage=>"https://alessioborzi.github.io"
+      }
+  },
+	Headline => "A package on tropical methods for toric intersection theory",
+	Configuration => {},
+  PackageExports => {
+    "NormalToricVarieties",
+    "Tropical",
+    "Package$gfanInterface"
+  },
+  PackageImports => {
+    "FourierMotzkin"
+  },
+	DebuggingMode => true,
+	AuxiliaryFiles => true,
+	CacheExampleOutput => true,
+  OptionalComponentsPresent => true,
+  UseCachedExampleOutput => true
+)
+
+export{
+  --types
+  "ToricCycle",
+
+  --functions / methods
+  "toricCycle",
+  "makeTransverse",
+  "isTransverse",
+  "degCycle",
+  "toricDivisorFromCycle",
+  "refineMultiplicity",
+  "pushforwardMultiplicity",
+  "poincareMatrix",
+  "poincareDuality",
+  "classFromTropical",
+  "classWonderfulCompactification",
+  "torusIntersection",
+  "classFromTropicalCox",
+  "polymakeConeContains",
+
+  --symbols
+  "PoincareMatrix"
+}
+
+protect maxRayList;
+protect cycleSupport;
+protect PicardBases;
+protect RaysMatrix;
+protect RaysMatrixRank;
+
+------------------------------------------------------------------------------
+-- CODE
+------------------------------------------------------------------------------
+
+load "TropicalToric/ToricCycle.m2";
+load "TropicalToric/ToricPullback.m2";
+load "TropicalToric/TropicalToricCode.m2";
+load "TropicalToric/polymakeContains.m2";
+
+------------------------------------------------------------------------------
+-- DOCUMENTATION
+------------------------------------------------------------------------------
+
+beginDocumentation()
+
+load "TropicalToric/ToricCycleDoc.m2";
+load "TropicalToric/TropicalToricDoc.m2";
+load "TropicalToric/polymakeContainsDoc.m2";
+
+------------------------------------------------------------------------------
+-- TESTS
+------------------------------------------------------------------------------
+
+load "TropicalToric/ToricCycleTest.m2";
+load "TropicalToric/TropicalToricTest.m2";
+
+end

--- a/M2/Macaulay2/packages/TropicalToric/README.md
+++ b/M2/Macaulay2/packages/TropicalToric/README.md
@@ -1,0 +1,33 @@
+# TropicalToric
+A [Macaulay2](http://www2.macaulay2.com/Macaulay2/) package for toric intersection theory using tropical geometry.
+## Installation
+[Download](https://github.com/AlessioBorzi/TropicalToric/archive/refs/heads/main.zip) the package, extract it. Open a terminal and `cd` to the extracted folder, open Macaulay2 and install the package with
+```
+installPackage "TropicalToric"
+```
+## Example
+First, load the package with
+```
+needsPackage "TropicalToric"
+```
+As an example, we can compute the class of a line in the projective plane
+```
+X = toricProjectiveSpace 2;
+R = QQ[x,y];
+I = ideal(x+y+1);
+L = classFromTropical(X,I)
+```
+We can compute intersection products of a toric divisor and a toric cycle and their intersection number
+```
+C = X_0 * X_{0}
+degCycle(C)
+```
+## Documentation
+For more information, access the documentation with the `help` command
+```
+help TropicalToric
+```
+or using a browser with
+```
+viewHelp TropicalToric
+```

--- a/M2/Macaulay2/packages/TropicalToric/ToricCycle.m2
+++ b/M2/Macaulay2/packages/TropicalToric/ToricCycle.m2
@@ -1,0 +1,299 @@
+ToricCycle = new Type of HashTable
+ToricCycle.synonym = "toric cycle"
+debug Core --- kludge to access "hasAttribute" and getAttribute
+
+------------------------------------------------------------------------------
+-- Expression
+------------------------------------------------------------------------------
+
+expression ToricCycle := Expression => C ->(
+  X := variety C;
+  divisorSymbol :=
+    if hasAttribute(X,ReverseDictionary) then
+      expression toString getAttribute(X,ReverseDictionary)
+    else
+      expression "V";
+  S := support C;
+  if S == {} then
+    return expression 0;
+  Sum apply(S, j ->(
+    coeff := expression abs(C#j);
+    if C#j == -1 then
+      Minus Subscript{divisorSymbol, j}
+    else if C#j < 0 then
+      Minus {coeff * Subscript{divisorSymbol, j}}
+    else if C#j == 1 then
+      Subscript{divisorSymbol, j}
+    else coeff * Subscript{divisorSymbol, j}
+    )
+  )
+);
+
+net ToricCycle := C -> net expression C
+ToricCycle#{Standard,AfterPrint} =
+ToricCycle#{Standard,AfterNoPrint} = C ->(
+    << endl; -- double space
+    << concatenate(interpreterDepth:"o") << lineNumber << " : ToricCycle on ";
+    << variety C << endl;
+);
+
+------------------------------------------------------------------------------
+-- Methods and constructors
+------------------------------------------------------------------------------
+
+variety ToricCycle := C -> C.variety;
+
+support ToricCycle := C -> C.cycleSupport;
+
+toricCycle = method(TypicalValue => ToricCycle)
+toricCycle (List, List, NormalToricVariety) := (L,S,X) ->(
+  new ToricCycle from L | {
+    symbol variety => X,
+    symbol cycleSupport => S,
+    symbol cache => new CacheTable
+  }
+);
+toricCycle (List, NormalToricVariety) := (L,X) ->(
+  S := new List;
+  for t in L do (
+    if t#1 != 0 then(
+      S = S | {t#0};
+    ) else(
+      continue
+    );
+  );
+  toricCycle(L,S,X)
+);
+
+ToricCycle _ List := ToricCycle => (D,L) ->(
+  if member(L,keys D) then(
+    return D#L
+  ) else(
+    return 0
+  )
+);
+
+ToricCycle _ ZZ := ToricCycle => (D,i) -> D_{i};
+
+NormalToricVariety _ List := (X,L) ->(
+  S := {sort L};
+  toricCycle({S_0 => 1}, S, X)
+);
+
+toricCycle(ToricDivisor) := D ->(
+    X := variety D;
+    L := for i from 0 to #rays X - 1 list ( {i}, (entries D)#i );
+    toricCycle(L,X)
+);
+
+toricCycle(ToricCycle) := D -> D;
+
+ToricCycle == ToricCycle := Boolean => (D,E) ->(
+    return variety D === variety E and (for orbit in sort support(D) list D#orbit)==(for orbit in sort support(E) list E#orbit);
+);
+
+toricDivisorFromCycle = method(TypicalValue => ToricDivisor)
+toricDivisorFromCycle(ToricCycle) := ToricDivisor => (D) ->(
+  X := D.variety;
+  L := apply(#(rays X), i -> D_i);
+  return toricDivisor(L,X)
+);
+
+------------------------------------------------------------------------------
+-- Addition and scalar multiplication
+------------------------------------------------------------------------------
+
+QQ * ToricCycle := ToricCycle => (k,C) ->(
+    if k == 0 then(
+        return toricCycle({},variety C)
+    );
+    L := apply(support C, s->(s => k*C_s) );
+    toricCycle(L, support C, variety C)
+);
+ZZ * ToricCycle := ToricCycle => (k,C) ->( promote(k,QQ) * C );
+
+-- Extend the multiplication of toric divisors
+QQ * ToricDivisor := ToricDivisor => (q,D) ->(
+    X := variety D;
+    toricDivisor (apply (# rays X, i -> q*D#i), X)
+);
+
+ToricCycle + ToricCycle := ToricCycle => (C,D) ->(
+    --assert(variety C === variety D);
+    U := toList(set support(C) + set support(D));
+    S := new List;
+    L := new List;
+    c := 0;
+    for u in U do(
+      c = C_u + D_u;
+      if not(c == 0) then(
+        L = L | {u => c};
+        S = S | {u};
+      ) else(
+        continue
+      );
+    );
+    toricCycle(L,S,variety C)
+);
+
+ToricCycle - ToricCycle := ToricCycle => (C,D) ->(C + (-1)*D);
+
+- ToricCycle := ToricCycle => (C) ->(-1)*C
+
+ToricDivisor + ToricCycle := ToricCycle => (D,C) ->(toricCycle(D) + C);
+ToricDivisor - ToricCycle := ToricCycle => (D,C) ->(toricCycle(D) - C);
+ToricCycle + ToricDivisor := ToricCycle => (C,D) ->(D+C);
+ToricCycle - ToricDivisor := ToricCycle => (C,D) ->(-(D-C));
+
+------------------------------------------------------------------------------
+-- Intersection product
+------------------------------------------------------------------------------
+
+isTransverse = method(TypicalValue => Boolean)
+isTransverse(ToricDivisor, List) := (D,E) ->(
+    -- the first set is support D
+    #( set( select( #(rays variety D), i -> D#i != 0) ) * set(E) ) == 0
+);
+
+--input: toric divisor D and a list C
+--output: a toric divisor D' linearly equivalent to D such that its support and C are disjoint
+makeTransverse = method(TypicalValue => ToricDivisor)
+makeTransverse (ToricDivisor, List) := (D,C) ->(
+  X := variety D;
+  d := #(rays X); -- number of rays of X
+  n := dim X;
+
+  if not(X.cache#?PicardBases) then(
+    X.cache#(symbol PicardBases) = {};
+    X.cache#(symbol RaysMatrix) = transpose matrix rays X;
+    X.cache#(symbol RaysMatrixRank) = rank (X.cache#RaysMatrix);
+  );
+
+  M := X.cache#RaysMatrix;
+  r := X.cache#RaysMatrixRank;
+
+  l := new List;
+  LL := X.cache#PicardBases; --list of tuples (l,M)
+  --where l index a basis of the Picard group of X
+  --and M is a matrix whose rows are the coefficients of sequations for the classes of divisors
+  k := position(LL, T -> isSubset(set C, set T#0));
+  if instance(k,ZZ) then(
+    M = (LL_k)#1;
+    l = (LL_k)#0;
+  ) else(
+    L := C | toList (set(0..(d-1)) - C); --find a basis that contains C
+    l = ( maxCol M_L )_1; --order the rays so that the ones indexed by C are first, then maxCol finds a maximal minor containing C
+    l = L_l; --reorder the indices
+
+    if r == n then ( --if M_l is a square matrix
+      --M = inverse(promote(M_{0..numRows M-1},QQ)) * M;  -- Gaussian elimination
+      M = entries (inverse(promote(M_l,QQ)) * M);  -- Gaussian elimination
+    )
+    else (
+      L = l | toList (set(0..(d-1)) - l); -- reorder ray indices to put l first
+      M = M_L;  -- reorder rays
+      l' := ( maxCol transpose M_(toList(0..r-1)) )_1; --find a nonzero minor
+      L' := l' | toList (set(0..(n-1)) - l'); -- reorder rows indices to put l' first
+      M = M^L'; -- reorder rows
+      M' := inverse promote(M_(toList(0..r-1))^(toList(0..r-1)),QQ);
+      Omega := matrix toList(n-r:toList(r:0));
+      M' = transpose ( transpose(M' | transpose Omega) | transpose(Omega | id_(ZZ^(n-r)) ) );
+      M = M' * M;
+      L'' := apply(#L, i->position(L,j->j==i));
+      M = entries (M_L'');
+    );
+    --cache the result
+    X.cache#PicardBases = X.cache#PicardBases | {(l,M)};
+  );
+  --subtract the equations to D
+  D = entries D;
+  for i from 0 to r-1 do (
+    D = D - (D_(l_i) * M_i);
+  );
+  toricDivisor(D,X)
+);
+
+-- We assume that X has no torus factors and is simplicial
+-- input: a divisor D on X, a cone C in the fan of X
+-- output: a cycle equivalent to D * X_C
+ToricDivisor * List := (D, C) ->(
+    -- if not(isQQCartier(D)) then
+    --   error "--the divisor is not QQCartier";
+    X := variety D;
+    i := dim X - #C; -- dimension of V(C)
+    if i > 0 and member(C,orbits(X,i)) then (
+      highDimCones := (orbits X)#(i-1);
+    ) else (
+      return toricCycle( {} , X );
+    );
+
+    if not isTransverse(D,C) then (
+      D = makeTransverse(D,C);
+    );
+
+    S := select( #(rays X), i -> D#i != 0); --support D
+    V := new List;
+    if isSmooth X then(
+      V = for r in S list (
+          C' := sort(C|{r});
+          if member(C',highDimCones) then
+              ( C' => D#r )
+          else
+              continue
+      );
+    ) else(
+      mult := abs(gcd flatten entries gens minors(#C,(transpose matrix rays X)_C)); -- lattice index of C
+      V = for r in support D list (
+        C' := sort(C|{r});
+        if member(C',highDimCones) then (
+          mult' := abs(gcd flatten entries gens minors(#C',(transpose matrix rays X)_C')); -- lattice index of C'
+          ( C' => ((mult / mult') * D#r) )
+        )
+        else (
+          continue
+        )
+      );
+    );
+    return toricCycle(V,X)
+);
+
+ToricDivisor * ToricDivisor := (D,E) ->(
+    D * toricCycle E
+);
+
+ToricDivisor * ToricCycle := (D,C) ->(
+    if support C == {} then
+      return C;
+    sum ( for c in support C list ((C#c) * (D*c)) )
+);
+
+ToricCycle * ToricDivisor := (C,D) -> D*C;
+
+ToricCycle * ToricCycle := (C,D) ->(
+  --assert(variety C === variety D);
+  X := variety D;
+  E := toricCycle({},{},X); --resulting cycle
+  for d in support D do(
+    V := C; --auxiliary cycle
+    for i in d do(
+      V = X_i * V;
+    );
+    V = (D#d) * V;
+    E = E + V;
+  );
+  return E;
+);
+
+------------------------------------------------------------------------------
+-- Degree
+------------------------------------------------------------------------------
+
+degCycle = method(TypicalValue => ZZ)
+degCycle (ToricCycle) := C ->(
+  X := variety C;
+  if not(support C == {}) and #(max X)_0 == #(support C)_0 then(
+      return sum apply(support C, c -> C#c);
+  ) else(
+    return 0;
+  );
+);

--- a/M2/Macaulay2/packages/TropicalToric/ToricCycleDoc.m2
+++ b/M2/Macaulay2/packages/TropicalToric/ToricCycleDoc.m2
@@ -1,0 +1,436 @@
+doc ///
+  Key
+    isTransverse
+    (isTransverse, ToricDivisor, List)
+  Headline
+    checks transversality of toric divisors and cones
+  Usage
+    isTransverse(D,C)
+  Inputs
+    D: ToricDivisor
+    C: List
+  Outputs
+    : Boolean
+  Description
+    Text
+        This function tests transversality of toric divisors and cones. Toric
+        divisors are represented using the ToricDivisor class and cones are represented
+        using lists.
+    Example
+        rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+        coneList={{0,1},{1,2},{2,3},{3,0}}
+        X = normalToricVariety(rayList,coneList)
+        D = X_3
+        E = {0,3}
+        F = {1,2}
+        isTransverse(D,E)
+        isTransverse(D,F)
+///
+
+doc ///
+  Key
+    makeTransverse
+    (makeTransverse, ToricDivisor, List)
+  Headline
+    Find a divisor linearly equivalent to a toric divisor D that is transverse to a given cone C
+  Usage
+    makeTransverse(D,C)
+  Inputs
+    D: ToricDivisor
+    C: List
+  Outputs
+    D: ToricDivisor
+  Description
+    Text
+        This function calculates a linearly equivalent divisor of a given divisor D
+        that is transverse to a given cone C.
+    Example
+        rayList={{1,0},{1,1},{0,1},{-1,-1}};
+        coneList={{0,1},{1,2},{2,3},{3,0}};
+        X = normalToricVariety fan (transpose matrix rayList,coneList);
+        D = X_0+X_1;
+        C = {1,2};
+        isTransverse(D,C)
+        makeTransverse(D,C)
+///
+
+doc ///
+  Key
+    ToricCycle
+    (expression,ToricCycle)
+    (net,ToricCycle)
+  Headline
+    the class of a toric cycle on a NormalToricVariety
+  Description
+    Text
+        A toric cycle on X is a finite formal sum of closed torus orbits corresponding to cones in the fan of X.
+    Text
+        Examples can be found on the toricCycle constructor page.
+  SeeAlso
+    toricCycle
+///
+
+doc ///
+  Key
+    toricCycle
+    (toricCycle,List,NormalToricVariety)
+    (toricCycle,List,List,NormalToricVariety)
+  Headline
+    Creates a ToricCycle
+  Usage
+    toricCycle(L,X)
+    toricCycle(D)
+  Inputs
+    L: List
+      a list of options (sigma => d) where d is the coefficient of the cycle associated to the cone sigma
+    X: NormalToricVariety
+      the variety the cycle lives on
+  Outputs
+    : ToricCycle
+  Description
+    Text
+        Toric cycles can be created with the constructor, and as they form an abelian group under addition,
+        arithmetic can be done with them.
+    Example
+        rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+        coneList={{0,1},{1,2},{2,3},{3,0}}
+        X = normalToricVariety(rayList,coneList)
+        cyc = toricCycle({{2,3} =>1,{3,0} => 4},X)
+        altcyc = (-2)*cyc
+        cyc + altcyc
+        cyc - altcyc
+        -cyc
+  SeeAlso
+    (symbol +, ToricCycle, ToricCycle)
+///
+
+doc ///
+  Key
+    (toricCycle,ToricDivisor)
+    (toricCycle,ToricCycle)
+  Headline
+    Creates a ToricCycle from a ToricDivisor
+  Usage
+    toricCycle(D)
+  Inputs
+    D: ToricDivisor
+  Outputs
+    : ToricCycle
+  Description
+    Text
+        This method converts a ToricDivisor into a ToricCycle.
+    Example
+        X = toricProjectiveSpace 3;
+        toricCycle(X_0)
+        toricCycle(X_1+X_2)
+  SeeAlso
+    (symbol +, ToricCycle, ToricCycle)
+///
+
+doc ///
+  Key
+    (support,ToricCycle)
+  Headline
+    Get the list of cones with non-zero coefficients in the cycle
+  Usage
+    support C
+  Inputs
+    C: ToricCycle
+  Outputs
+    : List
+      a list of integer vectors describing cones in the
+      fan of variety(C)
+  Description
+    Text
+        This function returns the list of cones, corresponding
+        to torus-invariant cycles, appearing in the support of
+        a ToricCycle.
+    Example
+        X = toricProjectiveSpace 4
+        Z1 = toricCycle({{0,1} => 3,{0,2} => 7,{1,2} => 82},X)
+        Z2 = toricCycle({{0,1} => 4,{0,2} => 5},X)
+        support Z1
+        support Z2
+///
+
+doc ///
+  Key
+    (variety,ToricCycle)
+  Headline
+    Get the ambient variety of the cycle
+  Usage
+    variety C
+  Inputs
+    C: ToricCycle
+  Outputs
+    : NormalToricVariety
+  Description
+    Text
+        This function returns the underlying toric variety of
+        the toric cycle.
+    Example
+        X = toricProjectiveSpace 2
+        Z = toricCycle({{0,1} => 3,{0,2} => 7,{1,2} => 82},X)
+        variety Z
+///
+
+doc ///
+  Key
+    (symbol *, ToricDivisor, List)
+  Headline
+    restriction of a Cartier toric divisor to the orbit closure of a cone
+  Usage
+    D*C
+  Inputs
+    D: ToricDivisor
+    C: List
+  Outputs
+    : ToricCycle
+      Returns the toric cycle given by restricting a Cartier toric divisor to the
+      orbit closure of the given cone
+  Description
+    Example
+        rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+        coneList={{0,1},{1,2},{2,3},{3,0}}
+        X = normalToricVariety(rayList,coneList)
+        D = X_3
+    Text
+        The only cone containing rays 2 and 3 is the cone {2,3}. There is no cone
+        containing rows 1 and 3.
+    Example
+        D*{2}
+        D*{1}
+    Text
+        This can also compute more complicated sums.
+    Example
+        D = X_0 + 2*X_1 + 3*X_2 + 4*X_3
+        C = (orbits X)#1#0
+        D*C
+///
+
+doc ///
+  Key
+    (symbol == , ToricCycle, ToricCycle)
+  Headline
+    equality of toric cycles
+  Usage
+    C == D
+  Inputs
+    C: ToricCycle
+    D: ToricCycle
+  Description
+    Text
+        This function checks whether the varieties of both cycles are the same,
+        and whether the coefficients in each orbit of the toric variety are the
+        same in both toric cycles.
+    Example
+        rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+        coneList={{0,1},{1,2},{2,3},{3,0}}
+        X = normalToricVariety(rayList,coneList)
+        D = X_3
+        D*{2} == toricCycle({{2,3} => 1},X)
+        D*{1} == toricCycle({},X)
+    Text
+        The elements of the list in the constructor of toric cycle must be in order. For example,
+        the following example has {3,0} instead of {0,3}.
+    Example
+        D*{0} == toricCycle({{0,3} => 1},X)
+  SeeAlso
+    (symbol *, ToricDivisor, List)
+///
+
+doc ///
+  Key
+    (symbol *, ToricDivisor, ToricCycle)
+    (symbol *, ToricCycle, ToricDivisor)
+  Headline
+    intersection product of a ToricDivisor and ToricCycle
+  Usage
+    D*C
+    C*D
+  Inputs
+    D: ToricDivisor
+    C: ToricCycle
+  Description
+    Text
+        Computes the intersection product of a ToricDivisor with a ToricCycle.
+    Example
+        X = toricProjectiveSpace 4
+        D = X_0+2*X_1+3*X_2+4*X_3
+        C = X_{2,3}
+        D*C
+    Text
+        Self intersection of the exceptional divisor.
+    Example
+        X = toricProjectiveSpace 2
+        Y = toricBlowup({0,1},X)
+        D = Y_3
+        C = Y_{3}
+        D*C
+///
+
+doc ///
+  Key
+    (symbol *, ToricCycle, ToricCycle)
+  Headline
+    intersection product of two toric cycles
+  Usage
+    D*C
+  Inputs
+    D: ToricCycle
+    C: ToricCycle
+  Description
+    Text
+        Computes the intersection product of a ToricCycle with another ToricCycle.
+    Example
+        X = toricProjectiveSpace 5
+        D = X_{0,1}+5*X_{1,3}-X_{2}+2*X_{3}
+        C = X_{2,3}
+        D*C
+    Text
+        Self intersection of the exceptional divisor.
+    Example
+        X = toricProjectiveSpace 2
+        Y = toricBlowup({0,1},X)
+        D = Y_{3}
+        D*D
+///
+
+doc ///
+  Key
+    (symbol +, ToricCycle, ToricCycle)
+    (symbol -, ToricCycle, ToricCycle)
+    (symbol -, ToricCycle)
+    (symbol +, ToricCycle, ToricDivisor)
+    (symbol -, ToricCycle, ToricDivisor)
+    (symbol +, ToricDivisor, ToricCycle)
+    (symbol -, ToricDivisor, ToricCycle)
+
+    (symbol *, QQ, ToricCycle)
+    (symbol *, ZZ, ToricCycle)
+    (symbol *, QQ, ToricDivisor)
+
+  Headline
+    perform arithmetic on toric cycles
+  Usage
+    C1 + C2
+    C1 - C2
+    5*C1
+    (1/2)*C1
+    -C1
+  Inputs
+    C1:ToricCycle
+    C2:ToricCycle
+  Description
+    Text
+        The set of torus-invariant cycles forms an abelian group
+        under addition.  The basic operations arising from this structure,
+        including addition, substraction, negation, and scalar
+        multplication by integers, are available.
+    Text
+        We illustrate a few of the possibilities on one variety.
+    Example
+        rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+        coneList={{0,1},{1,2},{2,3},{3,0}}
+        X = normalToricVariety(rayList,coneList)
+        cyc = toricCycle({{2,3} => 1,{3,0} => 4},X)
+        altcyc = (-2)*cyc
+        cyc + altcyc
+        cyc - altcyc
+        -cyc
+        X_{0} + X_{1}
+        2*X_{0,1} - X_{0,2}
+///
+
+doc ///
+  Key
+    (symbol _, NormalToricVariety, List)
+  Headline
+    Create toric cycles
+  Usage
+    X_L
+  Inputs
+    X: NormalToricVariety
+    L: List
+  Description
+    Text
+        Create a toric cycle directly from the toric variety
+    Example
+        rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+        coneList={{0,1},{1,2},{2,3},{3,0}}
+        X = normalToricVariety(rayList,coneList)
+        X_{1}
+        X_{0,2}
+        2 * X_{2} - X_{3}
+  SeeAlso
+    (symbol +, ToricCycle, ToricCycle)
+///
+
+doc ///
+  Key
+    (symbol _, ToricCycle, List)
+    (symbol _, ToricCycle, ZZ)
+  Headline
+    Coefficients of toric cycle
+  Usage
+    C_L
+  Inputs
+    C: ToricCycle
+    L: List
+  Description
+    Text
+        Another way to get the coefficients of a cycle C
+    Example
+        rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+        coneList={{0,1},{1,2},{2,3},{3,0}}
+        X = normalToricVariety(rayList,coneList)
+        C = X_{0,1} + X_{0,2} - 2*X_{0,3} + X_{0}
+        C_{0,1}
+        C_{0,2}
+        C_{0,3}
+        C_0
+  SeeAlso
+    (symbol +, ToricCycle, ToricCycle)
+///
+
+doc ///
+  Key
+    degCycle
+    (degCycle,ToricCycle)
+  Headline
+    Compute the degree of a cycle of maximal codimension
+  Usage
+    degCycle(C)
+  Inputs
+    C: ToricCycle
+  Outputs
+    d: ZZ
+  Description
+    Text
+        This function computes the sum of the coefficients of a cycle of maximal codimension
+    Example
+        rayList={{1,0},{1,1},{0,1},{-1,-1}};
+        coneList={{0,1},{1,2},{2,3},{3,0}};
+        X = normalToricVariety(rayList,coneList);
+        C = X_{0,1} + X_{1,2} - 3*X_{2,3}
+        degCycle(C)
+///
+
+doc ///
+  Key
+    toricDivisorFromCycle
+    (toricDivisorFromCycle,ToricCycle)
+  Headline
+    Convert a codimension one toric cycle into a toric divisor
+  Usage
+    degCycle(C)
+  Inputs
+    C: ToricCycle
+  Outputs
+    d: ZZ
+  Description
+    Example
+        X = toricProjectiveSpace 2;
+        D = X_{0} + X_{1};
+        toricDivisorFromCycle D
+///

--- a/M2/Macaulay2/packages/TropicalToric/ToricCycleDoc.m2
+++ b/M2/Macaulay2/packages/TropicalToric/ToricCycleDoc.m2
@@ -163,7 +163,7 @@ doc ///
   Inputs
     C: ToricCycle
   Outputs
-    : NormalToricVariety
+    : Variety
   Description
     Text
         This function returns the underlying toric variety of

--- a/M2/Macaulay2/packages/TropicalToric/ToricCycleDoc.m2
+++ b/M2/Macaulay2/packages/TropicalToric/ToricCycleDoc.m2
@@ -325,7 +325,7 @@ doc ///
     Text
         The set of torus-invariant cycles forms an abelian group
         under addition.  The basic operations arising from this structure,
-        including addition, substraction, negation, and scalar
+        including addition, subtraction, negation, and scalar
         multplication by integers, are available.
     Text
         We illustrate a few of the possibilities on one variety.

--- a/M2/Macaulay2/packages/TropicalToric/ToricCycleTest.m2
+++ b/M2/Macaulay2/packages/TropicalToric/ToricCycleTest.m2
@@ -1,0 +1,129 @@
+-- 0
+TEST ///
+rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+coneList={{0,1},{1,2},{2,3},{3,0}}
+X = normalToricVariety(rayList,coneList)
+-- toricCycle constructor
+D1 = toricCycle({{2,3} => 1,{0,3} => 4}, X)
+assert(D1 == X_{3,2} + 4*X_{3,0})
+assert(toricCycle(X_0) == toricCycle({0 => 1}, X))
+-- Scalar multiplication and addition
+D2 = (-2)*D1
+assert(D2 == toricCycle({{2,3} => -2,{0,3} => -8}, X))
+assert(D1 + D2 == ((-1)*D1))
+assert(D1 - D2 == 3*D1)
+assert(-D1 == (-1)*D1)
+///
+
+-- 1
+TEST ///
+rayList={{1,0},{1,2},{-1,-1}}
+coneList={{0,1},{1,2},{2,0}}
+X = normalToricVariety(rayList,coneList)
+-- toricCycle constructor
+D1 = toricCycle({{0,2} => 1,{0,1} => 4}, X)
+assert(D1 == X_{2,0} + 4*X_{1,0})
+assert(toricCycle(X_0) == toricCycle({0 => 1}, X))
+-- Scalar multiplication and addition
+D2 = (-2)*D1
+assert(D2 == toricCycle({{0,2} => -2,{0,1} => -8}, X))
+assert(D1 + D2 == ((-1)*D1))
+assert(D1 - D2 == 3*D1)
+assert(-D1 == (-1)*D1)
+///
+
+-- 2
+TEST ///
+rayList={{1,0,0},{0,1,0},{0,0,1},{1,1,1},{-1,-1,-1}}
+coneList={{0,1,3},{0,2,3},{1,2,3},{0,1,4},{0,2,4},{1,2,4}}
+X = normalToricVariety(rayList,coneList)
+-- toricCycle constructor
+D1 = toricCycle({{0,1,2} => -1,{0,2,3} => 2}, X)
+assert(D1 == -X_{1,2,0} + 2*X_{3,0,2})
+assert(toricCycle(X_0) == toricCycle({0 => 1}, X))
+-- Scalar multiplication and addition
+D2 = (-2)*D1
+assert(D2 == toricCycle({{1,2,0} => 2,{3,0,2} => -4}, X))
+assert(D1 + D2 == ((-1)*D1))
+assert(D1 - D2 == 3*D1)
+assert(-D1 == (-1)*D1)
+///
+
+-- 3
+TEST ///
+rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+coneList={{0,1},{1,2},{2,3},{3,0}}
+X = normalToricVariety(rayList,coneList)
+D1 = X_3
+D2 = X_2
+-- isTransverse
+assert(not isTransverse(D1,{3}))
+assert(isTransverse(D1,{0}))
+assert(not isTransverse(D2,{2}))
+assert(isTransverse(D2,{0}))
+-- makeTransverse
+assert( makeTransverse(D1,{0,3}) == toricDivisor( toList(4:promote(0,QQ)),X) + X_1 - X_2 )
+assert( makeTransverse(D2,{2,3}) == toricDivisor( toList(4:promote(0,QQ)),X) + X_0)
+-- ToricDivisor * List
+assert(D1*{3} == - toricCycle({({2,3} => 1)},X))
+assert(D1*{2} == toricCycle({({2,3} => 1)},X))
+assert(D1*{1} == toricCycle({},X))
+assert(D1*{0} == toricCycle({({0,3} => 1)},X))
+-- ToricDivisor * ToricCycle
+assert(D1*X_{3} == - toricCycle({({2,3} => 1)},X))
+assert(D1*(X_{2}+X_{3}) == toricCycle({},X))
+///
+
+--4
+TEST ///
+rayList={{1,0},{1,2},{-1,-1}}
+coneList={{0,1},{1,2},{2,0}}
+X = normalToricVariety(rayList,coneList)
+D1 = X_0
+D2 = X_2
+-- isTransverse
+assert(not isTransverse(D1,{0}))
+assert(isTransverse(D1,{1}))
+assert(not isTransverse(D2,{2}))
+assert(isTransverse(D2,{0}))
+-- makeTransverse
+assert( makeTransverse(D1,{0,1}) == toricDivisor( toList(3:promote(0,QQ)),X) + (1/2) * X_2 )
+assert( makeTransverse(D2,{2,0}) == toricDivisor( toList(3:promote(0,QQ)),X) + 2 * X_1)
+-- ToricDivisor * List
+assert(D1*{2} == toricCycle({({0,2} => 1)},X))
+assert(D1*{0} == toricCycle({({0,2} => 1/2)},X))
+assert(D1*{1} == toricCycle({({0,1} => 1/2)},X))
+assert(D2*{2} == toricCycle({({1,2} => 2)},X))
+-- ToricDivisor * ToricCycle
+assert(D1*X_{2} == toricCycle({({0,2} => 1)},X))
+assert(D1*(X_{0}+X_{1}) == toricCycle({{0,1} => 1/2, {0,2} => 1/2},X))
+///
+
+-- 5
+TEST ///
+rayList={{1,0,0},{0,1,0},{0,0,1},{1,1,1},{-1,-1,-1}}
+coneList={{0,1,3},{0,2,3},{1,2,3},{0,1,4},{0,2,4},{1,2,4}}
+X = normalToricVariety(rayList,coneList)
+D1 = X_0
+D2 = X_1
+-- isTransverse
+assert(not isTransverse(D1,{0}))
+assert(isTransverse(D1,{1}))
+assert(not isTransverse(D2,{1}))
+assert(isTransverse(D2,{0}))
+-- makeTransverse
+assert( makeTransverse(D1,{0,1,2}) == toricDivisor( toList(5:promote(0,QQ)),X) - X_3 + X_4)
+assert( makeTransverse(D2,{4,0,1}) == toricDivisor( toList(5:promote(0,QQ)),X) + X_2)
+-- ToricDivisor * List
+assert(D1*{0} == -X_{0,3}+X_{0,4})
+assert(D1*{1} == X_{0,1})
+assert(D1*{2} == X_{0,2})
+assert(D1*{3} == X_{0,3})
+assert(D1*{4} == X_{0,4})
+-- ToricDivisor * ToricCycle
+assert(D1*X_{3} == X_{0,3})
+assert(D1*(X_{2}+X_{3}) == X_{0,2}+X_{0,3})
+--degCycle
+assert(degCycle(X_{0,1,2}) == 1)
+assert(degCycle(X_{0,1,2} - X_{0,1,3}) == 0)
+///

--- a/M2/Macaulay2/packages/TropicalToric/ToricPullback.m2
+++ b/M2/Macaulay2/packages/TropicalToric/ToricPullback.m2
@@ -1,0 +1,86 @@
+-- All the methods in this file are NOT EXPORTED.
+
+-- THIS METHOD IS NOT EXPORTED. It is the same as in the package NormalToricVarieties
+-- Given a toric divisor which is assumed to be
+-- Cartier, this method returns the characters on each maximal cone which
+-- determine the Cartier divisor.
+cartierCoefficients = method ()
+cartierCoefficients ToricDivisor := List => D ->(
+  X := variety D;
+  rayMatrix := matrix rays X;
+  coeffs := transpose (matrix {entries D});
+  apply (max X, sigma -> coeffs^sigma // rayMatrix^sigma)
+);
+
+-- THIS METHOD IS NOT EXPORTED. It is the same as in the package NormalToricVarieties
+-- computes and caches the supporting hyperplanes with outer normal vectors
+-- fo each cone
+outerNormals = method()
+outerNormals (NormalToricVariety, List) := List => (X, sigma) ->(
+  if not X.cache.?outerNormals then (
+    X.cache.outerNormals = new MutableHashTable
+  );
+  if not X.cache.outerNormals#?sigma then (
+    V := transpose matrix rays X;
+    (H0, H1) := fourierMotzkin V_sigma;
+    X.cache.outerNormals#sigma = {H0, H1};
+  );
+  X.cache.outerNormals#sigma
+);
+
+-- THIS METHOD IS NOT EXPORTED. It is the same as in the package NormalToricVarieties
+-- covers the pair returned by 'fourierMotzkin' into a single matrix
+outerMatrix = method()
+outerMatrix List := Matrix => pair ->(
+  if pair#1 == 0 then transpose pair#0 else
+  transpose (pair#0 | pair#1 | - pair#1)
+);
+
+-- THIS METHOD IS NOT EXPORTED. It is the same as in the package NormalToricVarieties
+-- this method caches the index of a maximal cone in the target which contains
+-- the image of each ray of the source.
+rayMaxList = method()
+rayMaxList ToricMap := List => (cacheValue symbol maxRayList) (f ->(
+  X := source f;
+  Y := target f;
+  A := matrix f;
+  maxY := max Y;
+  -- find a maximal cone containing the image of each ray
+  normals := new MutableHashTable;
+  for ray in rays X list (
+    rho := A * transpose matrix {ray};
+    position(max Y, sigma ->(
+        if not normals#?sigma then (
+          normals#sigma = outerMatrix outerNormals(Y, sigma);
+        );
+        innerProducts := normals#sigma * rho;
+        all(flatten entries innerProducts, b -> b <= 0)
+      )
+    )
+  )
+));
+
+-- THIS METHOD IS NOT EXPORTED.
+-- This method is essentially the same as "pullback" in ToricMaps.m2 of the package
+-- NormalToricVarieties. The only difference is that it allows the input to be the
+-- same type of the output of cartierCoefficients. This is needed to optimize the
+-- method productMultiplicity in TropicaToricCode.m2
+----------------------------------------------------------------------
+-- see Thm 4.2.12.b and Prop 6.2.7 in Cox-Little-Schenck (Prop 6.1.20
+-- in the preprint) note: in CLS they use inner normals, whereas we
+-- use outer normals, hence the different sign
+toricPullback = method()
+toricPullback (ToricMap, List) := ToricDivisor => (f, cartierData) ->(
+  A := matrix f;
+  X := source f;
+  raysX := rays X;
+  maxConeIndices := rayMaxList f;
+  sum for i to # raysX - 1 list (
+    rho := A * transpose matrix {raysX_i};
+    (transpose cartierData_(maxConeIndices_i) * rho)_(0,0) * X_i
+  )
+);
+toricPullback (ToricMap, ToricDivisor) := ToricDivisor => (f,D) ->(
+  if not isCartier D then error "-- expected a Cartier divisor";
+  toricPullback(f,cartierCoefficients D);
+);

--- a/M2/Macaulay2/packages/TropicalToric/TropicalToricCode.m2
+++ b/M2/Macaulay2/packages/TropicalToric/TropicalToricCode.m2
@@ -1,0 +1,226 @@
+--input: a normal toric variety X,
+--       a balanced pure dimensional fan T with a refinement that is a subfan of X,
+--       a list l of weights of the maximal cones of T.
+--output: list of weights, indexed by the cones of X, induced by T
+refineMultiplicity = method(TypicalValue => List)
+refineMultiplicity (List, Fan, NormalToricVariety) := (l,T,X) ->(
+  k := dim T;
+  n := dim X;
+  if #(unique l) == 1 then(
+    return toList(#(orbits(X,n-k)):l_0);
+  );
+  maxConesT := maxCones T;
+  mult := {};
+  for sigma in orbits(X,n-k) do(
+    j := 0;
+    coneSigma := coneFromVData (transpose matrix rays X)_sigma;
+    --Find a maximal cone in T that contains the cone sigma
+    for i from 0 to (#maxConesT)-1 when j == 0 do(
+      coneT := coneFromVData (rays T)_(maxConesT_i);
+      if contains(coneT, coneSigma) then(
+        j = l_i;
+      );
+    );
+    mult = append(mult,j);
+  );
+  return mult
+);
+refineMultiplicity (TropicalCycle, NormalToricVariety) := (T,X) ->(
+  return refineMultiplicity(multiplicities T,fan T,X)
+)
+
+--input: normal toric varieties X,X' such that the identity on the lattices induces
+--       a toric map phi:X' -> X,
+--       list mult of multiplcities of cones of X' of dimension k
+--output: list of degrees deg([Y'] * phi^*(V(sigma)), where [Y'] is the class of the cycle
+--        Y' in X' corresponding to the Minkowski weight given by mult.
+-- Note that here [Y'] * V(sigma') = mult_sigma' for every cone sigma' of X'.
+-- From the projection formula, the resulting Minkowski weight on X corresponds
+-- to the pushforward phi_* [Y']
+pushforwardMultiplicity = method(TypicalValue => List)
+pushforwardMultiplicity (NormalToricVariety,NormalToricVariety,List,ZZ) := (X,X',mult,k) ->(
+  n := dim X;
+  d := #rays X;
+  phi := map(X,X',id_(ZZ^n));
+  rayMatrix := matrix rays X;
+  L := new List; --list of pullbacks phi*(X_i)
+  for i from 0 to d-1 do(
+    cartierData := apply (max X, sigma ->
+      if member(i,sigma) then(
+        (id_(ZZ^d))_{i}^sigma // rayMatrix^sigma
+      ) else(
+        matrix 0_(ZZ^n)
+      )
+    ); --this is faster than cartierCoefficients(X_i)
+    L = append(L, toricPullback(phi,cartierData));
+  ); --this is faster than L := apply(#rays X, i->pullback(phi,X_i) );
+  prod := new List;
+  for sigma in orbits(X,n-k) do(
+    P := toricCycle( product L_sigma ); --pullback of V(sigma)
+    --now compute [Y'] * pullback of V(sigma), substituting [Y'] * V(sigma') = m(sigma')
+    prod = append( prod, sum apply(#mult, i->P_((orbits(X',n-k))_i) * mult_i) );
+  );
+  prod
+);
+
+--input: smooth toric variety X, integer k
+--output: the matrix of products V(sigma)*V(tau), with dim(sigma) = k, dim(tau) = m-k,
+--        where m is the largest integer such that A^m(X) is not zero.
+--        The output is cached in X
+poincareMatrix = method (TypicalValue => Matrix)
+poincareMatrix (NormalToricVariety,ZZ) := (X,k) ->(
+  if X.cache#?(PoincareMatrix,k) then(
+    return X.cache#(PoincareMatrix,k);
+  );
+  if not(isSmooth X) then (
+    error ("--  the toric variety is not smooth")
+  );
+  n := dim X;
+  m := #(max X)_0;
+  M := {}; --matrix ( V(tau) * V(sigma) ) with dim(sigma) = k, dim(tau) = m-k
+  --note that the dimension of the cones in orbits(X,i) is n-i
+  for sigma in orbits(X,n-k) do(
+    M' := {};
+    for tau in orbits(X,n-(m-k)) do(
+      C := product( {X_sigma} | (tau / (i->X_i)) );
+      if support C == {} then (
+        M' = append(M',0);
+      )
+      else (
+        -- the cycles V(sigma') with dim sigma' = m are all equivalent
+        M' = append(M', sum apply(support C, c -> C#c));
+      )
+    );
+    M = append(M,M');
+  );
+  M = promote(matrix M,QQ);
+  X.cache#(symbol PoincareMatrix, k) = M;
+  M
+);
+
+--input: smooth normal toric variety X, list of integers l representing
+--       a function in Hom(A^k(X),Z)
+--output: the corresponding class in A^(m-k)(X) by Poincare duality,
+--        where m is the maximum codimension such that A^m(X) is not zero
+--        ( recall that A^k(X) corresponds to orbits(X,n-k) )
+poincareDuality = method(TypicalValue => List)
+poincareDuality (List,NormalToricVariety,ZZ) := (l, X, k) ->(
+  M := poincareMatrix(X,k);
+  v := promote(transpose matrix {l},QQ);
+  Y := flatten entries transpose solve(M,v)
+);
+
+--input: A simplicial toric variety X, an ideal I in the Laurent polynomial ring
+--output: a toric cycle whose class is the class of the closure of V(I) in X
+classFromTropical = method(TypicalValue => ToricCycle)
+classFromTropical (NormalToricVariety,Ideal) := (X, I) ->(
+  T := tropicalVariety(I);
+  k := dim T;
+  F := gfanFanCommonRefinement(fan X, fan T); --common refinement
+  X' := makeSimplicial (normalToricVariety F);
+  --ordered vector of multiplicities with respect to fan X'
+  mult := refineMultiplicity(T,X');
+  --vector of products [V(J)]*[V(sigma)] in X
+  prod := pushforwardMultiplicity(X,X',mult,k);
+  --apply Poincare duality
+  Y := poincareDuality(prod,X,k);
+  m := #(max X)_0;
+  O := orbits(X,dim X-(m-k));
+  D := sum apply(#O, s -> Y_s * X_(O_s));
+  return D
+);
+
+--input: A linear ideal I in the Laurent polynomial ring
+--output: a toric cycle whose class is the class of the
+--        closure of V(I+J) in a wonderful compactification of V(I)
+classWonderfulCompactification = method(TypicalValue => ToricCycle)
+classWonderfulCompactification (NormalToricVariety, Ideal, Ideal) := (X,I,J) ->(
+  if not(degree(I) == 1) then
+    error("-- the ideal is not linear!");
+  m := dim fan X;
+  n := dim X;
+  T := tropicalVariety(I+J);
+  k := dim T;
+  X':= makeSimplicial (normalToricVariety fan T); --no need to do the common refinement
+  mult := for C in orbits(X',(dim X)-k) list(
+    (multiplicities T)_(position(maxCones T, c -> isSubset(C,c)))
+  ); --faster than mult := refineMultiplicity(T,X');
+  prod := pushforwardMultiplicity(X,X',mult,k);
+  --apply Poincare duality
+  Y := poincareDuality(prod,X,k);
+  O := orbits(X,n-m+k); --we want the cycle to have codimension inside X the same that T has inside T'
+  D := sum apply(#O, s -> Y_s * X_(O_s));
+  return D
+);
+classWonderfulCompactification (NormalToricVariety, Ideal, RingElement) := (X,I,f) ->(
+  return classWonderfulCompactification(X,I,ideal(f))
+);
+classWonderfulCompactification (Ideal, Ideal) := (I,J) ->(
+  X := normalToricVariety fan tropicalVariety I;
+  return classWonderfulCompactification(X,I,J)
+);
+classWonderfulCompactification (Ideal, RingElement) := (I,f) ->(
+  return classWonderfulCompactification(I,ideal(f))
+);
+
+--input: Normal toric variety X, homogeneous ideal I of the Cox ring of X
+--output: (saturated) ideal J of the intersection of V(I) with the torus inside X
+--
+-- Let S = C[x_0 .. x_n] be the Cox ring of X, and let R be the Laurent ring of the torus inside X.
+-- Then we have  R \simeq (S_(x_0*...*x_n))_0
+-- here we are viewing the torus T in X as X \ V(x_0*...*x_n) = X \ (union of D_i's)
+torusIntersection = method()
+torusIntersection (NormalToricVariety,RingElement,Ring) := (X,g,TR) ->(
+  n := dim X;
+  R := matrix rays X;
+  l := new List;
+  expg := exponents g;
+  --apply the isomorphism from the Cox ring to the torus ring, working on the exponents
+  for m in expg do(
+    --dehomogenize dividing by the first monomial of g
+    v := transpose matrix {m - (expg_0)};
+    --write each monomial as a product of "variables of degree 0"
+    l = append( l, flatten entries transpose solve(R,v) );
+  );
+  --clear denominators
+  l = transpose l;
+  L := new List;
+  for r in l do (
+    L = append( L, toList(#(l_0):min(r)) );
+  );
+  l = transpose (l-L);
+  --from the exponents to the polynomial
+  f := sum apply(#l, i ->
+    ((listForm g)_i)_1 * product apply( n, j ->(TR_j)^((l_i)_j) )
+  );
+  return f
+);
+torusIntersection (NormalToricVariety,RingElement) := (X,g) ->(
+  n := dim X;
+  y := symbol y;
+  TR:= QQ[y_1..y_n]; --torus ring
+  return torusIntersection(X,g,TR)
+);
+torusIntersection (NormalToricVariety,Ideal,Ring) := (X,I,TR) ->(
+  G := new List;
+  for g in flatten entries (gens I) do(
+    G = append(G, torusIntersection(X,g,TR));
+  );
+  G = ideal G;
+  --saturate the ideal with respect to the product of variables in TR
+  for a in gens TR do(
+    G = saturate(G,a);
+  );
+  return G
+);
+torusIntersection (NormalToricVariety,Ideal) := (X,I) ->(
+  n := dim X;
+  y := symbol y;
+  TR:= QQ[y_1..y_n]; --torus ring
+  return torusIntersection(X,I,TR)
+);
+
+--input: A smooth toric variety X, an ideal I in the Cox ring of X
+--output: a toric cycle whose class is the class of V(I) in X
+classFromTropicalCox = method(TypicalValue => RingElement)
+classFromTropicalCox (NormalToricVariety,Ideal) := (X,I) -> classFromTropical(X, torusIntersection(X,I))

--- a/M2/Macaulay2/packages/TropicalToric/TropicalToricDoc.m2
+++ b/M2/Macaulay2/packages/TropicalToric/TropicalToricDoc.m2
@@ -159,7 +159,7 @@ doc ///
         essentially the same as classFromTropical, but it is optimized to this particular setting. Note that
         the closure of V(I) inside X is a wonderful compactification of V(I).
     Text
-        It is possible to explicitely input the toric variety, and this allows to implicitly specify the building set
+        It is possible to explicitly input the toric variety, and this allows to implicitly specify the building set
         of the wonderful compactification.
     Text
         A remarkable example among these is the moduli space of n-marked genus 0 curves M_0,n.

--- a/M2/Macaulay2/packages/TropicalToric/TropicalToricDoc.m2
+++ b/M2/Macaulay2/packages/TropicalToric/TropicalToricDoc.m2
@@ -1,0 +1,260 @@
+doc ///
+    Key
+    	TropicalToric
+    Headline
+    	Macaulay2 package for toric intersection theory using tropical geometry.
+    Description
+    	Text
+          This package implements the computations of classes in the
+          Chow ring of a toric variety using tropical geometry.
+          Part of this code is based on a package previously written by
+          Diane Maclagan, Sameera Vemulapalli, Corey Harris, Erika Pirnes and Ritvik Ramkumar.
+///
+
+doc ///
+  Key
+    refineMultiplicity
+    (refineMultiplicity,TropicalCycle,NormalToricVariety)
+    (refineMultiplicity,List,Fan,NormalToricVariety)
+  Headline
+    Compute the multiplicities of a refinement of a tropical variety
+  Usage
+    refineMultiplicity(T,X)
+  Inputs
+    T: TropicalCycle
+    X: NormalToricVariety
+      which fan refines T
+  Outputs
+    mult: List
+      list of the multiplicities, indexed by cones of X of the same dimension of T
+  Description
+    Text
+        This function calculate the multiplicities of a refinement of a tropical variety T.
+        The output is a list of integers indexed by orbits(X,n-k), where k = dim T, n = dim X
+        and X is the normal toric variety of the refinement.
+    Example
+        X = toricProjectiveSpace 3;
+        R = QQ[x_1 .. x_3];
+        f = x_1*x_2*x_3 + x_1*x_2 + x_1*x_3 + x_2*x_3;
+        T = tropicalVariety(ideal f);
+        F = gfanFanCommonRefinement(fan X, fan T);
+        X' = makeSimplicial (normalToricVariety F);
+        multiplicities T
+        refineMultiplicity(T,X')
+///
+
+doc ///
+  Key
+    pushforwardMultiplicity
+    (pushforwardMultiplicity,NormalToricVariety,NormalToricVariety,List,ZZ)
+  Headline
+    pushforward of Minkowski weights
+  Usage
+    pushforwardMultiplicity(X,X',mult,k)
+  Inputs
+    X: NormalToricVariety
+    X': NormalToricVariety
+    mult: List
+    k: ZZ
+  Outputs
+    prod: List
+      list of intersection products
+  Description
+    Text
+        The list mult is the list of multiplicities of the tropicalization of
+        the intersection of a subvariety Y of X with the torus. The tropicalization has the fan
+        structure of the fan of X', and k is the dimension of Y. This function calculates the intersection
+        products of Y and V(sigma), where sigma is a cone of X of dimension k. This is done by calculating
+        the pullback of V(sigma) in X', and substituting V(sigma') with m(sigma'), where sigma' is a cone
+        of dimension k in X'. This is the same as taking the class in X' corresponding to the Minkowski weights
+        given by Y and computing the Minkowski weights corresponding to the pushforward of this class on X.
+    Example
+        X = toricProjectiveSpace 3;
+        R = QQ[x_1 .. x_3];
+        f = x_1*x_2*x_3 + x_1*x_2 + x_1*x_3 + x_2*x_3;
+        T = tropicalVariety(ideal f);
+        F = gfanFanCommonRefinement(fan X, fan T);
+        X' = makeSimplicial (normalToricVariety F);
+        mult = refineMultiplicity(T,X');
+        pushforwardMultiplicity(X,X',mult,dim T)
+///
+
+doc ///
+  Key
+    poincareDuality
+    (poincareDuality,List,NormalToricVariety,ZZ)
+    poincareMatrix
+    (poincareMatrix,NormalToricVariety,ZZ)
+    (symbol PoincareMatrix)
+  Headline
+    Apply the isomorphism Hom(A^k(X),ZZ) = A_k(X)
+  Usage
+    poincareDuality(l, X, k)
+  Inputs
+    l: List
+    X: NormalToricVariety
+    k: ZZ
+  Outputs
+    Y: List
+  Description
+    Text
+        This function calculates the list of coefficients of a toric cycle corresponding to a list
+        of Minkowski weights.
+    Example
+        X = toricProjectiveSpace 3;
+        k = 2;
+        l = toList(#orbits(X,1):3)
+        poincareDuality(l, X, k)
+        poincareMatrix(X,2)
+///
+
+doc ///
+  Key
+    classFromTropical
+    (classFromTropical,NormalToricVariety,Ideal)
+  Headline
+    compute a toric cycle of X which class is the same as a given subvariety of X
+  Usage
+    classFromTropical(X,I)
+  Inputs
+    X: NormalToricVariety
+    I: Ideal
+  Outputs
+    D: ToricCycle
+  Description
+    Text
+        This function calculates a toric cycle which class is the same of a subvariety of a
+        normal toric variety X, under the hypothesis that X is simplicial. The subvariety is given
+        by the ideal of its intersection with the torus inside X.
+    Example
+        X = toricProjectiveSpace 3;
+        R = QQ[x_1 .. x_3];
+        I = ideal(x_1+x_2+x_3+1,x_1+2*x_2-x_3+4);
+        classFromTropical(X,I)
+///
+
+doc ///
+  Key
+    classWonderfulCompactification
+    (classWonderfulCompactification,NormalToricVariety,Ideal,Ideal)
+    (classWonderfulCompactification,NormalToricVariety,Ideal,RingElement)
+    (classWonderfulCompactification,Ideal,Ideal)
+    (classWonderfulCompactification,Ideal,RingElement)
+  Headline
+    compute a toric cycle of X which class is the same as a given subvariety of X
+  Usage
+    classWonderfulCompactification(X,I,J)
+  Inputs
+    X: NormalToricVariety
+    I: Ideal
+    J: Ideal
+  Outputs
+    D: ToricCycle
+  Description
+    Text
+        Given a hyperplane inside the torus, given by a linear ideal I, let X be a normal toric variety which fan
+        is supported on the tropicalization of V(I). This function calculates a toric cycle which class is the same
+        of a subvariety of V(I). The subvariety Y of V(I) is given by an ideal J such that Y = V(I+J), that is
+        Y is the intersection of V(J) and V(I) inside the torus of X. The purpose of this function is
+        essentially the same as classFromTropical, but it is optimized to this particular setting. Note that
+        the closure of V(I) inside X is a wonderful compactification of V(I).
+    Text
+        It is possible to explicitely input the toric variety, and this allows to implicitly specify the building set
+        of the wonderful compactification.
+    Text
+        A remarkable example among these is the moduli space of n-marked genus 0 curves M_0,n.
+        Below, we use this function on M_0,6 to compute one of the 15 Keel-Vermeire divisors.
+    Example
+        R = QQ[x_0..x_8];
+        I = ideal {-x_0+x_3+x_4, -x_1+x_3+x_5,-x_2+x_3+x_6, -x_0+x_2+x_7, -x_1+x_2+x_8, -x_0+x_1+1};
+        X = normalToricVariety fan tropicalVariety I;
+        f = x_0*x_1-x_2*x_3;
+        D = classWonderfulCompactification(X,I,f)
+///
+
+doc ///
+  Key
+    torusIntersection
+    (torusIntersection,NormalToricVariety,RingElement,Ring)
+    (torusIntersection,NormalToricVariety,RingElement)
+    (torusIntersection,NormalToricVariety,Ideal,Ring)
+    (torusIntersection,NormalToricVariety,Ideal)
+  Headline
+    compute the ideal of the intersection of a subvariety of a toric variety with the torus
+  Usage
+    torusIntersection(X,I)
+  Inputs
+    X: NormalToricVariety
+    I: Ideal
+        inside the Cox ring of X
+  Outputs
+    J: Ideal
+  Description
+    Text
+        This function calculates the ideal of the intersection of subavariety of a toric variety X
+        with the torus of X. The output is a ideal (saturated with respect to the product of variables)
+        inside the Laurent ring of the torus. The subvariety of X is given by its ideal in the Cox ring.
+        It applies the isomorphism of the Laurent polynomials with the degree zero part
+        of the localization with respect to the product of variables of the Cox ring.
+    Example
+        X = NormalToricVarieties$cartesianProduct apply((1,1), i-> toricProjectiveSpace i);
+        S = ring X;
+        f = 2 * S_1 + 3 * S_3 + S_0;
+        torusIntersection(X,f)
+        torusIntersection(X,ideal(f))
+    Example
+        X = toricProjectiveSpace 3;
+        S = ring X;
+        f = S_0*S_1*S_2+S_0*S_1*S_3+S_0*S_2*S_3+S_1*S_2*S_3;
+        torusIntersection(X,f)
+        I = ideal((S_1+S_2)*S_0, (S_1+S_2)*(S_0+S_1));
+        torusIntersection(X,I)
+///
+
+
+doc ///
+  Key
+    classFromTropicalCox
+    (classFromTropicalCox,NormalToricVariety,Ideal)
+  Headline
+    compute a toric cycle of X which class is the same as a given subvariety of X
+  Usage
+    classFromTropicalCox(X,I)
+  Inputs
+    X: NormalToricVariety
+    I: Ideal
+  Outputs
+    D: ToricCycle
+  Description
+    Text
+        This function calculates a toric cycle which class is the same of a subvariety of a
+        normal toric variety X, under the hypothesis that X is smooth. The subvariety is given
+        by its homogeneous ideal in the Cox ring of X.
+    Example
+        X = toricProjectiveSpace 3;
+        S = ring X;
+        I = ideal(S_0+S_1+S_2+1,S_0+2*S_1-S_2+4);
+        classFromTropicalCox(X,I)
+///
+
+-------------------------------------------------
+--
+-- doc ///
+--   Key
+--     name of the type / method
+--   Headline
+--     headline
+--   Usage
+--     functio(input)
+--   Inputs
+--     input: type of the input
+--       some text
+--   Outputs
+--     output: type of the output
+--       some text
+--   Description
+--     Text
+--        Some text
+--     Example
+--        examples
+-- ///

--- a/M2/Macaulay2/packages/TropicalToric/TropicalToricTest.m2
+++ b/M2/Macaulay2/packages/TropicalToric/TropicalToricTest.m2
@@ -1,0 +1,272 @@
+-- 0
+TEST ///
+X = toricProjectiveSpace 2;
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(y_1+y_2+1);
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+assert(mult == {1,1,1})
+prod = pushforwardMultiplicity(X,X',mult,k);
+assert(prod == {1,1,1})
+Y = poincareDuality(prod,X,k);
+O = orbits(X,k);
+D = sum apply(#O, s -> Y_s * X_(O_s));
+assert( D == X_{0} )
+assert( classFromTropical(X,I) == X_{0} )
+
+S = ring X;
+f = S_0+S_1+S_2;
+assert ( listForm torusIntersection(X,f) == listForm(y_1+y_2+1) )
+assert ( classFromTropical(X,I) == classFromTropicalCox(X,ideal(f)) )
+f = S_0*S_1+S_0*S_2+S_1*S_2;
+I = ideal(y_1*y_2+y_1+y_2);
+assert ( listForm(torusIntersection(X,f)) == listForm(y_1*y_2+y_1+y_2) )
+assert ( classFromTropical(X,I) == classFromTropicalCox(X,ideal(f)) )
+f = S_0^2 + S_1^2 + S_2^2;
+assert ( listForm torusIntersection(X,f) == listForm(y_1^2+y_2^2+1) )
+///
+
+-- 1
+TEST ///
+X = toricProjectiveSpace 2;
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(y_1*y_2+y_1+y_2);
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+assert(mult == {1,1,1})
+prod = pushforwardMultiplicity(X,X',mult,k);
+assert(prod == {2,2,2})
+Y = poincareDuality(prod,X,k);
+O = orbits(X,k);
+D = sum apply(#O, s -> Y_s * X_(O_s));
+assert( D == 2*X_{0} )
+assert( classFromTropical(X,I) == 2*X_{0} )
+///
+
+-- 2
+TEST ///
+X = toricProjectiveSpace 2;
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(y_1^2 + y_2 + 1);
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+assert(mult == {1,1,2})
+prod = pushforwardMultiplicity(X,X',mult,k);
+assert(prod == {2,2,2})
+Y = poincareDuality(prod,X,k);
+O = orbits(X,k);
+D = sum apply(#O, s -> Y_s * X_(O_s));
+assert( D == 2*X_{0} )
+assert( classFromTropical(X,I) == 2*X_{0} )
+///
+
+-- 3
+TEST ///
+X = toricProjectiveSpace 3;
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(y_1^2 + y_2 + y_3 + 1);
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+assert(mult == {1,1,1,1,2,1})
+prod = pushforwardMultiplicity(X,X',mult,k);
+assert(prod == {2,2,2,2,2,2})
+Y = poincareDuality(prod,X,k);
+O = orbits(X,k);
+D = sum apply(#O, s -> Y_s * X_(O_s));
+assert( D == 2*X_{0} )
+assert( classFromTropical(X,I) == 2*X_{0} )
+S = ring X;
+f = S_0*S_1*S_2+S_0*S_1*S_3+S_0*S_2*S_3+S_1*S_2*S_3;
+assert ( listForm(torusIntersection(X,f)) == listForm(y_1*y_2*y_3+y_1*y_2+y_1*y_3+y_2*y_3) )
+///
+
+-- 4
+TEST ///
+X = toricProjectiveSpace 3;
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(y_1 + y_2 + y_3 + 1, y_1 + 2*y_2 + 3*y_3 - 1); -- U_2,4
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+assert(mult == {1,1,1,1})
+prod = pushforwardMultiplicity(X,X',mult,k);
+assert(prod == {1,1,1,1})
+Y = poincareDuality(prod,X,k);
+O = orbits(X,k);
+D = sum apply(#O, s -> Y_s * X_(O_s));
+assert( D == X_{0,1} )
+assert( classFromTropical(X,I) == X_{0,1} )
+///
+
+-- 5
+TEST ///
+X = toricProjectiveSpace 4;
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(y_1^2 + y_2 + y_3 + y_4 + 1);
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+assert(mult == {1,1,1,1,1,1,1,2,1,1})
+prod = pushforwardMultiplicity(X,X',mult,k);
+assert(prod == toList(10:2))
+Y = poincareDuality(prod,X,k);
+O = orbits(X,k);
+D = sum apply(#O, s -> Y_s * X_(O_s));
+assert( D == 2*X_{0,1,2} )
+assert( classFromTropical(X,I) == 2*X_{0,1,2} )
+S = ring X;
+f = S_0^4 + S_1^4 + S_2^4 + S_4^4 + S_0*S_3^3 + S_1*S_3^3 + S_2*S_3^3 + S_4*S_3^3;
+assert ( listForm(torusIntersection(X,f)) == listForm(y_1^4+y_2^4+y_1*y_3^3+y_2*y_3^3+y_3^3*y_4+y_4^4+y_3^3+1) )
+///
+
+-- 6
+TEST ///
+X = toricProjectiveSpace 4;
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(y_1 + y_2 + y_3 + y_4 + 1, y_1 + 2*y_2 + 3*y_3 + 4*y_4 -1); -- U_3,5
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+assert(mult == toList(10:1))
+prod = pushforwardMultiplicity(X,X',mult,k);
+assert(prod == toList(10:1))
+Y = poincareDuality(prod,X,k);
+O = orbits(X,k);
+D = sum apply(#O, s -> Y_s * X_(O_s));
+assert( D == X_{0,1} )
+assert( classFromTropical(X,I) == X_{0,1} )
+///
+
+-- 7
+TEST ///
+-- Blow up of P^2 at one point
+X = normalToricVariety({{1,0},{1,1},{0,1},{-1,-1}},{{0,1},{1,2},{2,3},{3,0}});
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(y_1^2 + y_1*y_2 + y_2^2);
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+prod = pushforwardMultiplicity(X,X',mult,dim T);
+Y = poincareDuality(prod,X,k);
+O = orbits(X,k);
+D = sum apply(#O, s -> Y_s * X_(O_s));
+assert( mult == {2,2} )
+assert( prod == {0,2,0,2} )
+assert( D == 2*X_{0} )
+assert( classFromTropical(X,I) == 2*X_{0} )
+-- The class is 2(H-E)
+///
+
+-- 8
+TEST ///
+--chromatic polynomial of K_3 with Huh-Katz Theorem
+X = NormalToricVarieties$cartesianProduct apply((3,3), i-> toricProjectiveSpace i);
+n = dim X;
+TR = QQ[y_1..y_n];
+I = ideal(-y_1+y_2+y_3, y_1*y_4-1, y_2*y_5-1, y_3*y_6-1);
+D = classFromTropical(X,I);
+assert( D == 2* X_{0,1,2,4} + 3 * X_{0,1,4,5} + X_{0,4,5,6} )
+///
+
+-- 9
+TEST ///
+-- Keel-Vermeire divisor of M_0,6
+R = QQ[x_0..x_8];
+I = ideal {-x_0+x_3+x_4, -x_1+x_3+x_5,-x_2+x_3+x_6, -x_0+x_2+x_7, -x_1+x_2+x_8, -x_0+x_1+1};
+raysList = {{1,0,0,0,0,0,0,0,0},{0,1,0,0,0,0,0,0,0},
+{0,0,1,0,0,0,0,0,0},{-1,-1,-1,-1,0,0,0,0,0},
+{0,0,0,1,0,0,0,0,0},{0,0,0,0,1,0,0,0,0},
+{1,0,0,1,1,0,0,0,0},{0,0,0,0,0,1,0,0,0},
+{0,1,0,1,0,1,0,0,0},{0,0,0,-1,-1,-1,-1,0,0},
+{-1,-1,-1,-1,-1,-1,-1,0,0},{0,0,0,0,0,0,1,0,0},
+{0,0,1,1,0,0,1,0,0},{0,0,0,0,0,0,0,1,0},
+{1,0,1,0,0,0,0,1,0},{0,0,0,0,1,0,1,1,0},
+{1,0,1,1,1,0,1,1,0},{0,0,-1,0,0,0,-1,-1,-1},
+{-1,-1,-1,-1,0,0,-1,-1,-1},{0,0,-1,-1,-1,-1,-1,-1,-1},
+{-1,-1,-1,-1,-1,-1,-1,-1,-1},{0,0,0,0,0,0,0,0,1},
+{0,1,1,0,0,0,0,0,1},{0,0,0,0,0,1,1,0,1},{0,1,1,1,0,1,1,0,1}};
+coneList = {{0,6,16},{0,6,17},{0,6,21},{0,7,14},{0,7,17},{0,7,23},
+{0,9,14},{0,9,19},{0,9,21},{0,11,16},{0,11,19},{0,11,23},
+{0,14,16},{0,17,19},{0,21,23},{1,5,15},{1,5,17},{1,5,22},
+{1,8,13},{1,8,17},{1,8,24},{1,9,13},{1,9,19},{1,9,22},
+{1,11,15},{1,11,19},{1,11,24},{1,13,15},{1,17,19},{1,22,24},
+{2,5,16},{2,5,18},{2,5,22},{2,7,14},{2,7,18},{2,7,24},
+{2,9,14},{2,9,20},{2,9,22},{2,12,16},{2,12,20},{2,12,24},
+{2,14,16},{2,18,20},{2,22,24},{3,5,15},{3,5,18},{3,5,21},
+{3,7,13},{3,7,18},{3,7,23},{3,10,13},{3,10,20},{3,10,21},
+{3,11,15},{3,11,20},{3,11,23},{3,13,15},{3,18,20},{3,21,23},
+{4,6,16},{4,6,17},{4,6,21},{4,8,13},{4,8,17},{4,8,24},
+{4,10,13},{4,10,20},{4,10,21},{4,12,16},{4,12,20},{4,12,24},
+{4,13,16},{4,17,20},{4,21,24},{5,6,16},{5,6,17},{5,6,21},
+{5,15,16},{5,17,18},{5,21,22},{7,8,13},{7,8,17},{7,8,24},
+{7,13,14},{7,17,18},{7,23,24},{9,10,13},{9,10,20},{9,10,21},
+{9,13,14},{9,19,20},{9,21,22},{11,12,16},{11,12,20},{11,12,24},
+{11,15,16},{11,19,20},{11,23,24},{13,14,16},{13,15,16},{17,18,20},
+{17,19,20},{21,22,24},{21,23,24}};
+X = normalToricVariety(raysList,coneList);
+l = {0,1,2,4,5,7,11,13,21};
+f = x_0*x_1-x_2*x_3;
+D = classWonderfulCompactification(X,I,f);
+D = toricDivisorFromCycle D;
+Q = X_1 + X_5 + X_13 + 2*X_15 + X_16 - X_20;
+assert( makeTransverse(D,l) == makeTransverse(Q,l) )
+///
+
+-- 10
+TEST ///
+X = normalToricVariety({{1,0},{1,1},{0,1},{-1,0},{-1,-1},{0,-1}},{{0,1},{1,2},{2,3},{3,4},{4,5},{0,5}});
+n = dim X;
+TR = QQ[y_1..y_n];
+S = ring X;
+f = S_1*S_2*S_3*S_5 + S_0*S_3*S_4*S_5 + S_1*S_4*S_5^2;
+g = torusIntersection(X,f);
+assert ( listForm(g) == listForm(y_1+y_2+y_1*y_2) )
+I = ideal(g);
+T = tropicalVariety(I);
+k = dim T;
+F = gfanFanCommonRefinement(fan X, fan T);
+X' = makeSimplicial (normalToricVariety F);
+mult = refineMultiplicity(T,X');
+prod = pushforwardMultiplicity(X,X',mult,dim T);
+assert ( mult == toList( #(max X') : 1 ) )
+assert ( prod == {0,1,0,1,0,1} )
+D = classFromTropical(X,I);
+assert ( D == X_{0}+X_{1}+X_{2} )
+assert ( D == classFromTropicalCox(X,ideal(f)) )
+///
+
+
+-------------------------------------------------
+
+-- TEST ///
+-- Code
+-- assert(statement)
+-- ///

--- a/M2/Macaulay2/packages/TropicalToric/examples/___Normal__Toric__Variety_sp_us_sp__List.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/___Normal__Toric__Variety_sp_us_sp__List.out
@@ -1,0 +1,42 @@
+-- -*- M2-comint -*- hash: 1985264245
+
+i1 : rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+
+o1 = {{1, 0}, {0, 1}, {-1, -1}, {0, -1}}
+
+o1 : List
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}}
+
+o2 = {{0, 1}, {1, 2}, {2, 3}, {3, 0}}
+
+o2 : List
+
+i3 : X = normalToricVariety(rayList,coneList)
+
+o3 = X
+
+o3 : NormalToricVariety
+
+i4 : X_{1}
+
+o4 = X
+      {1}
+
+o4 : ToricCycle on X
+
+i5 : X_{0,2}
+
+o5 = X
+      {0, 2}
+
+o5 : ToricCycle on X
+
+i6 : 2 * X_{2} - X_{3}
+
+o6 = 2*X    - X
+        {2}    {3}
+
+o6 : ToricCycle on X
+
+i7 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Cycle_sp_eq_eq_sp__Toric__Cycle.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Cycle_sp_eq_eq_sp__Toric__Cycle.out
@@ -1,0 +1,40 @@
+-- -*- M2-comint -*- hash: -1849782264
+
+i1 : rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+
+o1 = {{1, 0}, {0, 1}, {-1, -1}, {0, -1}}
+
+o1 : List
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}}
+
+o2 = {{0, 1}, {1, 2}, {2, 3}, {3, 0}}
+
+o2 : List
+
+i3 : X = normalToricVariety(rayList,coneList)
+
+o3 = X
+
+o3 : NormalToricVariety
+
+i4 : D = X_3
+
+o4 = X
+      3
+
+o4 : ToricDivisor on X
+
+i5 : D*{2} == toricCycle({{2,3} => 1},X)
+
+o5 = true
+
+i6 : D*{1} == toricCycle({},X)
+
+o6 = true
+
+i7 : D*{0} == toricCycle({{0,3} => 1},X)
+
+o7 = true
+
+i8 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Cycle_sp_pl_sp__Toric__Cycle.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Cycle_sp_pl_sp__Toric__Cycle.out
@@ -1,0 +1,70 @@
+-- -*- M2-comint -*- hash: 163601047
+
+i1 : rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+
+o1 = {{1, 0}, {0, 1}, {-1, -1}, {0, -1}}
+
+o1 : List
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}}
+
+o2 = {{0, 1}, {1, 2}, {2, 3}, {3, 0}}
+
+o2 : List
+
+i3 : X = normalToricVariety(rayList,coneList)
+
+o3 = X
+
+o3 : NormalToricVariety
+
+i4 : cyc = toricCycle({{2,3} => 1,{3,0} => 4},X)
+
+o4 = X       + 4*X
+      {2, 3}      {3, 0}
+
+o4 : ToricCycle on X
+
+i5 : altcyc = (-2)*cyc
+
+o5 = - 2*X       - 8*X
+          {2, 3}      {3, 0}
+
+o5 : ToricCycle on X
+
+i6 : cyc + altcyc
+
+o6 = - X       - 4*X
+        {2, 3}      {3, 0}
+
+o6 : ToricCycle on X
+
+i7 : cyc - altcyc
+
+o7 = 3*X       + 12*X
+        {2, 3}       {3, 0}
+
+o7 : ToricCycle on X
+
+i8 : -cyc
+
+o8 = - X       - 4*X
+        {2, 3}      {3, 0}
+
+o8 : ToricCycle on X
+
+i9 : X_{0} + X_{1}
+
+o9 = X    + X
+      {0}    {1}
+
+o9 : ToricCycle on X
+
+i10 : 2*X_{0,1} - X_{0,2}
+
+o10 = 2*X       - X
+         {0, 1}    {0, 2}
+
+o10 : ToricCycle on X
+
+i11 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Cycle_sp_st_sp__Toric__Cycle.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Cycle_sp_st_sp__Toric__Cycle.out
@@ -1,0 +1,56 @@
+-- -*- M2-comint -*- hash: 468101149
+
+i1 : X = toricProjectiveSpace 5
+
+o1 = X
+
+o1 : NormalToricVariety
+
+i2 : D = X_{0,1}+5*X_{1,3}-X_{2}+2*X_{3}
+
+o2 = X       - X    + 2*X    + 5*X
+      {0, 1}    {2}      {3}      {1, 3}
+
+o2 : ToricCycle on X
+
+i3 : C = X_{2,3}
+
+o3 = X
+      {2, 3}
+
+o3 : ToricCycle on X
+
+i4 : D*C
+
+o4 = X          + X             + 5*X
+      {2, 3, 5}    {0, 1, 2, 3}      {1, 2, 3, 5}
+
+o4 : ToricCycle on X
+
+i5 : X = toricProjectiveSpace 2
+
+o5 = X
+
+o5 : NormalToricVariety
+
+i6 : Y = toricBlowup({0,1},X)
+
+o6 = Y
+
+o6 : NormalToricVariety
+
+i7 : D = Y_{3}
+
+o7 = Y
+      {3}
+
+o7 : ToricCycle on Y
+
+i8 : D*D
+
+o8 = - Y
+        {1, 3}
+
+o8 : ToricCycle on Y
+
+i9 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Cycle_sp_us_sp__List.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Cycle_sp_us_sp__List.out
@@ -1,0 +1,46 @@
+-- -*- M2-comint -*- hash: 23274687
+
+i1 : rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+
+o1 = {{1, 0}, {0, 1}, {-1, -1}, {0, -1}}
+
+o1 : List
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}}
+
+o2 = {{0, 1}, {1, 2}, {2, 3}, {3, 0}}
+
+o2 : List
+
+i3 : X = normalToricVariety(rayList,coneList)
+
+o3 = X
+
+o3 : NormalToricVariety
+
+i4 : C = X_{0,1} + X_{0,2} - 2*X_{0,3} + X_{0}
+
+o4 = X    + X       + X       - 2*X
+      {0}    {0, 1}    {0, 2}      {0, 3}
+
+o4 : ToricCycle on X
+
+i5 : C_{0,1}
+
+o5 = 1
+
+i6 : C_{0,2}
+
+o6 = 1
+
+i7 : C_{0,3}
+
+o7 = -2
+
+o7 : QQ
+
+i8 : C_0
+
+o8 = 1
+
+i9 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Divisor_sp_st_sp__List.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Divisor_sp_st_sp__List.out
@@ -1,0 +1,61 @@
+-- -*- M2-comint -*- hash: -1003275919
+
+i1 : rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+
+o1 = {{1, 0}, {0, 1}, {-1, -1}, {0, -1}}
+
+o1 : List
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}}
+
+o2 = {{0, 1}, {1, 2}, {2, 3}, {3, 0}}
+
+o2 : List
+
+i3 : X = normalToricVariety(rayList,coneList)
+
+o3 = X
+
+o3 : NormalToricVariety
+
+i4 : D = X_3
+
+o4 = X
+      3
+
+o4 : ToricDivisor on X
+
+i5 : D*{2}
+
+o5 = X
+      {2, 3}
+
+o5 : ToricCycle on X
+
+i6 : D*{1}
+
+o6 = 0
+
+o6 : ToricCycle on X
+
+i7 : D = X_0 + 2*X_1 + 3*X_2 + 4*X_3
+
+o7 = X  + 2*X  + 3*X  + 4*X
+      0      1      2      3
+
+o7 : ToricDivisor on X
+
+i8 : C = (orbits X)#1#0
+
+o8 = {0}
+
+o8 : List
+
+i9 : D*C
+
+o9 = 6*X
+        {0, 3}
+
+o9 : ToricCycle on X
+
+i10 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Divisor_sp_st_sp__Toric__Cycle.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/___Toric__Divisor_sp_st_sp__Toric__Cycle.out
@@ -1,0 +1,63 @@
+-- -*- M2-comint -*- hash: 261200426
+
+i1 : X = toricProjectiveSpace 4
+
+o1 = X
+
+o1 : NormalToricVariety
+
+i2 : D = X_0+2*X_1+3*X_2+4*X_3
+
+o2 = X  + 2*X  + 3*X  + 4*X
+      0      1      2      3
+
+o2 : ToricDivisor on X
+
+i3 : C = X_{2,3}
+
+o3 = X
+      {2, 3}
+
+o3 : ToricCycle on X
+
+i4 : D*C
+
+o4 = 10*X
+         {1, 2, 3}
+
+o4 : ToricCycle on X
+
+i5 : X = toricProjectiveSpace 2
+
+o5 = X
+
+o5 : NormalToricVariety
+
+i6 : Y = toricBlowup({0,1},X)
+
+o6 = Y
+
+o6 : NormalToricVariety
+
+i7 : D = Y_3
+
+o7 = Y
+      3
+
+o7 : ToricDivisor on Y
+
+i8 : C = Y_{3}
+
+o8 = Y
+      {3}
+
+o8 : ToricCycle on Y
+
+i9 : D*C
+
+o9 = - Y
+        {1, 3}
+
+o9 : ToricCycle on Y
+
+i10 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_class__From__Tropical.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_class__From__Tropical.out
@@ -1,0 +1,18 @@
+-- -*- M2-comint -*- hash: 124511163
+
+i1 : X = toricProjectiveSpace 3;
+
+i2 : R = QQ[x_1 .. x_3];
+
+i3 : I = ideal(x_1+x_2+x_3+1,x_1+2*x_2-x_3+4);
+
+o3 : Ideal of R
+
+i4 : classFromTropical(X,I)
+
+o4 = X
+      {0, 1}
+
+o4 : ToricCycle on X
+
+i5 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_class__From__Tropical__Cox.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_class__From__Tropical__Cox.out
@@ -1,0 +1,18 @@
+-- -*- M2-comint -*- hash: 1083445600
+
+i1 : X = toricProjectiveSpace 3;
+
+i2 : S = ring X;
+
+i3 : I = ideal(S_0+S_1+S_2+1,S_0+2*S_1-S_2+4);
+
+o3 : Ideal of S
+
+i4 : classFromTropicalCox(X,I)
+
+o4 = X
+      {0, 1}
+
+o4 : ToricCycle on X
+
+i5 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_class__Wonderful__Compactification.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_class__Wonderful__Compactification.out
@@ -1,0 +1,20 @@
+-- -*- M2-comint -*- hash: 1101768179
+
+i1 : R = QQ[x_0..x_8];
+
+i2 : I = ideal {-x_0+x_3+x_4, -x_1+x_3+x_5,-x_2+x_3+x_6, -x_0+x_2+x_7, -x_1+x_2+x_8, -x_0+x_1+1};
+
+o2 : Ideal of R
+
+i3 : X = normalToricVariety fan tropicalVariety I;
+
+i4 : f = x_0*x_1-x_2*x_3;
+
+i5 : D = classWonderfulCompactification(X,I,f)
+
+o5 = 2*X    + 2*X     - X     + 2*X     + 2*X     - X     + X    - X    - 2*X    + X
+        {9}      {10}    {11}      {13}      {14}    {17}    {2}    {5}      {6}    {7}
+
+o5 : ToricCycle on X
+
+i6 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_deg__Cycle.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_deg__Cycle.out
@@ -1,0 +1,22 @@
+-- -*- M2-comint -*- hash: 1474937778
+
+i1 : rayList={{1,0},{1,1},{0,1},{-1,-1}};
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}};
+
+i3 : X = normalToricVariety(rayList,coneList);
+
+i4 : C = X_{0,1} + X_{1,2} - 3*X_{2,3}
+
+o4 = - 3*X       + X       + X
+          {2, 3}    {0, 1}    {1, 2}
+
+o4 : ToricCycle on X
+
+i5 : degCycle(C)
+
+o5 = -1
+
+o5 : QQ
+
+i6 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_is__Transverse.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_is__Transverse.out
@@ -1,0 +1,48 @@
+-- -*- M2-comint -*- hash: -518461911
+
+i1 : rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+
+o1 = {{1, 0}, {0, 1}, {-1, -1}, {0, -1}}
+
+o1 : List
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}}
+
+o2 = {{0, 1}, {1, 2}, {2, 3}, {3, 0}}
+
+o2 : List
+
+i3 : X = normalToricVariety(rayList,coneList)
+
+o3 = X
+
+o3 : NormalToricVariety
+
+i4 : D = X_3
+
+o4 = X
+      3
+
+o4 : ToricDivisor on X
+
+i5 : E = {0,3}
+
+o5 = {0, 3}
+
+o5 : List
+
+i6 : F = {1,2}
+
+o6 = {1, 2}
+
+o6 : List
+
+i7 : isTransverse(D,E)
+
+o7 = false
+
+i8 : isTransverse(D,F)
+
+o8 = true
+
+i9 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_make__Transverse.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_make__Transverse.out
@@ -1,0 +1,26 @@
+-- -*- M2-comint -*- hash: 2007439952
+
+i1 : rayList={{1,0},{1,1},{0,1},{-1,-1}};
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}};
+
+i3 : X = normalToricVariety fan (transpose matrix rayList,coneList);
+
+i4 : D = X_0+X_1;
+
+o4 : ToricDivisor on X
+
+i5 : C = {1,2};
+
+i6 : isTransverse(D,C)
+
+o6 = false
+
+i7 : makeTransverse(D,C)
+
+o7 = 2*X  + 0 + 0 + X
+        0            3
+
+o7 : ToricDivisor on X
+
+i8 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_poincare__Duality.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_poincare__Duality.out
@@ -1,0 +1,31 @@
+-- -*- M2-comint -*- hash: -2132344894
+
+i1 : X = toricProjectiveSpace 3;
+
+i2 : k = 2;
+
+i3 : l = toList(#orbits(X,1):3)
+
+o3 = {3, 3, 3, 3, 3, 3}
+
+o3 : List
+
+i4 : poincareDuality(l, X, k)
+
+o4 = {3, 0, 0, 0}
+
+o4 : List
+
+i5 : poincareMatrix(X,2)
+
+o5 = | 1 1 1 1 |
+     | 1 1 1 1 |
+     | 1 1 1 1 |
+     | 1 1 1 1 |
+     | 1 1 1 1 |
+     | 1 1 1 1 |
+
+              6        4
+o5 : Matrix QQ  <--- QQ
+
+i6 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_polymake__Cone__Contains.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_polymake__Cone__Contains.out
@@ -1,0 +1,19 @@
+-- -*- M2-comint -*- hash: -2133601056
+
+i1 : v = {1,0,0};
+
+i2 : C = {{1,0,0},{0,1,0},{0,0,1}};
+
+i3 : polymakeConeContains(v,C)
+
+o3 = true
+
+i4 : v = {1,0,0};
+
+i5 : C = {{2,1,0},{0,1,0},{0,0,1}};
+
+i6 : polymakeConeContains(v,C)
+
+o6 = false
+
+i7 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_pushforward__Multiplicity.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_pushforward__Multiplicity.out
@@ -1,0 +1,23 @@
+-- -*- M2-comint -*- hash: -1987678326
+
+i1 : X = toricProjectiveSpace 3;
+
+i2 : R = QQ[x_1 .. x_3];
+
+i3 : f = x_1*x_2*x_3 + x_1*x_2 + x_1*x_3 + x_2*x_3;
+
+i4 : T = tropicalVariety(ideal f);
+
+i5 : F = gfanFanCommonRefinement(fan X, fan T);
+
+i6 : X' = makeSimplicial (normalToricVariety F);
+
+i7 : mult = refineMultiplicity(T,X');
+
+i8 : pushforwardMultiplicity(X,X',mult,dim T)
+
+o8 = {3, 3, 3, 3, 3, 3}
+
+o8 : List
+
+i9 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_refine__Multiplicity.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_refine__Multiplicity.out
@@ -1,0 +1,27 @@
+-- -*- M2-comint -*- hash: -1948415671
+
+i1 : X = toricProjectiveSpace 3;
+
+i2 : R = QQ[x_1 .. x_3];
+
+i3 : f = x_1*x_2*x_3 + x_1*x_2 + x_1*x_3 + x_2*x_3;
+
+i4 : T = tropicalVariety(ideal f);
+
+i5 : F = gfanFanCommonRefinement(fan X, fan T);
+
+i6 : X' = makeSimplicial (normalToricVariety F);
+
+i7 : multiplicities T
+
+o7 = {1, 1, 1, 1, 1, 1}
+
+o7 : List
+
+i8 : refineMultiplicity(T,X')
+
+o8 = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+
+o8 : List
+
+i9 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_support_lp__Toric__Cycle_rp.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_support_lp__Toric__Cycle_rp.out
@@ -1,0 +1,35 @@
+-- -*- M2-comint -*- hash: 1178755436
+
+i1 : X = toricProjectiveSpace 4
+
+o1 = X
+
+o1 : NormalToricVariety
+
+i2 : Z1 = toricCycle({{0,1} => 3,{0,2} => 7,{1,2} => 82},X)
+
+o2 = 3*X       + 7*X       + 82*X
+        {0, 1}      {0, 2}       {1, 2}
+
+o2 : ToricCycle on X
+
+i3 : Z2 = toricCycle({{0,1} => 4,{0,2} => 5},X)
+
+o3 = 4*X       + 5*X
+        {0, 1}      {0, 2}
+
+o3 : ToricCycle on X
+
+i4 : support Z1
+
+o4 = {{0, 1}, {0, 2}, {1, 2}}
+
+o4 : List
+
+i5 : support Z2
+
+o5 = {{0, 1}, {0, 2}}
+
+o5 : List
+
+i6 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_toric__Cycle.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_toric__Cycle.out
@@ -1,0 +1,56 @@
+-- -*- M2-comint -*- hash: 7462383
+
+i1 : rayList={{1,0},{0,1},{-1,-1},{0,-1}}
+
+o1 = {{1, 0}, {0, 1}, {-1, -1}, {0, -1}}
+
+o1 : List
+
+i2 : coneList={{0,1},{1,2},{2,3},{3,0}}
+
+o2 = {{0, 1}, {1, 2}, {2, 3}, {3, 0}}
+
+o2 : List
+
+i3 : X = normalToricVariety(rayList,coneList)
+
+o3 = X
+
+o3 : NormalToricVariety
+
+i4 : cyc = toricCycle({{2,3} =>1,{3,0} => 4},X)
+
+o4 = X       + 4*X
+      {2, 3}      {3, 0}
+
+o4 : ToricCycle on X
+
+i5 : altcyc = (-2)*cyc
+
+o5 = - 2*X       - 8*X
+          {2, 3}      {3, 0}
+
+o5 : ToricCycle on X
+
+i6 : cyc + altcyc
+
+o6 = - X       - 4*X
+        {2, 3}      {3, 0}
+
+o6 : ToricCycle on X
+
+i7 : cyc - altcyc
+
+o7 = 3*X       + 12*X
+        {2, 3}       {3, 0}
+
+o7 : ToricCycle on X
+
+i8 : -cyc
+
+o8 = - X       - 4*X
+        {2, 3}      {3, 0}
+
+o8 : ToricCycle on X
+
+i9 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_toric__Cycle_lp__Toric__Divisor_rp.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_toric__Cycle_lp__Toric__Divisor_rp.out
@@ -1,0 +1,19 @@
+-- -*- M2-comint -*- hash: -2132582148
+
+i1 : X = toricProjectiveSpace 3;
+
+i2 : toricCycle(X_0)
+
+o2 = X
+      {0}
+
+o2 : ToricCycle on X
+
+i3 : toricCycle(X_1+X_2)
+
+o3 = X    + X
+      {1}    {2}
+
+o3 : ToricCycle on X
+
+i4 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_toric__Divisor__From__Cycle.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_toric__Divisor__From__Cycle.out
@@ -1,0 +1,16 @@
+-- -*- M2-comint -*- hash: -834038959
+
+i1 : X = toricProjectiveSpace 2;
+
+i2 : D = X_{0} + X_{1};
+
+o2 : ToricCycle on X
+
+i3 : toricDivisorFromCycle D
+
+o3 = X  + X
+      0    1
+
+o3 : ToricDivisor on X
+
+i4 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_torus__Intersection.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_torus__Intersection.out
@@ -1,0 +1,51 @@
+-- -*- M2-comint -*- hash: -746296924
+
+i1 : X = NormalToricVarieties$cartesianProduct apply((1,1), i-> toricProjectiveSpace i);
+
+i2 : S = ring X;
+
+i3 : f = 2 * S_1 + 3 * S_3 + S_0;
+
+i4 : torusIntersection(X,f)
+
+o4 = 2y  + 3y  + 1
+       1     2
+
+o4 : QQ[y ..y ]
+         1   2
+
+i5 : torusIntersection(X,ideal(f))
+
+o5 = ideal(2y  + 3y  + 1)
+             1     2
+
+o5 : Ideal of QQ[y ..y ]
+                  1   2
+
+i6 : X = toricProjectiveSpace 3;
+
+i7 : S = ring X;
+
+i8 : f = S_0*S_1*S_2+S_0*S_1*S_3+S_0*S_2*S_3+S_1*S_2*S_3;
+
+i9 : torusIntersection(X,f)
+
+o9 = y y y  + y y  + y y  + y y
+      1 2 3    1 2    1 3    2 3
+
+o9 : QQ[y ..y ]
+         1   3
+
+i10 : I = ideal((S_1+S_2)*S_0, (S_1+S_2)*(S_0+S_1));
+
+o10 : Ideal of S
+
+i11 : torusIntersection(X,I)
+
+o11 = ideal(y  + y )
+             1    2
+
+o11 : Ideal of QQ[y ..y ]
+                   1   3
+
+i12 : 

--- a/M2/Macaulay2/packages/TropicalToric/examples/_variety_lp__Toric__Cycle_rp.out
+++ b/M2/Macaulay2/packages/TropicalToric/examples/_variety_lp__Toric__Cycle_rp.out
@@ -1,0 +1,22 @@
+-- -*- M2-comint -*- hash: 1211840699
+
+i1 : X = toricProjectiveSpace 2
+
+o1 = X
+
+o1 : NormalToricVariety
+
+i2 : Z = toricCycle({{0,1} => 3,{0,2} => 7,{1,2} => 82},X)
+
+o2 = 3*X       + 7*X       + 82*X
+        {0, 1}      {0, 2}       {1, 2}
+
+o2 : ToricCycle on X
+
+i3 : variety Z
+
+o3 = X
+
+o3 : NormalToricVariety
+
+i4 : 

--- a/M2/Macaulay2/packages/TropicalToric/polymakeContains.m2
+++ b/M2/Macaulay2/packages/TropicalToric/polymakeContains.m2
@@ -1,0 +1,35 @@
+polymakeConeContains = method(TypicalValue => Boolean)
+polymakeConeContains (List, List) := (v,C) ->(
+  --v is a list
+  --C is a list
+  v = toExternalString v;
+  v = replace("\\{","[",v);
+  v = replace("\\}","]",v);
+
+  C = toExternalString C;
+  C = replace("\\{","[",C);
+  C = replace("\\}","]",C);
+  C = replace("\\],","],\n",C);
+
+  outputFile := temporaryFileName();
+
+  codeString := "use application \"fan\";
+  my $v = new Vector("|v|");
+  my $C = new Cone(INPUT_RAYS=>"|C|");
+  open(OUT,\">\",\""|outputFile|"\");
+  print OUT $C->contains($v);
+  close OUT;
+  ";
+
+  polymakeCode := temporaryFileName();
+  polymakeCode << codeString << close;
+
+  run ("polymake --script "|polymakeCode);
+
+  o := get outputFile;
+  if o == "false" then(
+    return false;
+  ) else(
+    return true;
+  );
+);

--- a/M2/Macaulay2/packages/TropicalToric/polymakeContainsDoc.m2
+++ b/M2/Macaulay2/packages/TropicalToric/polymakeContainsDoc.m2
@@ -1,0 +1,26 @@
+doc ///
+  Key
+    polymakeConeContains
+    (polymakeConeContains,List, List)
+  Headline
+    Check if a vector is contained in a cone using polymake
+  Usage
+    polymakeConeContains(v,C)
+  Inputs
+    v: List
+    C: List
+  Outputs
+    b: Boolean
+  Description
+    Text
+        This method checks if a vector, given as a list, is contained in a cone, where the cone is given
+        as a list containing lists representing the vectors spanning the cone.
+    Example
+        v = {1,0,0};
+        C = {{1,0,0},{0,1,0},{0,0,1}};
+        polymakeConeContains(v,C)
+    Example
+        v = {1,0,0};
+        C = {{2,1,0},{0,1,0},{0,0,1}};
+        polymakeConeContains(v,C)
+///


### PR DESCRIPTION
We certify the following packages that were published in JSAG volume 14 ahead of the next release:

* `CotangentSchubert`
* `GeometricDecomposability`
* `InvariantRing` (this is a re-certification -- an earlier version was previously published In JSAG)
* `MultiplicitySequence`
* `Probability`
* `TropicalToric` *(new package)*

I had to make one small change from the published version to get `TropicalToric` to load without errors, likely due to the recent `Varieties` package changes.

The JSAG website says that volume 14 is "not yet complete".  I'll keep my eyes peeled and add any new ones that pop up before the release.