### PR TITLE
Reverted `about`, added `headlines`

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -137,8 +137,9 @@ DocumentTag ? DocumentTag := (x, y) -> x.Format ? y.Format
 DocumentTag ? String      := (x, y) -> x.Format ? y
 String      ? DocumentTag := (x, y) -> x        ? y.Format
 
--- helper for parsing " pkg :: key " to ("pkg", "key")
+-- helper for parsing " pkg :: key -- headline" to ("pkg", "key")
 parseDocumentTag := key -> (
+    key = first separate(" -- ", key); -- the spaces are there so "--" can be a valid key
     segments := separate("^[[:space:]]*|[[:space:]]*::[[:space:]]*|[[:space:]]*$", key);
     segments  = select(segments, segment -> segment =!= "");
     -- this is important, because the names of info nodes get extracted from text where

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -198,7 +198,6 @@ makeDocumentTag String      := opts -> key -> (
     then error ("mismatching packages ", pkg, " and ", toString opts#Package, " specified for key ", key);
     if pkg === null then pkg = opts#Package;
     (makeDocumentTag' new OptionTable from {Package => pkg}) key)
-makeDocumentTag TOH := opts -> first
 
 -- before creating links, we recreate the document tag as a hack to
 -- correct its package, if it is incorrect (e.g. truncate, quotient)

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -746,6 +746,7 @@ export {
 	"groupID",
 	"hash",
 	"hashTable",
+	"headlines",
 	"heft",
 	"height",
 	"help",

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -347,6 +347,10 @@ headline = method(Dispatch => Thing)
 headline Thing := key -> getOption(fetchRawDocumentationNoLoad makeDocumentTag key, Headline)
 headline DocumentTag := tag -> getOption(fetchRawDocumentation getPrimaryTag tag, Headline)
 
+headlines = method()
+headlines List := L -> netList(Boxes => false, HorizontalSpace => 1,
+    apply(#L, i -> {i, TO2(tag := makeDocumentTag L#i, format tag), commentize headline tag}))
+
 -- Compare with SYNOPSIS in document.m2
 getSynopsis := (key, tag, rawdoc) -> (
     if rawdoc === null then return null;

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -348,7 +348,8 @@ headline Thing := key -> getOption(fetchRawDocumentationNoLoad makeDocumentTag k
 headline DocumentTag := tag -> getOption(fetchRawDocumentation getPrimaryTag tag, Headline)
 
 headlines = method()
-headlines List := L -> TABLE apply(#L, i -> {i | ".", TO2(tag := makeDocumentTag L#i, format tag), commentize headline tag})
+headlines List := L -> TABLE apply(#L, i -> { pad(floor log_10(#L) + 2, i | "."),
+	TO2(tag := makeDocumentTag L#i, net tag), commentize headline tag })
 
 -- Compare with SYNOPSIS in document.m2
 getSynopsis := (key, tag, rawdoc) -> (

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -564,7 +564,7 @@ about Symbol   :=
 about Function := o -> f -> about("\\b" | toString f | "\\b", o)
 about String   := o -> re -> lastabout = (
     packagesSeen := new MutableHashTable;
-    NumberedVerticalList apply(sort join(
+    NumberedVerticalList sort join(
         flatten for pkg in loadedPackages list (
             pkgname := pkg#"pkgname";
             if packagesSeen#?pkgname then continue else packagesSeen#pkgname = 1;
@@ -574,7 +574,7 @@ about String   := o -> re -> lastabout = (
                     matchfun_re if o.Body then pkg#rawKeyDB),
                 select(keys pkg#"raw documentation",
                     matchfun_re if o.Body then pkg#"raw documentation"));
-            apply(keyList, key -> (pkgname,key))),
+            apply(keyList, key -> pkgname | " :: " | key )),
         flatten for pkg in getPackageInfoList() list (
             pkgname := pkg#"name";
             if packagesSeen#?pkgname then continue else packagesSeen#pkgname = 1;
@@ -583,10 +583,7 @@ about String   := o -> re -> lastabout = (
             db := if o.Body then openDatabase dbname;
             keyList := select(dbkeys, matchfun_re db);
             if o.Body then close db;
-            apply(keyList, key -> (pkgname,key)))
-	    ),(pkgname,key) -> SPAN { pkgname, " ", TOH {pkgname | "::" | key} }
-	)
-    )
+            apply(keyList, key -> pkgname | " :: " | key ))))
 
 -- TODO: should this go to system?
 pager = x -> if height stdio > 0

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -348,8 +348,7 @@ headline Thing := key -> getOption(fetchRawDocumentationNoLoad makeDocumentTag k
 headline DocumentTag := tag -> getOption(fetchRawDocumentation getPrimaryTag tag, Headline)
 
 headlines = method()
-headlines List := L -> netList(Boxes => false, HorizontalSpace => 1,
-    apply(#L, i -> {i, TO2(tag := makeDocumentTag L#i, format tag), commentize headline tag}))
+headlines List := L -> TABLE apply(#L, i -> {i | ".", TO2(tag := makeDocumentTag L#i, format tag), commentize headline tag})
 
 -- Compare with SYNOPSIS in document.m2
 getSynopsis := (key, tag, rawdoc) -> (

--- a/M2/Macaulay2/packages/Macaulay2Doc/debugging.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/debugging.m2
@@ -558,6 +558,7 @@ document {
      }
 
 -- TODO: this needs some upgrades
+-- TODO: also show how to use "headlines methods X"
 document {
   Key => {
     methods,

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
@@ -241,11 +241,13 @@ Node
       The packages searched are the loaded packages and the packages installed under one of the prefixes listed
       in @TO "prefixPath"@. The first search will take a few seconds while it reads all the documentation keys
       into memory.
-
-    -- this example won't work until after Macaulay2Doc is installed.
-    CannedExample
-      about resolution
-      help 5
+    Example
+      about firstFunction
+      help 1
+    Text
+      It is also possible to view a table of headlines corresponding to the results.
+    Example
+      headlines about firstFunction
   Caveat
     Since @TT "s"@ is taken as a regular expression, parentheses serve
     for grouping subexpressions, rather than matching themselves.
@@ -253,6 +255,7 @@ Node
     (help, ZZ)
     (symbol?, Symbol)
     apropos
+    headlines
     findSynonyms
     "regular expressions"
 
@@ -280,11 +283,42 @@ Node
       For example, to find all functions that start with @TT "mat"@ or @TT "Mat"@:
     Example
       apropos "^[mM]at"
+    Text
+      It is also possible to view a table of headlines corresponding to the results.
+    Example
+      headlines apropos "hilbert"
   SeeAlso
     help
     about
+    headlines
     findSynonyms
     "regular expressions"
+
+Node
+  Key
+    headlines
+  Headline
+    display a table of documentation headlines
+  Usage
+    headlines about s
+    headlines apropos p
+    headlines methods f
+  Description
+    Text
+      This method displays a table of documentation headlines for the input list.
+    Example
+      headlines about firstFunction
+      help 0
+      headlines apropos "hilbert"
+      headlines methods syz
+      code 0
+  SeeAlso
+    help
+    viewHelp
+    about
+    apropos
+    methods
+    code
 ///
 
 -- the node displayed by the help command by default


### PR DESCRIPTION
- **changed makeDocumentTag to strip -- comments**
- **reverted previous behavior of about**
- **added headlines as a help function**

Here's the upshot: you can get links to documentation along with the headlines:
```m2
i1 : headlines about firstFunction

o1 = 0 "firstFunction"      -- a silly first function
     1 "firstFunction(ZZ)"  -- a silly first function

i2 : headlines apropos "hilbert"

o2 = 0 "hilbertBasis"       -- computes the Hilbert basis of a Cone
     1 "hilbertFunction"    -- the Hilbert function                
     2 "hilbertPolynomial"  -- compute the Hilbert polynomial      
     3 "hilbertSeries"      -- compute the Hilbert series          

i3 : headlines methods syz

o3 = 0 "syz(GroebnerBasis)"  -- retrieve the syzygy matrix
     1 "syz(Matrix)"         -- compute the syzygy matrix
```
The output is a Table, but `help ZZ` and `code ZZ` still work.

On the other hand, `about` has been reverted to it's previous format so the entries are syntax highlighted:
```m2
i4 : about heft

o4 = {0 => Macaulay2Doc :: heft                }
     {1 => Macaulay2Doc :: heft vectors        }
     {2 => Macaulay2Doc :: heft(Monoid)        }
     {3 => Macaulay2Doc :: heft(PolynomialRing)}
     {4 => Macaulay2Doc :: heft(QuotientRing)  }
     {5 => Macaulay2Doc :: heft(Ring)          }
```

Hopefully this is a good compromise.