### PR TITLE
 Add additional space to store 64-bit hash codes on 32-bit machines

### DIFF
--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -27,6 +27,9 @@ threadCounter := 0;
 threadLocal HashCounter := (
     threadCounter = threadCounter + 1;
     hash_t(1000000 + 3 + (threadCounter-1) * 10000 ));
+-- give 32-bit machines enough space to store a 64-bit hash code
+-- TODO: instead, allow 64-bit entries in the array of thread local variables
+threadLocal HashCounterExtraBits := 0;
 
 export nextHash():hash_t := (
      if HashCounter == Ccode(hash_t, "18446744073709551615ull") -- check for integer overflow

--- a/M2/Macaulay2/m2/basictests/hashcodes.m2
+++ b/M2/Macaulay2/m2/basictests/hashcodes.m2
@@ -22,7 +22,7 @@ assert( (hash true) === 444777 )
 assert( (hash false) === 777333 )
 
 -- these might change if our floating point implementation changes, but let's check anyway:
-assert( hash 1.23p200 === 18446744072207201388 -* big endian *- or hash 1.23p200 == -640232547 -* little endian *- )
+assert( hash 1.23p200 === 18446744072207201388 -* 64-bit *- or hash 1.23p200 == 18446744073069319069 -* 32-bit *- )
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/basictests hashcodes.okay"


### PR DESCRIPTION
This is a followup to #3335, checking off the final checkbox from the TODO list in https://github.com/Macaulay2/M2/pull/3335#issuecomment-2191677295.

On 32-bit machines, thread local variables are stored in arrays of 32-bit chunks of memory.  But now that we use 64-bit hash codes, we were getting the hash counter by concatenating two adjacent elements of the array, giving us unexpected results.

We add a new thread local variable to store these extra 32 bits, fixing this issue.  This will be unnecessary if we switch to an atomic hash counter (see #3358).

Now that we can actually see what the expected result should be, we also update the hash code test for `RR` objects for 32-bit machines.