### PR TITLE
Remove unused "setup" functions in interpreter

### DIFF
--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -810,7 +810,7 @@ export notFun(rhs:Code):Expr := (
      else if a == True then False
      else if a == False then True
      else unarymethod(a,notS));
-setup(notS,notFun);
+setupop(notS,notFun);
 EqualEqualEqualfun(lhs:Code,rhs:Code):Expr := (
     -- # typical value: symbol ===, Thing, Thing, Boolean
      x := eval(lhs);

--- a/M2/Macaulay2/d/common.d
+++ b/M2/Macaulay2/d/common.d
@@ -49,26 +49,6 @@ export pos(c:Code):void := (					    -- for use in the debugger
      stdIO << codePosition(c) << endl;
      );
 
-export setup(word:Word):void := (
-     makeSymbol(word,dummyPosition,globalDictionary);
-     );
-export setup(word:Word,fn:unop):void := (
-     e := makeSymbol(word,dummyPosition,globalDictionary);
-     unopNameList = unopNameListCell(fn,e,unopNameList);
-     e.unary = fn;
-     );
-export setup(word:Word,fn:binop):void := (
-     e := makeSymbol(word,dummyPosition,globalDictionary);
-     binopNameList = binopNameListCell(fn,e,binopNameList);
-     e.binary = fn;
-     );
-export setup(word:Word,fun1:unop,fun2:binop):void := (
-     e := makeSymbol(word,dummyPosition,globalDictionary);
-     unopNameList = unopNameListCell(fun1,e,unopNameList);
-     binopNameList = binopNameListCell(fun2,e,binopNameList);
-     e.unary = fun1;
-     e.binary = fun2;
-     );
 export setuppostfix(e:SymbolClosure,fn:unop):void := (
      unopNameList = unopNameListCell(fn,e.symbol,unopNameList);
      e.symbol.postfix = fn;

--- a/M2/Macaulay2/d/common.d
+++ b/M2/Macaulay2/d/common.d
@@ -69,13 +69,6 @@ export setup(word:Word,fun1:unop,fun2:binop):void := (
      e.unary = fun1;
      e.binary = fun2;
      );
-export setup(word:Word,fun1:unop,fun2:unop):void := (
-     e := makeSymbol(word,dummyPosition,globalDictionary);
-     unopNameList = unopNameListCell(fun2,e,unopNameList);
-     unopNameList = unopNameListCell(fun1,e,unopNameList);
-     e.unary = fun1;
-     e.postfix = fun2;
-     );
 export setup(e:SymbolClosure,fn:unop):void := (
      unopNameList = unopNameListCell(fn,e.symbol,unopNameList);
      e.symbol.unary = fn;
@@ -93,12 +86,6 @@ export setup(e:SymbolClosure,fun1:unop,fun2:binop):void := (
      binopNameList = binopNameListCell(fun2,e.symbol,binopNameList);
      e.symbol.unary = fun1;
      e.symbol.binary = fun2;
-     );
-export setup(e:SymbolClosure,fun1:unop,fun2:unop):void := (
-     unopNameList = unopNameListCell(fun1,e.symbol,unopNameList);
-     unopNameList = unopNameListCell(fun2,e.symbol,unopNameList);
-     e.symbol.unary = fun1;
-     e.symbol.postfix = fun2;
      );
 export setupop(s:SymbolClosure,fun:unop):void := (
      unopNameList = unopNameListCell(fun,s.symbol,unopNameList);

--- a/M2/Macaulay2/d/common.d
+++ b/M2/Macaulay2/d/common.d
@@ -69,10 +69,6 @@ export setup(word:Word,fun1:unop,fun2:binop):void := (
      e.unary = fun1;
      e.binary = fun2;
      );
-export setup(e:SymbolClosure,fn:unop):void := (
-     unopNameList = unopNameListCell(fn,e.symbol,unopNameList);
-     e.symbol.unary = fn;
-     );
 export setuppostfix(e:SymbolClosure,fn:unop):void := (
      unopNameList = unopNameListCell(fn,e.symbol,unopNameList);
      e.symbol.postfix = fn;

--- a/M2/Macaulay2/d/common.d
+++ b/M2/Macaulay2/d/common.d
@@ -73,14 +73,6 @@ export setup(e:SymbolClosure,fn:ternop):void := (
 export setup(e:SymbolClosure,fn:multop):void := (
      multopNameList = multopNameListCell(fn,e.symbol,multopNameList);
      );
-export setupfun(name:string,fun:unop):Symbol := (
-     word := makeUniqueWord(name,
-	  parseinfo(precSpace,precSpace,precSpace,parsefuns(unaryop, defaultbinary)));
-     entry := makeSymbol(word,dummyPosition,globalDictionary);
-     unopNameList = unopNameListCell(fun,entry,unopNameList);
-     entry.unary = fun;
-     entry.Protected = true;
-     entry);
 export setupfun(name:string, value:function(Expr):Expr):Symbol := (
      word := makeUniqueWord(name,parseWORD);
      entry := makeSymbol(word,dummyPosition,globalDictionary);


### PR DESCRIPTION
This is based on a few commits that I'd originally proposed in #3419.

We remove some of the `setup` family of functions in `common.d` (which are used for associating a symbol with its function) that weren't being used anywhere:

* All of them that accept a `Word` argument.
* `setup(SymbolClosure, unop, unop)` (for unary operators that are both prefix and postfix, of which we have none)
* `setupfun(string, unop)`

We also remove `setup(SymbolClosure, unop)` since it was identical to `setupop`.