### PR TITLE
Use submodule for flint build (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -996,6 +996,7 @@ then AC_LANG(C)
 fi
 if test $BUILD_flint = yes
 then BUILTLIBS="-lflint $BUILTLIBS -lm"
+     AC_DEFINE([HAVE_FLINT_NMOD_H])
 fi
 
 dnl debian: 4ti2-

--- a/M2/libraries/Makefile.library.in
+++ b/M2/libraries/Makefile.library.in
@@ -92,7 +92,11 @@ else
 endif
 BUILDDIR      ?= $(UNTARDIR)/$(TARDIR)
 TAROPTIONS    ?= --gzip
+ifeq ($(SUBMODULE),true)
+UNTARCMD      ?= rsync -a @abs_top_srcdir@/submodules/$(LIBNAME)/* $(TARDIR)
+else
 UNTARCMD      ?= @TAR@ xf $(TARFILE_DIR)/$(TARFILE) $(TAROPTIONS)
+endif
 %.E: %.c; $(COMPILE.c) -E $(OUTPUT_OPTION) $<
 export PATH := @abs_top_srcdir@/usr-build/bin:$(PATH)
 all:prereq install post-install
@@ -115,13 +119,19 @@ unmark:; rm -f .configured-$(VERSION) .compiled-$(VERSION)
 package-clean: unmark ; if [ -d $(BUILDDIR) ]; then $(MAKE) $(NOTPARALLEL) -C $(BUILDDIR) clean ; fi
 PACKAGE-DISTCLEAN-TARGET := distclean
 package-distclean: unmark ; if [ -d $(BUILDDIR) ]; then $(MAKE) $(NOTPARALLEL) -C $(BUILDDIR) $(PACKAGE-DISTCLEAN-TARGET) ; fi
+ifeq ($(SUBMODULE),true)
+fetch: update-submodule
+else
 fetch: $(TARFILE_DIR)/$(TARFILE)
+endif
 patch: .patched-$(VERSION)
 license-dir: $(LICENSE_DIR)
 $(LICENSE_DIR):; $(MKDIR_P) $(LICENSE_DIR)
 compile: config-chk .compiled-$(VERSION) 
 configure: .configured-$(VERSION) config-chk 
 config-chk:
+update-submodule: download-enabled
+	git submodule update --init @abs_top_srcdir@/submodules/$(LIBNAME)
 
 PROGRAMS ?=
 LICENSEFILES ?=
@@ -181,7 +191,7 @@ endif
 	@ set -x ; ( $(CDBUILDDIR) && $(CONFIGURECMD) ) && touch $@
 
 PATCHCMD = cd $(UNTARDIR) && for i in $(PATCHFILE) ; do patch --batch -p0 < $$i ; done
-.patched-$(VERSION) : $(PATCHFILE) $(TARFILE_DIR)/$(TARFILE)
+.patched-$(VERSION) : $(PATCHFILE)
 	$(WHY)
 	if [ -d $(UNTARDIR) -a -d $(OLDUNTARDIR)/$(UNTARDIR) ] ; \
 	    then echo please remove or move $(OLDUNTARDIR)/$(UNTARDIR) out of the way ; \
@@ -192,6 +202,9 @@ PATCHCMD = cd $(UNTARDIR) && for i in $(PATCHFILE) ; do patch --batch -p0 < $$i 
 	cd $(UNTARDIR) && $(UNTARCMD)
 	$(PATCHCMD)
 	touch $@
+ifneq ($(SUBMODULE),true)
+.patched-$(VERSION): $(TARFILE_DIR)/$(TARFILE)
+endif
 .untarred2-$(VERSION) : $(TARFILE_DIR)/$(TARFILE)
 	$(WHY)
 	mkdir tmp ; (cd tmp && $(UNTARCMD)) && touch $@
@@ -223,10 +236,13 @@ CHECKFETCHED = case "$(URL)" in									\
 	    then echo tried to fetch file, but HTML file returned instead >&2 ; exit 1 ;	\
 	    fi ;;										\
 	esac
-$(TARFILE_DIR)/$(TARFILE) :
-ifeq (@DOWNLOAD@,yes)
+$(TARFILE_DIR)/$(TARFILE) : download-enabled
 	(cd $(TARFILE_DIR) && $(FETCHER) $(URL)/$(TARFILE) $(FETCHOPTS) && $(CHECKFETCHED))
-else
+distclean: package-distclean
+clean::; rm -rf .patched* .untarred* $(LIBNAME)* .checked* .compiled* .configured* .installed* .untarred2* diffs tmp $(UNTARDIR) $(OLDUNTARDIR)
+distclean: clean ; rm -rf Makefile
+download-enabled:
+ifneq (@DOWNLOAD@,yes)
 	@ echo "error: for the third-party library or program source \"$(LIBNAME)\"" >&2
 	@ echo "       the source code is not present in the file \"$@\"" >&2
 	@ echo "       so either download a \"fat\" tar file of the Macaulay2 source code" >&2
@@ -234,9 +250,6 @@ else
 	@ echo "       to enable automatic downloading of the source code over the internet" >&2
 	@ false
 endif
-distclean: package-distclean
-clean::; rm -rf .patched* .untarred* $(LIBNAME)* .checked* .compiled* .configured* .installed* .untarred2* diffs tmp $(UNTARDIR) $(OLDUNTARDIR)
-distclean: clean ; rm -rf Makefile
 
 SLIMIT ?= 8192
 TLIMIT ?= 100

--- a/M2/libraries/flint/Makefile.in
+++ b/M2/libraries/flint/Makefile.in
@@ -1,15 +1,15 @@
+SUBMODULE = true
 # LIBNAME = flint2
 HOMEPAGE = http://flintlib.org
 # git://github.com/wbhart/flint2.git
-URL = http://macaulay2.com/Downloads/OtherSourceCode
-VERSION = 2.8.4
+VERSION = 3.0.0
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PARALLEL = yes
 
 # Many other tests keep failing, so disable them all:
 CHECKTARGET = .
 
-LICENSEFILES = flint.h LICENSE
+LICENSEFILES = LICENSE
 ifeq (@DEBUG@,yes)
 CONFIGOPTIONS += --enable-assert
 CFLAGS += -O0 -fno-unroll-loops 
@@ -17,7 +17,8 @@ endif
 CFLAGS += -std=c90 -pedantic-errors
 # the flint configure script does not accept CPPFLAGS
 # CONFIGURECMD =  LIB_DIRS=$(LIBRARIESDIR)/lib ./configure  --with-gc --with-blas --disable-tls
-CONFIGURECMD =  LIB_DIRS=$(LIBRARIESDIR)/lib ./configure --without-blas --disable-tls \
+CONFIGURECMD =  ./bootstrap.sh && \
+	LIB_DIRS=$(LIBRARIESDIR)/lib ./configure --without-blas  \
 			--prefix='$(PREFIX)' --disable-shared CC='$(CC)' \
 			CFLAGS='$(CFLAGS) $(CPPFLAGS)'
 


### PR DESCRIPTION
We update the autotools build to use the submodule, matching the cmake behavior.

I tried this a few months ago without any luck because the current practice in the autotools build for submodules is to do out-of-tree builds, which flint doesn't support.  So instead, we use the existing code in the `libraries` directory, but instead of downloading and extracting a tarball, we update the submodule and copy its contents to the build directory.

This should also make moving any other libraries from tarballs to submodule much easier.  Adding `SUBMODULE = true` to the appropriate Makefile might be sufficient.  (I'm also tempted to move some of the existing submodules to this interface -- I think it's a lot cleaner than the current hodgepodge of targets in GNUMakefile.)

Closes: #1292