### PR TITLE
Document "Keywords" symbol

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/package-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/package-doc.m2
@@ -385,6 +385,19 @@ Node
 
 Node
   Key
+    Keywords
+  Headline
+    the list of keywords of a package
+  Description
+    Text
+      A symbol used as the name of an optional argument.  When used
+      with @TO newPackage@, it should provide a list of strings giving
+      the keywords of the package.  All packages should have at least
+      one keyword.  The keywords currently in use correspond to the
+      headings at @TO "packages provided with Macaulay2"@.
+
+Node
+  Key
      endPackage
     (endPackage, String)
   Headline


### PR DESCRIPTION
In response to https://github.com/Macaulay2/M2/pull/3366#discussion_r1685538289.  We provide a little bit more information about the `Keywords` option to `newPackage`.

### Before
```m2
i1 : help Keywords

o1 = Keywords -- an optional argument
     ********************************

     Description
     ===========

     A symbol used as the name of an optional argument.

     Functions with optional argument named Keywords:
     ================================================

       * "newPackage(...,Keywords=>...)" -- see "newPackage" -- the preamble of
         a package

     For the programmer
     ==================

     The object "Keywords" is a "symbol".
```

### After
```m2
i2 : help Keywords

o2 = Keywords -- the list of keywords of a package
     *********************************************

     Description
     ===========

     A symbol used as the name of an optional argument.  When used with
     "newPackage", it should provide a list of strings giving the keywords of
     the package.  All packages should have at least one keyword.  The keywords
     currently in use correspond to the headings at "packages provided with
     Macaulay2".



     Functions with optional argument named Keywords:
     ================================================

       * "newPackage(...,Keywords=>...)" -- see "newPackage" -- the preamble of
         a package

     For the programmer
     ==================

     The object "Keywords" is a "symbol".
```
