### PR TITLE
Remove unused semicolonfun (; is not a binary operator)

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -713,8 +713,6 @@ bitnotfun(e:Expr):Expr := (
     else WrongArgZZ());
 setupfun("bitnotfun", bitnotfun);
 
-semicolonfun(lhs:Code,rhs:Code):Expr := when eval(lhs) is err:Error do Expr(err) else eval(rhs);
-setup(SemicolonS,semicolonfun);
 starfun(rhs:Code):Expr := unarymethod(rhs,StarS);
 timesfun(lhs:Code,rhs:Code):Expr := (
      l := eval(lhs);


### PR DESCRIPTION
This would only be used if `x ; y` was converted into a `binaryCode` object, but it's converted into a `semiCode` object instead.