### PR TITLE
Check to see if we need to link against CoCoA when detecting libnormaliz (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1045,6 +1045,7 @@ AS_IF([test $BUILD_normaliz = no],
 	       SAVELIBS=$LIBS
 	       LIBS="$LIBS -lnormaliz -lnauty -lgmp"
 	       CHECK_NMZ_PACKAGE([ENFNORMALIZ], [-leantic -leanticxx])
+	       CHECK_NMZ_PACKAGE([NMZ_COCOA], [-lcocoa])
 	       AC_LINK_IFELSE(
 		   [AC_LANG_PROGRAM([
 		       #include <libnormaliz/cone.h>

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1021,6 +1021,19 @@ else AC_MSG_RESULT([no, will build])
      BUILD_csdp=yes
 fi
 
+AC_DEFUN([CHECK_NMZ_PACKAGE],
+    [AC_RUN_IFELSE(
+        [AC_LANG_PROGRAM([
+	    #include <libnormaliz/nmz_config.h>
+	    ], [
+	    #ifdef $1
+	      return 0;
+	    #else
+	      return 1;
+	    #endif
+	    ])],
+	[LIBS="$LIBS $2"])])
+
 AS_IF([test $BUILD_normaliz = no],
     [AC_MSG_CHECKING(whether the package normaliz is installed)
      AS_IF([command -v normaliz > /dev/null],
@@ -1031,18 +1044,7 @@ AS_IF([test $BUILD_normaliz = no],
 	       AC_LANG(C++)
 	       SAVELIBS=$LIBS
 	       LIBS="$LIBS -lnormaliz -lnauty -lgmp"
-	       dnl check if libnormaliz built w/ eantic
-	       AC_RUN_IFELSE(
-	           [AC_LANG_PROGRAM([
-		       #include <libnormaliz/nmz_config.h>
-		       ], [
-		       #ifdef ENFNORMALIZ
-		         return 0;
-		       #else
-		         return 1;
-		       #endif
-		       ])],
-		   [LIBS="$LIBS -leantic -leanticxx"])
+	       CHECK_NMZ_PACKAGE([ENFNORMALIZ], [-leantic -leanticxx])
 	       AC_LINK_IFELSE(
 		   [AC_LANG_PROGRAM([
 		       #include <libnormaliz/cone.h>

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1043,9 +1043,10 @@ AS_IF([test $BUILD_normaliz = no],
 	       AC_MSG_CHECKING([for libnormaliz])
 	       AC_LANG(C++)
 	       SAVELIBS=$LIBS
-	       LIBS="$LIBS -lnormaliz -lnauty -lgmp"
+	       LIBS="$LIBS -lnormaliz -lgmp"
 	       CHECK_NMZ_PACKAGE([ENFNORMALIZ], [-leantic -leanticxx])
 	       CHECK_NMZ_PACKAGE([NMZ_COCOA], [-lcocoa])
+	       CHECK_NMZ_PACKAGE([NMZ_NAUTY], [-lnauty])
 	       AC_LINK_IFELSE(
 		   [AC_LANG_PROGRAM([
 		       #include <libnormaliz/cone.h>


### PR DESCRIPTION
On Fedora, the autotools check for libnormaliz was failing because the Fedora normaliz package is built with CoCoA support.  We add a check, similar to the existing one for e-antic, to see if we need to add `-lcocoa` to the build flags when detecting it.

We introduce a macro, `CHECK_NMZ_PACKAGE`, to simplify this process and also use it to check if libnormaliz was built with nauty support.