### PR TITLE
Don't capture findProgram example

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -157,6 +157,7 @@ doc ///
       file, then @TT "name"@ should coincide with the name of this
       file.
     Example
+      -* no-capture-flag *-
       programPaths#"gfan" = "/path/to/gfan/"
       gfan = findProgram("gfan", "gfan _version --help", Verbose => true)
     Text


### PR DESCRIPTION
Otherwise, program output to stderr goes to build log instead of documentation.

Closes: #3292