### PR TITLE
Fix some warnings 

### DIFF
--- a/M2/Macaulay2/e/BasicPoly.cpp
+++ b/M2/Macaulay2/e/BasicPoly.cpp
@@ -51,7 +51,6 @@ void BasicPoly::displayCoefficient(std::ostream& o, T val, bool print_plus, bool
   bool is_negative = (val < 0);
   bool is_one = (val == 1 or val == -1);
 
-  T negative_val = - val;
   if (not is_negative and print_plus) o << '+';
   if (is_one)
     {

--- a/M2/Macaulay2/e/NCAlgebras/NCF4.cpp
+++ b/M2/Macaulay2/e/NCAlgebras/NCF4.cpp
@@ -357,7 +357,7 @@ void NCF4::autoreduceByLastElement()
 {
   if (mGroebner.size() <= 1) return;
   const Poly& lastPoly = *(mGroebner[mGroebner.size()-1]);
-  const Monom& leadMon = lastPoly.cbegin().monom();
+  Monom leadMon = lastPoly.cbegin().monom();
   for (auto fPtr = mGroebner.begin(); fPtr != mGroebner.end() - 1; ++fPtr)
   {
     ring_elem foundCoeff = getCoeffOfMonom(**fPtr,leadMon);

--- a/M2/Macaulay2/e/NCAlgebras/NCGroebner.cpp
+++ b/M2/Macaulay2/e/NCAlgebras/NCGroebner.cpp
@@ -205,7 +205,7 @@ void NCGroebner::autoreduceByLastElement()
 {
   if (mGroebner.size() <= 1) return;
   const Poly& lastPoly = *(mGroebner[mGroebner.size()-1]);
-  const Monom& leadMon = lastPoly.cbegin().monom();
+  Monom leadMon = lastPoly.cbegin().monom();
   for (auto fPtr = mGroebner.begin(); fPtr != mGroebner.end() - 1; ++fPtr)
   {
     ring_elem foundCoeff = getCoeffOfMonom(**fPtr,leadMon);

--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
@@ -248,7 +248,6 @@ MutableMatrix* ResF4toM2Interface::to_M2_MutableMatrix(SchreyerFrame& C,
   // ring of C.
   const PolynomialRing* RP = R->cast_to_PolynomialRing();
   const Monoid* M = RP->getMonoid();
-  const Ring* K = RP->getCoefficientRing();
 
   if (lev <= 0 or lev > C.maxLevel())
     {


### PR DESCRIPTION
This fixes some warnings when compiling under gcc. The issue fixed by the first commit in particular can cause crashes, since it was previously storing a reference to a temporary and may be related to #2959 and #3156, although it's hard to be completely sure.