### PR TITLE
Fix bug when displaying example errors

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -770,7 +770,7 @@ installPackage Package := opts -> pkg -> (
 	verboseLog("making example result files in ", minimizeFilename exampleOutputDir);
 	generateExampleResults(pkg, rawDocumentationCache, exampleDir, exampleOutputDir, verboseLog, pkgopts, opts);
 
-	if 0 < numExampleErrors then verboseLog concatenate apply(readDirectory exampleOutputDir,
+	if 0 < numExampleErrors then verboseLog stack apply(readDirectory exampleOutputDir,
 	    file -> if match("\\.errors$", file) then stack {
 		file, concatenate(width file : "*"), getErrors(exampleOutputDir | file)});
 


### PR DESCRIPTION
We were trying to concatenate a list of nets, but `concatenate` expects a list of strings.

### Before

Consider the following simple package:

```m2
newPackage("Foo", Headline => "foo",)
beginDocumentation()

doc ///
  Key
    Foo
  Description
    Example
      1/0
///
```

Of course, we get an error when installing it, but it's the wrong error!

```m2
i1 : installPackage("Foo", FileName => "Foo.m2")
 -- making example results for "Foo"                                        
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-1280044-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --no-randomize --no-readline --silent --stop --print-width 77 -e 'needsPackage("Foo",Reload=>true,FileName=>"/home/profzoom/tmp/Foo.m2")' <"/tmp/M2-1280044-0/0___Foo.m2" >>"/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/___Foo.errors" 2>&1
/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/___Foo.errors:0:1:(3):[10]: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-1280044-0/0___Foo.m2:0:1: (input file)
M2: *** Error 1
 -- 1.04873s elapsed
stdio:1:14:(3): error: expected strings, integers, or symbols
```
### After

```m2
i1 : installPackage("Foo", FileName => "Foo.m2")
 -- making example results for "Foo"                                        
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-1280380-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --no-randomize --no-readline --silent --stop --print-width 77 --srcdir "/home/profzoom/src/macaulay2/M2/M2" -e 'needsPackage("Foo",Reload=>true,FileName=>"/home/profzoom/tmp/Foo.m2")' <"/tmp/M2-1280380-0/0___Foo.m2" >>"/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/___Foo.errors" 2>&1
/home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/___Foo.errors:0:1:(3):[10]: (output file) error: Macaulay2 exited with status code 1
/tmp/M2-1280380-0/0___Foo.m2:0:1: (input file)
M2: *** Error 1
 -- 1.13406s elapsed
stdio:1:14:(3): error: installPackage: 1 error(s) occurred in running examples for package Foo
```