### PR TITLE
fixing some typos in packages

### DIFF
--- a/M2/Macaulay2/packages/Bertini/doc.m2
+++ b/M2/Macaulay2/packages/Bertini/doc.m2
@@ -1012,7 +1012,7 @@ doc ///
    S=importPoints(l,n)
  Inputs
    l: String
-     A string giving the  locaton of a Bertini solution file.
+     A string giving the location of a Bertini solution file.
    n: ZZ
      Number of coordinates for each solution.
  Outputs

--- a/M2/Macaulay2/packages/DGAlgebras.m2
+++ b/M2/Macaulay2/packages/DGAlgebras.m2
@@ -3414,7 +3414,7 @@ doc///
    a list, array or sequence representing a (single) multi-index in the complex defined by A
  Description
   Text
-   For example, consder the first five steps in the resolution of the residue field
+   For example, consider the first five steps in the resolution of the residue field
    in the following example:
   Example
    R = QQ[x,y,z]/(ideal(x^3,y^3,z^3,x*y*z))

--- a/M2/Macaulay2/packages/Divisor.m2
+++ b/M2/Macaulay2/packages/Divisor.m2
@@ -3637,7 +3637,7 @@ doc ///
 	Headline
 	 compute the ramification divisor of a finite inclusion of normal domains or a blowup over a smooth base
 	Usage
-	 ramficationDivisor( f )
+	 ramificationDivisor( f )
 	Inputs
 	 f: RingMap
 	 b: Boolean
@@ -3654,7 +3654,7 @@ doc ///
 	  f = map(S, R, {y^3});
 	  ramificationDivisor(f)
 	 Text
-	  The next example is a Veronese which is etale in codimension 1.
+	  The next example is a Veronese which is étale in codimension 1.
 	 Example
 	  R = QQ[x,y];
 	  T = QQ[a,b,c,d];

--- a/M2/Macaulay2/packages/LieTypes.m2
+++ b/M2/Macaulay2/packages/LieTypes.m2
@@ -1219,7 +1219,7 @@ fusionProduct(LieAlgebraModule,LieAlgebraModule,ZZ) := (V,W,l) -> (
         	while cnt < #pr do (
 --		    s := sum(u,pr'#i,times);
 		    s := killingForm(g,u,pr#i); -- is the same just more explicit
-		    sn := numerator s; sd := denominator s; -- in non simply laced types, there can be a denimonator
+		    sn := numerator s; sd := denominator s; -- in non simply laced types, there can be a denominator
 		    if sd == 1 and sn % l == 0 then break else if s < -l or s > l then (
 			u=u-((sn+l*sd)//(2*l*sd))*l*pr#i;
 			cnt=0;

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/reducedRowEchelonForm-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/reducedRowEchelonForm-doc.m2
@@ -9,7 +9,7 @@ doc ///
         R = reducedRowEchelonForm A
     Inputs
         A:Matrix
-            or @ofClass MutableMatrix@, a matrix over eiither a finite field or the rationals
+            or @ofClass MutableMatrix@, a matrix over either a finite field or the rationals
     Outputs
         R:Matrix
             or @ofClass MutableMatrix@, the same type as {\tt A}, the 

--- a/M2/Macaulay2/packages/MatrixSchubert/MatrixSchubertConstructionsDOC.m2
+++ b/M2/Macaulay2/packages/MatrixSchubert/MatrixSchubertConstructionsDOC.m2
@@ -718,7 +718,7 @@ doc ///
     	:Ideal
     Description
         Text
-            Given a permutation in 1-line notation or, more generally, a partial alternating sign matrix, outputs the associated alternating sign matrix ideal (which is called a Schubert determinantal ideal in the case of a permutation).  (The convention throughout this package is that the permutation matrix of a pemutation $w$ has 1's in positions $(i,w(i))$.)
+            Given a permutation in 1-line notation or, more generally, a partial alternating sign matrix, outputs the associated alternating sign matrix ideal (which is called a Schubert determinantal ideal in the case of a permutation).  (The convention throughout this package is that the permutation matrix of a permutation $w$ has 1's in positions $(i,w(i))$.)
 	    
 	    This function computes over the coefficient field of rational numbers unless an alternative is specified.
         Example

--- a/M2/Macaulay2/packages/NoetherianOperators.m2
+++ b/M2/Macaulay2/packages/NoetherianOperators.m2
@@ -1686,7 +1686,7 @@ polynomialAnn = (F') -> (
     ideal mingens ideal (allMons * mingens ker coeffs)        
 )
 
--- computes the annilihator of a vector space V of polynomials
+-- computes the annihilator of a vector space V of polynomials
 -- typically one expects that V is close under differentiation
 -- Input: a list which is a basis of V. Output: the ideal annihilator.
 vectorAnn = (V) -> (
@@ -1783,7 +1783,7 @@ polynomialVectorAnn = (F) -> (
     (mons, coeffs) := coefficients diffMat;
     image mingens image (allMons * mingens ker coeffs)        
 )
--- computes the annilihator of a vector space V of polynomials
+-- computes the annihilator of a vector space V of polynomials
 vectorSpaceAnn = (W) -> (
     intersect(apply(W / matrix, F -> polynomialVectorAnn(F)))      
 )

--- a/M2/Macaulay2/packages/OldPolyhedra.m2
+++ b/M2/Macaulay2/packages/OldPolyhedra.m2
@@ -1684,7 +1684,7 @@ fVector Cone := C -> apply(C#"dimension of the cone" + 1, d -> #faces(dim C - d,
 --  OUTPUT : 'L',  a list containing the Hilbert basis as one column matrices 
 hilbertBasis = method(TypicalValue => List)
 hilbertBasis Cone := C -> (
-     -- Computing the row echolon form of the matrix M
+     -- Computing the row echelon form of the matrix M
      ref := M -> (
 	  n := numColumns M;
 	  s := numRows M;
@@ -3794,7 +3794,7 @@ chkQQZZ = (M,msg) -> (
 
 
 -- PURPOSE : Computing the Hilbert basis of a standardised cone (project and lift algorithm
---   INPUT : 'A' a matrix, the row echolon form of the defining half-spaces of the cone
+--   INPUT : 'A' a matrix, the row echelon form of the defining half-spaces of the cone
 --  OUTPUT : a list of one column matrices, the generators of the cone over A intersected with 
 --     	     the positive orthant
 constructHilbertBasis = A -> (

--- a/M2/Macaulay2/packages/supplanted-packages/Polyhedra.m2
+++ b/M2/Macaulay2/packages/supplanted-packages/Polyhedra.m2
@@ -1216,7 +1216,7 @@ fVector Cone := C -> apply(C#"dimension of the cone" + 1, d -> #faces(dim C - d,
 --  OUTPUT : 'L',  a list containing the Hilbert basis as one column matrices 
 hilbertBasis = method(TypicalValue => List)
 hilbertBasis Cone := C -> (
-     -- Computing the row echolon form of the matrix M
+     -- Computing the row echelon form of the matrix M
      ref := M -> (
 	  n := numColumns M;
 	  s := numRows M;
@@ -2719,7 +2719,7 @@ chkZZQQ = (M,msg) -> (
 
 
 -- PURPOSE : Computing the Hilbert basis of a standardised cone (project and lift algorithm
---   INPUT : 'A' a matrix, the row echolon form of the defining half-spaces of the cone
+--   INPUT : 'A' a matrix, the row echelon form of the defining half-spaces of the cone
 --  OUTPUT : a list of one column matrices, the generators of the cone over A intersected with 
 --     	     the positive orthant
 constructHilbertBasis = A -> (

--- a/M2/Macaulay2/packages/undistributed-packages/Polyhedra2.m2
+++ b/M2/Macaulay2/packages/undistributed-packages/Polyhedra2.m2
@@ -608,7 +608,7 @@ hilbertBasis Cone := opts->C -> (
      if C#?"HilbertBasis" then return (apply(numRows C#"HilbertBasis",i->(transpose C#"HilbertBasis")_{i}));
      if opts#UsePolymake then runPolymake(C,"HilbertBasis")
      else (
-     -- Computing the row echolon form of the matrix M
+     -- Computing the row echelon form of the matrix M
      ref := M -> (
 	  n := numColumns M;
 	  s := numRows M;


### PR DESCRIPTION
just fixing a few typos, found using something like

`egrep -Rw --no-filename -o '[a-z]+ules?' packages/ | sort | uniq -c | sort -rn`
