### PR TITLE
Update "remove" to return the removed value

### DIFF
--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -603,9 +603,10 @@ remove(x:List,i:int):Expr:= (
      else if i >= n || i < -n then ArrayIndexOutOfBounds(i, n - 1)
      else (
 	  if i < 0 then i = n + i;
+	  ret := x.v.i;
 	  for j from i to n - 2 do x.v.j = x.v.(j + 1);
 	  Ccode(void, x.v, "->len = ", n - 1);
-	  nullE));
+	  ret));
 
 removefun(e:Expr):Expr := (
      when e
@@ -622,12 +623,14 @@ removefun(e:Expr):Expr := (
 		    when args.1 is key:stringCell do (
 	       		 if !f.isopen then return buildErrorPacket("database closed");
 	       		 if !f.Mutable then return buildErrorPacket("database not mutable");
-	       		 if 0 == dbmdelete(f.handle,key.v) then nullE
+			 ret := dbmfetch(f.handle,key.v);
+	       		 if 0 == dbmdelete(f.handle,key.v) then (
+			     when ret
+			     is s:string do toExpr(s)
+			     is null do nullE)
 	       		 else buildErrorPacket(dbmstrerror() + " : " + f.filename))
 		    else WrongArgString(2))
-	       is o:HashTable do (
-		    ret := remove(o,args.1);
-		    when ret is Error do ret else nullE)
+	       is o:HashTable do remove(o,args.1)
 	       else WrongArg(1,"a hash table or database")))
      else WrongNumArgs(2));
 setupfun("remove",removefun);

--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -87,9 +87,11 @@ export remove(x:HashTable,key:Expr):Expr := (
      hmod := int(h & (length(x.table)-1));
      p := x.table.hmod;
      prev := p;
+     ret := nullE;
      while p != p.next do (
 	  if p.key == key || equal(p.key,key)==True 
 	  then (
+	       ret = p.value;
 	       --preserve ordering -- we change the numEntries last upon insertion so decrease it first when removing.
 	       x.numEntries = x.numEntries - 1;
 	       if prev == p then x.table.hmod = p.next
@@ -102,7 +104,7 @@ export remove(x:HashTable,key:Expr):Expr := (
 	  prev = p;
 	  p = p.next);
      if !x.beingInitialized then unlock(x.mutex);
-     Expr(x));
+     ret);
 export storeInHashTable(x:HashTable,key:Expr,h:int,value:Expr):Expr := (
      if !x.Mutable then return buildErrorPacket("attempted to modify an immutable hash table");
      if !x.beingInitialized then lockWrite(x.mutex);

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -474,12 +474,12 @@ checkSymbol = sym -> if instance(sym, Symbol) or lookup(symbol <-, class sym) =!
 -- turns {x, y, z, y} into {x, y_0, z, y_1}
 -- adding 'toString' in a few places will eliminate more duplications
 -- but makes creating temporary rings in functions more difficult.
-dedupSymbols = varlist -> if 0 == repeats varlist then varlist else while 0 < repeats varlist do (
-    mapping := hashTable toList pairs varlist;
-    counter := applyPairs(tally varlist, (name, count) ->
-	name => new MutableList from if count == 1 then {name} else makeVars(count, name));
-    varlist  = apply(varlist, var -> remove(counter#var, 0));
-    if 0 == repeats varlist then break varlist else varlist)
+dedupSymbols = varlist -> (
+    while 0 < repeats varlist do (
+	counter := applyPairs(tally varlist, (name, count) ->
+	    name => new MutableList from if count == 1 then {name} else makeVars(count, name));
+	varlist  = apply(varlist, var -> remove(counter#var, 0)));
+    varlist)
 
 -- also used in AssociativeAlgebras.m2
 findSymbols = varlist -> dedupSymbols toList apply(pairs listSplice varlist,

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -471,9 +471,6 @@ makeVars = (n, var) -> toList(
 -- TODO: why is (symbol <-, T) and not (symbol <-, T, Thing) the right method sequence for assignment?
 checkSymbol = sym -> if instance(sym, Symbol) or lookup(symbol <-, class sym) =!= null then sym else error()
 
--- TODO: the compiled function remove should return the removed value
-remove' = (L, i) -> (x := L#i; remove(L, i); x)
-
 -- turns {x, y, z, y} into {x, y_0, z, y_1}
 -- adding 'toString' in a few places will eliminate more duplications
 -- but makes creating temporary rings in functions more difficult.
@@ -481,7 +478,7 @@ dedupSymbols = varlist -> if 0 == repeats varlist then varlist else while 0 < re
     mapping := hashTable toList pairs varlist;
     counter := applyPairs(tally varlist, (name, count) ->
 	name => new MutableList from if count == 1 then {name} else makeVars(count, name));
-    varlist  = apply(varlist, var -> remove'(counter#var, 0));
+    varlist  = apply(varlist, var -> remove(counter#var, 0));
     if 0 == repeats varlist then break varlist else varlist)
 
 -- also used in AssociativeAlgebras.m2

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -5,7 +5,7 @@ star := IMG { "src" => replace("PKG","Style",currentLayout#"package") | "GoldSta
 document {
      Key => "changes to Macaulay2, by version",
      Subnodes => {
---	  TO "changes made for the next release",
+	  TO "changes made for the next release",
 	  TO "changes, 1.24.05",
 	  TO "changes, 1.23",
 	  TO "changes, 1.22",
@@ -39,6 +39,18 @@ document {
 	  TO "list of obsolete functions"
 	  }
      }
+
+document {
+    Key => "changes made for the next release",
+    UL {
+	LI { "functionality changed in a way that could break code:",
+	    UL {
+		LI { "The function ", TO remove, ", which previously had no return value, now returns the value that was removed." }
+		}
+	    }
+	}
+    }
+
 
 document {
     Key => "changes, 1.24.05",

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_tables.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_tables.m2
@@ -296,10 +296,10 @@ doc ///
     the key to remove (must be @ofClass ZZ@ if @TT "T"@ is a mutable list or
     @ofClass String@ if it is a database)
  Outputs
-  :Nothing
+  :Thing -- the removed value
  Description
   Text
-   {\tt remove(T, k)} removes the entry of {\tt T} stored under
+   {\tt remove(T, k)} removes and returns the entry of {\tt T} stored under
    the key {\tt k}.
   Example
    T = new MutableHashTable from {a => 1, b => 2, c => 3}; peek T
@@ -328,8 +328,6 @@ doc ///
   Example
     remove(T, -1)
     peek T
-  Text
-   The {\tt remove} command does not return any output.
  SeeAlso
   applyKeys
   applyPairs

--- a/M2/Macaulay2/tests/normal/remove.m2
+++ b/M2/Macaulay2/tests/normal/remove.m2
@@ -1,17 +1,17 @@
 x = new MutableHashTable from {"a" => 1, "b" => 2, "c" => 3}
-remove(x, "a")
+assert(remove(x, "a") == 1)
 assert (pairs x == {("b", 2), ("c", 3)})
-remove(x, "d")
+assert(remove(x, "d") === null)
 assert (pairs x == {("b", 2), ("c", 3)})
 
 x = new MutableList from {1, 2, 3, 4}
-remove(x, 0)
+assert(remove(x, 0) == 1)
 assert(toList x == {2, 3, 4})
-remove(x, -1)
+assert(remove(x, -1) == 4)
 assert(toList x == {2, 3})
-remove(x, 1)
+assert(remove(x, 1) == 3)
 assert(toList x == {2})
-remove(x, 0)
+assert(remove(x, 0) == 2)
 assert(toList x == {})
 
 filename = temporaryFileName() | ".dbm"
@@ -20,7 +20,7 @@ x#"a" = "foo"
 x#"b" = "bar"
 x#"c" = "baz"
 assert(sort keys x == {"a", "b", "c"})
-remove(x, "a")
+assert(remove(x, "a") == "foo")
 assert(sort keys x == {"b", "c"})
 close x
 removeFile filename


### PR DESCRIPTION
This change was suggested by @mahrud in a comment in the code added in #3265.

### Before
```m2
i1 : x = new MutableList from {2, 4, 6, 8, 10}

o1 = MutableList{...5...}

o1 : MutableList

i2 : remove(x, -1) -- no return value

i3 :
```

### After
```m2
i2 : remove(x, -1)

o2 = 10

i3 : 
```