### PR TITLE
Fix factory compilation with flint >=3.1.0

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -432,13 +432,13 @@ _ADD_COMPONENT_DEPENDENCY(libraries flint "mp;mpfr;ntl" FLINT_FOUND)
 # https://service.mathematik.uni-kl.de/ftp/pub/Math/Singular/Factory/
 # TODO: what is ftmpl_inst.o?
 ExternalProject_Add(build-factory
-  URL               https://www.singular.uni-kl.de/ftp/pub/Math/Factory/factory-4.3.0.tar.gz
-  URL_HASH          SHA256=f1e25b566a8c06d0e98b9795741c6d12b5a34c5c0c61c078d9346d8bbc82f09f
+  URL               https://www.singular.uni-kl.de/ftp/pub/Math/Factory/factory-4.4.0.tar.gz
+  URL_HASH          SHA256=baf31159578463e26bf18ec68ec901228d79a819866dd96c02d85c73dfbaf030
   PREFIX            libraries/factory
   SOURCE_DIR        libraries/factory/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
-  PATCH_COMMAND     patch --batch < ${CMAKE_SOURCE_DIR}/libraries/factory/patch-4.3.0
+#  PATCH_COMMAND     patch --batch < ${CMAKE_SOURCE_DIR}/libraries/factory/patch-4.4.0
   CONFIGURE_COMMAND autoreconf -vif &&
                     ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}

--- a/M2/libraries/factory/Makefile.in
+++ b/M2/libraries/factory/Makefile.in
@@ -16,8 +16,8 @@
 # it at one of the ftp sites above.  Version 4.1.3 is available.
 
 URL = https://www.singular.uni-kl.de/ftp/pub/Math/Factory
-VERSION = 4.3.0
-PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+VERSION = 4.4.0
+#PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PRECONFIGURE = autoreconf -vif
 
 BUILDTARGET = all ftmpl_inst.o


### PR DESCRIPTION
Factory builds fail with flint >=3.1.0. See in particular https://github.com/Singular/Singular/pull/1209, updating factory to 4.4.0 fixes this.