### PR TITLE
Check for msolve version in autotools build

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1112,10 +1112,21 @@ then AC_MSG_RESULT([no, will build])
 fi
 
 AS_IF([test $BUILD_msolve = no],
-    [AC_MSG_CHECKING(whether msolve is installed)
+    [AC_MSG_CHECKING([whether msolve is installed])
      AS_IF([command -v msolve > /dev/null],
-         [AC_MSG_RESULT([yes])
-          FILE_PREREQS="$FILE_PREREQS `command -v msolve`"],
+         [AS_IF([msolve -V > /dev/null 2>&1],
+             [msolve_actual_version=$(msolve -V)
+              dnl keep in sync with msolveMinimumVersion in Msolve.m2
+              msolve_min_version=0.7.0
+              AX_COMPARE_VERSION(
+                  [$msolve_actual_version], [ge], [$msolve_min_version],
+                  [AC_MSG_RESULT([yes])
+                   FILE_PREREQS="$FILE_PREREQS `command -v msolve`"],
+                  [AC_MSG_RESULT([yes, but version $msolve_actual_version was \
+found and $msolve_min_version is required; will build])
+                   BUILD_msolve=yes])],
+             [AC_MSG_RESULT([yes, but cannot detect version; will build])
+              BUILD_msolve=yes])],
          [AC_MSG_RESULT([no, will build])
           BUILD_msolve=yes])])
 


### PR DESCRIPTION
Since the msolve package requires version 0.7.0, we check the msolve version during `configure` in the autotools build.  If msolve exists on the system but is too old, then we build the latest msolve.

~~I also fixed a bug in the warning message that occurs in the package when msolve is too old -- we were trying to concatenate the output of `printerr` (which is null) with a string.~~ *Edit:* This bug is fixed in https://github.com/antonleykin/M2/pull/31.