### PR TITLE
Fix baseFilename w/ empty string or string containing only /'s

### DIFF
--- a/M2/Macaulay2/m2/files.m2
+++ b/M2/Macaulay2/m2/files.m2
@@ -58,9 +58,10 @@ moveFile String := opts -> src -> if fileExists src or readlink src =!= null the
 	  return bak))
 
 baseFilename = fn -> (
-     fn = separate("/",fn);
-     while #fn > 0 and fn#-1 === "" do fn = drop(fn,-1);
-     last fn)
+    m := regex("([^/]+)/*$", fn);
+    if m =!= null then substring(m#1, fn)
+    else if #fn > 0 then "/"
+    else fn)
 
 findFiles = method(Options => new OptionTable from { Exclude => {}, FollowLinks => false })
 findFiles String := opts -> name -> (

--- a/M2/Macaulay2/tests/normal/files.m2
+++ b/M2/Macaulay2/tests/normal/files.m2
@@ -7,3 +7,12 @@ if fileExists homeDirectory then (
     assert(changeDirectory() == homeDirectory);
     assert(currentDirectory() == homeDirectory))
 removeDirectory dir
+
+assert(baseFilename "/foo/bar/baz" == "baz")
+assert(baseFilename "/foo/bar/baz/" == "baz")
+assert(baseFilename "foo" == "foo")
+assert(baseFilename "foo/" == "foo")
+assert(baseFilename "foo////" == "foo")
+assert(baseFilename "" == "")
+assert(baseFilename "/" == "/")
+assert(baseFilename "////" == "/")

--- a/bugs/dan/0.5-findFiles
+++ b/bugs/dan/0.5-findFiles
@@ -1,3 +1,0 @@
-
-i10 : findFiles "/"
-stdio:10:1:(1):[0]: error: array index -1 out of bounds 0 .. -1


### PR DESCRIPTION
Previously, we got an index error since we were calling `last` on a list returned by `separate`, which was empty in these cases.

We match the behavior of the `basename` command line utility for these cases.  The [POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/basename.html) says that "" and "//" are implementation defined, so we match the Linux version in these cases ("" and "/", respectively).  As per the POSIX standard, a string containing only slashes results in "/".

This fixes an old `findFiles` bug, so we remove the corresponding file in the `bugs` directory.