### PR TITLE
Simplify construction of empty matrices

### DIFF
--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -96,8 +96,7 @@ map(Module,Module,List) := Matrix => options -> (M,N,p) -> (
      local k;
      if N === null then (
 	  k = R;
-	  if #p === 0 then error "expected non-empty list of entries for matrix";
-	  rankN = #p#0;
+	  rankN = if #p === 0 then 0 else #p#0;
 	  )
      else if class N === ZZ then (
 	  k = R;
@@ -276,7 +275,7 @@ matrix(Matrix) := Matrix => opts -> (m) -> (
 matrix RingElement := matrix Number := opts -> r -> matrix({{r}}, opts)
 
 matrix(List) := Matrix => opts -> (m) -> (
-     if #m === 0 then error "expected nonempty list";
+     if #m === 0 then return matrix(ZZ, {});
      mm := apply(splice m,splice);
      if #mm === 0 then error "expected nonempty list";
      types := unique apply(mm,class);

--- a/M2/Macaulay2/m2/tables.m2
+++ b/M2/Macaulay2/m2/tables.m2
@@ -9,9 +9,10 @@ applyTable = (m,f) -> apply(m, v -> apply(v,f))
 subtable = (u,v,m) -> table(u, v, (i,j)->m_i_j)
 
 isTable = m -> (
-     instance(m, List) and
+     instance(m, List) and (
+     #m == 0 or
      #m > 0 and
-     all(m, row -> instance(row, List) and #row === #m#0))
+     all(m, row -> instance(row, List) and #row === #m#0)))
 
 transpose List := List => m -> (
      if isTable m

--- a/M2/Macaulay2/tests/normal/lists.m2
+++ b/M2/Macaulay2/tests/normal/lists.m2
@@ -18,3 +18,5 @@ assert (net i == "<|x, y, z|>"^0)
 assert (toList i === {x,y,z})
 assert (class i === AngleBarList)
 assert (delete(y, i) == <| x, z |>)
+
+assert isTable table(0, 0, identity)

--- a/M2/Macaulay2/tests/normal/matrix.m2
+++ b/M2/Macaulay2/tests/normal/matrix.m2
@@ -364,6 +364,13 @@ assert Equation(A + A, 0)
 assert Equation(A - A, 0)
 assert Equation(A, -A)
 
+-- empty matrix
+scan({matrix {}, matrix(ZZ, {}), map(ZZ^0, ZZ^0, {}), map(ZZ^0,, {})}, A -> (
+	    assert Equation(numRows A, 0);
+	    assert Equation(numColumns A, 0);
+	    assert Equation(source A, ZZ^0);
+	    assert Equation(target A, ZZ^0)))
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test matrix.out"
 -- End:


### PR DESCRIPTION
Let's say we want to construct the 0x0 matrix representing the trivial automorphism on the zero $\mathbb Z$-module.  There are a couple ways to do this:

```m2
i1 : map(ZZ^0, ZZ^0, {})

o1 = 0

o1 : Matrix 0 <-- 0

i2 : diagonalMatrix {}

o2 = 0

o2 : Matrix 0 <-- 0
```

However, the following choices which seem like they ought to work don't:

```m2
i3 : matrix {}
stdio:3:1:(3): error: expected nonempty list

i4 : matrix(ZZ, {})
stdio:4:1:(3): error: expected a table

i5 : map(ZZ^0, , {})
stdio:5:1:(3): error: expected non-empty list of entries for matrix
```

The "expected a table" error output after i4 is because of the following:

```m2
i6 : isTable {}

o6 = false
```

This seems strange since `{}` definitely seems like it should be a table, e.g., you can construct it using `table(0, 0, identity)`.

After this pull request, all of the following work:

```m2
i1 : matrix {}

o1 = 0

o1 : Matrix 0 <-- 0

i2 : matrix(ZZ, {})

o2 = 0

o2 : Matrix 0 <-- 0

i3 : map(ZZ^0, , {})

o3 = 0

o3 : Matrix 0 <-- 0

i4 : isTable {}

o4 = true
```

