### PR TITLE
Use flexible array members instead of struct hack

### DIFF
--- a/M2/Macaulay2/c/cprint.c
+++ b/M2/Macaulay2/c/cprint.c
@@ -296,7 +296,7 @@ static void cprintarraydef(node t){
      if (length(m) == 1) put("int len;");
      cprint(typ);
      put(" array[");
-     if (len!=NULL) cprint(len); else put("1");
+     if (len!=NULL) cprint(len);
      put("];};\n");
      }
 
@@ -379,8 +379,6 @@ static void cprintsomesizeof(node t, node arraylen){
 	       put(" + (");
 	       cprint(arraylen);
 	       put(")*sizeof(");
-	       cprint(typ);
-	       put(")-sizeof(");
 	       cprint(typ);
 	       put(")");
 	       }

--- a/M2/Macaulay2/d/M2mem.h
+++ b/M2/Macaulay2/d/M2mem.h
@@ -41,7 +41,7 @@ void *I_WRAP_SONAME_FNNAME_ZU(libgcZdsoZd1,GC_realloc)(void*, size_t);
 
 
 
-#define sizeofarray(s,len) (sizeof(*(s)) - sizeof((s)->array) + (len)*sizeof((s)->array[0]))
+#define sizeofarray(s,len) (sizeof(*(s)) + (len)*sizeof((s)->array[0]))
 #define sizeofarraytype(S,len) sizeofarray((S)0,len)
 #define sizeofstruct(s) sizeof(*(s))
 #define sizeofstructtype(S) sizeofstruct((S)0)

--- a/M2/Macaulay2/e/unit-tests/M2mem-replacement.h
+++ b/M2/Macaulay2/e/unit-tests/M2mem-replacement.h
@@ -19,7 +19,7 @@ extern char *getmoremem(char *, size_t oldsize, size_t newsize);
 extern char *getmoremem1(char *, size_t newsize);
 extern char *getmoremem_atomic(char *, size_t oldsize, size_t newsize);
 
-#define sizeofarray(s,len) (sizeof(*(s)) - sizeof((s)->array) + (len)*sizeof((s)->array[0]))
+#define sizeofarray(s,len) (sizeof(*(s)) + (len)*sizeof((s)->array[0]))
 #define sizeofarraytype(S,len) sizeofarray((S)0,len)
 #define sizeofstruct(s) sizeof(*(s))
 #define sizeofstructtype(S) sizeofstruct((S)0)


### PR DESCRIPTION
This fixes the compiler warnings we were getting when trying to allocate empty arrays, e.g.:

```
CC M2-tmp.c
../../../../Macaulay2/d/M2.d: In function ‘M2__prepare’:
../../../../Macaulay2/d/M2.d:142:9: warning: array subscript ‘struct M2_ArrayString_struct[0]’ is partly outside array bounds of ‘unsigned char[8]’ [-Warray-bounds]
  142 | export argc := 0;
      |         ^~
In file included from ../../../../Macaulay2/d/../../include/M2/gc-include.h:44,
                 from ../../../../Macaulay2/d/../c/scc-core.h:6,
                 from M2-tmp.c:2:
../../../../Macaulay2/d/M2.d:142:29: note: referencing an object of size 8 allocated by ‘GC_malloc’
  142 | export argc := 0;
      |                             ^        
../../../../Macaulay2/d/M2.d:142:9: warning: array subscript ‘struct M2_ArrayString_struct[0]’ is partly outside array bounds of ‘unsigned char[8]’ [-Warray-bounds]
  142 | export argc := 0;
      |         ^~
In file included from ../../../../Macaulay2/d/../../include/M2/gc-include.h:44,
                 from ../../../../Macaulay2/d/../c/scc-core.h:6,
                 from M2-tmp.c:2:
../../../../Macaulay2/d/M2.d:142:29: note: referencing an object of size 8 allocated by ‘GC_malloc’
  142 | export argc := 0;
      |                             ^        
../../../../Macaulay2/d/M2.d:142:9: warning: array subscript ‘struct M2_ArrayString_struct[0]’ is partly outside array bounds of ‘unsigned char[8]’ [-Warray-bounds]
  142 | export argc := 0;
      |         ^~
In file included from ../../../../Macaulay2/d/../../include/M2/gc-include.h:44,
                 from ../../../../Macaulay2/d/../c/scc-core.h:6,
                 from M2-tmp.c:2:
../../../../Macaulay2/d/M2.d:142:29: note: referencing an object of size 8 allocated by ‘GC_malloc’
  142 | export argc := 0;
      |                             ^
```

The problem was that previously arrays were defined using the "struct hack":
```c
struct M2_string_struct {int len;signed char array[1];};
```

We then allocated enough memory for the struct (which includes the pointer to the first element of the array) and `len - 1` more elements of the array.  But when `len` was 0, this was negative.

We can avoid this by using [flexible array members](https://en.wikipedia.org/wiki/Flexible_array_member), which were introduced in C99.  In particular, now arrays are defined like this:
```c
struct M2_string_struct {int len;signed char array[];};
```
We now allocate enough memory for the struct and all `len` members of the array, with no problems when `len` is 0.

Closes: #2274