### PR TITLE
Add "Precision" option to FourTiTwo::hilbertBasis

### DIFF
--- a/M2/Macaulay2/m2/shared.m2
+++ b/M2/Macaulay2/m2/shared.m2
@@ -7,7 +7,7 @@ needs "methods.m2"
 chi = method()
 
 cone = method()
-rays = method()
+rays = method(Options => true)
 
 decompose = method(Options => true)
 

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -181,13 +181,14 @@ hilbertBasis Matrix := Matrix => o -> (A ->(
      getMatrix(filename|".hil")
      ))
 
-rays Matrix := Matrix => (A ->(
+rays Matrix := Matrix => { Precision => 64 } >> o -> (A ->(
      filename := getFilename();
      if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     run4ti2("rays", rootPath | filename);
+     run4ti2("rays",
+	 "-p " | toString o.Precision | " " | rootPath | filename);
      getMatrix(filename|".ray")
      ))
 

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -153,17 +153,18 @@ toricCircuits Matrix := Matrix => (o -> A ->(
      getMatrix(filename|".cir")
      ))
 
-toricGraver = method()
-toricGraver Matrix := Matrix => (A ->(
+toricGraver = method(Options => {Precision => 32})
+toricGraver Matrix := Matrix => (o -> A ->(
      filename := getFilename();
      if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     run4ti2("graver -q ", rootPath | filename);
+     run4ti2("graver",
+	 "-q -p " | toString o.Precision | " " | rootPath | filename);
      getMatrix(filename|".gra")
      ))
-toricGraver (Matrix,Ring) := Ideal => ((A,S)->toBinomial(toricGraver(A),S))
+toricGraver (Matrix,Ring) := Ideal => (o -> (A,S)->toBinomial(toricGraver(A),S))
 
 hilbertBasis = method(Options=> {InputType => null, Precision => 32})
 hilbertBasis Matrix := Matrix => o -> (A ->(

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -484,6 +484,7 @@ doc ///
      Key
      	  toricGraverDegrees
           (toricGraverDegrees, Matrix)
+	  [toricGraverDegrees, Precision]
      Headline
      	  displays the degrees of all Graver basis elements for the toric ideal I_A
      Usage
@@ -491,6 +492,9 @@ doc ///
      Inputs
       	  A:Matrix    
 	       whose columns parametrize the toric variety. The toric ideal $I_A$ is the kernel of the map defined by {\tt A}
+	  Precision => {ZZ, String}
+	       32, 64, or "gmp", the precision of the integers used during the
+	       computation
      Description
      	  Text
 	       Equivalent to "output --degrees foo.gra" in 4ti2.

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -504,6 +504,7 @@ doc ///
      	  hilbertBasis
           (hilbertBasis, Matrix)
 	  [hilbertBasis, InputType]
+	  [hilbertBasis, Precision]
      Headline
      	  calculates the Hilbert basis of the cone; invokes "hilbert" from 4ti2
      Usage
@@ -511,6 +512,9 @@ doc ///
      Inputs
       	  A:Matrix    
 	       defining the cone $\{z : Az = 0, z \ge 0 \}$
+	  Precision => {ZZ, String}
+	       32, 64, or "gmp", the precision of the integers used during the
+	       computation
      Outputs
      	  B:Matrix 
 	       whose rows form the Hilbert basis of the cone $\{z : Az = 0, z \ge 0 \}$

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -162,7 +162,7 @@ toricGraver Matrix := Matrix => (A ->(
      ))
 toricGraver (Matrix,Ring) := Ideal => ((A,S)->toBinomial(toricGraver(A),S))
 
-hilbertBasis = method(Options=> {InputType => null})
+hilbertBasis = method(Options=> {InputType => null, Precision => 32})
 hilbertBasis Matrix := Matrix => o -> (A ->(
      filename := getFilename();
      if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
@@ -172,7 +172,8 @@ hilbertBasis Matrix := Matrix => o -> (A ->(
        	  F = openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     run4ti2("hilbert", rootPath | filename);
+     run4ti2("hilbert",
+	 "-p " | toString o.Precision | " " | rootPath | filename);
      getMatrix(filename|".hil")
      ))
 

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -444,6 +444,7 @@ doc ///
      	  toricGraver
           (toricGraver, Matrix)
      	  (toricGraver, Matrix, Ring)
+	  [toricGraver, Precision]
      Headline
      	  calculates the Graver basis of the toric ideal; invokes "graver" from 4ti2
      Usage
@@ -453,6 +454,9 @@ doc ///
 	       whose columns parametrize the toric variety. The toric ideal $I_A$ is the kernel of the map defined by {\tt A}
 	  R:Ring
 	       polynomial ring in which the toric ideal $I_A$ should live
+	  Precision => {ZZ, String}
+	       32, 64, or "gmp", the precision of the integers used during the
+	       computation
      Outputs
      	  B:Matrix 
 	       whose rows give binomials that form the Graver basis of the toric ideal of {\tt A}, or

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -380,6 +380,7 @@ doc ///
           (toricMarkov, Matrix)
 	  (toricMarkov, Matrix, Ring)
 	  [toricMarkov, InputType]
+	  [toricMarkov, Precision]
      Headline
      	  calculates a generating set of the toric ideal I_A, given A; invokes "markov" from 4ti2
      Usage
@@ -393,6 +394,9 @@ doc ///
 	       which is the string "lattice" if rows of {\tt A} specify a lattice basis
 	  R:Ring
 	       polynomial ring in which the toric ideal $I_A$ should live
+	  Precision => {ZZ, String}
+	       32, 64, or "arbitrary", the precision of the integers used during
+	       the computation
      Outputs
      	  B:Matrix 
 	       whose rows form a Markov Basis of the lattice $\{z {\rm integral} : A z = 0\}$

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -197,14 +197,15 @@ rays Matrix := Matrix => { Precision => 64 } >> o -> (A ->(
 -- the way 4ti2 does this is you tell it the whatever.mar or whatever.cir file and it writes the degrees
 -- to the screen.
 -- On the other hand, it doesn't matter because you can ask M2 for those degrees directly! 
-toricGraverDegrees = method()
-toricGraverDegrees Matrix := Matrix => (A ->(
+toricGraverDegrees = method(Options => {Precision => 32})
+toricGraverDegrees Matrix := Matrix => (o -> A ->(
      filename := getFilename();
      if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     run4ti2("graver", rootPath | filename);
+     run4ti2("graver",
+	 "-p " | toString o.Precision | " " | rootPath | filename);
      ret := run4ti2("output", "--degrees " | rootPath | filename|".gra");
      print ret#"output"
      ))

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -555,6 +555,9 @@ doc ///
      Inputs
       	  A:Matrix   
 	       defining the cone $\{z : Az = 0, z \ge 0 \}$
+	  Precision => {ZZ, String}
+	       32, 64, or "arbitrary", the precision of the integers used during
+	       the computation
      Outputs
      	  B:Matrix 
 	       whose rows are the extreme rays of the cone $\{z : Az = 0, z \ge 0 \}$

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -565,6 +565,7 @@ doc ///
      Key
      	  toricCircuits
           (toricCircuits, Matrix)
+	  [toricCircuits, Precision]
      Headline
      	  calculates the circuits of the toric ideal; invokes "circuits" from 4ti2
      Usage
@@ -572,6 +573,9 @@ doc ///
      Inputs
       	  A:Matrix    
                whose columns parametrize the toric variety. The toric ideal $I_A$ is the kernel of the map defined by {\tt A} 
+	  Precision => {ZZ, String}
+	       32, 64, or "arbitrary", the precision of the integers used during
+	       the computation
      Outputs
      	  B:Matrix 
 	       whose rows form the circuits of A

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -124,7 +124,7 @@ toricMarkov Matrix := Matrix => o -> (A) -> (
      )
 toricMarkov(Matrix,Ring) := o -> (A,S) -> toBinomial(toricMarkov(A,o), S)
 
-toricGroebner = method(Options=>{Weights=>null})
+toricGroebner = method(Options=>{Weights=>null, Precision => 64})
 toricGroebner Matrix := o -> (A) -> (
      filename := getFilename();
      if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
@@ -135,7 +135,8 @@ toricGroebner Matrix := o -> (A) -> (
 	  cost := concatenate apply(o.Weights, x -> (x|" "));
 	  (filename|".cost") << "1 " << #o.Weights << endl << cost << endl  << close;
 	  );
-     run4ti2("groebner", rootPath | filename);
+     run4ti2("groebner",
+	 "-p " | toString o.Precision | " " | rootPath | filename);
      getMatrix(filename|".gro")
      )
 toricGroebner(Matrix,Ring) := o -> (A,S) -> toBinomial(toricGroebner(A,o), S)

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -141,14 +141,15 @@ toricGroebner Matrix := o -> (A) -> (
      )
 toricGroebner(Matrix,Ring) := o -> (A,S) -> toBinomial(toricGroebner(A,o), S)
 
-toricCircuits = method()
-toricCircuits Matrix := Matrix => (A ->(
+toricCircuits = method(Options => {Precision => 64})
+toricCircuits Matrix := Matrix => (o -> A ->(
      filename := getFilename();
      if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      F := openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     run4ti2("circuits", rootPath | filename);
+     run4ti2("circuits",
+	 "-p " | toString o.Precision | " " | rootPath | filename);
      getMatrix(filename|".cir")
      ))
 

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -108,7 +108,7 @@ toBinomial(Matrix,Ring) := (M,S) -> (
      ideal apply(entries M, toBinom)
      )
 
-toricMarkov = method(Options=> {InputType => null})
+toricMarkov = method(Options=> {InputType => null, Precision => 64})
 toricMarkov Matrix := Matrix => o -> (A) -> (
      filename := getFilename();
      if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
@@ -118,7 +118,8 @@ toricMarkov Matrix := Matrix => o -> (A) -> (
        	  F = openOut(filename|".mat");
      putMatrix(F,A);
      close F;
-     run4ti2("markov", rootPath | filename);
+     run4ti2("markov",
+	 "-p " | toString o.Precision | " " | rootPath | filename);
      getMatrix(filename|".mar")
      )
 toricMarkov(Matrix,Ring) := o -> (A,S) -> toBinomial(toricMarkov(A,o), S)

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -341,6 +341,7 @@ doc ///
           (toricGroebner, Matrix)
      	  (toricGroebner, Matrix, Ring)
      	  [toricGroebner, Weights]
+	  [toricGroebner, Precision]
      Headline
      	  calculates a Groebner basis of the toric ideal I_A, given A; invokes "groebner" from 4ti2
      Usage
@@ -350,6 +351,9 @@ doc ///
 	       whose columns parametrize the toric variety. The toric ideal $I_A$ is the kernel of the map defined by {\tt A}.
      	  R:Ring
 	       ring with as least as many generators as the columns of {\tt A}
+	  Precision => {ZZ, String}
+	       32, 64, or "arbitrary", the precision of the integers used during
+	       the computation
      Outputs
      	  B:Matrix 
 	       whose rows give binomials that form a Groebner basis of the toric ideal of {\tt A}

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
@@ -433,7 +433,7 @@ fan NormalToricVariety := Fan => X -> (
 -- Basic attributes and properties
 ------------------------------------------------------------------------------
 -- The method 'rays' is defined in 'Polyhedra'
-rays NormalToricVariety := List => X -> X.rays
+rays NormalToricVariety := List => {} >> o -> X -> X.rays
 max  NormalToricVariety := List => X -> X.max
 dim NormalToricVariety := ZZ => (cacheValue symbol dim) (X -> #(rays X)#0)
 

--- a/M2/Macaulay2/packages/Polyhedra/core/globalMethods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/globalMethods.m2
@@ -21,7 +21,7 @@ isFullDimensional PolyhedralObject := X -> ambDim X == dim X
 -- PURPOSE : Giving the rays
 --   INPUT : 'PO'  a PolyhedralObject
 --  OUTPUT : a Matrix, containing the rays of PO as column vectors
-rays PolyhedralObject := PO -> getProperty(PO, rays)
+rays PolyhedralObject := {} >> o -> PO -> getProperty(PO, rays)
 
 linealitySpace = method(TypicalValue => Matrix)
 linealitySpace PolyhedralObject := PO -> getProperty(PO, computedLinealityBasis)

--- a/M2/Macaulay2/packages/ToricVectorBundles.m2
+++ b/M2/Macaulay2/packages/ToricVectorBundles.m2
@@ -1246,7 +1246,7 @@ rank ToricVectorBundle := T -> T#"rank of the vector bundle"
 -- PURPOSE : Giving the rays of the underlying Fan of a toric vector bundle
 --   INPUT : 'tvb',  a TorcVectorBundle
 --  OUTPUT : 'L',  a List containing the rays of the Fan underlying the bundle
-rays ToricVectorBundle := tvb -> raySortOfFan tvb#"ToricVariety"
+rays ToricVectorBundle := {} >> o -> tvb -> raySortOfFan tvb#"ToricVariety"
 
 
 -- PURPOSE : Computing the 'l'-th symmetric power of a Toric Vector Bundle

--- a/M2/Macaulay2/packages/Tropical.m2
+++ b/M2/Macaulay2/packages/Tropical.m2
@@ -726,7 +726,7 @@ convertToPolymake = (T) ->(
 
 --functions to get stuff from fans and tropical cycles
 
-rays TropicalCycle:= T->( rays fan T)
+rays TropicalCycle:= {} >> o -> T->( rays fan T)
 
 cones (ZZ,TropicalCycle):= (i,T)->( cones(i,fan T))
 


### PR DESCRIPTION
This is a partial response to #3195.  Fixing it would require messing around with how `hilbertBasis(Cone)` works in the `Polyhedra` package.

4ti2's `hilbert` program takes a `-p` command line option specifying which type of int to use for the computation -- 32-bit, 64-bit, or GMP (arbitrary precision).  Previously, we didn't support it, so we always used the 32-bit default.

We add a `Precision` option to allow the user to specify the precision.  For example:

```m2
i1 : needsPackage "FourTiTwo"

o1 = FourTiTwo

o1 : Package

i2 : A = matrix {{0, -964603, -843308, -794860, -671152, -549857, -528033, -501409, -404325}, {1, 585196, 511610, 482218, 407168, 333582, 320342, 304190, 245292}, {0, 235100, 205537, 193729, 163578, 134015, 128696, 122207, 98545}, {0, 157531, 137722, 129810, 109607, 89798, 86234, 81886, 66031}, {0, 292598, 255805, 241109, 203584, 166791, 160171, 152095, 122646}, {0, 242999, 212443, 200238, 169074, 138518, 133020, 126313, 101856}}

o2 = | 0 -964603 -843308 -794860 -671152 -549857 -528033 -501409 -404325 |
     | 1 585196  511610  482218  407168  333582  320342  304190  245292  |
     | 0 235100  205537  193729  163578  134015  128696  122207  98545   |
     | 0 157531  137722  129810  109607  89798   86234   81886   66031   |
     | 0 292598  255805  241109  203584  166791  160171  152095  122646  |
     | 0 242999  212443  200238  169074  138518  133020  126313  101856  |

              6       9
o2 : Matrix ZZ  <-- ZZ

i3 : hilbertBasis(A, InputType => "lattice")
stdio:4:1:(3): error: 4ti2 returned an error
running: /usr/bin/4ti2-hilbert -p 32 /tmp/M2-708358-0/0
-------------------------------------------------
4ti2 version 1.6.9
Copyright 1998, 2002, 2006, 2015 4ti2 team.
4ti2 comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome
to redistribute it under certain conditions.
For details, see the file COPYING.
-------------------------------------------------

Using 32 bit integers.

Lattice:

+       +       +       +       +       +       +       +       +
0       0       0       0       0       0       0       0       0
H       H       H       H       H       H       H       H       H

0 -964603 -843308 -794860 -671152 -549857 -528033 -501409 -404325
1  585196  511610  482218  407168  333582  320342  304190  245292
0  235100  205537  193729  163578  134015  128696  122207   98545
0  157531  137722  129810  109607   89798   86234   81886   66031
0  292598  255805  241109  203584  166791  160171  152095  122646
0  242999  212443  200238  169074  138518  133020  126313  101856

Results were near maximum precision (32bit).
Please restart with higher precision!


i4 : hilbertBasis(A, InputType => "lattice", Precision => 64)

o4 = | 0 0 0 0 0 0 1 0 1 |
     | 1 0 0 0 0 0 0 0 0 |
     | 0 0 0 0 1 1 0 1 1 |
     | 0 0 0 1 1 1 0 2 0 |
     | 0 1 0 0 1 0 0 0 1 |
     | 0 0 1 0 0 1 0 0 0 |
     | 0 2 1 1 1 0 0 0 0 |
     | 0 0 0 1 0 0 1 1 0 |
     | 0 1 1 1 0 0 1 0 0 |
     | 0 1 0 1 1 0 0 1 0 |

              10       9
o4 : Matrix ZZ   <-- ZZ

i5 : hilbertBasis(A, InputType => "lattice", Precision => "gmp")

o5 = | 0 0 0 0 0 0 1 0 1 |
     | 1 0 0 0 0 0 0 0 0 |
     | 0 0 0 0 1 1 0 1 1 |
     | 0 0 0 1 1 1 0 2 0 |
     | 0 1 0 0 1 0 0 0 1 |
     | 0 0 1 0 0 1 0 0 0 |
     | 0 2 1 1 1 0 0 0 0 |
     | 0 0 0 1 0 0 1 1 0 |
     | 0 1 1 1 0 0 1 0 0 |
     | 0 1 0 1 1 0 0 1 0 |

              10       9
o5 : Matrix ZZ   <-- ZZ
```

