### PR TITLE
Format better "about" output

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -192,6 +192,7 @@ makeDocumentTag String      := opts -> key -> (
     then error ("mismatching packages ", pkg, " and ", toString opts#Package, " specified for key ", key);
     if pkg === null then pkg = opts#Package;
     (makeDocumentTag' new OptionTable from {Package => pkg}) key)
+makeDocumentTag TOH := opts -> first
 
 -- before creating links, we recreate the document tag as a hack to
 -- correct its package, if it is incorrect (e.g. truncate, quotient)

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -564,7 +564,7 @@ about Symbol   :=
 about Function := o -> f -> about("\\b" | toString f | "\\b", o)
 about String   := o -> re -> lastabout = (
     packagesSeen := new MutableHashTable;
-    NumberedVerticalList sort join(
+    NumberedVerticalList apply(sort join(
         flatten for pkg in loadedPackages list (
             pkgname := pkg#"pkgname";
             if packagesSeen#?pkgname then continue else packagesSeen#pkgname = 1;
@@ -574,7 +574,7 @@ about String   := o -> re -> lastabout = (
                     matchfun_re if o.Body then pkg#rawKeyDB),
                 select(keys pkg#"raw documentation",
                     matchfun_re if o.Body then pkg#"raw documentation"));
-            apply(keyList, key -> TOH {pkgname | "::" | key})),
+            apply(keyList, key -> (pkgname,key))),
         flatten for pkg in getPackageInfoList() list (
             pkgname := pkg#"name";
             if packagesSeen#?pkgname then continue else packagesSeen#pkgname = 1;
@@ -583,7 +583,10 @@ about String   := o -> re -> lastabout = (
             db := if o.Body then openDatabase dbname;
             keyList := select(dbkeys, matchfun_re db);
             if o.Body then close db;
-            apply(keyList, key -> TOH {pkgname | "::" | key}))))
+            apply(keyList, key -> (pkgname,key)))
+	    ),(pkgname,key) -> SPAN { pkgname, " ", TOH {pkgname | "::" | key} }
+	)
+    )
 
 -- TODO: should this go to system?
 pager = x -> if height stdio > 0

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -574,7 +574,7 @@ about String   := o -> re -> lastabout = (
                     matchfun_re if o.Body then pkg#rawKeyDB),
                 select(keys pkg#"raw documentation",
                     matchfun_re if o.Body then pkg#"raw documentation"));
-            apply(keyList, key -> pkgname | "::" | key)),
+            apply(keyList, key -> TOH {pkgname | "::" | key})),
         flatten for pkg in getPackageInfoList() list (
             pkgname := pkg#"name";
             if packagesSeen#?pkgname then continue else packagesSeen#pkgname = 1;
@@ -583,7 +583,7 @@ about String   := o -> re -> lastabout = (
             db := if o.Body then openDatabase dbname;
             keyList := select(dbkeys, matchfun_re db);
             if o.Body then close db;
-            apply(keyList, key -> pkgname | "::" | key))))
+            apply(keyList, key -> TOH {pkgname | "::" | key}))))
 
 -- TODO: should this go to system?
 pager = x -> if height stdio > 0


### PR DESCRIPTION
This is an attempt to improve the output of `about`.
before:
```
i1 : about resolution

o1 = {0 => ChainComplexExtras::resolution(ChainComplex)             }
     {1 => Complexes::resolution(Complex)                           }
     {2 => EagonResolution::resolution(EagonData)                   }
     {3 => Macaulay2Doc::resolution                                 }
     {4 => Macaulay2Doc::resolution(...,DegreeLimit=>...)           }
     {5 => Macaulay2Doc::resolution(...,FastNonminimal=>...)        }
     {6 => Macaulay2Doc::resolution(...,HardDegreeLimit=>...)       }
     {7 => Macaulay2Doc::resolution(...,LengthLimit=>...)           }
     {8 => Macaulay2Doc::resolution(...,PairLimit=>...)             }
     {9 => Macaulay2Doc::resolution(...,SortStrategy=>...)          }
     {10 => Macaulay2Doc::resolution(...,StopBeforeComputation=>...)}
     {11 => Macaulay2Doc::resolution(...,Strategy=>...)             }
     {12 => Macaulay2Doc::resolution(...,SyzygyLimit=>...)          }
     {13 => Macaulay2Doc::resolution(Ideal)                         }
     {14 => Macaulay2Doc::resolution(Matrix)                        }
     {15 => Macaulay2Doc::resolution(Module)                        }
     {16 => NCAlgebra::resolution(NCMatrix)                         }

o1 : NumberedVerticalList
```
after:
```
i1 : about resolution
 -- warning: symbol "minimize" in Core.Dictionary is shadowed by a symbol in ChainComplexExtras.Dictionary
 --   use the synonym Core$minimize

o1 = {0 => "resolution" -- projective resolution                                                                                                     }
     {1 => "resolution(...,DegreeLimit=>...)" -- compute only up to this degree                                                                      }
     {2 => "resolution(...,FastNonminimal=>...)" -- compute a non-minimal graded free resolution                                                     }
     {3 => "resolution(...,HardDegreeLimit=>...)"                                                                                                    }
     {4 => "resolution(...,LengthLimit=>...)" -- stop when the resolution reaches this length                                                        }
     {5 => "resolution(...,PairLimit=>...)" -- stop when this number of pairs has been handled                                                       }
     {6 => "resolution(...,SortStrategy=>...)"                                                                                                       }
     {7 => "resolution(...,StopBeforeComputation=>...)" -- whether to stop the computation immediately                                               }
     {8 => "resolution(...,Strategy=>...)"                                                                                                           }
     {9 => "resolution(...,SyzygyLimit=>...)" -- stop when this number of syzygies is reached                                                        }
     {10 => "resolution(ChainComplex)" -- Resolves a ChainComplex.                                                                                   }
     {11 => "resolution(Complex)" -- minimal free resolution of a complex                                                                            }
     {12 => "resolution(EagonData)" -- outputs the resolution that is the 0th row of the Eagon double complex                                        }
     {13 => "resolution(Ideal)" -- compute a projective resolution of (the quotient ring corresponding to) an ideal                                  }
     {14 => "resolution(Matrix)" -- given a module map represented by a matrix, produce a comparison map between resolutions of its source and target}
     {15 => "resolution(Module)" -- compute a free resolution of a module                                                                            }
     {16 => "resolution(NCMatrix)" -- Compute the resolution of coker M as a map of free right modules                                               }

o1 : NumberedVerticalList
```
looks good, except we're getting this extra warning now. of course we would've gotten it anyway by invoking `help` so I think it's not a big deal?
