### PR TITLE
Don't try to read nonexistent directories when making package index

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -298,7 +298,8 @@ findDocumentationPaths := path -> (
 		    packagesdir := Layout#i#"packages";
 		    if not match(packagesdir | "$", dir) then return;
 		    prefix := substring(dir, 0, #dir - #packagesdir);
-		    (prefix, i))))))
+		    if isDirectory(prefix | Layout#i#"docdir")
+		    then (prefix, i))))))
 
 -- TODO: this function runs on startup, unless -q is given, and takes about 0.1~0.2s
 makePackageIndex = method(Dispatch => Thing)


### PR DESCRIPTION
Every time `makePackageIndex` is run (e.g., on startup), it tries to read each of the documentation directories based on the existence of the corresponding package directories.  But the existence of the latter doesn't guarantee the existence of the former, which can lead to errors.

For example:

```m2
i1 : uninstallAllPackages()

i2 : makeDirectory(applicationDirectory() | "local/" | currentLayout#"packages")

o2 = .Macaulay2/local/share/Macaulay2/

i3 : makePackageIndex()
stdio:3:1:(3): error: can't read directory '/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/' : No such file or directory
```

So we add simple check to make sure that each documentation directory really exists.