### PR TITLE
add CoefficientRing to smoothFanoVariety(d,0)

### DIFF
--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
@@ -378,7 +378,7 @@ smoothFanoToricVariety (ZZ,ZZ) := NormalToricVariety => opts -> (d, i) -> (
     	error "-- there are only 7622 smooth Fano toric 6-folds";
     if d > 6 then 
     	error "-- database doesn't include varieties with dimension > 6";
-    if i === 0 then return toricProjectiveSpace(d, CoefficientRing => opts.CoefficientRing);
+    if i === 0 then return toricProjectiveSpace(d, opts);
     if d < 5 then (
     	s := (getFano (d))#(d,i);
     	return normalToricVariety (s#0, s#1, 

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
@@ -378,7 +378,7 @@ smoothFanoToricVariety (ZZ,ZZ) := NormalToricVariety => opts -> (d, i) -> (
     	error "-- there are only 7622 smooth Fano toric 6-folds";
     if d > 6 then 
     	error "-- database doesn't include varieties with dimension > 6";
-    if i === 0 then return toricProjectiveSpace d;
+    if i === 0 then return toricProjectiveSpace(d, CoefficientRing => opts.CoefficientRing);
     if d < 5 then (
     	s := (getFano (d))#(d,i);
     	return normalToricVariety (s#0, s#1, 


### PR DESCRIPTION
In NormalToricVarieties, smoothFanoToricVariety(d,i) took a CoefficientRing option, which was previously erroneously ignored when i = 0 (i.e., for P^d). This just adds CoefficientRing => opts.CoefficientRing in that case. 