### PR TITLE
Bump line number after syntax errors

### DIFF
--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -142,6 +142,8 @@ readeval4(file:TokenFile,printout:bool,dictionary:Dictionary,returnLastvalue:boo
 		    	      if debugLevel == 123 then stderr <<  "-- error during parsing" << endl;
 			      if fileError(file) then return buildErrorPacket(fileErrorMessage(file));
 			      if stopIfError || returnIfError then return buildErrorPacket("--backtrace: parse error--");
+			      file.posFile.line = file.posFile.line + 1;
+			      file.posFile.column = ushort(0);
 			      );
 			 )
 		    else (

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -108,6 +108,8 @@ readeval4(file:TokenFile,printout:bool,dictionary:Dictionary,returnLastvalue:boo
 	       	    if fileError(file) then return buildErrorPacket(fileErrorMessage(file));
 	       	    if stopIfError || returnIfError then return buildErrorPacket("--backtrace: token read error--");
 		    if isatty(file) || file.posFile.file.fulllines then flushToken(file);
+		    file.posFile.line = file.posFile.line + 1;
+		    file.posFile.column = ushort(0);
 		    )
 	       )
 	  else (


### PR DESCRIPTION
This adds consistency with other errors.  For example, this is what happens when we have higher-level errors:

```m2
i1 : 1/0
stdio:1:2:(3): error: division by zero

i2 : 1/0
stdio:2:2:(3): error: division by zero

i3 : 1/0
stdio:3:2:(3): error: division by zero

i4 : currentPosition()

o4 = stdio:5:0

o4 : FilePosition
```

The current line number increases by 1 each time, as does the file position.

However, if it's a syntax error, this doesn't happen:

```m2
i1 : )
stdio:1:1:(3): error: syntax error at ')'

i1 : )
stdio:1:2:(3): error: syntax error at ')'

i1 : )
stdio:1:3:(3): error: syntax error at ')'

i1 : currentPosition()

o1 = stdio:2:0

o1 : FilePosition
```

### After

```m2
i1 : )
stdio:1:1:(3): error: syntax error at ')'

i2 : )
stdio:2:1:(3): error: syntax error at ')'

i3 : )
stdio:3:1:(3): error: syntax error at ')'

i4 : currentPosition()

o4 = stdio:5:0

o4 : FilePosition
```