### PR TITLE
Fix paths to Style files in html documentation

### DIFF
--- a/M2/Macaulay2/m2/system.m2
+++ b/M2/Macaulay2/m2/system.m2
@@ -241,8 +241,10 @@ locatePackageFile = (defaultPrefix,defaultLayoutIndex,pkgname,f) -> (
 
 locatePackageFileRelative = (defaultPrefix,defaultLayoutIndex,pkgname,f,installPrefix,installTail) -> (
      (prefix,tail) := locatePackageFile(defaultPrefix,defaultLayoutIndex,pkgname,f);
-     if prefix === installPrefix			    -- we assume these are both real paths, without symbolic links
-     then relativizeFilename(installTail, prefix | tail)
+     if prefix === installPrefix then (		    -- we assume these are both real paths, without symbolic links
+	 if isAbsolutePath installTail
+	 then relativizeFilename(installTail, prefix | tail)
+	 else relativizeFilename(installTail, tail))
      else prefix|tail)
 
 locateCorePackageFile = (pkgname,f) -> locatePackageFile(prefixDirectory,currentLayout,pkgname,f)


### PR DESCRIPTION
This partially reverts #3277, which fixed `viewHelp` when the `Style` package was installed to the application directory.  However, it did this at the cost of breaking all the other documentation installed to the application directory!

The problem was that when calling `makePackageIndex`, the `installTail` variable is set to an absolute path (the application directory), but when building the package documentation, it is a relative path.  So we can't use `relativizeFilename` in the same way in both situations.