### PR TITLE
Use VERSION instead of INSTALL for AC_CONFIG_SRCDIR

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1,6 +1,6 @@
 AC_INIT([Macaulay2],[m4_esyscmd_s([cat VERSION])],[https://github.com/Macaulay2/M2/issues],[Macaulay2],[https://macaulay2.com/])
 AC_MSG_NOTICE([configuring Macaulay2 version $PACKAGE_VERSION])
-AC_CONFIG_SRCDIR(INSTALL)
+AC_CONFIG_SRCDIR([VERSION])
 AC_CONFIG_HEADERS(include/M2/config.h)
 AC_CONFIG_FILES(m4_include(config/files))
 AC_SUBST(CONFIGURED_FILES,"$ac_config_files")


### PR DESCRIPTION
INSTALL was removed in #3334, but the builds were skipped so we didn't notice this was an issue.