### PR TITLE
Check for a few more programs in autotools builds

### DIFF
--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -130,7 +130,7 @@ $(EXEFILE): $(M2_OBJECTS) $(M2_LIBDEPS) | @pre_bindir@
 	@ $(WHY)
 	@ echo "compiling timestamp.cpp"
 	$(COMPILE.cc) @srcdir@/timestamp.cpp -o timestamp.o
-	time @CXX@ $(M2_LDFLAGS) timestamp.o $(M2_OBJECTS) $(M2_LIBRARIES) -o "$@".tmp
+	@CXX@ $(M2_LDFLAGS) timestamp.o $(M2_OBJECTS) $(M2_LIBRARIES) -o "$@".tmp
 ifneq ("$(EXECSTACK)","no")
 	@ if [ -x /usr/bin/execstack ] ;\
 	  then if (set -x ; execstack -q "$@".tmp; execstack -c "$@".tmp ) ; \

--- a/M2/Macaulay2/html-check-links/Makefile.in
+++ b/M2/Macaulay2/html-check-links/Makefile.in
@@ -8,7 +8,7 @@ YACC = @YACC@
 %.fixed.c : %.tab.c
 	sed 's="bison.simple"="/usr/share/bison.simple"=' <$< >$@.tmp
 	mv $@.tmp $@
-LEX = flex
+LEX = @LEX@
 LFLAGS += -f -s -i -8 -v
 CFLAGS += -Wall -g
 HSRC := buffer.h html-check-links.h getmem.h grammar.h

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -91,7 +91,7 @@ unmark-$1: ; rm -rf  @pre_libm2dir@/$1/.installed
 	ls -l $1-temporary
 	rm -rf $1-temporary
 	if [ -e @pre_infodir@/$1.info ]; then \
-		install-info --info-dir=@pre_infodir@ @pre_infodir@/$1.info; fi
+		@INSTALL_INFO@ --info-dir=@pre_infodir@ @pre_infodir@/$1.info; fi
 	@ [ "${IgnoreExampleErrors}" = true -o -f $$@ ] || (echo error: file $$@ not made by installPackage >&2; false)
 check-info::@pre_infodir@/$1.info.errors
 @pre_infodir@/$1.info.errors: @pre_infodir@/$1.info

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -268,9 +268,7 @@ AC_PROG_CXX()			# set CXXFLAGS before this
 AC_SUBST(GXX)			# gets set to yes or no by AC_PROG_CXX
 
 AC_PROG_YACC()
-if test "$YACC" = byacc
-then AC_MSG_ERROR([byacc found, but leads to a crash in scc1: install bison instead])
-fi
+AS_IF([test "$YACC" != "bison -y"], [AC_MSG_ERROR([bison is required])])
 
 AC_PROG_RANLIB()
 AC_PROG_INSTALL()

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -270,6 +270,12 @@ AC_SUBST(GXX)			# gets set to yes or no by AC_PROG_CXX
 AC_PROG_YACC()
 AS_IF([test "$YACC" != "bison -y"], [AC_MSG_ERROR([bison is required])])
 
+dnl TODO: once autoconf 2.70 is available everyowhere, use the following:
+dnl AC_PROG_LEX([noyywrap])
+dnl the pre-2.70 version w/o arguments is deprecated and gives a warning
+AC_PROG_LEX()
+AS_IF([test "$LEX" != "flex"], [AC_MSG_ERROR([flex is required])])
+
 AC_PROG_RANLIB()
 AC_PROG_INSTALL()
 AC_PROG_AWK()

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -174,6 +174,8 @@ AC_CHECK_PROGS(PATCH,patch,false)
 AS_IF([test $PATCH = false], AC_MSG_ERROR([patch is required]))
 AC_CHECK_PROGS(WHICH,which,false) dnl used by 4ti2
 AS_IF([test $WHICH = false], AC_MSG_ERROR([which is required]))
+AC_CHECK_PROGS(CMP,cmp,false)
+AS_IF([test $CMP = false], AC_MSG_ERROR([cmp is required]))
 
 AC_CHECK_TOOL(AR,ar,false)
 AC_CHECK_TOOL(AS,as,false)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -225,7 +225,12 @@ elif test "$DOCUMENTATION" = yes
 then DOCUMENTATION="html info"
 else for DOCTYPE in $DOCUMENTATION
     do case $DOCTYPE in
-            html|info|pdf)
+            html|pdf)
+                ;;
+            info)
+                AC_CHECK_PROGS([INSTALL_INFO], [install-info], [false])
+                AS_IF([test $INSTALL_INFO = false],
+                    AC_MSG_ERROR([install-info is required]))
                 ;;
             *)
                 AC_MSG_ERROR([unknown documentation type ($DOCTYPE); expected html, info, or pdf])

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -170,6 +170,8 @@ AC_CHECK_PROGS(OBJDUMP,objdump,false)
 AC_CHECK_PROGS(OBJCOPY,objcopy,false)
 AC_CHECK_PROGS(LDD,ldd,false)
 AC_CHECK_PROGS(GIT,git,false)
+AC_CHECK_PROGS(PATCH,patch,false)
+AS_IF([test $PATCH = false], AC_MSG_ERROR([patch is required]))
 
 AC_CHECK_TOOL(AR,ar,false)
 AC_CHECK_TOOL(AS,as,false)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -172,6 +172,8 @@ AC_CHECK_PROGS(LDD,ldd,false)
 AC_CHECK_PROGS(GIT,git,false)
 AC_CHECK_PROGS(PATCH,patch,false)
 AS_IF([test $PATCH = false], AC_MSG_ERROR([patch is required]))
+AC_CHECK_PROGS(WHICH,which,false) dnl used by 4ti2
+AS_IF([test $WHICH = false], AC_MSG_ERROR([which is required]))
 
 AC_CHECK_TOOL(AR,ar,false)
 AC_CHECK_TOOL(AS,as,false)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1110,7 +1110,16 @@ dnl factory needs to know:
 AC_SUBST(BUILD_ntl)
 
 AC_LANG(C++)
-AC_CHECK_HEADER(frobby.h,LIBS="-lfrobby $LIBS",BUILD_frobby=yes)
+AC_CHECK_HEADER([frobby.h],
+    [LIBS="-lfrobby $LIBS"],
+    dnl check /usr/include/frobby (e.g., on Fedora)
+    [SAVECPPFLAGS="$CPPFLAGS"
+     CPPFLAGS="$CPPFLAGS -I/usr/include/frobby"
+     AS_UNSET([ac_cv_header_frobby_h])
+     AC_CHECK_HEADER([frobby.h],
+         [LIBS="-lfrobby $LIBS"],
+         [CPPFLAGS="$SAVECPPFLAGS"
+          BUILD_frobby=yes])])
 if test $BUILD_frobby = yes
 then BUILTLIBS="-lfrobby $BUILTLIBS"
     dnl uncomment this to [1] when frobby is built from a submodule (?)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1122,8 +1122,7 @@ AC_CHECK_HEADER([frobby.h],
           BUILD_frobby=yes])])
 if test $BUILD_frobby = yes
 then BUILTLIBS="-lfrobby $BUILTLIBS"
-    dnl uncomment this to [1] when frobby is built from a submodule (?)
-    dnl AC_DEFINE([HAVE_FROBBY_VERSION], [0], [whether frobby has frobby_version])
+    AC_DEFINE([HAVE_FROBBY_VERSION], [1], [whether frobby has frobby_version])
 else
     AC_MSG_CHECKING([whether frobby has frobby_version])
     AC_COMPILE_IFELSE(

--- a/M2/include/config.Makefile.in
+++ b/M2/include/config.Makefile.in
@@ -160,27 +160,27 @@ ifeq "$(NORULES)" ""
 
 .SUFFIXES : .sig.tmp .sig .dep .d .dd -exports.h.tmp -exports.h -tmp.c -tmp.cc
 
-%.sig: ;	test -e $*.sig && cmp -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
-%-exports.h: ;	test -e $*-exports.h && cmp -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
+%.sig: ;	test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
+%-exports.h: ;	test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
 
 %.sig.tmp %.dep: %.d
 	$(SHOW)SCC1 -dep $*.d
 	$(HIDE)$(SCC1) -dep $(SCCFLAGS) $<
 	mv $*.dep.tmp $*.dep
-	test -e $*.sig && cmp -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
+	test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
 %.sig.tmp %.dep: %.dd
 	$(SHOW)SCC1 -dep $*.dd
 	$(HIDE)$(SCC1) -dep $(SCCFLAGS) $<
 	mv $*.dep.tmp $*.dep
-	test -e $*.sig && cmp -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
+	test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
 %-tmp.c	 %-exports.h.tmp: %.d
 	$(SHOW)SCC1 $*.d
 	$(HIDE)$(SCC1) $(SCCFLAGS) $<
-	test -e $*-exports.h && cmp -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
+	test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
 %-tmp.cc %-exports.h.tmp: %.dd
 	$(SHOW)SCC1 $*.dd
 	$(HIDE)$(SCC1) $(SCCFLAGS) $<
-	test -e $*-exports.h && cmp -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
+	test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
 %.o: %-tmp.c  %-exports.h
 	$(SHOW)CC $*-tmp.c
 	$(HIDE)$(COMPILE.c) $(DCFLAGS) $< $(OUTPUT_OPTION)

--- a/M2/libraries/Makefile.library.in
+++ b/M2/libraries/Makefile.library.in
@@ -191,7 +191,7 @@ endif
 	$(WHY)
 	@ set -x ; ( $(CDBUILDDIR) && $(CONFIGURECMD) ) && touch $@
 
-PATCHCMD = cd $(UNTARDIR) && for i in $(PATCHFILE) ; do patch --batch -p0 < $$i ; done
+PATCHCMD = cd $(UNTARDIR) && for i in $(PATCHFILE) ; do @PATCH@ --batch -p0 < $$i ; done
 .patched-$(VERSION) : $(PATCHFILE)
 	$(WHY)
 	if [ -d $(UNTARDIR) -a -d $(OLDUNTARDIR)/$(UNTARDIR) ] ; \

--- a/M2/libraries/Makefile.library.in
+++ b/M2/libraries/Makefile.library.in
@@ -93,7 +93,8 @@ endif
 BUILDDIR      ?= $(UNTARDIR)/$(TARDIR)
 TAROPTIONS    ?= --gzip
 ifeq ($(SUBMODULE),true)
-UNTARCMD      ?= rsync -a @abs_top_srcdir@/submodules/$(LIBNAME)/* $(TARDIR)
+UNTARCMD      ?= $(MKDIR_P) $(TARDIR) && \
+		  cp -r @abs_top_srcdir@/submodules/$(LIBNAME)/* $(TARDIR)
 else
 UNTARCMD      ?= @TAR@ xf $(TARFILE_DIR)/$(TARFILE) $(TAROPTIONS)
 endif


### PR DESCRIPTION
There are a number of programs (`time`, `patch`, `bison`, and `install-info`) that are required to build Macaulay2 using the autotools build, but we don't tell the user this when running `configure`.  This leads to surprises later on.  A few of these were mentioned in #3207.

We add checks for each of these.