### PR TITLE
Bump GMP to 6.3.0 (autotools)

### DIFF
--- a/M2/libraries/gmp/Makefile.in
+++ b/M2/libraries/gmp/Makefile.in
@@ -1,7 +1,7 @@
 VPATH = @srcdir@
 RELAX = yes
 URL = ftp://ftp.gnu.org/gnu/gmp
-VERSION = 6.1.0
+VERSION = 6.3.0
 TAROPTIONS = --bzip2
 TARFILE = $(LIBNAME)-$(VERSION).tar.bz2
 LICENSEFILES = README COPYING* doc/gmp.info*


### PR DESCRIPTION
In the rare instances when we need to build GMP in the autotools build, we were still building 6.1.0, which was released in 2015!  We bump to the latest version, 6.3.0.

Skipping the GitHub builds since they use the existing system GMP packages.