### PR TITLE
Add finite limit to virtual memory used when checking msolve

### DIFF
--- a/M2/libraries/msolve/Makefile.in
+++ b/M2/libraries/msolve/Makefile.in
@@ -6,7 +6,7 @@ LICENSEFILES = README.md COPYING
 
 PRECONFIGURE = ./autogen.sh
 
-VLIMIT = unlimited
+VLIMIT = 1500000
 
 include ../Makefile.library
 Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/msolve/Makefile


### PR DESCRIPTION
Rather than allowing unlimited virtual memory, we increase the upper bound to 1.5 GB, which should still allow all the tests to pass.

Here's an example of the tests passing after this commit: https://github.com/d-torrance/M2/actions/runs/10561928026/job/29258736811

I ran the tests a bunch of times locally, incrementing the upper bound by 100,000 until they all passed.  By 1.3 GB, they all passed but one (test/diff/diff_nonradical_shape-qq.sh), and then they all passed at 1.4 GB.  I figured I'd round up a bit more to 1.5 GB just in case.