### PR TITLE
A couple "viewHelp" fixes

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -318,7 +318,7 @@ makePackageIndex List := path -> (
 	BODY {
 	    PARA {"This is the directory for Macaulay2 and its packages. Bookmark this page for future reference,
 		or run the ", TT "viewHelp", " command in Macaulay2 to open up your browser on this page.
-		See the ", homeButton, " for the latest version."},
+		See the ", homeButton, " website for the latest version."},
 	    HEADER3 "Documentation",
 	    UL nonnull splice {
 		if prefixDirectory =!= null then (

--- a/M2/Macaulay2/m2/system.m2
+++ b/M2/Macaulay2/m2/system.m2
@@ -242,7 +242,7 @@ locatePackageFile = (defaultPrefix,defaultLayoutIndex,pkgname,f) -> (
 locatePackageFileRelative = (defaultPrefix,defaultLayoutIndex,pkgname,f,installPrefix,installTail) -> (
      (prefix,tail) := locatePackageFile(defaultPrefix,defaultLayoutIndex,pkgname,f);
      if prefix === installPrefix			    -- we assume these are both real paths, without symbolic links
-     then relativizeFilename(installTail,tail)
+     then relativizeFilename(installTail, prefix | tail)
      else prefix|tail)
 
 locateCorePackageFile = (pkgname,f) -> locatePackageFile(prefixDirectory,currentLayout,pkgname,f)


### PR DESCRIPTION
Two small updates to `viewHelp` (without any arguments):

* We restore the word "website" that I inadvertently removed back in [#2926](https://github.com/Macaulay2/M2/pull/2926).
* We properly load the css files if `Style` has been installed to the application directory, closing [#1516](https://github.com/Macaulay2/M2/issues/1516).

### Before
![image](https://github.com/Macaulay2/M2/assets/1992248/a1d22d9c-8ac0-4329-8ff2-2b193684bb5f)

### After
![image](https://github.com/Macaulay2/M2/assets/1992248/fb0bedf6-10d5-4f10-a3d0-89160f3cbdd0)
