### PR TITLE
Fix link to JSAG code for ConformalBlocks package

### DIFF
--- a/M2/Macaulay2/packages/ConformalBlocks.m2
+++ b/M2/Macaulay2/packages/ConformalBlocks.m2
@@ -16,7 +16,7 @@ newPackage(
 	  "acceptance date" => "2 August 2018",
 	  "published article URI" => "https://msp.org/jsag/2018/8-1/p08.xhtml",
 	  "published article DOI" => "10.2140/jsag.2018.8.81",
-	  "published code URI" => "https://msp.org/jsag/2018/8-1/jsag-v8-n1-x08-LieTypes.m2",
+	  "published code URI" => "https://msp.org/jsag/2018/8-1/jsag-v8-n1-x08-ConformalBlocks.m2",
 	  "repository code URI" => "https://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/ConformalBlocks.m2",
 	  "release at publication" => "923fbcc7c77b23f510bb0d740e00fc1722a2f397",	    -- git commit number in hex
 	  "version at publication" => "0.5",


### PR DESCRIPTION
Same article as `LieTypes`, but both packages are present on the JSAG site, so we might as well point to the correct one.

---

This is a quick followup to #3201 with one more fix.  Skipping the tests since we're just changing the contents of one string.