### PR TITLE
Document Binary and Prefix separately from operatorAttributes

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
@@ -52,7 +52,7 @@ document {
      }
 
 document {
-     Key => {"operatorAttributes", Flexible, Binary, Prefix, Postfix},
+     Key => {"operatorAttributes", Flexible, Postfix},
      Headline => "a hashtable with information about Macaulay2 operators",
      Usage => "operatorAttributes",
      Outputs => {{ "an experimental hash table that give information about ", TO "operators", " in the Macaulay2 language" }},


### PR DESCRIPTION
They also exist as names of optional arguments to `method` and `findProgram`, respectively, but this wasn't evident in the html documentation.

