### PR TITLE
Stop using PPA for Ubuntu GitHub builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -80,7 +80,6 @@ jobs:
       - name: Install requirements for Linux
         if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository -y -n ppa:macaulay2/macaulay2
           sudo apt-get update
           sudo apt-get install -y -q --no-install-recommends clang-15 gfortran libtool-bin ninja-build yasm ccache
           sudo apt-get install -y -q --no-install-recommends libboost-stacktrace-dev \


### PR DESCRIPTION
This was only necessary when we were using Ubuntu 20.04 and not all of the dependencies were in the official archives.  This is no longer an issue in 22.04 and beyond.