### PR TITLE
Build nauty 2.8.8

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -986,8 +986,8 @@ set(nauty_BINARIES
   genspecialg gentourng gentreeg hamheuristic labelg linegraphg listg multig newedgeg pickg
   planarg ranlabg shortg showg subdivideg twohamg vcolg watercluster2)
 ExternalProject_Add(build-nauty
-  URL               ${M2_SOURCE_URL}/nauty27b11.tar.gz
-  URL_HASH          SHA256=5d52211cec767d8d8e43483d96202be235f85696d1373c307291273463c812fa
+  URL               https://pallini.di.uniroma1.it/nauty2_8_8.tar.gz
+  URL_HASH          SHA256=159d2156810a6bb240410cd61eb641add85088d9f15c888cdaa37b8681f929ce
   PREFIX            libraries/nauty
   SOURCE_DIR        libraries/nauty/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/libraries/nauty/Makefile.in
+++ b/M2/libraries/nauty/Makefile.in
@@ -1,6 +1,5 @@
-# URL = http://cs.anu.edu.au/~bdm/nauty
-URL = http://macaulay2.com/Downloads/OtherSourceCode
-VERSION = 27b11
+URL = https://pallini.di.uniroma1.it
+VERSION = 2_8_8
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PRECONFIGURE = autoreconf -i
 TARFILE = nauty$(VERSION).tar.gz


### PR DESCRIPTION
This PR updates the nauty build for both autotools and cmake to 2.8.8 as requested in https://github.com/Macaulay2/M2/pull/3212#issuecomment-2103160371.

Skipping the GitHub builds since they use apt or homebrew copies of nauty, but I've tested both builds locally.