### PR TITLE
Honor CoefficientField option to MonomialAlgebras::affineAlgebra

### DIFF
--- a/M2/Macaulay2/packages/MonomialAlgebras.m2
+++ b/M2/Macaulay2/packages/MonomialAlgebras.m2
@@ -131,7 +131,7 @@ I:=binomialIdeal R;
 R/I)
 
 affineAlgebra List := opt-> B -> (
-I:=binomialIdeal B;
+I:=binomialIdeal(B, opt);
 (ring I)/I)
 
 affineAlgebra MonomialAlgebra := opt -> M-> affineAlgebra ring M
@@ -937,6 +937,10 @@ TEST ///
 5}, {1, 1, 3}, {4, 0, 1}, {0, 2, 3}}})
 ///
 
+TEST /// -- issue #636
+assert(coefficientRing affineAlgebra({{1, 2}, {3, 4}},
+	CoefficientField => QQ) === QQ)
+///
 
 doc ///
   Key


### PR DESCRIPTION
Closes: #636

### Before
```m2
i1 : needsPackage "MonomialAlgebras"

o1 = MonomialAlgebras

o1 : Package

i2 : affineAlgebra({{1, 2}, {3, 4}}, CoefficientField => QQ)

      ZZ
o2 = ---[x ..x ]
     101  0   1

o2 : PolynomialRing
```

### After

```m2
i2 : affineAlgebra({{1, 2}, {3, 4}}, CoefficientField => QQ)

o2 = QQ[x ..x ]
         0   1

o2 : PolynomialRing
```