### PR TITLE
De-duplicate three or more duplicate variables

### DIFF
--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -474,14 +474,22 @@ checkSymbol = sym -> if instance(sym, Symbol) or lookup(symbol <-, class sym) =!
 -- turns {x, y, z, y} into {x, y_0, z, y_1}
 -- adding 'toString' in a few places will eliminate more duplications
 -- but makes creating temporary rings in functions more difficult.
-dedupSymbols = varlist -> if 0 == repeats varlist then varlist else while 0 < repeats varlist do (
-    mapping := hashTable toList pairs varlist;
-    -- TODO: applyPairs with collision handler, and accepting MutableHashTable
-    counter := new MutableHashTable from applyKeys(mapping,
-	i -> varlist#i, dups -> makeVars(#dups, first dups));
-    varlist = values applyValues(mapping, var -> if instance(counter#(name := var), List)
-	then first(counter#name#0, counter#name = drop(counter#name, 1)) else var);
-    if 0 == repeats varlist then break varlist else varlist)
+dedupSymbols = varlist -> (
+    while repeats varlist > 0 do (
+	counts := tally varlist;
+	data := hashTable apply(keys counts,
+	    var -> (
+		var,
+		new MutableList from {
+		    0,
+		    if counts#var > 1 then (
+			makeVars(counts#var, var))
+		    else {var}}));
+	varlist = apply(varlist, var -> (
+		newvar := data#var#1#(data#var#0);
+		data#var#0 += 1;
+		newvar)));
+    varlist)
 
 -- also used in AssociativeAlgebras.m2
 findSymbols = varlist -> dedupSymbols toList apply(pairs listSplice varlist,

--- a/M2/Macaulay2/tests/normal/monoids.m2
+++ b/M2/Macaulay2/tests/normal/monoids.m2
@@ -230,6 +230,7 @@ assert(gens(B = A ** A) == {x_0,y_0,x_1,y_1}) -- TODO: eliminate the warning
 assert(gens(C = B ** B) == {x_(0,0),y_(0,0),x_(0,1),y_(0,1),x_(1,0),y_(1,0),x_(1,1),y_(1,1)})
 assert(toString gens(A ** B) == "{x, y, x_0, y_0, x_1, y_1}") -- TODO: not yet working without toString
 assert(toString gens(monoid[x,y,x,z]) == "{x_0, y, x_1, z}") -- TODO: not yet working without toString
+assert(toString gens(monoid[x,x,x]) == "{x_0, x_1, x_2}") -- issue #3261
 
 -- test ^** and runLengthEncode
 -- TODO: what should happen for odd powers?


### PR DESCRIPTION
We refactor the `dedupSymbols` helper function, which previously only de-duplicated up to two duplicate variables.

### Before
```m2
i1 : QQ[x,x]

o1 = QQ[x ..x ]
         0   1

o1 : PolynomialRing

i2 : QQ[x,x,x]
stdio:2:1:(3): error: baseName: no base name available
```

### After
```m2
i1 : QQ[x,x,x]

o1 = QQ[x ..x ]
         0   2

o1 : PolynomialRing
```

Closes: #3261