### PR TITLE
Use code() instead of help() for "methods" test

### DIFF
--- a/M2/Macaulay2/tests/normal/methods.m2
+++ b/M2/Macaulay2/tests/normal/methods.m2
@@ -129,7 +129,7 @@ assert( chainComplex (new X) === new X )
 
 -- this should list (net/info, HypertextContainer),
 -- even though HypertextContainer is not exported.
-assert(2 == length methods parent class help())
+assert(2 == length methods parent class code first)
 -- this used to fail because of a bug in (package, Sequence)
 debug Core
 assert(1 == length methods needsPackage "FirstPackage")


### PR DESCRIPTION
We just want something that returns a `DIV`, and calling `help()` during a test can run out of memory on some systems.

See https://github.com/Macaulay2/M2/pull/3382#discussion_r1713098508