### PR TITLE
Add PR template with some instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+<!--
+Thank you for contributing to Macaulay2!
+
+Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
+-->


### PR DESCRIPTION
When new PR's are opened, this will give some instructions inside the "Write" field (target the `development` branch, don't forget `=distributed-packages`, `Keywords`, and `DebuggingMode`).  They're inside a comment, so they won't actually appear on the PR page after it's been created.

See [Creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).

Skipping the builds and targeting `master` since this needs to be on the default branch to work.