### PR TITLE
Added Normaliz as a linked library

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -86,8 +86,8 @@ jobs:
                   libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev liblapack-dev libxml2-dev \
                   libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libmpfi-dev libntl-dev gfan \
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
-                  libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 normaliz coinor-csdp \
-                  nauty lrslib polymake phcpack w3c-markup-validator libtbb-dev qepcad libomp-15-dev
+                  libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 libnormaliz-dev normaliz coinor-csdp \
+                  libnauty2-dev nauty lrslib polymake phcpack w3c-markup-validator libtbb-dev qepcad libomp-15-dev
 
 # ----------------------
 #   Steps common to all build variants

--- a/M2/BUILD/docker/actions/Dockerfile
+++ b/M2/BUILD/docker/actions/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get install -y -q --no-install-recommends libatomic-ops-dev libboost-sta
 	libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev liblapack-dev libxml2-dev \
 	libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libntl-dev gfan \
 	libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
-	libsingular-dev singular-data libmemtailor-dev libmathic-dev libmathicgb-dev libcdd-dev \
+	libnauty-dev libnormaliz-dev libsingular-dev singular-data libcdd-dev \
 	cohomcalg topcom 4ti2 normaliz coinor-csdp nauty lrslib w3c-markup-validator libtbb-dev
 
 # Testing with clang-11 compiler

--- a/M2/BUILD/docker/debian/Dockerfile
+++ b/M2/BUILD/docker/debian/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y libatomic-ops-dev && apt-get clean
 
 # Libraries we can build (factory not available on ubuntu)
 RUN apt-get install -y libeigen3-dev  libglpk-dev libgmp3-dev libmpfr-dev \
-      libntl-dev libfrobby-dev libgc-dev && apt-get clean
+      libntl-dev libnauty-dev libnormaliz-dev libfrobby-dev libgc-dev && apt-get clean
 
 # Programs we can build
 # TODO: cohomcalg available soon. Polymake requires firefox???

--- a/M2/BUILD/docker/fedora/Dockerfile
+++ b/M2/BUILD/docker/fedora/Dockerfile
@@ -14,7 +14,8 @@ RUN microdnf install openblas-devel libxml2-devel readline-devel gdbm-devel \
 	boost-devel libatomic_ops-devel libomp-dev libtbb-dev
 
 # Libraries we can build (factory not available on ubuntu)
-RUN microdnf install eigen3-devel glpk-devel gmp-devel mpfr-devel ntl-devel libfrobby-devel gc-devel
+RUN microdnf install eigen3-devel glpk-devel gmp-devel mpfr-devel ntl-devel \
+	libnauty-devel libnormaliz-devel libfrobby-devel gc-devel
 
 # Programs we can build
 # TODO: cohomcalg available soon. Polymake requires firefox???

--- a/M2/BUILD/docker/ubuntu/Dockerfile
+++ b/M2/BUILD/docker/ubuntu/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get install -y --no-install-recommends software-properties-common && \
     apt-get install -y -q --no-install-recommends libeigen3-dev libgc-dev \
 	libglpk-dev libgmp3-dev libmpfr-dev libmps-dev libgtest-dev \
 	libntl-dev libflint-dev libsingular-dev singular-data libfrobby-dev \
-	libmemtailor-dev libmathic-dev libmathicgb-dev && apt-get clean
+	libnauty-dev libnormaliz-dev && apt-get clean
 
 # Programs we can build
 RUN apt-get install -y --no-install-recommends libcdd-dev lrslib \

--- a/M2/BUILD/docker/valgrind/Dockerfile
+++ b/M2/BUILD/docker/valgrind/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get install -y --no-install-recommends software-properties-common && \
     apt-get install -y -q --no-install-recommends libeigen3-dev libgc-dev \
 	libglpk-dev libgmp3-dev libmpfr-dev libmps-dev libgtest-dev \
 	libntl-dev libflint-dev libsingular-dev singular-data libfrobby-dev \
-	libmemtailor-dev libmathic-dev libmathicgb-dev && apt-get clean
+	libnauty-devel libnormaliz-devel && apt-get clean
 
 # Programs we can build
 RUN apt-get install -y --no-install-recommends libcdd-dev lrslib \

--- a/M2/INSTALL
+++ b/M2/INSTALL
@@ -86,7 +86,7 @@ various modern operating systems:
 
   Ubuntu and Debian:
     Install packages as root with:
-      apt-get install -y -q sudo 4ti2 autoconf bison cohomcalg curl emacs fflas-ffpack flex g++ gcc gfortran install-info libboost-dev libboost-math-dev libboost-regex-dev libboost-stacktrace-dev libc6-dev libcdd-dev libffi-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfi-dev libmpfr-dev libmps-dev libncurses-dev libncurses5-dev libntl-dev libreadline-dev libsingular-dev libtool libxml2-dev libz-dev lrslib lsb-release make normaliz npm openssh-server patch pinentry-curses pkg-config singular-data time topcom unzip xbase-clients yasm zlib1g-dev polymake git dpkg-dev gfan libeigen3-dev libtool-bin frobby libfrobby-dev nauty nauty-doc coinor-csdp coinor-csdp-doc libflint-dev libtbb-dev
+      apt-get install -y -q sudo 4ti2 autoconf bison cohomcalg curl emacs fflas-ffpack flex g++ gcc gfortran install-info libboost-dev libboost-math-dev libboost-regex-dev libboost-stacktrace-dev libc6-dev libcdd-dev libffi-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp3-dev libgtest-dev liblapack-dev liblzma-dev libmpc-dev libmpfi-dev libmpfr-dev libmps-dev libncurses-dev libncurses5-dev libntl-dev libreadline-dev libsingular-dev libtool libxml2-dev libz-dev lrslib lsb-release make libnormaliz-dev normaliz npm openssh-server patch pinentry-curses pkg-config singular-data time topcom unzip xbase-clients yasm zlib1g-dev polymake git dpkg-dev gfan libeigen3-dev libtool-bin frobby libfrobby-dev libnauty2-dev libnauty2 nauty nauty-doc coinor-csdp coinor-csdp-doc libflint-dev libtbb-dev
         # note: libz-dev seems to have been replaced by zlib1g-dev
         # note: libncurses-dev seems to have been replaced by libncurses5-dev
         # note: libreadline-gplv2-dev is an older GPL v2 version of libreadline
@@ -131,7 +131,7 @@ various modern operating systems:
 
   Fedora:
     Install packages with:
-      sudo dnf -y install autoconf bison boost-devel boost-stacktrace cddlib-devel cohomCalg csdp csdp-tools eigen3-devel emacs factory-devel factory-gftables fflas-ffpack-devel flex flint-devel frobby gcc-c++ gc-devel gdbm-devel git givaro-devel glpk-devel gmp-devel gtest gtest-devel kernel-devel lapack-devel libgfortran-static libmpc-devel libtool libxml2-devel mpfr-devel mpir-devel mpsolve nauty ncurses-devel ntl-devel patch pkgconf polymake qd readline-devel rpm-build rpmdevtools rpm-sign strace time which yasm rpmlint
+      sudo dnf -y install autoconf bison boost-devel boost-stacktrace cddlib-devel cohomCalg csdp csdp-tools eigen3-devel emacs factory-devel factory-gftables fflas-ffpack-devel flex flint-devel frobby gcc-c++ gc-devel gdbm-devel git givaro-devel glpk-devel gmp-devel gtest gtest-devel kernel-devel lapack-devel libgfortran-static libmpc-devel libtool libxml2-devel mpfr-devel mpir-devel libnormaliz-devel normaliz mpsolve libnauty-devel nauty ncurses-devel ntl-devel patch pkgconf polymake qd readline-devel rpm-build rpmdevtools rpm-sign strace time which yasm rpmlint
 
   Red Hat Enterprise Linux 6.7
     We have found that git 1.7.1 is too old, but have succeeded with these modules:

--- a/M2/INSTALL-CMake.md
+++ b/M2/INSTALL-CMake.md
@@ -27,7 +27,7 @@ There are 10 libraries that must be found on the system.
 - On Fedora/CentOS, install `openblas-devel gmp-devel libxml2-devel readline-devel gdbm-devel boost-devel libomp-devel tbb-devel libffi-devel`.
 - On Mac OS X, using Homebrew, install `gmp libxml2 readline gdbm boost libomp tbb libffi`.
 
-**TIP**: x86_64 binary packages for all dependencies on Mac OS X 10.15+ and Linux distributions are available through the [Macaulay2 tap](https://github.com/Macaulay2/homebrew-tap/) for Homebrew. To download the dependencies this way run:
+**TIP**: x86_64 and arm64 binary packages for all dependencies on Mac OS X 12+ and Linux distributions are available through the [Macaulay2 tap](https://github.com/Macaulay2/homebrew-tap/) for Homebrew. To download the dependencies this way run:
 ```
 brew tap Macaulay2/tap
 brew install --only-dependencies macaulay2/tap/M2
@@ -216,6 +216,8 @@ Macaulay2 uses several external libraries and programs, which can be built using
   - `build-mpfi`:	[MPFI] a multiple precision interval arithmetic library based on MPFR
   - `build-mpsolve`: [MPSolve] library for solving multiprecision polynomials
   - `build-msolve`:	[MSolve] library for solving multivariate polynomials
+  - `build-nauty`:	[nauty] library for computing automorphism groups of graphs and digraphs
+  - `build-normaliz`: [Normaliz] library for computations in affine monoids, lattice polytopes, and rational cones
   - `build-ntl`:	[NTL] library for doing number theory
 
 [Boehm-Demers-Weiser]: https://www.hboehm.info/gc/
@@ -243,8 +245,6 @@ Macaulay2 uses several external libraries and programs, which can be built using
   - `build-csdp`:	[CSDP] software for solving semidefinite programming problems
   - `build-gfan`:	[Gfan] software for computing Grobner fans and tropical varieties
   - `build-lrslib`:	[lrs] software for vertex enumeration/convex hull problems
-  - `build-nauty`:	[nauty] software for computing automorphism groups of graphs and digraphs
-  - `build-normaliz`: [Normaliz] software for computations in affine monoids, lattice polytopes, and rational cones
   - `build-topcom`:	[TOPCOM] software for computing triangulations of point configurations and oriented matroids
 
 Additionally, build targets are available for a few programs which are not built and distributed by default due to time or licensing constraints:

--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -9,6 +9,7 @@ use struct;
 
 header "// TODO: break apart this file so each piece includes only one:
 #include <interface/aring.h>
+#include <interface/cone.h>
 #include <interface/cra.h>
 #include <interface/factory.h>
 #include <interface/flint.h>
@@ -3850,6 +3851,16 @@ export rawNCReductionTwoSided(e:Expr):Expr := (
   ) else WrongNumArgs(2)
   );
 setupfun("rawNCReductionTwoSided",rawNCReductionTwoSided);
+
+-----------------------------------------------------------------------------
+-- Hilbert basis of a cone
+-----------------------------------------------------------------------------
+
+export rawHilbertBasis(e:Expr):Expr := (
+     when e is G:RawMatrixCell do toExpr(Ccode(RawMatrixOrNull, "rawHilbertBasis(", G.p, ")"))
+     else WrongArgMatrix());
+setupfun("rawHilbertBasis", rawHilbertBasis);
+
 -----------------------------------------------------------------------------
 -- LU
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -3856,6 +3856,11 @@ setupfun("rawNCReductionTwoSided",rawNCReductionTwoSided);
 -- Hilbert basis of a cone
 -----------------------------------------------------------------------------
 
+export rawFourierMotzkin(e:Expr):Expr := (
+     when e is G:RawMatrixCell do toExpr(Ccode(RawMatrixOrNull, "rawFourierMotzkin(", G.p, ")"))
+     else WrongArgMatrix());
+setupfun("rawFourierMotzkin", rawFourierMotzkin);
+
 export rawHilbertBasis(e:Expr):Expr := (
      when e is G:RawMatrixCell do toExpr(Ccode(RawMatrixOrNull, "rawHilbertBasis(", G.p, ")"))
      else WrongArgMatrix());

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -63,6 +63,8 @@ header "
    #endif
 
    #include <Eigen/Core>
+
+   #include <libnormaliz/version.h>
    ";
 
 header "
@@ -174,6 +176,7 @@ setupconst("version", Expr(toHashTable(Sequence(
 	"),
    "gdbm version" => gdbmversion(),
    "gmp version" => Ccode(constcharstar,"__gmp_version"),
+   "normaliz version" => Ccode(constcharstar,"stringize(NMZ_VERSION)"),
    "ntl version" => Ccode(constcharstar,"NTL_VERSION"),
    "frobby version" => Ccode(constcharstar,"frobby_version"),
    "flint version" => Ccode(constcharstar,"FLINT_VERSION"),

--- a/M2/Macaulay2/e/CMakeLists.txt
+++ b/M2/Macaulay2/e/CMakeLists.txt
@@ -121,6 +121,8 @@ set(CPPONLYFILES
   interface/computation.h # no .cpp yet
   interface/cra.cpp
   interface/cra.h
+  interface/cone.cpp
+  interface/cone.h
   interface/factory.cpp
   interface/factory.h
   interface/flint.cpp

--- a/M2/Macaulay2/e/Makefile.files
+++ b/M2/Macaulay2/e/Makefile.files
@@ -189,6 +189,7 @@ COMMANDS = \
 	engine \
 	interface/aring \
 	interface/cra \
+	interface/cone \
 	interface/factory \
 	interface/flint \
 	interface/freemodule \

--- a/M2/Macaulay2/e/dmat-lu-qq.hpp
+++ b/M2/Macaulay2/e/dmat-lu-qq.hpp
@@ -66,7 +66,7 @@ class DMatLinAlg<M2::ARingQQ>
 
   void matrixPLU(std::vector<size_t>& P, Mat& L, Mat& U)
   {
-    printf("dmat lu qq PLU\n");
+    // printf("dmat lu qq PLU\n");
     FlintQQMat A(mInputMatrix);
     FlintZZMat LU(A.numRows(), A.numColumns());
     fmpz_t den, den2;

--- a/M2/Macaulay2/e/interface/cone.cpp
+++ b/M2/Macaulay2/e/interface/cone.cpp
@@ -24,6 +24,7 @@ const Matrix /* or null */ *rawFourierMotzkin(const Matrix *C)
 {
   try
     {
+      // TODO: generalize the input type, in particular to allow lineality space
       const Ring *R = C->get_ring();
       const size_t c = C->n_cols();  // rank of ambient lattice
       const size_t r = C->n_rows();  // number of cone inequalities

--- a/M2/Macaulay2/e/interface/cone.cpp
+++ b/M2/Macaulay2/e/interface/cone.cpp
@@ -1,0 +1,62 @@
+// Written in 2021 by Mahrud Sayrafi
+
+#include "interface/cone.h"
+
+#include <M2/math-include.h>
+
+#include "debug.hpp"
+#include "interface/gmp-util.h"
+#include "interface/matrix.h"
+#include "matrix-con.hpp"
+#include "matrix.hpp"
+#include "relem.hpp"
+
+#include <libnormaliz/cone.h>
+#include <vector>
+
+typedef mpz_class Integer;
+
+/**
+ * \ingroup cones
+ */
+
+const Matrix /* or null */ *rawHilbertBasis(const Matrix *C)
+{
+  try
+    {
+      // TODO: Check that C is over ZZ
+      // TODO: for cones over QQ, lift to ZZ first
+      // TODO: Normaliz also supports algebraic cones defined over
+      // algebraic number fields embedded in RR
+      const Ring *R = C->get_ring();
+      const size_t c = C->n_cols();  // rank of ambient lattice
+      const size_t r = C->n_rows();  // number of cone rays
+
+      auto rays = libnormaliz::Matrix<Integer>(r, c);
+      for (size_t i = 0; i < r; i++)
+        for (size_t j = 0; j < c; j++)
+          rays[i][j] = static_cast<Integer>(C->elem(i, j).get_mpz());
+
+      auto cone = libnormaliz::Cone<Integer>(libnormaliz::Type::cone, rays);
+      // cone.compute(libnormaliz::ConeProperty::HilbertBasis,
+      //              libnormaliz::ConeProperty::DefaultMode);
+      auto HB = cone.getHilbertBasis();
+      size_t n = HB.size();  // number of basis elements
+
+      MatrixConstructor mat(R->make_FreeModule(n), c);
+      for (size_t i = 0; i < n; i++)
+        for (size_t j = 0; j < c; j++)
+          {
+            mpz_ptr z = newitem(__mpz_struct);
+            mpz_init_set(z, HB[i][j].get_mpz_t());
+            mpz_reallocate_limbs(z);
+            mat.set_entry(i, j, ring_elem(z));
+          }
+
+      return mat.to_matrix();
+  } catch (const exc::engine_error &e)
+    {
+      ERROR(e.what());
+      return nullptr;
+  }
+}

--- a/M2/Macaulay2/e/interface/cone.h
+++ b/M2/Macaulay2/e/interface/cone.h
@@ -22,6 +22,8 @@ extern "C" {
 /**** Cone routines (via Normaliz) ****************/
 /**************************************************/
 
+const Matrix /* or null */ *rawFourierMotzkin(const Matrix *C);
+
 const Matrix /* or null */ *rawHilbertBasis(const Matrix *C);
 
 #  if defined(__cplusplus)

--- a/M2/Macaulay2/e/interface/cone.h
+++ b/M2/Macaulay2/e/interface/cone.h
@@ -1,0 +1,31 @@
+#ifndef _cone_h_
+#  define _cone_h_
+
+#  include "engine-includes.hpp"
+
+// TODO: fix this
+#  if defined(__cplusplus)
+class Matrix;
+#  else
+typedef struct Matrix Matrix;
+#  endif
+
+/**
+   Cone interface routines
+ */
+
+#  if defined(__cplusplus)
+extern "C" {
+#  endif
+
+/**************************************************/
+/**** Cone routines (via Normaliz) ****************/
+/**************************************************/
+
+const Matrix /* or null */ *rawHilbertBasis(const Matrix *C);
+
+#  if defined(__cplusplus)
+}
+#  endif
+
+#endif /* _cone_h_ */

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -840,6 +840,7 @@ export {
 	"isRegularFile",
 	"isRing",
 	"isSkewCommutative",
+	"isSmooth",
 	"isSorted",
 	"isSquareFree",
 	"isSubmodule",

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -849,6 +849,7 @@ export {
 	"isSurjective",
 	"isTable",
 	"isUnit",
+	"isVeryAmple",
 	"isWellDefined",
 	"isWeylAlgebra",
 	"iterator",

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -403,6 +403,7 @@ findHeft List := opts -> degs -> (
      if all(degs,d->d#0 > 0) then return splice {  1, degrk-1:0 };
      if all(degs,d->d#0 < 0) then return splice { -1, degrk-1:0 };
     heftvec := - sum entries map(ZZ, rawFourierMotzkin raw matrix degs);
+    if heftvec === 0 then return null;
     if (g := gcd heftvec) > 1   then heftvec = apply(heftvec, h -> h // g);
     if checkHeft(degs, heftvec) then heftvec)
 

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -374,7 +374,7 @@ degreesMonoid List := memoize lookup(degreesMonoid, List)
 -- findHeft
 -----------------------------------------------------------------------------
 
-checkHeft = (degs, heftvec) -> all(degs, d -> sum apply(d, heftvec, times) > 0)
+checkHeft = (degs, heftvec) -> all(degs, d -> sum(d, heftvec, times) > 0)
 -- vector that zeros the torsion part of the degrees
 -- TODO: what should happen when there are zero-divisors that are not torsion?
 -- compare with freeComponents and torsionComponents in basis.m2
@@ -402,14 +402,7 @@ findHeft List := opts -> degs -> (
     -- TODO: should this heuristic look at other degree components also?
      if all(degs,d->d#0 > 0) then return splice {  1, degrk-1:0 };
      if all(degs,d->d#0 < 0) then return splice { -1, degrk-1:0 };
-    -- TODO: should FourierMotzkin become preloaded?
-    fm := symbolFrom_"FourierMotzkin" "fourierMotzkin";
-    A := transpose matrix degs;
-    B := first fm A;
-     r := rank source B;
-     f := (matrix{toList(r:-1)} * transpose B);
-     if f == 0 then return;
-    heftvec := first entries f;
+    heftvec := - sum entries map(ZZ, rawFourierMotzkin raw matrix degs);
     if (g := gcd heftvec) > 1   then heftvec = apply(heftvec, h -> h // g);
     if checkHeft(degs, heftvec) then heftvec)
 

--- a/M2/Macaulay2/m2/shared.m2
+++ b/M2/Macaulay2/m2/shared.m2
@@ -22,6 +22,7 @@ truncate = method(Options => true)
 isEmpty = method(TypicalValue => Boolean)
 
 isSmooth = method(TypicalValue => Boolean, Options => true)
+isVeryAmple = method(TypicalValue => Boolean, Options => true)
 
 -- symbols
 

--- a/M2/Macaulay2/m2/shared.m2
+++ b/M2/Macaulay2/m2/shared.m2
@@ -21,6 +21,8 @@ truncate = method(Options => true)
 
 isEmpty = method(TypicalValue => Boolean)
 
+isSmooth = method(TypicalValue => Boolean, Options => true)
+
 -- symbols
 
 protect Base

--- a/M2/Macaulay2/packages/Divisor.m2
+++ b/M2/Macaulay2/packages/Divisor.m2
@@ -68,7 +68,7 @@ export{
     "nonCartierLocus", --added checks, has IsGraded option, cached
     "isSNC", --added checks, has IsGraded option, cached
     "isZeroDivisor", --added checks
-    "isVeryAmple", --added checks, 
+    --"isVeryAmple", --added checks,
     --functions for getting maps to projective space from divisors (graded only)
 	"baseLocus", --added checks
 	"mapToProjectiveSpace", --added checks
@@ -1542,9 +1542,7 @@ baseLocus(WeilDivisor) := Ideal => (D1) -> (
 	baseLocus(M1)
 );
 
-isVeryAmple = method(Options => {Verbose=>false});
-
-isVeryAmple(WeilDivisor) := Boolean => o->(D1) -> (    
+isVeryAmple WeilDivisor := { Verbose => false } >> o -> D1 -> (
     if (D1#cache#?isVeryAmple == true) then (
         return D1#cache#isVeryAmple;
     );    
@@ -2485,9 +2483,8 @@ doc ///
 
 doc ///
 	 Key
-		isVeryAmple
 		(isVeryAmple, WeilDivisor)
-		[isVeryAmple, Verbose]
+	       [(isVeryAmple, WeilDivisor), Verbose]
 	Headline
 		whether a divisor is very ample.
 	Usage

--- a/M2/Macaulay2/packages/Divisor.m2
+++ b/M2/Macaulay2/packages/Divisor.m2
@@ -81,7 +81,7 @@ export{
 	"dualize", --added checks
 	"embedAsIdeal", --added checks, has IsGraded option
 	"isDomain", --added checks
-	"isSmooth", --added checks, has IsGraded option
+	--"isSmooth", --added checks, has IsGraded option
     --options
     "Safe", --an option, if set true then the above commands avoid doing any checks
 	"CoefficientType", --an option, one can set the coefficient type
@@ -1912,9 +1912,7 @@ isDomain(Ring) := Boolean => (R1) -> (
 );
 
 --checks whether R/J1 is regular
-isSmooth  = method(Options => {IsGraded => false});
-
-isSmooth(Ideal) := Boolean => o->J1 -> (
+isSmooth(Ideal) := Boolean => {IsGraded => false} >> o -> J1 -> (
 	--empty schemes are smooth (which is why we are first check whether ideals are the whole ring or contain the irrelevant ideal
 	flag := false;
 	if (o.IsGraded == true) then (
@@ -4073,9 +4071,8 @@ doc ///
 
 doc /// 
    	Key
-   	 isSmooth
    	 (isSmooth, Ideal)
-   	 [isSmooth, IsGraded]
+	 [(isSmooth, Ideal), IsGraded]
    	Headline
    	 whether R mod the ideal is smooth
    	Usage

--- a/M2/Macaulay2/packages/Divisor.m2
+++ b/M2/Macaulay2/packages/Divisor.m2
@@ -75,7 +75,7 @@ export{
     --general useful functions not directly related to divisors
     "idealPower", --added checks
     "reflexify", --added checks
-	"isReflexive", --added checks
+	--"isReflexive", --added checks
 	"reflexivePower", --added checks
 	"torsionSubmodule", --added checks
 	"dualize", --added checks
@@ -1712,14 +1712,12 @@ reflexifyModule(Module) := Module => o-> (M1) -> (
 	)
 );
 
-isReflexive = method(Options => {Strategy => NoStrategy, KnownDomain=>true});
-
-isReflexive(Module) := Boolean => o -> (M1) ->(
+isReflexive Module := Boolean => { Strategy => NoStrategy, KnownDomain => true } >> o -> M1 -> (
 	g := reflexify(M1, ReturnMap => true, Strategy => o.Strategy, KnownDomain=>o.KnownDomain);
 	(-1 == dim coker g)
 );
 
-isReflexive(Ideal) := Boolean => o-> (I1) ->(
+isReflexive Ideal := Boolean => { Strategy => NoStrategy, KnownDomain => true } >> o -> I1 -> (
 	J1 := reflexify(I1, Strategy => o.Strategy, KnownDomain=>o.KnownDomain);
 	(J1 == I1)
 );
@@ -3079,7 +3077,7 @@ doc ///
 	 Text
 	  In the above, when KnownDomain=>true (an incorrect assumption), this function returns the incorrect answer for $I$.
 	SeeAlso
-	 isReflexive
+	 (isReflexive, Ideal)
 	 dualize
 ///
 
@@ -3195,7 +3193,7 @@ doc ///
 	  J1 == J2
 	SeeAlso
 	 reflexify
-	 isReflexive
+	 (isReflexive, Ideal)
 ///
 
 
@@ -3309,19 +3307,18 @@ doc ///
 
 doc ///
 	Key
-	 isReflexive
 	 (isReflexive, Ideal)
 	 (isReflexive, Module)
-	 [isReflexive, Strategy]
-	 [isReflexive, KnownDomain]
+	 [(isReflexive, Ideal), Strategy]
+	 [(isReflexive, Ideal), KnownDomain]
+	 [(isReflexive, Module), Strategy]
+	 [(isReflexive, Module), KnownDomain]
 	Headline
 	 whether an ideal or module is reflexive
 	Usage
-	 isReflexive( I1 )
-	 isReflexive( M1 )
+	 isReflexive I
 	Inputs
-	 I1: Ideal
-	 M1: Module
+	 I:{Ideal,Module}
 	 Strategy => Symbol
 	   specify a strategy for the internal call to reflexify
 	 KnownDomain => Boolean

--- a/M2/Macaulay2/packages/FourTiTwo.m2
+++ b/M2/Macaulay2/packages/FourTiTwo.m2
@@ -28,6 +28,7 @@ newPackage(
 	Configuration => { "path" => "",
 	     "keep files" => true
 	      },
+	PackageExports => {"Polyhedra"}, -- for hilbertBasis
     	DebuggingMode => false
     	)
 
@@ -39,9 +40,9 @@ export {
      "toricGroebner",
      "toricCircuits",
      "toricGraver",
-     "hilbertBasis",
+     "toricGraverDegrees",
+     -- "hilbertBasis", -- defined in Polyhedra
      "InputType",
-     "toricGraverDegrees"
      }
 
 -- for backward compatibility
@@ -166,8 +167,8 @@ toricGraver Matrix := Matrix => (o -> A ->(
      ))
 toricGraver (Matrix,Ring) := Ideal => (o -> (A,S)->toBinomial(toricGraver(A),S))
 
-hilbertBasis = method(Options=> {InputType => null, Precision => 32})
-hilbertBasis Matrix := Matrix => o -> (A ->(
+-- hilbertBasis is defined in Polyhedra
+hilbertBasis Matrix := Matrix => { InputType => null, Precision => 32 } >> o -> A -> (
      filename := getFilename();
      if debugLevel >= debugLimit then << "using temporary file name " << filename << endl;
      if o.InputType === "lattice" then
@@ -179,7 +180,7 @@ hilbertBasis Matrix := Matrix => o -> (A ->(
      run4ti2("hilbert",
 	 "-p " | toString o.Precision | " " | rootPath | filename);
      getMatrix(filename|".hil")
-     ))
+     )
 
 rays Matrix := Matrix => { Precision => 64 } >> o -> (A ->(
      filename := getFilename();
@@ -408,7 +409,7 @@ doc ///
 	       the computation
      Outputs
      	  B:Matrix 
-	       whose rows form a Markov Basis of the lattice $\{z {\rm integral} : A z = 0\}$
+	       whose rows form a Markov Basis of the lattice $\{z : z \text{ is integral and } A z = 0\}$
 	       or the lattice spanned by the rows of {\tt A} if the option {\tt InputType => "lattice"} is used
      Description
      	  Text
@@ -523,10 +524,9 @@ doc ///
 
 doc ///
      Key
-     	  hilbertBasis
           (hilbertBasis, Matrix)
-	  [hilbertBasis, InputType]
-	  [hilbertBasis, Precision]
+	 [(hilbertBasis, Matrix), InputType]
+	 [(hilbertBasis, Matrix), Precision]
      Headline
      	  calculates the Hilbert basis of the cone; invokes "hilbert" from 4ti2
      Usage
@@ -534,13 +534,15 @@ doc ///
      Inputs
       	  A:Matrix    
 	       defining the cone $\{z : Az = 0, z \ge 0 \}$
+	  InputType => String
+	       use the string "lattice" if rows of {\tt A} specify a lattice basis
 	  Precision => {ZZ, String}
 	       32, 64, or "gmp", the precision of the integers used during the
 	       computation
      Outputs
      	  B:Matrix 
 	       whose rows form the Hilbert basis of the cone $\{z : Az = 0, z \ge 0 \}$
-	       or the cone $\{z A : z {\rm {} is an integral vector and } z A \ge 0 \}$ if {\tt InputType => "lattice"} is used
+	       or the cone $\{z A : z \text{ is an integral vector and } z A \ge 0 \}$ if {\tt InputType => "lattice"} is used
      Description
 	  Example
 	       A = matrix "1,1,1,1; 1,2,3,4"

--- a/M2/Macaulay2/packages/FourierMotzkin.m2
+++ b/M2/Macaulay2/packages/FourierMotzkin.m2
@@ -232,6 +232,7 @@ fourierMotzkin (Matrix, Matrix) := Sequence => (Z, H) -> (
      (sort A, sort E))
 
 
+-- TODO: use rawFourierMotzkin?
 --   INPUT : 'Z' a matrix; the columns are the rays generating the cone
 fourierMotzkin Matrix := Sequence => Z -> (
      -- creating zero equalities
@@ -431,7 +432,7 @@ document {
      heft);"
      },
      	  
-     PARA{}, "If a polynomial ring as a multigrading determined by a
+     PARA{}, "If a polynomial ring has a multigrading determined by a
      vector configuration, then a positive linear functional plays the
      role of a ", TO Heft, " vector.",
 

--- a/M2/Macaulay2/packages/FourierMotzkin.m2
+++ b/M2/Macaulay2/packages/FourierMotzkin.m2
@@ -335,9 +335,9 @@ document {
 	       {1,4,6},{1,5,4},{1,5,5},{1,5,6},{1,5,7},{1,6,3},
 	       {1,6,4},{1,6,5},{1,6,6},{1,6,7},{1,7,4},{1,7,5},
 	       {1,7,6},{1,7,8},{1,8,4},{1,8,5},{1,8,6}})",
-    	  "halfspaces = fourierMotzkin raylist",
-	  "numgens source halfspaces#0",
-	  "extremalRays = fourierMotzkin halfspaces",
+	  "halfspaceList = fourierMotzkin raylist",
+	  "numgens source halfspaceList#0",
+	  "extremalRays = fourierMotzkin halfspaceList",
 	  "numgens source extremalRays#0"
 	  },
      
@@ -356,13 +356,14 @@ document {
      Key => "Finding the facets of the cyclic polytope",
      
      "The ", EM "cyclic polytope", " is the convex hull of distinct
-     points on the moment curve.  The function ", TT "cyclicPolytope",
-     " produces a matrix such that columns generate the cyclic ", 
-     TT "d", "-polytope with ", TT "n", " vertices.",
+     points on the moment curve. We can either use the function ", TO "cyclicPolytope",
+     " to produce the cyclic ", TT "d", "-polytope with ", TT "n", " vertices,
+     or directly construct a matrix whose columns are the vertices of the polytope.",
         
      EXAMPLE {
-	  "cyclicPolytope = (d,n) -> map(ZZ^d, ZZ^n, (i,j) -> j^(i+1));",
-	  "vertices = cyclicPolytope(4,8)"
+	  "P = cyclicPolytope(4, 8)",
+	  "vertexList = vertices P",
+	  "vertexList == map(QQ^4, QQ^8, (i,j) -> j^(i+1))"
 	  },
      
      PARA{}, "To find the halfspace representation for the convex hull
@@ -376,14 +377,14 @@ document {
      R := ring V;
      n := numgens source V;
      map(R^1, R^n, {toList(n:1)}) || V);",
-	  "polyCone = homogenizePolytope vertices",
+	  "polyCone = homogenizePolytope vertexList",
 	  "H = fourierMotzkin polyCone",
-	  "halfspaces = H#0",
-	  "numgens source halfspaces"
+	  "halfspaceList = H#0",
+	  "numgens source halfspaceList"
 	  },
      
      "Since ", TT "H#1", " is zero, the polyhedral cone spans 5-space.
-     The columns in the matrix ", TT "halfspaces", " describe a
+     The columns in the matrix ", TT "halfspaceList", " describe a
      complete minimal system of inequalities for the convex hull of
      these points.  In particular, this polytope has 20 facets.",
           
@@ -391,10 +392,10 @@ document {
      compute the facet-vertex incidence matrix.",
 
      EXAMPLE {
-	  "inequalityVector = transpose submatrix(halfspaces,{0},)",
-	  "inequalityMatrix = transpose submatrix(halfspaces,{1..4},)",
+	  "inequalityVector = transpose submatrix(halfspaceList,{0},)",
+	  "inequalityMatrix = transpose submatrix(halfspaceList,{1..4},)",
           "ones = map(ZZ^1,ZZ^8,{toList(8:1)})",
-	  "M = (inequalityMatrix * vertices) + (ones ** inequalityVector)",
+	  "M = (inequalityMatrix * vertexList) + (ones ** inequalityVector)",
 	  "incidence = matrix table(20,8, (i,j) -> if M_(i,j) == 0 then 1 else 0)"
 	  },
 
@@ -493,7 +494,7 @@ document {
         
      EXAMPLE {
 	  "permutahedron = d -> transpose matrix permutations toList(1..d+1);",
-	  "vertices = permutahedron 3",
+	  "vertexList = permutahedron 3",
 	  },
      
      PARA{}, "To find the halfspace representation for permutahedron, we
@@ -506,16 +507,16 @@ document {
      R := ring V;
      n := numgens source V;
      map(R^1, R^n, {toList(n:1)}) || V);",
-	  "H = fourierMotzkin homogenizePolytope vertices",
+	  "H = fourierMotzkin homogenizePolytope vertexList",
 	  "transpose H#1",
-	  "halfspaces = H#0;",
-	  "numgens source halfspaces",
+	  "halfspaceList = H#0;",
+	  "numgens source halfspaceList",
 	  },
      
      "Since ", TT "H#1", " has one column vector, the polyhedral cone
      spans a 4-dimensional subspace of 5-space.  Indeed, the sum of
      the components for each vertex is 10.  The columns in the matrix
-     ", TT "halfspaces", " describe a complete minimal system of
+     ", TT "halfspaceList", " describe a complete minimal system of
      inequalities for permutahedron.  In particular, this polytope has
      14 facets.",
           
@@ -523,11 +524,11 @@ document {
      compute the facet-vertex incidence matrix.",
      
      EXAMPLE {
-	  "inequalityMatrix = transpose submatrix(halfspaces,{1..4},)",
-	  "M = inequalityMatrix * vertices",
+	  "inequalityMatrix = transpose submatrix(halfspaceList,{1..4},)",
+	  "M = inequalityMatrix * vertexList",
 	  "incidence = matrix table(14,24, (i,j) -> if M_(i,j) == 0 then 1 else 0)",
 	  "vertexDegree = map(ZZ^1,ZZ^14,{toList(14:1)}) * incidence",
-	  "facets = transpose(incidence * transpose map(ZZ^1,ZZ^24,{toList(24:1)}))"
+	  "facetList = transpose(incidence * transpose map(ZZ^1,ZZ^24,{toList(24:1)}))"
 	  },
 
      "We see that each vertex has degree 3.  Moreover, there are 8

--- a/M2/Macaulay2/packages/GroebnerStrata.m2
+++ b/M2/Macaulay2/packages/GroebnerStrata.m2
@@ -642,6 +642,7 @@ doc ///
       L = smallerMonomials M;
       mat = findWeightConstraints(M,L)
       needsPackage "Polyhedra"
+      needsPackage "FourTiTwo"
       dualCone posHull (-mat)
       rays oo
       posHull mat -- seems wrong?

--- a/M2/Macaulay2/packages/LatticePolytopes.m2
+++ b/M2/Macaulay2/packages/LatticePolytopes.m2
@@ -1389,7 +1389,7 @@ assert(isJetSpanned(latticePoints(convexHull(matrix{{0,2,0},{0,0,2}})),2,matrix{
 ///
 
 TEST ///
-assert(jetMatrix(latticePoints(convexHull(matrix{{0,2,0},{0,0,2}})),2,matrix{{1},{1}})==matrix {{1, 1, 1, 1, 1, 1}, {0, 0, 1, 2, 1, 0}, {0, 0, 0, 2, 0, 0}, {0, 0, 1, 0, 0, 0}, {0, 2, 1, 0, 0, 1}, {0, 2, 0, 0, 0, 0}});
+assert(jetMatrix(latticePoints(convexHull(matrix{{0,2,0},{0,0,2}})),2,matrix{{1},{1}}) == matrix {{1, 1, 1, 1, 1, 1}, {0, 0, 0, 1, 1, 2}, {0, 0, 0, 0, 0, 2}, {0, 0, 0, 0, 1, 0}, {0, 1, 2, 0, 1, 0}, {0, 0, 2, 0, 0, 0}});
 ///
 
 TEST ///

--- a/M2/Macaulay2/packages/LatticePolytopes.m2
+++ b/M2/Macaulay2/packages/LatticePolytopes.m2
@@ -407,8 +407,8 @@ listSmooth3D = () -> for P in Sm16in3D list convexHull P;
 
 -- PURPOSE : Test if a polyhedron is smooth.
 --           Extends isSmooth from package Polyhedra
-isSmooth(Polyhedron) := P -> isSmooth(normalFan(P));
-isSmooth(Matrix) := M -> isSmooth(normalFan(convexHull(M)));
+isSmooth Polyhedron := {} >> o -> P -> isSmooth normalFan P
+isSmooth Matrix     := {} >> o -> M -> isSmooth normalFan convexHull M
 
 
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/shared.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/shared.m2
@@ -11,6 +11,10 @@ document { Key => isSmooth,     methodstr, SeeAlso => {
 	"Varieties::isSmooth(Variety)", "SpaceCurves::isSmooth(Curve)",
 	"Polyhedra::isSmooth(Cone)", "NormalToricVarieties::isSmooth(NormalToricVariety)",
 	"SpecialFanoFourfolds::isSmooth(EmbeddedProjectiveVariety)" } }
+document { Key => isVeryAmple,  methodstr, SeeAlso => {
+	"Divisor::isVeryAmple(WeilDivisor)", "Polyhedra::isVeryAmple(Polyhedron)",
+	"PositivityToricBundles::isVeryAmple(ToricVectorBundleKlyachko)",
+	"NormalToricVarieties::isVeryAmple(ToricDivisor)" } }
 
 document { Key => cone,
     Headline => "mapping cone or polyhedral cone",

--- a/M2/Macaulay2/packages/Macaulay2Doc/shared.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/shared.m2
@@ -6,6 +6,11 @@ document { Key => decompose,    methodstr, SeeAlso => { "MinimalPrimes::MinimalP
 document { Key => truncate,     methodstr, SeeAlso => { "Truncations::Truncations" } }
 document { Key => chi,          methodstr }
 document { Key => isEmpty,      methodstr, SeeAlso => { "Polyhedra::Polyhedra",(isEmpty, RRi)} }
+document { Key => isSmooth,     methodstr, SeeAlso => {
+	"Divisor::isSmooth(Ideal)", "LatticePolytopes::isSmooth(Polyhedron)",
+	"Varieties::isSmooth(Variety)", "SpaceCurves::isSmooth(Curve)",
+	"Polyhedra::isSmooth(Cone)", "NormalToricVarieties::isSmooth(NormalToricVariety)",
+	"SpecialFanoFourfolds::isSmooth(EmbeddedProjectiveVariety)" } }
 
 document { Key => cone,
     Headline => "mapping cone or polyhedral cone",

--- a/M2/Macaulay2/packages/MonodromySolver/Documentation.m2
+++ b/M2/Macaulay2/packages/MonodromySolver/Documentation.m2
@@ -666,8 +666,8 @@ doc ///
         Text
 	    We will comput the mixed volume to find the number of solution counts.
         Example
-            mixedVolume = computeMixedVolume specializeSystem(p0,polys)
-            monodromySolve(polys,p0,{x0},SelectEdgeAndDirection=>selectBestEdgeAndDirection, Potential=>potentialE, TargetSolutionCount=>mixedVolume)
+            mixedVol = computeMixedVolume specializeSystem(p0,polys)
+            monodromySolve(polys,p0,{x0},SelectEdgeAndDirection=>selectBestEdgeAndDirection, Potential=>potentialE, TargetSolutionCount=>mixedVol)
     SeeAlso
         "selectBestEdgeAndDirection"
         "potentialLowerBound"

--- a/M2/Macaulay2/packages/NormalToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties.m2
@@ -27,7 +27,7 @@ newPackage(
     Headline => "routines for working with normal toric varieties and related objects",
     Keywords => {"Toric Geometry"},
     PackageExports => {"Polyhedra", "Schubert2", "Varieties","Truncations"},
-    PackageImports => {"FourierMotzkin","Normaliz","LLLBases"},
+    PackageImports => {"FourierMotzkin", "LLLBases"},
     DebuggingMode => false
     )
 

--- a/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
@@ -488,7 +488,7 @@ isAmple ToricDivisor := Boolean => D -> (
 	 ) 
      );
 
-isVeryAmple ToricDivisor := Boolean => D -> (
+isVeryAmple ToricDivisor := {} >> o -> D -> (
     if not isAmple D then return false;
     if isSmooth variety D then return true;    
     V := vertices D;

--- a/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
@@ -528,10 +528,7 @@ vertices ToricDivisor := Matrix => D -> (
 latticePoints ToricDivisor := Matrix => D -> (
     V := vertices D;
     if V === null then return null;
-    d := numRows V;
-    V = transpose (normaliz (transpose V,"polytope"))#"gen";
-    s := select (numColumns V, i -> V_(d,i) === 1);
-    c := (V_s)^{0..d-1};
+    c := matrix(vector \ latticePoints convexHull V);
     c_(sortColumns c) 
     );
 

--- a/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
@@ -488,9 +488,6 @@ isAmple ToricDivisor := Boolean => D -> (
 	 ) 
      );
 
-hilbertBasis(Matrix,Thing) := Matrix => opts -> (C, notused) -> (
-    transpose (normaliz(transpose C,"integral_closure"))#"gen")
-
 isVeryAmple ToricDivisor := Boolean => D -> (
     if not isAmple D then return false;
     if isSmooth variety D then return true;    
@@ -501,7 +498,7 @@ isVeryAmple ToricDivisor := Boolean => D -> (
     m := numColumns L;
     all (n, 
 	i -> (
-	    H := hilbertBasis(V - matrix {toList(n:1)} ** V_{i}, "notused");
+	    H := matrix(vector \ hilbertBasis coneFromVData(V - matrix {toList(n:1)} ** V_{i}));
 	    P := L - matrix {toList(m:1)} ** V_{i};
 	    isSubset(set entries transpose H, set entries transpose P)
 	    )

--- a/M2/Macaulay2/packages/NormalToricVarieties/DivisorsDocumentation.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/DivisorsDocumentation.m2
@@ -421,9 +421,8 @@ doc ///
             Cartier divisors.  For more information, see Theorem 4.2.1 in
             Cox-Little-Schenck's {\em Toric Varieties}.
     	Text
-            When the normal toric variety is @TO2(isSmooth, "smooth")@, the
-            Picard group is isomorphic to the 
-	    @TO2(classGroup, "class group")@.
+            When the normal toric variety is @TO2((isSmooth, NormalToricVariety), "smooth")@,
+            the Picard group is isomorphic to the @TO2(classGroup, "class group")@.
       	Example
     	    PP3 = toricProjectiveSpace 3;
 	    assert (isSmooth PP3 and isProjective PP3)
@@ -438,7 +437,7 @@ doc ///
     	    U = normalToricVariety ({{4,-1},{0,1}},{{0},{1}});
 	    assert (isSmooth U and not isComplete U and # max U =!= 1)
     	    picardGroup U
-    	    assert (classGroup U	=== picardGroup U and not isFreeModule picardGroup U)
+	    assert (classGroup U === picardGroup U and not isFreeModule picardGroup U)
     	Text
             For an affine toric variety, the Picard group is trivial.
 	Example
@@ -493,7 +492,7 @@ doc ///
             function returns a matrix representing this map with respect to
             the chosen bases.  
     	Text
-            On a @TO2(isSmooth, "smooth")@ normal toric variety, the Picard
+            On a @TO2((isSmooth, NormalToricVariety), "smooth")@ normal toric variety, the Picard
             group is isomorphic to the class group, so the inclusion map is
             the identity.
     	Example  
@@ -574,7 +573,7 @@ doc ///
 	    the chosen bases.  For more information, see Theorem 4.2.1 in
 	    Cox-Little-Schenck's {\em Toric Varieties}.
 	Text
-            On a @TO2(isSmooth, "smooth")@ normal toric variety, the map from
+            On a @TO2((isSmooth, NormalToricVariety), "smooth")@ normal toric variety, the map from
             the torus-invariant Cartier divisors to the Picard group is the
             same as the map from the @TO2(weilDivisorGroup, "Weil divisors")@
             to the @TO2(classGroup, "class group")@.
@@ -670,7 +669,7 @@ doc ///
 	    nefGenerators smoothFanoToricVariety (3,16)	    	    
 	    nefGenerators smoothFanoToricVariety (4,120)
 	Text
-	    There are @TO2(isSmooth, "smooth")@ @TO2(isComplete, "complete")@
+	    There are @TO2((isSmooth, NormalToricVariety), "smooth")@ @TO2(isComplete, "complete")@
             normal toric varieties with no nontrivial nef divisors.
     	Example    
             X = normalToricVariety ({{1,0,0},{0,1,0},{0,0,1},{0,-1,2},{0,0,-1},{-1,1,-1},{-1,0,-1},{-1,-1,0}},{{0,1,2},{0,2,3},{0,3,4},{0,4,5},{0,1,5},{1,2,7},{2,3,7},{3,4,7},{4,5,6},{4,6,7},{5,6,7},{1,5,7}});    

--- a/M2/Macaulay2/packages/NormalToricVarieties/Tests.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Tests.m2
@@ -206,7 +206,7 @@ Y = makeSmooth X;
 assert isWellDefined Y
 assert isSmooth Y
 assert (set rays Y === set {{-2,-3},{1,0},{0,1},{-1,-2},{-1,-1},{0,-1}})
-assert (sort max Y === sort {{0,5},{0,4},{1,2},{1,3},{2,4},{3,5}})
+assert (sort max Y === sort {{0,3},{0,4},{1,2},{1,5},{2,4},{3,5}})
 ///
 
 -- test 5

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricMapsDocumentation.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricMapsDocumentation.m2
@@ -1172,7 +1172,7 @@ doc ///
             torus-invariant Weil divisors on $X$.  For arbitrary normal toric
             varieties, the @TO weilDivisorGroup@ is not a functor.  However,
             @TO weilDivisorGroup@ is a contravariant functor on the category
-            of @TO2(isSmooth, "smooth")@ normal toric varieties.
+            of @TO2((isSmooth, NormalToricVariety), "smooth")@ normal toric varieties.
 	Text
 	    We illustrate this method on the projection from the first 
 	    @TO2(hirzebruchSurface, "Hirzebruch surface")@ to the 
@@ -1231,7 +1231,7 @@ doc ///
             class group of $Y$ to the class group of $X$.  For arbitrary normal
             toric varieties, the @TO classGroup@ is not a functor.  However,
             @TO classGroup@ is a contravariant functor on the category of
-            @TO2(isSmooth, "smooth")@ normal toric varieties.
+            @TO2((isSmooth, NormalToricVariety), "smooth")@ normal toric varieties.
 	Text
 	    We illustrate this method on the projection from the first 
 	    @TO2(hirzebruchSurface, "Hirzebruch surface")@ to the 
@@ -1252,7 +1252,7 @@ doc ///
             assert(f' * fromWDivToCl Y  == fromWDivToCl X  * f'')	    
 	Text
 	    The source of the toric map need not be 
-	    @TO2(isSmooth, "smooth")@.	    
+	    @TO2((isSmooth, NormalToricVariety), "smooth")@.
 	Example
 	    Z = toricBlowup({0, 1}, X, {1,2});
     	    assert (isWellDefined Z and not isSmooth Z)	    
@@ -1310,7 +1310,7 @@ doc ///
             assert(f' * fromCDivToPic Y  == fromCDivToPic X  * f'')	    
 	Text
 	    Neither the source nor the target of the toric map needs to be 
-	    @TO2(isSmooth, "smooth")@.	    
+	    @TO2((isSmooth, NormalToricVariety), "smooth")@.
 	Example  
 	    W = weightedProjectiveSpace {1, 1, 2};	     
 	    Z = toricBlowup({0, 1, 4}, (W ** toricProjectiveSpace 1), {0, -2, 1});
@@ -1370,7 +1370,7 @@ doc ///
             assert(f'' * fromCDivToPic Y == fromCDivToPic X  * f')
 	Text
 	    Neither the source nor the target of the toric map needs to be 
-	    @TO2(isSmooth, "smooth")@.	    
+	    @TO2((isSmooth, NormalToricVariety), "smooth")@.
 	Example  
 	    W = weightedProjectiveSpace {1, 1, 2};	     
 	    Z = toricBlowup({0, 1, 4}, (W ** toricProjectiveSpace 1), {0, -2, 1});

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
@@ -451,7 +451,7 @@ isSimplicial NormalToricVariety := Boolean => (
 	)
     );
 
-isSmooth NormalToricVariety := Boolean => (
+isSmooth NormalToricVariety := Boolean => {} >> o -> (
     cacheValue symbol isSmooth) (X -> (
     	rayGenMatrix := transpose matrix rays X;
     	b := all(max X, sigma -> 

--- a/M2/Macaulay2/packages/Normaliz.m2
+++ b/M2/Macaulay2/packages/Normaliz.m2
@@ -1672,9 +1672,9 @@ document {
      EXAMPLE lines ///
           R=ZZ/37[x,y];
           L={x^3, x^2*y, y^3, x*y^2};
-          (latticePoints,ehrhart)=ehrhartRing L;
-          latticePoints
-          ehrhart
+          (A, B) = ehrhartRing L;
+          A
+          B
      ///,
    TEST ///
    R=ZZ/37[x,y,z,t];
@@ -1734,9 +1734,9 @@ document {
      EXAMPLE lines ///
           R=ZZ/37[x,y];
           L={x^3, x^2*y, y^3, x*y^2};
-       (latticePoints,ehrhart)=ehrhartRing(allComputations=>true,L);
-           latticePoints.cache#"cone"
-           ehrhart.cache#"cone"
+	  (A, B) = ehrhartRing(L, allComputations => true);
+	  A.cache#"cone"
+	  B.cache#"cone"
      ///,
 }
 
@@ -1753,9 +1753,9 @@ document {
     EXAMPLE  lines ///
     R=ZZ/37[x,y,t];
     L={x^3, x^2*y, y^3, x*y^2};
-    (latticePoints,ehrhart)=ehrhartRing(L,t);
-          latticePoints
-          ehrhart
+    (A, B) = ehrhartRing(L, t);
+    A
+    B
    ///,
 }
 
@@ -1772,9 +1772,9 @@ document {
     EXAMPLE  lines ///
     R=ZZ/37[x,y,t];
     L={x^3, x^2*y, y^3, x*y^2};
-    (latticePoints,ehrhart)=ehrhartRing(allComputations=>true,L,t);
-          latticePoints.cache#"cone"
-          ehrhart.cache#"cone"
+    (A, B) = ehrhartRing(L, t, allComputations => true);
+    A.cache#"cone"
+    B.cache#"cone"
    ///,
 }
 

--- a/M2/Macaulay2/packages/OldPolyhedra.m2
+++ b/M2/Macaulay2/packages/OldPolyhedra.m2
@@ -93,7 +93,7 @@ export {"PolyhedralObject",
 	"isReflexive",
 	"isSimplicial", 
 	--"isSmooth", 
-	"isVeryAmple",
+	--"isVeryAmple",
 	"boundaryMap", 
 	"dualFaceLattice", 
 	"faceLattice",
@@ -1499,8 +1499,7 @@ isSmooth Fan := {} >> o -> F -> (
 -- PURPOSE : Checks if a polytope is very ample
 --   INPUT : 'P'  a Polyhedron, which must be compact
 --  OUTPUT : 'true' or 'false'
-isVeryAmple = method()
-isVeryAmple Polyhedron := P -> (
+isVeryAmple Polyhedron := {} >> o -> P -> (
      if not isCompact P then error("The polyhedron must be compact");
      if not dim P == ambDim P then error("The polyhedron must be full dimensional");
      if not isLatticePolytope P then error("The polyhedron must be a lattice polytope");

--- a/M2/Macaulay2/packages/OldPolyhedra.m2
+++ b/M2/Macaulay2/packages/OldPolyhedra.m2
@@ -92,7 +92,7 @@ export {"PolyhedralObject",
 	"isPure",
 	"isReflexive",
 	"isSimplicial", 
-	"isSmooth", 
+	--"isSmooth", 
 	"isVeryAmple",
 	"boundaryMap", 
 	"dualFaceLattice", 
@@ -1480,22 +1480,18 @@ isSimplicial PolyhedralObject := (cacheValue symbol isSimplicial)(X -> (
 
 
 -- PURPOSE : Checks if the input is smooth
-isSmooth = method(TypicalValue => Boolean)
-
 --   INPUT : 'C'  a Cone
 --  OUTPUT : 'true' or 'false'
-isSmooth Cone := C -> (
+isSmooth Cone := {} >> o -> C -> (
      -- generating the non-linealityspace cone of C
      R := lift(transpose rays C,ZZ);
      n := dim C - C#"dimension of lineality space";
      -- if the cone is full dimensional then it is smooth iff its rays form a basis over ZZ
      numRows R == n and (M := (smithNormalForm R)#0; product apply(n, i -> M_(i,i)) == 1))
-     
-	   
 
 --   INPUT : 'F'  a Fan
 --  OUTPUT : 'true' or 'false'
-isSmooth Fan := F -> (
+isSmooth Fan := {} >> o -> F -> (
      if not F.cache.?isSmooth then F.cache.isSmooth = all(toList F#"generatingCones",isSmooth);
      F.cache.isSmooth)
 
@@ -5871,7 +5867,7 @@ document {
      }
 
 document {
-     Key => {isSmooth, (isSmooth,Cone), (isSmooth,Fan)},
+     Key => {(isSmooth,Cone), (isSmooth,Fan)},
      Headline => "checks if a Cone or Fan is smooth",
      Usage => " b = isSmooth C \nb = isSmooth F",
      Inputs => {

--- a/M2/Macaulay2/packages/Polyhedra.m2
+++ b/M2/Macaulay2/packages/Polyhedra.m2
@@ -38,7 +38,6 @@ newPackage("Polyhedra",
         Email => "k.l@fu-berlin.de"
      }
      },
-    PackageExports=>{"FourTiTwo"},
     PackageImports=>{"IntegralClosure", "ReesAlgebra", "LLLBases"}
     )
 

--- a/M2/Macaulay2/packages/Polyhedra/core/cone/methods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/cone/methods.m2
@@ -11,11 +11,10 @@ facesAsCones(ZZ, Cone) := (d, C) -> (
 )
 
 
+-- PURPOSE : Checks if the input is smooth
 --   INPUT : 'C'  a Cone
 --  OUTPUT : 'true' or 'false'
-isSmooth Cone := C -> (
-   getProperty(C, smooth)
-)
+isSmooth Cone := {} >> o -> C -> getProperty(C, smooth)
 
 
 -- PURPOSE : Tests if a Cone is pointed

--- a/M2/Macaulay2/packages/Polyhedra/core/cone/methods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/cone/methods.m2
@@ -25,14 +25,14 @@ isPointed Cone := C -> (
    getProperty(C, pointed)
 )
 
--- hilbertBasis = method()
-hilbertBasis Cone := List => o -> (C -> (
+
+hilbertBasis = method(Options => true)
+hilbertBasis Cone := List => {} >> o -> (C -> (
       if isPointed C then getProperty(C, computedHilbertBasis)
       else error("Hilbert basis not implemented for non-pointed cones yet.")
    )
 )
 
-     
 
 --   INPUT : '(v,P)',  a weight vector 'v' given by a one column matrix over ZZ or QQ and a 
 --     	     	       Cone 'C'

--- a/M2/Macaulay2/packages/Polyhedra/core/cone/properties.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/cone/properties.m2
@@ -175,11 +175,10 @@ compute#Cone#computedDimension Cone := C -> (
 )
 
 
+importFrom_Core { "raw", "rawHilbertBasis" } -- calls libnormaliz
 compute#Cone#computedHilbertBasis = method()
 compute#Cone#computedHilbertBasis Cone := C -> (
-   inputMatrix := (facets C) || (hyperplanes C) || ( - hyperplanes C);
-   hb := transpose hilbertBasis(transpose inputMatrix, InputType=>"lattice");
-   hb = promote(hb, ring inputMatrix) // inputMatrix;
+   hb := transpose map(ZZ, rawHilbertBasis raw transpose rays C);
    apply(numColumns hb, i -> hb_{i})
 )
 

--- a/M2/Macaulay2/packages/Polyhedra/core/cone/properties.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/cone/properties.m2
@@ -179,12 +179,8 @@ compute#Cone#computedHilbertBasis = method()
 compute#Cone#computedHilbertBasis Cone := C -> (
    inputMatrix := (facets C) || (hyperplanes C) || ( - hyperplanes C);
    hb := transpose hilbertBasis(transpose inputMatrix, InputType=>"lattice");
-   r := ring inputMatrix;
-   result := apply(0..(numColumns hb - 1), i -> hb_i);
-   eq := hyperplanes C;
-   zero :=  transpose matrix {toList ((numRows eq):0)};
-   result = apply(result, h -> (promote(matrix h, r)) // inputMatrix);
-   toList result
+   hb = promote(hb, ring inputMatrix) // inputMatrix;
+   apply(numColumns hb, i -> hb_{i})
 )
 
 

--- a/M2/Macaulay2/packages/Polyhedra/core/fan/methods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/fan/methods.m2
@@ -15,11 +15,10 @@ linSpace Fan := F -> linealitySpace F
 isPointed Fan := F -> all(values getProperty(F, honestMaxObjects), c->isPointed c)
 
 
+-- PURPOSE : Checks if the input is smooth
 --   INPUT : 'F'  a Fan
 --  OUTPUT : 'true' or 'false'
-isSmooth Fan := F -> (
-   getProperty(F, smooth)
-)
+isSmooth Fan := {} >> o -> F -> getProperty(F, smooth)
 
 
 -- PURPOSE : Computing the subfan of all smooth cones of the Fan

--- a/M2/Macaulay2/packages/Polyhedra/core/globalMethods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/globalMethods.m2
@@ -66,8 +66,7 @@ fVector PolyhedralObject := PO -> getProperty(PO, computedFVector)
 -------------------------------------------------------------------------------
 -- For fan and cone
 isPointed = method(TypicalValue => Boolean)
--- PURPOSE : Checks if the input is smooth
-isSmooth = method(TypicalValue => Boolean)
+-- isSmooth = method(TypicalValue => Boolean)
 
 
 

--- a/M2/Macaulay2/packages/Polyhedra/documentation/intro.m2
+++ b/M2/Macaulay2/packages/Polyhedra/documentation/intro.m2
@@ -16,8 +16,9 @@ document {
 	PARA{}, TT "Polyhedra", " uses the ",
    UL {
       { TO "FourierMotzkin", " package by ", HREF("http://www.mast.queensu.ca/~ggsmith", "Gregory G. Smith")},
-      { TO "FourTiTwo", " package by ", HREF("http://pi.math.cornell.edu/~mike/", "Michael Stillman"),", ", HREF("http://people.math.gatech.edu/~jyu67/", "Josephine Yu"), ", and ",
+      { TO "FourTiTwo::FourTiTwo", " package by ", HREF("http://pi.math.cornell.edu/~mike/", "Michael Stillman"),", ", HREF("http://people.math.gatech.edu/~jyu67/", "Josephine Yu"), ", and ",
       HREF("http://math.iit.edu/~spetrov1/", "Sonja Petrovic")},
+      { TO "Normaliz::Normaliz", " package by Gesa Kaempf and Christof Soeger" },
       { TO "Topcom", " package by ",  HREF("http://pi.math.cornell.edu/~mike/", "Michael Stillman"), "."}
    },
 	

--- a/M2/Macaulay2/packages/Polyhedra/documentation/old_documentation.m2
+++ b/M2/Macaulay2/packages/Polyhedra/documentation/old_documentation.m2
@@ -1489,7 +1489,7 @@ document {
      }
 
 document {
-     Key => {isSmooth, (isSmooth,Cone), (isSmooth,Fan)},
+     Key => {(isSmooth,Cone), (isSmooth,Fan)},
      Headline => "checks if a Cone or Fan is smooth",
      Usage => " b = isSmooth C \nb = isSmooth F",
      Inputs => {

--- a/M2/Macaulay2/packages/Polyhedra/documentation/old_documentation.m2
+++ b/M2/Macaulay2/packages/Polyhedra/documentation/old_documentation.m2
@@ -1512,7 +1512,7 @@ document {
      }
 
 document {
-     Key => {isVeryAmple,(isVeryAmple,Polyhedron)},
+     Key => {(isVeryAmple, Polyhedron)},
      Headline => "checks if the Polyhedron is very ample",
      Usage => " b = isVeryAmple P",
      Inputs => {

--- a/M2/Macaulay2/packages/Polyhedra/documentation/old_documentation.m2
+++ b/M2/Macaulay2/packages/Polyhedra/documentation/old_documentation.m2
@@ -1593,7 +1593,7 @@ document {
      }
 
 document {
-     Key => {(hilbertBasis,Cone)},
+     Key => {hilbertBasis, (hilbertBasis,Cone)},
      Headline => "computes the Hilbert basis of a Cone",
      Usage => " HB = hilbertBasis C",
      Inputs => {
@@ -1612,12 +1612,16 @@ document {
      PARA{}, HREF("http://www.hemmecke.de/raymond/", "Raymond Hemmecke's"), " ", EM "On the 
      computation of Hilbert bases of cones", ", in A. M. Cohen, X.-S. Gao, and N. Takayama, 
      editors, Mathematical Software, ICMS 2002, pages 307317. World Scientific, 2002.",
-     
+
      EXAMPLE {
 	  " C = coneFromVData matrix {{1,2},{2,1}}",
 	  " hilbertBasis C"
-	  }
+	  },
+
+     PARA{}, "Beginning with Macaulay2 version 1.24.11, this method calls the internal function ",
+     TT "rawHilbertBasis", " which calls the C++ library ", TO2 {"normaliz", "libnormaliz"}, ".",
      
+     SeeAlso => {"FourTiTwo::hilbertBasis(Matrix)"}
      }
 
 document {

--- a/M2/Macaulay2/packages/Polyhedra/engine/alternatives.m2
+++ b/M2/Macaulay2/packages/Polyhedra/engine/alternatives.m2
@@ -12,6 +12,7 @@ loadAlternative String := name -> (
    else if name == "lcdd" then insertAlternatives(lcdd)
    else if name == "lcdd_gmp" then insertAlternatives(lcddGmp)
    else if name == "normaliz" then insertAlternatives(normalizPolyhedra)
+   else if name == "4ti2" then insertAlternatives(fourtitwoPolyhedra)
    else error("No such interface.")
 )
 

--- a/M2/Macaulay2/packages/Polyhedra/exports.m2
+++ b/M2/Macaulay2/packages/Polyhedra/exports.m2
@@ -48,7 +48,7 @@ export {
    "isPure",
    "isReflexive",
    "isSimplicial", 
-   "isSmooth", 
+   --"isSmooth",
    "isVeryAmple",
    "faces", 
    "facesAsPolyhedra",

--- a/M2/Macaulay2/packages/Polyhedra/exports.m2
+++ b/M2/Macaulay2/packages/Polyhedra/exports.m2
@@ -49,7 +49,7 @@ export {
    "isReflexive",
    "isSimplicial", 
    --"isSmooth",
-   "isVeryAmple",
+   --"isVeryAmple",
    "faces", 
    "facesAsPolyhedra",
    "facesAsCones",

--- a/M2/Macaulay2/packages/Polyhedra/exports.m2
+++ b/M2/Macaulay2/packages/Polyhedra/exports.m2
@@ -34,6 +34,7 @@ export {
    "linearTransform",
    "polyhedra", 
    "vertices",
+   "hilbertBasis",
    "areCompatible", 
    "commonFace", 
    "contains", 

--- a/M2/Macaulay2/packages/Polyhedra/extended/polyhedron/methods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/extended/polyhedron/methods.m2
@@ -48,8 +48,7 @@ polar Polyhedron := P -> getProperty(P, computedPolar)
 -- PURPOSE : Checks if a polytope is very ample
 --   INPUT : 'P'  a Polyhedron, which must be compact
 --  OUTPUT : 'true' or 'false'
-isVeryAmple = method()
-isVeryAmple Polyhedron := P -> getProperty(P, computedVeryAmple)
+isVeryAmple Polyhedron := {} >> o -> P -> getProperty(P, computedVeryAmple)
 
 
 -- PURPOSE : Computing the vertex-edge-matrix of a polyhedron

--- a/M2/Macaulay2/packages/Polyhedra/extended/polyhedron/methods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/extended/polyhedron/methods.m2
@@ -201,8 +201,8 @@ polarFace(Polyhedron, Polyhedron) := (f, P) -> (
 -- PURPOSE : Checks if a lattice polytope is reflexive
 --   INPUT : 'P'  a Polyhedron
 --  OUTPUT : 'true' or 'false'
-isReflexive = method(TypicalValue => Boolean)
-isReflexive Polyhedron := (cacheValue symbol isReflexive)(P -> isLatticePolytope P and inInterior(matrix toList(ambDim P:{0}),P) and isLatticePolytope polar P)
+isReflexive = method(TypicalValue => Boolean, Options => true)
+isReflexive Polyhedron := {} >> o -> (cacheValue symbol isReflexive)(P -> isLatticePolytope P and inInterior(matrix toList(ambDim P:{0}),P) and isLatticePolytope polar P)
 
 
 -- PURPOSE : Triangulating a compact Polyhedron

--- a/M2/Macaulay2/packages/Polyhedra/interfaces/fourtitwo.m2
+++ b/M2/Macaulay2/packages/Polyhedra/interfaces/fourtitwo.m2
@@ -1,0 +1,13 @@
+fourtitwoPolyhedra = new MutableHashTable
+fourtitwoPolyhedra#Cone = new MutableHashTable
+
+fourtitwoPolyhedra#Cone#computedHilbertBasis = method()
+fourtitwoPolyhedra#Cone#computedHilbertBasis Cone := C -> (
+   needsPackage "FourTiTwo";
+   InputType := (value getGlobalSymbol "InputType");
+   if debugLevel > 2 then << "Using FourTiTwo." << endl;
+   inputMatrix := (facets C) || (hyperplanes C) || ( - hyperplanes C);
+   hb := transpose hilbertBasis(transpose inputMatrix, InputType => "lattice");
+   hb = promote(hb, ring inputMatrix) // inputMatrix;
+   apply(numColumns hb, i -> hb_{i})
+)

--- a/M2/Macaulay2/packages/Polyhedra/interfaces/normaliz.m2
+++ b/M2/Macaulay2/packages/Polyhedra/interfaces/normaliz.m2
@@ -1,8 +1,15 @@
 normalizPolyhedra = new MutableHashTable
 normalizPolyhedra#Cone = new MutableHashTable
 
+HBFromNormalizCone := RC -> (
+   HB := transpose RC#"gen";
+   apply(numColumns HB, i -> HB_{i})
+   )
+
 normalizPolyhedra#Cone#computedHilbertBasis = method()
 normalizPolyhedra#Cone#computedHilbertBasis Cone := C -> (
+   needsPackage "Normaliz";
+   normaliz := (value getGlobalSymbol "normaliz");
    if debugLevel > 2 then << "Using Normaliz." << endl;
    if not isPointed C then error("Hilbert basis not implemented for non-pointed cones");
    if hasProperty(C, rays) then (
@@ -17,12 +24,5 @@ normalizPolyhedra#Cone#computedHilbertBasis Cone := C -> (
       if debugLevel > 2 then << "Normaliz computing with rays." << endl;
       return HBFromNormalizCone normaliz(transpose rays C, "integral_closure")
    )
-)
-
-HBFromNormalizCone = method()
-HBFromNormalizCone RationalCone := RC -> (
-   HB := RC#"gen";
-   HB = transpose HB;
-   flatten apply(numColumns HB, i -> HB_{i})
 )
 

--- a/M2/Macaulay2/packages/Polyhedra/loadFile.m2
+++ b/M2/Macaulay2/packages/Polyhedra/loadFile.m2
@@ -1,6 +1,6 @@
 needsPackage "FourierMotzkin"
--- needsPackage "FourTiTwo"
-needsPackage "Normaliz"
+-- needsPackage "FourTiTwo" -- see interfaces/fourtitwo.m2
+-- needsPackage "Normaliz" -- see interfaces/normaliz.m2
 needsPackage "Topcom"
 
 load "./exports.m2"
@@ -103,6 +103,7 @@ load "./tests/isWellDefined.m2"
 -- Interfaces to other software
 --
 load "./interfaces/fourierMotzkinAlternatives.m2"
+load "./interfaces/fourtitwo.m2"
 load "./interfaces/normaliz.m2"
 
 -------------------------------------------------------------------------------

--- a/M2/Macaulay2/packages/Polyhedra/tests/extended/regularSubdivision.m2
+++ b/M2/Macaulay2/packages/Polyhedra/tests/extended/regularSubdivision.m2
@@ -3,7 +3,7 @@ TEST ///
 P = convexHull matrix {{1,0,1,0},{1,1,0,0}};
 C1 = matrix {{0,1,0},{0,0,1}};
 C2 = matrix {{1,0,1},{0,1,1}}; 
-w = matrix {{1,0,1,0}};
+w = matrix {{1,0,0,1}};
 S = regularSubdivision (P,w);
 assert(S#0 == convexHull C1)
 assert(S#1 == convexHull C2)

--- a/M2/Macaulay2/packages/PositivityToricBundles.m2
+++ b/M2/Macaulay2/packages/PositivityToricBundles.m2
@@ -478,8 +478,7 @@ if separatesJets(tvb, Verbosity=>opts#Verbosity) >= 0 then true else false;
 --           check if the vector bundle is very ample, using [RJS, Cor. 6.7]
 --   INPUT : 'tvb', toric vector bundle
 --  OUTPUT :  'true' if very ample, otherwise 'false'
---isVeryAmple = method( Options => true ) -- conflicts with Polyhedra
-isVeryAmple (ToricVectorBundleKlyachko) := (tvb) -> if separatesJets(tvb) >= 1 then true else false;
+isVeryAmple ToricVectorBundleKlyachko := true >> opts -> tvb -> if separatesJets(tvb, opts) >= 1 then true else false
   
 ------------------------------------------------------------------------------
 -- METHOD: restrictToInvCurves, isNef, isAmple

--- a/M2/Macaulay2/packages/ReactionNetworks.m2
+++ b/M2/Macaulay2/packages/ReactionNetworks.m2
@@ -15,7 +15,7 @@ newPackage(
 --    	HomePage => "http://www.math.uiuc.edu/~doe/", --page not working
         Headline => "reaction networks",
 	Keywords => {"Applied Algebraic Geometry"},
-	PackageImports => {"Graphs", "Polyhedra"},
+	PackageImports => {"Graphs", "FourTiTwo"},
         DebuggingMode => false,
 --  	DebuggingMode => true,		 -- set to true only during development
 	AuxiliaryFiles => true

--- a/M2/Macaulay2/packages/SpaceCurves.m2
+++ b/M2/Macaulay2/packages/SpaceCurves.m2
@@ -54,7 +54,7 @@ export {
 --Curves
     	"Curve",
 	"curve",
-	"isSmooth",
+	--"isSmooth",
 --ACM curves
 	"positiveChars",
 	"isACMBetti",
@@ -273,12 +273,11 @@ curve Divisor := D -> (
 )
 degree Curve := C -> degree ideal C
 genus Curve := C -> genus ideal C
-isSmooth = method()
-isSmooth Ideal := I -> (
+isSmooth Ideal := {} >> o -> I -> (
     c := codim I;
     dim(I + minors(c, jacobian I)) == 0
     )
-isSmooth Curve := C -> isSmooth ideal C
+isSmooth Curve := {} >> o -> C -> isSmooth ideal C
 isPrime Curve := {} >> o -> C -> isPrime ideal C
 
 --V.Minimal Curves
@@ -711,7 +710,7 @@ SUBSECTION "Curves",
 UL{ 
     TO	  "Curve",
     TO	  "curve",
-    TO	  "isSmooth"
+    TO	  (isSmooth,Curve)
 },
 PARA{},
 SUBSECTION "Minimal curves",  
@@ -992,7 +991,7 @@ document {
     )     
 }
 document {
-    Key => {isSmooth,(isSmooth,Ideal),(isSmooth, Curve)},
+    Key => {(isSmooth,Ideal), (isSmooth,Curve)},
     Headline => "checks smoothness of an ideal or of a Curve",
     {
     "The method ", TT "isSmooth", " uses Jacobian criterion to check the smoothness of

--- a/M2/Macaulay2/packages/SpecialFanoFourfolds.m2
+++ b/M2/Macaulay2/packages/SpecialFanoFourfolds.m2
@@ -2699,8 +2699,8 @@ mapDefinedByDivisor = method();
 mapDefinedByDivisor (QuotientRing,VisibleList) := (R,D) -> rationalMap(R,new Tally from apply(select(D,l -> last l > 0),d -> first d => last d));
 mapDefinedByDivisor (MultiprojectiveVariety,VisibleList) := (X,D) -> rationalMap(X,new Tally from apply(select(D,l -> last l > 0),d -> first d => last d));
 
-isSmooth = method(TypicalValue => Boolean); -- sufficient conditions for smoothness ('Y' is assumed to be equidimensional)
-isSmooth EmbeddedProjectiveVariety := (cacheValue "isSmooth") (Y -> (
+-- sufficient conditions for smoothness ('Y' is assumed to be equidimensional)
+isSmooth EmbeddedProjectiveVariety := {} >> o -> (cacheValue "isSmooth") (Y -> (
     if Y.cache#?"singularLocus" or Y.cache#?"nonSaturatedSingularLocus" then return (dim singLocus Y == -1);
     X := fitVariety Y;
     isXsm := dim singLocus X == -1;

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -29,7 +29,7 @@ newPackage(
 importFrom_Core {
     "concatCols",
     "freeComponents",
-    "raw", "rawSelectByDegrees",
+    "raw", "rawHilbertBasis", "rawSelectByDegrees",
     "tryHooks",
     }
 
@@ -183,8 +183,7 @@ truncationMonomials(List, Ring) := opts -> (d, R) -> (
         F := freeComponents target A;
         b := transpose matrix{d_F};
         P := truncationPolyhedron(A^F, b, opts);
-        H := hilbertBasis cone P; -- ~50% of computation
-        H = for h in H list flatten entries h;
+        H := entries map(ZZ, rawHilbertBasis raw transpose rays cone P); -- ~50% of computation
         J := leadTerm ideal R1;
         ambR := ring J;
         -- generates the Nef cone
@@ -307,8 +306,7 @@ basisMonomials(List, Ring) := (d, R) -> R#(symbol basis', d) ??= (
         -- TODO: would be better if basisPolyhedron could account for torsion
         P := basisPolyhedron(A^F, b,
             Exterior => (options R1).SkewCommutative);
-        H := hilbertBasis cone P; -- ~40% of computation
-        H = for h in H list flatten entries h;
+        H := entries map(ZZ, rawHilbertBasis raw transpose rays cone P); -- ~40% of computation
         J := leadTerm ideal R1;
         ambR := ring J;
         -- generates the degree zero part of the basis

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -28,6 +28,7 @@ newPackage(
 
 importFrom_Core {
     "concatCols",
+    "freeComponents",
     "raw", "rawSelectByDegrees",
     "tryHooks",
     }
@@ -167,13 +168,15 @@ truncationMonomials(List, Module) := opts -> (degs, F) -> (
     (R1, phi1) := flattenRing (R := ring F);
     ext := if opts.Exterior =!= null then opts.Exterior else (options R1).SkewCommutative;
     nef := if opts.Nef      =!= null then opts.Nef      else  nefCone R1; -- changing to effCone gives an alternative result
+    -- the free components of the degree group
+    free := freeComponents degreeGroup R;
     -- TODO: call findMins on degs, but with respect to the Nef cone!
     -- checks to see if twist S(-a) needs to be truncated
-    isInNef := if nef === null then a -> any(degs, d -> d << a) else (
-	truncationCone := nef + convexHull matrix transpose degs;
+    isInNef := if nef === null then a -> any(degs, d -> d_free << a) else (
+        truncationCone := nef + convexHull(matrix (transpose degs)_free);
 	a -> contains(truncationCone, convexHull matrix transpose{a}));
     -- TODO: either figure out a way to use cached results or do this in parallel
-    directSum apply(degrees F, a -> if isInNef a then gens R^{a} else concatCols(
+    directSum apply(degrees F, a -> if isInNef a_free then gens R^{a} else concatCols(
 	     apply(degs, d -> truncationMonomials(d - a, R, Exterior => ext, Nef => nef)))))
 truncationMonomials(List, Ring) := opts -> (d, R) -> (
     -- inputs: a single multidegree, a graded ring
@@ -185,7 +188,9 @@ truncationMonomials(List, Ring) := opts -> (d, R) -> (
         (R1, phi1) := flattenRing R;
         -- generates the effective cone
         A := effGenerators R1;
-        P := truncationPolyhedron(A, transpose matrix{d}, opts);
+        F := freeComponents target A;
+        b := transpose matrix{d_F};
+        P := truncationPolyhedron(A^F, b, opts);
         H := hilbertBasis cone P; -- ~50% of computation
         H = for h in H list flatten entries h;
         J := leadTerm ideal R1;
@@ -306,7 +311,10 @@ basisMonomials(List, Ring) := (d, R) -> (
         (R1, phi1) := flattenRing R;
         -- generates the effective cone
         A := effGenerators R1;
-        P := basisPolyhedron(A, transpose matrix{d},
+        F := freeComponents target A;
+        b := transpose matrix{d_F};
+        -- TODO: would be better if basisPolyhedron could account for torsion
+        P := basisPolyhedron(A^F, b,
             Exterior => (options R1).SkewCommutative);
         H := hilbertBasis cone P; -- ~40% of computation
         H = for h in H list flatten entries h;
@@ -318,7 +326,8 @@ basisMonomials(List, Ring) := (d, R) -> (
         result := mingens ideal(mongens % J); -- ~40% of computation
         if R1 =!= ambR then result = result ** R1;
         if R =!= R1 then result = phi1^-1 result;
-        result))
+        psrc = rawSelectByDegrees(raw source result, d, d);
+        submatrix(result, , psrc)))
 
 -- FIXME: when M has relations, it should be pruned
 basis' = method(Options => options basis)

--- a/M2/Macaulay2/packages/Truncations/tests.m2
+++ b/M2/Macaulay2/packages/Truncations/tests.m2
@@ -369,18 +369,18 @@ needsPackage "Truncations"
 S = ZZ/32003[x_0,x_1,y_0,y_1,z_0..z_2, Degrees => {2:{1,0,0},2:{0,1,0},3:{0,0,1}}]
 
 n = 11 -- 78 twists
-elapsedTime truncate(compositions(3, n), S, MinimalGenerators => false); -- 10s -> 7.3s
+elapsedTime truncate(compositions(3, n), S, MinimalGenerators => false); -- 10s -> 7.3s -> 4.6s
 elapsedTime truncate(compositions(3, n), S, MinimalGenerators => false); -- 2.8s -> 0.2s, GOOD
 elapsedTime truncate(compositions(3, n), S); -- (28.8 ->) 7.8s -> 5.6s -> 0.19s GOOD
 elapsedTime truncate(compositions(3, n), S); -- (16.8 ->) 7.7s -> 5.4s -> 0.18s GOOD
 elapsedTime truncate(compositions(3, n), S^3, MinimalGenerators => false); -- 8.5s -> 0.6s, GOOD
 elapsedTime truncate(compositions(3, n), S^3, MinimalGenerators => false); -- 6.6s -> 0.5s GOOD
 
-elapsedTime truncate(compositions(3, n), S^3); -- (67s ->) 61s -> 72s -> 7.3s
+elapsedTime truncate(compositions(3, n), S^3); -- (67s ->) 61s -> 72s -> 7.3s -> 0.5s
 elapsedTime truncate(compositions(3, n), S^3); -- (54s ->) 60s -> 60s -> 0.4s GOOD
 
 n = 15 -- 136 twists
-elapsedTime truncate(compositions(3, n), S, MinimalGenerators => false); -- 31s -> 23.8s
+elapsedTime truncate(compositions(3, n), S, MinimalGenerators => false); -- 31s -> 23.8s -> 11.8
 elapsedTime truncate(compositions(3, n), S, MinimalGenerators => false); -- 0.8s GOOD
 elapsedTime truncate(compositions(3, n), S); -- (?? ->) >3min -> 0.8s GOOD
 elapsedTime truncate(compositions(3, n), S); -- (?? ->) >3min -> 0.7s GOOD

--- a/M2/Macaulay2/packages/Truncations/tests.m2
+++ b/M2/Macaulay2/packages/Truncations/tests.m2
@@ -340,7 +340,7 @@ TEST /// -- test of truncationPolyhedron with Nef option
   N = nefGenerators dP6
 
   A = effGenerators S -- generates the effective cone
-  P = truncationPolyhedron(A, {0,0,0,0}, Nef => nefCone dP6)
+  P = truncationPolyhedron(A, {0,0,0,0}, Cone => nefCone dP6)
   Q = truncationPolyhedron(A, {0,0,0,0})
   assert(#hilbertBasis cone P == 13)
   assert(#hilbertBasis cone Q == 10)

--- a/M2/Macaulay2/tests/engine/raw-hilbert-basis.m2
+++ b/M2/Macaulay2/tests/engine/raw-hilbert-basis.m2
@@ -1,0 +1,49 @@
+debug Core
+
+assert(map(ZZ, rawHilbertBasis raw matrix {{1, 3}, {2, 1}}) == matrix {{1, 1}, {1, 2}, {1, 3}, {2, 1}})
+
+m = matrix {
+    {0, 0, 0, 1, 0, 1, 0, 1},
+    {1, 0, 0, 0, 0, 0, 0, 0},
+    {0, 1, 0, 0, 0, 0, 0, 0},
+    {0, 0, 1, 1, 0, 0, 0, 0},
+    {0, 0, 0, 0, 1, 1, 0, 0},
+    {0, 0, 0, 0, 0, 0, 1, 1}};
+assert(rank target rawHilbertBasis raw m == 6)
+
+m = matrix {
+    {0, 1, 0, 0, 0, 0, 0, 0},
+    {0, 0, 1, 0, 0, 0, 0, 0},
+    {0, 0, 0, 1, 0, 0, 0, 0},
+    {0, 0, 0, 0, 1, 0, 0, 0},
+    {0, 0, 0, 0, 0, 1, 0, 0},
+    {1, 0, 0, 0, 0, 15, 0, 0},
+    {0, 0, 0, 0, 0, 0, 1, 0},
+    {1, 0, 0, 0, 0, 0, 15, 0},
+    {0, 0, 0, 0, 0, 0, 0, 1},
+    {1, 0, 0, 0, 0, 0, 0, 15}};
+assert(rank target rawHilbertBasis raw m == 143)
+
+end--
+
+restart
+debug Core
+needsPackage "Normaliz"
+needsPackage "FourTiTwo"
+needsPackage "Polyhedra"
+
+A = transpose map(ZZ, rawHilbertBasis raw m)
+B = hilbertBasis(coneFromVData transpose m, InputType => "lattice") / vector // matrix
+assert(A_(sortColumns A) == B_(sortColumns B))
+
+-- TODO: add test with non-trivial hyperplanes
+C = coneFromVData transpose m
+A' = facets C * transpose map(ZZ, rawHilbertBasis raw transpose rays C)
+B' = transpose hilbertBasis(transpose facets C, InputType=>"lattice")
+assert(A_(sortColumns A) == B_(sortColumns B))
+
+-- benchmarking 3 different methods
+C = coneFromVData transpose m
+benchmark "facets C * transpose (normaliz(transpose rays C, \"cone\"))#\"gen\""  -- ~0.02
+benchmark "facets C * transpose map(ZZ, rawHilbertBasis(raw transpose rays C))"  -- ~0.003
+benchmark "transpose hilbertBasis(transpose facets C, InputType => \"lattice\")" -- ~0.01

--- a/M2/Macaulay2/tests/normal/monoids.m2
+++ b/M2/Macaulay2/tests/normal/monoids.m2
@@ -135,6 +135,10 @@ assert(set first entries basis(degree D, S) === set L)
 -- FIXME should be homogeneous
 isHomogeneous sum({1,1,1,1}, L, times)
 
+-- test truncate
+needsPackage "Truncations"
+assert(set(truncate({0,3}, S))_* === set(monomials(X_0+2*X_1) | monomials(2*X_0+X_1) | monomials(3*X_0)))
+
 --- test passing a map of ZZ-modules for Degrees
 M = monoid[a,b,c, Degrees => A]
 assert(degreeGroup M == G)

--- a/M2/Macaulay2/tests/normal/schenck-book-2.m2
+++ b/M2/Macaulay2/tests/normal/schenck-book-2.m2
@@ -5,7 +5,7 @@ assert( (rays C) === map((ZZ)^3,(ZZ)^4,{{1, 0, 1, 0}, {0, 1, 0, 1}, {0, 0, 1, 1}
 assert( (fVector C) === {1,4,4,1} );
 Cv = dualCone C
 assert( (rays Cv) === map((ZZ)^3,(ZZ)^4,{{1, 0, 0, 1}, {0, 1, 0, 1}, {0, 0, 1, -1}}) );
-assert( (hilbertBasis C) === {map((ZZ)^3,(ZZ)^1,{{1}, {0}, {0}}),map((ZZ)^3,(ZZ)^1,{{0}, {1}, {0}}),map((ZZ)^3,(ZZ)^1,{{0}, {1}, {1}}),map((ZZ)^3,(ZZ)^1,{{1}, {0}, {1}})} );
+assert( (set hilbertBasis C) === new Set from {map((ZZ)^3,(ZZ)^1,{{1}, {0}, {0}}),map((ZZ)^3,(ZZ)^1,{{0}, {1}, {0}}),map((ZZ)^3,(ZZ)^1,{{0}, {1}, {1}}),map((ZZ)^3,(ZZ)^1,{{1}, {0}, {1}})} );
 C1 = posHull transpose matrix {{0,-1,0},{0,0,1},{ -1,0,0}};
 assert( (rays C1) === map((ZZ)^3,(ZZ)^3,{{-1, 0, 0}, {0, -1, 0}, {0, 0, 1}}) );
 assert( (linealitySpace C1) === map((ZZ)^3,(ZZ)^0,0) );
@@ -115,7 +115,7 @@ rays C
 fVector C
 Cv = dualCone C
 rays Cv
-hilbertBasis C
+set hilbertBasis C
 C1 = posHull transpose matrix {{0,-1,0},{0,0,1},{ -1,0,0}};
 rays C1
 linealitySpace C1

--- a/M2/cmake/FindNauty.cmake
+++ b/M2/cmake/FindNauty.cmake
@@ -1,0 +1,94 @@
+# Try to find the Nauty executable and library
+# See https://pallini.di.uniroma1.it
+#
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(Nauty 2.8.0)
+# to require version 2.8.0 to newer of NAUTY.
+#
+# Once done this will define
+#
+#  NAUTY_FOUND		- the Nauty library has correct version
+#  NAUTY_EXECUTABLE	- the Nauty executable
+#  NAUTY_INCLUDE_DIR	- the Nauty include directory
+#  NAUTY_LIBRARIES	- the Nauty library
+#  NAUTY_VERSION	- the Nauty version
+
+# Copyright (c) 2024, Mahrud Sayrafi, <mahrud@umn.edu>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+
+# Set Nauty_FIND_VERSION to 1.0.0 if no minimum version is specified
+if(NOT Nauty_FIND_VERSION)
+  if(NOT Nauty_FIND_VERSION_MAJOR)
+    set(Nauty_FIND_VERSION_MAJOR 1)
+  endif()
+  if(NOT Nauty_FIND_VERSION_MINOR)
+    set(Nauty_FIND_VERSION_MINOR 0)
+  endif()
+  if(NOT Nauty_FIND_VERSION_PATCH)
+    set(Nauty_FIND_VERSION_PATCH 0)
+  endif()
+
+  set(Nauty_FIND_VERSION "${Nauty_FIND_VERSION_MAJOR}.${Nauty_FIND_VERSION_MINOR}.${Nauty_FIND_VERSION_PATCH}")
+endif()
+
+macro(_NAUTY_check_version)
+  # Query NAUTY_VERSION
+  file(READ "${NAUTY_INCLUDE_DIR}/nauty/nauty.h" _NAUTY_H)
+
+  string(REGEX MATCH "define[ \t]+NAUTYVERSION[ \t]+\"([0-9]+)\.([0-9]+)\.([0-9]+)"
+    _NAUTY_version_match "${_NAUTY_H}")
+  set(NAUTY_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  set(NAUTY_MINOR_VERSION "${CMAKE_MATCH_2}")
+  set(NAUTY_PATCH_VERSION "${CMAKE_MATCH_3}")
+
+  set(NAUTY_VERSION
+    ${NAUTY_MAJOR_VERSION}.${NAUTY_MINOR_VERSION}.${NAUTY_PATCH_VERSION})
+
+  # Check whether found version exceeds minimum required
+  if(${NAUTY_VERSION} VERSION_LESS ${Nauty_FIND_VERSION})
+    set(NAUTY_VERSION_OK FALSE)
+    message(STATUS "Nauty version ${NAUTY_VERSION} found in ${NAUTY_INCLUDE_DIR}, "
+                   "but at least version ${Nauty_FIND_VERSION} is required")
+  else()
+    set(NAUTY_VERSION_OK TRUE)
+  endif()
+endmacro(_NAUTY_check_version)
+
+if(NOT NAUTY_FOUND)
+  set(NAUTY_INCLUDE_DIR NOTFOUND)
+  set(NAUTY_LIBRARIES NOTFOUND)
+
+  # search first if an NautyConfig.cmake is available in the system,
+  # if successful this would set NAUTY_INCLUDE_DIR and the rest of
+  # the script will work as usual
+  find_package(Nauty ${Nauty_FIND_VERSION} NO_MODULE QUIET)
+
+  # find the Nauty executable
+  find_program(NAUTY_EXECUTABLE NAMES dreadnaut nauty-dreadnaut)
+
+  if(NOT NAUTY_INCLUDE_DIR)
+    find_path(NAUTY_INCLUDE_DIR NAMES nauty/nauty.h
+      HINTS ENV NAUTYDIR
+      PATHS ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/include
+      PATH_SUFFIXES nauty
+      )
+  endif()
+
+  if(NAUTY_INCLUDE_DIR)
+    _NAUTY_check_version()
+  endif()
+
+  if(NOT NAUTY_LIBRARIES)
+    find_library(NAUTY_LIBRARIES NAMES nauty
+      HINTS ENV NAUTYDIR
+      PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
+      )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Nauty DEFAULT_MSG NAUTY_EXECUTABLE NAUTY_INCLUDE_DIR NAUTY_LIBRARIES NAUTY_VERSION_OK)
+
+  mark_as_advanced(NAUTY_EXECUTABLE NAUTY_INCLUDE_DIR NAUTY_LIBRARIES)
+
+endif()

--- a/M2/cmake/FindNauty.cmake
+++ b/M2/cmake/FindNauty.cmake
@@ -36,11 +36,15 @@ macro(_NAUTY_check_version)
   # Query NAUTY_VERSION
   file(READ "${NAUTY_INCLUDE_DIR}/nauty/nauty.h" _NAUTY_H)
 
-  string(REGEX MATCH "define[ \t]+NAUTYVERSION[ \t]+\"([0-9]+)\.([0-9]+)\.([0-9]+)"
+  string(REGEX MATCH "define[ \t]+NAUTYVERSION[ \t]+\"([0-9]+)\.([0-9]+)\.?([0-9]+)?"
     _NAUTY_version_match "${_NAUTY_H}")
   set(NAUTY_MAJOR_VERSION "${CMAKE_MATCH_1}")
   set(NAUTY_MINOR_VERSION "${CMAKE_MATCH_2}")
   set(NAUTY_PATCH_VERSION "${CMAKE_MATCH_3}")
+
+  if(NOT NAUTY_PATCH_VERSION)
+    set(NAUTY_PATCH_VERSION 0)
+  endif()
 
   set(NAUTY_VERSION
     ${NAUTY_MAJOR_VERSION}.${NAUTY_MINOR_VERSION}.${NAUTY_PATCH_VERSION})

--- a/M2/cmake/FindNormaliz.cmake
+++ b/M2/cmake/FindNormaliz.cmake
@@ -1,0 +1,98 @@
+# Try to find the Normaliz executable and library
+# See https://www.normaliz.uni-osnabrueck.de/
+#
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(Normaliz 3.9.1)
+# to require version 3.9.1 to newer of NORMALIZ.
+#
+# Once done this will define
+#
+#  NORMALIZ_FOUND	- the Normaliz library has correct version
+#  NORMALIZ_EXECUTABLE	- the Normaliz executable
+#  NORMALIZ_INCLUDE_DIR	- the Normaliz include directory
+#  NORMALIZ_LIBRARIES	- the Normaliz library
+#  NORMALIZ_VERSION	- the Normaliz version
+
+# Copyright (c) 2021, Mahrud Sayrafi, <mahrud@umn.edu>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+
+# Set Normaliz_FIND_VERSION to 1.0.0 if no minimum version is specified
+if(NOT Normaliz_FIND_VERSION)
+  if(NOT Normaliz_FIND_VERSION_MAJOR)
+    set(Normaliz_FIND_VERSION_MAJOR 1)
+  endif()
+  if(NOT Normaliz_FIND_VERSION_MINOR)
+    set(Normaliz_FIND_VERSION_MINOR 0)
+  endif()
+  if(NOT Normaliz_FIND_VERSION_PATCH)
+    set(Normaliz_FIND_VERSION_PATCH 0)
+  endif()
+
+  set(Normaliz_FIND_VERSION "${Normaliz_FIND_VERSION_MAJOR}.${Normaliz_FIND_VERSION_MINOR}.${Normaliz_FIND_VERSION_PATCH}")
+endif()
+
+macro(_NORMALIZ_check_version)
+  # Query NORMALIZ_VERSION
+  file(READ "${NORMALIZ_INCLUDE_DIR}/libnormaliz/version.h" _NORMALIZ_version_header)
+
+  string(REGEX MATCH "define[ \t]+NMZ_VERSION_MAJOR[ \t]+([0-9]+)"
+    _NORMALIZ_major_version_match "${_NORMALIZ_version_header}")
+  set(NORMALIZ_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+NMZ_VERSION_MINOR[ \t]+([0-9]+)"
+    _NORMALIZ_minor_version_match "${_NORMALIZ_version_header}")
+  set(NORMALIZ_MINOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+NMZ_VERSION_PATCH[ \t]+([0-9]+)"
+    _NORMALIZ_patch_version_match "${_NORMALIZ_version_header}")
+  set(NORMALIZ_PATCH_VERSION "${CMAKE_MATCH_1}")
+
+  set(NORMALIZ_VERSION
+    ${NORMALIZ_MAJOR_VERSION}.${NORMALIZ_MINOR_VERSION}.${NORMALIZ_PATCH_VERSION})
+
+  # Check whether found version exceeds minimum required
+  if(${NORMALIZ_VERSION} VERSION_LESS ${Normaliz_FIND_VERSION})
+    set(NORMALIZ_VERSION_OK FALSE)
+    message(STATUS "Normaliz version ${NORMALIZ_VERSION} found in ${NORMALIZ_INCLUDE_DIR}, "
+                   "but at least version ${Normaliz_FIND_VERSION} is required")
+  else()
+    set(NORMALIZ_VERSION_OK TRUE)
+  endif()
+endmacro(_NORMALIZ_check_version)
+
+if(NOT NORMALIZ_FOUND)
+  set(NORMALIZ_INCLUDE_DIR NOTFOUND)
+  set(NORMALIZ_LIBRARIES NOTFOUND)
+
+  # search first if an NormalizConfig.cmake is available in the system,
+  # if successful this would set NORMALIZ_INCLUDE_DIR and the rest of
+  # the script will work as usual
+  find_package(Normaliz ${Normaliz_FIND_VERSION} NO_MODULE QUIET)
+
+  # find the Normaliz executable
+  find_program(NORMALIZ_EXECUTABLE NAMES normaliz)
+
+  if(NOT NORMALIZ_INCLUDE_DIR)
+    find_path(NORMALIZ_INCLUDE_DIR NAMES libnormaliz/version.h
+      HINTS ENV NORMALIZDIR
+      PATHS ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/include
+      PATH_SUFFIXES normaliz
+      )
+  endif()
+
+  if(NORMALIZ_INCLUDE_DIR)
+    _NORMALIZ_check_version()
+  endif()
+
+  if(NOT NORMALIZ_LIBRARIES)
+    find_library(NORMALIZ_LIBRARIES NAMES normaliz
+      HINTS ENV NORMALIZDIR
+      PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
+      )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Normaliz DEFAULT_MSG NORMALIZ_EXECUTABLE NORMALIZ_INCLUDE_DIR NORMALIZ_LIBRARIES NORMALIZ_VERSION_OK)
+
+  mark_as_advanced(NORMALIZ_EXECUTABLE NORMALIZ_INCLUDE_DIR NORMALIZ_LIBRARIES)
+
+endif()

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -960,7 +960,7 @@ ExternalProject_Add(build-nauty
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
-_ADD_COMPONENT_DEPENDENCY(programs nauty "" NAUTY)
+_ADD_COMPONENT_DEPENDENCY(libraries nauty "" NAUTY_FOUND)
 
 
 # https://www.normaliz.uni-osnabrueck.de/

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -964,7 +964,7 @@ _ADD_COMPONENT_DEPENDENCY(libraries nauty "" NAUTY_FOUND)
 
 
 # https://www.normaliz.uni-osnabrueck.de/
-# normaliz needs libgmp, libgmpxx, boost and is used by the package Normaliz
+# normaliz needs libgmp, libgmpxx, boost, and openmp, and is used by the package Normaliz
 ExternalProject_Add(build-normaliz
   URL               https://github.com/Normaliz/Normaliz/releases/download/v3.10.2/normaliz-3.10.2.tar.gz
   URL_HASH          SHA256=0f649a8eae5535c18df15e8d35fc055fd0d7dbcbdd451e8876f4a47061481f07
@@ -977,6 +977,8 @@ ExternalProject_Add(build-normaliz
                       #-C --cache-file=${CONFIGURE_CACHE}
                       --disable-shared # TODO: for polymake --enable-shared
                       --without-flint # ${FLINT_ROOT}
+		      --without-nauty
+		      --without-cocoalib
                       "CPPFLAGS=${CPPFLAGS} -I${GMP_INCLUDE_DIRS}"
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}
@@ -990,16 +992,15 @@ ExternalProject_Add(build-normaliz
                       "OPENMP_CXXFLAGS=${OpenMP_CXX_FLAGS} ${OpenMP_CXX_LDLIBS}"
             COMMAND patch --fuzz=10 --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/normaliz/patch-libtool
   BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS}
-  INSTALL_COMMAND   ${CMAKE_STRIP} source/normaliz # TODO: for polymake ${MAKE} -j${PARALLEL_JOBS} install-strip
+  INSTALL_COMMAND   ${MAKE} -j${PARALLEL_JOBS} install
           COMMAND   ${CMAKE_COMMAND} -E make_directory ${M2_INSTALL_LICENSESDIR}/normaliz
           COMMAND   ${CMAKE_COMMAND} -E copy_if_different COPYING ${M2_INSTALL_LICENSESDIR}/normaliz
-          COMMAND   ${CMAKE_COMMAND} -E copy_if_different source/normaliz ${M2_INSTALL_PROGRAMSDIR}/
   TEST_COMMAND      ${MAKE} -j${PARALLEL_JOBS} check
   EXCLUDE_FROM_ALL  ON
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
-_ADD_COMPONENT_DEPENDENCY(programs normaliz "gmp;nauty" NORMALIZ)
+_ADD_COMPONENT_DEPENDENCY(libraries normaliz "gmp;nauty" NORMALIZ_FOUND)
 
 
 # https://www.wm.uni-bayreuth.de/de/team/rambau_joerg/TOPCOM/

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -10,7 +10,7 @@
 # Others, like TBB::tbb, FFI::ffi, and Boost::regex, are linked as imported libraries in those files.
 # TODO: turn all these libraries into imported libraries and find incompatibilities another way.
 set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
-set(LIBRARIES_LIST MPSOLVE FROBBY FACTORY FLINT NTL MPFI MPFR GMP BDWGC LAPACK)
+set(LIBRARIES_LIST MPSOLVE FROBBY NAUTY FACTORY FLINT NTL MPFI MPFR GMP BDWGC LAPACK)
 set(LIBRARY_LIST   READLINE HISTORY GDBM)
 
 message(CHECK_START " Checking for existing libraries and programs")
@@ -116,6 +116,7 @@ find_package(GMP	6.0.0 REQUIRED)
 #   ntl		Victor Shoup's Number Theory Library	(needs gmp, mpfr)
 #   flint	Fast Library for Number Theory		(needs gmp, mpfr, ntl)
 #   factory	Multivariate Polynomal Package		(needs gmp, mpfr, ntl, flint)
+#   Nauty	automorphism groups of graphs
 #   frobby	Computations With Monomial Ideals	(needs gmp)
 #   cddlib	Double Description Method of Motzkin	(needs gmp)
 #   msolve	Multivariate polynomial system solver	(needs gmp, mpfr, flint)
@@ -133,6 +134,7 @@ find_package(NTL       10.5.0)
 find_package(Flint	2.6.0)
 find_package(Factory	4.2.0)
 find_package(MPSolve	3.2.0)
+find_package(Nauty	2.7.0)
 # TODO: add minimum version checks
 find_package(MSolve	0.4.0)
 find_package(Frobby	0.9.0)
@@ -198,7 +200,6 @@ find_program(LRSLIB	NAMES	lrs)
 # TODO: check for alternatives as well: sdpa or mosek
 find_program(CSDP	NAMES	csdp)
 find_program(NORMALIZ	NAMES	normaliz)
-find_program(NAUTY	NAMES	dreadnaut nauty-dreadnaut)
 find_program(TOPCOM	NAMES	checkregularity topcom-checkregularity)
 # NOTE: we don't build the following by default, but some packages use them, so
 # we provide targets build-polymake, build-bertini, build-phcpack for building them.
@@ -208,7 +209,7 @@ find_program(PHCPACK	NAMES	phc)
 find_program(HOM4PS2	NAMES	hom4ps2) # TODO: http://www.math.nsysu.edu.tw/~leetsung/works/HOM4PS_soft.htm
 # TODO: Maple and package convex
 
-set(PROGRAM_OPTIONS 4ti2 cohomCalg Gfan lrslib CSDP Nauty Normaliz TOPCOM)
+set(PROGRAM_OPTIONS 4ti2 cohomCalg Gfan lrslib CSDP NAUTY_EXECUTABLE Normaliz TOPCOM)
 
 ###############################################################################
 ## List installed components and unset those that we wish to build ourselves

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -10,7 +10,7 @@
 # Others, like TBB::tbb, FFI::ffi, and Boost::regex, are linked as imported libraries in those files.
 # TODO: turn all these libraries into imported libraries and find incompatibilities another way.
 set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
-set(LIBRARIES_LIST MPSOLVE FROBBY NAUTY FACTORY FLINT NTL MPFI MPFR GMP BDWGC LAPACK)
+set(LIBRARIES_LIST MPSOLVE FROBBY NORMALIZ NAUTY FACTORY FLINT NTL MPFI MPFR GMP BDWGC LAPACK)
 set(LIBRARY_LIST   READLINE HISTORY GDBM)
 
 message(CHECK_START " Checking for existing libraries and programs")
@@ -117,6 +117,7 @@ find_package(GMP	6.0.0 REQUIRED)
 #   flint	Fast Library for Number Theory		(needs gmp, mpfr, ntl)
 #   factory	Multivariate Polynomal Package		(needs gmp, mpfr, ntl, flint)
 #   Nauty	automorphism groups of graphs
+#   Normaliz	Discrete convex geometry		(needs gmp, nauty, OpenMB)
 #   frobby	Computations With Monomial Ideals	(needs gmp)
 #   cddlib	Double Description Method of Motzkin	(needs gmp)
 #   msolve	Multivariate polynomial system solver	(needs gmp, mpfr, flint)
@@ -135,6 +136,7 @@ find_package(Flint	2.6.0)
 find_package(Factory	4.2.0)
 find_package(MPSolve	3.2.0)
 find_package(Nauty	2.7.0)
+find_package(Normaliz	3.8.0)
 # TODO: add minimum version checks
 find_package(MSolve	0.4.0)
 find_package(Frobby	0.9.0)
@@ -199,7 +201,6 @@ find_program(GFAN	NAMES	gfan)
 find_program(LRSLIB	NAMES	lrs)
 # TODO: check for alternatives as well: sdpa or mosek
 find_program(CSDP	NAMES	csdp)
-find_program(NORMALIZ	NAMES	normaliz)
 find_program(TOPCOM	NAMES	checkregularity topcom-checkregularity)
 # NOTE: we don't build the following by default, but some packages use them, so
 # we provide targets build-polymake, build-bertini, build-phcpack for building them.
@@ -209,7 +210,7 @@ find_program(PHCPACK	NAMES	phc)
 find_program(HOM4PS2	NAMES	hom4ps2) # TODO: http://www.math.nsysu.edu.tw/~leetsung/works/HOM4PS_soft.htm
 # TODO: Maple and package convex
 
-set(PROGRAM_OPTIONS 4ti2 cohomCalg Gfan lrslib CSDP NAUTY_EXECUTABLE Normaliz TOPCOM)
+set(PROGRAM_OPTIONS 4ti2 cohomCalg Gfan lrslib CSDP NAUTY_EXECUTABLE NORMALIZ_EXECUTABLE TOPCOM)
 
 ###############################################################################
 ## List installed components and unset those that we wish to build ourselves

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -640,10 +640,10 @@ AC_SUBST(BUILTLIBS)
 #    (Programs linked by this configure script are linked with the options in LIBS.  This allows libraries
 #    dependent on previously detected libraries to be detected by tests that involve linking.
 
-AC_SUBST(LIBLIST, " gc gdbm gmp mpfr mpfi readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest memtailor mathic mathicgb ")
+AC_SUBST(LIBLIST, " gc gdbm gmp mpfr mpfi normaliz readline ntl flint factory lapack mpsolve frobby glpk cddlib fplll givaro fflas_ffpack linbox gtest memtailor mathic mathicgb ")
 # The list LIBLIST is the list of libraries that might be used and linked into M2.
 
-AC_SUBST(PROGLIST, "4ti2 gfan normaliz csdp nauty cddplus lrslib gftables topcom cohomcalg")
+AC_SUBST(PROGLIST, "4ti2 gfan csdp nauty cddplus lrslib gftables topcom cohomcalg")
 # The list PROGLIST is the list of programs and libraries for them that are distributed with M2.
 #     Initially, we offer no option for not compiling some of them.
 
@@ -991,17 +991,33 @@ else AC_MSG_RESULT([no, will build])
      BUILD_csdp=yes
 fi
 
-AC_MSG_CHECKING(whether the package normaliz is installed)
-if command -v normaliz
-then normaliz_version=`normaliz --version | head -1 | cut -d " " -f 2`
-     AX_COMPARE_VERSION([$normaliz_version], [ge], [2.11],
-          [AC_MSG_RESULT([yes])
-           FILE_PREREQS="$FILE_PREREQS `command -v normaliz`"],
-          [AC_MSG_RESULT([yes, but < 2.11, will build])
-           BUILD_normaliz=yes])
-else AC_MSG_RESULT([no, will build])
-     BUILD_normaliz=yes
-fi
+AS_IF([test $BUILD_normaliz = no],
+    [AC_MSG_CHECKING(whether the package normaliz is installed)
+     AS_IF([command -v normaliz > /dev/null],
+	 [normaliz_version=`normaliz --version | head -1 | cut -d " " -f 2`
+	  AX_COMPARE_VERSION([$normaliz_version], [ge], [2.11],
+	      [AC_MSG_RESULT([yes])
+	       AC_MSG_CHECKING([for libnormaliz])
+	       AC_LANG(C++)
+	       SAVELIBS=$LIBS
+	       LIBS="$LIBS -lnormaliz -lnauty -lgmp"
+	       AC_LINK_IFELSE(
+		   [AC_LANG_PROGRAM([
+		       #include <libnormaliz/libnormaliz.h>
+		       ],
+		       [libnormaliz::Cone<long long>()])],
+		   [AC_MSG_RESULT([yes])
+		    FILE_PREREQS="$FILE_PREREQS `command -v normaliz`"],
+		   [AC_MSG_RESULT([no, will build])
+		    BUILD_normaliz=yes
+		    LIBS=$SAVELIBS])],
+	      [AC_MSG_RESULT([yes, but < 2.11, will build])
+	       BUILD_normaliz=yes])],
+        [AC_MSG_RESULT([no, will build])
+         BUILD_normaliz=yes])])
+
+AS_IF([test $BUILD_normaliz = yes],
+    [BUILTLIBS="-lnormaliz -fopenmp $BUILTLIBS"])
 
 if test "$BUILD_nauty" = no
 then dnl debian/fedora: nauty-

--- a/M2/libraries/normaliz/Makefile.in
+++ b/M2/libraries/normaliz/Makefile.in
@@ -1,6 +1,6 @@
 HOMEPAGE = https://www.normaliz.uni-osnabrueck.de/
 # get releases from https://github.com/Normaliz/Normaliz/releases
-VERSION = 3.10.2
+VERSION = 3.10.3
 #PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 
 URL = https://github.com/Normaliz/Normaliz/releases/download/v$(VERSION)
@@ -26,7 +26,7 @@ endif
 NORMFLAGS = 
 ####
 
-CXXFLAGS1 = $(CPPFLAGS) -Wall -O3 -Wno-unknown-pragmas -std=c++11 -I .. -I . $(CXXFLAGS0)
+CXXFLAGS1 = $(CPPFLAGS) -Wall -O3 -Wno-unknown-pragmas -I .. -I . $(CXXFLAGS0)
 BUILDOPTIONS =  CXX="$(CXX)" \
 		NORMFLAGS="$(NORMFLAGS)" \
 		CXXFLAGS="$(CXXFLAGS1)" \


### PR DESCRIPTION
- **added support for torsion class group for truncate**
- **renamed truncate option Nef to Cone**
- **fixed caching in truncationMonomials**
- **simplified hilbertBasis Cone in Polyhedra**
- **modified isVeryAmple ToricDivisor to use hilbertBasis Cone**
- **modified latticePoints ToricDivisor to use latticePoints Cone**
- **added Nauty as a library in CMake**
- **added Normaliz as a library in CMake**
- **updated installation documents and docker scripts**
- **added rawHilbertBasis using libnormaliz**
- **modified truncate, hilbertBasis Cone to use rawHilbertBasis**
- **moved hilbertBasis to Polyhedra**
- **fixed broken tests due to new order of hilbertBasis**
- **fixed a dependency in ReactionNetworks**
- **fixed a dependency in a GroebnerStrata example**
- **added rawFourierMotzkin, calling libnormaliz**
- **changed findHeft to use rawFourierMotzkin**
- **brushed up Normaliz, in preparation for overhaul**
- **moved isSmooth to Core**
- **moved isVeryAmple to Core**
- **fixed a conflict over isReflexive**
- **removed pesky printout**
- **added libnauty2-dev and libnormaliz-dev to github builds**
- **fixed broken examples in FourierMotzkin**
- **fixed symbol conflicts in Normaliz examples**
- **fixed bug in heft of degree zero rings**
- **fixed symbol conflicts in MonodromySolver examples**
- **wip: fix configure.ac for libnormaliz**

@d-torrance the last commit needs work for getting autotools to find and link with Normaliz. Could you help with this?
