### PR TITLE
Only include alloca.h if present (not on FreeBSD)

### DIFF
--- a/M2/Macaulay2/e/monoid.hpp
+++ b/M2/Macaulay2/e/monoid.hpp
@@ -1,7 +1,9 @@
 // Copyright 2004.  Michael E. Stillman
 #pragma once
 
+#ifdef HAVE_ALLOCA_H
 #include <alloca.h>  // for alloca
+#endif
 #include <stddef.h>  // for size_t
 #include <string>    // for string
 #include <vector>    // for vector


### PR DESCRIPTION
`alloca` is in stdlib.h in FreeBSD

