### PR TITLE
Compile d directory using C++17 (autotools)

### DIFF
--- a/M2/Macaulay2/d/Makefile.in
+++ b/M2/Macaulay2/d/Makefile.in
@@ -184,7 +184,7 @@ CFLAGS   += -Wunused-function
 CXXFLAGS += -Wunused-function
 
 CFLAGS   += -Wfatal-errors
-CXXFLAGS += -Wfatal-errors
+CXXFLAGS += -Wfatal-errors -std=gnu++17
 
 version.o : CPPFLAGS += -I@srcdir@/../e/memtailor -I@srcdir@/../e/mathic -I@srcdir@/../e/mathicgb
 version.o : CXXFLAGS += -Wno-unused-local-typedefs


### PR DESCRIPTION
We already do this in the `e` directory.  This silences the following compiler warnings:

```
CXX engine-tmp.cc
In file included from ../../../../Macaulay2/d/../e/ExponentList.hpp:9,
                 from ../../../../Macaulay2/d/../e/monomial.hpp:8,
                 from ../../../../Macaulay2/d/engine.dd:96:
../../../../Macaulay2/d/../e/ExponentVector.hpp: In static member function ‘static void ExponentVector<Exponent, overflow_check>::mult(int, ConstExponents, ConstExponents, Exponents)’:
../../../../Macaulay2/d/../e/ExponentVector.hpp:70:8: warning: ‘if constexpr’ only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
   70 |     if constexpr (OC)
      |        ^~~~~~~~~
../../../../Macaulay2/d/../e/ExponentVector.hpp: In static member function ‘static void ExponentVector<Exponent, overflow_check>::power(int, ConstExponents, Exponent, Exponents)’:
../../../../Macaulay2/d/../e/ExponentVector.hpp:82:8: warning: ‘if constexpr’ only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
   82 |     if constexpr (OC)
      |        ^~~~~~~~~
../../../../Macaulay2/d/../e/ExponentVector.hpp: In static member function ‘static void ExponentVector<Exponent, overflow_check>::multpower(int, ConstExponents, ConstExponents, Exponent, Exponents)’:
../../../../Macaulay2/d/../e/ExponentVector.hpp:95:8: warning: ‘if constexpr’ only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
   95 |     if constexpr (OC)
      |        ^~~~~~~~~
../../../../Macaulay2/d/../e/ExponentVector.hpp: In static member function ‘static void ExponentVector<Exponent, overflow_check>::divide(int, ConstExponents, ConstExponents, Exponents)’:
../../../../Macaulay2/d/../e/ExponentVector.hpp:117:8: warning: ‘if constexpr’ only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
  117 |     if constexpr (OC)
      |        ^~~~~~~~~
../../../../Macaulay2/d/../e/ExponentVector.hpp: In static member function ‘static void ExponentVector<Exponent, overflow_check>::quotient(int, ConstExponents, ConstExponents, Exponents)’:
../../../../Macaulay2/d/../e/ExponentVector.hpp:129:8: warning: ‘if constexpr’ only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
  129 |     if constexpr (OC)
      |        ^~~~~~~~~
../../../../Macaulay2/d/../e/ExponentVector.hpp: In static member function ‘static ExponentVector<Exponent, overflow_check>::Exponent ExponentVector<Exponent, overflow_check>::simple_degree(int, ConstExponents)’:
../../../../Macaulay2/d/../e/ExponentVector.hpp:190:8: warning: ‘if constexpr’ only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
  190 |     if constexpr (OC)
      |        ^~~~~~~~~
../../../../Macaulay2/d/../e/ExponentList.hpp: In static member function ‘static const ExponentList<Exponent, legacy_length>::Exponent ExponentList<Exponent, legacy_length>::length(ConstExponents)’:
../../../../Macaulay2/d/../e/ExponentList.hpp:73:8: warning: ‘if constexpr’ only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
   73 |     if constexpr (L)
      |        ^~~~~~~~~
../../../../Macaulay2/d/../e/ExponentList.hpp: In static member function ‘static const ExponentList<Exponent, legacy_length>::Exponent ExponentList<Exponent, legacy_length>::npairs(ConstExponents)’:
../../../../Macaulay2/d/../e/ExponentList.hpp:80:8: warning: ‘if constexpr’ only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
   80 |     if constexpr (L)
      |        ^~~~~~~~~
```