### PR TITLE
Only check that changeDirectory() works if HOME exists

### DIFF
--- a/M2/Macaulay2/tests/normal/files.m2
+++ b/M2/Macaulay2/tests/normal/files.m2
@@ -3,6 +3,7 @@
 dir = temporaryFileName()
 assert(changeDirectory makeDirectory dir == dir | "/")
 assert(currentDirectory() == dir | "/")
-assert(changeDirectory() == homeDirectory)
-assert(currentDirectory() == homeDirectory)
+if fileExists homeDirectory then (
+    assert(changeDirectory() == homeDirectory);
+    assert(currentDirectory() == homeDirectory))
 removeDirectory dir


### PR DESCRIPTION
It may not in some build environments (e.g., Ubuntu PPA builds).

This is a quick followup to #3269 after some of the PPA builds started failing:

```m2
../../m2/debugging.m2:18:6:(1):[9]: error: installPackage: 1 error(s) occurred running examples for package Macaulay2Doc:

_change__Directory.errors
*************************
i3 : changeDirectory dir

o3 = /tmp/M2-24422-0/0/

i4 : currentDirectory()

o4 = /tmp/M2-24422-0/0/

i5 : changeDirectory()
stdio:5:1:(3): error: changing directory failed: No such file or directory
```

[(full log)](https://launchpadlibrarian.net/733720639/buildlog_ubuntu-bionic-amd64.macaulay2_1.24.05+git202405271815-0ppa202406060058~ubuntu18.04.1_BUILDING.txt.gz)

