### PR TITLE
Remove nullary changeDirectory example

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/system.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/system.m2
@@ -670,9 +670,6 @@ doc ///
     Text
       If @VAR "dir"@ is omitted, then the current working directory
       is changed to the user's home directory.
-    Example
-      changeDirectory()
-      currentDirectory()
   SeeAlso
     currentDirectory
 ///


### PR DESCRIPTION
It changes the directory to the home directory, but this directory might not actually exist on the build system.

In #3287, I did the same thing for the `changeDirectory` tests, but I forgot about the docs!