### PR TITLE
small NormalToricVarieties fix

### DIFF
--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
@@ -699,7 +699,7 @@ toricBlowup (List, NormalToricVariety, List) := NormalToricVariety => (s, X, v) 
 	if all (s, i -> member (i,t)) then continue
 	else t | {n}
 	);
-    Z := normalToricVariety (rays X | {v}, coneList | coneList');
+    Z := normalToricVariety (rays X | {v}, coneList | coneList', CoefficientRing => X.cache.CoefficientRing);
     Z.cache.toricBlowup = X;
     Z
     );

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricVarieties.m2
@@ -630,7 +630,7 @@ regularSubdivisionLocal (NormalToricVariety, List, List) := (X,s,w) -> (
 	    coneList = drop (coneList,{k,k}) | coneList') 
 	);
     if coneList == max X then return X;
-    Y := normalToricVariety (rayList, coneList);
+    Y := normalToricVariety (rayList, coneList, CoefficientRing => X.cache.CoefficientRing, Variable => X.cache.Variable);
     Y.cache.Weights = apply (#rayList, i -> wtg i);
     Y 
     );    
@@ -693,13 +693,13 @@ toricBlowup (List, NormalToricVariety, List) := NormalToricVariety => (s, X, v) 
       	    if member (s#0,t) then continue
       	    else sort (t | s)
 	    );
-    	return normalToricVariety (rays X, coneList | coneList') 
+	return normalToricVariety (rays X, coneList | coneList', CoefficientRing => X.cache.CoefficientRing, Variable => X.cache.Variable)
 	);
     coneList' = for t in clStar list (
 	if all (s, i -> member (i,t)) then continue
 	else t | {n}
 	);
-    Z := normalToricVariety (rays X | {v}, coneList | coneList', CoefficientRing => X.cache.CoefficientRing);
+    Z := normalToricVariety (rays X | {v}, coneList | coneList', CoefficientRing => X.cache.CoefficientRing, Variable => X.cache.Variable);
     Z.cache.toricBlowup = X;
     Z
     );


### PR DESCRIPTION
Several methods in NormalToricVarieties (notably toricBlowup and thus makeSmooth and makeSimplicial) were discarding the CoefficientRing and Variable of the input toric variety. This fixes that by retaining these options from the input toric variety. 