### PR TITLE
fix #3260

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -1105,7 +1105,7 @@ texMathSuperscript := v -> (
     x := texMath v#0;
     y := texMath v#1;
     if precedence v#0 < p or class v#0 === Superscript or class v#0 === Power then x = "\\left(" | x | "\\right)"; -- precedence of double superscript
-    concatenate(x,"_{",y,"}",if class v#0===Symbol and last toString v#0=="'" then "{}") -- no braces around x
+    concatenate(x,"^{",y,"}") -- no braces around x
 )
 texMath Power := v -> if v#1 === 1 or v#1 === ONE then texMath v#0 else texMathSuperscript v
 texMath Superscript := v -> if v#1 === moduleZERO then "0" else texMathSuperscript v
@@ -1115,7 +1115,7 @@ texMath Subscript := v -> (
      x := texMath v#0;
      y := if class v#1 === Sequence then demark(",", apply(v#1,texMath)) else texMath v#1; -- no () for sequences
      if precedence v#0 <  p or class v#0 === Subscript then x = "\\left(" | x | "\\right)"; -- precedence or double subscript
-     concatenate(x,"_{",y,"}") -- no braces around x
+     concatenate(x,"_{",y,"}",if class v#0===Symbol and last toString v#0=="'" then "{}") -- no braces around x
      )
 
 -*


### PR DESCRIPTION
There was an unfortunate mix-up when trying to fix "an annoying double superscript bug for things like x'_1^2" in #3260 -- I modified the wrong method (superscript vs subscript). Re-fixed.