### PR TITLE
Updated release checklist

### DIFF
--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -249,15 +249,14 @@ newPackage String := opts -> pkgname -> (
     then error("newPackage: use the Contributors or Acknowledgement keywords to acknowledge contributors of " | pkgname);
     -- optional package values
     scan({
+	    (Keywords, List),
 	    (Date,     String),
 	    (Headline, String),
 	    (HomePage, String)}, (name, type) -> if opts#name =!= null and not instance(opts#name, type) then
 	error("newPackage: expected ", toString name, " option of class ", toString type));
-    if opts.?Keywords then (
-	 if class opts.Keywords =!= List then error "expected Keywords value to be a list";
-	 if not all(opts.Keywords, k -> class k === String) then error "expected Keywords value to be a list of strings";
-	 );
-    if #opts.Headline > 100 then error "newPackage: Headline should be less than 100 characters";
+    if opts.Keywords =!= null and any(opts.Keywords,
+	keyword -> not instance(keyword, String)) then error "newPackage: expected Keywords to be a list of strings";
+    if opts.Headline =!= null and #opts.Headline > 100 then error "newPackage: expected Headline to be less than 100 characters";
     -- the options coming from loadPackage are stored here
     loadOptions := if loadPackageOptions#?pkgname then loadPackageOptions#pkgname else loadPackageOptions#"default";
     -- the options are stored for readPackage

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -205,6 +205,7 @@ getpkgNoLoad = pkgname -> if isPackageLoaded pkgname then value PackageDictionar
 -----------------------------------------------------------------------------
 
 newPackage = method(
+    Dispatch => Thing,
     Options => {
 	Authors                   => {},
 	AuxiliaryFiles            => false,
@@ -224,6 +225,7 @@ newPackage = method(
 	UseCachedExampleOutput    => null,
 	Version                   => "0.0"
 	})
+newPackage Sequence := opts -> x -> newPackage splice(nonnull x, opts) -- to allow null entries
 newPackage String := opts -> pkgname -> (
     -- package name must be alphanumeric
     checkPackageName pkgname;

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -257,7 +257,7 @@ newPackage String := opts -> pkgname -> (
 	 if class opts.Keywords =!= List then error "expected Keywords value to be a list";
 	 if not all(opts.Keywords, k -> class k === String) then error "expected Keywords value to be a list of strings";
 	 );
-    -- TODO: if #opts.Headline > 100 then error "newPackage: Headline is capped at 100 characters";
+    if #opts.Headline > 100 then error "newPackage: Headline should be less than 100 characters";
     -- the options coming from loadPackage are stored here
     loadOptions := if loadPackageOptions#?pkgname then loadPackageOptions#pkgname else loadPackageOptions#"default";
     -- the options are stored for readPackage

--- a/M2/Macaulay2/packages/A1BrouwerDegrees.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees.m2
@@ -32,7 +32,7 @@ newPackage (
 	 Email => "atawfeek@uw.edu",
 	 HomePage => "https://www.atawfeek.com/"}
 	},
-    Headline => "for working with A1-Brouwer degree computations",
+    Headline => "A1-Brouwer degree computations",
     PackageImports => {},
     PackageExports => {},
     AuxiliaryFiles => true,

--- a/M2/Macaulay2/packages/AlgebraicSplines.m2
+++ b/M2/Macaulay2/packages/AlgebraicSplines.m2
@@ -9,7 +9,7 @@
 ------------------------------------------
 ------------------------------------------
 
-newPackage select((
+newPackage(
     "AlgebraicSplines",
         Version => "0.1.0", 
         Date => "27. May 2015",
@@ -27,7 +27,7 @@ newPackage select((
         PackageExports => {
 	    "FourierMotzkin"
 	    }
-        ), x -> x =!= null)
+    )
 
 export {
    "BaseRing",

--- a/M2/Macaulay2/packages/CMakeLists.txt
+++ b/M2/Macaulay2/packages/CMakeLists.txt
@@ -116,6 +116,7 @@ foreach(_target IN LISTS _target_prefixes)
   add_custom_target(${_target}-packages DEPENDS ${${_dependencies_list}})
 endforeach()
 
+# Makes the target all (possibly) depend on info-packages and install-packages
 set_target_properties(${_all_target_list} PROPERTIES EXCLUDE_FROM_ALL OFF)
 
 #################################################################################

--- a/M2/Macaulay2/packages/CellularResolutions.m2
+++ b/M2/Macaulay2/packages/CellularResolutions.m2
@@ -8,7 +8,7 @@ newPackage(
         {Name => "Jay Yang", Email => "jayy@wustl.edu"},
         {Name => "Aleksandra Sobieska", Email => "asobieska@math.wisc.edu"}
         },
-    Headline => "A package for cellular resolutions of monomial ideals",
+    Headline => "cellular resolutions of monomial ideals",
     AuxiliaryFiles => true, -- set to true if package comes with auxiliary files
     PackageExports => {"Polyhedra", "SimplicialComplexes", "Posets"},
     Keywords => {"Commutative Algebra"}

--- a/M2/Macaulay2/packages/CharacteristicClasses.m2
+++ b/M2/Macaulay2/packages/CharacteristicClasses.m2
@@ -9,7 +9,7 @@ newPackage(
 		  HomePage => "https://math.berkeley.edu/~mhelmer/"},
 	      {Name => "Christine Jost", 
 		  Email => "christine.e.jost@gmail.com"}},
-    	Headline => "CSM classes, Segre classes and the Euler characteristic for some subschemes of smooth complete toric varieties",
+	Headline => "CSM and Segre classes and the Euler characteristic for subschemes of smooth complete toric varieties",
 	Keywords => {"Intersection Theory"},
     	DebuggingMode => false,
 	PackageImports => { "Elimination", "PrimaryDecomposition", "NormalToricVarieties"},

--- a/M2/Macaulay2/packages/CohomCalg.m2
+++ b/M2/Macaulay2/packages/CohomCalg.m2
@@ -7,7 +7,7 @@ newPackage(
              Email => "mike@math.cornell.edu", 
              HomePage => "http://www.math.cornell.edu/People/Faculty/stillman.html"
              }},
-        Headline => "interface to CohomCalg software for computing cohomology of torus invariant divisors on a toric variety",
+        Headline => "interface to cohomCalg software for computing sheaf cohomology of line bundles on toric varieties",
 	Keywords => {"Toric Geometry", "Interfaces"},
         AuxiliaryFiles => true,
         PackageExports => {"NormalToricVarieties"},

--- a/M2/Macaulay2/packages/Complexes.m2
+++ b/M2/Macaulay2/packages/Complexes.m2
@@ -11,7 +11,7 @@ newPackage(
             Email => "mike@math.cornell.edu", 
             HomePage => "http://www.math.cornell.edu/~mike"
             }},
-    Headline => "development package for beta testing new version of chain complexes",
+    Headline => "beta testing new version of chain complexes",
     Keywords => {"Homological Algebra"},
     PackageExports => { "Truncations" },
     AuxiliaryFiles => true

--- a/M2/Macaulay2/packages/GeometricDecomposability.m2
+++ b/M2/Macaulay2/packages/GeometricDecomposability.m2
@@ -4,7 +4,7 @@ newPackage(
         "GeometricDecomposability",
         Version => "1.4.1",
         Date => "May 7, 2024",
-        Headline => "A package to check whether ideals are geometrically vertex decomposable",
+        Headline => "checking whether ideals are geometrically vertex decomposable",
         Authors => {
                 {
                 Name => "Mike Cummings",

--- a/M2/Macaulay2/packages/GroebnerStrata.m2
+++ b/M2/Macaulay2/packages/GroebnerStrata.m2
@@ -5,7 +5,7 @@ newPackage(
     	Date => "11 Nov 2021",
     	Authors => {
 	     {Name => "Mike Stillman", Email => "mike@math.cornell.edu", HomePage => "http://www.math.cornell.edu/~mike/"},
-	     {Name => "    Kristine Jones", Email => "kejones84@gmail.com"}},
+	     {Name => "Kristine Jones", Email => "kejones84@gmail.com"}},
 	Headline => "computing Groebner loci in Hilbert schemes",
         PackageImports => {"Elimination"},
     	DebuggingMode => false,

--- a/M2/Macaulay2/packages/GroebnerStrata.m2
+++ b/M2/Macaulay2/packages/GroebnerStrata.m2
@@ -6,7 +6,7 @@ newPackage(
     	Authors => {
 	     {Name => "Mike Stillman", Email => "mike@math.cornell.edu", HomePage => "http://www.math.cornell.edu/~mike/"},
 	     {Name => "    Kristine Jones", Email => "kejones84@gmail.com"}},
-    	Headline => "a Macaulay2 package for computing Groebner loci in Hilbert schemes",
+	Headline => "computing Groebner loci in Hilbert schemes",
         PackageImports => {"Elimination"},
     	DebuggingMode => false,
 	Keywords => {"Commutative Algebra"}

--- a/M2/Macaulay2/packages/Hadamard.m2
+++ b/M2/Macaulay2/packages/Hadamard.m2
@@ -9,7 +9,7 @@ newPackage(
 	    HomePage => "http://calvino.polito.it/~imanbj"
 	    }
 	}, -- TODO
-    Headline => "A package for the Hadamard products of projective subvarieties",
+    Headline => "Hadamard products of projective subvarieties",
     AuxiliaryFiles => false,
     DebuggingMode => false,
     Reload => false,

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/package-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/package-doc.m2
@@ -2,6 +2,8 @@
 --- author(s): Mahrud
 --- notes: functions below are all defined in packages.m2
 
+undocumented (newPackage, Sequence)
+
 doc ///
 Node
   Key

--- a/M2/Macaulay2/packages/Matroids.m2
+++ b/M2/Macaulay2/packages/Matroids.m2
@@ -5,7 +5,7 @@ newPackage("Matroids",
 	Authors => {{
 		Name => "Justin Chen",
 		Email => "jchen@math.berkeley.edu"}},
-	Headline => "a package for computations with matroids",
+	Headline => "computations with matroids",
 	Keywords => {"Matroids"},
 	HomePage => "https://github.com/jchen419/Matroids-M2",
 	PackageExports => {"Graphs", "Posets"},

--- a/M2/Macaulay2/packages/MixedMultiplicity.m2
+++ b/M2/Macaulay2/packages/MixedMultiplicity.m2
@@ -30,7 +30,6 @@ newPackage(
 	    }
 	},
     Headline => "Mixed Multiplicities",
-    Reload => true,
     Headline => "Mixed Multiplicities of ideals",
     PackageImports=>{"Divisor", "ReesAlgebra", "Depth", "Polyhedra"},
     Keywords => {"Commutative Algebra"},

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -10,7 +10,7 @@ newPackage(
 		  Email => "leykin@math.gatech.edu", 
 		  HomePage => "https://antonleykin.math.gatech.edu/"}},
 	  Keywords => {"Groebner Basis Algorithms" , "Interfaces"},
-    	Headline => "An interface to the msolve package (https://msolve.lip6.fr/) which computes Groebner Basis and does real root isolation",
+	Headline => "interface to the msolve library for solving multivariate polynomial systems using Groebner Bases",
 	PackageImports => { "Elimination", "Saturation" },
     	AuxiliaryFiles => true,
 	DebuggingMode => false

--- a/M2/Macaulay2/packages/MultigradedImplicitization.m2
+++ b/M2/Macaulay2/packages/MultigradedImplicitization.m2
@@ -10,7 +10,7 @@ newPackage(
     Email => "benhollering@gmail.com",
     HomePage => "https://sites.google.com/view/benhollering"}
   },
-  Headline => "A package for levaraging multigradings to solve implicitization problems",
+  Headline => "solving implicitization problems using multigradings",
   Keywords => {"Algebraic Statistics", "Commutative Algebra"},
   PackageImports => {"gfanInterface"}
 )

--- a/M2/Macaulay2/packages/MultiplierIdeals.m2
+++ b/M2/Macaulay2/packages/MultiplierIdeals.m2
@@ -39,8 +39,7 @@ newPackage(
       Name => "Claudiu Raicu"
     }
   },
-  Headline => "multiplier ideals, log canonical thresholds,
-    and jumping numbers",
+  Headline => "multiplier ideals, log canonical thresholds, and jumping numbers",
   Keywords => {"D-modules"},
   PackageImports=>{
     "ReesAlgebra",

--- a/M2/Macaulay2/packages/Nauty.m2
+++ b/M2/Macaulay2/packages/Nauty.m2
@@ -6,7 +6,7 @@
 -- License as published by the Free Software Foundation, either version 2
 -- of the License, or any later version.
 
-newPackage select((
+newPackage(
     "Nauty",
     Version => "1.4.3.1",
     Date => "01. March 2013",
@@ -32,7 +32,7 @@ newPackage select((
 	 "volume number" => "3",
 	 "volume URI" => "https://msp.org/jsag/2011/3-1/"
 	 }
-), x -> x =!= null)
+    )
 
 -------------------
 -- Configuration

--- a/M2/Macaulay2/packages/NautyGraphs.m2
+++ b/M2/Macaulay2/packages/NautyGraphs.m2
@@ -12,7 +12,7 @@
 -- License as published by the Free Software Foundation, either version 2
 -- of the License, or any later version.
 
-newPackage select((
+newPackage(
     "NautyGraphs",
     Version => "1.4.3.1",
     Date => "01. March 2013",
@@ -24,7 +24,7 @@ newPackage select((
     Configuration => {"path" => ""},
     PackageExports => {"Graphs"},
     DebuggingMode => false,
-), x -> x =!= null)
+    )
 
 -------------------
 -- Configuration

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry.m2
@@ -1,7 +1,7 @@
 -- -*- coding: utf-8 -*-
 -- licensed under GPL v2 or any later version
 
-newPackage select((
+newPackage(
      "NumericalAlgebraicGeometry",
      Version => "1.24",
      Date => "May 2024",
@@ -36,7 +36,7 @@ newPackage select((
 	  "volume number" => "3",
 	  "volume URI" => "https://msp.org/jsag/2011/3-1/"
 	  }
-     ), x -> x =!= null)
+    )
 
 -- Any symbols or functions that the user is to have access to
 -- must be placed in one of the following two lists

--- a/M2/Macaulay2/packages/PolyominoIdeals.m2
+++ b/M2/Macaulay2/packages/PolyominoIdeals.m2
@@ -20,8 +20,7 @@ newPackage(
 	},
 	Headline => "binomial ideals of collections of cells",
 	Keywords => {"Combinatorial Commutative Algebra"},
-	DebuggingMode => false,
-	Reload => true
+	DebuggingMode => false
 )
 
 export {

--- a/M2/Macaulay2/packages/Posets.m2
+++ b/M2/Macaulay2/packages/Posets.m2
@@ -9,7 +9,7 @@
 ------------------------------------------
 ------------------------------------------
 
-newPackage select((
+newPackage(
     "Posets",
         Version => "1.1.3",
         Date => "May 15, 2021",
@@ -44,7 +44,7 @@ newPackage select((
 	     "volume number" => "7",
 	     "volume URI" => "https://msp.org/jsag/2015/7-1/"
 	     },
-        ), x -> x =!= null)
+    )
 
 -- Load configurations
 posets'Precompute = if instance((options Posets).Configuration#"DefaultPrecompute", Boolean) then (options Posets).Configuration#"DefaultPrecompute" else true;

--- a/M2/Macaulay2/packages/RInterface.m2
+++ b/M2/Macaulay2/packages/RInterface.m2
@@ -11,15 +11,19 @@ newPackage("RInterface",
     AuxiliaryFiles => true,
     PackageImports => {"ForeignFunctions"})
 
-if not (options currentPackage).OptionalComponentsPresent
-then (
-    printerr "warning: R cannot be found; ending";
+
+endpkg = msg -> (
+    document {Key => RInterface,
+	Headline => (options currentPackage).Headline,
+	"Warning: RInterface was loaded without key components."};
+    printerr("warning: ", msg, "; ending");
     end)
 
+if not (options currentPackage).OptionalComponentsPresent
+then endpkg "R cannot be found"
+
 if not ForeignFunctions#"private dictionary"#?"foreignFunction"
-then (
-    printerr "warning: foreign function interface is not available; ending";
-    end)
+then endpkg "foreign function interface is not available"
 
 export {
     -- types

--- a/M2/Macaulay2/packages/RealRoots.m2
+++ b/M2/Macaulay2/packages/RealRoots.m2
@@ -18,7 +18,7 @@ newPackage(
 	 Email=>"thomasjyahl@tamu.edu",
 	 HomePage=>"https://www.github.com/tjyahl"}
 	},
-    Headline=>"Package for symbolically exploring, counting, and locating real solutions to general polynomial systems",
+    Headline=>"symbolically exploring, counting, and locating real solutions to general polynomial systems",
     Keywords=>{"Real Algebraic Geometry"},
     PackageImports=>{},
     PackageExports=>{}

--- a/M2/Macaulay2/packages/SLPexpressions.m2
+++ b/M2/Macaulay2/packages/SLPexpressions.m2
@@ -3,7 +3,7 @@
 
 -- TODO: compress (with CacheTable)
 
-newPackage select((
+newPackage(
      "SLPexpressions",
      Version => "1.21",
      Date => "Nov 2022",
@@ -36,7 +36,7 @@ newPackage select((
      --   but false after it is done
      --DebuggingMode => true
      DebuggingMode => false
-     ), x -> x =!= null)
+     )
 
 -- Any symbols or functions that the user is to have access to
 -- must be placed in one of the following two lists

--- a/M2/Macaulay2/packages/SagbiGbDetection.m2
+++ b/M2/Macaulay2/packages/SagbiGbDetection.m2
@@ -11,7 +11,6 @@ newPackage(
         DebuggingMode => false, 
         PackageExports => { "Polyhedra", "ReesAlgebra", "SubalgebraBases" },   
         PackageImports => { "SubalgebraBases"},   
-        Reload => true,
 	Keywords => {"Commutative Algebra"}
 )   
 

--- a/M2/Macaulay2/packages/SagbiGbDetection.m2
+++ b/M2/Macaulay2/packages/SagbiGbDetection.m2
@@ -1,6 +1,6 @@
 newPackage(
         "SagbiGbDetection",
-        Headline => "this package verifies whether the given generators of an ideal form the Gr\"obner basis or whether the given generators of a finitely generated subalgebra of a polynomial ring are the SAGBI basis",
+        Headline => "finding term orders for which the given generators of an ideal/algebra form a Gröbner/SAGBI basis",
         Version => "0.1",  
         Date => "April 11, 2023",
         Authors => {

--- a/M2/Macaulay2/packages/SegreClasses.m2
+++ b/M2/Macaulay2/packages/SegreClasses.m2
@@ -9,7 +9,7 @@ newPackage( "SegreClasses",
          Email => "Corey.Harris@mis.mpg.de",
          HomePage => "http://coreyharris.name"}
     },
-    Headline => "test containment of varieties and computes algebraic multiplicity of subvarieties and Fulton-MacPherson intersection products, via a very general Segre class computation",
+    Headline => "Segre class computations for containment of varieties and Fulton-MacPherson intersection products",
     Keywords => {"Intersection Theory"},
     DebuggingMode => false
 );

--- a/M2/Macaulay2/packages/SimpleDoc/templates.m2
+++ b/M2/Macaulay2/packages/SimpleDoc/templates.m2
@@ -1,25 +1,26 @@
 docTemplate = "doc ///
-Key
-Headline
-Usage
-Inputs
-Outputs
-Consequences
-  Item
-Description
-  Text
-  Tree
-  Code
-  Pre
-  Example
-  CannedExample
-ExampleFiles
-Acknowledgement
-Contributors
-References
-Caveat
-SeeAlso
-Subnodes
+Node
+  Key
+  Headline
+  Usage
+  Inputs
+  Outputs
+  Consequences
+    Item
+  Description
+    Text
+    Tree
+    Code
+    Pre
+    Example
+    CannedExample
+  ExampleFiles
+  Acknowledgement
+  Contributors
+  References
+  Caveat
+  SeeAlso
+  Subnodes
 ///"
 
 packagetemplate = "newPackage(

--- a/M2/Macaulay2/packages/SimplicialPosets.m2
+++ b/M2/Macaulay2/packages/SimplicialPosets.m2
@@ -21,7 +21,7 @@ newPackage(
 	Authors => {{
 		    Name => "Nathan Nichols",
 		    Email => "nicho997@umn.edu"}},
-        Headline => "Package for constructing Stanley simplicial poset rings.",
+        Headline => "constructing Stanley simplicial poset rings",
 	Keywords => {"Combinatorial Commutative Algebra"},
 	DebuggingMode => false,
 	PackageExports => {

--- a/M2/Macaulay2/packages/TSpreadIdeals.m2
+++ b/M2/Macaulay2/packages/TSpreadIdeals.m2
@@ -5,7 +5,7 @@ Version => "1.0",
 Date => "February 01, 2021",
 Authors => {{Name => "Luca Amata", Email => "lamata@unime.it", HomePage => "http://mat521.unime.it/amata"}
            },
-Headline => "A Macaulay2 package to deal with t-spread ideals of a polynomial ring",
+Headline => "t-spread ideals of a polynomial ring",
 Keywords => {"Commutative Algebra"},
 DebuggingMode => false
 )

--- a/M2/Macaulay2/packages/ToricInvariants.m2
+++ b/M2/Macaulay2/packages/ToricInvariants.m2
@@ -5,7 +5,7 @@ newPackage(
     	Authors => {{Name => "Martin Helmer", 
 		  Email => "m.helmer@math.ku.dk", 
 		  HomePage => "http://martin-helmer.com/"}},
-    	Headline => "Euclidean distance degrees, polar degrees, degree and codimension of the dual, and Chern-Mather classes of toric varieties X_A from the polytope conv(A) or from its Gale dual",
+	Headline => "Euclidean distance degrees, polar degrees, and Chern-Mather classes of toric varieties",
 	Keywords => {"Toric Geometry"},
     	DebuggingMode => false,
 	PackageImports => {"LLLBases", "Polyhedra" }

--- a/M2/Macaulay2/packages/Tropical.m2
+++ b/M2/Macaulay2/packages/Tropical.m2
@@ -12,12 +12,11 @@ newPackage(
     		{Name => "Paolo Tripoli", Email => "paolo.tripoli@nottingham.ac.uk", HomePage=>"https://sites.google.com/view/paolotripoli/home"},
    		{Name => "Magdalena Zajaczkowska", Email => "Magdalena.A.Zajaczkowska@gmail.com", HomePage=>""}
 		},
-	Headline => "A package for doing computations in tropical geometry",
+	Headline => "computations in tropical geometry",
 	Configuration => {
 		"path" => "",
 		"fig2devpath" => "",
---		"keepfiles" => true,
-"keepfiles" => false,
+		"keepfiles" => false,
 		"cachePolyhedralOutput" => true,
 		"tropicalMax" => false,
 		"polymakeCommand" =>""
@@ -25,7 +24,6 @@ newPackage(
     	OptionalComponentsPresent => true,
         PackageExports => {"gfanInterface","EliminationMatrices","Matroids","Polyhedra"},
 	AuxiliaryFiles => true,
---	AuxiliaryFiles => false,
 	CacheExampleOutput => true,
 	Keywords => {"Tropical Geometry"}
 )

--- a/M2/Macaulay2/packages/TropicalToric.m2
+++ b/M2/Macaulay2/packages/TropicalToric.m2
@@ -9,7 +9,7 @@ newPackage(
         HomePage=>"https://alessioborzi.github.io"
       }
   },
-	Headline => "A package on tropical methods for toric intersection theory",
+	Headline => "tropical methods for toric intersection theory",
 	Configuration => {},
   PackageExports => {
     "NormalToricVarieties",

--- a/M2/Macaulay2/packages/VNumber.m2
+++ b/M2/Macaulay2/packages/VNumber.m2
@@ -8,9 +8,8 @@ newPackage(
         {Name => "Emanuele Sgroi", Email => "emasgroi@unime.it", HomePage => "https://www.researchgate.net/profile/Emanuele-Sgroi"}},
     Headline => "compute v-number of homogeneous ideals and v-function of monomial ideals",
     Keywords => {"Documentation"},
-    DebuggingMode => false,
     PackageExports => {"PrimaryDecomposition","ReesAlgebra"},
-    Reload => true
+    DebuggingMode => false
 )
 
 export {"reesMap",

--- a/M2/Macaulay2/packages/VectorGraphics.m2
+++ b/M2/Macaulay2/packages/VectorGraphics.m2
@@ -6,7 +6,7 @@ newPackage(
         Authors => {{Name => "Paul Zinn-Justin",
                   Email => "pzinn@unimelb.edu.au",
                   HomePage => "http://blogs.unimelb.edu.au/paul-zinn-justin/"}},
-        Headline => "A package to produce SVG graphics",
+        Headline => "producing SVG graphics",
 	Keywords => {"Graphics"},
         DebuggingMode => false,
 	AuxiliaryFiles => true,

--- a/M2/Macaulay2/packages/undistributed-packages/NAGtools.m2
+++ b/M2/Macaulay2/packages/undistributed-packages/NAGtools.m2
@@ -2,7 +2,7 @@
 -- licensed under GPL v2 or any later version
 
 -- A collection of algorithms that use NumericalAlgebraicGeometry and related packages. 
-newPackage select((
+newPackage(
      "NAGtools",
      Version => "1.9",
      Date => "Apr 2016",
@@ -18,7 +18,7 @@ newPackage select((
      --   but false after it is done
      --DebuggingMode => true
      DebuggingMode => false
-     ), x -> x =!= null)
+    )
 
 -- Any symbols or functions that the user is to have access to
 -- must be placed in one of the following two lists

--- a/M2/Macaulay2/tests/normal/release-checklist.m2
+++ b/M2/Macaulay2/tests/normal/release-checklist.m2
@@ -9,6 +9,9 @@ if #pkgs > 0 then error("packages without a Keyword: ", demark_", " keys pkgs)
 pkgs = select(pkgopts, opts -> opts.DebuggingMode);
 if #pkgs > 0 then error("packages with 'DebuggingMode' turned on: ", demark_", " keys pkgs)
 
+pkgs = select(pkgopts, opts -> opts.Reload);
+if #pkgs > 0 then error("packages with 'Reload' turned on: ", demark_", " keys pkgs)
+
 -- c.f. commit 7a7e6f96
 pkgs = select(pkgopts, opts -> 100 < #opts.Headline)
 if #pkgs > 0 then error("packages whose headlines doesn't follow guidelines:", newline,

--- a/M2/Macaulay2/tests/normal/release-checklist.m2
+++ b/M2/Macaulay2/tests/normal/release-checklist.m2
@@ -1,19 +1,27 @@
 -- https://github.com/Macaulay2/M2/wiki/Internals:-Release-Checklist
 
-pkgs = select(separate_" " version#"packages",
-    p -> (readPackage p)#Keywords === {"Uncategorized"});
-if #pkgs > 0 then error("uncategorized packages:", newline,
-    toString stack sort pkgs)
+pkglist = sort separate_" " version#"packages";
+pkgopts = hashTable apply(pkglist, pkg -> (pkg, readPackage pkg));
 
-pkgs = select(separate_" " version#"packages",
-	p -> (readPackage p)#DebuggingMode);
-if #pkgs > 0 then error("packages with debugging mode turned on:", newline,
-    toString stack sort pkgs)
+pkgs = select(pkgopts, opts -> isMember("Uncategorized", opts.Keywords))
+if #pkgs > 0 then error("packages without a Keyword: ", demark_", " keys pkgs)
+
+pkgs = select(pkgopts, opts -> opts.DebuggingMode);
+if #pkgs > 0 then error("packages with 'DebuggingMode' turned on: ", demark_", " keys pkgs)
+
+-- c.f. commit 7a7e6f96
+pkgs = select(pkgopts, opts -> 100 < #opts.Headline)
+if #pkgs > 0 then error("packages whose headlines doesn't follow guidelines:", newline,
+    toString netList(toList \ pairs applyValues(pkgs, opts -> opts.Headline)))
 
 importFrom(Core, "fetchRawDocumentation")
-elapsedTime pkgs = select(separate_" " version#"packages",
-    p -> (
-	try (fetchRawDocumentation makeDocumentTag p).Description === {}
-	else false));
+elapsedTime pkgs = select(pkglist, pkg -> (
+	tag := makeDocumentTag(pkg|"::"|pkg);
+	rawdoc := fetchRawDocumentation tag;
+	rawdoc === null or rawdoc.Description === {}));
 if #pkgs > 0 then error("packages with no top level node:", newline,
     toString stack sort pkgs)
+
+end--
+restart
+load "release-checklist.m2"

--- a/M2/Macaulay2/tests/normal/release-checklist.m2
+++ b/M2/Macaulay2/tests/normal/release-checklist.m2
@@ -15,7 +15,8 @@ if #pkgs > 0 then error("packages with 'Reload' turned on: ", demark_", " keys p
 -- c.f. commit 7a7e6f96
 pkgs = select(pkgopts, opts -> 100 < #opts.Headline or match({
 --	    "^[A-Z]", -- headlines should not be capitalized, but hard to check
-	    "\\.$", -- headlines should not end with a period
+	    "\\.$",   -- headlines should not end with a period
+	    "\\n",    -- headlines should not contain line breaks
 	    -- redundant clauses for package headlines:
 	    "(T|t)his (P|p)ackage",
 	    "(P|p)ackage (for|on|to)"}, opts.Headline));

--- a/M2/Macaulay2/tests/normal/release-checklist.m2
+++ b/M2/Macaulay2/tests/normal/release-checklist.m2
@@ -13,7 +13,12 @@ pkgs = select(pkgopts, opts -> opts.Reload);
 if #pkgs > 0 then error("packages with 'Reload' turned on: ", demark_", " keys pkgs)
 
 -- c.f. commit 7a7e6f96
-pkgs = select(pkgopts, opts -> 100 < #opts.Headline)
+pkgs = select(pkgopts, opts -> 100 < #opts.Headline or match({
+--	    "^[A-Z]", -- headlines should not be capitalized, but hard to check
+	    "\\.$", -- headlines should not end with a period
+	    -- redundant clauses for package headlines:
+	    "(T|t)his (P|p)ackage",
+	    "(P|p)ackage (for|on|to)"}, opts.Headline));
 if #pkgs > 0 then error("packages whose headlines doesn't follow guidelines:", newline,
     toString netList(toList \ pairs applyValues(pkgs, opts -> opts.Headline)))
 


### PR DESCRIPTION
- **limited package headlines to 100 characters**
  - also fixes the top node check, which wasn't working.
- **removed Reload => true from packages**
- **implemented uniformity in headlines (cf. 7a7e6f96)**
- **removed line breaks from package headlines**

I'll seek approval from authors of affected packages in the comments.