### PR TITLE
CMake updates

### DIFF
--- a/M2/CMakeLists.txt
+++ b/M2/CMakeLists.txt
@@ -14,9 +14,9 @@
 ##  6. cmake --install BUILD/cmake
 ###############################################################################
 
-## Requires CMake version 3.15 and is tested with 3.19
-cmake_minimum_required(VERSION 3.15...3.19)
-cmake_policy(VERSION 3.14)
+## Requires CMake version 3.24 and is tested with 3.30
+cmake_minimum_required(VERSION 3.24...3.30)
+cmake_policy(VERSION 3.24)
 cmake_policy(SET CMP0096 NEW) # preserve leading zeros in version number
 
 ## Use the C++20 standard

--- a/M2/Macaulay2/editors/CMakeLists.txt
+++ b/M2/Macaulay2/editors/CMakeLists.txt
@@ -69,6 +69,10 @@ file(MAKE_DIRECTORY PRISM_DIR)
 file(COPY prism/ DESTINATION ${PRISM_DIR}
   FILES_MATCHING PATTERN "*.json" PATTERN "*.js" PATTERN "*.css")
 
+if(NOT NPM)
+  return()
+endif()
+
 add_custom_target(M2-prism ALL DEPENDS prism/prism.js)
 add_custom_command(OUTPUT prism/prism.js
   COMMENT "Generating prism.js syntax file"

--- a/M2/cmake/FindEAntic.cmake
+++ b/M2/cmake/FindEAntic.cmake
@@ -1,0 +1,45 @@
+# Try to find the e-antic libraries
+# See https://github.com/flatsurf/e-antic
+#
+# This file sets up e-antic for CMake. Once done this will define
+#  EANTIC_FOUND             - system has EANTIC lib
+#  EANTIC_INCLUDE_DIR       - the EANTIC include directory
+#  EANTIC_LIBRARIES         - Libraries needed to use EANTIC
+#
+# Copyright (c) 2020, Mahrud Sayrafi, <mahrud@umn.edu>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+
+if(NOT EANTIC_FOUND)
+  set(EANTIC_INCLUDE_DIR NOTFOUND)
+  set(EANTIC_LIBRARIES NOTFOUND)
+
+  # search first if an EAnticConfig.cmake is available in the system,
+  # if successful this would set EANTIC_INCLUDE_DIR and the rest of
+  # the script will work as usual
+  find_package(EAntic ${EAntic_FIND_VERSION} NO_MODULE QUIET)
+
+  if(NOT EANTIC_INCLUDE_DIR)
+    find_path(EANTIC_INCLUDE_DIR NAMES e-antic/e-antic.h
+      HINTS ENV EANTICDIR
+      PATHS ${INCLUDE_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/include
+      )
+  endif()
+
+  if(NOT EANTIC_LIBRARIES)
+    find_library(EANTIC_C_LIBRARY NAMES eantic
+      HINTS ENV EANTICDIR
+      PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
+      )
+    find_library(EANTIC_CXX_LIBRARY NAMES eanticxx
+      HINTS ENV EANTICDIR
+      PATHS ${LIB_INSTALL_DIR} ${CMAKE_INSTALL_PREFIX}/lib
+      )
+    set(EANTIC_LIBRARIES ${EANTIC_CXX_LIBRARY} ${EANTIC_C_LIBRARY})
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(EAntic DEFAULT_MSG EANTIC_INCLUDE_DIR EANTIC_LIBRARIES)
+
+  mark_as_advanced(EANTIC_INCLUDE_DIR EANTIC_LIBRARIES)
+endif()

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -1103,9 +1103,9 @@ ExternalProject_Add(build-polymake
 
 # http://homepages.math.uic.edu/~jan/download.html
 ExternalProject_Add(build-phcpack
-  URL               https://github.com/janverschelde/PHCpack/archive/v2.4.79.tar.gz
-  URL_HASH          SHA256=5b3542555958eb3692fa2d37a325b47466b2ab8b0854cc47995e5a83d2bc0146
-  DOWNLOAD_NAME     PHCpack-v2.4.79.tar.gz
+  URL               https://github.com/janverschelde/PHCpack/archive/refs/tags/v2.4.90.tar.gz
+  URL_HASH          SHA256=7db1529b019a24e6fc2217ecccbcf3aa56f1b098bbe2f75e834f415e58c8bde7
+  DOWNLOAD_NAME     PHCpack-2.4.90.tar.gz
   PREFIX            libraries/phcpack
   SOURCE_DIR        libraries/phcpack/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -484,8 +484,8 @@ endif()
 
 # https://github.com/algebraic-solving/msolve
 ExternalProject_Add(build-msolve
-  URL               https://github.com/algebraic-solving/msolve/archive/refs/tags/v0.6.7.tar.gz
-  URL_HASH          SHA256=1491e2da3ef7c324d7ddf10ee8ffc8c5cd9b11825d09c859ca9f64836559605e
+  URL               https://github.com/algebraic-solving/msolve/archive/refs/tags/v0.6.8.tar.gz
+  URL_HASH          SHA256=6588cc912656a08f9b32dff49f5021f9c2473ef068aa3388785cd08e876920ea
   PREFIX            libraries/msolve
   SOURCE_DIR        libraries/msolve/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -484,8 +484,8 @@ endif()
 
 # https://github.com/algebraic-solving/msolve
 ExternalProject_Add(build-msolve
-  URL               https://github.com/algebraic-solving/msolve/releases/download/v0.5.0/msolve-0.5.0.tar.gz
-  URL_HASH          SHA256=13ad04757b0ba0bd44cf9a5abcf5aff416d5560b035323e9561ad4d4c020cfe5
+  URL               https://github.com/algebraic-solving/msolve/archive/refs/tags/v0.6.7.tar.gz
+  URL_HASH          SHA256=1491e2da3ef7c324d7ddf10ee8ffc8c5cd9b11825d09c859ca9f64836559605e
   PREFIX            libraries/msolve
   SOURCE_DIR        libraries/msolve/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -10,7 +10,7 @@
 # Others, like TBB::tbb, FFI::ffi, and Boost::regex, are linked as imported libraries in those files.
 # TODO: turn all these libraries into imported libraries and find incompatibilities another way.
 set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
-set(LIBRARIES_LIST MPSOLVE FROBBY NORMALIZ NAUTY FACTORY FLINT NTL MPFI MPFR GMP BDWGC LAPACK)
+set(LIBRARIES_LIST MPSOLVE FROBBY NORMALIZ FACTORY FLINT NTL MPFI MPFR GMP BDWGC LAPACK)
 set(LIBRARY_LIST   READLINE HISTORY GDBM)
 
 message(CHECK_START " Checking for existing libraries and programs")
@@ -138,6 +138,7 @@ find_package(MPSolve	3.2.0)
 find_package(Nauty	2.7.0)
 find_package(Normaliz	3.8.0)
 # TODO: add minimum version checks
+find_package(EAntic	2.0.0)
 find_package(MSolve	0.4.0)
 find_package(Frobby	0.9.0)
 find_package(CDDLIB)  # 0.94m?
@@ -359,4 +360,19 @@ if(FFI_FOUND)
   check_function_exists(ffi_get_struct_offsets HAVE_FFI_GET_STRUCT_OFFSETS)
 else()
   unset(HAVE_FFI_GET_STRUCT_OFFSETS CACHE)
+endif()
+
+if(NORMALIZ_FOUND)
+  set(CMAKE_REQUIRED_INCLUDES "${NORMALIZ_INCLUDE_DIR}")
+  check_symbol_exists(ENFNORMALIZ "libnormaliz/nmz_config.h" HAVE_ENFNORMALIZ)
+  check_symbol_exists(NMZ_NAUTY   "libnormaliz/nmz_config.h" HAVE_NMZ_NAUTY)
+  if(HAVE_ENFNORMALIZ)
+    list(TRANSFORM LIBRARIES_LIST REPLACE NORMALIZ "NORMALIZ;EANTIC")
+  endif()
+  if(HAVE_NMZ_NAUTY)
+    list(TRANSFORM LIBRARIES_LIST REPLACE NORMALIZ "NORMALIZ;NAUTY")
+  endif()
+else()
+  unset(HAVE_ENFNORMALIZ CACHE)
+  unset(HAVE_NMZ_NAUTY CACHE)
 endif()

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -139,7 +139,7 @@ find_package(Nauty	2.7.0)
 find_package(Normaliz	3.8.0)
 # TODO: add minimum version checks
 find_package(EAntic	2.0.0)
-find_package(MSolve	0.4.0)
+find_package(MSolve	0.6.0)
 find_package(Frobby	0.9.0)
 find_package(CDDLIB)  # 0.94m?
 find_package(GTest	1.10)

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -343,6 +343,7 @@ check_function_exists(fcntl	HAVE_FCNTL)
 check_function_exists(personality	HAVE_PERSONALITY)
 check_function_exists(ioctl	HAVE_IOCTL)
 
+include(CheckSymbolExists)
 include(CheckCSourceCompiles)
 include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
- **changed cmake to link e-antic/nauty if normaliz needs it**
- **updated phcpack to v2.4.90 (cmake)**
- **updated msolve to v0.6.7 (cmake)**
- **fixed error when npm is not found**
- **bumped cmake minimum version requirement**
