### PR TITLE
A couple autotools libnormaliz detection updates

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1018,7 +1018,7 @@ AS_IF([test $BUILD_normaliz = no],
 	       LIBS="$LIBS -lnormaliz -lnauty -lgmp"
 	       AC_LINK_IFELSE(
 		   [AC_LANG_PROGRAM([
-		       #include <libnormaliz/libnormaliz.h>
+		       #include <libnormaliz/cone.h>
 		       ],
 		       [libnormaliz::Cone<long long>()])],
 		   [AC_MSG_RESULT([yes])

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1016,6 +1016,18 @@ AS_IF([test $BUILD_normaliz = no],
 	       AC_LANG(C++)
 	       SAVELIBS=$LIBS
 	       LIBS="$LIBS -lnormaliz -lnauty -lgmp"
+	       dnl check if libnormaliz built w/ eantic
+	       AC_RUN_IFELSE(
+	           [AC_LANG_PROGRAM([
+		       #include <libnormaliz/nmz_config.h>
+		       ], [
+		       #ifdef ENFNORMALIZ
+		         return 0;
+		       #else
+		         return 1;
+		       #endif
+		       ])],
+		   [LIBS="$LIBS -leantic -leanticxx"])
 	       AC_LINK_IFELSE(
 		   [AC_LANG_PROGRAM([
 		       #include <libnormaliz/cone.h>

--- a/M2/libraries/normaliz/Makefile.in
+++ b/M2/libraries/normaliz/Makefile.in
@@ -7,7 +7,11 @@ URL = https://github.com/Normaliz/Normaliz/releases/download/v$(VERSION)
 FIXTARCMD = :
 
 PRECONFIGURE = autoreconf -vif
-CONFIGOPTIONS += --disable-shared
+CONFIGOPTIONS += --disable-shared \
+	--without-cocoalib        \
+	--without-flint           \
+	--without-nauty           \
+	--without-e-antic
 
 # Mac OS X gcc has -fopenmp, but gives an internal compiler error if we try it:
 # I have filed a bug report, Bug ID# 8338749:


### PR DESCRIPTION
This is a quick followup to #3313 to improve the detection of libnormaliz in the autotools build.

Two changes:

* Instead of including `libnormaliz.h`, we include `cone.h`, since the former doesn't include the latter on older systems (e.g., Ubuntu 18.04) and we get a compile error trying to construct a `Cone` object.
* Check whether libnormaliz was built with e-antic (by checking if `ENFNORMALIZ` was defined in `nmz_config.h`), and if so, add the appropriate linker flags.