### PR TITLE
Allow empty lists as arguments to binary methods

### DIFF
--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -58,6 +58,7 @@ abs ZZ := abs RR := abs RRi := abs CC := abs QQ := abs0
 abs Constant := abs @@ numeric
 
 lcm = method(Binary => true)
+installMethod(lcm, () -> 1)
 lcm(ZZ,ZZ) := (f,g) -> (
     d := gcd(f, g);
     if d == 0 then 0

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -90,7 +90,7 @@ BinaryNoOptions := outputs -> (
     methodFunction List     :=
     methodFunction Sequence := args -> (
 	-- Common code for every associative method without options
-	if #args == 0 then return binaryCaller(methodFunction, 1 : methodFunction, args, outputs);
+	if #args == 0 then return binaryCaller(methodFunction, 1 : methodFunction, (), outputs);
 	if #args == 1 and (f := lookup(methodFunction, dispatchBy args#0)) =!= null then return f(args#0);
 	-- TODO: a rudimentary caching of the lookup call here would be a significant benefit
 	binaryLookup := (x, y) -> binaryCaller(methodFunction, (methodFunction, dispatchBy x, dispatchBy y), (x, y), outputs);
@@ -108,7 +108,7 @@ BinaryWithOptions := (opts, outputs) -> (
 	-- Common code for every associative method with options
 	-- this is essentially a method installed on (methodFunction, VisibleList)
 	if not instance(args, VisibleList) then args = 1:args;
-	if #args == 0 then return binaryCaller'(methodFunction, 1 : methodFunction, args, outputs, dispatcher(o, args));
+	if #args == 0 then return binaryCaller'(methodFunction, 1 : methodFunction, (), outputs, dispatcher(o, ()));
 	if #args == 1 and (f := lookup(methodFunction, dispatchBy args#0)) =!= null then return (dispatcher(o, args#0)) f;
 	-- Note: specializations for simultaneous computation may be implemented
 	-- by installing method functions on types that inherit from VisibleList

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -26,7 +26,7 @@ noMethodSingle = (M, args, outputs) -> toString stack     (  noMethErr M, printA
 noMethod       = (M, args, outputs) -> toString stack join( {noMethErr M},
     if class args === Sequence and 0 < #args and #args <= 4 then apply(#args,
 	i -> printArgs(toString (i+1), args#i, if outputs#?i then outputs#i else false))
-    else {   printArgs(" ",            args,   false) }) -- TODO: do better here, in what way?
+    else {   printArgs(" ",            args,   args === ()) }) -- TODO: do better here, in what way?
 
 -- TODO: what is this for exactly?
 badClass := meth -> (i, args) -> (

--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -84,6 +84,7 @@ new Set from List := Set => (X,x) -> set x -- compiled function
 elements Set := List => x -> keys x
 
 -- set operations
+installMethod(union, () -> set {})
 union(Set, Set) := Set + Set := Set => (x,y) -> merge(x,y,(i,j)->i)
 
 -- Set ++ Set := Set => (x,y) -> applyKeys(x,i->(0,i)) + applyKeys(y,j->(1,j))

--- a/M2/Macaulay2/tests/normal/gcd.m2
+++ b/M2/Macaulay2/tests/normal/gcd.m2
@@ -2,10 +2,12 @@ assert( gcd(2*3*5,2*3*7,2*5*7) == 2 )
 assert( gcd(2*3*5,2*3*7,2*5*7,3*5*7) == 1 )
 assert( gcd(1000:2) == 2 )
 assert( gcd splice(1000:2,3) == 1 )
+assert( gcd {} == 0 )
 assert( lcm(2,3,5,7) == 210 )
 assert( lcm(1000:2) == 2 )
 assert( lcm(0, 0) == 0 )
 assert( lcm(0/1, 0/1) == 0 )
+assert( lcm {} == 1 )
 
 R = ZZ/32003[x,y]
 f = (x+y)^3*(x-y^2)

--- a/M2/Macaulay2/tests/normal/set.m2
+++ b/M2/Macaulay2/tests/normal/set.m2
@@ -1,0 +1,3 @@
+-- TODO: add more set-related tests here
+
+assert(union {} == set {})


### PR DESCRIPTION
Currently, binary methods (like `gcd`) accept inputs using sequences or lists:

```m2
i1 : gcd(6, 9, 15)

o1 = 3

i2 : gcd {6, 9, 15}

o2 = 3
```
However, if a 0-argument method is installed, only sequences work:

```m2
i3 : gcd()

o3 = 0

i4 : gcd {}
stdio:4:1:(3): error: expected 0 arguments but got 1
```
This is because it passes along the argument of `{}` (a single argument -- a list) to a function expecting 0 arguments.  By swapping this argument out with `()`, it works:

```m2
i1 : gcd {}

o1 = 0
```

We also add a couple related changes:

* A 0-argument method for `lcm`:

  ```m2
  i2 : lcm {}

  o2 = 1
  ```
* Previously, "no method" errors when the input is empty seem to imply that we were calling the corresponding method for `Sequence` objects:
  ```m2
  i1 : intersect()
  stdio:1:1:(3): error: no method found for applying intersect to:
       argument   :  () (of class Sequence)
  ```
  But `intersect(Sequence)` *does* exist!  And it's not what we were calling.  So now, we get:
  ```m2
  i1 : intersect()
  stdio:1:1:(3): error: no method found for applying intersect to:
       argument   :  ()
  ```



