### PR TITLE
Load init.m2 after loading Core but before preloaded packages

### DIFF
--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -484,7 +484,6 @@ export {
 	"addDependencyTask",
 	"addEndFunction",
 	"addHook",
-	"addStartFunction",
 	"addStartTask",
 	"adjoint",
 	"adjoint'",

--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -49,6 +49,7 @@ addStartFunction( () -> (
 	if not noinitfile
 	then load(applicationDirectory() | "init.m2")))
 
+-- packages are loaded after init.m2, so preloaded packages can be adjusted
 addStartFunction( () -> (
 	if not isMember("--no-preload", commandLine)
 	then for pkg in Core#"preloaded packages" do needsPackage pkg))

--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -37,13 +37,23 @@ addStartFunction(
      	       dismiss "User";
 	       newPackage("User",
 		   Headline       => "default package for interpreter interactions",
-		   DebuggingMode  => true,
-		   PackageImports => if isMember("--no-preload", commandLine) then {} else Core#"preloaded packages");
+		   DebuggingMode  => true);
 	       User.PackageIsLoaded = true;
 	       path = prepend("./",path); -- now we search also the user's current directory, since our files have already been loaded
 	       path = unique apply( path, minimizeFilename);	    -- beautify
 	       allowLocalCreation User#"private dictionary";
-	       );
+	       )))
+
+-- the location of init.m2 is documented in the node "initialization file"
+addStartFunction( () -> (
+	if not noinitfile
+	then load(applicationDirectory() | "init.m2")))
+
+addStartFunction( () -> (
+	if not isMember("--no-preload", commandLine)
+	then for pkg in Core#"preloaded packages" do needsPackage pkg))
+
+addStartFunction( () -> (
 	  if not nobanner then (
 	       if topLevelMode === TeXmacs then stderr << TeXmacsBegin << "verbatim:";
 	       relevant := select(loadedPackages,mentionQ);

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -81,11 +81,11 @@ if firstTime then (
 	  symbol currentPrompts <- noPrompts;
 	  );
 
-     startFunctions := {};
+     startFunctions = {};
      addStartFunction = f -> ( startFunctions = append(startFunctions,f); f);
      runStartFunctions = () -> scan(startFunctions, f -> f());
 
-     endFunctions := {};
+     endFunctions = {};
      addEndFunction = f -> ( endFunctions = append(endFunctions,f); f);
      runEndFunctions = () -> (
 	  save := endFunctions;

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -609,10 +609,6 @@ loadCore = path -> (
 
 (loadDepth = 3; processCommandLineOptions 3; loadDepth = 0)
 
-if class Core =!= Symbol and not core "noinitfile" then (
-    -- the location of init.m2 is documented in the node "initialization file"
-    trySimpleLoad("init.m2", applicationDirectory() | "init.m2"));
-
 (core "runStartFunctions")()
 
 loadDepth = 0;

--- a/M2/Macaulay2/packages/Macaulay2Doc/system.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/system.m2
@@ -43,7 +43,6 @@ document {
 	"Dumping and restoring the state of the system:",
 	  TO "top level loop", -- see repl.m2
 	  TO "restart",
-	  TO "addStartFunction",
 	  TO "addEndFunction",
 	"Interface to the operating system:",
 	  TO "alarm",
@@ -593,16 +592,7 @@ document {
 	  afresh, as described in ", TO "Invoking the program", "."
 	  }
      }
-document {
-     Key => addStartFunction,
-     Headline => "add a startup function",
-     Usage => "addStartFunction f",
-     Inputs => { "f" => Function },
-     Consequences => {
-	  {"When the program restarts, the function ", TT "f", " will be called, with no arguments."}
-	  },
-     SeeAlso => {"addEndFunction"}
-     }
+
 document {
      Key => addEndFunction,
      Headline => "add an ending function",
@@ -610,8 +600,7 @@ document {
      Inputs => { "f" => Function },
      Consequences => {
 	  {"When the program is about the exit, the function ", TT "f", " will be called, with no arguments."}
-	  },
-     SeeAlso => {"addStartFunction"}
+	  }
      }
 
 document {


### PR DESCRIPTION
This way, we can call `importFrom_Core` from `init.m2` without sacrificing the ability to modify the list of preloaded packages.

Closes: #3410