### PR TITLE
Deduplicate identical entries in "code methods X"

### DIFF
--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -180,7 +180,7 @@ methods Sequence := F -> (
     -- this line makes so `methods parent class help()` shows (net, HypertextContainer)
     -- despite the fact that HypertextContainer is not exported by default.
     scan(select(F, e -> instance(e, Type)), T -> scan(sequenceMethods(T, F, tallyF), key -> found#key = true));
-    previousMethodsFound = new NumberedVerticalList from sortByName select(keys found, isCallable))
+    previousMethodsFound = new NumberedVerticalList from sortByLocation select(keys found, isCallable))
 
 methods ScriptedFunctor := -- TODO: OO and other scripted functors aren't supported
 -- FIXME: why is 'methods Format' giving two things?
@@ -192,7 +192,7 @@ methods Thing  := F -> (
     -- TODO: either finish or remove nullaryMethods
     if nullaryMethods#?(1:F) then found#(1:F) = true;
     searchAllDictionaries(Type, T -> scan(thingMethods(T, F), key -> found#key = true));
-    previousMethodsFound = new NumberedVerticalList from sortByName keys found)
+    previousMethodsFound = new NumberedVerticalList from sortByLocation keys found)
 
 -- this one is here because it needs previousMethodsFound
 options ZZ := i -> options previousMethodsFound#i

--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -255,7 +255,7 @@ locate Symbol      := FilePosition => x -> if (x':=locate' x) =!= null then new 
 locate List        := List     => x -> apply(x, locate)
 protect symbol locate
 
-
+sortByLocation = sortBy(toString @@ locate)
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/tests/normal/methods.m2
+++ b/M2/Macaulay2/tests/normal/methods.m2
@@ -113,6 +113,12 @@ u Number := identity
 assert( u ZZ === ZZ )
 assert( u(ZZ,FOO=>BAR) === (new OptionTable from {FOO => BAR},ZZ) )
 
+-- "code methods" should deduplicates identical functions
+u Matrix := identity
+s = code methods u
+assert match("-- code for method: u\\(Number\\)", toString net s#0)
+assert match("-- code for method: u\\(Matrix\\)", toString net s#0)
+
 -- chainComplex is now an example, because it is defined by chainComplex = method(Options => true, Dispatch => Thing, TypicalValue => ChainComplex)
 X = new Type of BasicList
 chainComplex X := { FOO => BAR } >> o -> x -> (o,x);


### PR DESCRIPTION
Before:
```m2
o1 = -- code for method: toList(BasicList)
     function toList1: source code not available
     ---------------------------------------------------------------------------
     -- code for method: toList(Set)
     function toList1: source code not available
     ---------------------------------------------------------------------------
     -- code for method: toList(String)
     function toList1: source code not available
     ---------------------------------------------------------------------------
     -- code for method: toList(Thing)
     ../linuxbrew/.linuxbrew/share/Macaulay2/Core/iterators.m2:28:18-28:37:
     --source code:
     toList Thing := x -> for y in x list y
```
After:
```m2
o1 = -- code for method: toList(Thing)
     ../../../../feature/M2/Macaulay2/m2/iterators.m2:29:18-29:37:
     toList Thing := x -> for y in x list y
     ------------------------------------------------------------------------------------------------------------------------
     -- code for method: toList(String)
     -- code for method: toList(BasicList)
     -- code for method: toList(Set)
     compiled function toList1: source code not available
```

Also sorts the methods by location, rather than name:
```m2
i3 : locate methods(map, Module, List)

o3 = {0 => (../../../../feature/M2/Macaulay2/m2/matrix1.m2:93:45-157:10) }
     {1 => (../../../../feature/M2/Macaulay2/m2/matrix1.m2:93:45-157:10) }
     {2 => (../../../../feature/M2/Macaulay2/m2/matrix1.m2:93:45-157:10) }
     {3 => (../../../../feature/M2/Macaulay2/m2/ringmap.m2:568:47-568:94)}
     {4 => (../../../../feature/M2/Macaulay2/m2/ringmap.m2:569:48-569:84)}
```

Closes #3364.