### PR TITLE
Fix compilation error with bdwgc 7

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -57,7 +57,9 @@ void* profFunc(ArgCell* p);
 void* testFunc(ArgCell* p);
 
 static void * GC_start_performance_measurement_0(void *) {
+#ifdef GC_start_performance_measurement /* added in bdwgc 8 */
   GC_start_performance_measurement();
+#endif
   return NULL;
 }
 

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -2068,6 +2068,9 @@ toExternalString(e:Expr):Expr := (
 setupfun("toExternalString0",toExternalString);
 
 header "
+#ifndef GC_get_full_gc_total_time /* added in bdwgc 8 */
+unsigned long GC_get_full_gc_total_time(void) {return 0;}
+#endif
 #define DEF_GC_FN0(s)	static void * s##_0(void *client_data) { (void) client_data; return (void *) (long) s(); }
 DEF_GC_FN0(GC_get_full_gc_total_time)
 DEF_GC_FN0(GC_get_free_space_divisor)


### PR DESCRIPTION
This is a short followup to #3186.

The new garbage collector timing feature added to `time` relies on two functions that were added in bdwgc 8.  They also might be unavailable if bdwgc was compiled with `NO_CLOCK`.  In either case, compilation will fail.  This is a problem, for example, on the Ubuntu LTS releases 18.04 and 20.04, which both have bdwgc 7.

We add workarounds for when these functions are unavailable.  Note that if this is the case, then `time` will always print 0 for time spent in garbage collection.

Here's an example of the build failure before this patch ([full log](https://launchpadlibrarian.net/728147115/buildlog_ubuntu-focal-amd64.macaulay2_1.23.0.1+git202405051947-0ppa202405051952~ubuntu20.04.1_BUILDING.txt.gz)):

```shell
main.cpp: In function ‘void* GC_start_performance_measurement_0(void*)’:
main.cpp:60:3: error: ‘GC_start_performance_measurement’ was not declared in this scope; did you mean ‘GC_start_performance_measurement_0’?
   60 |   GC_start_performance_measurement();
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   GC_start_performance_measurement_0
compilation terminated due to -Wfatal-errors.
```