### PR TITLE
Added persistent history using readline

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -14,7 +14,6 @@
 
 #include <gdbm.h>
 #include <mpfr.h>
-#include <readline/readline.h>
 
 #include <boost/stacktrace.hpp>
 #include <atomic>
@@ -90,7 +89,6 @@ int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[]
   interrupt_jmp.is_set = FALSE;
 
   signal(SIGPIPE,SIG_IGN); /* ignore the broken pipe signal */
-  rl_catch_signals = FALSE; /* tell readline not to catch signals, such as SIGINT */
 
   static struct ArgCell* M2_vargs;
   M2_vargs = (ArgCell*) GC_MALLOC_UNCOLLECTABLE(sizeof(struct ArgCell));

--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -129,6 +129,12 @@ static char **M2_completion(const char *text, int start, int end) {
   return rl_completion_matches(text, M2_completion_generator);
 }
 
+int system_readHistory(char *filename) { return read_history(filename); }
+int system_appendHistory(int n, char *filename)
+{
+  return append_history(n, filename);
+}
+
 void system_addHistory(char *buf) { add_history(buf); }
 char *system_getHistory(const int n)
 {

--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -140,6 +140,7 @@ char *system_getHistory(const int n)
 void system_initReadlineVariables(void) {
   static char readline_name[] = "M2";
   static char basic_word_break_characters[] = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r";
+  rl_catch_signals = FALSE; /* tell readline not to catch signals, such as SIGINT */
   rl_readline_name = readline_name;
   rl_attempted_completion_function = M2_completion;
   rl_basic_word_break_characters = basic_word_break_characters;

--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -95,6 +95,10 @@ extern void fatalarrayindex(int indx, int len, const char *file, int line, int c
 
 extern void fatalarraylen(int len, const char *file, int line, int column);
 
+/******************************************************************************/
+/*  Functions dealing with libreadline and completion                         */
+/******************************************************************************/
+
 static char *M2_completion_generator(const char *text, int state) {
   static int i;
   static char **v;
@@ -123,6 +127,14 @@ static char **M2_completion(const char *text, int start, int end) {
   rl_attempted_completion_over = TRUE;
   /* if (start > 0 && rl_line_buffer[start-1] == '"') ... filename completion ... */
   return rl_completion_matches(text, M2_completion_generator);
+}
+
+void system_addHistory(char *buf) { add_history(buf); }
+char *system_getHistory(const int n)
+{
+  HIST_ENTRY *entry = history_get(n);
+  if (entry != NULL) return entry->line;
+  return NULL;
 }
 
 void system_initReadlineVariables(void) {

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -20,7 +20,7 @@ header "// required for toString routines
 #include <interface/ring.h>                 // for IM2_Ring_to_string
 #include <interface/ringelement.h>          // for IM2_RingElement_to_string
 #include <interface/ringmap.h>              // for IM2_RingMap_to_string
-#include <readline/history.h>               // for history_get";
+";
 
 internalName(s:string):string := (
      -- was "$" + s in 0.9.2
@@ -1705,19 +1705,6 @@ locate(e:Expr):Expr := (
 	  locate2(f.model.body))
      else WrongArg("a function, symbol, sequence, or null"));
 setupfun("locate", locate).Protected = false; -- will be overloaded in m2/methods.m2
-
-historyGet(e:Expr):Expr := (
-    when e
-    is n:ZZcell do (
-	if !isInt(n) then WrongArgSmallInteger()
-	else (
-	    entry := Ccode(voidPointer, "history_get(", toInt(n), ")");
-	    if entry == nullPointer()
-	    then buildErrorPacket("no history entry with that offset")
-	    else toExpr(tostring(Ccode(charstar, "((HIST_ENTRY *)", entry,
-			")->line")))))
-    else WrongArgZZ());
-setupfun("historyGet", historyGet);
 
 powermod(e:Expr):Expr := (
      when e is s:Sequence do

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -669,6 +669,22 @@ getHistory(e:Expr):Expr := (
     else WrongArgZZ());
 setupfun("getHistory", getHistory);
 
+readHistory(e:Expr):Expr := (
+    when e is filename:stringCell
+    do toExpr(readHistory(tocharstar(expandFileName(filename.v))))
+    else WrongArgString(1));
+setupfun("readHistory", readHistory);
+
+appendHistory(e:Expr):Expr := (
+    when e is s:Sequence do if length(s) != 2 then WrongNumArgs(2) else
+    when s.0 is n:ZZcell do if !isInt(n) then WrongArgSmallInteger(1) else
+    when s.1 is filename:stringCell
+    do toExpr(appendHistory(toInt(n), tocharstar(expandFileName(filename.v))))
+    else WrongArgString(2)
+    else WrongArgZZ(1)
+    else WrongNumArgs(2));
+setupfun("appendHistory", appendHistory);
+
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d interp.o "
 -- End:

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -662,6 +662,13 @@ runBasicTests(e:Expr):Expr := (
      else WrongNumArgs(0));
 setupfun("runBasicTests",runBasicTests);
 
+getHistory(e:Expr):Expr := (
+    when e is n:ZZcell do if isInt(n)
+    then toExpr(tostring(getHistory(toInt(n))))
+    else WrongArgSmallInteger()
+    else WrongArgZZ());
+setupfun("getHistory", getHistory);
+
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d interp.o "
 -- End:

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -7,7 +7,6 @@ use expr;
 use stdio0;
 
 header "#include \"../system/m2fileinterface.h\"
-        #include <readline/history.h>
 	#include <assert.h>";
 
 --provide a constant representation of default buffer size for a file
@@ -743,9 +742,8 @@ export filbuf(o:file):int := (
 		    then 0 -- take care of "string files" made by stringTokenFile in interp.d
 		    else (
 			ret := read(o.infd,o.inbuffer,n,o.insize);
-			if ret > 0 && o == stdIO then (
-			    buf := tocharstarn(o.inbuffer, ret - 1);
-			    Ccode(void, "add_history(", buf, ")"));
+			if ret > 0 && o == stdIO
+			then addHistory(tocharstarn(o.inbuffer, ret - 1));
 			ret)));
 	  if r == ERROR then (
 	       fileErrorMessage(o,"read");

--- a/M2/Macaulay2/d/system.d
+++ b/M2/Macaulay2/d/system.d
@@ -178,6 +178,8 @@ import strncmp(s:string,t:string,n:int):int;
 import history():array(string);
 import getHistory(n:int):charstar;
 import addHistory(s:charstar):void;
+import appendHistory(n:int,f:charstar):int;
+import readHistory(f:charstar):int;
 import chdir(name:string):int;
 import initReadlineVariables():void;
 import handleInterruptsSetup(handleInterrupts:bool):void;

--- a/M2/Macaulay2/d/system.d
+++ b/M2/Macaulay2/d/system.d
@@ -176,6 +176,8 @@ import realpath(filename:string):(null or string);
 import readDirectory(name:string):(null or array(string));
 import strncmp(s:string,t:string,n:int):int;
 import history():array(string);
+import getHistory(n:int):charstar;
+import addHistory(s:charstar):void;
 import chdir(name:string):int;
 import initReadlineVariables():void;
 import handleInterruptsSetup(handleInterrupts:bool):void;

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -100,10 +100,6 @@ factoryversion():constcharstar := Ccode(returns,"
      ");
 
 header "#include <readline/readline.h>";
-readlineversion():constcharstar := Ccode(returns,"
-     static char buf[8];
-     snprintf(buf, 8, \"%d.%d\", (rl_readline_version>>8)&0xff, rl_readline_version&0xff );
-     return buf");
 
 header "#include <gdbm.h>";
 gdbmversion():constcharstar := Ccode(returns, "return gdbm_version");
@@ -192,7 +188,7 @@ setupconst("version", Expr(toHashTable(Sequence(
    "mathic version" => Ccode(constcharstar,"MATHIC_VERSION_STRING"),
    "mathicgb version" => Ccode(constcharstar,"MATHICGB_VERSION_STRING"),
    "factory version" => factoryversion(),
-   "readline version" => readlineversion(),
+   "readline version" => Ccode(constcharstar,"stringize(RL_VERSION_MAJOR) \".\" stringize(RL_VERSION_MINOR)"),
    "mpfr version" => Ccode(constcharstar,"MPFR_VERSION_STRING"),
    "mpfi version" => Ccode(constcharstar,"MPFI_VERSION_STRING"),
    "tbb version" => Ccode(constcharstar,"

--- a/M2/Macaulay2/m2/Core.m2
+++ b/M2/Macaulay2/m2/Core.m2
@@ -119,16 +119,16 @@ needs = filename -> if not filesLoaded#?filename then load filename else (
 -----------------------------------------------------------------------------
 -- Setup persistent history
 -----------------------------------------------------------------------------
-historyFilename = "~/.Macaulay2-history"
+historyFilename = "history.m2"
 
-if not gotarg "--no-readline" then (
-    addStartFunction(() -> readHistory historyFilename);
+if not noinitfile and not gotarg "--no-readline" then (
+    addStartFunction(() -> readHistory(applicationDirectory() | historyFilename));
     -- TODO: find a better alternative to addEndFunction, because
     -- exiting with Ctrl+D duplicates the last line of history file,
     -- but if we use lineNumber-1, then exit and restart miss the first
     -- entry from the current session. Moreover, maybe we shouldn't save
     -- exit and restart in the history anyway.
-    addEndFunction(() -> appendHistory(lineNumber, historyFilename));
+    addEndFunction(() -> appendHistory(lineNumber, applicationDirectory() | historyFilename));
     )
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/Core.m2
+++ b/M2/Macaulay2/m2/Core.m2
@@ -117,6 +117,21 @@ needs = filename -> if not filesLoaded#?filename then load filename else (
      if filetime < fileTime filepath then load filepath)
 
 -----------------------------------------------------------------------------
+-- Setup persistent history
+-----------------------------------------------------------------------------
+historyFilename = "~/.Macaulay2-history"
+
+if not gotarg "--no-readline" then (
+    addStartFunction(() -> readHistory historyFilename);
+    -- TODO: find a better alternative to addEndFunction, because
+    -- exiting with Ctrl+D duplicates the last line of history file,
+    -- but if we use lineNumber-1, then exit and restart miss the first
+    -- entry from the current session. Moreover, maybe we shouldn't save
+    -- exit and restart in the history anyway.
+    addEndFunction(() -> appendHistory(lineNumber, historyFilename));
+    )
+
+-----------------------------------------------------------------------------
 -- Load the rest of Core
 -----------------------------------------------------------------------------
 

--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -65,7 +65,7 @@ code FilePosition := x -> (
 	       else if filename === "stdio" then (
 		    start = 1;
 		    stop = x#3 - x#1 + 1;
-		    toString stack apply(x#1..x#3, historyGet))
+		    toString stack apply(x#1..x#3, getHistory))
 	       else (
 		    if not fileExists filename then error ("couldn't find file ", filename);
 		    get filename

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -9,7 +9,7 @@ debuggingMode = true
 stopIfError = false
 notify = false
 debugWarningHashcode = null
-gotarg := arg -> any(commandLine, s -> s === arg)
+gotarg = arg -> any(commandLine, s -> s === arg)
 randomSeed = -- initializing this here so the startup is reproducible
 if gotarg "--no-randomize" then 0 else (currentTime() << 16) + processID()
 if gotarg "--notify" then notify = true

--- a/M2/Macaulay2/m2/system.m2
+++ b/M2/Macaulay2/m2/system.m2
@@ -112,6 +112,9 @@ setUpApplicationDirectory = () -> (
      f := (n,c) -> (n = dir|n; if not fileExists n then n << c << close);
      f("init.m2", sampleInitFile);
      f("README", readmeFile);
+     f(historyFilename, concatenate(
+	     "-- This is the beginning of your Macaulay2 log stored at ",
+	     dir, historyFilename, newline));
      )
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
This adds persistent history for M2 running in terminal.

- **moved historyGet to getHistory in interp.dd**
- **moved rl_catch_signals to initReadlineVariables**
- **added persistent history using libreadline**
- **simplified getting libreadline's version**

There are a few kinks to be resolved, but I think it's fine for now. Closes #2819.