### PR TITLE
Moved git state from version.dd to version.m2

### DIFF
--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -134,11 +134,6 @@ foreach(_d_source IN LISTS DLIST)
   list(APPEND CLIST ${_c_source})
 endforeach()
 
-# To avoid unnecessary recompiling, only version.dd is given GIT_DESCRIPTION
-set_property(SOURCE version-tmp.cc APPEND PROPERTY COMPILE_DEFINITIONS
-  GIT_DESCRIPTION="${GIT_DESCRIPTION}"
-  GIT_BRANCH="${GIT_BRANCH}")
-
 ###############################################################################
 ## Compile the interpreter
 

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -216,9 +216,9 @@ setupconst("version", Expr(toHashTable(Sequence(
    "packages" => Ccode(constcharstar,"DISTRIBUTED_PACKAGES"),
    "build" => Ccode(constcharstar,"buildsystemtype"),
    "host" => Ccode(constcharstar,"hostsystemtype"),
-   "git description" => Ccode(constcharstar,"GIT_DESCRIPTION"),
-   "git branch" => Ccode(constcharstar, "GIT_BRANCH")
-   ))));
+   "git description" => Ccode(constcharstar, "PACKAGE_VERSION \"-bin\""),
+   "git branch"      => "version.m2 not found"
+   )))).Protected = false; -- "git description" and "git branch" will be added in m2/version.m2
 
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d version.o "

--- a/M2/Macaulay2/m2/CMakeLists.txt
+++ b/M2/Macaulay2/m2/CMakeLists.txt
@@ -38,6 +38,7 @@ add_custom_command(OUTPUT ${CORE_DIR}/tvalues.m2
   DEPENDS M2-binary
   VERBATIM)
 
+## Populate GIT_DESCRIPTION and GIT_BRANCH
 configure_file(version.m2.in ${M2_DIST_PREFIX}/${M2_INSTALL_DATADIR}/Core/version.m2 @ONLY)
 
 foreach(filename IN LISTS M2LIST ITEMS

--- a/M2/Macaulay2/m2/Makefile.in
+++ b/M2/Macaulay2/m2/Makefile.in
@@ -20,6 +20,10 @@ DUMPEDM2DOCFILES := \
 		@srcdir@/../packages/Macaulay2Doc/functions/*.m2 \
 		@srcdir@/../packages/Macaulay2Doc/operators/*.m2 \
 		../packages/Macaulay2Doc.m2
+############################## version.m2
+all: version.m2
+version.m2: version.m2.in ; ./config.status Macaulay2/m2/version.m2
+clean::; rm -f version.m2
 ############################## tvalues.m2
 STOP = --stop
 ARGS = -q --silent $(STOP) -e errorDepth=0

--- a/M2/Macaulay2/m2/Makefile.in
+++ b/M2/Macaulay2/m2/Makefile.in
@@ -13,18 +13,13 @@ Makefile: Makefile.in ; cd ../.. && ./config.status Macaulay2/m2/Makefile
 ##############################
 .SUFFIXES: .m2
 .PHONY: html initialize tags install-tmp
-# there is a parallel list of tutorials in overview3.m2
-DUMPEDM2FILES := Core.m2 startup.m2
-DUMPEDM2SRCFILES := Core.m2 startup.m2.in
+DUMPEDM2FILES := Core.m2 startup.m2 version.m2 $(shell cat @srcdir@/loadsequence)
+DUMPEDM2SRCFILES := Core.m2 startup.m2.in version.m2.in
 DUMPEDM2DOCFILES := \
 		@srcdir@/../packages/Macaulay2Doc/*.m2 \
 		@srcdir@/../packages/Macaulay2Doc/functions/*.m2 \
 		@srcdir@/../packages/Macaulay2Doc/operators/*.m2 \
 		../packages/Macaulay2Doc.m2
-############################## loadsequence
-LOADSEQUENCE := $(shell cat @srcdir@/loadsequence)
-DUMPEDM2FILES += $(LOADSEQUENCE)
-DUMPEDM2SRCFILES += $(patsubst version.m2, version.m2.in, $(LOADSEQUENCE))
 ############################## tvalues.m2
 STOP = --stop
 ARGS = -q --silent $(STOP) -e errorDepth=0

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -42,12 +42,6 @@ toString := value' getGlobalSymbol if firstTime then "simpleToString" else "toSt
 local exe
 local topBuilddir
 
-m2version := (
-    v := replace("^release-", "", version#"git description");
-    if v == version#"VERSION" then v -- stable release (at release tag)
-    else if version#"git branch" == "" then v
-    else concatenate(v, 1, "(", version#"git branch", ")"))
-
 -- this next bit has to be *parsed* after the "debug" above, to prevent the symbols from being added to the User dictionary
 if firstTime then (
      -- all global definitions here are set to read-only
@@ -279,8 +273,33 @@ if firstTime then (
      initlayout();
      )
 
+pathsearch := (exe) -> (
+    if not isFixedExecPath exe then (
+	-- we search the path, but we don't do it the same way execvp does, too bad.
+	PATH := separate(":", getenv "PATH" | ":.:/bin:/usr/bin");
+	PATH = apply(PATH, dir -> if dir === "" then "." else dir);
+	exe = scan(PATH, dir -> if fileExists(dir | "/" | exe) then break(dir | "/" | exe)));
+    exe)
+
 dir  := s -> ( m := regex(".*/",s); if m === null or 0 === #m then "./" else substring(m#0#0,m#0#1-1,s))
 base := s -> ( m := regex(".*/",s); if m === null or 0 === #m then s    else substring(m#0#1,      s))
+exe = minimizeFilename (
+    -*
+    -- this can be a reliable way to get the executable in linux
+    -- but we don't want to use it because we don't want to chase symbolic links and it does that for us
+    processExe := "/proc/self/exe";
+    if fileExists processExe and readlink processExe =!= null then readlink processExe
+    else
+    *-
+    if isAbsolutePath commandLine#0 then commandLine#0 else
+    if isStablePath commandLine#0 then concatenate(currentDirectory() | commandLine#0)
+    else pathsearch commandLine#0)
+
+if not isAbsolutePath exe then exe = currentDirectory() | exe;
+exe = concatenate(realpath dir exe, base exe)
+if notify then printerr("executable      = ", exe)
+
+-- called by M2version()
 initcurrentlayout := () -> (
      issuffix := (s,t) -> t =!= null and s === substring(t,-#s);
      bindir = dir exe | "/";
@@ -315,8 +334,10 @@ initcurrentlayout := () -> (
      if notify then printerr("topBuilddir     = ", topBuilddir);
      topSrcdir = if topBuilddir =!= null and fileExists(topBuilddir|"srcdir") then (
 	  sdir := first lines get(topBuilddir|"srcdir");
-	  minimizeFilename concatPath(topBuilddir,sdir));
+	  realpath concatPath(topBuilddir, sdir));
      if notify then printerr("topSrcdir       = ", topSrcdir);
+     coredir = prefixDirectory | replace("PKG", "Core", currentLayout#"package");
+     if notify then printerr("coredir         = ", coredir);
      )
 
 prefixDirectory = null					    -- prefix directory, after installation, e.g., "/usr/local/"
@@ -329,21 +350,13 @@ nocore = false
 noinitfile = false
 interpreter := commandInterpreter
 
--*
-getRealPath := fn -> (					    -- use this later if realpath doesn't work
-     local s;
-     while ( s = readlink fn; s =!= null ) do fn = if isAbsolutePath s then s else minimizeFilename(fn|"/../"|s);
-     fn)
-*-
-
-pathsearch := e -> (
-     if not isFixedExecPath e then (
-	  -- we search the path, but we don't do it the same way execvp does, too bad.
-	  PATH := separate(":",if "" =!= getenv "PATH" then getenv "PATH" else ".:/bin:/usr/bin");
-	  PATH = apply(PATH, x -> if x === "" then "." else x);
-	  scan(PATH, p -> if fileExists (p|"/"|e) then (e = p|"/"|e; break));
-	  );
-     e)
+M2version := () -> (
+    initcurrentlayout();
+    trySimpleLoad("version.m2", coredir | "version.m2");
+    v := replace("^release-", "", version#"git description");
+    if version#"VERSION"    == v  -- stable release (at release tag)
+    or version#"git branch" == "" then v
+    else concatenate(v, 1, "(", version#"git branch", ")"))
 
 progname := notdir commandLine#0
 usage := arg -> (
@@ -461,7 +474,7 @@ action := hashTable {
 			      << TeXmacsEnd << endl << flush)));
 	       )
 	  ),
-     "--version" => arg -> ( << m2version << newline; exit 0; ),
+     "--version" => arg -> ( << M2version() << newline; exit 0; ),
      "--webapp" => arg -> ( printWidth=0; topLevelMode = global WebApp; )
      };
 
@@ -538,30 +551,16 @@ processCommandLineOptions := phase0 -> (			    -- 3 passes
 
 if firstTime then processCommandLineOptions 1
 
-exe = minimizeFilename (
-     -*
-     -- this can be a reliable way to get the executable in linux
-     -- but we don't want to use it because we don't want to chase symbolic links and it does that for us
-     processExe := "/proc/self/exe";
-     if fileExists processExe and readlink processExe =!= null then readlink processExe
-     else 
-     *-
-     if isAbsolutePath commandLine#0 then commandLine#0 else
-     if isStablePath commandLine#0 then concatenate(currentDirectory()|commandLine#0)
-     else pathsearch commandLine#0)
-if not isAbsolutePath exe then exe = currentDirectory() | exe ;
-exe = concatenate(realpath dir exe, base exe)
-if notify then printerr("executable = ", exe)
+-- also calls initcurrentlayout()
+srcversion = M2version()
 
 if firstTime and not nobanner then (
      if topLevelMode === TeXmacs then stderr << TeXmacsBegin << "verbatim:";
-     stderr << "Macaulay2, version " << m2version << newline << flush;
+     stderr << "Macaulay2, version " << srcversion << newline << flush;
      if topLevelMode === TeXmacs then stderr << TeXmacsEnd << flush)
 
 scan(commandLine, arg -> if arg === "-q" then noinitfile = true)
 homeDirectory = getenv "HOME" | "/"
-
-initcurrentlayout()
 
 path = {}
 pkgpath = {}

--- a/M2/Macaulay2/m2/version.m2.in
+++ b/M2/Macaulay2/m2/version.m2.in
@@ -1,7 +1,17 @@
-srcversion := "@PACKAGE_VERSION@"
+-- this file is populated by the build system
+
+gitversion = new HashTable from {
+    "git description" => "@GIT_DESCRIPTION@",
+    "git branch"      => "@GIT_BRANCH@",
+    }
+version = merge(version, gitversion, last)
+protect symbol version
+
+srcversion := version#"git description"
 binversion := version#"VERSION"
-if srcversion =!= binversion
-then stderr << "--warning: mismatch: source code version: " << srcversion << " != executable version " << binversion << endl
+
+if not match(binversion, srcversion)
+then printerr("warning: source code version: ", srcversion, " != executable version ", binversion)
 
 -- Local Variables:
 -- compile-command: "cd $M2BUILDDIR && ./config.status Macaulay2/m2/version.m2"

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -60,6 +60,10 @@ if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE   GIT_DESCRIPTION)
+  if(NOT GIT_DESCRIPTION)
+    message(NOTICE "## Git repository detected, but could not use `git describe`")
+    set(GIT_DESCRIPTION release-${PACKAGE_VERSION})
+  endif()
   execute_process(
     COMMAND ${GIT_EXECUTABLE} branch --show-current
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -547,11 +547,10 @@ case $COMPRESS in
     *) AC_MSG_ERROR(unrecognized option for enable-compress) ;;
 esac
 
-AC_SUBST(GIT_DESCRIPTION)
-GIT_DESCRIPTION=`$GIT describe --tags --dirty || echo release-$PACKAGE_VERSION`
-AC_DEFINE_UNQUOTED(GIT_DESCRIPTION,"$GIT_DESCRIPTION",[summary of git status])
-GIT_BRANCH=`$GIT branch --show-current`
-AC_DEFINE_UNQUOTED([GIT_BRANCH], ["$GIT_BRANCH"], [current git branch])
+AC_SUBST([GIT_DESCRIPTION],
+         [`$GIT describe --tags --dirty || echo release-$PACKAGE_VERSION`])
+AC_SUBST([GIT_BRANCH],
+         [`$GIT branch --show-current`])
 
 AC_SUBST(DEB,no)
 AC_ARG_ENABLE(deb,  AS_HELP_STRING(--enable-deb,prepare a *.deb package (for debian, ubuntu, ...)), DEB=$enableval)


### PR DESCRIPTION
Finally closes #3250, which has been _such_ a pain ...

The main difficulty was rearranging startup.m2 to:
1. set prefixDirectory
2. set currentLayout
3. and based on those find the Core directory where version.m2 lives

all before the version is printed.

If `version.m2` is not found, for whatever reason, we get:
```m2
Macaulay2, version 1.24.05-bin (version.m2 not found)
```
The "-bin" indicates that this is the version stored in the binary only.