### PR TITLE
Only run lint workflow on pull requests (or workflow dispatch)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,10 @@
 name: Lint
-on: [ push, pull_request ]
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - development
 
 jobs:
   codespell:


### PR DESCRIPTION
This way, it won't be run on all pushes of arbitrary branches to developers' forks unless explicitly requested using a workflow dispatch.

Minus the weekly run, the proposed settings are the same as the "Build and Test" workflow.