### PR TITLE
Don't try to run tests that are functions during installPackage

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -724,13 +724,6 @@ installPackage Package := opts -> pkg -> (
 	close rawdocDatabase;
 	verboseLog "closed the database";
 
-	-- run tests that are functions
-	-- TODO: is this used anywhere?
-	verboseLog "running tests that are functions";
-	scan(pairs pkg#"test inputs", (key, str) -> if instance(str, Function) then (
-		verboseLog("  running test ", key, ", function ", str);
-		str()));
-
 	-- directories for cached and generated example outputs
 	exampleDir := realpath currentSourceDir | pkg#"pkgname" | "/examples" | "/";
 	exampleOutputDir := installPrefix | replace("PKG", pkg#"pkgname", installLayout#"packageexampleoutput");


### PR DESCRIPTION
There are none.  Every value in `pkg#"test inputs"` is a `TestInput` object.

Closes: #672