### PR TITLE
Remove copyright blurb from startup banner

### DIFF
--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -134,9 +134,9 @@ foreach(_d_source IN LISTS DLIST)
 endforeach()
 
 # To avoid unnecessary recompiling, only version.dd is given GIT_DESCRIPTION
-set_source_files_properties(version-tmp.cc
-  PROPERTIES COMPILE_DEFINITIONS
-  "GIT_DESCRIPTION=\"${GIT_DESCRIPTION}\";GIT_BRANCH=\"${GIT_BRANCH}\"")
+set_property(SOURCE version-tmp.cc APPEND PROPERTY COMPILE_DEFINITIONS
+  GIT_DESCRIPTION="${GIT_DESCRIPTION}"
+  GIT_BRANCH="${GIT_BRANCH}")
 
 ###############################################################################
 ## Compile the interpreter

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -162,12 +162,6 @@ if firstTime then (
 
      toAbsolutePath = pth -> if pth =!= "stdio" and not isAbsolutePath pth then "/" | relativizeFilename("/", pth) else pth;
 
-     startupBanner = "Macaulay2, version " | m2version | ///
-Copyright 1993-2024 Daniel R. Grayson and Michael E. Stillman
-This program comes with ABSOLUTELY NO WARRANTY.  This is free
-software, and you are welcome to redistribute it under certain
-conditions; type 'copyright' for details.///;
-
      use = x -> x;				  -- temporary, until methods.m2
 
      Attributes = new MutableHashTable;
@@ -562,7 +556,7 @@ if notify then printerr("executable = ", exe)
 
 if firstTime and not nobanner then (
      if topLevelMode === TeXmacs then stderr << TeXmacsBegin << "verbatim:";
-     stderr << startupBanner << newline << flush;
+     stderr << "Macaulay2, version " << m2version << newline << flush;
      if topLevelMode === TeXmacs then stderr << TeXmacsEnd << flush)
 
 scan(commandLine, arg -> if arg === "-q" then noinitfile = true)


### PR DESCRIPTION
This is a quick followup to #3240.  Based on feedback, we remove the legal notices that were added to the startup banner.