### PR TITLE
Add support for the quotient ring ZZ/n when n is large or composite

### DIFF
--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -87,7 +87,8 @@ ZZp Ideal := opts -> (I) -> (
         else if typ === "Flint" then rawARingZZpFlint n
         else if typ === "Aring" then rawARingZZp n
         else if typ === "Old" then rawZZp n
-        else error("unknown implementation choice: "|typ|///. Choices are "Flint" (default), "Ffpack", "Aring", "Old"///);
+        else error("unknown implementation choice: ", typ, ". ", newline,
+	    ///Choices are "Flint" (default), "Ffpack", "Aring", "Old"///);
 	  S.cache = new CacheTable;
 	  S.isBasic = true;
 	  S.ideal = I;

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -80,8 +80,8 @@ ZZp Ideal := opts -> (I) -> (
      else if savedQuotients#?(typ, n) then
          savedQuotients#(typ, n)
      else (
-	  if not isPrime n
-	  then error ("ZZ/n not implemented yet for composite n = ", toString n);
+	  if not isPrime n or n > 2^64
+	  then return ZZ[DegreeRank => 0]/n;
 	  S := new QuotientRing from 
       if typ === "Ffpack" then rawARingGaloisField(n,1)  
         else if typ === "Flint" then rawARingZZpFlint n

--- a/M2/Macaulay2/packages/EngineTests/LinearAlgebra.Test.FLINT.m2
+++ b/M2/Macaulay2/packages/EngineTests/LinearAlgebra.Test.FLINT.m2
@@ -11,6 +11,7 @@ export {
 
 ZZpFlint = (char) ->
 (
+   assert(isPrime char and char < 2^64);
    ZZp(char, Strategy => "Flint")
 )
 

--- a/M2/Macaulay2/packages/EngineTests/Ring.Test.ZZp.m2
+++ b/M2/Macaulay2/packages/EngineTests/Ring.Test.ZZp.m2
@@ -124,8 +124,9 @@ TEST ///
   -- the following should all give errors.
   assert try (ZZpFlint 1; false) else true
   assert try (ZZpFFPACK 1; false) else true
-  assert try (ZZp(1, Strategy=>null); false) else true
-  assert try (ZZp(1, Strategy=>"Aring"); false) else true
+  assert try (ZZp(2, Strategy=>null); false) else true
+  assert try (rawARingZZp 1; false) else true -- Strategy => "ARing"
+  assert try (rawZZp      1; false) else true -- Strategy => "Old"
 ///
 
 

--- a/M2/Macaulay2/tests/normal/powers-of-zero.m2
+++ b/M2/Macaulay2/tests/normal/powers-of-zero.m2
@@ -9,8 +9,10 @@ checkPowersOfZero = (n, F) -> (
 previousPrime = (n) -> if n < 2 then null else (while not isPrime n do n = n-1; n)
 
 assert checkPowersOfZero(30, ZZ/5)
+assert checkPowersOfZero(30, ZZ/24)
 assert checkPowersOfZero(30, ZZ/32003)
 assert checkPowersOfZero(30, ZZ/1048583) -- nextPrime 2^20
+assert checkPowersOfZero(30, ZZ/nextPrime 2^100)
 if version#"pointer size" > 4 then (
     assert checkPowersOfZero(30, ZZ/(nextPrime 2^40)); -- nextPrime 2^40
     assert checkPowersOfZero(30, ZZ/(nextPrime 2^60)); -- nextPrime 2^60


### PR DESCRIPTION
We currently use FLINT for quotient rings created by `ZZ/n` and thus require `n` to be prime and to fit inside an `unsigned int`:

```m2
i1 : ZZ/24
stdio:1:3:(3): error: ZZ/n not implemented yet for composite n = 24

i2 : ZZ/nextPrime 2^100
stdio:2:3:(3): error: expected argument 1 to be a small integer
```

But the engine handles these things just fine if we create a quotient ring of a polynomial ring with no variables, as suggested in #272:

```m2
i1 : ZZ/24

     ZZ[]
o1 = ----
      24

o1 : QuotientRing

i2 : ZZ/nextPrime 2^100

                   ZZ[]
o2 = -------------------------------
     1267650600228229401496703205653

o2 : QuotientRing
```

Closes: #272

