### PR TITLE
Build GMP when building FLINT if GMP is too old (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -929,6 +929,12 @@ fi
 if test $BUILD_flint = yes
 then BUILTLIBS="-lflint $BUILTLIBS -lm"
      AC_DEFINE([HAVE_FLINT_NMOD_H])
+     AS_IF([test $BUILD_gmp = no],
+         [AC_SEARCH_LIBS([__gmpn_gcd_11], [gmp], [],
+             [AC_MSG_WARN([flint requires __gmp_gcd_11, so we will build gmp])
+              BUILD_gmp=yes
+              LIBS_GMP="-lgmpxx -lgmp"
+              BUILTLIBS="$LIBS_GMP $BUILTLIBS"])])
 fi
 
 dnl debian: 4ti2-


### PR DESCRIPTION
This is an issue on RHEL 8, where the GMP package has version 6.1.2, which does not include the `__gmpn_gcd_11` function, but it's required when building FLINT 3.  So if we find ourselves in the situation of needing to build FLINT when GMP already exists on the system, first check to see if this symbol exists, and if it doesn't, insist on also building GMP.