### PR TITLE
small update to NumericalAG packages

### DIFF
--- a/M2/Macaulay2/packages/NAGtypes.m2
+++ b/M2/Macaulay2/packages/NAGtypes.m2
@@ -22,7 +22,7 @@ export {
      -- service functions
      "generalEquations", 
      -- witness set
-     "WitnessSet", "witnessSet", "equations", "slice", "points", 
+     "WitnessSet", "witnessSet", "equations", "slice", "points", "declareIrreducible", 
      "Equations", "Slice", "Points", "ProjectionDimension", 
      "sliceEquations", "projectiveSliceEquations", "IsIrreducible", 
      "ProjectiveWitnessSet", "AffineChart", "projectiveWitnessSet",

--- a/M2/Macaulay2/packages/NAGtypes/WitnessSet.m2
+++ b/M2/Macaulay2/packages/NAGtypes/WitnessSet.m2
@@ -36,6 +36,8 @@ codim WitnessSet := {} >> o -> W -> numgens ring W - dim W
 ring WitnessSet := W -> if member(class W.Equations, {Ideal,PolySystem}) then ring W.Equations else ring ideal equations W
 degree WitnessSet := W -> #W.Points
 ideal WitnessSet := W -> if class W.Equations === PolySystem then ideal W.Equations else W.Equations
+declareIrreducible = method()
+declareIrreducible WitnessSet := W -> W.cache.IsIrreducible = true 
 
 witnessSet = method(TypicalValue=>WitnessSet)
 witnessSet (PolySystem,Matrix,List) := (F,S,P) -> 
@@ -172,17 +174,19 @@ numericalAffineSpace PolynomialRing := R -> (
     C := coefficientRing R; 
     A := random(C^n,C^n);
     b := random(C^n,C^1);
-    numericalVariety {witnessSet(ideal R, A|(-b), {point entries transpose solve(A,b)})}
+    W := witnessSet(ideal R, A|(-b), {point entries transpose solve(A,b)});
+    declareIrreducible W;
+    numericalVariety {W}
     )
 -- ProjectiveNumericalVariety is not a type!
 projectiveNumericalVariety = method( -* TypicalValue=>ProjectiveNumericalVariety *- )
 projectiveNumericalVariety List := Ws -> new ProjectiveNumericalVariety from numericalVariety Ws
 
 check NumericalVariety := o-> V -> (
-     if any(keys V, k->(class k =!= ZZ or k<0)) 
-     then error "the keys of a NumericalVariety should be nonnegative integers";
-     scan(keys V, k->if class k === ZZ then scan(V#k, W->(
-		    if dim W != k then 
-		    error "dimension of a witness set does not match the key in NumericalVariety";
-		    )));
-     )
+    if any(keys V, k->(class k =!= ZZ or k<0)) 
+    then error "the keys of a NumericalVariety should be nonnegative integers";
+    scan(keys V, k->if class k === ZZ then scan(V#k, W->(
+		if dim W != k then 
+		error "dimension of a witness set does not match the key in NumericalVariety";
+		)));
+    )

--- a/M2/Macaulay2/packages/NAGtypes/doc-NAGtypes.m2
+++ b/M2/Macaulay2/packages/NAGtypes/doc-NAGtypes.m2
@@ -585,7 +585,7 @@ document {
 	      ", the witness set describes a lifted variety (its projection on the first ", 
 	      TT "ProjectionDimension", " coordinates is the variety the witness set represents)"},
 	  },     
-     SeeAlso => {witnessSet, ProjectiveWitnessSet, NumericalVariety}
+     SeeAlso => {witnessSet, ProjectiveWitnessSet, NumericalVariety, declareIrreducible}
      }
 
 document {
@@ -652,6 +652,17 @@ peek w///
 -- peek w
 -- ///
 }
+
+doc ///
+Key
+    declareIrreducible
+    (declareIrreducible,WitnessSet)
+Headline
+    declares a component represented by the witness set irreducible
+Description
+    Text
+      This is a service method that for a witness set {\tt W} sets the flag {\tt W.cache.IsIrreducible} to {\tt true}.
+///
 
 document {
 	Key => {(sliceEquations,Matrix,Ring),sliceEquations,

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry.m2
@@ -3,8 +3,8 @@
 
 newPackage select((
      "NumericalAlgebraicGeometry",
-     Version => "1.23",
-     Date => "Feb 2024",
+     Version => "1.24",
+     Date => "May 2024",
      Headline => "numerical algebraic geometry",
      HomePage => "http://people.math.gatech.edu/~aleykin3/NAG4M2",
      AuxiliaryFiles => true,

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/SYSTEMS/0-dim-regular/vision.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/SYSTEMS/0-dim-regular/vision.m2
@@ -51,7 +51,6 @@ PS.NumberOfVariables = 8 -- hack!!!
 -- squarePS = squareUp PS 
 gPS = gateSystem(PS,drop(gens R1,8));  
 PH = parametricSegmentHomotopy gPS
---makeGateMatrix(PS,Parameters=>drop(gens R1,8));  
 --PH = parametricSegmentHomotopy PS
 printAsSLP(PH.GateHomotopy#"X"|matrix{{PH.GateHomotopy#"T"}},PH.GateHomotopy#"Hx")
 

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/decomposition.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/decomposition.m2
@@ -79,7 +79,7 @@ decompose WitnessSet := {} >> unusedOpts -> (W) -> (
      incomplete := select(new List from cs, c->#c!=0);
      if #incomplete>0 then print "-- decompose: some witness points were not classified";
      irred := apply(i'cs, c->witnessSet(W.Equations, W.Slice, (W.Points)_c));
-     scan(irred, c->c.cache.IsIrreducible = true);
+     scan(irred, c->declareIrreducible c);
      irred | if #incomplete == 0 then {} 
              else {
 		 witnessSet(

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/doc.m2
@@ -1101,7 +1101,42 @@ doc ///
 	G = F^{0,2}
     	gateMatrix G	
     ///
-    
+
+doc ///
+    Key
+      (polySystem, GateSystem, PolynomialRing)
+    Headline
+      classical polynomial system associated to a gate system
+    Usage
+      F = polySystem(G,R)
+    Inputs
+      G:
+      R:
+    Outputs
+      F: PolySystem
+    Description
+      Text
+        Given a gate system and a polynomial ring,
+	this function constructs a classical (represented via M2 polynomial map) polynomial system.
+      Example
+        variables = declareVariable \ {x,y}
+	G = gateSystem(matrix{variables}, matrix{{x*y-1},{x^3+y^2-2},{x^2+2*y-3}})
+	R = CC[X,Y]
+	F = polySystem(G,R)
+	evaluate(F,matrix{{1,2}})
+	evaluate(G,matrix{{1,2}})
+      Text
+        The ring is expected to be of the form {\tt K[x_1..x_n]} or {\tt K[a_1..a_m][x_1..x_n]}.
+	In the latter case, the gate system is expected to take {\tt m} parameters.  
+      Example
+        variables = declareVariable \ {x,y}
+        params = declareVariable \ {a,b,c}
+	G = gateSystem(matrix{params}, matrix{variables}, matrix{{x*y-1},{a*x^2+b*y^2-c}})
+	R = CC[A,B,C][X,Y]
+	F = polySystem(G,R)
+	equations F
+///
+
 undocumented {
     (toExternalString,GateSystem),
     (evaluateJacobian,GateSystem,Matrix),

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/extraNAGtypes.m2
@@ -321,7 +321,6 @@ specialize (GateParameterHomotopy,MutableMatrix) := (PH, M) -> (
     ) 
 *-
 
--- !!! replaces makeGateMatrix
 gateSystem PolySystem := GateSystem => F -> if F#?GateSystem then F#GateSystem else 
   F#GateSystem = gateSystem(F,parameters F)
 gateSystem (PolySystem,List-*of parameters*-) := (F,P) -> ( 
@@ -337,6 +336,14 @@ gateSystem (PolySystem,List-*of parameters*-) := (F,P) -> (
  
 -- !!! a general problem: some methods need PolySystem to be changed to GateSystem
 gateMatrix PolySystem := F -> gateMatrix gateSystem F
+
+polySystem(GateSystem, PolynomialRing) := (G,R) -> (
+    -- check that the ring is of form K[x] or K[y][x] !!!
+    C := coefficientRing R;
+    if numgens R != numVariables G then error "numbers of variables don't match";
+    if numgens C != numParameters G then error "numbers of parameters don't match";
+    polySystem transpose evaluate(G, vars C, vars R)
+    )
 
 -- Homotopy that follows a segment in the parameter space 
 parametricSegmentHomotopy = method()

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/witness-set.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/witness-set.m2
@@ -22,7 +22,8 @@ polySystem WitnessSet := W->if W.cache.?SolutionSystem then W.cache.SolutionSyst
     	)
 
 check WitnessSet := o -> W -> for p in W.Points do 
-if residual(polySystem(equations polySystem W | slice W), p) > 1000*DEFAULT.Tolerance then error "check failed" --!!!
+if residual(polySystem(equations polySystem W | slice W), p) > 1000*DEFAULT.Tolerance
+then error "check failed" -- !!! should we check this differently: e.g., Newton method convergence?
 
 randomSlice = method()
 randomSlice (ZZ,ZZ,Ring) := (d,n,C) -> (randomUnitaryMatrix n)^(toList(0..d-1)) | random(C^d,C^1)   

--- a/M2/Macaulay2/packages/SLPexpressions.m2
+++ b/M2/Macaulay2/packages/SLPexpressions.m2
@@ -213,8 +213,9 @@ Gate / Gate := (a,b) -> divideGate(a,b)
 ValueHashTable = new Type of MutableHashTable
 valueHashTable = method()
 valueHashTable (List,List) := (a,b) -> new ValueHashTable from apply(a,b,identity)
-			
-value (InputGate,ValueHashTable) := (g,h)-> if h#?g then h#g else h#g = (if isConstant g then g.Name else error "value for inputGate is not set")
+
+value (Gate,ValueHashTable) := (g,h) -> error "undefined for abstract type Gate"
+value (InputGate,ValueHashTable) := (g,h) -> if h#?g then h#g else h#g = (if isConstant g then g.Name else error "value for inputGate is not set")
 value (SumGate,ValueHashTable) :=  (g,h) -> if h#?g then h#g else h#g = (sum apply(g.Inputs, a->value(a,h)))
 value (ProductGate,ValueHashTable) := (g,h) -> if h#?g then h#g else h#g = (product apply(g.Inputs, a->value(a,h)))
 value (DetGate,ValueHashTable) := (g,h) -> if h#?g then h#g else h#g = (det matrix applyTable(g.Inputs, a->value(a,h)))

--- a/M2/Macaulay2/packages/SLPexpressions/doc.m2
+++ b/M2/Macaulay2/packages/SLPexpressions/doc.m2
@@ -249,7 +249,8 @@ doc ///
 doc ///
     Key
     	"evaluating gates"
-     	(value, InputGate, ValueHashTable)    
+	(value, Gate, ValueHashTable)    
+	(value, InputGate, ValueHashTable)    
      	(value, SumGate, ValueHashTable)
         (value, ProductGate, ValueHashTable)
         (value, DivideGate, ValueHashTable)


### PR DESCRIPTION
Introduced a service method `declareIrreducible` that is used in few places now, including `numericalAffineSpace`.

Made a conversion function `polySystem(GateSystem,PolynomialRing)` that makes a "classical" `PolySystem` from a `GateSystem`. 

Updated the version to 1.24 :)