### PR TITLE
Add toExternalString(MutableMatrix)

### DIFF
--- a/M2/Macaulay2/m2/enginering.m2
+++ b/M2/Macaulay2/m2/enginering.m2
@@ -237,10 +237,12 @@ reduce := (r,s) -> (
 	  );
      (a,b))
 
+-- printing
 expression EngineRing := R -> if hasAttribute(R,ReverseDictionary) then expression getAttribute(R,ReverseDictionary) else expression toString R.RawRing -- should never be used
-texMath EngineRing := R -> texMath expression R
+
 toString EngineRing := toString @@ expression
-net EngineRing := net @@ expression
+net      EngineRing :=      net @@ expression
+texMath  EngineRing :=  texMath @@ expression
 
 ZZ _ EngineRing := 
 RR _ EngineRing :=
@@ -279,7 +281,6 @@ coefficientRing FractionField := F -> coefficientRing last F.baseRings
 	    dim FractionField := F -> 0
      expression FractionField := F -> if hasAttribute(F,ReverseDictionary) then expression getAttribute(F,ReverseDictionary) else (expression frac) (expression last F.baseRings)
      describe FractionField := F -> Describe (expression frac) (describe last F.baseRings)
-     toExternalString FractionField := F -> toString describe F
 
 -- freduce := (f) -> (numerator f)/(denominator f)
 

--- a/M2/Macaulay2/m2/galois.m2
+++ b/M2/Macaulay2/m2/galois.m2
@@ -7,9 +7,6 @@ needs "polyrings.m2"
 GaloisField = new Type of EngineRing
 GaloisField.synonym = "Galois field"
 
-toExternalString GaloisField := k -> toString describe k
-toString GaloisField := toString @@ expression
-net GaloisField := net @@ expression
 expression GaloisField := F -> if hasAttribute(F,ReverseDictionary) then expression getAttribute(F,ReverseDictionary) else (expression GF) (expression F.order)
 describe GaloisField := F -> Describe (expression GF) (expression F.order)
 

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -16,6 +16,7 @@ precision MutableMatrix := precision @@ ring
 expression MutableMatrix := m -> MatrixExpression append(applyTable(entries m, expression), symbol MutableMatrix => true)
 texMath MutableMatrix := m -> texMath expression m
 net MutableMatrix := m -> net expression m
+toExternalString MutableMatrix := lookup(toExternalString, MutableHashTable)
 
 map(Ring,RawMutableMatrix) := opts -> (R,m) -> (
      new MutableMatrix from {

--- a/M2/Macaulay2/m2/nets.m2
+++ b/M2/Macaulay2/m2/nets.m2
@@ -69,14 +69,13 @@ toExternalString Net := x -> if height x + depth x == 0 then
      concatenate("(horizontalJoin())", "^", toString height x) else
      concatenate(format toString x, "^", toString(height x - 1))
 
-toExternalString MutableHashTable := s -> (
-     if hasAttribute(s,ReverseDictionary) then return toString getAttribute(s,ReverseDictionary);
-     error "anonymous mutable hash table cannot be converted to external string";
-     )
-toExternalString Type := s -> (
-     if hasAttribute(s,ReverseDictionary) then return toString getAttribute(s,ReverseDictionary);
-     error "anonymous type cannot be converted to external string";
-     )
+toExternalString MutableHashTable :=
+toExternalString MutableList      := s -> (
+    if hasAttribute(s,ReverseDictionary)
+    then toString getAttribute(s,ReverseDictionary)
+    else error("anonymous ", synonym class s,
+	" cannot be converted to external string"))
+
 toExternalString HashTable := s -> (
      concatenate (
 	  "new ", toExternalString class s,
@@ -86,10 +85,6 @@ toExternalString HashTable := s -> (
 	  then demark(", ", apply(pairs s, (k,v) -> toExternalString k | " => " | toExternalString v) )
 	  else "",
 	  "}"))
-toExternalString MutableList := s -> (
-     error "anonymous mutable list cannot be converted to external string";
-     -- concatenate("new ",toExternalString class s, " from {...", toString(#s), "...}" )
-     )
 mid := s -> (
      if #s === 1 then toExternalString s#0
      else between(",",apply(toSequence s,x -> if x === null then "" else toExternalString x))

--- a/M2/Macaulay2/m2/polyrings.m2
+++ b/M2/Macaulay2/m2/polyrings.m2
@@ -64,8 +64,6 @@ expression PolynomialRing := R -> (
     if hasAttribute(R, ReverseDictionary)
     then expression getAttribute(R, ReverseDictionary)
     else(expression last R.baseRings) expressionPolynomialRing R)
-
-toExternalString PolynomialRing := toString @@ describe
 -- the rest are inherited from EngineRing
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -55,7 +55,6 @@ expression QuotientRing := S -> (
     if hasAttribute(S, ReverseDictionary)
     then expression getAttribute(S, ReverseDictionary)
     else new Divide from { unhold expression ambient S, unhold expression printRels S })
-toExternalString QuotientRing := toString @@ describe
 -- TODO: add AfterPrint for QuotientRing
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/rings.m2
+++ b/M2/Macaulay2/m2/rings.m2
@@ -79,6 +79,13 @@ isHomogeneous Ring := R -> (
      degreeLength R == 0 
      )
 
+-- printing
+-- technically this should not be allowed, since rings are mutable
+-- and therefore "R === value toExternalString R" will always be false,
+-- however, this is good enough to serialize a ring for another session.
+toExternalString Ring := toString @@ describe
+-- the rest of the printing methods will inherit from methods on Type
+
 -----------------------------------------------------------------------------
 -- promote, lift, liftable, and isConstant
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/packages/LocalRings/doc.m2
+++ b/M2/Macaulay2/packages/LocalRings/doc.m2
@@ -373,7 +373,7 @@ importFrom_Core { "headline" }
 scan({ baseRing, char, coefficientRing, degreeLength, degrees, dim, frac, generators, isCommutative, numgens },
     m -> document { Key => (m, LocalRing), Headline => headline makeDocumentTag (m, Ring), PARA {"See ", TO (m, Ring)} })
 
-undocumented apply({describe, expression, precision, presentation, toExternalString}, m -> (m, LocalRing))
+undocumented apply({describe, expression, precision, presentation}, m -> (m, LocalRing))
 
 end--
 

--- a/M2/Macaulay2/packages/LocalRings/localring.m2
+++ b/M2/Macaulay2/packages/LocalRings/localring.m2
@@ -22,6 +22,7 @@
 ---------------------------------------------------------------------------
 
 importFrom_Core {
+    "unhold",
     "getAttribute", "hasAttribute", "ReverseDictionary", "indexStrings", "indexSymbols",
     "generatorExpressions", "generatorSymbols", "commonEngineRingInitializations",
     "rawFraction", "rawNumerator", "rawDenominator", "rawIsLocalUnit", "rawLocalRing" }
@@ -36,8 +37,7 @@ LocalRing#{Standard,AfterPrint} = RP -> (
 
 localRing = method(TypicalValue => LocalRing)
        describe LocalRing := RP -> Describe (expression localRing) (expression last RP.baseRings, expression RP.maxIdeal)
-     expression LocalRing := RP -> if hasAttribute(RP, ReverseDictionary) then expression getAttribute(RP, ReverseDictionary) else describe RP
-toExternalString LocalRing:= RP -> toString describe RP
+     expression LocalRing := RP -> if hasAttribute(RP, ReverseDictionary) then expression getAttribute(RP, ReverseDictionary) else new FunctionApplication from unhold describe RP
 coefficientRing LocalRing := RP -> coefficientRing ring RP.maxIdeal
   isWellDefined LocalRing := RP -> isPrime RP.maxIdeal
   isCommutative LocalRing := RP -> isCommutative ring RP.maxIdeal -- FIXME make sure this is correct

--- a/M2/Macaulay2/packages/SchurRings.m2
+++ b/M2/Macaulay2/packages/SchurRings.m2
@@ -69,21 +69,14 @@ SchurRing.synonym = "Schur ring"
 ClassFunction = new Type of HashTable
 ClassFunction.synonym = "Class function"
 
-expression SchurRing := S -> new FunctionApplication from { schurRing, (expression last S.baseRings, S.Symbol, S.numgens ) }
+describe SchurRing := S -> Describe (expression schurRing) (expression last S.baseRings, S.Symbol, S.numgens)
+undocumented (describe, SchurRing)
+
+expression SchurRing := S -> (
+    if hasAttribute(S, ReverseDictionary)
+    then toString getAttribute(S, ReverseDictionary)
+    else new FunctionApplication from unhold describe S)
 undocumented (expression, SchurRing)
-
-toExternalString SchurRing := R -> toString expression R
-undocumented (toExternalString, SchurRing),
-
-toString SchurRing := R -> (
-     if hasAttribute(R,ReverseDictionary) then toString getAttribute(R,ReverseDictionary)
-     else toString expression R)
-undocumented (toString, SchurRing)
-
-net SchurRing := R -> (
-     if hasAttribute(R,ReverseDictionary) then toString getAttribute(R,ReverseDictionary)
-     else net expression R)
-undocumented (net, SchurRing)
 
 rawmonom2partition = (m) -> (
      reverse splice apply(rawSparseListFormMonomial m, (x,e) -> e:x)


### PR DESCRIPTION
### Before
```m2
i1 : toExternalString mutableMatrix {{1, 2}, {3, 4}}
stdio:1:1:(3): error: can't convert local symbol or invisible global symbol 'RawMutableMatrix' to external string
null: here is the first use of 'RawMutableMatrix'
```

### After
```m2
i1 : toExternalString mutableMatrix {{1, 2}, {3, 4}}

o1 = mutableMatrix(map(ZZ^2,ZZ^2,{{1, 2}, {3, 4}}))
```