### PR TITLE
Build Normaliz 3.10.2

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -1022,8 +1022,8 @@ _ADD_COMPONENT_DEPENDENCY(programs nauty "" NAUTY)
 # https://www.normaliz.uni-osnabrueck.de/
 # normaliz needs libgmp, libgmpxx, boost and is used by the package Normaliz
 ExternalProject_Add(build-normaliz
-  URL               https://github.com/Normaliz/Normaliz/releases/download/v3.10.1/normaliz-3.10.1.tar.gz
-  URL_HASH          SHA256=365e1d1e2a338dc4df1947a440e606bb66dd261307e617905e8eca64eaafcf6e
+  URL               https://github.com/Normaliz/Normaliz/releases/download/v3.10.2/normaliz-3.10.2.tar.gz
+  URL_HASH          SHA256=0f649a8eae5535c18df15e8d35fc055fd0d7dbcbdd451e8876f4a47061481f07
   PREFIX            libraries/normaliz
   SOURCE_DIR        libraries/normaliz/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/libraries/normaliz/Makefile.in
+++ b/M2/libraries/normaliz/Makefile.in
@@ -1,12 +1,9 @@
 HOMEPAGE = https://www.normaliz.uni-osnabrueck.de/
 # get releases from https://github.com/Normaliz/Normaliz/releases
-# version 3.2 uses autoconf, so take advantage of that when upgrading
-VERSION = 3.9.2
-VERSION2 = 3.9
+VERSION = 3.10.2
 #PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 
-# these authors sometimes change the file without changing the name, so we copy it to our own site:
-URL = http://macaulay2.com/Downloads/OtherSourceCode
+URL = https://github.com/Normaliz/Normaliz/releases/download/v$(VERSION)
 FIXTARCMD = :
 
 PRECONFIGURE = autoreconf -vif


### PR DESCRIPTION
Normaliz 3.10.2 was released on March 1 -- see https://github.com/Normaliz/Normaliz/releases/tag/v3.10.2.  It appears to be compatible with Macaulay2.  I uploaded it to Debian shortly after it was released and nothing has broken yet.  :)

This PR updates both the autotools and cmake builds to build this latest version when Normaliz isn't already present on the user's system.

Note that the GitHub builds don't actually test this code, as they install Normaliz via apt or homebrew, but I've tested both builds locally and they worked.

Cc: @ggsmith 