### PR TITLE
Update hashFromAddress function to return larger hashes

### DIFF
--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -37,14 +37,17 @@ export nextHash():hash_t := (
      HashCounter = HashCounter + 1;
      HashCounter);
 
--- Knuth, Art of Computer Programming, Section 6.4
--- constant is approx. 2^64 / phi
-export fibonacciHash(k:hash_t,p:int):hash_t := (
-    Ccode(hash_t, "(11400714819323198485ull * ",k,") >> (64 - ",p,")"));
-
--- hash codes for mutable objects that don't use nextHash
--- we use 9 since #buckets ZZ = 2^9
-export hashFromAddress(e:Expr):hash_t := fibonacciHash(Ccode(hash_t, "(long)", e), 9);
+------------------------------------------------------------
+-- hash codes for mutable objects that don't use nextHash --
+------------------------------------------------------------
+-- We use Fibonacci hashing (Knuth, Art of Computer Programming, Section 6.4)
+-- The constant 11400714819323198485 is approximately 2^64 / phi.
+-- We want to use the p most significant bits for hashing (where 2^p is the
+-- number of buckets), but in practice we use the p least significant bits,
+-- so we swap them.  We use p = 10 here since #buckets Matrix = 2^10.
+export hashFromAddress(e:Expr):hash_t := (
+    x := Ccode(hash_t, "11400714819323198485ull * (unsigned long)", e);
+    Ccode(hash_t, "(", x, " >> 54) | (", x, " << 10)"));
 
 export NULL ::= null();
 


### PR DESCRIPTION
Currently, function closures have relatively small hashes:

```m2
i1 : hash(() -> null)

o1 = 402

i2 : hash(() -> null)

o2 = 251
```

This is because, by construction, they will always be less than 2^9 = 512.  But this leads to occasional [build failures](https://launchpadlibrarian.net/745639495/buildlog_ubuntu-noble-amd64.macaulay2_1.24.05+git202408231026-0ppa202408211846~ubuntu24.04.1_BUILDING.txt.gz):

```m2
ii17 : assert ( hash res =!= hash syz )
testing.m2:24:6:(3):[5]: error: assertion failed
```

On average, we'd expect this build failure to happen 1 out of every 512 builds.  (Note that `res` and `syz` actually have slightly larger hashes -- they're `SpecialExpr` objects and not `FunctionClosure` objects, so we take a linear combination the hashes of the underlying function closures and the `MethodFunctionWithOptions` type.)

Currently, what we do is apply Fibonacci hashing to the address of the function in memory (basically, divide it by the golden ratio) and take only the 9 most significant bits.

The proposal is to move these most significant bits (switching from 9 to 10, since there's at least one hash table -- the type `Matrix` -- with 2^10 buckets) to the end of the hash and the remaining 54 least significant bits to the beginning.  This way, the chances of two functions having the same hash will be vanishingly small, but we still take advantage of Fibonacci hashing when it's time to use the hash to stuff things in a hash table.

So afterwards:

```m2
i1 : hash(() -> null)

o1 = 9799832789158200301

i2 : hash(() -> null)

o2 = 14699749183737299083
```

We also combine the corresponding code into a single function and improve the accompanying comment.