### PR TITLE
Add generic documentation nodes for Flexible and Postfix symbols

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/options.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/options.m2
@@ -16,7 +16,7 @@ optionalNames := select(unique \\ flatten \\ keys \ opts, s -> instance(s, Symbo
     not isUndocumented(d := makeDocumentTag s) and (isMissingDoc d or headline d === "an optional argument"))
 
 optionalValues := unique(flatten \\ values \ opts
-    | { Prune, Binomial, Test, Center, Right, Left } -- for manually added Symbols
+    | { Prune, Binomial, Test, Center, Right, Left, Flexible, Postfix } -- for manually added Symbols
     | last \ last \ hooks methods()) -- e.g. catch Iterate from [(saturate, Ideal, Ideal), Strategy -> Iterate]
 
 optionalValues = select(optionalValues, s -> instance(s, Symbol) and isGlobalSymbol toString s and

--- a/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/repl.m2
@@ -52,7 +52,7 @@ document {
      }
 
 document {
-     Key => {"operatorAttributes", Flexible, Postfix},
+     Key => {"operatorAttributes"},
      Headline => "a hashtable with information about Macaulay2 operators",
      Usage => "operatorAttributes",
      Outputs => {{ "an experimental hash table that give information about ", TO "operators", " in the Macaulay2 language" }},


### PR DESCRIPTION
This is a quick followup to #3327 implementing @mahrud's suggestion from https://github.com/Macaulay2/M2/pull/3327#issuecomment-2187937581.