### PR TITLE
Use unlimited virtual memory when running msolve tests (autotools)

### DIFF
--- a/M2/libraries/msolve/Makefile.in
+++ b/M2/libraries/msolve/Makefile.in
@@ -6,5 +6,7 @@ LICENSEFILES = README.md COPYING
 
 PRECONFIGURE = ./autogen.sh
 
+VLIMIT = unlimited
+
 include ../Makefile.library
 Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/msolve/Makefile


### PR DESCRIPTION
Most of the tests fail using the default 400000 kB.

Closes: #3428

Here's a successful run of the tests after this change: https://github.com/d-torrance/M2/actions/runs/10552691192/job/29231880174