### PR TITLE
Version 1.1 of package "A1BrouwerDegrees"

### DIFF
--- a/M2/Macaulay2/packages/A1BrouwerDegrees.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees.m2
@@ -36,8 +36,7 @@ newPackage (
     PackageImports => {},
     PackageExports => {},
     AuxiliaryFiles => true,
-    DebuggingMode => true,
-    Keywords => {"Homotopy Theory","Commutative Algebra"},
+    Keywords => {"Homotopy Theory","Commutative Algebra"}
     )
 
 export{

--- a/M2/Macaulay2/packages/A1BrouwerDegrees.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees.m2
@@ -1,104 +1,101 @@
 --A1BrouwerDegrees.m2
-newPackage(
+newPackage (
     "A1BrouwerDegrees",
-    Version=>"1.0",
-    Date=>"June 5, 2023",
-    Authors=>{
-        {Name=>"Nikita Borisov",
-	 Email=>"nborisov@sas.upenn.edu",
-	 HomePage=>"https://www.math.upenn.edu/people/nikita-borisov"},
-        {Name=>"Thomas Brazelton",
-	 Email=>"brazelton@math.harvard.edu",
-	 HomePage=>"https://tbrazel.github.io/"},
-        {Name=>"Frenly Espino",
-	 Email=>"frenly@sas.upenn.edu",
-	 HomePage=>"https://www.math.upenn.edu/people/frenly-espino"},
-         {Name=>"Tom Hagedorn",
-	 Email=>"hagedorn@tcnj.edu",
-	 HomePage=>"https://hagedorn.pages.tcnj.edu/"},
-        {Name=>"Zhaobo Han",
-	 Email=>"zbtomhan@sas.upenn.edu",
-	 HomePage=>"https://www.linkedin.com/in/zhaobo-han-77b1301a2/"},
-     	{Name=>"Jordy Lopez Garcia",
-	 Email=>"jordy.lopez@tamu.edu",
-	 HomePage=>"https://jordylopez27.github.io/"},
-        {Name=>"Joel Louwsma",
-	 Email=>"jlouwsma@niagara.edu",
-	 HomePage=>"https://www.joellouwsma.com/"},
-        {Name=>"Andrew Tawfeek",
-	 Email=>"atawfeek@uw.edu",
-	 HomePage=>"https://www.atawfeek.com/"},
-        {Name=>"Wern Juin Gabriel Ong",
-	 Email=>"gong@bowdoin.edu",
-	 HomePage=>"https://wgabrielong.github.io/"}
+    Version => "1.1",
+    Date => "July 23, 2024",
+    Authors => {
+        {Name => "Nikita Borisov",
+	 Email => "nborisov@sas.upenn.edu",
+	 HomePage => "https://www.math.upenn.edu/people/nikita-borisov"},
+        {Name => "Thomas Brazelton",
+	 Email => "brazelton@math.harvard.edu",
+	 HomePage => "https://tbrazel.github.io/"},
+        {Name => "Frenly Espino",
+	 Email => "frenly@sas.upenn.edu",
+	 HomePage => "https://www.math.upenn.edu/people/frenly-espino"},
+         {Name => "Tom Hagedorn",
+	 Email => "hagedorn@tcnj.edu",
+	 HomePage => "https://hagedorn.pages.tcnj.edu/"},
+        {Name => "Zhaobo Han",
+	 Email => "zbtomhan@sas.upenn.edu",
+	 HomePage => "https://www.linkedin.com/in/zhaobo-han-77b1301a2/"},
+     	{Name => "Jordy Lopez Garcia",
+	 Email => "jordy.lopez@tamu.edu",
+	 HomePage => "https://jordylopez27.github.io/"},
+        {Name => "Joel Louwsma",
+	 Email => "jlouwsma@niagara.edu",
+	 HomePage => "https://www.joellouwsma.com/"},
+        {Name => "Wern Juin Gabriel Ong",
+	 Email => "gong@bowdoin.edu",
+	 HomePage => "https://wgabrielong.github.io/"},
+        {Name => "Andrew Tawfeek",
+	 Email => "atawfeek@uw.edu",
+	 HomePage => "https://www.atawfeek.com/"}
 	},
-    Headline=>"for working with A1-Brouwer degree computations",
-    PackageImports=>{
-	"Parametrization",
-	"RealRoots",
-	"RationalPoints2"
-	},
-    PackageExports=>{},
-    AuxiliaryFiles=>true,
-    Keywords => {"Commutative Algebra"}
+    Headline => "for working with A1-Brouwer degree computations",
+    PackageImports => {},
+    PackageExports => {},
+    AuxiliaryFiles => true,
+    DebuggingMode => true
     )
-
 
 export{
     
     -- ArithmeticMethods.m2
-    "localAlgebraBasis",
-    "padicValuation",
-
+    "getPadicValuation",
+    "getLocalAlgebraBasis",
+    
     --MatrixMethods.m2
-    "congruenceDiagonalize",
+    "diagonalizeViaCongruence",
     
     --GrothendieckWittClasses.m2    
+    "makeGWClass",
     "GrothendieckWittClass",
-    "baseField",
-    "gwClass",
-    "gwAdd",
-    "gwMultiply",
+    "getBaseField",
+    "getMatrix",
+    "addGW",
+    "multiplyGW",
     
     --BuildingForms.m2
-    "diagonalForm",
-    "hyperbolicForm",
-    "PfisterForm",
+    "makeDiagonalForm",
+    "makeHyperbolicForm",
+    "makePfisterForm",
     
     --SimplifiedRepresentatives.m2
-    "diagonalClass",
-    "diagonalEntries",
+    "getDiagonalClass",
+    "getDiagonalEntries",
     
-    --HilbertSymbols.m2
-    "HilbertSymbol",
-    "HilbertSymbolReal",
+    --getHilbertSymbols.m2
+    "getHilbertSymbolReal",
+    "getHilbertSymbol",
     
     --GWInvariants.m2
-    "signature",
-    "integralDiscriminant",
-    "relevantPrimes",
-    "HasseWittInvariant",
+    "getRank",
+    "getSignature",
+    "getIntegralDiscriminant",
+    "getRelevantPrimes",
+    "getHasseWittInvariant",
 
     --LocalGlobalDegrees.m2
-    "globalA1Degree",
-    "localA1Degree",
+    "getGlobalA1Degree",
+    "getLocalA1Degree",
     
     --IsomorphismOfForms.m2
-    "gwIsomorphic",
+    "isIsomorphicForm",
     
     --Isotropy.m2
-    "isIsotropic",
     "isAnisotropic",
+    "isIsotropic",
 
     --AnisotropicDimension.m2
-    "anisotropicDimensionQp",
-    "anisotropicDimension",
-    "WittIndex",
+    "getAnisotropicDimensionQQp",
+    "getAnisotropicDimension",
+    "getWittIndex",
     
     --Decomposition.m2
-    "anisotropicPart",
-    "sumDecomposition",
-    "sumDecompositionString"
+    "getAnisotropicPart",
+    "getSumDecomposition",
+    "getSumDecompositionString"
     
     }
 
@@ -108,34 +105,34 @@ load "./A1BrouwerDegrees/Code/ArithmeticMethods.m2"
 -- Basic manipulations of matrices we will use
 load "./A1BrouwerDegrees/Code/MatrixMethods.m2"
 
--- Establishing the GrothendieckWittClass type and some basic manipulations
+-- Establishing the GrothendieckWittClass type and some basic operations
 load "./A1BrouwerDegrees/Code/GrothendieckWittClasses.m2"
 
--- For building new symmetric bilinear forms
+-- Building new Grothendieck-Witt classes
 load "./A1BrouwerDegrees/Code/BuildingForms.m2"
 
--- For providing simplified representatives of symmetric bilinear forms
+-- Providing simplified representatives of Grothendieck-Witt classes
 load "./A1BrouwerDegrees/Code/SimplifiedRepresentatives.m2"
 
--- For Hilbert symbols over p-adic numbers
+-- Hilbert symbols over the p-adic rational numbers
 load "./A1BrouwerDegrees/Code/HilbertSymbols.m2"
 
--- Invariants of symmetric bilinear forms
+-- Invariants of Grothendieck-Witt classes and symmetric bilinear forms
 load "./A1BrouwerDegrees/Code/GWInvariants.m2"
     
--- Local and global A1-brouwer degrees
+-- Computing local and global A1-Brouwer degrees
 load "./A1BrouwerDegrees/Code/LocalGlobalDegrees.m2"
 
 -- Checking if forms are isomorphic
 load "./A1BrouwerDegrees/Code/IsomorphismOfForms.m2"
 
--- For verifying (an)isotropy
+-- Verifying (an)isotropy
 load "./A1BrouwerDegrees/Code/Isotropy.m2"
 
--- Anisotropic dimension
+-- Computing anisotropic dimension
 load "./A1BrouwerDegrees/Code/AnisotropicDimension.m2"
 
--- Finally, decomposing forms
+-- Decomposing Grothendieck-Witt classes and symmetric bilinear forms
 load "./A1BrouwerDegrees/Code/Decomposition.m2"
 
 ----------------------------
@@ -148,12 +145,46 @@ beginDocumentation()
 
 document{
     Key => A1BrouwerDegrees,
-    Headline => "for working with A1-Brouwer degree computations",
-    PARA{"This package is intended computing and manipulating ", TO2(localA1Degree,"local"), " and ", TO2(globalA1Degree,"global"), " ", TEX///$\mathbb{A}^1$///, EM "-Brouwer degrees."," Global Brouwer degrees are non-degenerate symmetric bilinear forms valued in the Grothendieck-Witt ring of a field ", TEX///$\text{GW}(k)$///, "."},
-    PARA{"In order to simplify the forms produced, this package produces invariants of symmetric bilinear forms, including their ", TO2(WittIndex,"Witt indices"), ", their ", TO2(integralDiscriminant,"discriminants"), ", and their ", TO2(HasseWittInvariant, "Hasse Witt invariants"), ". Quadratic forms can furthermore be ", TO2(sumDecomposition,"decomposed"), " into their isotropic and ", TO2(anisotropicPart,"anisotropic parts"), ". Finally, and perhaps most crucially, we can certify whether two symmetric bilinear forms are ", TO2(gwIsomorphic,"isomorphic") , " in the Grothendieck-Witt ring."},
-    }
+    Headline => "package for working with A1-Brouwer degree computations",
+    PARA{"This package is intended to allow the computation and manipulation of ", TO2(getLocalA1Degree,"local"), 
+	" and ", TO2(getGlobalA1Degree,"global"), " ", TEX///$\mathbb{A}^1$///, EM "-Brouwer degrees.",
+	" Global Brouwer degrees are non-degenerate symmetric bilinear forms valued in the Grothendieck-Witt ring of a field ", TEX///$\text{GW}(k)$///, "."},
+    PARA{"In order to simplify the forms produced, this package produces invariants of symmetric bilinear forms, including their ", 
+	TO2(getWittIndex,"Witt indices"), ", their ", 
+	TO2(getIntegralDiscriminant,"discriminants"), ", and their ", 
+	TO2(getHasseWittInvariant, "Hasse-Witt invariants"), ". Quadratic forms can be ", 
+	TO2(getSumDecomposition,"decomposed"), " into their isotropic and ", TO2(getAnisotropicPart,"anisotropic parts"), 
+	". Finally, and perhaps most crucially, we can certify whether two symmetric bilinear forms are ", TO2(isIsomorphicForm,"isomorphic") , " in the Grothendieck-Witt ring."},
+PARA{"Below is an example using the methods provided by this package to compute the ", TO2(getLocalA1Degree,"local"),
+        " and ", TO2(getGlobalA1Degree,"global"), " ", TEX///$\mathbb{A}^1$///,  "-Brouwer degrees for an endomorphism ",
+	TEX///$\mathbb{A}_{\mathbb{Q}}^1\rightarrow \mathbb{A}_{\mathbb{Q}}^1.$///, " defined by ",TEX///$$ f(x)=(x^2+x+1)(x-3)(x+2).$$///,
+	" We first compute the global degree."},
+    EXAMPLE {
+    "R = QQ[x]",
+    "f = {x^4 - 6*x^2 - 7*x - 6}",
+    "alpha = getGlobalA1Degree f",
+    "beta = getSumDecomposition alpha",
+    },
+    PARA{"We can also compute the local degrees at the respective ideals."},   
+    EXAMPLE {
+    "I1 = ideal(x^2 + x + 1);",
+    "alpha1 = getLocalA1Degree(f, I1)",
+    "I2 = ideal(x - 3)",
+    "alpha2 = getLocalA1Degree(f, I2)",
+    "I3 = ideal(x + 2);",
+    "alpha3 = getLocalA1Degree(f, I3)", 
+    },
 
-undocumented {
+    PARA{"We can then use the ", TO isIsomorphicForm, "  method to verify that the ", 
+    TO2(getLocalA1Degree, "local"), " degrees sum to the ", TO2(getGlobalA1Degree, "global"), 
+    " degree."},
+    EXAMPLE{
+	"alpha' = addGW(alpha1, addGW(alpha2, alpha3))",
+	"isIsomorphicForm(alpha,alpha')",
+	"beta' = getSumDecomposition alpha'",
+	},
+    },
+undocumented{
     }
 
 load "./A1BrouwerDegrees/Documentation/ArithmeticMethodsDoc.m2"
@@ -180,336 +211,322 @@ load "./A1BrouwerDegrees/Documentation/AnisotropicDimensionDoc.m2"
 
 load "./A1BrouwerDegrees/Documentation/DecompositionDoc.m2"
 
+
 ----------------------------
 ----------------------------
 -- Testing
 ----------------------------
 ----------------------------
 
-
--- Diagonal form testing
+-- Tests for getDiagonalClass
 -- Test 0
 TEST ///
-print("diagonal form testing");
-M1=matrix(RR, {{0, 1}, {1, 0}});
-G1=gwClass(M1);
-M2=diagonalClass(G1);
-assert(M2.matrix===matrix(RR, {{1, 0}, {0, -1}}));
+M1 = matrix(RR, {{0,1},{1,0}});
+G1 = makeGWClass M1;
+G2 = getDiagonalClass G1;
+assert(getMatrix(G2) === matrix(RR, {{1,0},{0,-1}}));
 ///
 
 -- Test 1
 TEST ///
-M3=matrix(CC, {{1, 2, 3}, {2, 4, 5}, {3, 5, 7}});
-G2=gwClass(M3);
-M4=diagonalClass(G2);
-assert(M4.matrix===matrix(CC, {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}));
+M3 = matrix(CC, {{1,2,3},{2,4,5},{3,5,7}});
+G3 = makeGWClass M3;
+G4 = getDiagonalClass G3;
+assert(getMatrix(G4) === matrix(CC, {{1,0,0},{0,1,0},{0,0,1}}));
 ///
 
 --Test 2
 TEST ///
-M3=matrix(QQ, {{1, 2, 3}, {2, 4, 5}, {3, 5, 7}});
-G2=gwClass(M3);
-M4=diagonalClass(G2);
-assert(M4.matrix===matrix(QQ,{{1, 0, 0}, {0, -2, 0}, {0, 0, 2}}));
+M5 = matrix(QQ, {{1,2,3},{2,4,5},{3,5,7}});
+G5 = makeGWClass M5;
+G6 = getDiagonalClass G5;
+assert(getMatrix(G6) === matrix(QQ, {{1,0,0},{0,-2,0},{0,0,2}}));
 ///
 
--- gwTypeTest.m2
 -- Test 3
 TEST ///
-M = matrix(QQ,{{1,0},{0,1}});
-N = matrix(QQ, {{1, 2}, {2, 5}});
-beta = gwClass(M);
-gamma = gwClass(N);
-assert(baseField(beta) === QQ)
-assert(beta.matrix === M)
---Operations within GW-classes
-A = gwAdd(beta, gamma);
-B = gwMultiply(beta, gamma);
-assert(A.matrix === matrix(QQ, {{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 2}, {0, 0, 2, 5}}));
-assert(B.matrix === matrix(QQ, {{1, 2, 0, 0}, {2, 5, 0, 0}, {0, 0, 1, 2}, {0, 0, 2, 5}}));
+-- Tests for GrothendieckWittClass type
+M1 = matrix(QQ, {{1,0},{0,1}});
+M2 = matrix(QQ, {{1,2},{2,5}});
+G1 = makeGWClass M1;
+G2 = makeGWClass M2;
+assert(getBaseField(G1) === QQ);
+assert(getMatrix(G1) === M1);
+-- Tests for addGW and multiplyGW
+G3 = addGW(G1, G2);
+G4 = multiplyGW(G1, G2);
+assert(getMatrix(G3) === matrix(QQ, {{1,0,0,0},{0,1,0,0},{0,0,1,2},{0,0,2,5}}));
+assert(getMatrix(G4) === matrix(QQ, {{1,2,0,0},{2,5,0,0},{0,0,1,2},{0,0,2,5}}));
 ///
 
-
--- Testing for global and local A1 degrees
+-- Tests for getGlobalA1Degree and getLocalA1Degree
 -- Test 4
 TEST ///
-T1 = QQ[x]
-f = {x^2}
-beta = globalA1Degree(f)
-gamma = gwClass(matrix(QQ,{{0,1},{1,0}}))
-assert(gwIsomorphic(beta,gamma))
+T1 = QQ[x];
+f = {x^2};
+alpha = getGlobalA1Degree f;
+beta = makeGWClass matrix(QQ, {{0,1},{1,0}});
+assert(isIsomorphicForm(alpha, beta));
 ///
 
 -- Test 5
 TEST ///
-T1 = QQ[z_1..z_2];
-f1 = {(z_1-1)*z_1*z_2, (3/5)*z_1^2 - (17/3)*z_2^2};
-f1GD = globalA1Degree(f1);
-assert(WittIndex(f1GD) == 3);
-q=ideal {z_1,z_2};
-r=ideal {z_1-1,z_2^2-(9/85)};
-f1LDq= localA1Degree(f1,q);
-f1LDr= localA1Degree(f1,r);
-f1LDsum = gwAdd(f1LDq, f1LDr);
-assert(gwIsomorphic(f1LDsum, f1GD));
+QQ[z_1,z_2];
+f1 = {(z_1 - 1)*z_1*z_2, (3/5)*z_1^2 - (17/3)*z_2^2};
+f1GD = getGlobalA1Degree f1;
+assert(getWittIndex(f1GD) == 3);
+I1 = ideal(z_1, z_2);
+I2 = ideal(z_1 - 1, z_2^2 - 9/85);
+f1LD1 = getLocalA1Degree(f1, I1);
+f1LD2 = getLocalA1Degree(f1, I2);
+f1LDsum = addGW(f1LD1, f1LD2);
+assert(isIsomorphicForm(f1LDsum, f1GD));
 ///
 
 -- Test 6
 TEST ///
-T2 = GF(17)[w];
+GF(17)[w];
 f2 = {w^4 + w^3 - w^2 - w};
-f2GD= globalA1Degree(f2);
-assert(WittIndex(f2GD) == 2);
-p=ideal {w+1};
-f2LDp = localA1Degree(f2, p);
-assert(WittIndex(f2LDp) == 1);
-s=ideal{w-1};
-f2LDs = localA1Degree(f2, s);
-t=ideal{w};
-f2LDt = localA1Degree(f2, t);
-f2LDsum = gwAdd(gwAdd(f2LDp, f2LDs),f2LDt);
-assert(gwIsomorphic(f2LDsum, f2GD));
+f2GD = getGlobalA1Degree f2;
+assert(getWittIndex(f2GD) == 2);
+J1 = ideal(w + 1);
+f2LD1 = getLocalA1Degree(f2, J1);
+assert(getWittIndex(f2LD1) == 1);
+J2 = ideal(w - 1);
+f2LD2 = getLocalA1Degree(f2, J2);
+J3 = ideal(w);
+f2LD3 = getLocalA1Degree(f2, J3);
+f2LDsum = addGW(addGW(f2LD1, f2LD2), f2LD3);
+assert(isIsomorphicForm(f2LDsum, f2GD));
 ///
 
--- Testing for building forms
+-- Tests for building forms
 -- Test 7
 TEST ///
-twoH = hyperbolicForm(GF(17),4);
-P = PfisterForm(GF(17),(2,3));
-assert(gwIsomorphic(P,twoH));
+P = makePfisterForm(GF(17), (2,3));
+twoH = makeHyperbolicForm(GF(17), 4);
+assert(isIsomorphicForm(P, twoH));
 ///
 
 -- Test 8
 TEST ///
-H = hyperbolicForm(RR);
-A = diagonalForm(RR,(1,-1));
-B = gwClass(matrix(RR,{{0,1},{1,0}}));
-assert(gwIsomorphic(H,A));
-assert(gwIsomorphic(H,B));
+alpha = makeDiagonalForm(RR, (1,-1));
+beta = makeGWClass matrix(RR, {{0,1},{1,0}});
+H = makeHyperbolicForm RR;
+assert(isIsomorphicForm(alpha, H));
+assert(isIsomorphicForm(beta, H));
 ///
 
--- Test for local algebra basis
+-- Test for getLocalAlgebraBasis
 -- Test 9
 TEST ///
-QQ[x,y]
-f = {x^2+1-y,y};
-p = ideal(x^2+1,y);
-assert(localAlgebraBasis(f,p) == {1,x}); 
+QQ[x,y];
+f = {x^2 + 1 - y, y};
+p = ideal(x^2 + 1, y);
+assert(getLocalAlgebraBasis(f, p) == {1,x}); 
 ///
 
--- Tests for diagonalClass and diagonalEntries
+-- Tests for getDiagonalClass and getDiagonalEntries
 -- Test 10
 TEST ///
-M1 = matrix(CC,{{1,0,0},{0,2,0},{0,0,-3}});
-M2 = matrix(CC,{{1,0,0},{0,1,0},{0,0,1}});
-G = gwClass(M1);
-assert((diagonalClass(G)).matrix == M2);
-assert(diagonalEntries(G) == {1,2,-3});
-
+M1 = matrix(CC, {{1,0,0},{0,2,0},{0,0,-3}});
+M2 = matrix(CC, {{1,0,0},{0,1,0},{0,0,1}});
+G = makeGWClass M1;
+assert(getMatrix(getDiagonalClass G) == M2);
+assert(getDiagonalEntries(G) == {1,2,-3});
 ///
 
 -- Test 11
 TEST ///
-M1 = matrix(RR,{{1,0,0},{0,2,0},{0,0,-3}});
-M2 = matrix(RR,{{1,0,0},{0,1,0},{0,0,-1}});
-G = gwClass(M1);
-assert((diagonalClass(G)).matrix == M2);
-assert(diagonalEntries(G) == {1,2,-3});
+M1 = matrix(RR, {{1,0,0},{0,2,0},{0,0,-3}});
+M2 = matrix(RR, {{1,0,0},{0,1,0},{0,0,-1}});
+G = makeGWClass M1;
+assert(getMatrix(getDiagonalClass G) == M2);
+assert(getDiagonalEntries(G) == {1,2,-3});
 ///
 
 -- Test 12
 TEST ///
-M = matrix(QQ,{{1,0,0},{0,2,0},{0,0,-3}});
-G = gwClass(M);
-assert((diagonalClass(G)).matrix == M);
-assert(diagonalEntries(G) == {1,2,-3})
+M = matrix(QQ, {{1,0,0},{0,2,0},{0,0,-3}});
+G = makeGWClass M;
+assert(getMatrix(getDiagonalClass G) == M);
+assert(getDiagonalEntries(G) == {1,2,-3});
 ///
     
 -- Test 13
 TEST ///
-M = matrix(GF(5),{{1,0,0},{0,2,0},{0,0,-3}});
-G = gwClass(M);
-assert((diagonalClass(G)).matrix == M);
-assert(diagonalEntries(G) == {1,2,-3});
+M = matrix(GF(5), {{1,0,0},{0,2,0},{0,0,-3}});
+G = makeGWClass M;
+assert(getMatrix(getDiagonalClass G) == M);
+assert(getDiagonalEntries(G) == {1,2,-3});
 ///
 
 -- Test 14
 TEST ///
 kk = GF(7);
-M1 = matrix(kk,{{1,0,0},{0,2,0},{0,0,-3}});
-M2 = matrix(kk,{{1,0,0},{0,1,0},{0,0,1}});
-G = gwClass(M1);
-assert((diagonalClass(G)).matrix == M2);
-assert(diagonalEntries(G) == {1,2,-3});
+M1 = matrix(kk, {{1,0,0},{0,2,0},{0,0,-3}});
+M2 = matrix(kk, {{1,0,0},{0,1,0},{0,0,1}});
+G = makeGWClass M1;
+assert(getMatrix(getDiagonalClass G) == M2);
+assert(getDiagonalEntries(G) == {1,2,-3});
 ///
 
 -- Test 15
 TEST ///
-M1 = matrix(QQ,{{18,0,0},{0,125/9,0},{0,0,-8/75}});
-M2 = matrix(QQ,{{2,0,0},{0,5,0},{0,0,-6}});
-G1 = gwClass(M1);
-assert((diagonalClass(G1)).matrix == M2);
+M1 = matrix(QQ, {{18,0,0},{0,125/9,0},{0,0,-8/75}});
+M2 = matrix(QQ, {{2,0,0},{0,5,0},{0,0,-6}});
+G1 = makeGWClass M1;
+assert(getMatrix(getDiagonalClass G1) == M2);
 ///
 
-
--- Test for p-adic valuation
+-- Test for getPadicValuation
 -- Test 16
 TEST ///
-assert(padicValuation(27,3) == 3);
+assert(getPadicValuation(27,3) == 3);
 ///
 
--- Test for congruenceDiagonalize
 -- Test 17
 TEST ///
-B=matrix(QQ,{{0/1,1},{1,0}});
-eta = gwClass(B)
-assert(WittIndex(eta) == 1);
-
-P=matrix(QQ,{{0/1, 5,1},{2,2,1},{0,0,1}});
-A=matrix(QQ,{{1/1,0,0},{0,-1,0},{0,0,1}});
-assert(WittIndex(gwClass(congruenceDiagonalize(P*A*transpose(P)))) == 1);
+-- Test for getWittIndex and diagonalizeViaCongruence
+B = matrix(QQ, {{0/1,1},{1,0}});
+beta = makeGWClass B;
+assert(getWittIndex(beta) == 1);
+P = matrix(QQ, {{0/1, 5,1},{2,2,1},{0,0,1}});
+A = matrix(QQ, {{1/1,0,0},{0,-1,0},{0,0,1}});
+assert(getWittIndex(makeGWClass(diagonalizeViaCongruence(P*A*transpose(P)))) == 1);
 ///
 
-
--- Test for gwClass
+-- Test for makeGWClass
 -- Test 18
 TEST ///
-M1 = matrix(QQ,{{1/1,0,0},{0,1,0},{0,0,1}});
-M2 = matrix(QQ,{{1/1,24/10,0},{24/10,-5,0},{0,0,69}});
-M3 = matrix(GF(7),{{1,0,0},{0,2,0},{0,0,-3}});
-assert(class(gwClass(M1)) === GrothendieckWittClass);
-assert(class(gwClass(M2)) === GrothendieckWittClass);
-assert(class(gwClass(M3)) === GrothendieckWittClass);
+M1 = matrix(QQ, {{1/1,0,0},{0,1,0},{0,0,1}});
+M2 = matrix(QQ, {{1/1,24/10,0},{24/10,-5,0},{0,0,69}});
+M3 = matrix(GF(7), {{1,0,0},{0,2,0},{0,0,-3}});
+assert(class(makeGWClass M1) === GrothendieckWittClass);
+assert(class(makeGWClass M2) === GrothendieckWittClass);
+assert(class(makeGWClass M3) === GrothendieckWittClass);
 ///
 
--- Test for baseField
+-- Test for getBaseField
 -- Test 19
 TEST ///
-M = gwClass(matrix(QQ,{{1/1,0,0},{0,2,3},{0,3,1}}));
-M1 = gwClass(matrix(RR,{{1.0,24/10,-2.41},{24/10,-5,0},{-2.41,0,69}}));
-M2 = gwClass(matrix(CC,{{1*ii,24/10,-2.41},{24/10,-5,0},{-2.41,0,69+ii}}));
-M3 = gwClass(matrix(GF(7),{{1,0,0},{0,2,0},{0,0,-3}}));
+M1 = makeGWClass matrix(QQ, {{1/1,0,0},{0,2,3},{0,3,1}});
+M2 = makeGWClass matrix(RR, {{1.0,24/10,-2.41},{24/10,-5,0},{-2.41,0,69}});
+M3 = makeGWClass matrix(CC, {{1*ii,24/10,-2.41},{24/10,-5,0},{-2.41,0,69+ii}});
+M4 = makeGWClass matrix(GF(7), {{1,0,0},{0,2,0},{0,0,-3}});
 
-assert(baseField(M) === QQ);
-assert(baseField(M1) === RR_53);
-assert(baseField(M2) === CC_53);
-assert(toString(baseField(M3)) === toString(GF(7)));
+assert(getBaseField(M1) === QQ);
+assert(getBaseField(M2) === RR_53);
+assert(getBaseField(M3) === CC_53);
+assert((getBaseField M4).order == 7);
 ///
 
--- Test for gwAdd
+-- Test for addGW
 -- Test 20
 TEST ///
-M1 = gwClass(matrix(QQ, {{1/1,0,-3},{0,23,0},{-3,0,-2/5}}));
-M2 = gwClass(matrix(QQ, {{0,1/2,0},{1/2,5/9,0},{0,0,1}}));
-M3 = gwClass(matrix(QQ, {{1/1,0,-3,0,0,0},{0,23,0,0,0,0},{-3,0,-2/5,0,0,0},{0,0,0,0,1/2,0},{0,0,0,1/2,5/9,0},{0,0,0,0,0,1}}))
+A1 = makeGWClass matrix(QQ, {{1/1,0,-3},{0,23,0},{-3,0,-2/5}});
+A2 = makeGWClass matrix(QQ, {{0,1/2,0},{1/2,5/9,0},{0,0,1}});
+A3 = makeGWClass matrix(QQ, {{1/1,0,-3,0,0,0},{0,23,0,0,0,0},{-3,0,-2/5,0,0,0},{0,0,0,0,1/2,0},{0,0,0,1/2,5/9,0},{0,0,0,0,0,1}})
 
-G1 = gwClass(matrix(RR, {{sqrt(2),0,-3},{0,sqrt(5),0},{-3,0,-1/5}}));
-G2 = gwClass(matrix(RR, {{1/3}}));
-G3 = gwClass(matrix(RR, {{sqrt(2),0,-3,0},{0,sqrt(5),0,0},{-3,0,-1/5,0},{0,0,0,1/3}}));
+B1 = makeGWClass matrix(RR, {{sqrt(2),0,-3},{0,sqrt(5),0},{-3,0,-1/5}});
+B2 = makeGWClass matrix(RR, {{1/3}});
+B3 = makeGWClass matrix(RR, {{sqrt(2),0,-3,0},{0,sqrt(5),0,0},{-3,0,-1/5,0},{0,0,0,1/3}});
 
-H1 = gwClass(matrix(CC, {{2*ii,0,0},{0,-2,0},{0,0,-3}}));
-H2 = gwClass(matrix(CC, {{1,0,-3+ii,0},{0,-2,0,0},{-3+ii,0,-3,0},{0,0,0,5}}));
-H3 = gwClass(matrix(CC, {{2*ii,0,0,0,0,0,0},{0,-2,0,0,0,0,0},{0,0,-3,0,0,0,0},{0,0,0,1,0,-3+ii,0},{0,0,0,0,-2,0,0},{0,0,0,-3+ii,0,-3,0},{0,0,0,0,0,0,5}}));
+C1 = makeGWClass matrix(CC, {{2*ii,0,0},{0,-2,0},{0,0,-3}});
+C2 = makeGWClass matrix(CC, {{1,0,-3+ii,0},{0,-2,0,0},{-3+ii,0,-3,0},{0,0,0,5}});
+C3 = makeGWClass matrix(CC, {{2*ii,0,0,0,0,0,0},{0,-2,0,0,0,0,0},{0,0,-3,0,0,0,0},{0,0,0,1,0,-3+ii,0},{0,0,0,0,-2,0,0},{0,0,0,-3+ii,0,-3,0},{0,0,0,0,0,0,5}});
 
-assert(gwAdd(M1,M2) === M3);
-assert(gwAdd(G1,G2) === G3);
-assert(gwAdd(H1,H2) === H3);
+assert(addGW(A1, A2) === A3);
+assert(addGW(B1, B2) === B3);
+assert(addGW(C1, C2) === C3);
 ///
 
 -- Test for isIsotropic/isAnisotropic
 -- Test 21
 TEST ///
-A1=matrix(QQ, {{0, 1/1},{1/1, 0}});
-assert(isIsotropic(A1)===true);
-assert(isAnisotropic(gwClass(A1))===false);
+A1 = matrix(QQ, {{0,1/1},{1/1,0}});
+assert(isIsotropic A1);
+assert(not isAnisotropic makeGWClass(A1));
 
-A2=matrix(RR, {{1, -2, 4}, {-2, 2, 0}, {4, 0, -7}});
-assert(isAnisotropic(A2)===false);
-assert(isIsotropic(gwClass(A2))===true);
+A2 = matrix(RR, {{1,-2,4},{-2,2,0},{4,0,-7}});
+assert(not isAnisotropic A2);
+assert(isIsotropic makeGWClass A2);
 
-K=GF(13^4);
-A3=matrix(K, {{7, 81, 63}, {81, 7, 55}, {63, 55, 109}});
-assert(isIsotropic(gwClass(A3))===true);
---Isotropic by the Chevalley-Warning Theorem.
+k = GF(13^4);
+A3=matrix(k, {{7,81,63},{81,7,55},{63,55,109}});
+assert(isIsotropic makeGWClass A3);
+-- Isotropic by the Chevalley-Warning Theorem
 
-A4=matrix(QQ, {{5, 0}, {0, 5}});
-assert(isAnisotropic(A4)===true);
+A4 = matrix(QQ, {{5,0},{0,5}});
+assert(isAnisotropic A4);
 
-A5=matrix(CC, {{3+ii, 0}, {0, 5-ii}});
-assert(isAnisotropic(A5)===false);
+A5 = matrix(CC, {{3+ii,0},{0,5-ii}});
+assert(not isAnisotropic A5);
 ///
 
---Test for isIsomorphicFormQ
+-- Tests for isIsomorphicForm
 -- Test 22
 TEST ///
-B1=matrix(QQ, {{1/1, -2/1, 4/1}, {-2/1, 2/1, 0}, {4/1, 0, -7/1}});
-B2=matrix(QQ, {{-17198/4225, -166126/975, -71771/1560}, {-166126/975, -27758641/4050, -251077/135}, {-71771/1560, -251077/135, -290407/576}});
-assert(gwIsomorphic(gwClass(B1), gwClass(B2))===true);
-B3=matrix(QQ, {{-38/1, -50/1, 23/1}, {-50/1, -62/1, 41/1}, {23/1, 41/1, 29/1}});
-assert(gwIsomorphic(gwClass(B1), gwClass(B3))===true);
+B1 = matrix(QQ, {{1/1,-2/1,4/1},{-2/1,2/1,0},{4/1,0,-7/1}});
+B2 = matrix(QQ, {{-17198/4225,-166126/975,-71771/1560},{-166126/975,-27758641/4050,-251077/135},{-71771/1560,-251077/135,-290407/576}});
+assert(isIsomorphicForm(makeGWClass B1, makeGWClass B2));
+B3 = matrix(QQ, {{-38/1,-50/1,23/1},{-50/1,-62/1,41/1},{23/1,41/1,29/1}});
+assert(isIsomorphicForm(makeGWClass B1, makeGWClass B3));
 ///
 
-
---Test for gwIsomorphic
 --Test 23
 
 TEST ///
-D1=matrix(QQ, {{1/1, -2/1, 4/1}, {-2/1, 2/1, 0}, {4/1, 0, -7/1}});
-D2=matrix(QQ, {{-38/1, -50/1, 23/1}, {-50/1, -62/1, 41/1}, {23/1, 41/1, 29/1}});
-assert(gwIsomorphic(gwClass(D1), gwClass(D2))===true);
+A1 = matrix(RR, {{1/1,-2/1,4/1},{-2/1,2/1,0},{4/1,0,-7/1}});
+A2 = matrix(RR, {{-38/1,-50/1,23/1},{-50/1,-62/1,41/1},{23/1,41/1,29/1}});
+assert(isIsomorphicForm(makeGWClass A1, makeGWClass A2));
 
-C1=matrix(RR, {{1/1, -2/1, 4/1}, {-2/1, 2/1, 0}, {4/1, 0, -7/1}});
-C2=matrix(RR, {{-38/1, -50/1, 23/1}, {-50/1, -62/1, 41/1}, {23/1, 41/1, 29/1}});
-assert(gwIsomorphic(gwClass(C1), gwClass(C2))===true);
+B1 = matrix(QQ, {{1/1,-2/1,4/1},{-2/1,2/1,0},{4/1,0,-7/1}});
+B2 = matrix(QQ, {{-38/1,-50/1,23/1},{-50/1,-62/1,41/1},{23/1,41/1,29/1}});
+assert(isIsomorphicForm(makeGWClass B1, makeGWClass B2));
 
-M=GF(13^1)
-C3=matrix(M, {{1, 11, 4}, {11, 2, 0}, {4, 0, 6}});
-C4=matrix(M, {{1, 2, 10}, {2, 3, 2}, {10, 2, 3}});
-assert(gwIsomorphic(gwClass(C3), gwClass(C4))===true);
+k = GF(13)
+C1 = matrix(k, {{1,11,4},{11,2,0},{4,0,6}});
+C2 = matrix(k, {{1,2,10},{2,3,2},{10,2,3}});
+assert(isIsomorphicForm(makeGWClass C1, makeGWClass C2));
 ///
 
 -- Test for GWinvariants
 -- Test 24
 TEST ///
-M1 = gwClass(matrix(QQ, {{1/1,0,-3},{0,23,0},{-3,0,-2/5}}));
-M2 = gwClass(matrix(QQ, {{1/1,0,0},{0, 23,0},{0,0,-2/5}}));
-M3 = gwClass(matrix(QQ, {{1/1,0,0},{0,-23,0},{0,0,-2/5}}));
-M4 = gwClass(matrix(QQ, {{-1/1,0,0},{0,-23,0},{0,0,-2/5}}));
+M1 = makeGWClass matrix(QQ, {{1/1,0,-3},{0,23,0},{-3,0,-2/5}});
+M2 = makeGWClass matrix(QQ, {{1/1,0,0},{0, 23,0},{0,0,-2/5}});
+M3 = makeGWClass matrix(QQ, {{1/1,0,0},{0,-23,0},{0,0,-2/5}});
+M4 = makeGWClass matrix(QQ, {{-1/1,0,0},{0,-23,0},{0,0,-2/5}});
 
-assert(signature(M1) == 1);
-assert(signature(M2) == 1);
-assert(signature(M3) == -1);
-assert(signature(M4) == -3);
+assert(getSignature(M1) == 1);
+assert(getSignature(M2) == 1);
+assert(getSignature(M3) == -1);
+assert(getSignature(M4) == -3);
 
-assert(integralDiscriminant(M1)==-5405);
-assert(relevantPrimes(M1) == {23, 5, 47} );
-assert(HasseWittInvariant(M1, 5) == -1);
-assert(HasseWittInvariant(M1, 23) == 1);
-assert(HasseWittInvariant(M1, 47) == -1);
+assert(getIntegralDiscriminant(M1) == -5405);
+assert(getRelevantPrimes(M1) == {23, 5, 47});
+assert(getHasseWittInvariant(M1, 5) == -1);
+assert(getHasseWittInvariant(M1, 23) == 1);
+assert(getHasseWittInvariant(M1, 47) == -1);
 ///
 
--- Test for hilbertSymbols
+-- Test for getHilbertSymbols
 -- Test 25
 TEST ///
-a = HilbertSymbol(100, 7, 3);
-assert(a==1);
+assert(getHilbertSymbol(100, 7, 3) == 1);
+assert(getHilbertSymbol(100/121, 7/169, 3) == 1);
 
-b = HilbertSymbol(100/121, 7/169, 3);
-assert(b==1);
+assert(getHilbertSymbol(5, 1/9, 7) == 1);
+assert(getHilbertSymbol(1/9, 5, 7) == 1);
 
-assert(HilbertSymbol(5, 1/9, 7)==1);
-assert(HilbertSymbol(1/9, 5, 7)==1);
+assert(getHilbertSymbol(3, 11, 3) == -1);
+assert(getHilbertSymbol(3, 11, 2) == -1);
+assert(getHilbertSymbol(-3, -11, 2) == 1);
+assert(getHilbertSymbol(-5, 11, 2) == -1);
 
-assert(HilbertSymbol(3, 11, 3)==-1);
-assert(HilbertSymbol(3, 11, 2)==-1);
-assert(HilbertSymbol(-3, -11, 2)==1);
-assert(HilbertSymbol(-5, 11, 2) == -1);
-
-
-assert(HilbertSymbolReal(-3/1, 5)==1);
-assert(HilbertSymbolReal(-3, -5/1)==-1);
-assert(HilbertSymbolReal(-3/1, -5)==-1);
-assert(HilbertSymbolReal(3, 5)==1);
+assert(getHilbertSymbolReal(-3/1, 5) == 1);
+assert(getHilbertSymbolReal(-3, -5/1) == -1);
+assert(getHilbertSymbolReal(-3/1, -5) == -1);
+assert(getHilbertSymbolReal(3, 5) == 1);
 ///
-
-

--- a/M2/Macaulay2/packages/A1BrouwerDegrees.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees.m2
@@ -36,7 +36,8 @@ newPackage (
     PackageImports => {},
     PackageExports => {},
     AuxiliaryFiles => true,
-    DebuggingMode => true
+    DebuggingMode => true,
+    Keywords => {"Homotopy Theory","Commutative Algebra"},
     )
 
 export{

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/ArithmeticMethods.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/ArithmeticMethods.m2
@@ -2,223 +2,213 @@
 -- Arithmetic operations
 ------------------------
 
--- Input: A rational number or an integer
--- Output: Smallest magnitude integer in its square class
+-- Input: An integer or rational number n
+-- Output: The smallest magnitude integer in the same integer square class as n
 
-squarefreePart = method()
-squarefreePart (QQ) := (ZZ) => (n) -> (
-    if n == 0 then (
-        return 0
-        );
-    if n > 0 then (
-        tableOfPrimeFactorsQQ := hashTable(factor(numerator(n)*denominator(n)));
-        return product(apply(keys(tableOfPrimeFactorsQQ),p -> p^(tableOfPrimeFactorsQQ#p%2)))
-        );
-    if n < 0 then (
-        tableOfPrimeFactorsQQNeg := hashTable(factor(numerator(-n)*denominator(-n)));
-        return -product(apply(keys(tableOfPrimeFactorsQQNeg),p -> p^(tableOfPrimeFactorsQQNeg#p%2)))
-        );
+getSquarefreePart = method()
+getSquarefreePart ZZ := ZZ => n -> (
+    if n == 0 then return 0;
+    tableOfPrimeFactors := hashTable factor abs n;
+    return sub(n/abs(n),ZZ)*product(apply(keys(tableOfPrimeFactors),p -> p^(tableOfPrimeFactors#p%2)));
     )
 
-squarefreePart (ZZ) := (ZZ) => (n) -> (
-    if n == 0 then (
-        return 0
-        );
-    if n > 0 then (
-        tableOfPrimeFactors := hashTable(factor(n));
-        return product(apply(keys(tableOfPrimeFactors),p -> p^(tableOfPrimeFactors#p%2)))
-        );
-    if n < 0 then (
-        tableOfPrimeFactorsNeg := hashTable(factor(-n));
-        return -product(apply(keys(tableOfPrimeFactorsNeg),p -> p^(tableOfPrimeFactorsNeg#p%2)))
-        );
+getSquarefreePart QQ := ZZ => n -> (
+    getSquarefreePart(numerator(n)*denominator(n))
     )
 
 -- Input: An integer or rational number n
 -- Output: A list of prime factors of n
 
-primeFactors = method()
-primeFactors (ZZ) := List => (n) -> (
-    if abs(n) == 1 then(
-	return {};
-	);
-    
-    return sort keys(hashTable(factor(abs(n))))
-    );
-
-primeFactors (QQ) := List => (n) -> (
-    if (not liftable(n,ZZ) == true) then(
-	error "tried to take prime factors of a rational";
-	);
-    
-    return primeFactors(sub(n,ZZ));   
+getPrimeFactors = method()
+getPrimeFactors ZZ := List => n -> (
+    sort keys hashTable(factor abs n)
     )
 
--- Input: An integer n and a prime number p
+getPrimeFactors QQ := List => n -> (
+    if not liftable(n, ZZ) then error "gatPrimeFactors expected an integer";
+    getPrimeFactors sub(n, ZZ)  
+    )
+
+-- Input: An integer or rational number n and a prime number p
 -- Output: The p-adic valuation of n
 
-padicValuation = method()
-padicValuation (ZZ, ZZ) := (ZZ) => (n, p) -> (
-    if (n < 0) then (n = -n);
-    if (n == 0) then error "Error: Trying to find prime factorization of 0";
-    H := hashTable (factor n);
-    a := 0;
-    if H#?p then (
-    	a = H#p;)
-    else (
-	a = 0;
-	);
-    return a;
-    );
+getPadicValuation = method()
+getPadicValuation (ZZ, ZZ) := ZZ => (n, p) -> (
+    if n == 0 then error "Trying to find prime factorization of 0";
+    H := hashTable factor abs n;
+    if H#?p then return H#p else return 0;
+    )
 
--- Input: A rational number q and a prime number p
--- Output: the p-adic valuation of q
-padicValuation (QQ, ZZ) := (ZZ) => (q, p) -> (
-    num := numerator(q);
-    denom := denominator(q);
-    return (padicValuation(num,p) - padicValuation(denom,p));
-);
+getPadicValuation (QQ, ZZ) := ZZ => (q, p) -> (
+    getPadicValuation(numerator q, p) - getPadicValuation(denominator q, p)
+    )
 
--- Input: An element a of a finite field
--- Output: True if a is a square, false otherwise
+-- Input: An element of a finite field
+-- Output: Boolean that gives whether the element is a square
 
-legendreBoolean = method()
-legendreBoolean (RingElement) := (Boolean) => a -> (
-    if not instance(ring(a),GaloisField) then error "Error: this works only for Galois fields";
-    q := (ring(a)).order;
+isGFSquare = method()
+isGFSquare RingElement := Boolean => a -> (
+    if not instance(ring a, GaloisField) then 
+        error "isGFSquare only works for Galois fields";
+    q := (ring a).order;
     -- Detects if a is a square in F_q
     a^((q-1)//2) == 1 
     )
 
--- Input: An integer a and a prime p
--- Output: 1, if a is a unit square,  -1, if a = p^(even power)x  (non-square unit), 0 otherwise
--- Note:  The terminology "Square Symbol" comes from John Voight's Quaternion Algebra book
+-- Input: An integer a and a prime number p
+-- Output: 1 if a is a unit square, -1 if a = p^(even power) x (non-square unit), 0 otherwise
+-- Note: The terminology "Square Symbol" comes from John Voight's Quaternion Algebra book
 
-squareSymbol = method()
-squareSymbol(ZZ, ZZ) := (ZZ) => (a, p) -> (
-    x := getSymbol "x";
-    R := GF(p, Variable => x);
-    e1 := padicValuation(a,p);
-    if (even e1) then (
+getSquareSymbol = method()
+getSquareSymbol (ZZ,ZZ) := ZZ => (a,p) -> (
+    R := GF(p);
+    e1 := getPadicValuation(a,p);
+    if even e1 then (
     	a1 := sub(a/(p^e1), ZZ);
 	a2 := sub(a1, R);
-	if legendreBoolean(a2) then (
-	    ans := 1;
-	    ) 
-	else (
-	    ans = -1;
-	    );
-	)
-    else (
-	ans = 0;
-	);
-    return ans;
-    );
+	if isGFSquare a2 then return 1 else return -1;
+        );
+    return 0;
+    )
 
 ------------------------------
 -- P-adic methods
 ------------------------------
 
--- Boolean checking if two integers a and b differ by a square in Qp
+-- Input: Two integers a and b, and a prime number p
+-- Output: Boolean that gives whether a and b differ by a square in QQ_p
 
-equalUptoPadicSquare = method()
-equalUptoPadicSquare (ZZ, ZZ, ZZ) := (Boolean) => (a, b, p) -> (
+isEqualUpToPadicSquare = method()
+isEqualUpToPadicSquare (ZZ,ZZ,ZZ) := Boolean => (a,b,p) -> (
     
--- One has to handle the cases when p is odd, and p = 2 differently
+-- One has to separately handle the cases when p is odd and when p = 2
 
-if (odd p) then (
-    -- p is odd and we need to check that the powers of p have the same parity, and the units
-    -- differ by a square in GF(p)
-    a1 := squarefreePart(a);
-    b1 := squarefreePart(b);
-    if (padicValuation(a1, p ) != padicValuation(b1, p)) then (
-	return false;
+    if odd p then (
+        -- if p is odd, we need to check that the p-adic valuations of a and b have the same parity and the units
+        -- differ by a square in GF(p)
+        a1 := getSquarefreePart a;
+        b1 := getSquarefreePart b;
+        if (getPadicValuation(a1,p) != getPadicValuation(b1,p)) then (
+            return false;
+            )
+        else (
+    	    -- c1 will be an integer coprime to p
+	    c1 := getSquarefreePart(a1*b1);
+	    return isGFSquare sub(c1, GF(p)); 
+	    );
         )
     else (
-    	-- c1 will be an integer prime to p
-	c1 := squarefreePart(a1*b1);
-	x := getSymbol "x";
-	return (legendreBoolean( sub(c1, GF(p, Variable => x)))); 
-	);
+        -- Case when p = 2. Here we have to check that the p-adic valuations of a and b have the same parity and 
+        -- that the units agree mod 8.
+        a1 = getSquarefreePart a;
+        b1 = getSquarefreePart b;
+        if getPadicValuation(a1,p) != getPadicValuation(b1,p) then (
+	    return false;
+            )
+        else (
+    	    -- c1 will be an integer coprime to p
+	    c1 = getSquarefreePart(a1*b1);
+	    c1 = c1 % 8;
+	    -- If c1 = 1, then the two odd units are congruent mod 8 and are squares in QQ_2
+	    return c1 == 1; 
+	    );
+        );
     )
-else (
-    -- Case when p=2.  Then we have to check that the powers of p have the same parity, and 
-    -- that the units agree mod 8.
-    a1 = squarefreePart(a);
-    b1 = squarefreePart(b);
-    if (padicValuation(a1, p ) != padicValuation(b1, p)) then (
-	return false;
-        )
-    else (
-    	-- c1 will be an integer prime to p
-	c1 = squarefreePart(a1*b1);
-	c1 = c1 % 8;
-	-- if c1 =1, then the two odd units are congruent mod 8, and are squares in Q2
-	return (c1 == 1); 
-	);
-    );
-  );
 
--- Boolean to check if an integer a is a p-adic square
+-- Input: An integer a and a prime number p
+-- Output: Boolean that gives whether a is a square in QQ_p
 
 isPadicSquare = method()
-isPadicSquare (ZZ, ZZ) := (Boolean) => (a, p) -> (
-    return equalUptoPadicSquare(a,1,p)
-    );
+isPadicSquare (ZZ,ZZ) := Boolean => (a,p) -> (
+    isEqualUpToPadicSquare(a,1,p)
+    )
 
 ------------------------------
 -- Commutative algebra methods
 ------------------------------
 
--- Input: A list L of functions f1,...,fn over the same ring R and p is a prime ideal of an isolated zero
+-- Input: A list L of functions f1,...,fn over the same ring R and p a prime ideal of an isolated zero
 -- Output: A list of basis elements of the local k-algebra Q_p(f) = R[x]_p/(f)
 
-localAlgebraBasis = method()
-localAlgebraBasis (List, Ideal) := (List) => (L,p) -> (
+getLocalAlgebraBasis = method()
+getLocalAlgebraBasis (List, Ideal) := List => (L, p) -> (
     
-    -- Determine whether or not an ideal is prime
-    if isPrime(p) == false then (
-        error "Error: ideal is not prime"
-        );
+    -- Verify that the ideal p is prime
+    if not isPrime p then error "ideal is not prime";
     
     -- Ambient ring
     R := ring L#0;
-    I := ideal(L);
+    I := ideal L;
     
-    -- Check whether or not an ideal is zero-dimensional
-    if dim I > 0  then (
-        error "Error: morphism does not have isolated zeroes"
-        );
-    if (not isSubset(I,p)) then (
-        error "Error: prime is not a zero of function"
-        );
-    J := I:saturate(I,p);
+    -- Check whether the ideal I is zero-dimensional
+    if dim I > 0 then error "morphism does not have isolated zeros";
+    if not isSubset(I, p) then error "prime is not a zero of function";
+    J := I:saturate(I, p);
     A := R/J;
-    B := basis(A);
-    return flatten(entries(B))
+    B := basis A;
+    flatten entries B
     )
 
--- Input: A zero-dimensional ideal (f_1,..f_n) < k[x_1..x_n].
--- Output: The rank of the global algebra  k[x_1..x_n].
+-- Input: A zero-dimensional ideal (f_1,...,f_n) < k[x_1,...,x_n]
+-- Output: The rank of the global algebra as a k-vector space
 
-rankGlobalAlgebra = method()
-rankGlobalAlgebra (List) := (ZZ) => (Endo) -> (
+getGlobalAlgebraRank = method()
+getGlobalAlgebraRank List := ZZ => Endo -> (
     
     -- Get the underlying field    
-    kk := coefficientRing(ring(Endo#0));    
-    if isField(kk) == false then(
-    	kk = toField(kk);
-    	);
+    kk := coefficientRing ring(Endo#0);    
+    if not isField kk then kk = toField kk;
     
-    -- Let S = k[x_1..x_n] be the ambient polynomial ring
+    -- Let S = kk[x_1,...,x_n] be the ambient polynomial ring
     S := ring(Endo#0);
     
-    -- First check if the morphism does not have isolated zeroes
-    if dim ideal(Endo) > 0  then (
-	error "Error: ideal is not zero-dimensional";
-	);
+    -- First check verify that the morphism has isolated zeroes
+    if dim ideal(Endo) > 0  then error "ideal is not zero-dimensional";
     
     -- Get the rank of S/ideal(Endo) as a kk-vector space
-    return numColumns(basis(S/ideal(Endo)));   
+    numColumns basis(S/ideal(Endo))
     )
 
+-- Input: A pair of integers a and b
+-- Output: A pair of integers x and y such that a*x + b*y = gcd(a,b)
+-- This is adapted from the igcdx method from the Parametrization package
+
+computeExtendedEuclidean = method()
+computeExtendedEuclidean(ZZ,ZZ) := (a,b) -> (
+    if a % b == 0 then (
+        return {0,1};
+        )
+    else (
+        L := computeExtendedEuclidean(b, a % b);
+        return {L#1, L#0 - L#1*(a // b)};
+        );
+    )
+
+-- Input: A list of four integers a,b,p,q
+-- Output: An integer solution x to the congruences x = a (mod p) and x = b (mod q)
+-- This is adapted from the chineseRemainder0 method from the Parametrization package
+
+solveCongruencePair = method()
+solveCongruencePair(ZZ,ZZ,ZZ,ZZ) := (a,b,n,m) -> (
+    k := a - b;
+    L := computeExtendedEuclidean(n,m);
+    u := L#0;
+    v := L#1;
+    a - k*u*n % n*m
+    )
+
+-- This is adapted from the chineseRemainder method from the Parametrization package
+
+solveCongruenceList = method()
+solveCongruenceList(List,List) := (L1,L2) -> (
+    q := 1;
+    a := L1#0;
+    n := L2#0;
+    L := {};
+    while q<#L1 do (
+        a = solveCongruencePair(a, L1#q, n, L2#q);
+        n = n*L2#q;
+        q = q + 1
+        );
+    a
+    )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/BuildingForms.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/BuildingForms.m2
@@ -1,169 +1,141 @@
-
 -----------------------
 -- Producing new forms
 -----------------------
 
--- Input: A field kk, and a list of elements a_1, ... , a_n of kk
--- Output: The diagonal form <a_1,...,a_n> 
+-- Input: A field kk of characteristic not 2, and a list of elements a_1,...,a_n of kk
+-- Output: The Grothendieck-Witt class represented by the diagonal form <a_1,...,a_n> 
 
-diagonalForm = method()
-diagonalForm(Ring,RingElement) := GrothendieckWittClass => (kk,a) -> (
-    return gwClass(matrix(kk,{{sub(a,kk)}}))
+makeDiagonalForm = method()
+makeDiagonalForm (Ring, RingElement) := GrothendieckWittClass => (kk, a) -> (
+    makeGWClass matrix(kk, {{sub(a, kk)}})
     )
 
-diagonalForm(Ring,ZZ) := GrothendieckWittClass => (kk,a) -> (
-    return gwClass(matrix(kk,{{sub(a,kk)}}))
+makeDiagonalForm (Ring, ZZ) := GrothendieckWittClass => (kk, a) -> (
+    makeGWClass matrix(kk, {{sub(a, kk)}})
     )
 
-diagonalForm(Ring,QQ) := GrothendieckWittClass => (kk,a) -> (
-    return gwClass(matrix(kk,{{sub(a,kk)}}))
+makeDiagonalForm (Ring, QQ) := GrothendieckWittClass => (kk, a) -> (
+    makeGWClass matrix(kk, {{sub(a, kk)}})
     )
 
-diagonalForm(Ring, Sequence) := GrothendieckWittClass => (kk,L) -> (
+makeDiagonalForm (Ring, Sequence) := GrothendieckWittClass => (kk, L) -> (
     -- Get the length of the input sequence
     n := #L;
     
-    -- Build an n x n identity matrix
+    -- Build an n x n mutable identity matrix
     A := mutableIdentity(kk, n);
     
-    for i from 0 to (n-1) do(
-	A_(i,i) = sub(L_i,kk);
-	);
+    for i from 0 to n - 1 do A_(i,i) = sub(L_i, kk);
     
-    -- A is mutable so we take matrix(A) to plug it into gwClass
-    return gwClass(matrix(A))
+    -- A is mutable so we take matrix A and form a Grothendieck-Witt class
+    makeGWClass matrix A
     )
 
-diagonalForm(InexactFieldFamily,RingElement) := GrothendieckWittClass => (kk,a) -> (
-    return gwClass(matrix(kk,{{sub(a,kk)}}))
+makeDiagonalForm (InexactFieldFamily,RingElement) := GrothendieckWittClass => (kk, a) -> (
+    makeGWClass matrix(kk, {{sub(a, kk)}})
     )
 
-diagonalForm(InexactFieldFamily,ZZ) := GrothendieckWittClass => (kk,a) -> (
-    return gwClass(matrix(kk,{{sub(a,kk)}}))
+makeDiagonalForm (InexactFieldFamily,ZZ) := GrothendieckWittClass => (kk, a) -> (
+    makeGWClass matrix(kk, {{sub(a, kk)}})
     )
 
-diagonalForm(InexactFieldFamily,QQ) := GrothendieckWittClass => (kk,a) -> (
-    return gwClass(matrix(kk,{{sub(a,kk)}}))
+makeDiagonalForm (InexactFieldFamily,QQ) := GrothendieckWittClass => (kk, a) -> (
+    makeGWClass matrix(kk, {{sub(a, kk)}})
     )
 
-diagonalForm(InexactFieldFamily, Sequence) := GrothendieckWittClass => (kk,L) -> (
+makeDiagonalForm (InexactFieldFamily, Sequence) := GrothendieckWittClass => (kk, L) -> (
     -- Get the length of the input sequence
     n := #L;
     
-    -- Build an n x n identity matrix
+    -- Build an n x n mutable identity matrix
     A := mutableIdentity(kk, n);
     
-    for i from 0 to (n - 1) do(
-	A_(i,i) = sub(L_i,kk);
-	);
+    for i from 0 to n - 1 do A_(i,i) = sub(L_i, kk);
     
-    -- A is mutable so we take matrix(A) to plug it into gwClass
-    return gwClass(matrix(A))
+    -- A is mutable so we take matrix A and form a Grothendieck-Witt class
+    makeGWClass matrix A
     )
 
--- Input: A field kk
--- Output: An even number, giving an optional rank n for a totally hyperbolic form
+-- Input: A field kk of characteristic not 2, and an optional even rank n (default is n = 2)
+-- Output: A Grothendieck-Witt class over kk represented by a totally hyperbolic form of rank n
 
-hyperbolicForm = method()
-
-hyperbolicForm(Ring) := GrothendieckWittClass => (kk) -> (
-    return gwClass(matrix(kk,{{1,0},{0,-1}}))
+makeHyperbolicForm = method()
+makeHyperbolicForm Ring := GrothendieckWittClass => kk -> (
+    makeGWClass matrix(kk, {{1,0},{0,-1}})
     )
 
--- Can take an optional input specifying an (even) rank of a totally hyperbolic form. Default is 2
-hyperbolicForm(Ring,ZZ) := GrothendieckWittClass => (kk,n) -> (
-	if odd n then error "inputted rank is odd";
-	H := matrix(kk,{{1,0},{0,-1}});
-    	k := sub(n/2,ZZ);
-    	outputMatrix := diagonalMatrix(kk,{});
-    	for i from 0 to k - 1 do(
-	    outputMatrix = outputMatrix ++ H;
-	    );
-        return gwClass(outputMatrix)
+makeHyperbolicForm (Ring, ZZ) := GrothendieckWittClass => (kk, n) -> (
+    if odd n then error "entered rank is odd";
+    H := matrix(kk, {{1,0},{0,-1}});
+    m := sub(n/2, ZZ);
+    outputMatrix := diagonalMatrix(kk, {});
+    for i from 0 to m - 1 do outputMatrix = outputMatrix ++ H;
+    makeGWClass outputMatrix
     )
 
-hyperbolicForm(InexactFieldFamily) := GrothendieckWittClass => (kk) -> (
-    return gwClass(matrix(kk,{{1,0},{0,-1}}))
+makeHyperbolicForm InexactFieldFamily := GrothendieckWittClass => kk -> (
+    makeGWClass matrix(kk, {{1,0},{0,-1}})
     )
 
--- Can take an optional input specifying an (even) rank of a totally hyperbolic form. Default is 2
-hyperbolicForm(InexactFieldFamily,ZZ) := GrothendieckWittClass => (kk,n) -> (
-	if odd n then error "inputted rank is odd";
-	H := matrix(kk,{{1,0},{0,-1}});
-    	k := sub(n/2,ZZ);
-    	outputMatrix := diagonalMatrix(kk,{});
-    	for i from 0 to k - 1 do(
-	    outputMatrix = outputMatrix ++ H;
-	    );
-        return gwClass(outputMatrix)
+makeHyperbolicForm (InexactFieldFamily, ZZ) := GrothendieckWittClass => (kk, n) -> (
+    if odd n then error "entered rank is odd";
+    H := matrix(kk, {{1,0},{0,-1}});
+    m := sub(n/2, ZZ);
+    outputMatrix := diagonalMatrix(kk, {});
+    for i from 0 to m - 1 do outputMatrix = outputMatrix ++ H;
+    makeGWClass outputMatrix
     )
 
--- Input: A field kk, and a list of elements a_1, ... , a_n of kk
+-- Input: A field kk of characteristic not 2, and a list of elements a_1,...,a_n of kk
 -- Output: The Pfister form <<a_1,...,a_n>>
 
-PfisterForm = method()
-PfisterForm(Ring,RingElement) := GrothendieckWittClass => (kk,a) -> (
-    return diagonalForm(kk,(1,(-1)*a))
-    );
+makePfisterForm = method()
+makePfisterForm (Ring, RingElement) := GrothendieckWittClass => (kk, a) -> (
+    makeDiagonalForm(kk, (1, sub((-1)*a, kk)))
+    )
 
-PfisterForm(Ring,ZZ) := GrothendieckWittClass => (kk,a) -> (
-    return diagonalForm(kk,(1,(-1)*a))
-    );
+makePfisterForm (Ring, ZZ) := GrothendieckWittClass => (kk, a) -> (
+    makeDiagonalForm(kk, (1, sub((-1)*a, kk)))
+    )
 
-PfisterForm(Ring,QQ) := GrothendieckWittClass => (kk,a) -> (
-    return diagonalForm(kk,(1,(-1)*a))
-    );
+makePfisterForm (Ring, QQ) := GrothendieckWittClass => (kk, a) -> (
+    makeDiagonalForm(kk, (1, sub((-1)*a, kk)))
+    )
 
-PfisterForm(Ring,Sequence) := GrothendieckWittClass => (kk,L) -> (
+makePfisterForm (Ring, Sequence) := GrothendieckWittClass => (kk, L) -> (
     -- Get the length of the input sequence
     n := #L;
-    if n == 0 then error "list is empty";
     
-    -- If there is just one entry L_0 return the form <1, -L_0>
-    firstPfisterForm := diagonalForm(kk,(1,(-1)*L_0));
-    if n == 1 then(
-	return firstPfisterForm
+    -- Iteratively multiply <1,-L_0>*<1,-L_1>*...
+    outputForm := makeDiagonalForm(kk, 1);
+    for i from 0 to n - 1 do (
+	ithPfister := makePfisterForm(kk, L_i);
+	outputForm = multiplyGW(outputForm, ithPfister);
 	);
-    
-    -- If n>1 iteratively multiply <1,-L_0>*<1,-L_1>*...
-    outputForm := firstPfisterForm;
-    for i from 1 to (n-1) do (
-	ithPfister := diagonalForm(kk,(1,(-1)*L_i));
-	outputForm = gwMultiply(outputForm,ithPfister);
-	);
-    
-    return outputForm
-   )
+    outputForm
+    )
 
-PfisterForm(InexactFieldFamily,RingElement) := GrothendieckWittClass => (kk,a) -> (
-    return diagonalForm(kk,(1,(-1)*a))
-    );
+makePfisterForm (InexactFieldFamily, RingElement) := GrothendieckWittClass => (kk, a) -> (
+    makeDiagonalForm(kk, (1, sub((-1)*a, kk)))
+    )
 
-PfisterForm(InexactFieldFamily,ZZ) := GrothendieckWittClass => (kk,a) -> (
-    return diagonalForm(kk,(1,(-1)*a))
-    );
+makePfisterForm (InexactFieldFamily,ZZ) := GrothendieckWittClass => (kk, a) -> (
+    makeDiagonalForm(kk,(1, sub((-1)*a, kk)))
+    )
 
-PfisterForm(InexactFieldFamily,QQ) := GrothendieckWittClass => (kk,a) -> (
-    return diagonalForm(kk,(1,(-1)*a))
-    );
+makePfisterForm (InexactFieldFamily,QQ) := GrothendieckWittClass => (kk, a) -> (
+    makeDiagonalForm(kk,(1, sub((-1)*a, kk)))
+    )
 
-PfisterForm(InexactFieldFamily,Sequence) := GrothendieckWittClass => (kk,L) -> (
+makePfisterForm (InexactFieldFamily,Sequence) := GrothendieckWittClass => (kk, L) -> (
     -- Get the length of the input sequence
     n := #L;
-    if n == 0 then error "list is empty";
     
-    -- If there is just one entry L_0 return the form <1, -L_0>
-    firstPfisterForm := diagonalForm(kk,(1,(-1)*L_0));
-    if n == 1 then(
-	return firstPfisterForm
+    -- Iteratively multiply <1,-L_0>*<1,-L_1>*...
+    outputForm := makeDiagonalForm(kk, 1);
+    for i from 0 to n - 1 do (
+	ithPfister := makePfisterForm(kk, L_i);
+	outputForm = multiplyGW(outputForm, ithPfister);
 	);
-    
-    -- If n>1 iteratively multiply <1,-L_0>*<1,-L_1>*...
-    outputForm := firstPfisterForm;
-    for i from 1 to (n-1) do(
-	ithPfister := diagonalForm(kk,(1,(-1)*L_i));
-	outputForm = gwMultiply(outputForm,ithPfister);
-	);
-    
-    return outputForm
-   )
+    outputForm
+    )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Decomposition.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Decomposition.m2
@@ -124,7 +124,7 @@ getAnisotropicPartQQDimension2 GrothendieckWittClass := GrothendieckWittClass =>
 	    B = matrix(A) || B;
 	    );
 
-	-- Step 5f: Try to solve sytem of equations over GF(2)
+	-- Step 5f: Try to solve system of equations over GF(2)
         kk := GF(2);
     	W = matrix(kk, entries W);
     	B = matrix(kk, entries B);

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Decomposition.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Decomposition.m2
@@ -1,321 +1,291 @@
-
--- Input: A form 1 over QQ of anisotropic dimension d >= 4
--- Output: A form < a > so that q + < a > has anisotropic dimension d - 1
-
+-- Input: A form q over QQ of anisotropic dimension d >= 4
+-- Output: A form < a > so that q + < -a > has anisotropic dimension d - 1
 -- Note: This is Koprowski/Rothkegel's Algorithm 5 in the case of QQ
 
-QQanisotropicDimension4 = method()
-QQanisotropicDimension4 (GrothendieckWittClass) := (GrothendieckWittClass) => beta ->(
-    if not (anisotropicDimensionQQ(beta) >= 4) then error "anisotropic dimension of inputted form is not >=4";
+reduceAnisotropicPartQQDimension4 = method()
+reduceAnisotropicPartQQDimension4 GrothendieckWittClass := GrothendieckWittClass => beta -> (
+    if getAnisotropicDimensionQQ(beta) < 4 then
+	error "anisotropic dimension of form is not >= 4";
     
-    -- If the signature is non-negative then return <1>
-    if signature(beta) >= 0 then(
-	return gwClass(matrix(QQ,{{1}}))
-	);
+    -- If the signature is non-negative then return < 1 >
+    if getSignature(beta) >= 0 then return makeDiagonalForm(QQ, 1);
     
-    -- Otherwise return <-1>
-    if signature(beta) < 0 then(
-	return gwClass(matrix(QQ,{{-1}}))	        
-        );	
-    );
+    -- Otherwise return < -1 >
+    if getSignature(beta) < 0 then return makeDiagonalForm(QQ, -1);	
+    )
 
 -- Input: A form q over QQ of anisotropic dimension 3
 -- Output: A form < a > so that q + < -a > has anisotropic dimension 2
-
 -- Note: This is Koprowski/Rothkegel's Algorithm 7 in the case of QQ
-QQanisotropicDimension3 = method()
-QQanisotropicDimension3 (GrothendieckWittClass) := (GrothendieckWittClass) => beta ->(
-    d := integralDiscriminant(beta);
+
+reduceAnisotropicPartQQDimension3 = method()
+reduceAnisotropicPartQQDimension3 GrothendieckWittClass := GrothendieckWittClass => beta -> (
+    if getAnisotropicDimensionQQ(beta) != 3 then
+	error "anisotropic dimension of form is not 3";
+
+    d := getIntegralDiscriminant beta;
     
-    -- Build lists of primes where the p-adic valuation of the discriminant is even or is odd
-    L1 := {};
+    -- Build lists of relevant primes where the p-adic valuation of the discriminant is even or is odd
+    L1 := {1};
     L2 := {};
-    S1 := {};
+    S1 := {1};
     S2 := {};
-    for p in relevantPrimes(beta) do(
-	if odd padicValuation(d,p) then(
-	    L1 = append(L1,p);
-	    S1 = append(S1,d-1);
+    for p in getRelevantPrimes(beta) do (
+	if odd getPadicValuation(d,p) then (
+	    L1 = append(L1, p);
+	    S1 = append(S1, d - 1);
 	    );
-	if even padicValuation(d,p) then(
-	    L2 = append(L2,p^2);
-	    S2 = append(S2,p)
+	if even getPadicValuation(d,p) then (
+	    L2 = append(L2, p^2);
+	    S2 = append(S2, p)
 	    );
 	);
     
-    -- We are looking for an element which is equivalent to d-1 mod p for each p in L1, and equivalent to p mod p^2 for each p in L2
-    -- we use the chineseRemainder method from the "Parametrization" package to find such an element
-    alpha := chineseRemainder(S1 | S2, L1 |L2);
-    a := squarefreePart(alpha);
+    -- We are looking for an element which is equivalent to (d - 1) mod p for each p in L1 and equivalent to p mod p^2 for each p in L2
+    -- We use the solveCongruenceList method to find such an element
+    alpha := solveCongruenceList(S1 | S2, L1 | L2);
+    a := getSquarefreePart alpha;
+    makeDiagonalForm(QQ, a)
+    )
+
+-- Input: A form q over QQ of anisotropic dimension 2
+-- Output: The anisotropic part of q
+-- Note: This is Koprowski/Rothkegel's Algorithm 8 in the case of QQ
+
+getAnisotropicPartQQDimension2 = method()
+getAnisotropicPartQQDimension2 GrothendieckWittClass := GrothendieckWittClass => beta -> (
+    if getAnisotropicDimensionQQ(beta) != 2 then
+	error "anisotropic dimension of form is not 2";
+
+    n := getRank beta;
+
+    -- Shortcut: if the form has anisotropic dimension 2 and the form is rank 2, return the form itself
+    if n == 2 then return beta; 
     
-    return diagonalForm(QQ,a);
-
-    );
-
--- Constructs the anisotropic part of a form with anisotropic dimension 2
--- 
-QQanisotropicDimension2 = method()
-QQanisotropicDimension2 (GrothendieckWittClass) := (GrothendieckWittClass) => beta ->(
-    n := numRows beta.matrix;
-
-    -- Shortcut: if the form has anisotropic dimension 2 and the form is dimension 2, return the form itself
-    -- if (n==2) then(
-    -- 	return beta;
-    -- 	);
-        
-    
-    -- Step 1: We want the Witt index to be 0 mod 4 in their terminology --- note they define the Witt index to be
-    -- the integer w so that q = wH + q_a. This is not the same as the dimension of a maximal totally isotropic subspace
-    w := (n - anisotropicDimensionQQ(beta))/2;
-    w = sub(w,ZZ);
+    -- Step 1: We want the Witt index to be 0 mod 4 
+    w := getWittIndex beta;
     q := beta;
-    if ((w % 4) != 0) then(
+    if (w % 4) != 0 then (
 	w = w % 4;
-	q = gwAdd(q, hyperbolicForm(QQ,2*(4-w)));
+	q = addGW(q, makeHyperbolicForm(QQ, 2*(4-w)));
 	n = n + 2*(4-w);
 	);
-    -- Step 2: Compute discriminant (note they use a signed version of the discriminant in their algorithm)
-    d:= ((-1)^(n*(n-1)/2))*integralDiscriminant(q);
+
+    -- Step 2: Compute discriminant (note that Koprowski/Rothkegel use a signed version of the discriminant in their algorithm)
+    d := ((-1)^(n*(n-1)/2))*getIntegralDiscriminant(q);
     
-    -- Step 3: Take relevant primes plus dyadic ones
-    L := relevantPrimes(beta);
-    if not member(2,L) then(
-	L = append(L,2);
-	);
+    -- Step 3: Take relevant primes plus 2
+    S := getRelevantPrimes beta;
+    if not member(2, S) then S = append(S, 2);
     
-    -- Start the loop at p=2
-    p:=2;
+    -- Start the loop at p = 2
+    p := 2;
     solnFound := false;
     
-    
-    while not solnFound do(
-	r := #L;
-    	-- Step 5c: Make a vector of exponents of Hasse invariants
-	W := mutableMatrix(QQ,r,1);
-	for i from 0 to (r-1) do(
-	    W_(i,0) = (1 - (HasseWittInvariant(q,L_i)))/2;
-	    );
-       	
+    while not solnFound do (
+	s := #S;
 
-	-- Step 5b: 
-	W = matrix(W);
-    	if (d < 0) then(
-	    if not (abs(signature(q)) == 2) then (error "signature isn't pm 2");
-	    
-	    if (signature(q) == 2) then (
-		W = matrix(QQ,{{0}}) || W;
-		);
-	    if (signature(q) == -2) then(
-		W = matrix(QQ,{{1}}) || W;
+	-- Step 5a: Make a basis for the group of S-singular elements
+	basisES:= append(S, -1);
+	m := #basisES;
+
+    	-- Step 5c: Make a vector of exponents of Hasse invariants
+	W := mutableMatrix(QQ, s,1);
+	for i from 0 to s - 1 do
+	    W_(i,0) = (1 - (getHasseWittInvariant(q, S_i)))/2;
+       	
+	-- Step 5b / 5f: 
+	W = matrix W;
+    	if d < 0 then (
+	    if abs(getSignature(q)) != 2 then
+		error "getSignature isn't pm 2";
+	    if getSignature(q) == 2 then W = matrix(QQ, {{0}}) || W;
+	    if getSignature(q) == -2 then W = matrix(QQ, {{1}}) || W;
 	    );
-	);
         
     	-- Step 5e: Make a matrix of Hilbert symbols
-    	B := mutableIdentity(QQ,r);
-    	for i from 0 to (r-1) do(
-	    for j from 0 to (r-1) do(
-	    	B_(i,j) = (1 - HilbertSymbol(L_j, d, L_i))/2;
-	    	);
+    	B := mutableMatrix(QQ, s,m);	
+    	for i from 0 to s - 1 do (
+	    for j from 0 to m - 1 do
+	    	B_(i,j) = (1 - getHilbertSymbol(basisES_j, d,S_i))/2;
 	    );
-	B = matrix(B);
+	B = matrix B;
     	
-	-- Step 5d: Append a zero column on the front if the discriminant is negative
-    	if (d < 0) then(
-	    zeroVec := mutableMatrix(QQ,1,r);
-	    for i from 0 to (r-1) do(
-	    	zeroVec_(0,i) = 0
+	-- Step 5d: Append a zero column on the left if the discriminant is negative
+    	if (d < 0) then (
+	    A := mutableMatrix(QQ, 1,m);
+	    for i from 0 to m - 1 do (
+	    	if basisES_i > 0 then (
+		    A_(0,i) = 0;
+		    )
+		else 
+                    A_(0,i) = 1;
 	    	);
-	    B = matrix(zeroVec) || B;
+	    B = matrix(A) || B;
 	    );
-        kk := GF(2);
-    	W = matrix(kk,entries(W));
-    	B = matrix(kk,entries(B));
 
-	
-	if (class(solve(B,W)) === Matrix) then(
-	    X := solve(B,W);
+	-- Step 5f: Try to solve sytem of equations over GF(2)
+        kk := GF(2);
+    	W = matrix(kk, entries W);
+    	B = matrix(kk, entries B);
+
+	if class(solve(B, W)) === Matrix then (
+	    X := solve(B, W);
 	    solnFound = true;
 	    break;
 	    )
-	else(
-	    p = nextPrime(p+1);
-	    while (member(p,L)==true) do(
-		p = nextPrime(p+1);
-		);
-
-	    L = append(L,p);
+	else (
+	    p = nextPrime(p + 1);
+	    while member(p, S) do p = nextPrime(p + 1);
+	    S = append(S, p);
 	    );
 	);
-  
-    alpha := sub(1,ZZ);
-    for j from 0 to (r-1) do(
-	alpha = alpha * ((L_j)^(sub(X_(j,0),ZZ)));
-	);
-    return diagonalForm(QQ,(alpha, -alpha*d))
-    
-   );
-
-
-
--- Input: Any form over QQ
--- Output: Its anisotropic part
-QQanisotropicPart = method()
-QQanisotropicPart (GrothendieckWittClass) := (GrothendieckWittClass) => (beta) -> (
-    beta = diagonalClass(beta);
-    
-    n := numRows(beta.matrix);
-    d := anisotropicDimension(beta);
-    
-    -- If the form is anisotropic 
-    if n == d then(return beta);
-    
-    -- Initialize an empty quadratic form
-    outputForm := diagonalForm(QQ,());
-    alpha := 1;
-    
-    
-    while d>=4 do(
-	d = anisotropicDimension(beta);
-	outputForm = gwAdd(outputForm,QQanisotropicDimension4(beta));
-	alpha = ((QQanisotropicDimension4(beta)).matrix)_(0,0);
-	
-	beta = gwAdd(beta, diagonalForm(QQ,((-1)*alpha)));
-	);
-    
-    if d==3 then(
-	outputForm = gwAdd(outputForm,QQanisotropicDimension3(beta));
-	alpha = ((QQanisotropicDimension3(beta)).matrix)_(0,0);
-	
-	beta = gwAdd(beta, diagonalForm(QQ,((-1)*alpha)));
-	);
-    
-    if d==2 then(
-       outputForm = gwAdd(outputForm, QQanisotropicDimension2(beta));
-       );
-    
-    if d==1 then(
-	outputForm = gwAdd(outputForm, diagonalForm(QQ,(integralDiscriminant(beta))));
-	);
-    
-    return outputForm;
-    
-    
-    );
-
--- Input: A symmetric matrix representing a quadratic form or a GrothendieckWittClass; over QQ, RR, CC, or a finite field of characteristic not 2
--- Output: A symmetric matrix or GrothendieckWittClass that is the anisotropic part of the input
-
-anisotropicPart = method()
-anisotropicPart (Matrix) := (Matrix) => (A) -> (
-    k := ring A;
-    -- Ensure base field is supported
-    if not (k === CC or instance(k,ComplexField) or k === RR or instance(k,RealField) or k === QQ or (instance(k, GaloisField) and k.char != 2)) then (
-        error "Base field not supported; only implemented over QQ, RR, CC, and finite fields of characteristic not 2";
-        );
-    -- Ensure underlying matrix is symmetric
-    if (transpose(A) != A) then (
-        error "Underlying matrix is not symmetric";
-	);
-    diagA := congruenceDiagonalize(A);
-    -- Over CC, the anisotropic part is either the rank 0 form or the rank 1 form, depending on the anisotropic dimension
-    if (k === CC or instance(k,ComplexField)) then (
-        if (anisotropicDimension(A)==0) then (
-            return (diagonalMatrix(CC,{}));
-            )
-        else (
-            return (matrix(CC,{{1}}));
-            );
-        )
-    --Over RR, the anisotropic part consists of the positive entries in excess of the number of negative entries, or vice versa
-    else if (k === RR or instance(k,RealField)) then (
-        posEntries := numPosDiagEntries(diagA);
-        negEntries := numNegDiagEntries(diagA);
-        if (posEntries > negEntries) then (
-            return (id_(RR^(posEntries-negEntries)));
-            )
-        else if (posEntries < negEntries) then (
-            return (-id_(RR^(negEntries-posEntries)));
-            )
-        else (
-            return (diagonalMatrix(RR,{}));
-            );
-        )
-    -- Over QQ, call anisotropicPartQQ
-    else if (k === QQ) then (
-        return (QQanisotropicPart(gwClass(nondegeneratePartDiagonal(A)))).matrix;
-        )
-    -- Over a finite field, if the anisotropic dimension is 1, then the form is either <1> or <e>, where e is any nonsquare representative, and if the anisotropic dimension is 2 then the form is <1,-e>
-    else if (instance(k, GaloisField) and k.char != 2) then (
-        if (anisotropicDimension(A)==1) then (
-            return (matrix(k,{{sub((-1)^((numNonzeroDiagEntries(diagA)-1)/2),k)*det(nondegeneratePartDiagonal(diagA))}}));
-            )
-        else if (anisotropicDimension(A)==0) then (
-            return (diagonalMatrix(k,{}));
-            )
-        else (
-            return (matrix(k,{{1,0},{0,sub((-1)^((numNonzeroDiagEntries(diagA)-2)/2),k)*det(nondegeneratePartDiagonal(diagA))}}));
-            );
-        )
-    -- We should never get here
-    else error "Problem with base field"
+    alpha := sub(1, ZZ);
+    for j from 0 to m - 1 do
+	alpha = alpha * (basisES_j)^(sub(X_(j,0), ZZ));
+    makeDiagonalForm(QQ, (alpha, -getSquarefreePart(alpha*d)))
     )
 
+-- Input: A Grothendieck-Witt class representing a symmetric bilinear form over QQ
+-- Output: The Grothendieck-Witt class representing the anisotropic part of this form
 
-anisotropicPart (GrothendieckWittClass) := (GrothendieckWittClass) => (alpha) -> (
-    return (gwClass(anisotropicPart(alpha.matrix)));
+getAnisotropicPartQQ = method()
+getAnisotropicPartQQ GrothendieckWittClass := GrothendieckWittClass => beta -> (
+    beta = getDiagonalClass beta;
+    n := getRank beta;
+    
+    -- If the form is anisotropic 
+    if getAnisotropicDimension(beta) == n then return beta;
+    
+    -- Initialize an empty symmetric bilinear form
+    outputForm := makeDiagonalForm(QQ, ());    
+    alpha := 1;
+
+    while getAnisotropicDimension(beta) >= 4 do (
+	outputForm = addGW(outputForm, reduceAnisotropicPartQQDimension4(beta));
+	alpha = (getMatrix reduceAnisotropicPartQQDimension4 beta)_(0,0);	
+	beta = addGW(beta, makeDiagonalForm(QQ, ((-1)*alpha)));
+	);
+    
+    if getAnisotropicDimension(beta) == 3 then (
+	outputForm = addGW(outputForm, reduceAnisotropicPartQQDimension3(beta));
+	alpha = (getMatrix reduceAnisotropicPartQQDimension3 beta)_(0,0);	
+	beta = addGW(beta, makeDiagonalForm(QQ, ((-1)*alpha)));
+	);
+    
+    if getAnisotropicDimension(beta) == 2 then
+        outputForm = addGW(outputForm, getAnisotropicPartQQDimension2 beta);
+    
+    if getAnisotropicDimension(beta) == 1 then
+	outputForm = addGW(outputForm, makeDiagonalForm(QQ, ((-1)^((n-1)/2))*getIntegralDiscriminant(beta)));
+    
+    outputForm
+    )
+
+-- Input: A symmetric matrix representing a symmetric bilinear form or a GrothendieckWittClass; over QQ, RR, CC, or a finite field of characteristic not 2
+-- Output: A symmetric matrix or GrothendieckWittClass that is the anisotropic part of the input
+
+getAnisotropicPart = method()
+getAnisotropicPart Matrix := Matrix => A -> (
+    k := ring A;
+    -- Ensure base field is supported
+    if not (instance(k, ComplexField) or instance(k, RealField) or k === QQ or (instance(k, GaloisField) and k.char != 2)) then
+        error "Base field not supported; only implemented over QQ, RR, CC, and finite fields of characteristic not 2";
+    -- Ensure underlying matrix is symmetric
+    if not isSquareAndSymmetric A then
+	error "Underlying matrix is not symmetric";
+    -- Over CC, the anisotropic part is either the rank 0 form or the rank 1 form, depending on the anisotropic dimension
+    if instance(k, ComplexField) then (
+        if getAnisotropicDimension(A) == 0 then (
+            return diagonalMatrix(CC, {});
+            )
+        else
+            return matrix(CC, {{1}});
+        )
+    --Over RR, the anisotropic part consists of the positive entries in excess of the number of negative entries, or vice versa
+    else if instance(k, RealField) then (
+        diagonalA := diagonalizeViaCongruence A;
+        posEntries := countPosDiagEntries diagonalA;
+        negEntries := countNegDiagEntries diagonalA;
+        if posEntries > negEntries then (
+            return id_(RR^(posEntries - negEntries));
+            )
+        else if posEntries < negEntries then (
+            return -id_(RR^(negEntries - posEntries));
+            )
+        else
+            return diagonalMatrix(RR, {});
+        )
+    -- Over QQ, call getAnisotropicPartQQ
+    else if k === QQ then (
+        return getMatrix getAnisotropicPartQQ(makeGWClass getNondegeneratePartDiagonal A);
+        )
+    -- Over a finite field, if the anisotropic dimension is 1, then the form is either < 1 > or < e >, where e is any nonsquare representative,
+    -- and if the anisotropic dimension is 2 then the form is <1,-e>
+    else if (instance(k, GaloisField) and k.char != 2) then (
+        diagA := diagonalizeViaCongruence(A);
+        if getAnisotropicDimension(A) == 1 then (
+            return matrix(k, {{sub((-1)^((getRank(diagA)-1)/2), k)*det(getNondegeneratePartDiagonal diagA)}});
+            )
+        else if getAnisotropicDimension(A) == 0 then (
+            return diagonalMatrix(k, {});
+            )
+        else
+            return matrix(k, {{1,0},{0, sub((-1)^((getRank(diagA)-2)/2), k)*det(getNondegeneratePartDiagonal diagA)}});
+        );
+    )
+
+getAnisotropicPart GrothendieckWittClass := GrothendieckWittClass => alpha -> (
+    makeGWClass getAnisotropicPart getMatrix(alpha)
     )
 
 ---------------------------------------
 -- Simplifying a form
 ---------------------------------------
 
--- Input: A Grothendieck-Witt class beta over a field kk
+-- Input: A Grothendieck-Witt class beta over over QQ, RR, CC, or a finite field of characteristic not 2
 -- Output: A simplified diagonal representative of beta
-sumDecompositionVerbose = method()
-sumDecompositionVerbose (GrothendieckWittClass) := (GrothendieckWittClass, String) => beta ->(
+getSumDecompositionVerbose = method()
+getSumDecompositionVerbose GrothendieckWittClass := (GrothendieckWittClass, String) => beta -> (
     -- Get base field of beta
-    kk := baseField(beta);
+    kk := getBaseField beta;
+
+    if getRank(beta) == 0 then
+	return (makeGWClass(diagonalMatrix(kk, {})), "empty form");
     
     outputString := "";
     
-    
     -- Get isotropic dimension of beta and construct its isotropic and anistropic parts
-    w := WittIndex(beta);
+    w := getWittIndex beta;
     
-    if w > 0 then(
-	outputString = outputString | toString(w) | "H";
-	);
+    if w > 0 then outputString = outputString | toString(w) | "H";
     
-    hyperbolicPart := hyperbolicForm(kk,2*w);
-    alpha := anisotropicPart(beta);
+    hyperbolicPart := makeHyperbolicForm(kk,2*w);
+    alpha := getAnisotropicPart beta;
     
-    if numRows(alpha.matrix) > 0 then(
-        D := diagonalEntries(alpha);
-        for i from 0 to (length(D)-1) do (
-	    outputString = outputString | "+ <" | toString(D_i) | ">";
-    )
+    if getRank(alpha) > 0 then (
+        D := getDiagonalEntries alpha;
+        for i from 0 to length(D) - 1 do
+	    outputString = outputString | " + <" | toString(D_i) | ">";
 	);
     
     -- Return a simplified form of beta
-    return (gwAdd(alpha,hyperbolicPart),outputString)
+    return (addGW(alpha, hyperbolicPart), outputString);
     )    
 
--- Input: A Grothendieck-Witt class beta over a field k
+-- Input: A Grothendieck-Witt class beta over over QQ, RR, CC, or a finite field of characteristic not 2
 -- Output: A simplified diagonal representative of beta
 
-sumDecomposition = method()
-sumDecomposition (GrothendieckWittClass) := (GrothendieckWittClass) => beta -> (
-    beta.cache.diagonalClass = (sumDecompositionVerbose(beta))_0;
-    return (sumDecompositionVerbose(beta))_0
-);
+getSumDecomposition = method()
+getSumDecomposition GrothendieckWittClass := GrothendieckWittClass => beta -> (
+    beta.cache.getDiagonalClass = (getSumDecompositionVerbose beta)_0;
+    (getSumDecompositionVerbose beta)_0
+    )
 
--- Input: A Grothendieck-Witt class beta over a field k
--- Output: The decomposition as a sum of hyperbolic and rank one forms
+-- Input: A Grothendieck-Witt class beta over over QQ, RR, CC, or a finite field of characteristic not 2
+-- Output: The decomposition of beta as a sum of hyperbolic and rank one forms
 
-sumDecompositionString = method()
-sumDecompositionString (GrothendieckWittClass) := (String) => beta -> (
-    return (sumDecompositionVerbose(beta))_1
-);
-
-
-
+getSumDecompositionString = method()
+getSumDecompositionString GrothendieckWittClass := String => beta -> (
+    (getSumDecompositionVerbose beta)_1
+    )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/GWInvariants.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/GWInvariants.m2
@@ -2,181 +2,133 @@
 -- Invariants
 ---------------------------------------
 
--- Input: A diagonal matrix
--- Output: The number of nonzero entries on the diagonal of a diagonal matrix to which it is congruent
--- Note: numNonzeroDiagEntries is *not* included as a method in the A1BrowerDegrees package
+-- Input: A Grothendieck-Witt class alpha
+-- Output: The rank of a symmetric bilinear form representing alpha
 
-numNonzeroDiagEntries = method()
-numNonzeroDiagEntries (Matrix) := (Matrix) => (A) -> (
-    if not isDiagonal(A) then(
-        A = congruenceDiagonalize(A);
-        );
-    nonzeroDiagEntries := 0;
-    for i from 0 to (numRows(A)-1) do (
-        if A_(i,i) != 0 then (
-            nonzeroDiagEntries = nonzeroDiagEntries + 1;
-            );
-        );
-    return(nonzeroDiagEntries);
+getRank = method()
+getRank GrothendieckWittClass := ZZ => alpha -> (
+    numRows getMatrix alpha
     )
 
--- Input: A diagonal matrix over QQ or RR
--- Output: The number of positive entries on the diagonal of a diagonal matrix to which it is congruent
--- Note: numPosDiagEntries is *not* included as a method in the A1BrowerDegrees package
+getRank Matrix := ZZ => M -> (
+    if numRows(M) == 0 then return 0;
+    rank M
+    )
 
-numPosDiagEntries = method()
-numPosDiagEntries (Matrix) := (Matrix) => (A) -> (
-    if not isDiagonal(A) then(
-        A = congruenceDiagonalize(A);
-        );
+-- Input: A symmetric matrix or Grothendieck-Witt class defined over QQ or RR
+-- Output: The number of positive entries on the diagonal of a diagonal matrix to which the underlying matrix is congruent
+-- Note: countPosDiagEntries is *not* included as a method in the A1BrowerDegrees package
+
+countPosDiagEntries = method()
+countPosDiagEntries Matrix := Matrix => A -> (
+    -- Ensure matrix is symmetric
+    if not isSquareAndSymmetric A then error "Matrix is not symmetric";
+    -- Ensure base field is QQ or RR
     k := ring A;
-    if not (k === RR or instance(k,RealField) or k === QQ) then(
+    if not (instance(k, RealField) or k === QQ) then
         error "Only implemented over QQ and RR";
-        );
+    if not isDiagonal A then A = diagonalizeViaCongruence A;
     posDiagEntries := 0;
-    for i from 0 to (numRows(A)-1) do (
-        if A_(i,i) > 0 then (
-            posDiagEntries = posDiagEntries + 1;
-            );
+    for i from 0 to numRows(A) - 1 do (
+        if A_(i,i) > 0 then posDiagEntries = posDiagEntries + 1;
         );
-    return(posDiagEntries);
+    posDiagEntries
     )
 
--- Input: A diagonal matrix over QQ or RR
--- Output: The number of positive entries on the diagonal of a diagonal matrix to which it is congruent
--- Note: numPosDiagEntries is *not* included as a method in the A1BrowerDegrees package
+countPosDiagEntries GrothendieckWittClass := ZZ => beta -> (
+    countPosDiagEntries getMatrix beta
+    )
 
-numNegDiagEntries = method()
-numNegDiagEntries (Matrix) := (Matrix) => (A) -> (
-    if not isDiagonal(A) then(
-        A = congruenceDiagonalize(A);
-        );
+-- Input: A symmetric matrix or Grothendieck-Witt class defined over QQ or RR
+-- Output: The number of positive entries on the diagonal of a diagonal matrix to which the underlying matrix is congruent
+-- Note: countPosDiagEntries is *not* included as a method in the A1BrowerDegrees package
+
+countNegDiagEntries = method()
+countNegDiagEntries Matrix := Matrix => A -> (
+    -- Ensure matrix is symmetric
+    if not isSquareAndSymmetric A then error "Matrix is not symmetric";
+    -- Ensure base field is QQ or RR
     k := ring A;
-    if not (k === RR or instance(k,RealField) or k === QQ) then(
+    if not (instance(k, RealField) or k === QQ) then
         error "Only implemented over QQ and RR";
-        );
+    if not isDiagonal A then A = diagonalizeViaCongruence A;
     negDiagEntries := 0;
-    for i from 0 to (numRows(A)-1) do (
-        if A_(i,i) < 0 then (
-            negDiagEntries = negDiagEntries + 1;
-            );
+    for i from 0 to numRows(A) - 1 do (
+        if A_(i,i) < 0 then negDiagEntries = negDiagEntries + 1;
         );
-    return(negDiagEntries);
+    negDiagEntries
     )
 
--- Input: A Grothendieck-Witt class beta defined over QQ or RR
--- Output: The number of positive entries on the diagonal of a diagonal matrix representing the Grothendieck-Witt class
--- Note:  numPosEntries is *not* included as a method in the A1BrowerDegrees package
-
-numPosEntries = method()
-numPosEntries (GrothendieckWittClass) := ZZ => beta ->(
-    return(numPosDiagEntries(beta.matrix));
-    );
-
--- Input: A Grothendieck-Witt class beta defined over QQ or RR
--- Output: The number of negative entries on the diagonal of a diagonal matrix representing the Grothendieck-Witt class
--- Note:  numNegEntries is *not* included as a method in the A1BrowerDegrees package
-
-numNegEntries = method()
-numNegEntries (GrothendieckWittClass) := ZZ => beta ->(
-    return(numNegDiagEntries(beta.matrix));
-    );
+countNegDiagEntries GrothendieckWittClass := ZZ => beta -> (
+    countNegDiagEntries getMatrix beta
+    )
 
 -- Input: A Grothendieck-Witt class beta defined over QQ or RR
 -- Output: The signature of beta
 
-signature = method()
-signature (GrothendieckWittClass) := ZZ => (beta) ->(
-    sig := numPosEntries(beta) - numNegEntries(beta);
-    return sig
-    );
+getSignature = method()
+getSignature GrothendieckWittClass := ZZ => beta -> (
+    countPosDiagEntries(beta) - countNegDiagEntries(beta)
+    )
 
 ---------------------------
 -- Comparing forms over QQ
 ---------------------------
 
--- Input: A Grothendieck-Witt class beta defined over QQ
+-- Input: A Grothendieck-Witt class defined over QQ
 -- Output: A squarefree integral representative of its discriminant
 
-integralDiscriminant = method()
-integralDiscriminant (GrothendieckWittClass) := (ZZ) => (beta) -> (
-    B:= beta.matrix;
-    rankForm:= numRows(B);
-    kk:= ring B;
-    
-    if (not (kk === QQ)) then (error "GrothendieckWittClass is not over QQ");
-    
-    -- Take an integral diagonal representative for beta
-    gamma := diagonalClass(beta);
-    G := gamma.matrix;
-    
-    discrimForm:= 1;
-    for i from 0 to (rankForm-1) do(
-	discrimForm = discrimForm * (G_(i,i));
-	);
-    
-    return sub(squarefreePart(discrimForm),ZZ);
-    );
+getIntegralDiscriminant = method()
+getIntegralDiscriminant GrothendieckWittClass := ZZ => beta -> (
+    kk := getBaseField beta;
+    if not kk === QQ then error "GrothendieckWittClass is not over QQ";
 
--- Input: A Grothendieck-Witt class beta defined over QQ
--- Output: The smallest list of primes that divide its discriminant
-
-relevantPrimes = method()
-relevantPrimes (GrothendieckWittClass) := List => (beta) -> (
-    B := beta.matrix;
-    rankForm := numRows(B);
-    kk:= ring B;
-    
-    -- Take a diagonal integral representative of the form
-    gamma := diagonalClass(beta);
-    D := diagonalEntries(gamma);
-    
-    L := {};
-    
-    -- Append all the prime factors of each of the entries appearing on a diagonal
-    for x in D do(
-	L = unique(L | primeFactors(sub(x,ZZ)));
-	);
-    
-    return L
-    );
-
--- Two Q forms over Q_p are isomorphic if they have same rank, same discriminant, and same Hasse-Witt invariant   
-
-HasseWittInvariant = method()
-
--- epsilonHilbert computes the epsilon function for a diagonal quadratic form over Q_p
--- Function requires the list of the diagonal elements of the quadratic form, to be integers
-
--- Input:  A list of the diagonal elements (f_i) for the quadratic form, assumed to be integers, and a prime p
--- Output: The HasseWittInvariant function for the quadratic form (f_i) for Q_p
-
-HasseWittInvariant (List, ZZ) := ZZ => (L,p) -> (
-       a := 1;
-       len := #L;
-       
-       -- Replace every entry of L with its squarefree part so we can be sure we're evaluating at integers
-       f := {};
-       for x in L do(
-	   f = append(f,squarefreePart(x));
-	   );
-       
-       for i from 0 to len - 1 do (
-	   if not liftable(f_i,ZZ) then (error "Error:  Hilbert symbol evaluated at a non-integer");
-	   );
-       for i from 0 to len - 2 do (
-       	   for j from i + 1 to len - 1 do (
-	       a = a * HilbertSymbol(f_i, f_j, p);
-	       );
-	   );
-       
-       return a;
-    );
-
-HasseWittInvariant(GrothendieckWittClass, ZZ) := ZZ => (beta,p) -> (
-    kk := baseField beta;
-    if not (kk === QQ) then error "method is only implemented over the rationals";
-    if not isPrime(p) then error "second argument must be a prime number";
-    return HasseWittInvariant(diagonalEntries(diagonalClass(beta)),p)
-    
+    -- Return a squarefree integral representative of the product of diagonal entries of a diagonal representative of the form 
+    getSquarefreePart product getDiagonalEntries(beta)
     )
+
+-- Input: A Grothendieck-Witt class defined over QQ
+-- Output: The list of primes that divide entries of its diagonal representative
+
+getRelevantPrimes = method()
+getRelevantPrimes GrothendieckWittClass := List => beta -> (
+    kk := getBaseField beta;
+    if not kk === QQ then error "GrothendieckWittClass is not over QQ";
+    
+    -- Find the diagonal entries of a diagonal integral representative of the form
+    D := getDiagonalEntries getDiagonalClass beta;
+    
+    -- Make a list of all prime factors of diagonal entries
+    L := {};
+    for x in D do L = unique(L | getPrimeFactors(sub(x, ZZ)));
+    L
+    )
+
+-- Input:  A list of the diagonal elements of a symmetric bilinear form 
+-- or a Grothendieck-Witt class over QQ, and a prime number p
+-- Output: The Hasse-Witt invariant of the symmetric bilinear form or Grothendieck-Witt class over QQ_p
+
+getHasseWittInvariant = method()
+getHasseWittInvariant (List, ZZ) := ZZ => (L, p) -> (
+    if not isPrime p then error "second argument must be a prime number";
+
+    a := 1;
+    len := #L;
+       
+    -- Replace every entry of L by its squarefree part so we can work with integers
+    f := {};
+    for x in L do f = append(f, getSquarefreePart x);
+    for i from 0 to len - 2 do (
+       	for j from i + 1 to len - 1 do
+	    a = a * getHilbertSymbol(f_i,f_j,p);
+	);
+    a
+    )
+
+getHasseWittInvariant(GrothendieckWittClass, ZZ) := ZZ => (beta, p) -> (
+    kk := getBaseField beta;
+    if not kk === QQ then
+	error "method is only implemented over the rational numbers";
+    getHasseWittInvariant(getDiagonalEntries beta, p)
+    )
+

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/GrothendieckWittClasses.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/GrothendieckWittClasses.m2
@@ -1,108 +1,117 @@
--- We define GrothendieckWittClass to be a new type,
---    meant to represent the isomorphism class of a symmetric bilinear form
---    over a base field.
+-- Input: A matrix
+-- Output: Boolean that gives whether the matrix defines a nondegenerate symmetric bilinear form over a field of characteristic not 2
+
+isWellDefinedGW = method()
+isWellDefinedGW Matrix := Boolean => M -> (
+    
+    -- Return false if the matrix isn't square and symmetric
+    if not isSquareAndSymmetric M then return false;
+
+    -- Return false if the matrix represents a degenerate form
+    if isDegenerate M then return false;
+
+    -- Return false if the matrix isn't defined over a field
+    if not isField ring M then return false;
+    
+    -- Returns false if the matrix is defined over a field of characteristic 2
+    if char(ring M) == 2 then return false;
+
+    -- Otherwise, return true
+    true
+    )
+
+-- We define GrothendieckWittClass to be a new type, meant to represent the isomorphism class 
+-- of a nondegenerate symmetric bilinear form over a field of characteristic not 2
+
 GrothendieckWittClass = new Type of HashTable
-GrothendieckWittClass.synonym = "Grothendieck Witt Class"
+GrothendieckWittClass.synonym = "Grothendieck-Witt Class"
 
--- Input: A symmetric matrix M defined over an arbitrary field
--- Output: The isomorphism class of a symmetric bilinear form represented by M
+-- Input: A matrix M representing a nondegenerate symmetric bilinear form over a field of characteristic not 2
+-- Output: The GrothendieckWittClass representing the symmetric bilinear form determined by M
 
--- Note: A class in GW can be constructed from a representing matrix
-
-gwClass = method()
-gwClass (Matrix) := GrothendieckWittClass => M -> (
-   if (isWellDefined(M)) then (
+makeGWClass = method()
+makeGWClass Matrix := GrothendieckWittClass => M -> (
+   if isWellDefinedGW M then (
         new GrothendieckWittClass from {
             symbol matrix => M,
             symbol cache => new CacheTable
             }
         )
     else (
-        error "gwClass called on a matrix that does not represent a nondegenerate symmetric bilinear form over a field of characteristic not 2";
-        )
+        error "makeGWClass called on a matrix that does not represent a nondegenerate symmetric bilinear form over a field of characteristic not 2";
+	)
     )
 
--- This allows us to extract the matrix from a class
-matrix GrothendieckWittClass := Matrix => beta -> beta.matrix
+-- Input: A GrothendieckWittClass
+-- Output: A net for printing the underlying matrix
 
+net GrothendieckWittClass := Net => alpha -> (
+    net getMatrix alpha
+    )
 
+-- Input: A GrothendieckWittClass
+-- Output: A string for printing the underlying matrix
 
--- Check whether a matrix defines a nondegenerate symmeteric bilinear form
-isWellDefined (Matrix) := Boolean => M -> (
-    
-    -- Returns false if a matrix isn't symmetric
-    --	  Note that this will also return false if a matrix isn't square,
-    --	      so we don't need another check for that.
-    if not isSquareAndSymmetric(M) then(
-	<< "-- Defining matrix is not symmetric" << endl;
-	return false;
-	);
-
-    -- Returns false if the matrix represents a degenerate form
-    if isDegenerate(M) then (
-	<< "-- Defining matrix is degenerate" << endl;
-	return false;
-        );
-
-    -- Returns false if the matrix isn't defined over a field
-    if not isField ring M then (
-	<< "-- Matrix is not defined over a field" << endl;
-	return false;
-	);
-    
-    -- Returns false if a matrix is defined over a field of characteristic two
-    if char ring M == 2 then(
-	<< "-- Package does not support base fields of characteristic two" <<endl;
-	return false;
-	);
-    
-    true);
+texMath GrothendieckWittClass := String => alpha -> (
+    texMath getMatrix alpha
+    )
 
 -- Input: A Grothendieck-Witt class beta, the isomorphism class of a symmetric bilinear form
--- Output: The base ring of beta
+-- Output: The base field of beta
 
-baseField = method()
-baseField GrothendieckWittClass := Ring => beta -> (
-    ring beta.matrix
+getBaseField = method()
+getBaseField GrothendieckWittClass := Ring => beta -> (
+    ring getMatrix beta
     )
 
--- Input: Two Grothendieck-Witt classes beta and gamma
+-- Input: A GrothendieckWittClass representing a symmetric bilinear form determined by a matrix M
+-- Output: The matrix M
+
+getMatrix = method()
+getMatrix GrothendieckWittClass := Matrix => alpha -> (
+    alpha.matrix
+    )
+
+-- Input: Two Grothendieck-Witt classes beta and gamma over the same field
 -- Output: The direct sum of beta and gamma
 
-gwAdd = method()
-gwAdd(GrothendieckWittClass, GrothendieckWittClass) := GrothendieckWittClass => (beta, gamma) -> (
-    Kb := baseField(beta);
-    Kg := baseField(gamma);
+addGW = method()
+addGW (GrothendieckWittClass,GrothendieckWittClass) := GrothendieckWittClass => (beta,gamma) -> (
+    Kb := getBaseField beta;
+    Kg := getBaseField gamma;
     
     -- Galois field case
     if instance(Kb, GaloisField) and instance(Kg, GaloisField) then (
-	-- Returns an error if the underlying fields of the two classes beta and gamma are different
-	if not Kb.order == Kg.order  then error "Error: these classes have different underlying fields";
-	return gwClass(beta.matrix ++ substitute(gamma.matrix,Kb))
+	-- Return an error if the underlying fields of the two classes are different
+	if not Kb.order == Kg.order then
+	    error "these classes have different underlying fields";
+	return makeGWClass(getMatrix beta ++ sub(getMatrix gamma, Kb));
 	);
     
-    -- remaining cases
-    if not Kb === Kg then error "Error: these classes have different underlying fields";
-    	return gwClass(beta.matrix ++ gamma.matrix)
+    -- Remaining cases
+    if not Kb === Kg then
+	error "these classes have different underlying fields";
+    makeGWClass(getMatrix beta ++ getMatrix gamma)
     )
 
--- Input: Two Grothendieck-Witt classes beta and gamma
+-- Input: Two Grothendieck-Witt classes beta and gamma over the same field
 -- Output: The tensor product of beta and gamma
 
-gwMultiply = method()
-
-gwMultiply(GrothendieckWittClass, GrothendieckWittClass) := GrothendieckWittClass => (beta, gamma) -> (
-    Kb := baseField(beta);
-    Kg := baseField(gamma);
+multiplyGW = method()
+multiplyGW (GrothendieckWittClass,GrothendieckWittClass) := GrothendieckWittClass => (beta,gamma) -> (
+    Kb := getBaseField beta;
+    Kg := getBaseField gamma;
     
     -- Galois field case
     if instance(Kb, GaloisField) and instance(Kg, GaloisField) then (
-	-- Returns an error if the underlying fields of the two classes beta and gamma are different
-	if not Kb.order == Kg.order  then error "Error: these classes have different underlying fields";
-	return gwClass(beta.matrix ** substitute(gamma.matrix,Kb))
+	-- Return an error if the underlying fields of the two classes are different
+	if not Kb.order == Kg.order then
+	    error "these classes have different underlying fields";
+	return makeGWClass(getMatrix beta ** substitute(getMatrix gamma,Kb));
 	);
     
-    -- remaining cases
-    if not Kb === Kg then error "Error: these classes have different underlying fields";
-    	return gwClass(beta.matrix ** gamma.matrix)
+    -- Remaining cases
+    if not Kb === Kg then
+	error "these classes have different underlying fields";
+    makeGWClass(getMatrix beta ** getMatrix gamma)
     )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/HilbertSymbols.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/HilbertSymbols.m2
@@ -1,106 +1,84 @@
-
-
--- Over k = R, the real symbol is 1 if either a or b is positive, and -1 if they are both negative.
+-- Input: A pair of nonzero rational numbers a and b
+-- Output: 1 if either a or b is positive; -1 if they are both negative
 -- See Serre, III Theorem 1
 
-HilbertSymbolReal = method()
-HilbertSymbolReal (QQ, QQ) := (ZZ) => (a, b) -> (
-    if (a==0) then (error "first argument to HilbertSymbolReal must be nonzero");
-    if (b==0) then (error "second argument to HilbertSymbolReal must be nonzero");
+getHilbertSymbolReal = method()
+getHilbertSymbolReal (QQ, QQ) := ZZ => (a, b) -> (
+    if (a == 0 or b == 0) then
+	error "the arguments of getHilbertSymbolReal must be nonzero";
     if (a < 0 and b < 0) then (
 	return -1;
 	)
-    else (
-	if (a>0 or b>0) then (
-	    return 1;
-	    );
-	);
-    );
+    else
+	return 1;
+    )
 
-HilbertSymbolReal (QQ, ZZ) := (ZZ) => (a,b) -> (
+getHilbertSymbolReal (QQ, ZZ) := ZZ => (a, b) -> (
     b1 := b/1;
-    return HilbertSymbolReal(a, b1);
-    );
+    getHilbertSymbolReal(a,b1)
+    )
 
-HilbertSymbolReal (ZZ, QQ) := (ZZ) => (a,b) -> (
+getHilbertSymbolReal (ZZ, QQ) := ZZ => (a, b) -> (
     a1 := a/1;
-    return HilbertSymbolReal(a1, b);
-    );
+    getHilbertSymbolReal(a1,b)
+    )
 
-HilbertSymbolReal (ZZ, ZZ) := (ZZ) => (a,b) -> (
+getHilbertSymbolReal (ZZ, ZZ) := ZZ => (a, b) -> (
     a1:= a/1;
     b1:= b/1;
-    return HilbertSymbolReal(a1, b1);
-    );
+    getHilbertSymbolReal(a1,b1)
+    )
 
+-- Input: A pair of rational numbers a and b and a prime number p. The integers a and b are considered as elements of QQ_p
+-- Output: The Hilbert symbol (a,b)_p following Serre, III Theorem 1
 
--- Input: Any integers a and b and a prime p. The integers a and b are considered as elements of QQ_p.
--- Output: The Hilbert symbol (a,b)_p following Serre III Theorem 1
-
-HilbertSymbol = method()
-HilbertSymbol (ZZ, ZZ, ZZ) := (ZZ) => (a, b, p) -> (
-    if (a==0 or b==0) then error "first two arguments to HilbertSymbol must be nonzero";
-    if (not isPrime(p)) then error "third argument of HilbertSymbol must be a prime";
+getHilbertSymbol = method()
+getHilbertSymbol (ZZ, ZZ, ZZ) := ZZ => (a, b, p) -> (
+    if (a == 0 or b == 0) then
+	error "first two arguments of getHilbertSymbol must be nonzero";
+    if not isPrime p then
+	error "third argument of getHilbertSymbol must be prime";
     
-    alpha := padicValuation(a,p);
-    beta := padicValuation(b,p);
-    u := sub(a/p^alpha,ZZ);
+    alpha := getPadicValuation(a,p);
+    beta := getPadicValuation(b,p);
+    u := sub(a/p^alpha, ZZ);
     v := sub(b/p^beta, ZZ);
     
-    -- If epsilon(p) = 0
-    if (p % 4 == 1) then(
-	return ((squareSymbol(u,p))^beta * (squareSymbol(v,p))^alpha);
-	);
+    if (p % 4 == 1) then
+	return ((getSquareSymbol(u,p))^beta) * ((getSquareSymbol(v,p))^alpha);
     
-    -- If epsilon(p) = 1
-    if (p % 4 == 3) then(
-	return ((-1)^(alpha*beta))*(((squareSymbol(u,p))^beta) * ((squareSymbol(v,p))^alpha));
-	
-	);
+    if (p % 4 == 3) then
+	return ((-1)^(alpha*beta))*((getSquareSymbol(u,p))^beta) * ((getSquareSymbol(v,p))^alpha);
     
-    -- Finally if p=2
-    if p == 2 then(
-	-- The reductions of u, v must be mod 8, as the calculation of (u-1)/2, (u^2-1)/8 below 
-	-- depends on 
-	-- the mod 8 reduction
-	u = (u % 8);
-	v = (v % 8);
-	alpha = (alpha % 2);
-	beta = (beta % 2);
-	d := sub(((u-1)/2)*((v-1)/2) + alpha*((v^2-1)/8) + beta*((u^2-1)/8),ZZ);
-	return ((-1)^d)
+    if p == 2 then (
+	-- The reductions of u and v are mod 8, as the calculation of (u-1)/2 and (u^2-1)/8 below 
+	-- depends on their mod 8 reduction
+	u = u % 8;
+	v = v % 8;
+	alpha = alpha % 2;
+	beta = beta % 2;
+	d := sub((u-1)*(v-1)/4 + alpha*(v^2-1)/8 + beta*(u^2-1)/8, ZZ);
+	return (-1)^d;
 	);
-    
-    );
+    )
 
-HilbertSymbol (QQ, QQ, ZZ) := (ZZ) => (a, b, p) -> (
+getHilbertSymbol (QQ, QQ, ZZ) := ZZ => (a, b, p) -> (
  
--- if a, b are rational numbers with denominators,  one can multiply by square of denominator to 
--- get a', b' integers.  Then evaluate HilbertSymbol (a', b', p);
+-- If a and b are rational numbers with denominators, one can multiply by the square of their denominators to 
+-- get integers a' and b' and then evaluate getHilbertSymbol (a',b',p)
     
-    if not liftable(a, ZZ) then (
-	a1 := numerator a;
-	a2 := denominator a;
-	a = a1*a2;
-	);
-	
-    if not liftable(b, ZZ) then (
-	b1 := numerator b;
-	b2 := denominator b;
-	b = b1*b2;
-	);
+    if not liftable(a, ZZ) then a = numerator(a)*denominator(a);
+    if not liftable(b, ZZ) then b = numerator(b)*denominator(b);
     
-    a = sub(a,ZZ);
-    b = sub(b,ZZ);
-    return HilbertSymbol(a,b,p);
-    );
+    a = sub(a, ZZ);
+    b = sub(b, ZZ);
+    getHilbertSymbol(a,b,p)
+    )
 
-HilbertSymbol (ZZ, QQ, ZZ) := (ZZ) => (a, b, p) -> (
-    a1:=a/1;
-    return HilbertSymbol(a1,b, p);    
-   );
+getHilbertSymbol (ZZ, QQ, ZZ) := ZZ => (a, b, p) -> (
+    getHilbertSymbol(a/1,b, p)
+    )
 
-HilbertSymbol (QQ, ZZ, ZZ) := (ZZ) => (a, b, p) -> (
-   b1:=b/1;
-   return HilbertSymbol(a, b1, p);    
-   );
+getHilbertSymbol (QQ, ZZ, ZZ) := ZZ => (a, b, p) -> (
+   getHilbertSymbol(a,b/1, p)
+   )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/IsomorphismOfForms.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/IsomorphismOfForms.m2
@@ -1,97 +1,85 @@
+-- Input: A pair of Grothendieck-Witt classes or a pair of matrices representing symmetric bilinear forms over QQ
+-- Output: Boolean that gives whether the Grothendieck-Witt classes/symmetric bilinear forms are isomorphic
 
--- Input: Two Grothendieck-Witt classes or symmetric matrices representing quadratic forms over QQ
--- Output: Boolean checking whether the Grothendieck-Witt classes/quadratic forms are isomorphic
-
-isIsomorphicFormQ = method()
-isIsomorphicFormQ (GrothendieckWittClass, GrothendieckWittClass) := Boolean => (alpha, beta) -> (
-    if (not baseField(alpha) === QQ) then error "first input must be a form defined over QQ";
-    if (not baseField(beta) === QQ) then error "second input must be a form defined over QQ";
+isIsomorphicFormQQ = method()
+isIsomorphicFormQQ (GrothendieckWittClass,GrothendieckWittClass) := Boolean => (alpha,beta) -> (
+    if not getBaseField(alpha) === QQ then
+	error "first input must have base field QQ";
+    if not getBaseField(beta) === QQ then
+	error "second input must have base field QQ";
     
-    -- Check if the ranks agree
-    if (not numRows(alpha.matrix) == numRows(beta.matrix)) then return false;
+    -- If the ranks differ, then the forms are not isomorphic
+    if getRank(alpha) != getRank(beta) then return false;
     
-    -- Check if the signatures (Hasse-Witt invariants at RR) agree
-    if (not signature(alpha) == signature(beta)) then return false;
+    -- If the signatures (Hasse-Witt invariants at RR) differ, then the forms are not isomorphic
+    if getSignature(alpha) != getSignature(beta) then return false;
     
-    -- Check if the discriminants agree
-    if (not integralDiscriminant(alpha) == integralDiscriminant(beta)) then return false;
-    
-    -- Check if all the Hasse-Witt invariants agree
-    PrimesToCheck := unique(relevantPrimes(alpha) | relevantPrimes(beta));
-    flag := 0;
-    for p in PrimesToCheck do(
-	if (HasseWittInvariant(alpha,p) != HasseWittInvariant(beta,p)) then(
-	    flag = 1;
-	    break;
-	    );
-	);
-    if flag == 0 then (
-	return true;
-	)
-    else (
+    -- If the discriminants differ, then the forms are not isomorphic
+    if getIntegralDiscriminant(alpha) != getIntegralDiscriminant(beta) then
 	return false;
+    
+    -- Check the Hasse-Witt invariants
+    PrimesToCheck := unique(getRelevantPrimes(alpha) | getRelevantPrimes(beta));
+    for p in PrimesToCheck do (
+        -- If any Hasse-Witt invariants differ, then the forms are not isomorphic
+	if (getHasseWittInvariant(alpha, p) != getHasseWittInvariant(beta, p)) then
+	    return false;
 	);
-    );
-
-isIsomorphicFormQ (Matrix, Matrix) := Boolean => (M,N) -> (
-    return isIsomorphicFormQ(gwClass(M),gwClass(N));
-    );
-
--- Input: Two Grothendieck-Witt classes alpha and beta, defined over CC, RR, QQ, or a finite field of characteristic not 2
--- Output: Boolean checking if alpha and beta are the same
-
-gwIsomorphic = method()
-gwIsomorphic (GrothendieckWittClass,GrothendieckWittClass) := (Boolean) => (alpha,beta) -> (
-    return(isIsometricForm(alpha.matrix,beta.matrix));
+    -- If we get here, then the rank, signature, discriminant, and all Hasse-Witt invariants agree,
+    -- so thus the forms are isomorphic
+    true
     )
 
--- Input: Two symmetric bilinear forms represented as matrices
--- Output: Boolean checking whether two symmetric bilinear forms are isometric
+isIsomorphicFormQQ (Matrix,Matrix) := Boolean => (M,N) -> (
+    isIsomorphicFormQQ(makeGWClass M, makeGWClass N)
+    )
 
-isIsometricForm = method()
-isIsometricForm (Matrix,Matrix) := (Boolean) => (A,B) -> (
+-- Input: Two matrices representing symmetric bilinear forms over CC, RR, QQ, or a finite field of characteristic not 2
+-- Output: Boolean that gives whether the bilinear forms are isomorphic
+
+isIsomorphicForm = method()
+isIsomorphicForm (Matrix,Matrix) := Boolean => (A,B) -> (
     k1 := ring A;
     k2 := ring B;
     -- Ensure both base fields are supported
-    if not (k1 === CC or instance(k1,ComplexField) or k1 === RR or instance(k1,RealField) or k1 === QQ or (instance(k1, GaloisField) and k1.char != 2)) then (
+    if not (instance(k1, ComplexField) or instance(k1, RealField) or k1 === QQ or (instance(k1, GaloisField) and k1.char != 2)) then
         error "Base field not supported; only implemented over QQ, RR, CC, and finite fields of characteristic not 2";
-        );
-    if not (k2 === CC or instance(k2,ComplexField) or k2 === RR or instance(k2,RealField) or k2 === QQ or (instance(k1, GaloisField) and k1.char != 2)) then (
+    if not (instance(k2, ComplexField) or instance(k2, RealField) or k2 === QQ or (instance(k1, GaloisField) and k1.char != 2)) then
         error "Base field not supported; only implemented over QQ, RR, CC, and finite fields of characteristic not 2";
-        );
     
     -- Ensure both matrices are symmetric
-    if not isSquareAndSymmetric(A) then error "Underlying matrix is not symmetric";
-    if not isSquareAndSymmetric(B) then error "Underlying matrix is not symmetric";
-    
-    diagA := congruenceDiagonalize(A);
-    diagB := congruenceDiagonalize(B);
+    if not isSquareAndSymmetric A then
+	error "Underlying matrix is not symmetric";
+    if not isSquareAndSymmetric B then
+	error "Underlying matrix is not symmetric";
     
     -----------------------------------
     -- Complex numbers
     -----------------------------------
     
-    -- Over CC, diagonal forms over spaces of the same dimension are equivalent if and only if they have the same number of nonzero entries
-    if (k1 === CC or instance(k1,ComplexField)) and (k2 === CC or instance(k2,ComplexField)) then (
-        return ((numRows(A) == numRows(B)) and (numNonzeroDiagEntries(diagA) == numNonzeroDiagEntries(diagB)));
+    -- Over CC, forms over spaces of the same dimension are isomorphic if and only if they have the same rank
+    if (instance(k1, ComplexField) and instance(k2, ComplexField)) then (
+        return (numRows(A) == numRows(B) and getRank(A) == getRank(B));
         )
     
     -----------------------------------
     -- Real numbers
     -----------------------------------
     
-    -- Over RR, diagonal forms of the same dimension are equivalent if and only if they have the same number of positive and negative entries
-    else if ((k1 === RR or instance(k1,RealField)) and (k2 === RR or instance(k2,RealField))) then (
-        return ((numRows(A) == numRows(B)) and (numPosDiagEntries(diagA) == numPosDiagEntries(diagB)) and (numNegDiagEntries(diagA) == numNegDiagEntries(diagB)));
+    -- Over RR, diagonal forms of the same dimension are isomorphic if and only if they have the same number of positive and negative entries
+    else if (instance(k1, RealField) and instance(k2, RealField)) then (
+        diagA := diagonalizeViaCongruence A;
+        diagB := diagonalizeViaCongruence B;
+        return (numRows(A) == numRows(B) and countPosDiagEntries(diagA) == countPosDiagEntries(diagB) and countNegDiagEntries(diagA) == countNegDiagEntries(diagB));
         )
     
     -----------------------------------
     -- Rational numbers
     -----------------------------------
     
-    -- Over QQ, if spaces have same dimension and nondegenerate parts have same dimension, then call isIsomorphicFormQ, which checks equivalence over all completions
-    else if ((k1 === QQ) and (k2 === QQ)) then (
-        return ((numRows(A) == numRows(B)) and (numRows(nondegeneratePartDiagonal(A)) == numRows(nondegeneratePartDiagonal(B))) and (isIsomorphicFormQ(nondegeneratePartDiagonal(A),nondegeneratePartDiagonal(B))));
+    -- Over QQ, if the spaces have same dimension, then call isIsomorphicFormQQ on the nondegenerate parts of the forms
+    else if (k1 === QQ and k2 === QQ) then (
+        return (numRows(A) == numRows(B) and isIsomorphicFormQQ(getNondegeneratePartDiagonal A, getNondegeneratePartDiagonal B));
         )
     
     -----------------------------------
@@ -100,8 +88,16 @@ isIsometricForm (Matrix,Matrix) := (Boolean) => (A,B) -> (
     
     -- Over a finite field, diagonal forms over spaces of the same dimension are equivalent if and only if they have the same number of nonzero entries and the product of these nonzero entries is in the same square class
     else if (instance(k1, GaloisField) and instance(k2, GaloisField) and k1.char !=2 and k2.char != 2 and k1.order == k2.order) then (
-        return ((numRows(A) == numRows(B)) and (numNonzeroDiagEntries(diagA) == numNonzeroDiagEntries(diagB)) and (legendreBoolean(det(nondegeneratePartDiagonal(A))) == legendreBoolean(sub(det(nondegeneratePartDiagonal(B)),k1))));
+        return (numRows(A) == numRows(B) and getRank(A) == getRank(B) and isGFSquare(det(getNondegeneratePartDiagonal A)) == isGFSquare(sub(det(getNondegeneratePartDiagonal B), k1)));
         )
-    -- If we get here, the base fields are not isomorphic
-    else error "Base fields are not isomorphic"
+    -- If we get here, then the base fields are not the same
+    else
+	error "Base fields are not the same";
+    )
+
+-- Input: Two Grothendieck-Witt classes alpha and beta, defined over CC, RR, QQ, or a finite field of characteristic not 2
+-- Output: Boolean that gives whether alpha and beta are the same Grothendieck-Witt class
+
+isIsomorphicForm (GrothendieckWittClass,GrothendieckWittClass) := Boolean => (alpha,beta) -> (
+    isIsomorphicForm(getMatrix alpha, getMatrix beta)
     )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Isotropy.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Isotropy.m2
@@ -1,36 +1,33 @@
-
 -- Input: A matrix representing a symmetric bilinear form over QQ, RR, CC, or a finite field of characteristic not 2
--- Output: Boolean returning whether the symmetric bilinear form is anisotropic
+-- Output: Boolean that gives whether the symmetric bilinear form is anisotropic
 	
 isAnisotropic = method()
-isAnisotropic (Matrix) := (Boolean) => (A) -> (
+isAnisotropic Matrix := Boolean => A -> (
     k := ring A;
     -- Ensure base field is supported
-    if not (k === CC or instance(k,ComplexField) or k === RR or instance(k,RealField) or k === QQ or (instance(k, GaloisField) and k.char != 2)) then (
+    if not (instance(k, ComplexField) or instance(k, RealField) or k === QQ or (instance(k, GaloisField) and k.char != 2)) then
         error "Base field not supported; only implemented over QQ, RR, CC, and finite fields of characteristic not 2";
-        );
-    n := numRows(A);
-    return (n == anisotropicDimension(A));
+    numRows(A) == getAnisotropicDimension(A)
     )
 
--- Input: A Grothendieck-Witt class alpha over QQ, RR, CC, or a finite field of characteristic not 2
--- Output: Boolean returning whether alpha is anisotropic
+-- Input: A Grothendieck-Witt class over QQ, RR, CC, or a finite field of characteristic not 2
+-- Output: Boolean that gives whether the Grothendieck-Witt class is anisotropic
 
-isAnisotropic (GrothendieckWittClass) := (Boolean) => (alpha) -> (
-    return (isAnisotropic(alpha.matrix));
+isAnisotropic GrothendieckWittClass := Boolean => alpha -> (
+    isAnisotropic getMatrix alpha
     )
 
 -- Input: A matrix representing a symmetric bilinear form over QQ, RR, CC, or a finite field of characteristic not 2
--- Output: Boolean returning whether the symmetric bilinear form is isotropic	
+-- Output: Boolean that gives whether the symmetric bilinear form is isotropic	
 
 isIsotropic = method()
-isIsotropic (Matrix) := (Boolean) => (A) -> (
-    return (not isAnisotropic(A));
+isIsotropic Matrix := Boolean => A -> (
+    not isAnisotropic A
     )
 
--- Input: A Grothendieck-Witt class alpha over QQ, RR, CC, or a finite field of characteristic not 2
--- Output: Boolean returning whether alpha is isotropic
+-- Input: A Grothendieck-Witt class over QQ, RR, CC, or a finite field of characteristic not 2
+-- Output: Boolean that gives whether the Grothendieck-Witt class is isotropic
 
-isIsotropic (GrothendieckWittClass) := (Boolean) => (alpha) -> (
-    return (not isAnisotropic(alpha));
+isIsotropic GrothendieckWittClass := Boolean => alpha -> (
+    not isAnisotropic alpha
     )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/LocalGlobalDegrees.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/LocalGlobalDegrees.m2
@@ -2,230 +2,208 @@
 -- A1-Brouwer degree methods
 ----------------------------
 
--- Input: A list f = {f_1, f_2, ..., f_n} of polynomials kk^n -> kk^n
+-- Input: A list f = {f_1, f_2, ..., f_n} of polynomials giving a map kk^n -> kk^n
 -- Output: The Grothendieck-Witt class deg^(A^1)(f)
 
-globalA1Degree = method()
-globalA1Degree (List) := (GrothendieckWittClass) => (Endo) -> (
-    -- Endo is the list {f_1, f_2, ..., f_n} of polynomials kk^n -> kk^n
-    
+getGlobalA1Degree = method()
+getGlobalA1Degree List := GrothendieckWittClass => Endo -> (
+    -- Endo is the list {f_1,f_2,...,f_n} of polynomials giving a map kk^n -> kk^n
     -- n is the number of polynomials
-    n := #Endo; -- n is the no. of polynomials    
+    n := #Endo;
 
-    -- Get the underlying field, assert it is a field
-    kk := coefficientRing(ring(Endo#0)); 
+    -- Get the underlying ring, and ensure it is a field
+    kk := coefficientRing ring(Endo#0); 
+    if not isField kk then kk = toField kk;
     
-    if isField(kk) == false then(
-	kk = toField(kk);
-	);
+    -- Let S = kk[x_1..x_n] be the ambient polynomial ring
+    S := ring(Endo#0);
     
-    -- Let S = k[x_1..x_n] be the ambient polynomial ring
-    S:=ring(Endo#0);
+    -- Check whether the morphism has isolated zeros
+    if dim ideal(Endo) > 0  then
+	error "morphism does not have isolated zeros";
     
-    -- First check if the morphism does not have isolated zeroes
-    if dim ideal(Endo) > 0  then error "Error: morphism does not have isolated zeroes";
+    -- Check whether the number of variables matches the number of polynomials
+    if #(gens S) != n then
+	error "the number of variables does not match the number of polynomials";
     
-    -- Check the number of variables matches the number of polynomials
-    if not #(gens S) == n then error "Error: the number of variables does not match the number of polynomials.";
+    -- If the field is CC, output the Grothendieck-Witt class of an identity matrix of the appropriate rank
+    if instance(kk, ComplexField) then (
+    	rankAlgebra := getGlobalAlgebraRank Endo;
+    	return makeGWClass id_(CC^rankAlgebra);
+        );
     
-    -- If the field is CC, just output gwClass of an identity matrix of rank = rankAlgebra
-    if (kk === CC or instance(kk,ComplexField)) then(
-    	rankAlgebra:=rankGlobalAlgebra(Endo);
-    	return gwClass(matrix(mutableIdentity(CC,rankAlgebra)));
-    );
-    
-    -- If the field is RR, ask the user to run it over QQ instead, then simplify over RR
-    if (kk === RR or instance(kk,RealField)) then error "Error: globalA1Degree method does not work over the reals. Instead, define the polynomials over QQ to output a GrothendieckWittClass. Then extract the matrix, base change it to RR, and then run sumDecomposition().";    
+    -- If the field is RR, ask the user to run the computation over QQ instead and then base change to RR
+    if instance(kk, RealField) then error "getGlobalA1Degree method does not work over the reals. Instead, define the polynomials over QQ to output a GrothendieckWittClass. Then extract the matrix, base change it to RR, and run getSumDecomposition().";    
     
     -- Create internal rings/matrices
     
-    -- Initialize a polynomial ring in X_i's and Y_i's to compute the Bezoutian in
+    -- Initialize a polynomial ring in X_i's and Y_i's in which to compute the Bezoutian
     X := local X;
     Y := local Y;
- 
-    R := kk(monoid[X_1..X_n|Y_1..Y_n]);
-    -- Create an (n x n) matrix D which will be populated by \Delta_{ij} in the paper
+    R := kk(monoid[X_1..X_n | Y_1..Y_n]);
+
+    -- Create an (n x n) matrix D to be populated by \Delta_{ij} from the Brazelton-McKean-Pauli paper
     D := "";
-    try D = mutableMatrix id_((frac R)^n) else D= mutableMatrix id_(R^n);
+    try D = mutableMatrix id_((frac R)^n) else D = mutableMatrix id_(R^n);
     
-    for i from 0 to (n-1) do (
-	for j from 0 to (n-1) do(
-	    -- iterate through the entries of the matrix D and populate it with the following information ...
-        -- create the list {Y_1, ..., Y_(j-1), X_j, ..., X_n}. Note Macaulay2 is 0-indexed hence the difference in notation. 
-	    targetList1 := apply(toList (Y_1..Y_j|X_(j+1)..X_n),i->i_R);
-        -- create the list {Y_1, ..., Y_j, X_(j+1), ..., X_n }. Note Macaulay2 is 0-indexed hence the difference in notation. 
-	    targetList2 := apply(toList (Y_1..Y_(j+1)| X_(j+2)..X_n),i->i_R); 
-        -- suppose our endomorphisms are given in the variables x_1, ..., x_n.
-        -- map f_i(x_1, ..., x_n) to f_i(Y_1, ..., Y_(j-1), X_j, ..., X_n) resp.
-        -- then take the difference f_i(Y_1, ..., Y_(j-1), X_j, ..., X_n) - f_i(Y_1, ... Y_j, X_(j+1), ..., X_n)
-        numeratorD := ((map(R,S,targetList1))(Endo_i)-(map(R,S,targetList2))(Endo_i)); 
-        -- divide it by X_j - Y_j, Note Macaulay2 is 0-indexed hence the difference in notation. 
-	    D_(i,j)= numeratorD/((X_(j+1))_R-(Y_(j+1))_R); 
-	); 
-    );
+    for i from 0 to n - 1 do (
+	for j from 0 to n - 1 do (
+	    -- Iterate through the entries of the matrix D and populate it as follows
+            -- Create the list {Y_1,...,Y_(j-1), X_j,...,X_n}. Note that Macaulay2 is 0-indexed hence the difference in notation. 
+	    targetList1 := apply(toList(Y_1..Y_j | X_(j+1)..X_n), i->i_R);
+            -- Create the list {Y_1,...,Y_j, X_(j+1),...,X_n}. Note that Macaulay2 is 0-indexed hence the difference in notation. 
+	    targetList2 := apply(toList (Y_1..Y_(j+1) | X_(j+2)..X_n), i->i_R); 
+            -- Suppose our endomorphisms are given in the variables x_1,...,x_n
+            -- Map f_i(x_1,...,x_n) to f_i(Y_1,...,Y_(j-1), X_j,...,X_n) resp.
+            -- Take the difference f_i(Y_1,...,Y_(j-1), X_j,...,X_n) - f_i(Y_1,...,Y_j, X_(j+1),...,X_n)
+            numeratorD := (map(R, S, targetList1)) (Endo_i) - (map(R, S, targetList2)) (Endo_i); 
+            -- Divide this by X_j - Y_j. Note that Macaulay2 is 0-indexed hence the difference in notation. 
+	    D_(i,j) = numeratorD / ((X_(j+1))_R - (Y_(j+1))_R); 
+	    ); 
+        );
     
     -- Set up the local variables bezDet and bezDetR
     bezDet:="";
     bezDetR:="";
 
-
-    -- The determinant of D is interpreted as living in Frac(k[x_1..x_n]),
-    -- so we can try to lift it to k[x_1..x_n]           
-    if liftable(det(D),R) == true then(
-	bezDetR = lift(det(D),R);
-	);
+    -- The determinant of D is interpreted as an element of Frac(k[x_1..x_n]), so we can try to lift it to k[x_1..x_n]           
+    if liftable(det D, R) then bezDetR = lift(det D, R);
     
-    -- In some computations, applying lift(-,R) won't work. So we instead lift
-    -- the numerator and then divide by a lift of the denominator (which will be
-    -- a scalar) to the coefficient ring k
-    if not liftable(det(D),R) == true then(
-	bezDet = lift(numerator(det(D)), R) / lift(denominator(det(D)),coefficientRing R);
+    -- In some computations, applying lift(-,R) doesn't work, so we instead lift the numerator and
+    -- then divide by a lift of the denominator (which will be a scalar) to the coefficient ring kk
+    if not liftable(det D, R) then (
+	bezDet = lift(numerator det D, R) / lift(denominator det D, coefficientRing R);
     	bezDetR = lift(bezDet, R);
 	);
 
-    -- Define formal variables X_i, Y_i that replace x_i
+    -- Define formal variables X_i and Y_i that replace x_i
     RX := kk[X_1..X_n]; 
     RY := kk[Y_1..Y_n];
 
-    -- mapxtoX replaces all instances of x_i with X_i. mapxtoY does the same but with Y_i's
-    mapxtoX := (map(RX,S,toList(X_1..X_n))); 
-    mapxtoY := (map(RY,S,toList(Y_1..Y_n)));
+    -- mapxtoX replaces all instances of x_i with X_i; mapxtoY replaces all instances of y_i with Y_i
+    mapxtoX := map(RX,S,toList(X_1..X_n)); 
+    mapxtoY := map(RY,S,toList(Y_1..Y_n));
 
-    -- Compute the standard basis of kk[X_1, ..., X_n]/(f_1, ..., f_n)
+    -- Compute the standard basis of kk[X_1,...,X_n]/(f_1,...,f_n)
     standBasisX := basis (RX/(ideal (leadTerm (mapxtoX ideal Endo)))); 
     standBasisY := basis (RY/(ideal (leadTerm (mapxtoY ideal Endo)))); 
 
-    -- defines an ideal (f_1(X), ..., f_n(X))
-    id1 := (ideal apply(toList(0..n-1), i-> mapxtoX(Endo_i))); 
-    -- defines an ideal (f_1(Y), ..., f_n(Y))
-    id2 := (ideal apply(toList(0..n-1), i-> mapxtoY(Endo_i))); 
+    -- Define an ideal (f_1(X),...,f_n(X))
+    id1 := ideal apply(toList(0..n-1), i-> mapxtoX(Endo_i)); 
+    -- Define an ideal (f_1(Y),...,f_n(Y))
+    id2 := ideal apply(toList(0..n-1), i-> mapxtoY(Endo_i)); 
 
-    -- takes the sum of the ideals (f_1(X),...,f_n(X)) + (f_1(Y),...,f_n(Y)) in the ring kk[X_1..Y_n]
-    promotedEndo := sub(id1,R)+sub(id2,R); 
+    -- Take the sum of ideals (f_1(X),...,f_n(X)) + (f_1(Y),...,f_n(Y)) in the ring kk[X_1..Y_n]
+    promotedEndo := sub(id1, R) + sub(id2, R); 
 
-    -- Here we're using that (R/I) \otimes_R (R/J) = R/(I+J) in order to express Q(f) \otimes Q(f), where X's are the variables in first term, Y's are variables in second par
+    -- Here we're using that (R/I) \otimes_R (R/J) = R/(I+J) in order to express Q(f) \otimes Q(f),
+    -- where X's are the variables in first part and Y's are variables in second part
     Rquot := R/promotedEndo; 
 
-
-    -- moves the standard bases to the quotient ring
+    -- Move the standard bases to the quotient ring
     sBXProm := sub(standBasisX, Rquot); 
     sBYProm := sub(standBasisY, Rquot); 
     
-    --reduces the bezDetR determinant subject to the ideal in the X's and Y's
+    -- Reduce the bezDetR determinant subject to the ideal in the X's and Y's
     bezDetRed := bezDetR % promotedEndo;
 
-    
-    -- define a ring map that takes the coefficients to the field kk instead of considering it as an element of the quotient ring
-    phi0 := map(kk,Rquot,(toList ((2*n):0))); 
+    -- Define a ring map that takes the coefficients to the field kk instead of considering it as an element of the quotient ring
+    phi0 := map(kk,Rquot, (toList ((2*n):0))); 
 
     -- m is the dimension of the basis for the algebra
-    m := numColumns(sBXProm);
+    m := numColumns sBXProm;
 
-    -- Now create Bezoutian matrix B for the quadratic form by reading off the coefficients. 
-    -- B is a (m x m) matrix.  Coefficient B_(i,j) is the coefficient of the (ith basis vector x jth basis vector) in tensor product.
+    -- Create the Bezoutian matrix B for the symmetric bilinear form by reading off the coefficients. 
+    -- B is an (m x m) matrix. The coefficient B_(i,j) is the coefficient of the (ith basis vector x jth basis vector) in the tensor product.
     -- phi0 maps the coefficient to kk
     B := mutableMatrix id_(kk^m);
     for i from 0 to m - 1 do (
-        for j from 0 to m - 1 do (
+        for j from 0 to m - 1 do
             B_(i,j) = phi0(coefficient((sBXProm_(0,i)**sBYProm_(0,j))_(0,0), bezDetRed));
         );
-    );
-    return gwClass(matrix(B));
-
-    );
-
+    makeGWClass matrix B
+    )
 
 ---------
 -- Local
 ---------
 
--- Input: A list f = {f_1, f_2, ..., f_n} of polynomials kk^n -> kk^n and a prime ideal in the zero locus V(f)
+-- Input: A list f = {f_1,f_2,...,f_n} of polynomials giving a map kk^n -> kk^n and a prime ideal in the zero locus V(f)
 -- Output: The Grothendieck-Witt class deg^(A^1)_p (f)
 
-localA1Degree = method()
-localA1Degree (List, Ideal) := (GrothendieckWittClass) => (Endo,p) -> (
-    -- Endo is the list {f_1, f_2, ..., f_n} of polynomials kk^n -> kk^n
-    
+getLocalA1Degree = method()
+getLocalA1Degree (List, Ideal) := GrothendieckWittClass => (Endo,p) -> (
+    -- Endo is the list {f_1,f_2,...,f_n} of polynomials giving a map kk^n -> kk^n
     -- n is the number of polynomials
-    n := #Endo; -- n is the no. of polynomials
-    
+    n := #Endo;
 
-    -- Get the underlying field, assert it is a field
-    kk := coefficientRing(ring(Endo#0)); 
-    
-       
-    if isField(kk) == false then(
-	kk = toField(kk);
-	);
+    -- Get the underlying ring, and ensure it is a field
+    kk := coefficientRing ring(Endo#0); 
+    if not isField kk then kk = toField kk;
 
-    
-    -- Let S = k[x_1..x_n] be the ambient polynomial ring
+    -- Let S = kk[x_1..x_n] be the ambient polynomial ring
     S := ring(Endo#0);
     
-    -- Create the ideal J.  It has prop that  k[x_1 .. x_n]_p/I_p is isom to k[x_1 .. x_n]/J    
-    J := (ideal Endo):saturate(ideal Endo,p);
+    -- Create the ideal J. It has the property that k[x_1..x_n]_p/I_p is isomorphic to k[x_1..x_n]/J    
+    J := (ideal Endo):saturate(ideal Endo, p);
     
     -- Get the dimension of the local algebra Q_p(f)
-    localFormRank := numColumns(basis(S/J));
+    localFormRank := numColumns basis(S/J);
     
-    -- First check if the morphism does not have isolated zeroes
-    if dim ideal(Endo) > 0  then error "Error: morphism does not have isolated zeroes";
+    -- Check whether the morphism has isolated zeros
+    if dim ideal(Endo) > 0 then
+	error "morphism does not have isolated zeros";
     
-    -- Check the number of variables matches the number of polynomials
-    if not #(gens S) == n then error "Error: the number of variables does not match the number of polynomials.";
-    
-    -- If the field is CC, just output gwClass of an identity matrix of rank = localFormRank
-    if (kk === CC or instance(kk,ComplexField)) then(
-	return gwClass(matrix(mutableIdentity(CC,localFormRank)))
-    );
-    
-    -- If the field is RR, ask the user to run it over QQ instead, then simplify over RR
-    if (kk === RR or instance(kk,RealField)) then error "Error: localA1Degree method does not work over the reals. Instead, define the polynomials over QQ to output a GrothendieckWittClass. Then extract the matrix, base change it to RR, and then run sumDecomposition().";
-    
+    -- Check whether the number of variables matches the number of polynomials
+    if #(gens S) != n then
+	error "the number of variables does not match the number of polynomials";
+
+    -- If the field is CC, output the Grothendieck-Witt class of an identity matrix of the appropriate rank
+    if instance(kk, ComplexField) then
+    	return makeGWClass id_(CC^localFormRank);
+
+    -- If the field is RR, ask the user to run the computation over QQ instead and then base change to RR
+    if instance(kk, RealField) then
+        error "getLocalA1Degree method does not work over the reals. Instead, define the polynomials over QQ to output a GrothendieckWittClass. Then extract the matrix, base change it to RR, and run getSumDecomposition().";
     
     -- Create internal rings/matrices
-    
-    -- Initialize a polynomial ring in X_i's and Y_i's to compute the Bezoutian in
+
+    -- Initialize a polynomial ring in X_i's and Y_i's in which to compute the Bezoutian
     X := local X;
     Y := local Y;
-   -- R := kk[X_1..Y_n];
-    R := kk(monoid[X_1..X_n|Y_1..Y_n]);
-    
-    -- Create a matrix D which will be populated by \Delta_{ij} in the paper
+    R := kk(monoid[X_1..X_n | Y_1..Y_n]);
+
+    -- Create an (n x n) matrix D to be populated by \Delta_{ij} from the Brazelton-McKean-Pauli paper
     D := "";
-    try D = mutableMatrix id_((frac R)^n) else D= mutableMatrix id_(R^n);
+    try D = mutableMatrix id_((frac R)^n) else D = mutableMatrix id_(R^n);
     
-    for i from 0 to (n-1) do (
-	for j from 0 to (n-1) do(
-	    -- iterate through the entries of the matrix D and populate it with the following information ...
-        -- create the list {Y_1, ..., Y_(j-1), X_j, ..., X_n}. Note Macaulay2 is 0-indexed hence the difference in notation. 
-	    targetList1 := apply(toList (Y_1..Y_j|X_(j+1)..X_n),i->i_R);
-        -- create the list {Y_1, ..., Y_j, X_(j+1), ..., X_n }. Note Macaulay2 is 0-indexed hence the difference in notation. 
-	    targetList2 := apply(toList (Y_1..Y_(j+1)| X_(j+2)..X_n),i->i_R); 
-        -- suppose our endomorphisms are given in the variables x_1, ..., x_n.
-        -- map f_i(x_1, ..., x_n) to f_i(Y_1, ..., Y_(j-1), X_j, ..., X_n) resp.
-        -- then take the difference f_i(Y_1, ..., Y_(j-1), X_j, ..., X_n) - f_i(Y_1, ... Y_j, X_(j+1), ..., X_n)
-        numeratorD := ((map(R,S,targetList1))(Endo_i)-(map(R,S,targetList2))(Endo_i)); 
-        -- divide it by X_j - Y_j, Note Macaulay2 is 0-indexed hence the difference in notation. 
-	    D_(i,j)= numeratorD/((X_(j+1))_R-(Y_(j+1))_R); 
-	); 
-    );
+    for i from 0 to n - 1 do (
+	for j from 0 to n - 1 do (
+	    -- Iterate through the entries of the matrix D and populate it as follows
+            -- Create the list {Y_1,...,Y_(j-1), X_j,...,X_n}. Note that Macaulay2 is 0-indexed hence the difference in notation. 
+	    targetList1 := apply(toList (Y_1..Y_j | X_(j+1)..X_n), i -> i_R);
+            -- Create the list {Y_1,...,Y_j, X_(j+1), ..., X_n}. Note that Macaulay2 is 0-indexed hence the difference in notation. 
+	    targetList2 := apply(toList (Y_1..Y_(j+1) | X_(j+2)..X_n), i -> i_R); 
+            -- Suppose our endomorphisms are given in the variables x_1,...,x_n
+            -- Map f_i(x_1,...,x_n) to f_i(Y_1,...,Y_(j-1), X_j,...,X_n) resp.
+            -- Take the difference f_i(Y_1,...,Y_(j-1), X_j,...,X_n) - f_i(Y_1,...,Y_j, X_(j+1),...,X_n)
+            numeratorD := (map(R, S, targetList1)) (Endo_i) - (map(R, S, targetList2)) (Endo_i); 
+            -- Divide this by X_j - Y_j. Note that Macaulay2 is 0-indexed hence the difference in notation. 
+	    D_(i,j)= numeratorD / ((X_(j+1))_R - (Y_(j+1))_R); 
+	    ); 
+        );
     
     -- Set up the local variables bezDet and bezDetR
     bezDet := "";
     bezDetR := "";   
     
-    -- The determinant of D is interpreted as living in Frac(k[x_1..x_n]),
-    -- so we can try to lift it to k[x_1..x_n]           
-    if liftable(det(D),R) == true then(
-	bezDetR = lift(det(D),R);
-	);
-    
-    -- In some computations, applying lift(-,R) won't work. So we instead lift
-    -- the numerator and then divide by a lift of the denominator (which will be
-    -- a scalar) to the coefficient ring k
-    if not liftable(det(D),R) == true then(
-	bezDet = lift(numerator(det(D)), R) / lift(denominator(det(D)),coefficientRing R);
+    -- The determinant of D is interpreted as an element of Frac(k[x_1..x_n]), so we can try to lift it to k[x_1..x_n]           
+    if liftable(det D, R) then bezDetR = lift(det D, R);
+
+    -- In some computations, applying lift(-,R) doesn't work, so we instead lift the numerator and
+    -- then divide by a lift of the denominator (which will be a scalar) to the coefficient ring kk
+    if not liftable(det D, R) then (
+	bezDet = lift(numerator det D, R) / lift(denominator det D, coefficientRing R);
     	bezDetR = lift(bezDet, R);
 	);    
     
@@ -233,48 +211,47 @@ localA1Degree (List, Ideal) := (GrothendieckWittClass) => (Endo,p) -> (
     RX := kk[X_1..X_n]; 
     RY := kk[Y_1..Y_n];
     
-    -- mapxtoX replaces all instances of x_i with X_i. mapxtoY does the same but with Y_i's
-    mapxtoX := (map(RX,S,toList(X_1..X_n)));
-    mapxtoY := (map(RY,S,toList(Y_1..Y_n)));
+    -- mapxtoX replaces all instances of x_i with X_i; mapxtoY replaces all instances of y_i with Y_i
+    mapxtoX := map(RX, S, toList(X_1..X_n));
+    mapxtoY := map(RY, S, toList(Y_1..Y_n));
 
-    -- Find standard basis and define local quotient ring
-    list1 := (apply(toList(0..n-1), i-> mapxtoX(Endo_i))); -- list (f_1(X), ..., f_n(X))
-    list2 := (apply(toList(0..n-1), i-> mapxtoY(Endo_i))); -- list (f_1(Y), ..., f_n(Y))
+    -- Find the standard basis and define the local quotient ring
+    -- list (f_1(X),...,f_n(X)
+    list1 := apply(toList(0..n-1), i-> mapxtoX(Endo_i)); 
+    -- list (f_1(Y),...,f_n(Y))
+    list2 := apply(toList(0..n-1), i-> mapxtoY(Endo_i)); 
     
-    -- Apply localAlgebraBasis to compute standard basis for localization
-    standBasisX := localAlgebraBasis(list1,mapxtoX p);
-    standBasisY := localAlgebraBasis(list2,mapxtoY p); 
+    -- Apply getLocalAlgebraBasis to compute standard basis for localization
+    standBasisX := getLocalAlgebraBasis(list1, mapxtoX p);
+    standBasisY := getLocalAlgebraBasis(list2, mapxtoY p); 
     
     -- Take the ideal sum of J in the X_i's with J in the Y_i's
-    localIdeal :=sub(mapxtoX(J),R)+sub(mapxtoY(J),R);
-    
-    -- Here we're using that (R/I) \otimes_R (R/J) = R/(I+J) in order to express Q_p(f) \otimes Q_p(f), where X's are the variables in first term, Y's are variables in second par
-    Rquot:=R/localIdeal;
+    localIdeal := sub(mapxtoX J, R) + sub(mapxtoY J, R);
+
+    -- Here we're using that (R/I) \otimes_R (R/J) = R/(I+J) in order to express Q(f) \otimes Q(f),
+    -- where X's are the variables in first part and Y's are variables in second part
+    Rquot := R/localIdeal;
 
     -- Move the standard bases to the quotient ring
-    sBXProm := apply(toList(0..#standBasisX-1),i-> sub(standBasisX_i,Rquot));
-    sBYProm := apply(toList(0..#standBasisY-1),i-> sub(standBasisY_i,Rquot));
+    sBXProm := apply(toList(0..#standBasisX-1), i -> sub(standBasisX_i, Rquot));
+    sBYProm := apply(toList(0..#standBasisY-1), i -> sub(standBasisY_i, Rquot));
    
-    -- Now reduce the bezDetR determinant subject to the local ideal in both the X's, Y's.
+    -- Reduce the bezDetR determinant subject to the local ideal in both the X's and Y's.
     bezDetRed := bezDetR % localIdeal;
-    
-    -- ring map that takes the coefficients to the field kk instead of considering it as an element of the quotient ring 
-    phi0 := map(kk,Rquot,(toList ((2*n):0))); 
+
+    -- Define a ring map that takes the coefficients to the field kk instead of considering it as an element of the quotient ring
+    phi0 := map(kk, Rquot, (toList ((2*n):0))); 
     
     -- m is the dimension of the basis for the local ring
     m := #sBXProm;
-    
-    -- Now create Bezoutian matrix B for the quadratic form by reading off the local coefficients. 
-    -- B is a (m x m) matrix.  Coefficient B_(i,j) is the coefficient of the (ith basis vector x jth basis vector) in tensor product.
+
+    -- Create the Bezoutian matrix B for the symmetric bilinear form by reading off the local coefficients. 
+    -- B is an (m x m) matrix. The coefficient B_(i,j) is the coefficient of the (ith basis vector x jth basis vector) in the tensor product.
     -- phi0 maps the coefficient to kk    
     B:= mutableMatrix id_(kk^m);
-    for i from 0 to m-1 do (
-        for j from 0 to m-1 do (
-            B_(i,j)=phi0(coefficient((sBXProm_i**sBYProm_j)_(0,0), bezDetRed));
+    for i from 0 to m - 1 do (
+        for j from 0 to m - 1 do
+            B_(i,j) = phi0(coefficient((sBXProm_i**sBYProm_j)_(0,0), bezDetRed));
         );
-    );
-    return gwClass(matrix(B));
-    );
-
-
-
+    makeGWClass matrix B
+    )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/MatrixMethods.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/MatrixMethods.m2
@@ -3,227 +3,185 @@
 -----------------------
 
 -- Input: A matrix
--- Output: True if the matrix is a square; false otherwise
+-- Output: Boolean that gives whether the matrix is square
 
 isSquare = method()
-isSquare (Matrix) := Boolean => M -> (
+isSquare Matrix := Boolean => M -> (
     numRows(M) == numColumns(M)
     )
 
 -- Input: A matrix
--- Output: True if the matrix is a square and symmetric; false otherwise
+-- Output: Boolean that gives whether the matrix is square and symmetric
 
 isSquareAndSymmetric = method()
-isSquareAndSymmetric (Matrix) := Boolean => M -> (
+isSquareAndSymmetric Matrix := Boolean => M -> (
     transpose(M) == M
     )
 
--- Input: A matrix
--- Output: True if the matrix represents a degenerate bilinear form; false otherwise
+-- Input: A symmetric matrix
+-- Output: Boolean that gives whether the matrix represents a degenerate bilinear form
 
 isDegenerate = method()
-isDegenerate (Matrix) := Boolean => M ->(
-    det(M) == 0
-    )
-
-isNondegenerate = method()
-isNondegenerate (Matrix) := Boolean => M ->(
-    not isDegenerate(M)
-    )
-
--- Input: A matrix
--- Output: True if the matrix is upper-left triangular, meaning that all the entries below the main antidiagonal are zero; false otherwise
-
-isUpperLeftTriangular = method()
-isUpperLeftTriangular (Matrix) := Boolean => M -> (
-    if not isSquare(M) then error "Error: matrix isn't square";
-    n := numRows(M);
-    for i from 1 to n - 1 do(
-	for j from 0 to i - 1 do(
-    	-- If any entry in this range is nonzero then the matrix isn't upper left triangular
-		if not M_(i,j) == 0 then(
-		    return false
-		    );
-		
-        );
-    );
-    true
-    )
- 
--- Input: A square matrix
--- Output: True if the matrix is diagonal; false otherwise
-
-isDiagonal = method()
-isDiagonal (Matrix) := Boolean => M -> (
-
-    if not isSquare(M) then error "Error: matrix is not a square";
-
-    n := numRows(M);
-    
-    for i from 0 to n-2 do(
-	for j from  i+1 to n-1 do(
-	    
-	    -- Search in the matrix entries that aren't on diagonal
-	    if i != j  then(
-		
-		-- If any entry off diagonal  is nonzero then the matrix isn't diagonal
-		if  M_(i,j) != 0 or M_(j,i) != 0  then(
-		    return false
-		    );
-		);
-        );
-    );
-    true
+isDegenerate Matrix := Boolean => M -> (
+    if not isSquareAndSymmetric M then error "matrix is not symmetric";
+    if numRows(M) == 0 then (
+	return false;
+	)
+    else
+	return det(M) == 0;
     )
 
 -- Input: A symmetric matrix
+-- Output: Boolean that gives whether the matrix represents a nondegenerate bilinear form
+
+isNondegenerate = method()
+isNondegenerate Matrix := Boolean => M -> (
+    not isDegenerate M
+    )
+ 
+-- Input: A square matrix
+-- Output: Boolean that gives whether the matrix is diagonal
+
+isDiagonal = method()
+isDiagonal Matrix := Boolean => M -> (
+
+    if not isSquare M then error "matrix is not a square";
+
+    n := numRows M;
+    -- Check the matrix entries that aren't on the diagonal
+    for i from 0 to n - 2 do (
+	for j from  i + 1 to n - 1 do
+	    -- If any off-diagonal entry is nonzero, then the matrix isn't diagonal
+	    if  M_(i,j) != 0 or M_(j,i) != 0 then return false;
+        );
+    -- Otherwise, the matrix is diagonal
+    true
+    )
+
+-- Input: A symmetric matrix over a field
 -- Output: A diagonal matrix congruent to the original matrix
 
-congruenceDiagonalize = method()
-congruenceDiagonalize (Matrix) := (Matrix) => (AnonMut) -> (
+diagonalizeViaCongruence = method()
+diagonalizeViaCongruence Matrix := Matrix => AnonMut -> (
     k := ring AnonMut;
-    if isField k == false then error "Error: expected matrix entries from a field";
-    if not isSquareAndSymmetric(AnonMut) then error "matrix is not symmetric";
+    if not isField k then error "expected matrix over a field";
+    if not isSquareAndSymmetric AnonMut then
+	error "matrix is not symmetric";
     
-    -- If the matrix is already diagonal then return it
-    if isDiagonal(AnonMut) == true then(
-	return AnonMut
-	);
+    -- If the matrix is already diagonal, then return it
+    if isDiagonal AnonMut then return AnonMut;
     
-    -- Otherwise we iterate through columns and rows under the diagonal, and perform row operations followed by the corresponding
-    -- transpose operation on columns in order to reduce to a diagonal matrix congruent to the original
+    -- Otherwise, we iterate through positions below the diagonal, performing row operations followed by the corresponding
+    -- column operations in order to obtain a diagonal matrix congruent to the original
     A := mutableMatrix AnonMut;
-    n := numRows(A);
-    for col from 0 to (n - 1) do (
+    n := numRows A;
+    for col from 0 to n - 1 do (
 	-- If diagonal entry in column "col" is zero
         if A_(col,col) == 0 then (
             for row from col + 1 to n - 1 do ( 
-		-- Scan for nonzero entries below the diagonal entry
+		-- Scan for nonzero entries in column "col" below the diagonal entry
                 if A_(row,col) != 0 then (
                     if A_(row,row) == 0 then (
-		        -- Row reduction to make A_(col,col) nonzero
-                        rowAdd(A,col,1,row);
-		        -- Column reduction to keep reduced matrix congruent to original matrix
-                        columnAdd(A,col,1,row);
+		        -- Row operation to make A_(col,col) nonzero
+                        rowAdd(A, col,1,row);
+		        -- Column operation to keep reduced matrix congruent to original matrix
+                        columnAdd(A, col,1,row);
                         )
                     else (
 		        -- Row and column swaps to make A_(col,col) nonzero
-                -- Better alternative for keeping entries smaller in A in case A_(row,row)!=0
-                        rowSwap(A,col,row);
-                        columnSwap(A,col,row);
+                        rowSwap(A, col,row);
+                        columnSwap(A, col,row);
                         );
                     break;
                     );
                 );
             );
-        -- Now A_(col,col) != 0 unless there was a zero row/column and we use it to clear the column below
+        -- Now A_(col,col) != 0 unless there was a zero row/column; we use it to clear column "col" below this entry
         if A_(col,col) != 0 then (
-            for row from (col+1) to (n-1) do (
-                temp:=A_(row,col);
-                -- More row reduction make every entry below A_(col,col) is zero
-                rowAdd(A,row,-temp/A_(col,col),col);
-	        -- Column reduction to keep reduced matrix congruent
-                columnAdd(A,row,-temp/A_(col,col),col);
+            for row from col + 1 to n - 1 do (
+                temp := A_(row,col);
+                -- Row operation to make A_(row,col) zero
+                rowAdd(A, row, -temp/A_(col,col), col);
+	        -- Column operation to keep reduced matrix congruent
+                columnAdd(A, row, -temp/A_(col,col), col);
                 );
             );
         );
-    return matrix A 
+    matrix A 
     )
 
--- Input: A symmetric matrix 
--- Output: A diagonal matrix congruent to the original matrix, with squares stripped out
+-- Input: A symmetric matrix over QQ, RR, CC, and finite fields of characteristic not 2
+-- Output: A diagonal matrix congruent to the original matrix, with squarefree entries on the diagonal
 
-congruenceDiagonalizeSimplify = method()
-congruenceDiagonalizeSimplify (Matrix) := (Matrix) => (AnonMut) -> (
+diagonalizeAndSimplifyViaCongruence = method()
+diagonalizeAndSimplifyViaCongruence Matrix := Matrix => AnonMut -> (
     k := ring AnonMut;
-    if not (k === CC or instance(k,ComplexField) or k === RR or instance(k,RealField) or k === QQ or (instance(k, GaloisField) and k.char != 2)) then (
+    if not (instance(k, ComplexField) or instance(k, RealField) or k === QQ or (instance(k, GaloisField) and k.char != 2)) then (
         error "Base field not supported; only implemented over QQ, RR, CC, and finite fields of characteristic not 2";
         );
-    if not isSquareAndSymmetric(AnonMut) then error "matrix is not symmetric";
+    if not isSquareAndSymmetric AnonMut then error "matrix is not symmetric";
 
-    diagForm := congruenceDiagonalize(AnonMut);
-    A := mutableMatrix diagForm;
-    n := numRows(A);
+    A := mutableMatrix diagonalizeViaCongruence AnonMut;
+    n := numRows A;
 
-    -- If the field is the complex numbers, we can replace each nonzero entry of the diagonalization by 1
-    if (k === CC or instance(k,ComplexField)) then (
-	for i from 0 to (n-1) do (
-	    if A_(i,i) != 0 then (
-		A_(i,i) = 1;
-		);
+    -- If the field is the complex numbers, replace each nonzero entry of the diagonalization by 1
+    if instance(k, ComplexField) then (
+	for i from 0 to n - 1 do (
+	    if A_(i,i) != 0 then A_(i,i) = 1;
             );
-	return (matrix A);
 	)
     
-    -- If the field is the real numbers, we can replace each positive entry of the diagonalization by 1 and each negative entry by -1
-    else if (k === RR or instance(k,RealField)) then (
-	for i from 0 to (n-1) do (
-	    if A_(i,i) > 0 then (
-		A_(i,i) = 1;
-		);
-	    if A_(i,i) < 0 then (
-		A_(i,i) = -1;
-		);
+    -- If the field is the real numbers, replace each positive entry of the diagonalization by 1 and each negative entry by -1
+    else if instance(k, RealField) then (
+	for i from 0 to n - 1 do (
+	    if A_(i,i) > 0 then A_(i,i) = 1;
+	    if A_(i,i) < 0 then A_(i,i) = -1;
 	    );
-	return (matrix A);
 	)
 
-    -- If the field is the rational numbers, we can diagonalize and take squarefree parts
-    else if (k === QQ) then (
-	for i from 0 to (n-1) do (
-            A_(i,i) = squarefreePart(A_(i,i));
-	    );
-	return (matrix A);
+    -- If the field is the rational numbers, replace each diagonal entry by its squarefree part
+    else if k === QQ then (
+	for i from 0 to n - 1 do
+            A_(i,i) = getSquarefreePart A_(i,i);
 	)
 
-    -- Over a finite field, we can diagonalize and replace every entry by 1 or a nonsquare representative
+    -- Over a finite field, replace each diagonal entry by 1 or a nonsquare representative
     else if (instance(k, GaloisField) and k.char != 2) then (
-        nonSquareRep := sub(-1,k);
-        if (legendreBoolean(sub(-1,k))) then (
-	    for i from 0 to (n-1) do (
-	        if (diagForm_(i,i) != 0 and (not legendreBoolean(diagForm_(i,i)))) then (
-	     	    nonSquareRep = diagForm_(i,i);
+        -- Initially let the nonsquare representative be -1
+        nonSquareRep := sub(-1, k);
+        -- If -1 is a square, then find another nonsquare representative
+        if isGFSquare sub(-1, k) then (
+	    for i from 0 to n - 1 do (
+	        if (A_(i,i) != 0 and not isGFSquare(A_(i,i))) then (
+                    -- If there is a nonsquare on the diagonal, choose it as the nonsquare representative
+	     	    nonSquareRep = A_(i,i);
                     break;
 		    );
                 );
 	    );
-	for i from 0 to (n-1) do (
-	    if (A_(i,i) != 0 and legendreBoolean(A_(i,i))) then (
+	for i from 0 to n - 1 do (
+	    if (A_(i,i) != 0 and isGFSquare(A_(i,i))) then
 		A_(i,i) = 1;
-		);
-	    if (A_(i,i) != 0 and not legendreBoolean(A_(i,i))) then (
+	    if (A_(i,i) != 0 and not isGFSquare(A_(i,i))) then
 		A_(i,i) = nonSquareRep;
-		);
 	    );
-	return (matrix A);
-	)
-
-    -- We should never get here
-    else error "Problem with base field"
+	);
+    matrix A
     )
 
--- Input: A symmetric matrix representing a quadratic form
--- Output: A diagonal matrix representing the nondegenerate part of the quadratic form
+-- Input: A matrix representing a symmetric bilinear form
+-- Output: A diagonal matrix representing the nondegenerate part of the symmetric bilinear form
 
-nondegeneratePartDiagonal = method()
-nondegeneratePartDiagonal (Matrix) := (Matrix) => (A) -> (
-    diagA := congruenceDiagonalize(A);
+getNondegeneratePartDiagonal = method()
+getNondegeneratePartDiagonal Matrix := Matrix => A -> (
+    diagA := diagonalizeViaCongruence A;
     i := 0;
-    while (i < numRows(diagA)) do (
-        if (diagA_(i,i) == 0) then (
-            diagA = submatrix'(diagA,{i},{i});
+    while i < numRows(diagA) do (
+        if diagA_(i,i) == 0 then (
+            diagA = submatrix'(diagA, {i},{i});
             )
-        else (
+        else
             i = i+1;
-            );
         );
-    return (diagA);
-    )
-
--- Input: A symmetric matrix representing a quadratic form
--- Output: The dimension of the nondegenerate part of the quadratic form
-
-nondegenerateDimension = method()
-nondegenerateDimension (Matrix) := (ZZ) => (A) -> (
-    return (numRows(nondegeneratePartDiagonal(A)));
+    diagA
     )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/SimplifiedRepresentatives.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/SimplifiedRepresentatives.m2
@@ -2,36 +2,35 @@
 -- Simplifying forms
 ---------------------
 
--- Input: A GrothendieckWittClass over QQ, RR, CC, or a finite field of characteristic not 2
--- Output: A diagonalized form of the GrothendieckWittClass, with squares stripped out
+-- Input: A Grothendieck-Witt class beta over QQ, RR, CC, or a finite field of characteristic not 2
+-- Output: A diagonalized form of beta, with squarefree entries on the diagonal
 
-diagonalClass = method()
-diagonalClass (GrothendieckWittClass) := (GrothendieckWittClass) => (beta) -> (
+getDiagonalClass = method()
+getDiagonalClass GrothendieckWittClass := GrothendieckWittClass => beta -> (
 
-    -- Check if the diagonalClass has already been computed, if so recall it from the cache
-    if beta.cache.?diagonalClass then return beta.cache.diagonalClass;
+    -- Check if the diagonal class has already been computed; if so, recall it from the cache
+    if beta.cache.?getDiagonalClass then return beta.cache.getDiagonalClass;
 
-    diagonalClassOfBetaMatrix := congruenceDiagonalizeSimplify(beta.matrix);
+    getDiagonalClassOfBetaMatrix := diagonalizeAndSimplifyViaCongruence getMatrix beta;
 
-    -- The diagonal form gets cached in the GWclass type
-    beta.cache.diagonalClass = gwClass(diagonalClassOfBetaMatrix);
-    return gwClass(diagonalClassOfBetaMatrix);
-    );
+    -- The computed diagonal class gets stored in the cache
+    beta.cache.getDiagonalClass = makeGWClass getDiagonalClassOfBetaMatrix;
+    makeGWClass getDiagonalClassOfBetaMatrix
+    )
 
--- Input: A Grothendieck-Witt class beta
--- Output: The diagonal entries of a diagonal matrix representing beta as a list
+-- Input: A Grothendieck-Witt class beta over QQ, RR, CC, or a finite field of characteristic not 2
+-- Output: A list of the diagonal entries of a diagonal matrix representing beta
 
-diagonalEntries = method()
-diagonalEntries (GrothendieckWittClass) := (List) => (beta) -> (
+getDiagonalEntries = method()
+getDiagonalEntries GrothendieckWittClass := List => beta -> (
     
-    M := congruenceDiagonalize(beta.matrix);
-    L := {};
+    M := diagonalizeViaCongruence getMatrix beta;
     n := numRows M;
+    L := {};
     
-    for i from 0 to (n-1) do(
+    for i from 0 to n - 1 do
 	L = append(L, M_(i,i));
-	);
-    return L
-    );
+    L
+    )
     
     

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/AnisotropicDimensionDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/AnisotropicDimensionDoc.m2
@@ -1,7 +1,7 @@
 document{
-    Key => {anisotropicDimensionQp, (anisotropicDimensionQp, GrothendieckWittClass, ZZ)},
-    Headline => "returns the anisotropic dimension of a rational symmetric bilinear form over the p-adics",
-    Usage => "anisotropicDimensionQp(beta, p)",
+    Key => {getAnisotropicDimensionQQp, (getAnisotropicDimensionQQp, GrothendieckWittClass, ZZ)},
+    Headline => "returns the anisotropic dimension of a rational symmetric bilinear form over the p-adic rational numbers",
+    Usage => "getAnisotropicDimensionQQp(beta, p)",
     Inputs => {
 	GrothendieckWittClass => "beta" => {"over ", TEX///$\mathbb{Q}$///},
 	ZZ => "p" => {"a prime number"},
@@ -9,71 +9,48 @@ document{
     Outputs => {
         ZZ => {"the rank of the anisotropic part of ", TEX///$\beta$///, " over ", TEX///$\mathbb{Q}_p$///},
 	},
-    PARA{"This is an implementation of [KC18, Algorithm 8] in Macaulay2, which computes the anisotropic dimension of rational forms over the ", TEX///$p$///,"-adics. Note that any form of rank ", TEX///$\ge 5$///, " is always isotropic, so this method will return 0, 1, 2, 3, or 4."},
+    PARA{"This is an implementation of [KC18, Algorithm 8], which computes the anisotropic dimension of rational forms over the ", TEX///$p$///,"-adic rational numbers. Note that any form of rank ", TEX///$\ge 5$///, " is isotropic, so this method will always return 0, 1, 2, 3, or 4."},
     PARA{EM "Citations:"},
     UL{
-	
 	{"[KC18] P. Koprowski, A. Czogala, ", EM "Computing with quadratic forms over number fields,", " Journal of Symbolic Computation, 2018."},
     },
-    SeeAlso => {"anisotropicDimension"}   
+    SeeAlso => {"getAnisotropicDimension"}   
 }
-
--- document{
---     Key => {(anisotropicDimensionQQ, GrothendieckWittClass), anisotropicDimensionQQ},
---     Headline => "Returns the anisotropic dimension of a symmetric bilinear form over the rationals",
---     Usage => "anisotropicDimensionQQ(beta)",
---     Inputs => {
--- 	GrothendieckWittClass => "beta" => {"Any class ", TEX///$\beta\in\text{GW}(\mathbb{Q})$///, ". "},
--- 	},
---     Outputs => {
---         ZZ => {"The rank of the anisotropic part of ", TEX///$\beta$///, "."},
--- 	},
---     PARA{"This is an implementation of [KC18, Algorithm 9] in Macaulay2. Using ", TO2(anisotropicDimensionQp,"anisotropicDimensionQp"), " and  ", TO2(signature,"signature"), " we can understand the anisotropic dimension of ", TEX///$\beta$///, " at all its relevant completions. The anisotropic dimension over ", TEX///$\mathbb{Q}$///, " is then computed as the maximum of the anisotropic dimensions over all completions."},
---     PARA{EM "Citations:"},
---     UL{
-	
--- 	{"[KC18] P. Koprowski, A. Czogala, ", EM "Computing with quadratic forms over number fields,", " Journal of Symbolic Computation, 2018."},
---     },
---     SeeAlso => {"anisotropicDimensionQp", "anisotropicDimension"}   
--- }
-
 
 
 document{
-    Key => {anisotropicDimension, (anisotropicDimension, GrothendieckWittClass), (anisotropicDimension, Matrix)},
+    Key => {getAnisotropicDimension, (getAnisotropicDimension, GrothendieckWittClass), (getAnisotropicDimension, Matrix)},
     Headline => "returns the anisotropic dimension of a symmetric bilinear form",
-    Usage => "anisotropicDimension(beta)",
+    Usage => "getAnisotropicDimension beta",
     Inputs => {
-	GrothendieckWittClass => "beta" => {"over a field ", TEX///$k$///, " where ", TEX///$k$///, " is the complex numbers, reals, rationals, or a finite field"},
+	GrothendieckWittClass => "beta" => {"over a field ", TEX///$k$///, " where ", TEX///$k$///, " is ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
 	},
     Outputs => {
         ZZ => {"the rank of the anisotropic part of ", TEX///$\beta$///},
 	},
-    PARA{"By Witt decomposition, any form decomposes uniquely as ", TEX///$\beta \cong k \mathbb{H} \oplus \beta_a$///," where the form ", TEX///$\beta_a$///," is anisotropic. The rank of ", TEX///$\beta_a$///, " is called the ", EM "anisotropic dimension", " of ", TEX///$\beta$///, "."},
-    PARA{"The anisotropic dimension of a form defined over the rationals is the maximum of the ", TO2(anisotropicDimensionQp,"anistropic dimension at each of the completions"), " of ", TEX///$\mathbb{Q}$///, "."},
-    SeeAlso => {"WittIndex", "anisotropicDimensionQp", "anisotropicDimension"}   
+    PARA{"By the Witt Decomposition Theorem, any non-degenerate form decomposes uniquely as ", TEX///$\beta \cong n \mathbb{H} \oplus \beta_a$///," where the form ", TEX///$\beta_a$///," is anisotropic. The rank of ", TEX///$\beta_a$///, " is called the ", EM "anisotropic dimension", " of ", TEX///$\beta$///, "."},
+    PARA{"The anisotropic dimension of a form defined over the rational numbers is the maximum of the ", TO2(getAnisotropicDimensionQQp,"anistropic dimension at each of the completions"), " of ", TEX///$\mathbb{Q}$///, "."},
+    SeeAlso => {"getWittIndex", "getAnisotropicDimensionQQp", "getAnisotropicPart"}   
 }
 
 
 document{
-    Key => {WittIndex, (WittIndex, GrothendieckWittClass)},
+    Key => {getWittIndex, (getWittIndex, GrothendieckWittClass)},
     Headline => "returns the Witt index of a symmetric bilinear form",
-    Usage => "WittIndex(beta)",
+    Usage => "getWittIndex beta",
     Inputs => {
-	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(k)$///, ", where ", TEX///$k$///, " is the complex numbers, reals, rationals, or a finite field"},
+	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(k)$///, " where ", TEX///$k$///, " is ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
 	},
     Outputs => {
         ZZ => {"the rank of the totally isotropic part of ", TEX///$\beta$///},
 	},
-    PARA{"By Witt decomposition, any form decomposes uniquely as ", TEX///$\beta \cong k \mathbb{H} \oplus \beta_a$///," where the form ", TEX///$\beta_a$///," is anisotropic. The integer ", TEX///$k$///, " is called the ", EM "Witt index", " of ", TEX///$\beta$///, ". See for instance [L05, I.4.3]."},
+    PARA{"By the Witt Decomposition Theorem, any non-degenerate form decomposes uniquely as ", TEX///$\beta \cong n \mathbb{H} \oplus \beta_a$///," where the form ", TEX///$\beta_a$///," is anisotropic. The integer ", TEX///$n$///, " is called the ", EM "Witt index", " of ", TEX///$\beta$///, ". See for instance [L05, I.4.3]."},
     
         PARA{EM "Citations:"},
     UL{
-	
 	{"[L05] T.Y. Lam, ", EM "Introduction to quadratic forms over fields,", " American Mathematical Society, 2005."},
     },
-    
-    SeeAlso => {"anisotropicDimension", "anisotropicDimensionQp"}   
+    SeeAlso => {"getAnisotropicDimension"}   
 }
 
 

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/ArithmeticMethodsDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/ArithmeticMethodsDoc.m2
@@ -1,65 +1,25 @@
--- document {
---     Key => {(squarefreePart, QQ), (squarefreePart, ZZ), squarefreePart},
--- 	Headline => "smallest magnitude representative of a square class over the rationals or integers",
--- 	Usage => "squarefreePart(q)",
--- 	Inputs => {
--- 	    QQ => "q" => {"a rational number"},
--- 	    -- ZZ => "n" => {"an integer"}
--- 	    },
--- 	Outputs => {
--- 	    ZZ => { "the smallest magnitude integer in the square class of ", TT "n"}
--- 	    },
--- 	PARA {"Given a rational number (or integer), ", TT "q", ", this command outputs the smallest magnitude integer, ",
---                 TEX///$m$///, ", such that ", TEX///$q=lm$///, " for some rational number (or integer) ",
--- 				TEX///$l$///, "."},
--- 	EXAMPLE lines ///
--- 		 squarefreePart(15/72)
--- 		 squarefreePart(-1/3)
--- 	 	 ///,
---         }
-    
-    
--- document{
---     Key => {(legendreBoolean, RingElement), legendreBoolean},
---     Headline => "Basic Legendre symbol over a finite field",
---     Usage => "legendreBoolean(a)",
---     Inputs => {
--- 	RingElement => "a" => {"Any element in a finite field ", TEX///$a\in \mathbb{F}_q$///, "."},
--- 	},
---     Outputs =>{
--- 	Boolean => {"Whether ", TEX///$a$///, " is a square in ", TEX///$\mathbb{F}_q$///, "."},
--- 	},
---     PARA{"Given an element of a finite field, will return a Boolean checking if it is a square."},
---     EXAMPLE lines///
---     a = sub(-1,GF(5));
---     legendreBoolean(a)
---     b = sub(-1,GF(7));
---     legendreBoolean(b)
---     ///,
---     }
-
 document{
-    Key => {padicValuation, (padicValuation, ZZ, ZZ), (padicValuation, QQ, ZZ)},
-    Headline => "p-adic valuation of a rational number or integer",
-    Usage => "padicValuation(a, p)",
+    Key => {getPadicValuation, (getPadicValuation, ZZ, ZZ), (getPadicValuation, QQ, ZZ)},
+    Headline => "p-adic valuation of a rational number",
+    Usage => "getPadicValuation(a, p)",
     Inputs => {
-	ZZ => "a" => {"a non-zero rational number in ", TEX///$\mathbb{Q}_p$///},
-	ZZ => "p" => {"a rational prime number"},
+	QQ => "a" => {"a non-zero rational number in ", TEX///$\mathbb{Q}_p$///},
+	ZZ => "p" => {"a prime number"},
 	},
     Outputs =>{
-	ZZ => {"an integer ", TEX///$n$///, " where ",TEX///$a=p^n u$///, " and ", TEX///$u$///," is a unit in ", TEX///$\mathbb{Z}_p$///},
+	ZZ => {TEX///$n$///, " where ",TEX///$a=p^n u$///, " and ", TEX///$u$///," is a unit in ", TEX///$\mathbb{Z}_p$///},
         },
     EXAMPLE lines///
     a = 363/7;
-    padicValuation(a, 11)
+    getPadicValuation(a, 11)
     ///,
     }
 
 
 document {
-    Key => {localAlgebraBasis, (localAlgebraBasis, List, Ideal)},
+    Key => {getLocalAlgebraBasis, (getLocalAlgebraBasis, List, Ideal)},
 	Headline => "produces a basis for a local finitely generated algebra over a field k",
-	Usage => "localAlgebraBasis(L,p)",
+	Usage => "getLocalAlgebraBasis(L, p)",
 	Inputs => {
 	    List => "L" => {"of polynomials ", TEX///$f=(f_1, \dots ,f_n)$///, " over the same ring"},
 	    Ideal => "p" => {"a prime ideal of an isolated zero"}
@@ -68,17 +28,16 @@ document {
 	    List => {"of basis elements of the local ",TEX///$k$///,"-algebra ", TEX///$Q_p(f)$/// }
 	    },
 	PARA {"Given an endomorphism of affine space, ", TEX///$f=(f_1,\dots ,f_n)$///,
-			", given as a list of polynomials called ", TT "L", " and the prime ideal of an isolated zero, this command returns a list of basis elements of the local k-algebra ", TEX///$Q_p(f)$///, " by computing a normal basis for ", TEX///$(I:(I:p^{\infty}))$///, " (vis. [S02, Proposition 2.5])."},
+			", given as a list of polynomials called ", TT "L", " and the prime ideal of an isolated zero, this command returns a list of basis elements of the local k-algebra ", TEX///$Q_p(f)$///, " by computing a normal basis for ", TEX///$(I:(I:p^{\infty}))$///, " (see [S02, Proposition 2.5])."},
 	EXAMPLE lines ///
 		 QQ[x,y];
-		 f = {x^2+1-y,y};
-		 p = ideal(x^2+1,y);
-		 localAlgebraBasis(f,p) 
+		 f = {x^2 + 1 - y, y};
+		 p = ideal(x^2 + 1, y);
+		 getLocalAlgebraBasis(f, p) 
 	 	 ///,
         PARA{EM "Citations:"},
     UL{
-	
 	{"[S02] B. Sturmfels, ", EM "Solving Systems of Polynomial Equations,", " American Mathematical Society, 2002."},
 	},
-    SeeAlso => {"localA1Degree"}
+    SeeAlso => {"getLocalA1Degree"}
 }

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/BuildingFormsDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/BuildingFormsDoc.m2
@@ -1,35 +1,36 @@
 document {
-    Key => {diagonalForm, (diagonalForm, Ring, RingElement), (diagonalForm,Ring,ZZ),(diagonalForm,Ring,QQ),(diagonalForm,Ring,Sequence), (diagonalForm,InexactFieldFamily,RingElement), (diagonalForm,InexactFieldFamily,ZZ), (diagonalForm,InexactFieldFamily,QQ),(diagonalForm,InexactFieldFamily,Sequence)},
+    Key => {makeDiagonalForm, (makeDiagonalForm, Ring, RingElement), (makeDiagonalForm, Ring, ZZ), (makeDiagonalForm, Ring, QQ), (makeDiagonalForm, Ring, Sequence), (makeDiagonalForm, InexactFieldFamily, RingElement), (makeDiagonalForm, InexactFieldFamily, ZZ), (makeDiagonalForm, InexactFieldFamily, QQ), (makeDiagonalForm, InexactFieldFamily, Sequence)},
     Headline => "the Grothendieck-Witt class of a diagonal form",     
-	Usage => "diagonalForm(k,a)
-	          diagonalForm(k,L)",
+	Usage => "makeDiagonalForm(k, a)
+	          makeDiagonalForm(k, L)",
 	Inputs => {
-	    Ring => "k" => {"a field"},
+	    Ring => "k" => {"a field of characteristic not 2"},
 	    RingElement => "a" => {"any element ", TEX///$a\in k$///},
 	    Sequence => "L" => {"of elements ",TEX///$a_{i} \in k$///, ", where ", TEX///$i = 1,\dots, n$///},
 	    }, 
 	Outputs => { 
 	    GrothendieckWittClass => {"the diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle \in \text{GW}(k)$///},
 	    },
-	PARA {"Given a sequence of elements ", TEX///$a_1,\ldots,a_n \in k$///, " we can form the diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " defined to be the block sum of each of the rank one forms ", TEX///$\langle a_i \rangle \colon k \times k \to k$///, " ", TEX///$(x,y) \mapsto a_i xy$///, "."},
+	PARA {"Given a sequence of elements ", TEX///$a_1,\ldots,a_n \in k$///, " we can form the diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " defined to be the block sum of each of the rank one forms ", TEX///$\langle a_i \rangle \colon k \times k \to k,$///, " ", TEX///$(x,y) \mapsto a_i xy$///, "."},
 	EXAMPLE lines ///
-    	    	 diagonalForm(QQ,(3,5,7))
+    	    	 makeDiagonalForm(QQ, (3,5,7))
 	 	 ///,
-	PARA{"Inputting a ring element, an integer, or a rational instead of a sequence will produce a rank one form instead. For instance:"},
+	PARA{"Inputting a ring element, an integer, or a rational number instead of a sequence will produce a rank one form instead. For instance:"},
 	EXAMPLE lines ///
-	diagonalForm(GF(29),5/13)
-	diagonalForm(RR,2)
+	makeDiagonalForm(GF(29), 5/13)
+	makeDiagonalForm(RR, 2)
 	///,
-    SeeAlso => {"diagonalClass", "congruenceDiagonalize", "diagonalEntries"}
+    SeeAlso => {"getDiagonalClass", "diagonalizeViaCongruence", "getDiagonalEntries"}
 }
 
+
 document {
-    Key => {PfisterForm, (PfisterForm, Ring, RingElement), (PfisterForm,Ring,ZZ),(PfisterForm,Ring,QQ),(PfisterForm,Ring,Sequence), (PfisterForm,InexactFieldFamily,RingElement), (PfisterForm,InexactFieldFamily,ZZ), (PfisterForm,InexactFieldFamily,QQ),(PfisterForm,InexactFieldFamily,Sequence)},
+    Key => {makePfisterForm, (makePfisterForm, Ring, RingElement), (makePfisterForm, Ring, ZZ),(makePfisterForm, Ring, QQ), (makePfisterForm, Ring, Sequence), (makePfisterForm, InexactFieldFamily, RingElement), (makePfisterForm, InexactFieldFamily, ZZ), (makePfisterForm, InexactFieldFamily, QQ), (makePfisterForm, InexactFieldFamily, Sequence)},
     Headline => "the Grothendieck-Witt class of a Pfister form",     
-	Usage => "PfisterForm(k,a)
-	          PfisterForm(k,L)",
+	Usage => "makePfisterForm(k, a)
+	          makePfisterForm(k, L)",
 	Inputs => {
-	    Ring => "k" => {"a field"},
+	    Ring => "k" => {"a field of characteristic not 2"},
 	    RingElement => "a" => {"any element ", TEX///$a\in k$///},
 	    Sequence => "L" => {"of elements ", TEX///$L = (a_1,\ldots,a_n)$///, " with ", TEX///$a_i \in k$///},
 	    }, 
@@ -38,35 +39,35 @@ document {
 	    },
 	PARA {"Given a sequence of elements ", TEX///$a_1,\ldots,a_n \in k$///, " we can form the Pfister form ", TEX///$\langle\langle a_1,\ldots,a_n\rangle\rangle$///, " defined to be the rank ", TEX///$2^n$///, " form defined as the product ", TEX///$\langle 1, -a_1\rangle \otimes \cdots \otimes \langle 1, -a_n \rangle$///, "."},
 	EXAMPLE lines ///
-    	    	 PfisterForm(QQ,(2,6))
+    	    	 makePfisterForm(QQ, (2,6))
 	 	 ///,
 	PARA{"Inputting a ring element, an integer, or a rational instead of a sequence will produce a one-fold Pfister form instead. For instance:"},
 	EXAMPLE lines ///
-	PfisterForm(GF(13),-2/3)
-	PfisterForm(CC,3)
+	makePfisterForm(GF(13), -2/3)
+	makePfisterForm(CC, 3)
 	///
 }
 
 
 document {
-    Key => {hyperbolicForm, (hyperbolicForm, Ring), (hyperbolicForm, Ring, ZZ), (hyperbolicForm, InexactFieldFamily), (hyperbolicForm, InexactFieldFamily, ZZ)},
+    Key => {makeHyperbolicForm, (makeHyperbolicForm, Ring), (makeHyperbolicForm, Ring, ZZ), (makeHyperbolicForm, InexactFieldFamily), (makeHyperbolicForm, InexactFieldFamily, ZZ)},
     Headline => "the Grothendieck-Witt class of a hyperbolic form",     
-	Usage => "hyperbolicForm(k)
-	          hyperbolicForm(k,n)",
+	Usage => "makeHyperbolicForm k
+	          makeHyperbolicForm(k, n)",
 	Inputs => {
-	    Ring => "k" => {"a field"},
+	    Ring => "k" => {"a field of characteristic not 2"},
 	    ZZ => "n" => {"an even number, giving an optional rank ", TEX///$n$///, " for a totally hyperbolic form"},
 	    }, 
 	Outputs => { 
-	    GrothendieckWittClass => {"the hyperbolic form ", TEX///$\mathbb{H} = \langle 1, -1\rangle \in \text{GW}(k)$///, " or the totally hyperbolic form ", TEX///$\frac{n}{2}\mathbb{H}$///, " if an optional rank is specified"},
+	    GrothendieckWittClass => {"the hyperbolic form ", TEX///$\mathbb{H} = \langle 1, -1\rangle \in \text{GW}(k)$///, " or the totally hyperbolic form ", TEX///$\left(\displaystyle\frac{n}{2}\right)\mathbb{H}$///, " if an optional rank ",TEX///$n$///," is specified"},
 	    },
 	PARA {"By default outputs the rank two hyperbolic form over the input field ", TEX///$k$///, "."},
 	EXAMPLE lines ///
-    	    	 hyperbolicForm(GF(7))
+    	    	 makeHyperbolicForm GF(7)
 	 	 ///,
 	PARA{"Specifying a rank yields a copy of sums of the rank two hyperbolic form. Only even rank inputs are accepted."},
 	EXAMPLE lines ///
-        hyperbolicForm(RR,4)
+        makeHyperbolicForm(RR, 4)
 	///,
-    SeeAlso => {"isAnisotropic", "sumDecomposition", "sumDecompositionString"}
+    SeeAlso => {"isAnisotropic", "getSumDecomposition", "getSumDecompositionString"}
 }

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/DecompositionDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/DecompositionDoc.m2
@@ -1,86 +1,84 @@
 document {
-    Key => {sumDecomposition, (sumDecomposition, GrothendieckWittClass)},
-    Headline => "produces a simplified diagonal representative of a Grothendieck Witt class",
-    Usage => "sumDecomposition(beta)",
+    Key => {getSumDecomposition, (getSumDecomposition, GrothendieckWittClass)},
+    Headline => "produces a simplified diagonal representative of a Grothendieck-Witt class",
+    Usage => "getSumDecomposition beta",
     Inputs => {
-        GrothendieckWittClass => "beta" => {"a symmetric bilinear form defined over a field ", TEX///$k$///},
+        GrothendieckWittClass => "beta" => {"a symmetric bilinear form defined over ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
     },
     Outputs => { 
 	GrothendieckWittClass => {"a diagonal representative of the Grothendieck Witt class of the input form"},
-	--String => {"The decomposition as a sum of hyperbolic and rank one forms."},
 	},
-    PARA {"Given a symmetric bilinear form ", TT"beta", " over a field ", TEX///$k$///, ", we decompose it as a sum of some number of hyperbolic and rank one forms."},
+    PARA {"Given a symmetric bilinear form ", TT"beta", " over ", 
+        TEX///$\mathbb{Q},$///," ",TEX///$ \mathbb{R},$///," ",
+	TEX///$\mathbb{C}$///, " or a finite field of characteristic not 2, we decompose it as a sum of some number of hyperbolic and rank one forms."},
     EXAMPLE lines ///
-    M = matrix(RR,{{2.091,2.728,6.747},{2.728,7.329,6.257},{6.747,6.257,0.294}});
-    beta = gwClass(M);
-    sumDecomposition(beta)
+    M = matrix(RR, {{2.091,2.728,6.747},{2.728,7.329,6.257},{6.747,6.257,0.294}});
+    beta = makeGWClass M;
+    getSumDecomposition beta
     ///,
     PARA {"Over ", TEX///$\mathbb{R}$///, " there are only two square classes and a form is determined uniquely by its rank and signature [L05, II Proposition 3.2]. A form defined by the ", TEX///$3\times 3$///, " Gram matrix ", TT"M", " above is isomorphic to the form ", TEX///$\langle 1,-1,1\rangle $///, "."},
     EXAMPLE lines ///
-    M = matrix(GF(13),{{9,1,7,4},{1,10,3,2},{7,3,6,7},{4,2,7,5}});
-    beta = gwClass(M);
-    sumDecomposition(beta)
+    M = matrix(GF(13), {{9,1,7,4},{1,10,3,2},{7,3,6,7},{4,2,7,5}});
+    beta = makeGWClass M;
+    getSumDecomposition beta
     ///,
+    PARA {"Over ", TEX///$\mathbb{F}_{q}$///, " forms can similarly be diagonalized, in the above case as ", TEX///$\langle 1,-1,1,-6 \rangle$///, "."},
     PARA{EM "Citations:"},
     UL{
-	
 	{"[L05] T.Y. Lam, ", EM "Introduction to quadratic forms over fields,", " American Mathematical Society, 2005."},
 	},
-    SeeAlso => {"sumDecompositionString"},
+    SeeAlso => {"getSumDecompositionString", "getAnisotropicPart", "getWittIndex"},
 }
 
 document {
-    Key => {sumDecompositionString, (sumDecompositionString, GrothendieckWittClass)},
-    Headline => "produces a simplified diagonal representative of a Grothendieck Witt class",
-    Usage => "sumDecompositionString(beta)",
+    Key => {getSumDecompositionString, (getSumDecompositionString, GrothendieckWittClass)},
+    Headline => "produces a simplified diagonal representative of a Grothendieck-Witt class",
+    Usage => "getSumDecompositionString beta",
     Inputs => {
-        GrothendieckWittClass => "beta" => {"a symmetric bilinear form defined over a field ", TEX///$k$///},
+        GrothendieckWittClass => "beta" => {"a symmetric bilinear form defined over ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
     },
     Outputs => { 
-	--GrothendieckWittClass => {"a diagonal representative of the Grothendieck Witt class of the input form"},
 	String => {"the decomposition as a sum of hyperbolic and rank one forms"},
 	},
     PARA {"Given a symmetric bilinear form ", TT"beta", " over a field ", TEX///$k$///, ", we return a simplified diagonal form of ", TT"beta","."},
     EXAMPLE lines ///
-    M = matrix(RR,{{2.091,2.728,6.747},{2.728,7.329,6.257},{6.747,6.257,0.294}});
-    beta = gwClass(M);
-    sumDecompositionString(beta)
+    M = matrix(RR, {{2.091,2.728,6.747},{2.728,7.329,6.257},{6.747,6.257,0.294}});
+    beta = makeGWClass M;
+    getSumDecompositionString beta
     ///,
     PARA {"Over ", TEX///$\mathbb{R}$///, " there are only two square classes and a form is determined uniquely by its rank and signature [L05, II Proposition 3.2]. A form defined by the ", TEX///$3\times 3$///, " Gram matrix ", TT"M", " above is isomorphic to the form ", TEX///$\langle 1,-1,1\rangle $///, "."},
     EXAMPLE lines ///
-    M = matrix(GF(13),{{9,1,7,4},{1,10,3,2},{7,3,6,7},{4,2,7,5}});
-    beta = gwClass(M);
-    sumDecompositionString(beta)
+    M = matrix(GF(13), {{9,1,7,4},{1,10,3,2},{7,3,6,7},{4,2,7,5}});
+    beta = makeGWClass M;
+    getSumDecompositionString beta
     ///,
-    PARA {"Over ", TEX///$\mathbb{F}_{q}$///, " forms can similarly be diagonalized. In this case as ", TEX///$\langle 1,-1,1,-6 \rangle$///, "."},
+    PARA {"Over ", TEX///$\mathbb{F}_{q}$///, " forms can similarly be diagonalized, in the above case as ", TEX///$\langle 1,-1,1,-6 \rangle$///, "."},
     PARA{EM "Citations:"},
     UL{
-	
 	{"[L05] T.Y. Lam, ", EM "Introduction to quadratic forms over fields,", " American Mathematical Society, 2005."},
 	},
-    SeeAlso => {"sumDecomposition"},
+    SeeAlso => {"getSumDecomposition", "getAnisotropicPart", "getWittIndex"},
 }
 
 
 document {
-    Key => {anisotropicPart, (anisotropicPart, GrothendieckWittClass), (anisotropicPart, Matrix)},
-    Headline => "returns the anisotropic part of a Grothendieck Witt class",
-    Usage => "anisotropicPart(beta)",
+    Key => {getAnisotropicPart, (getAnisotropicPart, GrothendieckWittClass), (getAnisotropicPart, Matrix)},
+    Headline => "returns the anisotropic part of a Grothendieck-Witt class",
+    Usage => "getAnisotropicPart beta",
     Inputs => {
-        GrothendieckWittClass => "beta" => {"a symmetric bilinear form defined over a field ", TEX///$k$///},
+        GrothendieckWittClass => "beta" => {"a symmetric bilinear form defined over ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
     },
     Outputs => { 
 	GrothendieckWittClass => {"the anisotropic part of ", TEX///$\beta$///},
     },
-    PARA {"Given a form ", TEX///$\beta$///, " we may compute its anisotropic part inductively by reference to its ", TO2(anisotropicDimension,"anisotropic dimension"), ". Over the complex numbers and the reals this is trivial, and over finite fields it is a fairly routine computation, however over the rationals some more sophisticated algorithms are needed from the literature. For this methods we implement algorithms developed for number fields by Koprowski and Rothkegel [KR23]. Note also that a Chinese Remainder Theorem method is needed in reducing from anisotropic dimension three as in [KR23, Algorithm 7], so we import one from the ", TT "Parametrization", " package."},
+    PARA{"By the Witt Decomposition Theorem, any non-degenerate form decomposes uniquely as ", TEX///$\beta \cong n \mathbb{H} \oplus \beta_a$///," where the form ", TEX///$\beta_a$///," is anisotropic. We compute the anisotropic part ", TEX///$\beta_a$///," inductively by reference to its ", TO2(getAnisotropicDimension,"anisotropic dimension"), ". Over the complex numbers and real numbers this is straightforward, and over finite fields it is a fairly routine computation. Over the rational numbers some more sophisticated algorithms are needed from the literature. For this we implement algorithms developed for number fields by Koprowski and Rothkegel [KR23]."},
     EXAMPLE lines ///
-    alpha = diagonalForm(QQ,(3,-3,2,5,1,-9));
-    anisotropicPart(alpha)
+    alpha = makeDiagonalForm(QQ, (3,-3,2,5,1,-9));
+    getAnisotropicPart alpha
     ///,
     PARA{EM "Citations:"},
     UL{
-	
-	{"[KR23] P. Koprowski and B. Rothkegel, ", EM "The anisotropic part of a quadratic form over a number field,", " Journal of Symbolic Computatoin, 2023."},
+	{"[KR23] P. Koprowski and B. Rothkegel, ", EM "The anisotropic part of a quadratic form over a number field,", " Journal of Symbolic Computation, 2023."},
 	},
-    SeeAlso => {"anisotropicDimension", "WittIndex"},
+    SeeAlso => {"getAnisotropicDimension", "getWittIndex", "getSumDecomposition", "getSumDecompositionString"},
 }

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/GWInvariantsDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/GWInvariantsDoc.m2
@@ -1,26 +1,27 @@
 document{
-    Key => {signature, (signature, GrothendieckWittClass)},
-    Headline => "outputs the signature of a symmetric bilinear form over the real or rational numbers",
-    Usage => "signature(beta)",
+    Headline => "computes the signature of a symmetric bilinear form over the real numbers or rational numbers",
+    Key => {getSignature, (getSignature, GrothendieckWittClass)},
+    Usage => "getSignature beta",
     Inputs => {
 	GrothendieckWittClass => "beta" => {"a symmetric bilinear form defined over ", TEX///$\mathbb{Q}$///, " or ", TEX///$\mathbb{R}$///},
 	},
     Outputs => {
 	ZZ => "n" => {"the ", EM "signature", " of the symmetric bilinear form ", TEX///$\beta$///},
 	},
-    PARA{"Given a symmetric bilinear form, after diagonalizing it, we can consider the number of positive entries minus the number of negative entries appearing along the diagonal. This is the ", EM "signature", " of a symmetric bilinear form, and is one of the primary invariants we use to classify forms. For more information see ", TO2(gwIsomorphic,"gwIsomorphic"), "."},
+    PARA{"Given a symmetric bilinear form, after diagonalizing it, we can consider the number of positive entries minus the number of negative entries appearing along the diagonal. This is the ", EM "signature", " of a symmetric bilinear form, and is one of the primary invariants used to classify forms. For more information see ", TO2(isIsomorphicForm,"isIsomorphicForm"), "."},
     EXAMPLE lines ///
-    M = matrix(RR,{{0,0,1},{0,1,0},{1,0,0}});
-    beta = gwClass(M);
-    signature(beta)
+    M = matrix(RR, {{0,0,1},{0,1,0},{1,0,0}});
+    beta = makeGWClass M;
+    getSignature beta
     ///,
-    SeeAlso => {"gwIsomorphic", "sumDecomposition", "sumDecompositionString"}
+    SeeAlso => {"isIsomorphicForm", "getHilbertSymbolReal", "getSumDecomposition", "getSumDecompositionString"}
     }
 
+
 document{
-    Key => {integralDiscriminant, (integralDiscriminant, GrothendieckWittClass)},
-    Headline => "outputs an integral discriminant for a rational symmetric bilinear form",
-    Usage => "integralDiscriminant(beta)",
+    Key => {getIntegralDiscriminant, (getIntegralDiscriminant, GrothendieckWittClass)},
+    Headline => "computes the integral discriminant for a rational symmetric bilinear form",
+    Usage => "getIntegralDiscriminant beta",
     Inputs => {
 	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(\mathbb{Q})$///},
 	},
@@ -28,51 +29,76 @@ document{
         ZZ => {"an integral square class representative of ", TEX///$\text{disc}(\beta)$///},
 	},
     EXAMPLE lines ///
-    beta = gwClass(matrix(QQ,{{1,4,7},{4,3,-1},{7,-1,5}}));
-    integralDiscriminant(beta)
-    diagonalClass(beta)
+    beta = makeGWClass matrix(QQ, {{1,4,7},{4,3,-1},{7,-1,5}});
+    getIntegralDiscriminant beta
+    getDiagonalClass beta
     ///,
+    SeeAlso => {"isIsomorphicForm"}
 }
 
+
 document{
-    Key => {HasseWittInvariant, (HasseWittInvariant, GrothendieckWittClass, ZZ), (HasseWittInvariant, List, ZZ)},
-    Headline => "outputs the Hasse-Witt invariant for a prime p for the quadratic form of the Grothendieck-Witt class",
-    Usage => "HasseWittInvariant(beta, p)",
+    Key => {getHasseWittInvariant, (getHasseWittInvariant, GrothendieckWittClass, ZZ), (getHasseWittInvariant, List, ZZ)},
+    Headline => "computes the Hasse-Witt invariant at a prime p for the quadratic form of the Grothendieck-Witt class",
+    Usage => "getHasseWittInvariant(beta, p)",
     Inputs => {
 	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(\mathbb{Q})$///},
-	ZZ => "p" => {"an integral prime number"},
+	ZZ => "p" => {"a prime number"},
 	},
     Outputs => {
-        ZZ => {"the Hasse-Witt invariant for ", TEX///$\beta$///," for the prime ",TEX///$p$///},
+        ZZ => {"the Hasse-Witt invariant of ", TEX///$\beta$///," at the prime ",TEX///$p$///},
 	},
-    PARA{"The ", EM "Hasse-Witt invariant", " of a diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " over a field ", TEX///$K$///, " is defined to be the product ", TEX///$\prod_{i<j} \left((a_i,a_j)_p \right)$///, " where ", TEX///$(-,-)_p$///, " is the ", TO2(HilbertSymbol,"Hilbert symbol"), "."},
-    PARA{"The Hasse-Witt invariant of a form will be equal to 1 for almost all primes. In particular after diagonalizing a form ", TEX///$\beta \cong \left\langle a_1,\ldots,a_n\right\rangle$///, " then the Hasse-Witt invariant at a prime ", TEX///$p$///, " will be 1 automatically if ", TEX///$p\nmid a_i$///, " for all ", TEX///$i$///, ". Thus we only have to compute the invariant at ", TO2(relevantPrimes, "primes dividing diagonal entries"),  "."},
+    PARA{"The ", EM "Hasse-Witt invariant", " of a diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " over a field ", TEX///$K$///, " is defined to be the product ", TEX///$\prod_{i<j} \left(a_i,a_j\right)_p $///, " where ", TEX///$(-,-)_p$///, " is the ", TO2(getHilbertSymbol,"Hilbert symbol"), "."},
+    PARA{"The Hasse-Witt invariant of a form will be equal to 1 for almost all primes. In particular, after diagonalizing a form ", TEX///$\beta \cong \left\langle a_1,\ldots,a_n\right\rangle$///, " the Hasse-Witt invariant at a prime ", TEX///$p$///, " will be 1 automatically if ", TEX///$p\nmid a_i$///, " for all ", TEX///$i$///, ". Thus we only have to compute the Hasse-Witt invariant at ", TO2(getRelevantPrimes, "primes dividing diagonal entries"),  "."},
     EXAMPLE lines ///
-    beta = gwClass(matrix(QQ,{{1,4,7},{4,3,-1},{7,-1,5}}));
-    HasseWittInvariant(beta, 7)
+    beta = makeGWClass matrix(QQ, {{1,4,7},{4,3,-1},{7,-1,5}});
+    getHasseWittInvariant(beta, 7)
     ///,
+    SeeAlso => {"isIsomorphicForm", "getRelevantPrimes"}
 }
 
 
-
 document{
-    Key => {relevantPrimes, (relevantPrimes, GrothendieckWittClass)},
-    Headline => "outputs a list of primes at which the Hasse-Witt invariants of a symmetric bilinear form may be non-trivial",
-    Usage => "relevantPrimes(beta)",
+    Key => {getRelevantPrimes, (getRelevantPrimes, GrothendieckWittClass)},
+    Headline => "outputs a list containing all primes p where the Hasse-Witt invariant of a symmetric bilinear form is nontrivial",
+    Usage => "getRelevantPrimes beta",
     Inputs => {
 	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(\mathbb{Q})$///},
 	},
     Outputs => {
-        List => {"a finite list of primes ", TEX///$(p_1,\ldots,p_r)$///, " for which the Hasse-Witt invariants ", TEX///$\phi_p(\beta)$///," may be nontrivial"},
+        List => {"a finite list of primes ", TEX///$(p_1,\ldots,p_r)$///, " containing all primes ",
+	    TEX///$p$///, " where the ",TO2(getHasseWittInvariant,"Hasse-Witt invariant "), TEX///$\phi_p(\beta)$///," is nontrivial"},
 	},
-    PARA{"It is a classical result that the ", TO2(HasseWittInvariant,"Hasse-Witt invariants"), " of a quadratic form are equal to 1 for all but finitely many primes (see e.g. [S73, IV Section 3.3]. As the Hasse-Witt invariants are computed as a product of ", TO2(HilbertSymbol,"Hilbert symbols") , " of the pairwise entries appearing on a diagonalization of the symbol, it suffices to consider primes dividing diagonal entries."},
+    PARA{"It is a classical result that the ", TO2(getHasseWittInvariant,"Hasse-Witt invariants"), " of a quadratic form are equal to 1 for all but finitely many primes (see e.g. [S73, IV Section 3.3]). As the Hasse-Witt invariants are computed as a product of ", TO2(getHilbertSymbol,"Hilbert symbols") , " of the pairwise entries appearing on a diagonalization of the symbol, it suffices to consider primes dividing diagonal entries."},
    EXAMPLE lines ///
-   beta = diagonalForm(QQ,(6,7,22));
-   relevantPrimes(beta)
+   beta = makeDiagonalForm(QQ, (6,7,22));
+   getRelevantPrimes beta
    ///,
    PARA{EM "Citations:"},
     UL{
-	
 	{"[S73] J.P. Serre, ", EM "A course in arithmetic,", " Springer-Verlag, 1973."},
     },
+    SeeAlso => {"getHasseWittInvariant"}
+}
+
+document {
+        Key => {getRank, (getRank, GrothendieckWittClass), (getRank, Matrix)},
+        Headline => "calculates the rank of a symmetric bilinear form",
+        Usage => "getRank beta",
+        Inputs => {
+            GrothendieckWittClass => "beta" => {"denoted by ",  TEX///$\beta \in  GW(\mathbb{Q})$///, " or a symmetric matrix ", TEX///$\beta$///}
+            },
+        Outputs => {
+            ZZ => {"the rank of the form ", TEX///$\beta$///}
+           },
+        PARA {"This computes the rank of the form ", TEX///$\beta$/// },
+        EXAMPLE lines ///
+                 beta = makeDiagonalForm(QQ, (3,5,7,11))
+                 getRank beta
+		 ///,                
+        EXAMPLE lines ///
+                 M = matrix(QQ, {{1,4,7},{4,3,-1},{7,-1,5}})
+                 getRank M
+                 ///,
+    SeeAlso => {"isIsomorphicForm", "getSignature"}
 }

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/GrothendieckWittClassesDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/GrothendieckWittClassesDoc.m2
@@ -1,83 +1,113 @@
 document{
-    Key => GrothendieckWittClass,
+    Key => {GrothendieckWittClass, (net, GrothendieckWittClass), (texMath, GrothendieckWittClass)},
     Headline => "a new type, intended to capture the isomorphism class of an element of the Grothendieck-Witt ring of a base field",
     PARA {"A ", TT "GrothendieckWittClass" ," object is a type of ", TO2(HashTable, "HashTable"), " encoding the isomorphism class of a non-degenerate symmetric bilinear form ", TEX///$V \times V \to k$///, " over a field ", TEX///$k$///, "."},
-    PARA{"Given any basis ", TEX///$e_1,\ldots,e_n$///, " for ", TEX///$V$///, " as a ", TEX///$k$///, "-vector space, we can encode the symmetric bilinear form ", TEX///$\beta$///, " by how it acts on basis elements. That is, we can produce a matrix ", TEX///$\left(\beta(e_i,e_j)\right)_{i,j}$///, ". This is called a ", EM "Gram matrix", " for the symmetric bilinear form. A change of basis will produce a congruent Gram matrix, thus a matrix represents a symmetric bilinear form uniquely up to matrix congruence."},
+    PARA{"Given any basis ", TEX///$e_1,\ldots,e_n$///, " for ", TEX///$V$///, " as a ", TEX///$k$///, "-vector space, we can encode the symmetric bilinear form ", TEX///$\beta$///, " by how it acts on basis elements. That is, we can produce a matrix ", TEX///$\left(\beta(e_i,e_j)\right)_{i,j}$///, ". This is called a ", EM "Gram matrix", " for the symmetric bilinear form. A change of basis produces a congruent Gram matrix, so thus a matrix represents a symmetric bilinear form uniquely up to matrix congruence."},
 	
-	
-    PARA{"A GrothendieckWittClass object can be built from a symmetric ", TO2(matrix, "matrix"), " over a field using the ", TO2(gwClass,"gwClass"), " method."},
+    PARA{"A GrothendieckWittClass object can be built from a symmetric ", TO2(matrix, "matrix"), " over a field using the ", TO2(makeGWClass,"makeGWClass"), " method."},
     EXAMPLE lines///
-    beta = gwClass(matrix(QQ,{{0,1},{1,0}}))
+    beta = makeGWClass matrix(QQ, {{0,1},{1,0}})
     class beta
     ///,
-    PARA{"The underlying matrix representative of a form can be recovered via the ", TT "matrix", " command, and its underlying field can be recovered using ", TO2(baseField,"baseField"), "."},
+    PARA{"The underlying matrix representative of a form can be recovered via the ", TO2(getMatrix, "getMatrix"), " command or the ", TT "matrix", " command, and its underlying field can be recovered using ", TO2(getBaseField,"getBaseField"), "."},
     EXAMPLE lines///
-    beta.matrix
-    baseField(beta)
+    getMatrix beta
+    getBaseField beta
     ///,
-    PARA{"For computational purposes, it is often desirable to diagonalize a Gram matrix. Any symmetric bilinear form admits a diagonal Gram matrix representative by ", EM "Sylvester's law of inertia", ", and this is implemented via the ", TO2(diagonalClass, "diagonalClass"), " method."},
+    PARA{"For computational purposes, it is often desirable to diagonalize a Gram matrix. Any symmetric bilinear form admits a diagonal Gram matrix representative, and this is implemented via the ", TO2(getDiagonalClass, "getDiagonalClass"), " method."},
     EXAMPLE lines///
-    diagonalClass(beta)
+    getDiagonalClass beta
     ///,
     PARA{"Once a form has been diagonalized, it is recorded in the cache for ", TT "GrothendieckWittClass", " and can therefore be quickly recovered."},
     EXAMPLE lines///
-    beta.cache.diagonalClass
+    beta.cache.getDiagonalClass
     ///,
-    SeeAlso => {"gwClass","diagonalClass","baseField"},
+    PARA{"We additionally have the following methods which can be applied to Grothendieck-Witt classes:"},
+    UL{
+	{TO2(getRank,"getRank"),": returns the rank of a form,"},
+	{TO2(getSignature,"getSignature"),": returns the signature of a form over the real numbers or rational numbers,"},
+	{TO2(getIntegralDiscriminant,"getIntegralDiscriminant"),": returns an integral representative for the discriminant of a form over the rational numbers,"},
+	{TO2(getHasseWittInvariant,"getHasseWittInvariant"),": returns the Hasse-Witt invariant for a form over the rational numbers at a particular prime,"},
+	{TO2(getAnisotropicDimension,"getAnisotropicDimension"),": returns the anisotropic dimension of a form,"},
+	{TO2(getAnisotropicPart,"getAnisotropicPart"),": returns the anisotropic part of a form,"},
+	{TO2(getSumDecomposition,"getSumDecomposition"),": returns a simplified diagonal representative of a form,"},
+	{TO2(getSumDecompositionString,"getSumDecompositionString"),": returns a string to quickly read a form,"},
+	},
+    PARA{"and Boolean methods for Grothendieck-Witt classes:"},
+    UL{
+	{TO2(isIsotropic,"isIsotropic"),": returns whether the form is isotropic,"},
+	{TO2(isAnisotropic,"isAnisotropic"),": returns whether the form is anisotropic."},
+	},
+    PARA{"Forms can be created via the following methods:"},
+    UL{
+	{TO2(makeDiagonalForm,"makeDiagonalForm"),": creates a diagonal form over a field out of an element or list of field elements,"},
+	{TO2(makeHyperbolicForm,"makeHyperbolicForm"),": creates a hyperbolic form over a field,"},
+	{TO2(makePfisterForm,"makePfisterForm"),": creates a Pfister form over a field out of an element or list of field elements."},
+	},
+    SeeAlso => {"makeGWClass", "getBaseField", "getMatrix", "getDiagonalClass"},
     }
 
 document {
-    Key => {gwClass, (gwClass, Matrix), (matrix, GrothendieckWittClass), (isWellDefined, Matrix)},
-	Headline => "the Grothendieck Witt class of a symmetric matrix",
-	Usage => "gwClass(M)",
+    Key => {makeGWClass, (makeGWClass, Matrix), (isWellDefinedGW, Matrix)},
+	Headline => "the Grothendieck-Witt class of a symmetric matrix",
+	Usage => "makeGWClass M",
 	Inputs => {
-	    Matrix => "M" => {"a symmetric matrix defined over an arbitrary field"}
+	    Matrix => "M" => {"a non-singular symmetric matrix defined over an arbitrary field of characteristic not 2"}
 	    },
 	Outputs => {
-	    GrothendieckWittClass => { "the isomorphism class of a symmetric bilinear form represented by ", TEX/// $M$///}
+	    GrothendieckWittClass => {"the isomorphism class of the non-degenerate symmetric bilinear form represented by ", TEX/// $M$///}
 	    },
 	PARA {"Given a symmetric matrix, ", TEX///$M$///, ", this command outputs an object of type ", TT "GrothendieckWittClass", ". ",
-                "This output has the representing matrix, ", TEX///$M$///, ", and the base field of the matrix stored in its CacheTable."},
+                "This output has the representing matrix, ", TEX///$M$///, ", and the base field of the matrix stored in its ",TO2(CacheTable,"CacheTable.")},
 	EXAMPLE lines ///
-		 M := matrix(QQ,{{0,0,1},{0,1,0},{1,0,0}});
-		 beta = gwClass(M)
+		 M := matrix(QQ, {{0,0,1},{0,1,0},{1,0,0}});
+		 beta = makeGWClass M
 	 	 ///,
-	PARA{"The matrix representing a ", TT "GrothendieckWittClass", " element can be recovered using the ", TT "matrix", " command:"},
-	EXAMPLE lines ///
-	    	beta.matrix
-		///,
-        PARA{"The base field which the form ", TEX///$\beta$///, " is implicitly defined over can be recovered with the ", TO2(baseField,"baseField"), " method."},
-	EXAMPLE lines ///
-	    	baseField beta
-		///,
 		
-	SeeAlso => {"baseField","GrothendieckWittClass"}
+	SeeAlso => {"GrothendieckWittClass", "getMatrix", "getBaseField"}
         }
 
 document {
-    Key => {baseField, (baseField, GrothendieckWittClass)},
-	Headline => "the base field of a Grothendieck Witt class",
-	Usage => "baseField(beta)",
+    Key => {getMatrix, (getMatrix, GrothendieckWittClass)},
+	Headline => "the underlying matrix of a Grothendieck-Witt class",
+	Usage => "getMatrix beta",
 	Inputs => {
-	    GrothendieckWittClass => "beta" => {"the isomorphism class of a symmetric bilinear form"}
+	    GrothendieckWittClass => "beta" => {"the isomorphism class of a non-degenerate symmetric bilinear form over a field of characteristic not 2"}
 	    },
 	Outputs => {
-	    Ring => { "the base field of the Grothendieck-Witt class ", TT "beta" }
+	    Ring => {"the underlying matrix of the Grothendieck-Witt class ", TT "beta"}
 	    },
-	PARA {"Given the isomorphism class of a symmetric bilinear form, ", TT "beta", 
-                ", this command outputs the base field of the form."},
+	PARA {"Given the isomorphism class of a symmetric bilinear form, ", TT "beta", ", this command outputs the underlying matrix of the form."},
 	EXAMPLE lines ///
-		 beta = gwClass(matrix(QQ,{{0,2},{2,0}}));
-		 baseField beta
+		 beta = makeGWClass matrix(QQ, {{0,2},{2,0}});
+		 getMatrix beta
+	 	 ///,
+    SeeAlso => {"GrothendieckWittClass", "makeGWClass"}
+        }
+
+document {
+    Key => {getBaseField, (getBaseField, GrothendieckWittClass)},
+	Headline => "the base field of a Grothendieck-Witt class",
+	Usage => "getBaseField beta",
+	Inputs => {
+	    GrothendieckWittClass => "beta" => {"the isomorphism class of a non-degenerate symmetric bilinear form over a field of characteristic not 2"}
+	    },
+	Outputs => {
+	    Ring => {"the base field of the Grothendieck-Witt class ", TT "beta"}
+	    },
+	PARA {"Given the isomorphism class of a symmetric bilinear form, ", TT "beta", ", this command outputs the base field of the form."},
+	EXAMPLE lines ///
+		 beta = makeGWClass matrix(QQ, {{0,2},{2,0}});
+		 getBaseField beta
 	 	 ///,
     SeeAlso => {"GrothendieckWittClass"}
         }
 
 
 document {
-    Key => {gwAdd, (gwAdd, GrothendieckWittClass, GrothendieckWittClass)},
+    Key => {addGW, (addGW, GrothendieckWittClass, GrothendieckWittClass)},
     Headline => "the direct sum of two Grothendieck-Witt classes",     
-    Usage => "gwAdd(beta, gamma)",
+    Usage => "addGW(beta, gamma)",
 	Inputs => {
 	    GrothendieckWittClass => "beta" => {"the isomorphism class of a non-degenerate symmetric bilinear form represented by a matrix ", TT "M"},
 	    GrothendieckWittClass => "gamma" => {"the isomorphism class of a non-degenerate symmetric bilinear form represented by a matrix ", TT "N"},
@@ -87,34 +117,34 @@ document {
 	    },
 	PARA {"This computes the direct sum of the Grothendieck-Witt classes ",TT "beta"," and ",TT "gamma","."},
 	EXAMPLE lines ///
-		 M = matrix(QQ,{{1,0},{0,1}});
-		 N = matrix(QQ, {{1, 2}, {2, 5}});
-		 beta = gwClass(M);
-		 gamma = gwClass(N);
-    	    	 gwAdd(beta, gamma)
+		 M = matrix(QQ, {{1,0},{0,1}});
+		 N = matrix(QQ, {{1,2},{2,5}});
+		 beta = makeGWClass M;
+		 gamma = makeGWClass N;
+    	    	 addGW(beta, gamma)
 	 	 ///,
-    SeeAlso => {"GrothendieckWittClass", "gwClass", "gwMultiply"}
+    SeeAlso => {"GrothendieckWittClass", "makeGWClass", "multiplyGW"}
 }
 
 document {
-    Key => {gwMultiply, (gwMultiply, GrothendieckWittClass, GrothendieckWittClass)},
+    Key => {multiplyGW, (multiplyGW, GrothendieckWittClass, GrothendieckWittClass)},
     Headline => "the tensor product of two Grothendieck-Witt classes",     
-	Usage => "gwMultiply(beta, gamma)",
+	Usage => "multiplyGW(beta, gamma)",
 	Inputs => {
 	    GrothendieckWittClass => "beta" => {"the isomorphism class of a non-degenerate symmetric bilinear form represented by a matrix ", TT "M"},
 	    GrothendieckWittClass => "gamma" => {"the isomorphism class of a non-degenerate symmetric bilinear form represented by a matrix ", TT "N"},
 	    }, 
 	Outputs => { 
-	    GrothendieckWittClass => {"the isomorphism class of the tensor product of the bilinear forms represented by the matrices ", TT "M", " and ", TT "N"},
+	    GrothendieckWittClass => {"the isomorphism class of the tensor product ",TEX///$M\otimes N$///," of the bilinear forms represented by the matrices ", TT "M", " and ", TT "N"},
 	    },
-	PARA {"This computes the tensor product of the Grothendieck-Witt classes ",TT "beta"," and ",TT "gamma","."},
+	PARA {"This computes the tensor product ",TEX///$\beta\otimes\gamma$///," of the Grothendieck-Witt classes ",TT "beta"," and ",TT "gamma","."},
 	EXAMPLE lines ///
-    	    	 M = matrix(QQ,{{1,0},{0,1}});
-		 N = matrix(QQ, {{1, 2}, {2, 5}});
-		 beta = gwClass(M);
-		 gamma = gwClass(N);
-    	    	 gwMultiply(beta, gamma)
+    	    	 M = matrix(QQ, {{1,0},{0,1}});
+		 N = matrix(QQ, {{1,2},{2,5}});
+		 beta = makeGWClass M;
+		 gamma = makeGWClass N;
+    	    	 multiplyGW(beta, gamma)
 	 	 ///,
-    SeeAlso => {"GrothendieckWittClass", "gwClass", "gwAdd"}
+    SeeAlso => {"GrothendieckWittClass", "makeGWClass", "addGW"}
 }
 

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/HilbertSymbolsDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/HilbertSymbolsDoc.m2
@@ -1,53 +1,73 @@
 document{
-    Key => {HilbertSymbol, (HilbertSymbol, ZZ, ZZ, ZZ),  (HilbertSymbol, QQ, QQ, ZZ),  (HilbertSymbol, ZZ, QQ, ZZ),  (HilbertSymbol, QQ, ZZ, ZZ)},
-    Headline => "computes the Hilbert symbol of two integers or rational numbers at a prime",
-    Usage => "HilbertSymbol(a,b,p)",
+    Key => {getHilbertSymbol, (getHilbertSymbol, ZZ, ZZ, ZZ), (getHilbertSymbol, QQ, QQ, ZZ), (getHilbertSymbol, ZZ, QQ, ZZ), (getHilbertSymbol, QQ, ZZ, ZZ)},
+    Headline => "computes the Hilbert symbol of two rational numbers at a prime",
+    Usage => "getHilbertSymbol(a, b, p)",
     Inputs => {
-	QQ => "a" => {"any integer or rational number, considered as an element of ", TEX///$\mathbb{Q}_p$///},
-	QQ => "b" => {"any integer or rational number, considered as an element of ", TEX///$\mathbb{Q}_p$///},
-	ZZ => "p" => {"any integer prime number"},
+	QQ => "a" => {"a nonzero integer or rational number, considered as an element of ", TEX///$\mathbb{Q}_p$///},
+	QQ => "b" => {"a nonzero integer or rational number, considered as an element of ", TEX///$\mathbb{Q}_p$///},
+	ZZ => "p" => {"a prime number"},
 	},
     Outputs => {
 	ZZ => {"the ", EM "Hilbert symbol ", TEX///$(a,b)_p$///},
 	},
-    PARA{"The ", EM "Hasse-Witt invariant", " of a diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " over a field ", TEX///$K$///, " is defined to be the product ", TEX///$\prod_{i<j}  \phi(a_i,a_j)$///, " where ", TEX///$\phi \colon K \times K \to \left\{\pm 1\right\}$///, " is any ", EM "symbol", " (see e.g. [MH73, III.5.4] for a definition). It is a classical result of Hilbert that over a local field of characteristic not equal to two, there is one and only symbol, ", TEX///$(-,-)_p$///,  " called the ", EM "Hilbert symbol", " ([S73, Chapter III]) computed as follows:"},
-    PARA{TEX///$(a,b)_p = \begin{cases} 1 & z^2 = ax^2 + by^2 \text{ has a nonzero solution in } K^3 \\ -1 & \text{otherwise.} \end{cases}$///},
-    PARA{"Consider the following example, where we observe that ", TEX///$z^2 = 2x^2 + y^2$///," does admit nonzero solutions mod 7, in particular ", TEX///$(x,y,z) = (1,0,3)$///, ":"},
+    PARA{"The ", EM "Hasse-Witt invariant", " of a diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " over a field ", TEX///$k$///, " is defined to be the product ", 
+	TEX///$\prod_{i<j}  \left( a_i,a_j \right)_p$///, " where ",
+    -- " where ", TEX///$\phi \colon k \times k \to \left\{\pm 1\right\}$///, " is any ", EM "symbol", " (see e.g. [MH73, III.5.4] for a definition). It is a classical result of Hilbert that over a local field of characteristic not equal to two, there is a unique symbol, ", 
+	TEX///$(-,-)_p$///,  " is the ", EM "Hilbert symbol", " ([S73, Chapter III]) computed as follows:"},
+    PARA{TEX///$(a,b)_p = \begin{cases} 1 & \text{if }z^2 = ax^2 + by^2 \text{ has a nonzero solution in } K^3 \\ -1 & \text{otherwise.} \end{cases}$///},
+    PARA{"Consider the following example, where we observe that ", TEX///$z^2 = 2x^2 + y^2$///," does admit nonzero solutions mod 7, in particular ", TEX///$(x,y,z) = (1,0,3),$///, 
+	" and then by Hensel's lemma, has a solution over ",TEX///$\mathbb{Q}_7$///, "."},
     EXAMPLE lines///
-    HilbertSymbol(2,1,7)
+    getHilbertSymbol(2,1,7)
     ///,
+    PARA{"In contrast, since ", TEX///$z^2 = 7x^2 + 3y^2$///, 
+	" does not have a  nonzero solution mod 7, the Hilbert symbol will be ",
+	TEX///$-1.$///},
+    EXAMPLE lines///                                                                         
+    getHilbertSymbol(7,3,7)                                                               
+    ///,                  
+    PARA{"Over ",TEX///$\mathbb{Q}_2$///, " the equation ", TEX///$z^2 = 2x^2 + 2y^2$///,
+	" has a non-trivial solution, whereas the equation ", TEX///$z^2=2x^2+3y^2$///, 
+	" does not. Hence, their Hilbert symbols are 1 and -1, respectively."},
+    EXAMPLE lines///                                                                         
+    getHilbertSymbol(2,2,2)
+    getHilbertSymbol(2,3,2)                                                               
+    ///,                  
     PARA{"Computing Hasse-Witt invariants is a key step in classifying symmetric bilinear forms over the rational numbers, and in particular certifying their ", TO2(isIsotropic, "(an)isotropy"), "."},
     PARA{EM "Citations:"},
     UL{
-	
 	{"[S73] J.P. Serre, ", EM "A course in arithmetic,", " Springer-Verlag, 1973."},
 	{"[MH73] Milnor and Husemoller, ", EM "Symmetric bilinear forms,", " Springer-Verlag, 1973."},
     },
+    SeeAlso => {"getHilbertSymbolReal", "getHasseWittInvariant"}
 }
 
 document{
-    Key => {HilbertSymbolReal, (HilbertSymbolReal, QQ, QQ),  (HilbertSymbolReal, ZZ, ZZ),  (HilbertSymbolReal, ZZ, QQ),  (HilbertSymbolReal, QQ, ZZ)},
-    Headline => "computes the Hilbert symbol of two rational numbers over the reals",
-    Usage => "HilbertSymbolReal(a,b,p)",
+    Key => {getHilbertSymbolReal, (getHilbertSymbolReal, QQ, QQ), (getHilbertSymbolReal, ZZ, ZZ), (getHilbertSymbolReal, ZZ, QQ), (getHilbertSymbolReal, QQ, ZZ)},
+    Headline => "computes the Hilbert symbol of two rational numbers over the real numbers",
+    Usage => "getHilbertSymbolReal(a, b)",
     Inputs => {
-	QQ => "a" => {"any non-zero integer or rational number, considered as an element of ", TEX///$\mathbb{Q}_p$///},
-	QQ => "b" => {"any non-zero integer or rational number, considered as an element of ", TEX///$\mathbb{Q}_p$///},
+	QQ => "a" => {"a nonzero integer or rational number, considered as an element of ", TEX///$\mathbb{R}$///},
+	QQ => "b" => {"a nonzero integer or rational number, considered as an element of ", TEX///$\mathbb{R}$///},
 	},
     Outputs => {
 	ZZ => {"the ", EM "Hilbert symbol ", TEX///$(a,b)_{\mathbb{R}}$///},
 	},
-    PARA{"The ", EM "Hasse-Witt invariant", " of a diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " over a field ", TEX///$K$///, " is defined to be the product ", TEX///$\prod_{i<j}  \phi(a_i,a_j)$///, " where ", TEX///$\phi \colon K \times K \to \left\{\pm 1\right\}$///, " is any ", EM "symbol", " (see e.g. [MH73, III.5.4] for a definition). It is a classical result of Hilbert that over a local field of characteristic not equal to two, there is one and only symbol, ", TEX///$(-,-)_p$///,  " called the ", EM "Hilbert symbol", " ([S73, Chapter III]) computed as follows:"},
+    PARA{"The ", EM "Hasse-Witt invariant", " of a diagonal form ", 
+	TEX///$\langle a_1,\ldots,a_n\rangle$///, " over a field ", TEX///$k$///, " is defined to be the product ",
+	TEX///$\prod_{i<j}  \left( a_i,a_j \right)_{\mathbb{R}}$///, " where ", 
+	TEX///$(-,-)_{\mathbb{R}}$///,  " is the ", EM "Hilbert symbol", " ([S73, Chapter III]) computed as follows:"},
     PARA{TEX///$(a,b)_{\mathbb{R}} = \begin{cases} 1 & z^2 = ax^2 + by^2 \text{ has a nonzero solution in } {\mathbb{R}}^3 \\ -1 & \text{otherwise.} \end{cases}$///},
     PARA{TEX///$(a,b)_{\mathbb{R}}$///," will equal 1 unless both ",TEX///$a,\,b$///," are negative."},
     PARA{"Consider the example, that ",TEX///$z^2=-3x^2-2y^2/3$///," does not admit a non-zero solution. Thus:"}, 
      EXAMPLE lines///
-    HilbertSymbolReal(-3,-2/3) == -1
+    getHilbertSymbolReal(-3, -2/3) == -1
     ///,
     PARA{"Computing Hasse-Witt invariants is a key step in classifying symmetric bilinear forms over the rational numbers, and in particular certifying their ", TO2(isIsotropic, "(an)isotropy"), "."},
     PARA{EM "Citations:"},
     UL{
-	
 	{"[S73] J.P. Serre, ", EM "A course in arithmetic,", " Springer-Verlag, 1973."},
 	{"[MH73] Milnor and Husemoller, ", EM "Symmetric bilinear forms,", " Springer-Verlag, 1973."},
     },
+    SeeAlso => {"getHilbertSymbol", "getSignature"}
 }

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/IsomorphismOfFormsDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/IsomorphismOfFormsDoc.m2
@@ -1,68 +1,67 @@
 document{
-    Key => {gwIsomorphic, (gwIsomorphic, GrothendieckWittClass, GrothendieckWittClass)},
-    Headline => "determines whether two Grothendieck Witt classes are isomorphic over CC, RR, QQ, or a finite field.",
-    Usage => "gwIsomorphic(alpha,beta)",
+    Key => {isIsomorphicForm, (isIsomorphicForm, GrothendieckWittClass, GrothendieckWittClass), (isIsomorphicForm, Matrix, Matrix)},
+    Headline => "determines whether two Grothendieck-Witt classes over CC, RR, QQ, or a finite field of characteristic not 2 are isomorphic.",
+    Usage => "isIsomorphicForm(alpha, beta)",
     Inputs => {
-	GrothendieckWittClass => "alpha" => {"denoted by ",TEX///$\alpha$///},
-	GrothendieckWittClass => "beta" => {"denoted by ",TEX///$\beta$///},
+	GrothendieckWittClass => "alpha" => {"denoted by ", TEX///$\alpha$///, " over ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
+	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta$///, " over ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
 	},
     Outputs => {
-	Boolean => {"returns true or false depending on whether two Grothendieck Witt classes are equal in the Grothendieck-Witt ring"},
+	Boolean => {"whether the two Grothendieck-Witt classes are equal as elements of the Grothendieck-Witt ring"},
 	},
-    PARA{"Given two matrices representing symmetric bilinear forms over a field ", TEX///$k$///, ", it is a fundamental question to ask when they are representing the same symmetric bilinear form, i.e. when they are equal in the Grothendieck-Witt ring ", TEX///$\text{GW}(k)$///,"."},
+    PARA{"Given two matrices representing symmetric bilinear forms over a field ", TEX///$k$///, ", it is a fundamental question to ask when they represent isomorphic symmetric bilinear forms, i.e. when they are equal in the Grothendieck-Witt ring ", TEX///$\text{GW}(k)$///,"."},
     
     PARA{EM "Sylvester's Law of Inertia", " proves that any symmetric bilinear form can be diagonalized into a block sum of rank one symmetric bilinear forms. Since the rank one forms ", TEX///$\langle a \rangle \colon k \times k \to k$///, ", ", TEX///$(x,y) \mapsto axy$///, " and ", TEX///$\langle ab^2 \rangle \colon k \times k \to k$///, ", ", TEX///$(x,y) \mapsto ab^2xy$///, " differ by a change of basis in the ground field, it follows they are isomorphic (provided that ", TEX///$a,b\ne 0$///, "). Thus after diagonalizing a form, it suffices to consider the square class of each entry appearing along the diagonal. Consider the following example over the complex numbers:"},
     EXAMPLE lines ///
-    alpha = gwClass(matrix(CC,{{2,3,1},{3,-1,0},{1,0,0}}))
-    beta = gwClass(matrix(CC,{{2,4,-1},{4,5,7},{-1,7,9}}))
-    gwIsomorphic(alpha,beta)
+    alpha = makeGWClass matrix(CC, {{2,3,1},{3,-1,0},{1,0,0}})
+    beta = makeGWClass matrix(CC, {{2,4,-1},{4,5,7},{-1,7,9}})
+    isIsomorphicForm(alpha,beta)
     ///,
-    PARA{"The two forms are isomorphic since they can be diagonalized, after which they can be rewritten as the identity matrix after a change of basis, since every nonzero element is a square class over ", TEX///$\mathbb{C}$///, " (the same is true for any quadratically closed field). Thus we have that the ", EM "rank", " of a form completely determines it over the complex numbers. That is, it provides an isomorphism ", TEX///$\text{GW}(\mathbb{C}) \to \mathbb{Z}$/// ,"."},
-    PARA{"Over the reals, the story is a bit different. Since there are two classes over the reals, ", TEX///$ \mathbb{R}^\times / \left(\mathbb{R}^\times\right)^2 \cong \left\{\pm 1\right\}$///," we have a further invariant which classifies symmetric bilinear forms, called the ", TO2(signature, "signature"), ". This is computed as first diagonalizing, then taking the number of positive entries appearing on the diagonal minus the number of negative entries appearing on the diagonal."},
+    PARA{"The two forms are isomorphic since they can be diagonalized, after which they can be rewritten as the identity matrix after a change of basis, since every nonzero element is a square over ", TEX///$\mathbb{C}$///, " (the same is true for any quadratically closed field). Thus we have that the ", EM "rank", " of a form completely determines it over the complex numbers. That is, it provides an isomorphism ", TEX///$\text{GW}(\mathbb{C}) \to \mathbb{Z}$/// ,"."},
+    PARA{"Over the real numbers, the story is a bit different. Since there are two square classes of nonzero real numbers, ", TEX///$ \mathbb{R}^\times / \left(\mathbb{R}^\times\right)^2 \cong \left\{\pm 1\right\}$///," we have a further invariant which classifies symmetric bilinear forms, called the ", TO2(getSignature, "signature"), ". This is computed as first diagonalizing, then taking the number of positive entries appearing on the diagonal minus the number of negative entries appearing on the diagonal."},
     EXAMPLE lines ///
-    gamma = gwClass(matrix(RR,{{1,0,0},{0,-1,0},{0,0,1}}));
-    signature(gamma)
+    gamma = makeGWClass matrix(RR, {{1,0,0},{0,-1,0},{0,0,1}});
+    getSignature gamma
     ///,
-    PARA{"Rank and signature completely classify symmetric bilinear forms over the reals."},
+    PARA{"Rank and signature completely classify symmetric bilinear forms over the real numbers."},
     EXAMPLE lines ///
-    delta = gwClass(matrix(RR,{{0,0,1},{0,1,0},{1,0,0}}));
-    gwIsomorphic(gamma,delta)
+    delta = makeGWClass matrix(RR, {{0,0,1},{0,1,0},{1,0,0}});
+    isIsomorphicForm(gamma, delta)
     ///,
-    PARA{"Over finite fields, rank is still an invariant of a form, however signature no longer makes sense as the field is not totally ordered. Instead we consider the ", EM "discriminant", " of the non-degenerate symmetric bilinear form, which is the determinant of any Gram matrix representing the form. The discriminant is well-defined once we consider its target as landing in square classes of the field. ", TEX///$\text{GW}(\mathbb{F}_q) \to \mathbb{F}_q^\times / \left(\mathbb{F}_q^\times\right)^2$///, ". Over finite fields we look to compare both rank and discriminant of a form."},
+    PARA{"Over finite fields, rank is still an invariant of a form, however signature no longer makes sense as the field is not totally ordered. Instead we consider the ", EM "discriminant", " of the non-degenerate symmetric bilinear form, which is the determinant of any Gram matrix representing the form. The discriminant is well-defined once we consider its target as landing in square classes of the field. ", TEX///$\text{GW}(\mathbb{F}_q) \to \mathbb{F}_q^\times / \left(\mathbb{F}_q^\times\right)^2$///, ". Over finite fields we compare both rank and discriminant of forms."},
     EXAMPLE lines///
-    alphaF = gwClass(matrix(GF(7),{{1,2,2},{2,0,1},{2,1,5}}))
-    betaF = gwClass(matrix(GF(7),{{2,5,1},{5,6,1},{1,1,3}}))
-    gammaF = gwClass(matrix(GF(7),{{0,2,4},{2,3,3},{4,3,1}}))
-    det(alphaF.matrix)    
-    det(betaF.matrix)
-    det(gammaF.matrix)
+    alphaF = makeGWClass matrix(GF(7), {{1,2,2},{2,0,1},{2,1,5}})
+    betaF = makeGWClass matrix(GF(7), {{2,5,1},{5,6,1},{1,1,3}})
+    gammaF = makeGWClass matrix(GF(7), {{0,2,4},{2,3,3},{4,3,1}})
+    det getMatrix alphaF 
+    det getMatrix betaF
+    det getMatrix gammaF
     ///,
     PARA{"We see that ", TEX///$\text{disc}(\alpha)$///, " is a square, while the discriminants of ", TEX///$\beta$///, " and ", TEX///$\gamma$///, " are not. Therefore we see that ", TEX///$\beta \cong \gamma$///, " but neither of them are isomorphic to ", TEX///$\alpha$///, "."},
     EXAMPLE lines///
-    gwIsomorphic(alphaF,betaF)
-    gwIsomorphic(alphaF,gammaF)
-    gwIsomorphic(betaF,gammaF)
+    isIsomorphicForm(alphaF,betaF)
+    isIsomorphicForm(alphaF,gammaF)
+    isIsomorphicForm(betaF,gammaF)
     ///,
-    PARA{"Over the rationals, further invariants must be considered. We first check if the rank, discriminant, and signature (when considered as a real form) all agree. If so, we must further check whether the ", EM "Hasse-Witt invariants", " agree at all primes. This is an instance of the ", EM "Hasse-Minkowski principle", " which states that quadratic forms are isomorphic over a global field if and they are isomorphic over all its completions (see [S73, IV Theorem 7] or [L05, VI.3.3])."},
-    PARA{"The ", EM "Hasse-Witt invariant", " of a diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " over a field ", TEX///$K$///, " is defined to be the product ", TEX///$\prod_{i<j} \left( \phi(a_i,a_j) \right)$///, " where ", TEX///$\phi \colon K \times K \to \left\{\pm 1\right\}$///, " is any ", EM "symbol", " (see e.g. [MH73, III.5.4] for a definition). It is a classical result of Hilbert that over a local field of characteristic not equal to two, there is one and only symbol, ", TEX///$(-,-)_p$///,  " called the ", TO2(HilbertSymbol,"Hilbert symbol"), " ([S73, Chapter III]) computed as follows:"},
+    PARA{"Over the rational numbers, further invariants must be considered. We first check if the rank, discriminant, and signature (when considered as a real form) all agree. If so, we must further check whether the ", EM "Hasse-Witt invariants", " agree at all primes. This is an instance of the ", EM "Hasse-Minkowski principle", " which states that quadratic forms are isomorphic over a global field if and they are isomorphic over all its completions (see [S73, IV Theorem 7] or [L05, VI.3.3])."},
+    PARA{"The ", EM "Hasse-Witt invariant", " of a diagonal form ", TEX///$\langle a_1,\ldots,a_n\rangle$///, " over a field ", TEX///$K$///, " is defined to be the product ", TEX///$\prod_{i<j} \left( \phi(a_i,a_j) \right)$///, " where ", TEX///$\phi \colon K \times K \to \left\{\pm 1\right\}$///, " is any ", EM "symbol", " (see e.g. [MH73, III.5.4] for a definition). It is a classical result of Hilbert that over a local field of characteristic not equal to two, there is a unique symbol, ", TEX///$(-,-)_p$///,  " called the ", TO2(getHilbertSymbol,"Hilbert symbol"), " ([S73, Chapter III]) computed as follows:"},
     PARA{TEX///$(a,b)_p = \begin{cases} 1 & z^2 = ax^2 + by^2 \text{ has a nonzero solution in } K^3 \\ -1 & \text{otherwise.} \end{cases}$///},
     PARA{"Consider the following example, where we observe that ", TEX///$z^2 = 2x^2 + y^2$///," does admit nonzero solutions mod 7, in particular ", TEX///$(x,y,z) = (1,0,3)$///, ":"},
     EXAMPLE lines///
-    HilbertSymbol(2,1,7)
+    getHilbertSymbol(2,1,7)
     ///,
-    PARA{"The Hasse invariant will be 1 for almost all primes. In particular after diagonalizing a form ", TEX///$\beta \cong \left\langle a_1,\ldots,a_n\right\rangle$///, " then the Hasse invariant at a prime ", TEX///$p$///, " will be 1 automatically if ", TEX///$p\nmid a_i$///, " for all ", TEX///$i$///, ". Thus we only have finitely many Hasse invariants to compare for any pair of symmetric bilinear forms."},
+    PARA{"The Hasse invariant will be 1 for almost all primes. In particular, after diagonalizing a form ", TEX///$\beta \cong \left\langle a_1,\ldots,a_n\right\rangle$///, " then the Hasse invariant at a prime ", TEX///$p$///, " will automatically be 1 if ", TEX///$p\nmid a_i$///, " for all ", TEX///$i$///, ". Thus we only have finitely many Hasse invariants to compare for any pair of symmetric bilinear forms."},
     EXAMPLE lines///
-    alphaQ = gwClass(matrix(QQ,{{1,4,7},{4,3,2},{7,2,-1}}))
-    betaQ = gwClass(matrix(QQ,{{0,0,1},{0,2,7},{1,7,3}}))
-    gwIsomorphic(alphaQ,betaQ)
+    alphaQ = makeGWClass matrix(QQ, {{1,4,7},{4,3,2},{7,2,-1}})
+    betaQ = makeGWClass matrix(QQ, {{0,0,1},{0,2,7},{1,7,3}})
+    isIsomorphicForm(alphaQ,betaQ)
     ///,
     PARA{EM "Citations:"},
     UL{
-	
 	{"[S73] J.P. Serre, ", EM "A course in arithmetic,", " Springer-Verlag, 1973."},
 	{"[L05] T.Y. Lam, ", EM "Introduction to quadratic forms over fields,", " American Mathematical Society, 2005."},
 	{"[MH73] Milnor and Husemoller, ", EM "Symmetric bilinear forms,", " Springer-Verlag, 1973."},
     },
-    SeeAlso => {"signature", "sumDecomposition", "sumDecompositionString"}
+    SeeAlso => {"getRank", "getSignature", "getIntegralDiscriminant", "getRelevantPrimes", "getHasseWittInvariant", "getSumDecomposition", "getSumDecompositionString"}
 }
 

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/IsotropyDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/IsotropyDoc.m2
@@ -1,24 +1,24 @@
 document{
     Key => {isIsotropic, (isIsotropic, GrothendieckWittClass), (isIsotropic, Matrix)},
     Headline => "determines whether a Grothendieck-Witt class is isotropic",
-    Usage => "isIsotropic(beta)",
+    Usage => "isIsotropic beta",
     Inputs => {
-	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(k)$///, ", where ", TEX///$k$///, " is the rationals, reals, complex numbers, or a finite field."},
+	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(k)$///, ", where ", TEX///$k$///, " is ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
 	},
     Outputs => {
         Boolean => {"whether ", TEX///$\beta$///, " is isotropic"},
 	},
     PARA{"This is the negation of the boolean-valued ", TO2(isAnisotropic,"isAnisotropic"), ". See documentation there."},    
-    SeeAlso => {"isAnisotropic", "HilbertSymbol", "signature"}
+    SeeAlso => {"isAnisotropic", "getWittIndex", "getAnisotropicDimension"}
 }
 
 
 document{
     Key => {isAnisotropic, (isAnisotropic, GrothendieckWittClass), (isAnisotropic, Matrix)},
     Headline => "determines whether a Grothendieck-Witt class is anisotropic",
-    Usage => "isAnisotropic(beta)",
+    Usage => "isAnisotropic beta",
     Inputs => {
-	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(k)$///, ", where ", TEX///$k$///, " is the rationals, reals, complex numbers, or a finite field"},
+	GrothendieckWittClass => "beta" => {"denoted by ", TEX///$\beta\in\text{GW}(k)$///, ", where ", TEX///$k$///, " is ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"},
 	},
     Outputs => {
         Boolean => {"whether ", TEX///$\beta$///, " is anisotropic"},
@@ -26,32 +26,31 @@ document{
     PARA{"Recall a symmetric bilinear form ", TEX///$\beta$///, " is said to be ", EM "isotropic", " if there exists a nonzero vector ", TEX///$v$///, " for which ", TEX///$\beta(v,v) = 0$///, ". Witt's decomposition theorem implies that a non-degenerate symmetric bilinear form decomposes uniquely into an isotropic and an anisotropic part. Certifying (an)isotropy is then an important computational problem when working with the Grothendieck-Witt ring."},
     PARA{"Over ", TEX///$\mathbb{C}$///, ", any form of rank two or higher contains a copy of the hyperbolic form, and hence is isotropic. Thus we can determine anisotropy simply by a consideration of rank."},
     EXAMPLE lines///
-    isAnisotropic(gwClass(matrix(CC,{{3}})))
-    isAnisotropic(gwClass(matrix(CC,{{2,0},{0,5}})))
+    isAnisotropic makeGWClass matrix(CC, {{3}})
+    isAnisotropic makeGWClass matrix(CC, {{2,0},{0,5}})
     ///,
     PARA{"Forms over ", TEX///$\mathbb{R}$///, " are anisotropic if and only if all its diagonal entries are positive or are negative."},
     EXAMPLE lines///
-    isAnisotropic(gwClass(matrix(RR,{{3,0,0},{0,5,0},{0,0,7}})))
-    isAnisotropic(gwClass(matrix(RR,{{0,2},{2,0}})))
+    isAnisotropic makeGWClass matrix(RR, {{3,0,0},{0,5,0},{0,0,7}})
+    isAnisotropic makeGWClass matrix(RR, {{0,2},{2,0}})
     ///,
     PARA{"Over finite fields, a form is anisotropic so long as it is nondegenerate, of rank ", TEX///$\le 2$///," and not isomorphic to the hyperbolic form."},
     EXAMPLE lines///
-    isAnisotropic(gwClass(matrix(GF(7),{{1,0,0},{0,1,0},{0,0,1}})))
-    isAnisotropic(gwClass(matrix(GF(7),{{3,0},{0,3}})))
+    isAnisotropic makeGWClass matrix(GF(7), {{1,0,0},{0,1,0},{0,0,1}})
+    isAnisotropic makeGWClass matrix(GF(7), {{3,0},{0,3}})
     ///,
     PARA{"Over ", TEX///$\mathbb{Q}$///, " things become a bit more complicated. We can exploit the local-to-global principle for isotropy (the ", EM "Hasse-Minkowski principle", "), which states that a form is isotropic over ", TEX///$\mathbb{Q}$///, " if and only if it is isotropic over all its completions, meaning all the ", TEX///$p$///, "-adic numbers and ", TEX///$\mathbb{R}$///, " [L05, VI.3.1]. We note, however, the classical result that all forms of rank ", TEX///$\ge 5$///, " in ", TEX///$\mathbb{Q}_p$///, " are isotropic [S73, IV Theorem 6]. Thus isotropy in this range of ranks is equivalent to checking it over the real numbers."},
     EXAMPLE lines///
-    beta = gwClass(matrix(QQ,{{1, 0, 2, 0, 3}, {0, 6, 1, 1, -1},{2, 1, 5, 2, 0}, {0, 1, 2, 4, -1}, {3, -1, 0,-1, 1}}));
-    isAnisotropic(beta)
-    diagonalClass(beta)
+    beta = makeGWClass matrix(QQ, {{1,0,2,0,3},{0,6,1,1,-1},{2,1,5,2,0},{0,1,2,4,-1},{3,-1,0,-1,1}});
+    isAnisotropic beta
+    getDiagonalClass beta
     ///,
-    PARA{"For forms of rank ", TEX///$\le 4$///, " the problem reduces to computing the maximum anisotropic dimension of the form over local fields. Ternary forms are isotropic away from primes dividing the coefficients of the form in a diagonal basis by e.g. [L05, VI.2.5(2)], so there are only finitely many places to check. Over these ",TO2(relevantPrimes,"relevant primes"), ", isotropy of a form ", TEX///$\beta \in \text{GW}(\mathbb{Q})$///, " over ", TEX///$\mathbb{Q}_p$///," is equivalent to the statement that ", TEX///$(-1,-\text{disc}(\beta))_p = H(\beta)$///, " where ", TEX///$H(\beta)$///, " denotes the ", TO2(HasseWittInvariant,"Hasse-Witt invariant"), " attached to ", TEX///$\beta$///, " and ", TEX///$(-,-)_p$///," is the ", TO2(HilbertSymbol, "Hilbert Symbol"), "."},
-    PARA{"A binary form ", TEX///$q$///, " is isotropic if and only if it is isomorphic to the hyperbolic form, which implies in particular that the rank, ", TO2(signature,"signature"), ", and ", TO2(integralDiscriminant,"discriminant"), " of ", TEX///$q$///, " agree with that of ", TEX///$\mathbb{H}=\langle 1,-1\rangle$///, ". " },
+    PARA{"For forms of rank ", TEX///$\le 4$///, " the problem reduces to computing the maximum anisotropic dimension of the form over local fields. Ternary forms are isotropic away from primes dividing the coefficients of the form in a diagonal basis by e.g. [L05, VI.2.5(2)], so there are only finitely many places to check. Over these ",TO2(getRelevantPrimes,"relevant primes"), ", isotropy of a form ", TEX///$\beta \in \text{GW}(\mathbb{Q})$///, " over ", TEX///$\mathbb{Q}_p$///," is equivalent to the statement that ", TEX///$(-1,-\text{disc}(\beta))_p = H(\beta)$///, " where ", TEX///$H(\beta)$///, " denotes the ", TO2(getHasseWittInvariant,"Hasse-Witt invariant"), " attached to ", TEX///$\beta$///, " and ", TEX///$(-,-)_p$///," is the ", TO2(getHilbertSymbol, "Hilbert Symbol"), "."},
+    PARA{"A binary form ", TEX///$q$///, " is isotropic if and only if it is isomorphic to the hyperbolic form, which implies in particular that the rank, ", TO2(getSignature,"signature"), ", and ", TO2(getIntegralDiscriminant,"discriminant"), " of ", TEX///$q$///, " agree with that of ", TEX///$\mathbb{H}=\langle 1,-1\rangle$///, ". " },
     PARA{EM "Citations:"},
     UL{
-	
 	{"[S73] J.P. Serre, ", EM "A course in arithmetic,", " Springer-Verlag, 1973."},
 	{"[L05] T.Y. Lam, ", EM "Introduction to quadratic forms over fields,", " American Mathematical Society, 2005."},
     },
-    SeeAlso => {"isIsotropic"}   
+    SeeAlso => {"isIsotropic", "getAnisotropicDimension", "getAnisotropicPart", "getWittIndex"}   
 }

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/LocalGlobalDegreesDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/LocalGlobalDegreesDoc.m2
@@ -1,9 +1,11 @@
 document {
-    Key => {globalA1Degree, (globalA1Degree, List)},
-    Headline => "computes a global A1-Brouwer degree of a list of n polynomials in n variables over a field k",
-    Usage => "globalA1Degree(L)",
+    Key => {getGlobalA1Degree, (getGlobalA1Degree, List)},
+    Headline => "computes the global A1-Brouwer degree of a list of n polynomials in n variables over a field k",
+    Usage => "getGlobalA1Degree L",
     Inputs => {
-	List => "L" => {"of polynomials ", TEX///$f = (f_1, \ldots, f_n)$///, " in the polynomial ring ", TEX///$k[x_1,\ldots,x_n]$///, " over a field ", TEX///$k$///}
+	List => "L" => {"of polynomials ", TEX///$f = (f_1, \ldots, f_n)$///, " in the polynomial ring ", TEX///$k[x_1,\ldots,x_n]$///, " where ", TEX///$k$///,
+	    " is ", TEX///$\mathbb{Q}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2. Over ", 
+	    TEX///$\mathbb{R},$///," the user is prompted to instead do the computation over ", TEX///$\mathbb{Q}$///, " and then base change to ", TEX///$\mathbb{R}$///, "."}
 	},
     Outputs => {
 	GrothendieckWittClass => {"the class ", TEX///$\text{deg}^{\mathbb{A}^1}(f)$///, " in the Grothendieck-Witt ring ", TEX///$\text{GW}(k)$///}
@@ -19,33 +21,32 @@ document {
     PARA{"Following recent work of B. McKean and Pauli [BMP23], the ", TEX///$\mathbb{A}^1$///, "-Brouwer degree can be computed as a multivariate ", EM "Bezoutian bilinear form.", " The algorithms for producing such a form are developed here."},
     EXAMPLE lines ///
     QQ[x];
-    f = {x^2+1};
-    globalA1Degree(f)
+    f = {x^2 + 1};
+    getGlobalA1Degree f
     ///,
     PARA{"The previous example produces a rank two form with signature zero. This corresponds to the fact that the degree of the complex map ", TEX///$\mathbb{C}\to\mathbb{C},\ z\mapsto z^2$///, " has degree two, while the associated real map ", TEX///$\mathbb{R}\to\mathbb{R},\ x\mapsto x^2$///, " has global degree zero."},
     PARA{"Following [M21] we may think about the ",TEX///$\mathbb{A}^1$///, "-Brouwer degree ", TEX///$\text{deg}^{\mathbb{A}^1}(f)$///, " as a quadratically enriched intersection multiplicity of the hyperplanes ", TEX///$V(f_1)\cap \cdots \cap V(f_n).$///, " As a toy example, consider the curve ", TEX///$y=x(x-1)(x+1)$///, " intersecting the ", TEX///$x$///, "-axis."},
     EXAMPLE lines ///
     QQ[x,y];
     f = {x^3 - x^2 - y, y};
-    globalA1Degree(f)
+    getGlobalA1Degree f
     ///,
     PARA{"The rank of this form is three, as cubics over the complex numbers have three roots counted with multiplicity. This form has signature one, which indicates that when the cubic intersects the ", TEX///$x$///, "-axis, when the three points of intersection are counted with a sign corresponding to a right hand rule, the sum equals one."},
     
-    PARA{"The global ", TEX///$\mathbb{A}^1$///, "-Brouwer degree can be computed as a sum over the ", TO2(localA1Degree,"local degrees"), " at the points in the zero locus of the morphism. In the previous example, we see that ", TEX///$V(f)$///, " consists of three points on the affine line. We can compute local degrees at all of these and verify that the local degrees sum to the global degree:"},
+    PARA{"The global ", TEX///$\mathbb{A}^1$///, "-Brouwer degree can be computed as a sum over the ", TO2(getLocalA1Degree,"local degrees"), " at the points in the zero locus of the morphism. In the previous example, we see that ", TEX///$V(f)$///, " consists of three points on the affine line. We can compute local degrees at all of these and verify that the local degrees sum to the global degree:"},
     EXAMPLE lines///
     QQ[x,y];
     f = {x^3 - x^2 - y, y};
-    point1 = ideal{x-1, y};
-    point2 = ideal{x, y};
-    globalA1Degree(f);
-    localA1Degree(f,point1);
-    localA1Degree(f,point2);
-    gwIsomorphic(globalA1Degree(f), gwAdd(localA1Degree(f,point1), localA1Degree(f,point2)));
+    point1 = ideal(x - 1, y);
+    point2 = ideal(x, y);
+    getGlobalA1Degree f
+    getLocalA1Degree(f, point1)
+    getLocalA1Degree(f, point2)
+    isIsomorphicForm(getGlobalA1Degree f, addGW(getLocalA1Degree(f, point1), getLocalA1Degree(f, point2)))
     ///,
     
     PARA{EM "Citations:"},
     UL{
-	
 	{"[BW23] T. Bachmann, K. Wickelgren, ", EM "Euler classes: six-functors formalism, dualities, integrality and linear subspaces of complete intersections,", " J. Inst. Math. Jussieu, 2023."},
 	{"[EL77] D. Eisenbud, H. Levine, ", EM "An algebraic formula for the degree of a C^infinity map germ,", " Annals of Mathematics, 1977."},
 	{"[K77] G. Khimshiashvili, ", EM "The local degree of a smooth mapping,", " Sakharth. SSR Mcn. Akad. Moambe, 1977."},
@@ -55,38 +56,41 @@ document {
 	{"[BMP23] T. Brazelton, S. McKean, S. Pauli, ", EM "Bezoutians and the A1-Degree,", " Algebra & Number Theory, 2023."},
 	{"[SS76] S. Scheja, S. Storch, ", EM "Uber Spurfunktionen bei vollstandigen Durchschnitten,", " J. Reine Angew. Math., 1975."},
 	},
-    SeeAlso => {"localA1Degree", "sumDecomposition", "sumDecompositionString"}
+    SeeAlso => {"getLocalA1Degree", "getSumDecomposition", "getSumDecompositionString"}
     }
 
+
 document {
-    Key => {localA1Degree, (localA1Degree, List, Ideal)},
+    Key => {getLocalA1Degree, (getLocalA1Degree, List, Ideal)},
     Headline => "computes a local A1-Brouwer degree of a list of n polynomials in n variables over a field k at a prime ideal in the zero locus",
-    Usage => "locallA1Degree(L,p)",
+    Usage => "locallA1Degree(L, p)",
     Inputs => {
-	List => "L" => {"of polynomials ", TEX///$f = (f_1, \ldots, f_n)$///, " in the polynomial ring ", TEX///$k[x_1,\ldots,x_n]$///, " over a field ", TEX///$k$///},
-	Ideal => "p" => {"a prime ideal ", TEX///$p \trianglelefteq k[x_1,\ldots,x_n]$///, " in the zero locus ", TEX///$V(f)$///},
+	List => "L" => {"of polynomials ", TEX///$f = (f_1, \ldots, f_n)$///, " in the polynomial ring ", TEX///$k[x_1,\ldots,x_n]$///, " where ", 
+	    TEX///$k$///, " is ", TEX///$\mathbb{Q}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2. Over ", 
+TEX///$\mathbb{R},$///, " the user is prompted to instead do the computation over ", TEX///$\mathbb{Q}$///, " and then base change to ", TEX///$\mathbb{R}$///, "."},
+	Ideal => "p" => {"a prime ideal ", TEX///$p \subset k[x_1,\ldots,x_n]$///, " corresponding to a point in the zero locus ", TEX///$V(f)$///},
 	},
     Outputs => {
 	GrothendieckWittClass => {"the class ", TEX///$\text{deg}_p^{\mathbb{A}^1}(f)$///, " in the Grothendieck-Witt ring ", TEX///$\text{GW}(k)$///}
 	},
     PARA{"Given an endomorphism of affine space ", TEX///$f=(f_1,\dots ,f_n) \colon \mathbb{A}^n_k \to \mathbb{A}^n_k$///, " and an isolated zero ", TEX///$p\in V(f)$/// ,", we may compute its local ", TEX///$\mathbb{A}^1$///, EM "-Brouwer degree", " valued in the Grothendieck-Witt ring ", TEX///$\text{GW}(k)$///, "."
 	},
-    PARA{"For historical and mathematical background, see ", TO2(globalA1Degree, "global A1-degrees"), "."},
+    PARA{"For historical and mathematical background, see ", TO2(getGlobalA1Degree, "global A1-degrees"), "."},
     EXAMPLE lines ///
     T1 = QQ[z_1..z_2];
-    f1 = {(z_1-1)*z_1*z_2, (3/5)*z_1^2 - (17/3)*z_2^2};
-    f1GD = globalA1Degree(f1);
-    q=ideal {z_1,z_2};
-    r=ideal {z_1-1,z_2^2-(9/85)};
-    f1LDq= localA1Degree(f1,q)
-    f1LDr= localA1Degree(f1,r)
-    f1LDsum = gwAdd(f1LDq, f1LDr)
+    f1 = {(z_1 - 1)*z_1*z_2, (3/5)*z_1^2 - (17/3)*z_2^2};
+    f1GD = getGlobalA1Degree f1;
+    q = ideal(z_1, z_2);
+    r = ideal(z_1-1, z_2^2 - 9/85);
+    f1LDq = getLocalA1Degree(f1, q)
+    f1LDr = getLocalA1Degree(f1, r)
+    f1LDsum = addGW(f1LDq,f1LDr)
     ///,
     PARA{"The sum of the local A1-degrees is equal to the global A1-degree:"},
     EXAMPLE lines///
-    gwIsomorphic(f1GD,f1LDsum)
+    isIsomorphicForm(f1GD,f1LDsum)
     ///,
-    SeeAlso => {"globalA1Degree", "sumDecomposition", "sumDecompositionString"}
+    SeeAlso => {"getGlobalA1Degree", "getSumDecomposition", "getSumDecompositionString"}
     }
 
 

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/MatrixMethodsDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/MatrixMethodsDoc.m2
@@ -1,17 +1,17 @@
 document {
-	Key => {congruenceDiagonalize, (congruenceDiagonalize, Matrix)},
-	Headline => "diagonalizing a symmetric matrix via congruence",
-	Usage => "congruenceDiagonalize(M)",
+	Key => {diagonalizeViaCongruence, (diagonalizeViaCongruence, Matrix)},
+	Headline => "diagonalizes a symmetric matrix via congruence",
+	Usage => "diagonalizeViaCongruence M",
 	Inputs => {
 	    Matrix => "M" => {"a symmetric matrix over any field"}
 	    },
 	Outputs => {
-	    Matrix => { "a diagonal matrix congruent to ", TT "M" }
+	    Matrix => {"a diagonal matrix congruent to ", TT "M"}
 	    },
 	PARA {"Given a symmetric matrix ", TEX///$M$///, " over any field, this command gives a diagonal matrix congruent to ", TEX///$M$///,". Note that the order in which the diagonal terms appear is not specified."},
 	EXAMPLE lines ///
-		 M=matrix(GF(17), {{7, 9}, {9, 6}});
-		 congruenceDiagonalize(M)
+		 M = matrix(GF(17), {{7,9},{9,6}});
+		 diagonalizeViaCongruence M
 	 	 ///,
-	SeeAlso => {"diagonalClass"}
+	SeeAlso => {"getDiagonalClass", "getDiagonalEntries"}
      	}

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/SimplifiedRepresentativesDoc.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Documentation/SimplifiedRepresentativesDoc.m2
@@ -1,47 +1,47 @@
 document {
-    Key => {diagonalClass, (diagonalClass, GrothendieckWittClass)},
+    Key => {getDiagonalClass, (getDiagonalClass, GrothendieckWittClass)},
 	Headline => "produces a diagonalized form for any Grothendieck-Witt class, with simplified terms on the diagonal",
-	Usage => "diagonalClass(beta)",
+	Usage => "getDiagonalClass beta",
 	Inputs => {
-	    GrothendieckWittClass => "beta" => {"over a field ", TEX///$k$///,", where ", TEX///$k$///, " is the rationals, reals, complex numbers, or a finite field of characteristic not 2"}
+	    GrothendieckWittClass => "beta" => {"over ", TEX///$\mathbb{Q}$///,", ",TEX///$ \mathbb{R}$///,", ",TEX///$\mathbb{C}$///, ", or a finite field of characteristic not 2"}
 	    },
 	Outputs => {
 	    GrothendieckWittClass => {"a form isomorphic to ", TEX///$\beta$///, " with a diagonal Gram matrix"}
 	    },
-	PARA {"Given a symmetric bilinear form, this method calls the ", TO2(congruenceDiagonalize,"congruenceDiagonalize"), " command in order to produce a diagonal symmetric bilinear form isomorphic to ", TEX///$\beta$///, ", with reduced square classes appearing as the diagonal entries."},
+	PARA {"Given a symmetric bilinear form, this method uses the ", TO2(diagonalizeViaCongruence,"diagonalizeViaCongruence"), " command in order to produce a diagonal symmetric bilinear form isomorphic to ", TEX///$\beta$///, ", with reduced square classes appearing as the diagonal entries."},
 	EXAMPLE lines ///
-	M = matrix(QQ,{{9,1,7,4},{1,10,3,2},{7,3,6,7},{4,2,7,5}});
-	beta = gwClass(M);
-	diagonalClass(beta)
+	M = matrix(QQ, {{9,1,7,4},{1,10,3,2},{7,3,6,7},{4,2,7,5}});
+	beta = makeGWClass M;
+	getDiagonalClass beta
 	///,
 	PARA{"Note that the  ", TO2(GrothendieckWittClass, "GrothendieckWittClass"), " type caches diagonal versions of a form once they've been computed. We can recover this quickly in the following way."},
 	EXAMPLE lines///
-	beta.cache.diagonalClass
+	beta.cache.getDiagonalClass
 	///,
-	SeeAlso => {"congruenceDiagonalize"}
+	SeeAlso => {"diagonalizeViaCongruence", "getDiagonalEntries"}
 	}    
 
 
 document {
-    Key => {diagonalEntries, (diagonalEntries, GrothendieckWittClass)},
+    Key => {getDiagonalEntries, (getDiagonalEntries, GrothendieckWittClass)},
 	Headline => "extracts a list of diagonal entries for a GrothendieckWittClass",
-	Usage => "diagonalEntries(beta)",
+	Usage => "getDiagonalEntries beta",
 	Inputs => {
-	    GrothendieckWittClass => "beta" => {"over a field ", TEX///$k$///,", where ", TEX///$k$///, " is the rationals, reals, complex numbers, or a finite field of characteristic not 2"}
+	    GrothendieckWittClass => "beta" => {"over a field of characteristic not 2"}
 	    },
 	Outputs => {
 	    List => "L" => {" of elements ", TEX///$a_i\in k$///,", where ", TEX///$i = 1,\dots,n $///,", such that ", TEX///$\beta \cong \langle a_1,\ldots,a_n\rangle$///}
 	    },
-	PARA {"Given a diagonal form, ", TT "diagonalEntries", " will extract the elements along the diagonal."},
+	PARA {"Given a diagonal form, ", TT "getDiagonalEntries", " will extract the elements along the diagonal."},
 	EXAMPLE lines ///
-	beta = gwClass(matrix(QQ,{{3,0,0},{0,2,0},{0,0,7}}))
-	diagonalEntries beta
+	beta = makeGWClass matrix(QQ, {{3,0,0},{0,2,0},{0,0,7}})
+	getDiagonalEntries beta
         ///,
 	PARA{"If the form is not given with a diagonal representative, this method will first diagonalize it."},
 	EXAMPLE lines///
-	gamma = gwClass(matrix(RR,{{0,0,1},{0,1,0},{1,0,0}}))
-	diagonalEntries gamma
+	gamma = makeGWClass matrix(RR, {{0,0,1},{0,1,0},{1,0,0}})
+	getDiagonalEntries gamma
 	///,
-	SeeAlso => {"diagonalClass", "congruenceDiagonalize"}
+	SeeAlso => {"getDiagonalClass", "diagonalizeViaCongruence"}
 	}
 


### PR DESCRIPTION
Updated version of M2 package "A1BrouwerDegrees," following JSAG referee reports:

- Fixed bug in extracting the anisotropic part of a quadratic form over the rationals
- Renamed most methods to fit style conventions of M2
- Removed dependency on `Parametrization` and `RealRoots` packages
- Removed conflicts with existing M2 commands
- Expanded documentation
- Polished code to be more readable