### PR TITLE
Add support for calling loadPackage for "User" package

### DIFF
--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -39,6 +39,7 @@ addStartFunction(
 		   Headline       => "default package for interpreter interactions",
 		   DebuggingMode  => true,
 		   PackageImports => if isMember("--no-preload", commandLine) then {} else Core#"preloaded packages");
+	       User.PackageIsLoaded = true;
 	       path = prepend("./",path); -- now we search also the user's current directory, since our files have already been loaded
 	       path = unique apply( path, minimizeFilename);	    -- beautify
 	       allowLocalCreation User#"private dictionary";


### PR DESCRIPTION
Previously, we got an error because User.m2 doesn't exist.

The use case I was interested in is creating and running tests outside of a package:

```m2
i1 : TEST "assert(1 + 1 == 2)"

i2 : tests User

o2 = HashTable{0 => TestInput[stdio:1:1-2:1]}

o2 : HashTable

i3 : code 0

o3 =  -- stdio:2:1: location of test code
     assert(1 + 1 == 2)
```

So far, so good!  But now:

```m2
i4 : check User
 -- capturing check(0, "User")                  -- 0.057196 seconds elapsed
stdio:4:5:(3): error: file not found on path: "User.m2"
```
The problem is due to loadPackage, which always tries to load a file.  If we just immediately return the `User` package when `loadPackage "User"` is called, then everything works:

```m2
i2 : check User
 -- capturing check(0, "User")                   -- 0.0576815 seconds elapsed

i3 : 
```