### PR TITLE
Delete check for program licenses directory

### DIFF
--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -565,8 +565,6 @@ homeDirectory = getenv "HOME" | "/"
 
 initcurrentlayout()
 
-if firstTime and fileExists(prefixDirectory | currentLayout#"program licenses") then
-
 path = {}
 pkgpath = {}
 corepath = {}


### PR DESCRIPTION
This is another short followup to #3240.  I forgot to delete a line that was left over from when `copyright` was a string, which is no longer the case.

Also, the next thing after the `then` at the end of the line was the definition of the `path` variable.  So if the `"program licenses"` directory doesn't exist (e.g., in the Debian/Ubuntu package where we don't vendor any 3rd party programs or libraries), then we immediately got the following error:

```m2
/usr/share/Macaulay2/Core/startup.m2:583:16:(0): error: expected argument 1 to be a list or sequence
```

This was from a call to `join`, which expects lists and sequences, but argument 1 was `path`, which was still just a symbol.