### PR TITLE
Add check to see if we need to link against -latomic

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1863,6 +1863,21 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([int main() {}])],
 rm -f conftest.mapfile
 LDFLAGS=$SAVE
 
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358
+AC_MSG_CHECKING([whether we need to link with -latomic])
+AC_LANG([C++])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([
+	#include <atomic>
+	], [std::atomic<int64_t> x; x++])],
+	[AC_MSG_RESULT([no])],
+	[LIBS="$LIBS -latomic"
+	 AC_LINK_IFELSE([AC_LANG_PROGRAM([
+		#include <atomic>
+		], [std::atomic<int64_t> x; x++])],
+		[AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([error])
+		 AC_MSG_ERROR([unable to handle 64-bit atomics])])])
+
 AC_SUBST(DUMPDATAFILE,Macaulay2-$ARCH-data)
 
 test "$MEMDEBUG" = yes && M2_CPPFLAGS="$M2_CPPFLAGS -DMEMDEBUG"


### PR DESCRIPTION
This is necessary to handle 64-bit atomics (which are used by TBB) on certain 32-bit architectures (e.g., powerpc and m68k) due to a [GCC bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358).

Otherwise, we end up with the following linking error ([full log](https://buildd.debian.org/status/fetch.php?pkg=macaulay2&arch=powerpc&ver=1.24.05%2Bds-1&stamp=1715757140&raw=0)):

```
/usr/bin/ld: ../e/NCAlgebras/NCF4.o: undefined reference to symbol '__atomic_fetch_add_8@@LIBATOMIC_1.0'
/usr/bin/ld: /lib/powerpc-linux-gnu/libatomic.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

@mahrud: Do you think it's worth adding an equivalent check to the cmake build?  This is only an issue on certain old-school 32-bit architectures.