### PR TITLE
Fix LU decomposition of empty real/complex matrices

### DIFF
--- a/M2/Macaulay2/e/dmat-lu-inplace.hpp
+++ b/M2/Macaulay2/e/dmat-lu-inplace.hpp
@@ -284,6 +284,9 @@ inline void DMatLUinPlace<M2::ARingRR>::computeLU()
   int info;
   int min = (rows <= cols) ? rows : cols;
 
+  if (min == 0)
+    return;
+
   // printf("entering DMatLUinPlace::computeLUNaive for RR\n");
 
   int* perm = newarray_atomic(int, min);
@@ -344,6 +347,9 @@ inline void DMatLUinPlace<M2::ARingCC>::computeLU()
   int cols = static_cast<int>(mLU.numColumns());
   int info;
   int min = (rows <= cols) ? rows : cols;
+
+  if (min == 0)
+    return;
 
   // printf("entering DMatLUtemplate::computeLUNaive for RR\n");
 

--- a/M2/Macaulay2/tests/normal/LU.m2
+++ b/M2/Macaulay2/tests/normal/LU.m2
@@ -83,3 +83,9 @@ M == L*U
 L*U
 M
 M == checkLU LUdecomposition M
+
+-- empty matrix (reported by Joel Louwsma in Zulip)
+scan({map(RR^0, RR^0, {}), map(CC^0, CC^0, {})}, M -> (
+	checkLU M;
+	assert Equation(rank M, 0);
+	assert Equation(det M, 1)))


### PR DESCRIPTION
This fixes an issue brought up by Joel Louwsma in Zulip:

> When trying to compute the rank and determinant of a 0x0 matrix over real or complex fields, I get errors.
> ```m2
> i1 : rank(diagonalMatrix(RR_53,{}))
> ** On entry to DGETRF parameter number 4 had an illegal value
> i2 : det(diagonalMatrix(RR_53,{}))
> ** On entry to DGETRF parameter number 4 had an illegal value
> i3 : rank(diagonalMatrix(CC_53,{}))
> ** On entry to ZGETRF parameter number 4 had an illegal value
> i4 : det(diagonalMatrix(CC_53,{}))
> ** On entry to ZGETRF parameter number 4 had an illegal value
> ```

We previously weren't checking to see if the matrix was empty prior to calling these LAPACK routines to compute the LU decomposition (which is used by both `rank` and `det`).  Adding this check fixes the issue:

```m2
i1 : rank(diagonalMatrix(RR_53,{}))

o1 = 0

i2 : det(diagonalMatrix(RR_53,{}))

o2 = 1

o2 : RR (of precision 53)

i3 : rank(diagonalMatrix(CC_53,{}))

o3 = 0

i4 : det(diagonalMatrix(CC_53,{}))

o4 = 1

o4 : CC (of precision 53)
```

