### PR TITLE
Added deprecation warning for Matrix \\ Matrix

### DIFF
--- a/M2/Macaulay2/m2/lists.m2
+++ b/M2/Macaulay2/m2/lists.m2
@@ -27,10 +27,11 @@ Sequence | Sequence := Sequence => join
 List + List  := List => (v,w) -> apply(v,w,plus)
      - List  := List => v -> apply(v,minus)
 List - List  := List => (v,w) -> apply(v,w,difference)
+List * Thing := List => (v,a) -> apply(v,x->x * a)
 Thing * List := List => (a,v) -> apply(v,x->a * x)
 List ** List := List => (X,Y) -> flatten for x in X list apply(Y, y -> (x, y))
 
-List / Thing := List => (v,b) -> apply(v,x->x / b)	    -- slight conflict with List / Function!
+List /  RingElement := List /  Number := List => (v,b) -> apply(v,x->x /  b)
 List // RingElement := List // Number := List => (v,b) -> apply(v,x->x // b)
 List  % RingElement := List  % Number := List => (v,b) -> apply(v,x->x  % b)
 

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -335,8 +335,10 @@ quotientRemainder(Matrix,Matrix) := Matrix => (f,g) -> (
 	  map(M, L, rem)
      ))
 
+leftQuotientWarn = true
+
 Matrix // Matrix := Matrix => (f,g) -> quotient(f,g)
-Matrix \\ Matrix := (g,f) -> f // g
+Matrix \\ Matrix := (g,f) -> (if leftQuotientWarn then (leftQuotientWarn = false; printerr "Warning: 'm \\\\ n' is deprecated; use 'n // m' instead."); f // g)
 quotient'(Matrix,Matrix) := Matrix => (f,g) -> (
      if not isFreeModule source f or not isFreeModule target f
      or not isFreeModule source g or not isFreeModule target g then error "expected maps between free modules";

--- a/M2/Macaulay2/packages/BettiCharacters.m2
+++ b/M2/Macaulay2/packages/BettiCharacters.m2
@@ -465,7 +465,7 @@ action(ChainComplex,List,List,ZZ):=ActionOnComplex=>op->(C,l,l0,i) -> (
 	    error "action: expected ring actor matrix to be a one-row substitution matrix";
 	    );
     	--convert variable substitutions to matrices
-	l=apply(l,g->(vars R)\\lift(g,R));
+	l=apply(l,g->lift(g,R)//(vars R));
 	) else (
 	--if ring actors are matrices they must be square
     	if not all(l,g->numRows(g)==n) then (
@@ -556,7 +556,7 @@ actors(ActionOnComplex,ZZ) := List => (A,i) -> (
 	    -- given a map of free modules C.dd_i : F <-- F',
 	    -- the inverse group action on the ring (as substitution)
 	    -- and the group action on F, computes the group action on F'
-	    (gInv,g0) -> sub(C.dd_i,gInv)\\(g0*C.dd_i)
+	    (gInv,g0) -> (g0*C.dd_i)//sub(C.dd_i,gInv)
 	    );
     	-- make cache function from f and run it on A
     	((cacheValue (symbol actors,i)) f) A
@@ -568,7 +568,7 @@ actors(ActionOnComplex,ZZ) := List => (A,i) -> (
 	    -- and the group action on F', computes the group action on F
 	    -- it is necessary to transpose because we need a left factorization
 	    -- but M2's command // always produces a right factorization
-	    transpose(transpose(C.dd_(i+1))\\transpose(sub(C.dd_(i+1),gInv)*g0))
+	    transpose(transpose(sub(C.dd_(i+1),gInv)*g0)//transpose(C.dd_(i+1)))
 	    );
     	-- make cache function from f and run it on A
     	((cacheValue (symbol actors,i)) f) A
@@ -656,7 +656,7 @@ action(Module,List,List):=ActionOnGradedModule=>op->(M,l,l0) -> (
 	    error "action: expected ring actor matrix to be a one-row substitution matrix";
 	    );
     	--convert variable substitutions to matrices
-	l=apply(l,g->(vars R)\\lift(g,R));
+	l=apply(l,g->lift(g,R)//(vars R));
 	) else (
 	--if ring actors are matrices they must be square
     	if not all(l,g->numRows(g)==n) then (

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -105,6 +105,7 @@ document {
     (symbol*,  ChainComplexMap, ChainComplexMap),
     (symbol*,  RingElement, RingElement),
     (symbol*,  Thing, List),
+    (symbol*,  List, Thing),
     (symbol*,  ZZ, ProjectiveHilbertPolynomial),
     (symbol*,  ProjectiveHilbertPolynomial, ZZ),
     (symbol*,  RingElement, Vector),

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
@@ -109,7 +109,7 @@ document {
      }
 
 document {
-     Key => {(symbol /,List,Thing)},
+     Key => {(symbol /,List,RingElement),(symbol /,List,Number)},
      Headline => "vector division",
      Usage => "v/c",
      Inputs => {"v" => "to be treated as a vector", "c" => "a number or scalar ring element"},

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc8.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc8.m2
@@ -196,17 +196,17 @@ document {
      }
 
 document { 
-     Key => {(symbol //, Matrix, Matrix),(symbol \\, Matrix, Matrix),
+     Key => {(symbol //, Matrix, Matrix),
        (symbol //, RingElement, MonomialIdeal),
        (symbol //, RingElement, GroebnerBasis),
        (symbol //, RingElement, RingElement),
        (symbol //, Matrix, MonomialIdeal),
        (symbol //, Matrix, GroebnerBasis),
-       (symbol //, Matrix, RingElement),(symbol \\, Matrix, RingElement),
-       (symbol //, RingElement, Matrix),(symbol \\, RingElement, Matrix)
+       (symbol //, Matrix, RingElement),
+       (symbol //, RingElement, Matrix)
        },
      Headline => "factor a map through another",
-     Usage => "f//g\ng\\\\f",
+     Usage => "f//g",
      Inputs => {
 	  "f" => {"between modules F --> H, or ",
 	     ofClass RingElement},
@@ -231,8 +231,7 @@ document {
      for the image of ", TT "g", ".",
      PARA{},
      "If the remainder ", TT "f - g*h", " is zero,
-     then the quotient ", TT "f//g", " satisfies the equation ", TT "f === g * (f//g)", "
-     and the quotient ", TT "g\\\\f", " satisfies the equation ", TT "f === g * (g\\\\f)", ".",
+     then the quotient ", TT "f//g", " satisfies the equation ", TT "f === g * (f//g)", ".",
      PARA{},
      "One common use is the following.  If an ideal contains 1, then we may write 1 in terms
      of the generators of the ideal.  First we make an ideal.",

--- a/M2/Macaulay2/packages/Quasidegrees.m2
+++ b/M2/Macaulay2/packages/Quasidegrees.m2
@@ -863,7 +863,7 @@ needsPackage"Dmodules"
 A = matrix{{1,1,1,1},{0,1,5,11}}
 R = toGradedRing(A,QQ[a..d])
 I = toricIdeal(A,R)
-S = quasidegreesLocalCohomology R^1/I
+S = quasidegreesLocalCohomology(R^1/I)
 T = {}; for i to #S-1 do T=T|{(S_i)_0}
 for i to #T-1 do assert(holonomicRank(gkz(A,{0,0}))<holonomicRank(gkz(A,entries(T_i))))
 ///


### PR DESCRIPTION
This PR is in preparation for a PR in the next release which will change `g \\ f` to call `quotient'(f, g)` instead of being a synonym for `f // g = quotient(f, g)`, and which will add a new algorithm that works for arbitrary modules rather than only free modules, as well as maps of coherent sheaves. This change was suggested in #1448 during work on PrimaryDecompositions with @mikestillman, and recently came up again during work on Varieties with @ggsmith and others. 

Here is the warning:
```m2
i1 : M = ZZ^3;

i2 : id_M \\ id_M
 -- Note: 'm \\ n' is deprecated; use 'n // m' instead.

o2 = | 1 0 0 |
     | 0 1 0 |
     | 0 0 1 |

              3       3
o2 : Matrix ZZ  <-- ZZ
```
Note that the current algorithm for `quotient'` is even more limited than `quotient`, because `dual` doesn't work for maps between non-free modules:
```m2
i1 : M = coker(5 * id_(ZZ^2));

i2 : f = map(M, M, {{1,2},{3,4}});

o2 : Matrix M <-- M

i3 : g = map(M, M, {{2,3},{4,0}});

o3 : Matrix M <-- M

i4 : quotient(f * g, f)

o4 = | 2  -2 |
     | -1 0  |

o4 : Matrix M <-- M

i5 : quotient'(f * g, g)
stdio:5:1:(3): error: expected maps between free modules
```
Lack of good notation and hard to find documentation has lead to people resorting to code such as this:
https://github.com/Macaulay2/M2/blob/615b0e603edfe2e0f774b60ceba74a4c61384b71/M2/Macaulay2/packages/BettiCharacters.m2#L569-L571

Other change:
- **added deprecation warning for Matrix \\ Matrix**
- **removed Matrix \\ Matrix from documentation**
- **removed Matrix \\ Matrix from BettiCharacters**
- **added List*Thing, replaced List/Thing**
- **fixed an incorrect test in Quasidegrees**