### PR TITLE
Check for overflow when entering RR precision w/ "p" syntax

### DIFF
--- a/M2/Macaulay2/d/convertr.d
+++ b/M2/Macaulay2/d/convertr.d
@@ -158,7 +158,13 @@ export convert(e:ParseTree):Code := (
 	  var := token.entry;
 	  wrd := token.word;
 	  if wrd.typecode == TCRR
-	  then Code(realCode(parseRR(wrd.name),position(token)))
+	  then (
+	       x:= parseRR(wrd.name);
+	       when x
+	       is y:RR do Code(realCode(y, position(token)))
+	       is null do Code(Error(position(token),
+		       "expected precision to be a small non-negative integer",
+		       nullE,false,dummyFrame)))
 	  else if wrd.typecode == TCint
 	  then Code(integerCode(parseInt(wrd.name),position(token)))
  	  else if wrd.typecode == TCstring

--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -2,8 +2,9 @@
 use tokens;
 use lex;
 
-export parseRR(s:string):RR := (			    -- 4.33234234234p345e-9
+export parseRR(s:string):RRorNull := (			    -- 4.33234234234p345e-9
      prec := defaultPrecision;
+     overflow := false;
      ss := new string len length(s) + 1 do (		    -- we add 1 to get at least one null character at the end
      	  inPrec := false;
 	  foreach c in s do (
@@ -13,7 +14,11 @@ export parseRR(s:string):RR := (			    -- 4.33234234234p345e-9
 		    )
 	       else if inPrec then (
 		    if isdigit(c) then (
-			 prec = 10 * prec + (c - '0');
+			 if !overflow then (
+			     newprec := 10 * prec + (c - '0');
+			     if newprec < prec
+			     then overflow = true
+			     else prec = newprec)
 			 )
 		    else (
 			 inPrec = false;
@@ -25,7 +30,8 @@ export parseRR(s:string):RR := (			    -- 4.33234234234p345e-9
 		    ));
 	  while true do provide char(0);
 	  );
-     toRR(ss,prec));
+      if overflow then RRorNull(null())
+      else RRorNull(toRR(ss, prec)));
 parseError := false;
 parseMessage := "";
 utf8(w:varstring,i:int):varstring := (


### PR DESCRIPTION
The integer given after the "p" should fit inside an unsigned long.

New behavior:

```m2
i2 : 2p18446744073709551616
stdio:2:1:(3): error: expected precision to be a small non-negative integer
```

Closes: #3333