### PR TITLE
Export changeDirectory

### DIFF
--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1316,11 +1316,6 @@ readlinkfun(e:Expr):Expr := (
      else WrongArgString());
 setupfun("readlink",readlinkfun);
 
-changeDirectory(e:Expr):Expr := (
-     when e is filename:stringCell do if chdir(filename.v) == -1 then buildErrorPacket(syscallErrorMessage("changing directory")) else nullE
-     else WrongArgString());
-setupfun("changeDirectory",changeDirectory);
-
 realpathfun(e:Expr):Expr := (
      when e is f:stringCell do (
      	  when realpath(expandFileName(f.v))
@@ -1731,6 +1726,21 @@ getcwdfun(e:Expr):Expr := (				    -- this has to be a function, because getcwd 
      if length(s) == 0 then cwd() else WrongNumArgs(0)
      else WrongNumArgs(0));
 setupfun("currentDirectory",getcwdfun);
+
+changeDirectory(dir:string):Expr := (
+    if chdir(expandFileName(dir)) == -1
+    then buildErrorPacket(syscallErrorMessage("changing directory"))
+    else getcwdfun(emptySequenceE));
+
+changeDirectory(e:Expr):Expr := (
+    when e
+    is filename:stringCell do changeDirectory(filename.v)
+    is a:Sequence do (
+	if length(a) == 0
+	then changeDirectory("~")
+	else WrongArg("a string or ()"))
+    else WrongArg("a string or ()"));
+setupfun("changeDirectory",changeDirectory);
 
 export debuggerHook := nullE;
 

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -535,6 +535,7 @@ export {
 	"centerString",
 	"chainComplex",
 	"changeBase",
+	"changeDirectory",
 	"char",
 	"characters",
 	"check",

--- a/M2/Macaulay2/m2/files.m2
+++ b/M2/Macaulay2/m2/files.m2
@@ -17,7 +17,8 @@ makeDirectory String := name -> (			    -- make the whole path, too
      name = minimizeFilename name;
      parts := separate("/", name);
      if last parts === "" then parts = drop(parts,-1);
-     makeDir fold((a,b) -> ( makeDir a; a|"/"|b ), parts))
+     makeDir fold((a,b) -> ( makeDir a; a|"/"|b ), parts);
+     name)
 
 copyFile = method(Options => new OptionTable from { Verbose => false, UpdateOnly => false })
 copyFile(String,String) := opts -> (src,tar) -> (

--- a/M2/Macaulay2/packages/Macaulay2Doc/system.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/system.m2
@@ -1223,6 +1223,7 @@ document {
      Headline => "make a directory",
      Usage => "makeDirectory dir",
      Inputs => { "dir" => String => "a path to the desired directory" },
+     Outputs => { String => "the name of the newly made directory" },
      Consequences => { { "the directory is made, with as many new path components as needed" } },
      EXAMPLE lines ///
 	  dir = temporaryFileName()

--- a/M2/Macaulay2/packages/Macaulay2Doc/system.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/system.m2
@@ -644,8 +644,39 @@ document {
      ///,
      PARA {
 	  "If a component of the path to the current directory no longer exist, an error will be signalled."
-	  }
+	  },
+     SeeAlso => {changeDirectory}
      }
+
+doc ///
+  Key
+    changeDirectory
+  Headline
+    change the current working directory
+  Usage
+    changeDirectory dir
+  Inputs
+    dir:String
+  Outputs
+    :String -- the new working directory
+  Description
+    Text
+      Change the current working directory to @VAR "dir"@.
+    Example
+      dir = temporaryFileName()
+      makeDirectory dir
+      changeDirectory dir
+      currentDirectory()
+    Text
+      If @VAR "dir"@ is omitted, then the current working directory
+      is changed to the user's home directory.
+    Example
+      changeDirectory()
+      currentDirectory()
+  SeeAlso
+    currentDirectory
+///
+
 document {
      Key => exec,
      Headline => "execute another program",

--- a/M2/Macaulay2/tests/normal/files.m2
+++ b/M2/Macaulay2/tests/normal/files.m2
@@ -1,0 +1,8 @@
+-- TODO: add more unit tests for file operations
+
+dir = temporaryFileName()
+assert(changeDirectory makeDirectory dir == dir | "/")
+assert(currentDirectory() == dir | "/")
+assert(changeDirectory() == homeDirectory)
+assert(currentDirectory() == homeDirectory)
+removeDirectory dir


### PR DESCRIPTION
I've often wanted the option to change the current working directory inside M2 (e.g, if without realizing I run `M-x M2` inside Emacs when the active buffer is visiting some file in some strange directory).

It turns out that a `changeDirectory` function already exists, but it just wasn't exported!

We update it slightly (allowing the expansion of `~` to the user's home directory and changing to the home directory when there's no input), document it, and add unit tests.

```m2
i1 : currentDirectory()

o1 = /home/profzoom/tmp/

i2 : makeDirectory "foo"

i3 : changeDirectory "foo"

i4 : currentDirectory()

o4 = /home/profzoom/tmp/foo/
```