### PR TITLE
Document use of global variable "a" as generator of Galois field

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/GF-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/GF-doc.m2
@@ -10,7 +10,9 @@ document {
 	  Usage => "GF(p,n)\nGF(q)",
 	  Inputs => {
 	       "p" => "a prime number", "n",
-	       Variable => Symbol => "the name to use for the generator of the field",
+	       Variable => Symbol => {
+		   "the name to use for the generator of the field.  If null, ",
+		   "then ", VAR "a", " is used."},
 	       SizeLimit => ZZ => {
 		    "the limit on the size of a Galois field whose elements will be represented
 		    internally as powers of the primitive element"
@@ -30,11 +32,10 @@ document {
 	  ///,
 	  EXAMPLE lines ///
 	  K = GF 8
-	  x = K_0
-	  x^3+x
+	  a^3+a
 	  ///
 	  ),
-     SeeAlso => {toField},
+     SeeAlso => {toField, "finite fields"},
      SYNOPSIS (
 	  BaseFunction => GF,
 	  Usage => "GF R",

--- a/M2/Macaulay2/packages/Macaulay2Doc/overviewC.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/overviewC.m2
@@ -97,7 +97,7 @@ document {
 	"Two basic finite fields are:",
      UL {
 	  TO2 {"integers modulo a prime", "ZZ/p"},
-	  TT "GF(p^n)"
+	  TO2 {"GF", "GF(p^n)"}
 	  },
      "Create a finite field with $q = p^n$ elements using",
      EXAMPLE "F = GF(81,Variable=>a)",
@@ -133,8 +133,11 @@ document {
      "In general, to make a finite field with ", TT "q", " elements, we use
      ", TO "GF", ".",
      EXAMPLE "k = GF 81",
-     "The generator of the field can be obtained as usual.",
-     EXAMPLE "k_0",
+     "The generator of the field is available as the variable ", VAR "a",
+     " or it can be obtained as usual.",
+     EXAMPLE {
+	 "a",
+	 "k_0"},
      "You may use ", TO "ambient", " to see the quotient ring the field is made from.",
      EXAMPLE "ambient k",
      "Use ", TO "ideal", " to see the ideal that defined that quotient ring.",


### PR DESCRIPTION
We update the `GF` and `finite fields` documentation nodes to mention the fact that if `GF` is called without the `Variable` option, then the variable `a` is used as the generator of the field.  My earlier attempt at changing the behavior led to lots of failing tests, so this behavior is widely used -- see #3255.

This was previously undocumented, leading to confusion trying to construct polynomial rings over Galois fields with `a` as a variable as in #3254.

We also link these two documentation nodes to one another.