### PR TITLE
Submodule updates for autotools build

### DIFF
--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -83,10 +83,6 @@ ifneq (@host_alias@,)
 # it was ../configure --build=@host_alias@ (for cross compiling)
 SUBMODULE_CONFIGOPTIONS += --host=@host_alias@
 endif
-copy-license-files-from-memtailor: LICENSE_FILES = README.md license.txt
-
-# the Makefile is the target used to run "configure" in the submodule:
-submodules/memtailor/Makefile: SUBMODULE_CONFIGOPTIONS += --with-gtest=yes
 
 # Note: we don't necessarily use the "install" target of submodules, even
 # though we did so for libraries.  The problem with "install" targets is that
@@ -171,10 +167,6 @@ submodules/$1/Makefile:@srcdir@/submodules/$1/configure @srcdir@/submodules/$1/M
 		LIBS="$$(LIBS)"								\
 		$$(SUBMODULE_CONFIGOPTIONS)
 
-@srcdir@/submodules/$1/configure.ac: $(if $(or $(filter yes, @DOWNLOAD@), \
-	$(filter $1, memtailor)), \
-	git-checkout-in-$1, git-checkout-warning-for-$1)
-
 git-checkout-warning-for-$1:
 	@ echo "error: for the submodule \"$1\"" >&2
 	@ echo "       the source code is not present in the directory \"submodules/$1\"" >&2
@@ -190,14 +182,6 @@ git-checkout-warning-for-$1:
 endef
 $(foreach s,@SUBLIST@,$(eval $(call submodule-rules,$s)))
 $(foreach s,@BUILDSUBLIST@,$(eval $(call build-submodule-rules,$s)))
-
-# installation into usr-dist
-all-in-memtailor:    install-in-memtailor
-
-install-in-memtailor:    $(BUILTLIBPATH)/include/memtailor.h
-
-$(BUILTLIBPATH)/include/memtailor.h:
-	$(MAKE) -C submodules/memtailor install
 
 all-in-Macaulay2: all-in-submodules
 

--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -92,7 +92,6 @@ submodules/mathicgb/Makefile : SUBMODULE_CONFIGOPTIONS += --with-gtest=yes \
 	--disable-cli # possibly add this option? --with-tbb
 submodules/mathic/Makefile   : SUBMODULE_CONFIGOPTIONS += --with-gtest=yes
 submodules/memtailor/Makefile: SUBMODULE_CONFIGOPTIONS += --with-gtest=yes
-submodules/fflas_ffpack/Makefile: LIBS += @LINALGLIBS@
 
 # Note: we don't necessarily use the "install" target of submodules, even
 # though we did so for libraries.  The problem with "install" targets is that
@@ -123,9 +122,6 @@ $(foreach t,$(BUILDSUBTARGETS),$(eval $t-in-submodules:))
 define build-submodule-rules
 $(foreach t,$(BUILDSUBTARGETS),$(eval $t-in-submodules:$t-in-$1))
 endef
-
-# disable these ffpack checks, because they fail, and they're compile time only:
-no-check-fflas_ffpack = 1
 
 $(foreach t,$(SUBTARGETS) $(GITSUBTARGETS),$(eval $t-in-submodules:))
 define submodule-rules
@@ -211,19 +207,13 @@ $(foreach s,@SUBLIST@,$(eval $(call submodule-rules,$s)))
 $(foreach s,@BUILDSUBLIST@,$(eval $(call build-submodule-rules,$s)))
 
 # installation into usr-dist
-## It's annoying that fflas_ffpack will copy the files during installation every time.
-all-in-fflas_ffpack: install-in-fflas_ffpack
 all-in-memtailor:    install-in-memtailor
 all-in-mathic:       install-in-mathic
 all-in-mathicgb:     install-in-mathicgb
 
-install-in-fflas_ffpack: $(BUILTLIBPATH)/include/fflas-ffpack/fflas-ffpack.h
 install-in-memtailor:    $(BUILTLIBPATH)/include/memtailor.h
 install-in-mathic:       $(BUILTLIBPATH)/include/mathic.h
 install-in-mathicgb:     $(BUILTLIBPATH)/include/mathicgb.h
-
-$(BUILTLIBPATH)/include/fflas-ffpack/fflas-ffpack.h:
-	$(MAKE) -C submodules/fflas_ffpack install
 
 $(BUILTLIBPATH)/include/memtailor.h:
 	$(MAKE) -C submodules/memtailor install

--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -234,12 +234,6 @@ $(BUILTLIBPATH)/include/mathic.h:
 $(BUILTLIBPATH)/include/mathicgb.h:
 	$(MAKE) -C submodules/mathicgb install
 
-ifeq (@BUILD_givaro@,yes)
-# fflas_ffpack depends on givaro, so if they both get built, then build givaro first.
-# This is a counterintuitive way to specify a dependence of one submodule on another.
-submodules/fflas_ffpack/Makefile: install-in-givaro
-endif
-
 all-in-Macaulay2: all-in-submodules
 
 ## 

--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -6,22 +6,8 @@ VPATH = @srcdir@
 .PHONY:unconfigure-libs reconfigure configure-help report-M2-location help scripts
 all install:										\
 	check-make config.status configured check-for-undefined-configure-variables	\
-	optional-git-submodule-update							\
 	srcdir protect-configs configured-files check-machine				\
 	M2 all-in-subdirs report-M2-location
-ifeq "@DEVELOPMENT@" "yes"
-optional-git-submodule-update:
-	: skipping automatic updating of submodules, because --enable-development was specified
-else ifeq "@BUILDSUBLIST@" ""
-optional-git-submodule-update:
-	: skipping automatic updating of submodules, because no submodules are being built
-else ifeq "@DOWNLOAD@" "yes"
-optional-git-submodule-update:
-	cd @srcdir@/.. && git submodule update
-else
-optional-git-submodule-update:
-	: skipping automatic updating of submodules, because --enable-download not provided to configure script
-endif
 configured-files: @CONFIGURED_FILES@
 $(foreach f,@CONFIGURED_FILES@,$(eval $f: @srcdir@/$f.in; ./config.status $f))
 M2: GNUmakefile
@@ -55,135 +41,12 @@ endef
 #   subdirectories of the source tree
 #     usr-build  -- install tools needed for rebuilding the configure script here, if needed
 #   subdirectories of the build tree
-#     usr-host   -- install the results of compilation of libraries, programs, and submodules, here, for the target machine
+#     usr-host   -- install the results of compilation of libraries and programs here, for the target machine
 #     usr-dist   -- place copies of everything needed in the final Macaulay2 distribution here, for the target machine
 
 check-stripped:
 	@ echo "-- checking for unstripped binaries"
 	file @pre_programsdir@/* $(BUILTLIBPATH)/bin/* @pre_bindir@/M2-binary usr-dist/bin/M2-binary usr-host/bin/* | (! grep "not stripped")
-
-## submodules
-
-ifeq (@SHARED@,no)
-SUBMODULE_CONFIGOPTIONS += --disable-shared
-else
-# Our current strategy with submodules is to use them in place, so they don't have to be
-# installed.  We like avoiding the installation step, because running "make install" a second time
-# causes files to be copied again.  With shared libraries, though, the libraries have to be installed
-# for use at run-time and then distributed as part of binary distributions.  So we disable the building of
-# shared libraries here.
-SUBMODULE_CONFIGOPTIONS += --disable-shared
-endif
-
-ifneq (@build_alias@,)
-# it was ../configure --build=@build_alias@
-SUBMODULE_CONFIGOPTIONS += --build=@build_alias@
-endif
-ifneq (@host_alias@,)
-# it was ../configure --build=@host_alias@ (for cross compiling)
-SUBMODULE_CONFIGOPTIONS += --host=@host_alias@
-endif
-
-# Note: we don't necessarily use the "install" target of submodules, even
-# though we did so for libraries.  The problem with "install" targets is that
-# they *always* copy their files, which is annoying.  Moreover, our submodules
-# don't even come with "uninstall" targets, typically.
-# include/config.Makefile.in for lines that add the locations of the the
-# include files and libraries to CPPFLAGS and LDFLAGS.
-BUILDSUBTARGETS = check all run-configure check install
-
-# Even for submodules not scheduled to be built, we might as well arrange
-# for these targets to fire also for them when doing them for all submodules:
-SUBTARGETS = clean distclean
-GITSUBTARGETS = git-clean git-update git-status git-describe
-
-$(foreach t,$(BUILDSUBTARGETS),$(eval $t:$t-in-submodules))
-
-$(foreach t,$(BUILDSUBTARGETS),$(eval $t-in-submodules:))
-define build-submodule-rules
-$(foreach t,$(BUILDSUBTARGETS),$(eval $t-in-submodules:$t-in-$1))
-endef
-
-$(foreach t,$(SUBTARGETS) $(GITSUBTARGETS),$(eval $t-in-submodules:))
-define submodule-rules
-$(foreach t,$(SUBTARGETS) $(GITSUBTARGETS),$(eval $t-in-submodules:$t-in-$1))
-all-in-$1: run-configure-in-$1 build-in-$1 copy-license-files-from-$1
-copy-license-files-from-submodules: copy-license-files-from-$1
-copy-license-files-from-$1:
-	@$(MKDIR_P) $(BUILTLIBPATH)/licenses/$1
-	@for i in $$(LICENSE_FILES); do                                     \
-	  if ! ls $(BUILTLIBPATH)/licenses/$1/$$$$i > /dev/null 2>&1; then  \
-	    cp -v @srcdir@/submodules/$1/$$$$i $(BUILTLIBPATH)/licenses/$1; \
-	  fi ;                                                              \
-	done
-build-in-$1: submodules/$1/Makefile
-	$(MAKE) -C submodules/$1 all
-check-in-$1: run-configure-in-$1
-ifeq ($(no-check-$1),)
-	$(MAKE) -C submodules/$1 check
-endif
-
-install-in-$1: build-in-$1
-
-# it may look odd to make submodules/$1/Makefile, but this allows recovery if the submodule
-# has been updated or cleaned, and needing scripts (such as "missing") installed by libtool 
-# are no longer there:
-$(foreach c, clean distclean,
-    $(eval $c-in-$1:; + if [ -f submodules/$1/Makefile ]; then $(MAKE) submodules/$1/Makefile && $(MAKE) -C submodules/$1 $c; fi)
-    $(eval $c: $c-in-$1))
-
-git-checkout-in-$1:; cd @srcdir@/.. && git submodule update --init M2/submodules/$1
-git-update-in-$1:; cd @srcdir@/submodules/$1 && git checkout master && git pull
-git-status-in-$1:; cd @srcdir@/submodules/$1 && git status
-git-clean-in-$1:; cd @srcdir@/submodules/$1 && git clean -Xdf
-git-describe-in-$1:; cd @srcdir@/submodules/$1 && git describe --dirty --long --always --abbrev=40 --all
-run-configure-in-submodules: run-configure-in-$1
-run-configure-in-$1: submodules/$1/Makefile
-unconfigure-in-submodules: unconfigure-in-$1
-unconfigure-in-$1:; rm -f submodules/$1/Makefile
-submodules/$1/Makefile:@srcdir@/submodules/$1/configure @srcdir@/submodules/$1/Makefile.in
-	$(MKDIR_P) submodules/$1
-	@ $(call cdw,submodules/$1) &&							\
-	 @abs_srcdir@/submodules/$1/configure						\
-		--prefix=$(BUILTLIBPATH)						\
-		PKG_CONFIG_PATH="$$(BUILTLIBPATH)/lib/pkgconfig:$$(PKG_CONFIG_PATH)"	\
-		GTEST_PATH=@GTEST_PATH@							\
-		AR=@AR@									\
-		AS=@AS@									\
-		DLLTOOL=@DLLTOOL@							\
-		OBJDUMP=@OBJDUMP@							\
-		STRIP=@STRIP@								\
-		CXXFLAGS="$$(CXXFLAGS)"							\
-		CFLAGS="$$(CFLAGS)"							\
-		FFLAGS="$$(FCFLAGS)"							\
-		FCFLAGS="$$(FCFLAGS)"							\
-		TARGET_ARCH=$$(TARGET_ARCH)						\
-		CPPFLAGS="$$(CPPFLAGS)"							\
-		CC="$$(CC)"								\
-		CXX="$$(CXX)"								\
-		LDFLAGS="$$(LDFLAGS)"							\
-		LOADLIBES="$$(LOADLIBES)"						\
-		LDLIBS="$$(LDLIBS)"							\
-		LIBS="$$(LIBS)"								\
-		$$(SUBMODULE_CONFIGOPTIONS)
-
-git-checkout-warning-for-$1:
-	@ echo "error: for the submodule \"$1\"" >&2
-	@ echo "       the source code is not present in the directory \"submodules/$1\"" >&2
-	@ echo "       so either run 'git submodule update --init' in the source tree" >&2
-	@ echo "       or rerun the Macaulay2 \"configure\" command with the added option \"--enable-download\"" >&2
-	@ echo "       to enable automatic downloading of the source code over the internet." >&2
-	@ echo "       To clone a repository together with its submodules, add the option" >&2
-	@ echo "       '--recursive' to the 'git clone' command." >&2
-	@ false
-
-@srcdir@/submodules/$1/configure @srcdir@/submodules/$1/Makefile.in: @srcdir@/submodules/$1/configure.ac @srcdir@/submodules/$1/Makefile.am
-	cd @srcdir@/submodules/$1 && NOCONFIGURE=1 ./autogen.sh
-endef
-$(foreach s,@SUBLIST@,$(eval $(call submodule-rules,$s)))
-$(foreach s,@BUILDSUBLIST@,$(eval $(call build-submodule-rules,$s)))
-
-all-in-Macaulay2: all-in-submodules
 
 ## 
 distclean:clean distclean-in-subdirs distclean-this-dir
@@ -305,19 +168,6 @@ help:
 	@ echo "  check-in-libraries"
 	@ echo "  install-in-libraries"
 	@ echo "  clean-in-libraries"
-	@ echo ""
-	@ echo "targets for all submodules:"
-	@ echo "  all-in-submodules"
-	@ echo "  build-in-submodules"
-	@ echo "  check-in-submodules"
-	@ echo "  install-in-submodules"
-	@ echo "  clean-in-submodules"
-	@ echo ""
-	@ echo "targets for a submodule FOO:"
-	@ echo "  all-in-FOO"
-	@ echo "  build-in-FOO"
-	@ echo "  check-in-FOO"
-	@ echo "  clean-in-FOO"
 	@ echo ""
 	@ echo "configuration display:"
 	@ echo "  status                    show options used with 'configure'"

--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -85,11 +85,8 @@ SUBMODULE_CONFIGOPTIONS += --host=@host_alias@
 endif
 copy-license-files-from-memtailor: LICENSE_FILES = README.md license.txt
 copy-license-files-from-mathic: LICENSE_FILES = README.md lgpl-*
-copy-license-files-from-mathicgb: LICENSE_FILES = README.md gpl-*
 
 # the Makefile is the target used to run "configure" in the submodule:
-submodules/mathicgb/Makefile : SUBMODULE_CONFIGOPTIONS += --with-gtest=yes \
-	--disable-cli # possibly add this option? --with-tbb
 submodules/mathic/Makefile   : SUBMODULE_CONFIGOPTIONS += --with-gtest=yes
 submodules/memtailor/Makefile: SUBMODULE_CONFIGOPTIONS += --with-gtest=yes
 
@@ -105,16 +102,6 @@ BUILDSUBTARGETS = check all run-configure check install
 # for these targets to fire also for them when doing them for all submodules:
 SUBTARGETS = clean distclean
 GITSUBTARGETS = git-clean git-update git-status git-describe
-
-ifneq (,$(findstring memtailor,@BUILDSUBLIST@))
-all-in-mathicgb all-in-mathic:all-in-memtailor
-endif
-
-ifneq (,$(findstring mathic ,@BUILDSUBLIST@))
-all-in-mathicgb:all-in-mathic
-endif
-
-all-in-mathicgb:all-in-mathic all-in-memtailor
 
 $(foreach t,$(BUILDSUBTARGETS),$(eval $t:$t-in-submodules))
 
@@ -187,7 +174,7 @@ submodules/$1/Makefile:@srcdir@/submodules/$1/configure @srcdir@/submodules/$1/M
 		$$(SUBMODULE_CONFIGOPTIONS)
 
 @srcdir@/submodules/$1/configure.ac: $(if $(or $(filter yes, @DOWNLOAD@), \
-	$(filter $1, memtailor mathic mathicgb)), \
+	$(filter $1, memtailor mathic)), \
 	git-checkout-in-$1, git-checkout-warning-for-$1)
 
 git-checkout-warning-for-$1:
@@ -209,20 +196,15 @@ $(foreach s,@BUILDSUBLIST@,$(eval $(call build-submodule-rules,$s)))
 # installation into usr-dist
 all-in-memtailor:    install-in-memtailor
 all-in-mathic:       install-in-mathic
-all-in-mathicgb:     install-in-mathicgb
 
 install-in-memtailor:    $(BUILTLIBPATH)/include/memtailor.h
 install-in-mathic:       $(BUILTLIBPATH)/include/mathic.h
-install-in-mathicgb:     $(BUILTLIBPATH)/include/mathicgb.h
 
 $(BUILTLIBPATH)/include/memtailor.h:
 	$(MAKE) -C submodules/memtailor install
 
 $(BUILTLIBPATH)/include/mathic.h:
 	$(MAKE) -C submodules/mathic install
-
-$(BUILTLIBPATH)/include/mathicgb.h:
-	$(MAKE) -C submodules/mathicgb install
 
 all-in-Macaulay2: all-in-submodules
 

--- a/M2/GNUmakefile.in
+++ b/M2/GNUmakefile.in
@@ -84,10 +84,8 @@ ifneq (@host_alias@,)
 SUBMODULE_CONFIGOPTIONS += --host=@host_alias@
 endif
 copy-license-files-from-memtailor: LICENSE_FILES = README.md license.txt
-copy-license-files-from-mathic: LICENSE_FILES = README.md lgpl-*
 
 # the Makefile is the target used to run "configure" in the submodule:
-submodules/mathic/Makefile   : SUBMODULE_CONFIGOPTIONS += --with-gtest=yes
 submodules/memtailor/Makefile: SUBMODULE_CONFIGOPTIONS += --with-gtest=yes
 
 # Note: we don't necessarily use the "install" target of submodules, even
@@ -174,7 +172,7 @@ submodules/$1/Makefile:@srcdir@/submodules/$1/configure @srcdir@/submodules/$1/M
 		$$(SUBMODULE_CONFIGOPTIONS)
 
 @srcdir@/submodules/$1/configure.ac: $(if $(or $(filter yes, @DOWNLOAD@), \
-	$(filter $1, memtailor mathic)), \
+	$(filter $1, memtailor)), \
 	git-checkout-in-$1, git-checkout-warning-for-$1)
 
 git-checkout-warning-for-$1:
@@ -195,16 +193,11 @@ $(foreach s,@BUILDSUBLIST@,$(eval $(call build-submodule-rules,$s)))
 
 # installation into usr-dist
 all-in-memtailor:    install-in-memtailor
-all-in-mathic:       install-in-mathic
 
 install-in-memtailor:    $(BUILTLIBPATH)/include/memtailor.h
-install-in-mathic:       $(BUILTLIBPATH)/include/mathic.h
 
 $(BUILTLIBPATH)/include/memtailor.h:
 	$(MAKE) -C submodules/memtailor install
-
-$(BUILTLIBPATH)/include/mathic.h:
-	$(MAKE) -C submodules/mathic install
 
 all-in-Macaulay2: all-in-submodules
 

--- a/M2/check-configure/Makefile.in
+++ b/M2/check-configure/Makefile.in
@@ -1,9 +1,9 @@
 VPATH = @srcdir@
 LDFLAGS = -L$(BUILTLIBPATH)/lib
 CPPFLAGS = -I$(BUILTLIBPATH)/include
-SYSTEM_MEMTAILOR = $(if $(filter memtailor, @BUILDSUBLIST@),no,yes)
-SYSTEM_MATHIC    = $(if $(filter mathic   , @BUILDSUBLIST@),no,yes)
-SYSTEM_MATHICGB  = $(if $(filter mathicgb , @BUILDSUBLIST@),no,yes)
+SYSTEM_MEMTAILOR = $(if $(filter memtailor, @BUILDLIBLIST@),no,yes)
+SYSTEM_MATHIC    = $(if $(filter mathic   , @BUILDLIBLIST@),no,yes)
+SYSTEM_MATHICGB  = $(if $(filter mathicgb , @BUILDLIBLIST@),no,yes)
 include ../include/config.Makefile
 check: clean-and-config
 clean:; rm -rf tmp

--- a/M2/config/files
+++ b/M2/config/files
@@ -37,6 +37,7 @@ libraries/gmp/Makefile
 libraries/mpfr/Makefile
 libraries/mpfi/Makefile
 libraries/mpir/Makefile
+libraries/mathic/Makefile
 libraries/mathicgb/Makefile
 libraries/gtest/Makefile
 libraries/4ti2/Makefile

--- a/M2/config/files
+++ b/M2/config/files
@@ -37,6 +37,7 @@ libraries/gmp/Makefile
 libraries/mpfr/Makefile
 libraries/mpfi/Makefile
 libraries/mpir/Makefile
+libraries/memtailor/Makefile
 libraries/mathic/Makefile
 libraries/mathicgb/Makefile
 libraries/gtest/Makefile

--- a/M2/config/files
+++ b/M2/config/files
@@ -37,6 +37,7 @@ libraries/gmp/Makefile
 libraries/mpfr/Makefile
 libraries/mpfi/Makefile
 libraries/mpir/Makefile
+libraries/mathicgb/Makefile
 libraries/gtest/Makefile
 libraries/4ti2/Makefile
 libraries/gfan/Makefile

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -671,14 +671,14 @@ AC_SUBST(BUILTLIBS)
 #    (Programs linked by this configure script are linked with the options in LIBS.  This allows libraries
 #    dependent on previously detected libraries to be detected by tests that involve linking.
 
-AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro linbox gtest ")
+AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest ")
 # The list LIBLIST is the list of libraries that might be used and linked into M2.
 
 AC_SUBST(PROGLIST, "4ti2 gfan normaliz csdp nauty cddplus lrslib gftables topcom cohomcalg")
 # The list PROGLIST is the list of programs and libraries for them that are distributed with M2.
 #     Initially, we offer no option for not compiling some of them.
 
-AC_SUBST(SUBLIST, " memtailor mathic mathicgb fflas_ffpack ")
+AC_SUBST(SUBLIST, " memtailor mathic mathicgb ")
 
 # The list SUBLIST is the list of submodules that might be used and linked into M2.
 

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -671,14 +671,14 @@ AC_SUBST(BUILTLIBS)
 #    (Programs linked by this configure script are linked with the options in LIBS.  This allows libraries
 #    dependent on previously detected libraries to be detected by tests that involve linking.
 
-AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest mathic mathicgb ")
+AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest memtailor mathic mathicgb ")
 # The list LIBLIST is the list of libraries that might be used and linked into M2.
 
 AC_SUBST(PROGLIST, "4ti2 gfan normaliz csdp nauty cddplus lrslib gftables topcom cohomcalg")
 # The list PROGLIST is the list of programs and libraries for them that are distributed with M2.
 #     Initially, we offer no option for not compiling some of them.
 
-AC_SUBST(SUBLIST, " memtailor ")
+AC_SUBST(SUBLIST, " ")
 
 # The list SUBLIST is the list of submodules that might be used and linked into M2.
 
@@ -1263,6 +1263,7 @@ if test $with_system_memtailor = no
 then
     BUILD_memtailor=yes
     BUILTLIBS="-lmemtailor $BUILTLIBS"
+    BUILD_ALWAYS="$BUILD_ALWAYS memtailor"
 else AC_LANG(C++)
     AC_SEARCH_LIBS(MEMTAILOR_VERSION_STRING,memtailor,,BUILD_memtailor=yes)
     AC_CHECK_HEADER(memtailor.h,,BUILD_memtailor=yes)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -671,14 +671,14 @@ AC_SUBST(BUILTLIBS)
 #    (Programs linked by this configure script are linked with the options in LIBS.  This allows libraries
 #    dependent on previously detected libraries to be detected by tests that involve linking.
 
-AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest mathicgb ")
+AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest mathic mathicgb ")
 # The list LIBLIST is the list of libraries that might be used and linked into M2.
 
 AC_SUBST(PROGLIST, "4ti2 gfan normaliz csdp nauty cddplus lrslib gftables topcom cohomcalg")
 # The list PROGLIST is the list of programs and libraries for them that are distributed with M2.
 #     Initially, we offer no option for not compiling some of them.
 
-AC_SUBST(SUBLIST, " memtailor mathic ")
+AC_SUBST(SUBLIST, " memtailor ")
 
 # The list SUBLIST is the list of submodules that might be used and linked into M2.
 
@@ -1276,6 +1276,7 @@ if test $with_system_mathic = no
 then
     BUILD_mathic=yes
     BUILTLIBS="-lmathic $BUILTLIBS"
+    BUILD_ALWAYS="$BUILD_ALWAYS mathic"
 else AC_LANG(C++)
     AC_SEARCH_LIBS(MATHIC_VERSION_STRING,mathic,,BUILD_mathic=yes)
     AC_CHECK_HEADER(mathic.h,,BUILD_mathic=yes)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -671,14 +671,14 @@ AC_SUBST(BUILTLIBS)
 #    (Programs linked by this configure script are linked with the options in LIBS.  This allows libraries
 #    dependent on previously detected libraries to be detected by tests that involve linking.
 
-AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll linbox gtest ")
+AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro linbox gtest ")
 # The list LIBLIST is the list of libraries that might be used and linked into M2.
 
 AC_SUBST(PROGLIST, "4ti2 gfan normaliz csdp nauty cddplus lrslib gftables topcom cohomcalg")
 # The list PROGLIST is the list of programs and libraries for them that are distributed with M2.
 #     Initially, we offer no option for not compiling some of them.
 
-AC_SUBST(SUBLIST, " memtailor mathic mathicgb fflas_ffpack givaro ")
+AC_SUBST(SUBLIST, " memtailor mathic mathicgb fflas_ffpack ")
 
 # The list SUBLIST is the list of submodules that might be used and linked into M2.
 

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -678,10 +678,6 @@ AC_SUBST(PROGLIST, "4ti2 gfan normaliz csdp nauty cddplus lrslib gftables topcom
 # The list PROGLIST is the list of programs and libraries for them that are distributed with M2.
 #     Initially, we offer no option for not compiling some of them.
 
-AC_SUBST(SUBLIST, " ")
-
-# The list SUBLIST is the list of submodules that might be used and linked into M2.
-
 # These three lists reflect dependencies, with prerequisites listed first, including the following dependencies:
 #    mathicgb needs mathic and memtailor
 #    mathic needs memtailor
@@ -727,7 +723,7 @@ AC_SUBST(FILE_PREREQS)
 # even if the option "--disable-building" is specified:
 BUILD_ALWAYS=""
 
-for i in $LIBLIST $SUBLIST $PROGLIST
+for i in $LIBLIST $PROGLIST
 do eval BUILD_$i=no
 done
 
@@ -744,9 +740,9 @@ PKGNAME_fflas_ffpack=fflas-ffpack
 #############################################################################
 
 LIBLIST=" $LIBLIST "
-AC_ARG_ENABLE(build-libraries, AS_HELP_STRING(--enable-build-libraries=...,[list of libraries, submodules, and programs to build from downloaded source code (e.g., gc gdbm mpir mpfr mpfi readline ntl gftables factory lapack mpsolve frobby glpk cddlib givaro fflas_ffpack linbox 4ti2 gfan normaliz csdp nauty cddplus lrslib)]),
+AC_ARG_ENABLE(build-libraries, AS_HELP_STRING(--enable-build-libraries=...,[list of libraries and programs to build from downloaded source code (e.g., gc gdbm mpir mpfr mpfi readline ntl gftables factory lapack mpsolve frobby glpk cddlib givaro fflas_ffpack linbox 4ti2 gfan normaliz csdp nauty cddplus lrslib)]),
     [for i in $enableval
-     do case " $LIBLIST $SUBLIST $PROGLIST " in
+     do case " $LIBLIST $PROGLIST " in
 	    *" $i "*) 
 	        eval BUILD_$i=yes 
 		BUILD_ALWAYS="$BUILD_ALWAYS $i"
@@ -1720,12 +1716,6 @@ do eval t=\$BUILD_$i
    test "$t" = yes && BUILDLIBLIST="$BUILDLIBLIST $i"
 done
 
-AC_SUBST(BUILDSUBLIST)
-for i in $SUBLIST
-do eval t=\$BUILD_$i
-   test "$t" = yes && BUILDSUBLIST="$BUILDSUBLIST $i"
-done
-
 AC_SUBST(BUILDPROGLIST)
 for i in $PROGLIST
 do eval t=\$BUILD_$i
@@ -1905,7 +1895,6 @@ AC_SUBST(DESC,$PACKAGE_VERSION-$host_cpu-$OS-$REL)
 # by the 'configure' script, will be simply "alpha".
 
 AC_MSG_NOTICE([using BUILDLIBLIST  = $BUILDLIBLIST])
-AC_MSG_NOTICE([using BUILDSUBLIST  = $BUILDSUBLIST])
 AC_MSG_NOTICE([using BUILDPROGLIST = $BUILDPROGLIST])
 AC_MSG_NOTICE([using BUILDLIST     = $BUILDLIST])
 AC_MSG_NOTICE([using BUILD_ALWAYS  = $BUILD_ALWAYS])

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -671,14 +671,14 @@ AC_SUBST(BUILTLIBS)
 #    (Programs linked by this configure script are linked with the options in LIBS.  This allows libraries
 #    dependent on previously detected libraries to be detected by tests that involve linking.
 
-AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest ")
+AC_SUBST(LIBLIST, " gc gdbm gmp mpir mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest mathicgb ")
 # The list LIBLIST is the list of libraries that might be used and linked into M2.
 
 AC_SUBST(PROGLIST, "4ti2 gfan normaliz csdp nauty cddplus lrslib gftables topcom cohomcalg")
 # The list PROGLIST is the list of programs and libraries for them that are distributed with M2.
 #     Initially, we offer no option for not compiling some of them.
 
-AC_SUBST(SUBLIST, " memtailor mathic mathicgb ")
+AC_SUBST(SUBLIST, " memtailor mathic ")
 
 # The list SUBLIST is the list of submodules that might be used and linked into M2.
 
@@ -1289,6 +1289,7 @@ if test $with_system_mathicgb = no
 then
     BUILD_mathicgb=yes
     BUILTLIBS="-lmathicgb $BUILTLIBS"
+    BUILD_ALWAYS="$BUILD_ALWAYS mathicgb"
 else AC_LANG(C++)
     AC_SEARCH_LIBS(MATHICGB_VERSION_STRING,mathicgb,,BUILD_mathicgb=yes)
     AC_CHECK_HEADER(mathicgb.h,,BUILD_mathicgb=yes)

--- a/M2/libraries/fflas_ffpack/Makefile.in
+++ b/M2/libraries/fflas_ffpack/Makefile.in
@@ -3,10 +3,10 @@
 # svn://linalg.org/fflas-ffpack/
 # This link is broken: http://linalg.org/projects/fflas-ffpack
 # http://linalg.org/
-URL = http://macaulay2.com/Downloads/OtherSourceCode
-VERSION = 2.2.2
+SUBMODULE = true
+VERSION = 2.5.0
 PRECONFIGURE = autoreconf -vif
-PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 TARDIR = fflas-ffpack-$(VERSION)
 TARFILE = fflas-ffpack-$(VERSION).tar.gz
 

--- a/M2/libraries/frobby/Makefile.in
+++ b/M2/libraries/frobby/Makefile.in
@@ -1,18 +1,11 @@
 # note: the next revision of frobby should come from https://github.com/Macaulay2/frobby
-
+SUBMODULE = true
 LICENSEFILES = COPYING
 # author: Bjarke Roune <bjarke@cs.au.dk>
-#VERSION = 0.7.7-M2
-#VERSION = mike3
-VERSION = 0.9.0
-PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+VERSION = 0.9.5
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 
 VPATH = @srcdir@
-TARDIR = frobby_v$(VERSION)
-TARFILE := frobby_v$(VERSION).tar.gz
-# this site was unreliable:
-# URL = http://www.broune.com/frobby
-URL = http://macaulay2.com/Downloads/OtherSourceCode
 
 BUILDTARGET = library
 BUILDOPTIONS = GMP_INC_DIR=$(LIBRARIESDIR)/include	\

--- a/M2/libraries/gc/Makefile.in
+++ b/M2/libraries/gc/Makefile.in
@@ -1,12 +1,14 @@
 HOMEPAGE = http://www.hboehm.info/gc/
+SUBMODULE = true
+LIBNAME = bdwgc
 URL = http://www.hboehm.info/gc/gc_source/
 GITURL = https://github.com/ivmai/bdwgc/
-URL = http://macaulay2.com/Downloads/OtherSourceCode
-VERSION = 8.0.4
+VERSION = 8.2.6
 #VERSION = 7.6.2
 LICENSEFILES = README.QUICK
-PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 SHARED = yes			# the foreign functions package needs this
+PRECONFIGURE = ./autogen.sh
 
 # We can also get the sources from the home page above or from
 #   https://github.com/ivmai/bdwgc/

--- a/M2/libraries/givaro/Makefile.in
+++ b/M2/libraries/givaro/Makefile.in
@@ -2,14 +2,13 @@
 # svn://scm.forge.imag.fr/var/lib/gforge/chroot/scmrepos/svn/givaro/trunk
 # see also (for older releases) https://forge.imag.fr/projects/givaro for source code
 # see also (for newer releases) https://github.com/linbox-team/givaro/releases
-URL = http://macaulay2.com/Downloads/OtherSourceCode
-
 # compilation of givaro needs a little extra memory
+SUBMODULE = true
 VLIMIT = 900000
 MLIMIT = 900000
 
-VERSION = 4.1.1
-#PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+VERSION = 4.2.0
+PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 # the patch modifies test/Makefile.am, so we must remake test/Makefile.in
 PRECONFIGURE = autoreconf -vif
 

--- a/M2/libraries/givaro/patch-4.2.0
+++ b/M2/libraries/givaro/patch-4.2.0
@@ -1,0 +1,26 @@
+From c7744bb133496cd7ac04688f345646d505e1bf52 Mon Sep 17 00:00:00 2001
+From: "Benjamin A. Beasley" <code@musicinmybrain.net>
+Date: Thu, 19 Jan 2023 09:12:22 -0500
+Subject: [PATCH] Add missing #include <cstdint> for (u)int64_t
+
+Fixes failure to compile on GCC 13.
+---
+ src/library/poly1/givdegree.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/library/poly1/givdegree.h b/src/library/poly1/givdegree.h
+index 3753a425..eb85a0dd 100644
+--- givaro-4.2.0/src/library/poly1/givdegree.h
++++ givaro-4.2.0/src/library/poly1/givdegree.h
+@@ -19,6 +19,8 @@
+ #ifndef __GIVARO_poly1degree_H
+ #define __GIVARO_poly1degree_H
+ 
++#include <cstdint>
++
+ #include <iostream>
+ 
+ namespace Givaro {
+-- 
+2.40.1
+

--- a/M2/libraries/gtest/Makefile.in
+++ b/M2/libraries/gtest/Makefile.in
@@ -1,6 +1,7 @@
 # from https://github.com/google/googletest/archive/release-1.8.0.tar.gz, renamed to gtest-1.8.0.tar.gz
-VERSION = 1.10.0
-TARDIR = googletest-release-$(VERSION)/googletest
+SUBMODULE = true
+LIBNAME = googletest
+VERSION = 1.11.0
 CONFIGURECMD = :
 BUILDCMD = :
 
@@ -11,7 +12,7 @@ VLIMIT = 1400000
 TLIMIT = 400
 
 
-INSTALLCMD = $(MKDIR_P) $(BUILTLIBPATH)/include && rm -rf $(BUILTLIBPATH)/include/gtest && ln -s ../../libraries/gtest/$(BUILDDIR) $(BUILTLIBPATH)/include/gtest
+INSTALLCMD = $(MKDIR_P) $(BUILTLIBPATH)/include && rm -rf $(BUILTLIBPATH)/include/gtest && ln -s ../../libraries/gtest/$(BUILDDIR)/googletest $(BUILTLIBPATH)/include/gtest
 CHECKTARGET = .
 
 include ../Makefile.library

--- a/M2/libraries/mathic/Makefile.in
+++ b/M2/libraries/mathic/Makefile.in
@@ -1,0 +1,12 @@
+HOMEPAGE = https://github.com/broune/mathic
+SUBMODULE = true
+VPATH = @srcdir@
+VERSION = 20230812-865f9dcf7a
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+PRECONFIGURE = autoreconf -i
+CONFIGOPTIONS = --disable-shared PKG_CONFIG_PATH=$(LIBRARIESDIR)/lib/pkgconfig GTEST_PATH=@GTEST_PATH@ --with-gtest=yes
+include ../Makefile.library
+Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/mathic/Makefile
+# Local Variables:
+# compile-command: "make -w -C $M2BUILDDIR/libraries/mathic "
+# End:

--- a/M2/libraries/mathicgb/Makefile.in
+++ b/M2/libraries/mathicgb/Makefile.in
@@ -1,0 +1,12 @@
+HOMEPAGE = https://github.com/broune/mathicgb
+SUBMODULE = true
+VPATH = @srcdir@
+VERSION = 20240205-4cd2bd1357
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+PRECONFIGURE = autoreconf -i
+CONFIGOPTIONS = --disable-shared PKG_CONFIG_PATH=$(LIBRARIESDIR)/lib/pkgconfig GTEST_PATH=@GTEST_PATH@ --with-gtest=yes
+include ../Makefile.library
+Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/mathicgb/Makefile
+# Local Variables:
+# compile-command: "make -w -C $M2BUILDDIR/libraries/mathicgb "
+# End:

--- a/M2/libraries/memtailor/Makefile.in
+++ b/M2/libraries/memtailor/Makefile.in
@@ -1,0 +1,14 @@
+SUBMODULE = true
+HOMEPAGE = https://github.com/broune/memtailor
+VPATH = @srcdir@
+VERSION = 20210630-51b88ac2f9
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+URL = http://www.math.uiuc.edu/Macaulay2/Downloads/OtherSourceCode
+PRECONFIGURE = autoreconf -i
+CONFIGOPTIONS = --disable-shared PKG_CONFIG_PATH=$(LIBRARIESDIR)/lib/pkgconfig GTEST_PATH=@GTEST_PATH@ --with-gtest=yes
+LICENSEFILES = license.txt
+include ../Makefile.library
+Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/memtailor/Makefile
+# Local Variables:
+# compile-command: "make -w -C $M2BUILDDIR/libraries/memtailor "
+# End:


### PR DESCRIPTION
Rather than building tarballs and submodules completely differently using the autotools build, we do everything in the `libraries` directory, as was done for flint in #3281.  This simplifies maintenance, as all we need to do to switch back and forth between tarball and submodule builds is set the `SUBMODULE` variable in the approriate Makefile.  It also allows us to remove a bunch of code from GNUmakefile.

We also update the autotools build to use the same submodules that the cmake build does, adding bdwgc, frobby, and googletest.