### PR TITLE
MatrixSchubert - Fixing isPatternAvoiding

### DIFF
--- a/M2/Macaulay2/packages/MatrixSchubert/MatrixSchubertTests.m2
+++ b/M2/Macaulay2/packages/MatrixSchubert/MatrixSchubertTests.m2
@@ -237,6 +237,9 @@ assert(isPatternAvoiding({1,4,6,2,3,7,5}, {1,4,3,2}));
 assert(not isPatternAvoiding({7,2,5,8,1,3,6,4}, {2,1,4,3}));
 assert(isPatternAvoiding({1,6,9,2,4,7,3,5,8}, {2,1,4,3}));
 
+assert(not isPatternAvoiding({3,1,2},{3,1,2}));
+assert(isPatternAvoiding({3,1,2},{2,3,1}));
+
 --isVexillary
 assert(not isVexillary({7,2,5,8,1,3,6,4}));
 assert(isVexillary({1,6,9,2,4,7,3,5,8}));

--- a/M2/Macaulay2/packages/MatrixSchubert/MatrixSchubertTests.m2
+++ b/M2/Macaulay2/packages/MatrixSchubert/MatrixSchubertTests.m2
@@ -238,6 +238,7 @@ assert(not isPatternAvoiding({7,2,5,8,1,3,6,4}, {2,1,4,3}));
 assert(isPatternAvoiding({1,6,9,2,4,7,3,5,8}, {2,1,4,3}));
 
 assert(not isPatternAvoiding({3,1,2},{3,1,2}));
+assert(not isPatternAvoiding({1,2,3,6,4,5}, {3,1,2}));
 assert(isPatternAvoiding({3,1,2},{2,3,1}));
 
 --isVexillary

--- a/M2/Macaulay2/packages/MatrixSchubert/permutationMethods.m2
+++ b/M2/Macaulay2/packages/MatrixSchubert/permutationMethods.m2
@@ -224,18 +224,14 @@ isPatternAvoiding (List,List) := Boolean => (perm, pattern) -> (
     --input validation
     if not (isPerm perm) then error(toString perm | " is not a permutation.");
     --assume permutation is pattern-avoiding, break if not true
-    isAvoiding := true;
     for idx in subsets(0..#perm-1, #pattern) do {
-        vals := perm_(sort idx);
+        vals := perm_(idx);
         sortedVals := sort(vals);
         relPositions := hashTable toList apply(0..#vals-1, i -> {sortedVals#i, i});
         p := toList apply(vals, i -> (relPositions#i) + 1); 
-        if p == pattern then {
-            isAvoiding = false;
-            break;
-        };
+        if p == pattern then return false;
     };
-    isAvoiding
+    true
 )
 
 --------------------------------

--- a/M2/Macaulay2/packages/MatrixSchubert/permutationMethods.m2
+++ b/M2/Macaulay2/packages/MatrixSchubert/permutationMethods.m2
@@ -226,10 +226,10 @@ isPatternAvoiding (List,List) := Boolean => (perm, pattern) -> (
     --assume permutation is pattern-avoiding, break if not true
     isAvoiding := true;
     for idx in subsets(0..#perm-1, #pattern) do {
-        vals = perm_(sort idx);
-        sortedVals = sort(vals);
-        relPositions = hashTable toList apply(0..#vals-1, i -> {sortedVals#i, i});
-        p = toList apply(vals, i -> (relPositions#i) + 1); 
+        vals := perm_(sort idx);
+        sortedVals := sort(vals);
+        relPositions := hashTable toList apply(0..#vals-1, i -> {sortedVals#i, i});
+        p := toList apply(vals, i -> (relPositions#i) + 1); 
         if p == pattern then {
             isAvoiding = false;
             break;

--- a/M2/Macaulay2/packages/MatrixSchubert/permutationMethods.m2
+++ b/M2/Macaulay2/packages/MatrixSchubert/permutationMethods.m2
@@ -226,10 +226,14 @@ isPatternAvoiding (List,List) := Boolean => (perm, pattern) -> (
     --assume permutation is pattern-avoiding, break if not true
     isAvoiding := true;
     for idx in subsets(0..#perm-1, #pattern) do {
-        sortedIdx := sort(idx);
-        pairwiseComparison := apply(pattern_{0..#pattern-2}, pattern_{1..#pattern-1}, (i,j) -> perm#(sortedIdx#(i-1)) < perm#(sortedIdx#(j-1))); -- pairwise comparison of permutation according to pattern
-        isAvoiding = not all(pairwiseComparison, i -> i == true); -- true if there was one inequality that failed, else all inequalities are true and so not pattern-avoiding
-        if not isAvoiding then break;
+        vals = perm_(sort idx);
+        sortedVals = sort(vals);
+        relPositions = hashTable toList apply(0..#vals-1, i -> {sortedVals#i, i});
+        p = toList apply(vals, i -> (relPositions#i) + 1); 
+        if p == pattern then {
+            isAvoiding = false;
+            break;
+        };
     };
     isAvoiding
 )

--- a/M2/Macaulay2/packages/MatrixSchubert/permutationMethodsDOC.m2
+++ b/M2/Macaulay2/packages/MatrixSchubert/permutationMethodsDOC.m2
@@ -268,13 +268,15 @@ doc ///
             For example, a permutation $w$ is $2143$-avoiding if there does not exist indices $i < j < k < l$
             such that $w_j < w_i < w_l < w_k$.
         Example
-            w = {7,2,5,8,1,3,6,4}
-            pattern2143 = {2,1,4,3}
+            w = {7,2,5,8,1,3,6,4};
+            pattern2143 = {2,1,4,3};
             isPatternAvoiding(w, pattern2143)
 
-            v = {2,3,7,1,5,8,4,6}
-            pattern1432 = {1,4,3,2}
+            v = {2,3,7,1,5,8,4,6};
+            pattern1432 = {1,4,3,2};
             isPatternAvoiding(v, pattern1432)
+
+            isPatternAvoiding({3,1,2},{3,1,2})
 ///
 
 


### PR DESCRIPTION
isPatternAvoiding was checking if the permutation avoided the inverse of the given pattern instead of the actual pattern (all of the tests patterns were involutions so this wasn't spotted). It now properly checks if a permutation avoids the right pattern.
This fixes #3291