### PR TITLE
Update givaro submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/Macaulay2/fflas-ffpack.git
 [submodule "M2/submodules/givaro"]
 	path = M2/submodules/givaro
-	url = https://github.com/Macaulay2/givaro.git
+	url = https://github.com/linbox-team/givaro
 [submodule "M2/submodules/googletest"]
 	path = M2/submodules/googletest
 	url = https://github.com/google/googletest.git

--- a/M2/libraries/givaro/Makefile.in
+++ b/M2/libraries/givaro/Makefile.in
@@ -8,7 +8,7 @@ VLIMIT = 900000
 MLIMIT = 900000
 
 VERSION = 4.2.0
-PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 # the patch modifies test/Makefile.am, so we must remake test/Makefile.in
 PRECONFIGURE = autoreconf -vif
 


### PR DESCRIPTION
The master branch of the upstream repository includes a fix for building on GCC 14.  It also includes a GCC 13 fix that we were applying as a patch in the autotools build, so we drop it.

I think this should fix #3323.  I tested in on Debian unstable using GCC 14.