### PR TITLE
Fixed a bug in MultigradedBGG::foldComplex

### DIFF
--- a/M2/Macaulay2/packages/MultigradedBGG.m2
+++ b/M2/Macaulay2/packages/MultigradedBGG.m2
@@ -194,17 +194,12 @@ minimizeDM(DifferentialModule) := r ->(
 ---
 
 --  Input:  a free complex F and a degree d
---  Output: the corresponding free differential module of degree da
+--  Output: the corresponding free differential module of degree d
 foldComplex = method();
 foldComplex(Complex,ZZ) := DifferentialModule => (F,d)->(
     R := ring F;
-    L := apply(length F+1,j->(
-	    --sasha: i removed the concatMatrices method since 'matrix {_}' just does the same thing
-	    transpose matrix {apply(length F+1,i->map(F_j,F_i, if i == j+1 then F.dd_i else 0))}
-	));
-    FDiff := transpose(matrix {L});
-    FMod := F_0;
-    scan(length F+1, i-> FMod = FMod ++ ((F_(i+1))**(R)^{(i+1)*d}));
+    FDiff := directSum apply(min F .. max F + 1, i -> F.dd_i);
+    FMod := directSum apply(min F .. max F, i -> F_i ** R^{i*d});
     degFDiff := map(FMod,FMod,FDiff, Degree=>d); 
     differentialModule(complex({-degFDiff,-degFDiff})[1]) 
     )
@@ -1242,3 +1237,9 @@ L = stronglyLinearStrand(M)
 assert(L == koszulComplex {x_1})
 ///
 
+TEST ///
+  S = QQ[x,y]
+  K = koszulComplex vars S
+  assert(differential foldComplex(K, 0) == map(S^{{0}, 2:{-1}, {-2}},S^{{0}, 2:{-1}, {-2}},{{0, x, y, 0}, {0, 0, 0, -y}, {0, 0, 0, x}, {0, 0, 0, 0}}))
+  assert(differential foldComplex(dual K, 0) == map(S^{{2}, 2:{1}, {0}},S^{{2}, 2:{1}, {0}},{{0, -y, x, 0}, {0, 0, 0, x}, {0, 0, 0, y}, {0, 0, 0, 0}}))
+///


### PR DESCRIPTION
See the added test for the example that was failing before, which was a free complex whose concentration was not 0 to n.

Before:
```m2
i1 : needsPackage "MultigradedBGG";

i2 : S = QQ[x,y,z];

i3 : K = koszulComplex vars S

      1      3      3      1
o3 = S  <-- S  <-- S  <-- S
                           
     0      1      2      3

o3 : Complex

i4 : foldComplex(dual K, 0) -- this is wrong

      1      1      1
o4 = S  <-- S  <-- S
                    
     -1     0      1

o4 : DifferentialModule

i5 : differential foldComplex(dual K, 0) -- this is wrong

o5 = 0

             1      1
o5 : Matrix S  <-- S
```
After:
```m2
i4 : foldComplex(dual K, 0)

      8      8      8
o4 = S  <-- S  <-- S
                    
     -1     0      1

o4 : DifferentialModule

i5 : differential foldComplex(dual K, 0)

o5 = {-3} | 0 z -y x 0  0  0 0 |
     {-2} | 0 0 0  0 -y x  0 0 |
     {-2} | 0 0 0  0 -z 0  x 0 |
     {-2} | 0 0 0  0 0  -z y 0 |
     {-1} | 0 0 0  0 0  0  0 x |
     {-1} | 0 0 0  0 0  0  0 y |
     {-1} | 0 0 0  0 0  0  0 z |
     {0}  | 0 0 0  0 0  0  0 0 |

              8      8
o5 : Matrix S  <-- S
```

cc: @sashahbc