### PR TITLE
Use lookup in validate for getting qname

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -179,11 +179,12 @@ net  PRE  :=
 net   TT  :=
 net CODE  :=
 net SAMP  :=
-net  KBD  :=
 info TT   :=
 info SAMP :=
-info  KBD :=
 info CODE :=  x -> horizontalJoin apply(noopts x,net)
+
+net  KBD :=
+info KBD := x -> formatNoEscaping toString horizontalJoin apply(noopts x,net)
 
 info PRE  := x ->
     wrap(printWidth, "-", concatenate apply(noopts x,toString @@ info))

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -64,8 +64,8 @@ optTO := key -> (
 	-- TODO: figure out how to align the lists using padding
 	-- ref = pad(ref, printWidth // 4);
 	(format ptag, fkey, next(), fixup (
-		if currentHelpTag === ptag then MaybeQuotedTT fkey
-		else SPAN {MaybeQuotedTT fkey, " -- see ", TOH{ptag}})))
+		if currentHelpTag === ptag then KBD fkey
+		else SPAN {KBD fkey, " -- see ", TOH{ptag}})))
     -- need an alternative here for secondary tags such as (export,Symbol)
     else (fkey, fkey, next(), TOH{tag}))
 -- this isn't different yet, work on it!

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -46,12 +46,6 @@ seeAbout := (f, i) -> (
 --   the last member is the corresponding hypertext entry in the UL list
 -----------------------------------------------------------------------------
 
--- we want quotes around elements of the "Ways to use" list so that
--- "* String" works when running "help" inside Macaulay2, but we don't
--- need the quotes otherwise
-MaybeQuotedTT = new IntermediateMarkUpType of TT
-net MaybeQuotedTT := x -> formatNoEscaping x#0
-
 counter := 0
 next := () -> counter = counter + 1
 optTO := key -> (

--- a/M2/Macaulay2/m2/validate.m2
+++ b/M2/Macaulay2/m2/validate.m2
@@ -22,7 +22,7 @@ flagError := x -> (haderror = true; printerr("warning: ", x))
 
 noqname := (tag, x) -> (
     if instance(tag, IntermediateMarkUpType)
-    then warning(format toString x, " is an instance of an intermediate markup type ", format toString tag, " with no qname, appearing in hypertext during validation")
+    then warning concatenate(format toString x, " is an instance of an intermediate markup type ", format toString tag, " with no qname, appearing in hypertext during validation")
     else   error(format toString x, " is of an unrecognized type ", format toString tag, " with no qname, appearing in hypertext during validation"))
 
 -- see content.m2

--- a/M2/Macaulay2/m2/validate.m2
+++ b/M2/Macaulay2/m2/validate.m2
@@ -29,8 +29,9 @@ noqname := (tag, x) -> (
 chk := (p, x) -> (
     c := class x;
     if c === Option or c === OptionTable or c === LITERAL then return;
-    if not c.?qname then return noqname(c, x);
-    if not validContent#(p.qname)#?(c.qname) and c.qname =!= "comment"
+    cqname := lookup(qname, c);
+    if cqname === null then return noqname(c, x);
+    if not validContent#(lookup(qname, p))#?cqname and cqname =!= "comment"
     then flagError("element of type ", toString p, " may not contain an element of type ", toString c))
 
 -----------------------------------------------------------------------------
@@ -40,8 +41,9 @@ chk := (p, x) -> (
 validate = method()
 validate(Type, BasicList) := (T, x) -> (
     haderror = false;
-    if not T.?qname then return noqname(T, x);
-    if not validContent#?(T.qname) then error("internal error: valid content for qname ", toString T, " not recorded yet");
+    Tqname := lookup(qname, T);
+    if Tqname === null then return noqname(T, x);
+    if not validContent#?Tqname then error("internal error: valid content for qname ", toString T, " not recorded yet");
     scan(x, e -> chk(T, e));
     if haderror then error("validation failed: ", x))
 

--- a/M2/Macaulay2/packages/Style/doc.css
+++ b/M2/Macaulay2/packages/Style/doc.css
@@ -89,7 +89,8 @@ span.tt {
 
 kbd {
   font-family: monospace;
-  padding: 3px 5px;
+  font-size: 75%;
+  padding: 1px 5px;
   vertical-align: middle;
   border: solid 1px;
   border-radius: 6px;

--- a/M2/Macaulay2/packages/Style/doc.css
+++ b/M2/Macaulay2/packages/Style/doc.css
@@ -88,13 +88,16 @@ span.tt {
 }
 
 kbd {
+  display: inline-block;
   font-family: monospace;
-  font-size: 75%;
-  padding: 1px 5px;
+  padding: 0.25rem;
+  line-height: 0.8em;
   vertical-align: middle;
-  border: solid 1px;
+  background-color: #f6f8fa;
+  border: solid 0px #afb8c133;
+  border-bottom-color: #afb8c133;
   border-radius: 6px;
-  box-shadow: inset 0 -1px 0;
+  box-shadow: inset 0 -1px 0 #afb8c133;
 }
 
 div#buttons {display: flex;}


### PR DESCRIPTION
This allows us to use inheritance for getting the qname of hypertext types (e.g, `MaybeQuotedTT` is a child of `TT` and should inherit its qname).

This fixes all the `MaybeQuotedTT` warnings that are cropping up in #3370.  (@mahrud - would you rather I push this to that branch?)

We also fix a "no method" error that was occurring when we encountered this "no qname" warning with a positive `debugLevel`.
