### PR TITLE
Add an mpfi patch

### DIFF
--- a/M2/libraries/mpfi/Makefile.in
+++ b/M2/libraries/mpfi/Makefile.in
@@ -3,6 +3,7 @@
 VERSION = 1.5.4
 LICENSEFILES = README COPYING.LESSER
 TARFILE = $(LIBNAME)-$(VERSION).tar.gz
+PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 
 #############################################################################
 CONFIGOPTIONS += --disable-thread-safe

--- a/M2/libraries/mpfi/patch-1.5.4
+++ b/M2/libraries/mpfi/patch-1.5.4
@@ -1,0 +1,60 @@
+From a02e3f9cc10767cc4284a2ef6554f6df85e41982 Mon Sep 17 00:00:00 2001
+From: REVOL Nathalie <nathalie.revol@inria.fr>
+Date: Sat, 19 Mar 2022 18:09:45 +0100
+Subject: [PATCH] incorret types: corrected
+
+---
+ mpfi/src/div_ext.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/mpfi/src/div_ext.c b/mpfi/src/div_ext.c
+index 30cd3db..f1e5c2d 100644
+--- mpfi-1.5.4/src/div_ext.c
++++ mpfi-1.5.4/src/div_ext.c
+@@ -59,17 +59,17 @@ mpfi_div_ext (mpfi_ptr res1, mpfi_ptr res2, mpfi_srcptr op1, mpfi_srcptr op2)
+       mpfr_init2 (tmp1, mpfi_get_prec(res1));
+       mpfr_init2 (tmp2, mpfi_get_prec(res2));
+       if ( mpfr_number_p (&(op2->left)) ) {
+-        tmp = mpfr_div (&(tmp2), &(op1->right), &(op2->left), MPFI_RNDD);
++        tmp = mpfr_div (tmp2, &(op1->right), &(op2->left), MPFI_RNDD);
+       }
+       else { /* denominator has infinite left endpoint */
+-        mpfr_set_zero (&(tmp2), 1);
++        mpfr_set_zero (tmp2, 1);
+       }
+ 
+       if ( mpfr_number_p (&(op2->right)) ) {
+-        tmp = mpfr_div ( &(tmp1), &(op1->right), &(op2->right), MPFI_RNDU);
++        tmp = mpfr_div ( tmp1, &(op1->right), &(op2->right), MPFI_RNDU);
+       }
+       else { /* denominator has infinite right endpoint */
+-        mpfr_set_zero( &(tmp1), -1);
++        mpfr_set_zero( tmp1, -1);
+       }
+ 
+       mpfr_set_inf (&(res1->left), -1);
+@@ -86,17 +86,17 @@ mpfi_div_ext (mpfi_ptr res1, mpfi_ptr res2, mpfi_srcptr op1, mpfi_srcptr op2)
+       mpfr_init2 (tmp1, mpfi_get_prec(res1));
+       mpfr_init2 (tmp2, mpfi_get_prec(res2));
+       if ( mpfr_number_p (&(op2->left)) ) {
+-        tmp = mpfr_div (&(tmp1), &(op1->left), &(op2->left), MPFI_RNDU);
++        tmp = mpfr_div (tmp1, &(op1->left), &(op2->left), MPFI_RNDU);
+       }
+       else { /* denominator has infinite left endpoint */
+-        mpfr_set_zero (&(tmp1), -1);
++        mpfr_set_zero (tmp1, -1);
+       }
+ 
+       if ( mpfr_number_p (&(op2->right)) ) {
+-        tmp = mpfr_div ( &(tmp2), &(op1->left), &(op2->right), MPFI_RNDD);
++        tmp = mpfr_div ( tmp2, &(op1->left), &(op2->right), MPFI_RNDD);
+       }
+       else { /* denominator has infinite right endpoint */
+-        mpfr_set_zero( &(tmp2), 1);
++        mpfr_set_zero( tmp2, 1);
+       }
+       mpfr_set_inf (&(res1->left), -1);
+       mpfr_set (&(res1->right), tmp1, MPFI_RNDU);
+-- 
+2.40.1
+


### PR DESCRIPTION
I just built a Fedora 40 package for 1.24.05 and posted it to the website.   I took some notes on the process and updated INSTALL accordingly.  One of the few dependencies without an existing Fedora package is mpfi, and it needed a patch ([cherry-picked from upstream's git repo](https://gitlab.inria.fr/mpfi/mpfi/-/issues/21774)) to compile with the latest gcc.

I also built a Rocky Linux 9.4 (compatible with RHEL 9.4) package, but didn't think to take notes about what I did until afterwards...  There was lots of fiddling with FFLAS-FFPACK flags!