### PR TITLE
Add ts file for Macaulay2Web syntax highlighting

### DIFF
--- a/M2/Macaulay2/editors/Macaulay2Web/M2-symbols.ts.in
+++ b/M2/Macaulay2/editors/Macaulay2Web/M2-symbols.ts.in
@@ -1,0 +1,1 @@
+export default [@M2SYMBOLS@];

--- a/M2/Macaulay2/editors/make-M2-symbols.m2
+++ b/M2/Macaulay2/editors/make-M2-symbols.m2
@@ -151,6 +151,12 @@ symbolsForTextMate = template -> (
     output = replace("@M2CONSTANTS@", demark("|", CONSTANTS), output);
     output)
 
+symbolsForMacaulay2Web = template -> (
+    output := concatenate("// ", banner, newline, newline, template);
+    output = replace("@M2VERSION@",   version#"VERSION",    output);
+    output = replace("@M2SYMBOLS@",   demark(",", format \ SYMBOLS), output);
+    output)
+
 -------------------------------------------------------------------------------
 -- Generate syntax files from templates in the same directory
 
@@ -186,6 +192,10 @@ generateGrammar("pygments/macaulay2.py", symbolsForPygments)
 generateGrammar("highlightjs/macaulay2.js", symbolsForHighlightJS)
 
 generateGrammar("textmate/macaulay2.tmLanguage.json", symbolsForTextMate)
+
+-- Macaulay2Web: Write M2-symbols.ts
+generateGrammar("Macaulay2Web/M2-symbols.ts", symbolsForMacaulay2Web)
+
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/emacs M2-symbols "


### PR DESCRIPTION
f7dabde33694f8df59509b886413abd89ba4c5ea removed a line from `macaulay2.js.in` which was used by Macaulay2Web.
Since Macaulay2Web uses typescript anyway, a new file `macaulay2.ts.in` is created with the missing line put back, and a comment that it's used by Macaulay2Web.