### PR TITLE
Fix code location when reading history from a file

### DIFF
--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -143,6 +143,8 @@ char *system_getHistory(const int n)
   return NULL;
 }
 
+int system_historyLength() { return history_length; }
+
 void system_initReadlineVariables(void) {
   static char readline_name[] = "M2";
   static char basic_word_break_characters[] = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r";

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -686,6 +686,14 @@ appendHistory(e:Expr):Expr := (
     else WrongNumArgs(2));
 setupfun("appendHistory", appendHistory);
 
+historyLength(e:Expr):Expr := (
+    when e
+    is s:Sequence do (
+	if length(s) == 0 then toExpr(historyLength())
+	else WrongNumArgs(0))
+    else WrongNumArgs(0));
+setupfun("historyLength", historyLength);
+
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d interp.o "
 -- End:

--- a/M2/Macaulay2/d/system.d
+++ b/M2/Macaulay2/d/system.d
@@ -180,6 +180,7 @@ import getHistory(n:int):charstar;
 import addHistory(s:charstar):void;
 import appendHistory(n:int,f:charstar):int;
 import readHistory(f:charstar):int;
+import historyLength():int;
 import chdir(name:string):int;
 import initReadlineVariables():void;
 import handleInterruptsSetup(handleInterrupts:bool):void;

--- a/M2/Macaulay2/m2/Core.m2
+++ b/M2/Macaulay2/m2/Core.m2
@@ -123,9 +123,8 @@ historyFilename = "history.m2"
 historyOffset = 0;
 
 if not noinitfile and not gotarg "--no-readline" then (
-    addStartFunction(() -> (
-	    readHistory(applicationDirectory() | historyFilename);
-	    historyOffset = historyLength()));
+    readHistory(applicationDirectory() | historyFilename);
+    historyOffset = historyLength();
     -- TODO: find a better alternative to addEndFunction, because
     -- exiting with Ctrl+D duplicates the last line of history file,
     -- but if we use lineNumber-1, then exit and restart miss the first

--- a/M2/Macaulay2/m2/Core.m2
+++ b/M2/Macaulay2/m2/Core.m2
@@ -120,9 +120,12 @@ needs = filename -> if not filesLoaded#?filename then load filename else (
 -- Setup persistent history
 -----------------------------------------------------------------------------
 historyFilename = "history.m2"
+historyOffset = 0;
 
 if not noinitfile and not gotarg "--no-readline" then (
-    addStartFunction(() -> readHistory(applicationDirectory() | historyFilename));
+    addStartFunction(() -> (
+	    readHistory(applicationDirectory() | historyFilename);
+	    historyOffset = historyLength()));
     -- TODO: find a better alternative to addEndFunction, because
     -- exiting with Ctrl+D duplicates the last line of history file,
     -- but if we use lineNumber-1, then exit and restart miss the first

--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -65,7 +65,8 @@ code FilePosition := x -> (
 	       else if filename === "stdio" then (
 		    start = 1;
 		    stop = x#3 - x#1 + 1;
-		    toString stack apply(x#1..x#3, getHistory))
+		    toString stack apply(x#1..x#3,
+			i -> getHistory(i + historyOffset)))
 	       else (
 		    if not fileExists filename then error ("couldn't find file ", filename);
 		    get filename


### PR DESCRIPTION
At startup, we use a new compiled function (`historyLength()`, which returns the value of readline's `history_length` variable) to determine how many lines of history we've saved from previous sessions.  We add this value to the line numbers of any code from `stdio` when calling `code` so we get the correct lines back when calling `getHistory`.

### Before
```m2
i1 : f = x -> x^2;

i2 : code f

o2 = stdio:1:6-1:11: --source code:
     -- This is the beginning of your Macaulay2 log stored at /home/profzoom/.Macaulay2/history.m2
```

### After
```m2
i1 : f = x -> x^2;

i2 : code f

o2 = stdio:1:4-1:12: --source code:
     f = x -> x^2;
```

Closes: #3415