### PR TITLE
Fix check(11, "SumsOfSquares") on Fedora rawhide

### DIFF
--- a/M2/Macaulay2/packages/SemidefiniteProgramming.m2
+++ b/M2/Macaulay2/packages/SemidefiniteProgramming.m2
@@ -37,7 +37,6 @@ export {
     "changeSolver",
     "criticalIdeal",
 --Method options
-    "Verbosity",
     "Solver",
     "Scaling"
 }

--- a/M2/Macaulay2/packages/SumsOfSquares.m2
+++ b/M2/Macaulay2/packages/SumsOfSquares.m2
@@ -63,7 +63,7 @@ export {
 --##########################################################################--
 
 -- Constants
-MaxRoundTol = 32 --maximum rounding tolerance
+MaxRoundTol = 33 --maximum rounding tolerance
 HighPrecision = 1e-10 --e.g. for numerical linear algebra
 MedPrecision = 1e-6 --e.g. for SDP solutions
 LowPrecision = 1e-4


### PR DESCRIPTION
As reported in https://github.com/Macaulay2/M2/issues/1579#issuecomment-2282749223, `check(11, "SumsOfSquares")` is failing on Fedora rawhide due an update in the csdp package.  (For an example of a failing build, see https://github.com/d-torrance/M2-workflows/actions/runs/10609828175/job/29406195683.)

The problem was that it gave up trying to round a real matrix to a rational matrix after 32 attempts.  If we bump this to 33, then it passes.  (For a successful run on Fedora rawhide, see https://github.com/d-torrance/M2/actions/runs/10632956367/job/29476969319.)

Also, a slightly related change: we stop exporting the `Verbosity` symbol in the SemidefiniteProgramming package (which is exported by SumsOfSquares and handles the csdp interface) since it's now exported by Core.

Cc: @diegcif, @tom111 