### PR TITLE
Regenerate configure script when building mpsolve (autotools)

### DIFF
--- a/M2/libraries/mpsolve/Makefile.in
+++ b/M2/libraries/mpsolve/Makefile.in
@@ -15,6 +15,8 @@ LICENSEFILES = README
 # their use of libtool prevents this from working -- somehow "make install" rebuilds mpsolve during the installation, after we strip it
 # STRIPFILES = src/mpsolve/mpsolve
 
+PRECONFIGURE = autoreconf -fvi
+
 INSTALLTARGET = install-strip
 CONFIGOPTIONS += --disable-shared		\
 		 --disable-dependency-tracking	\


### PR DESCRIPTION
The configure script shipped in the tarball tries to run aclocal-1.16, but automake 1.17 was recently released and 1.16 is no longer available on some systems (e.g., Arch Linux).

For example (from https://github.com/d-torrance/M2-workflows/actions/runs/10797383121/job/29948523223);

```
+ make -j1 prefix=/__w/M2-workflows/M2-workflows/M2/M2/BUILD/usr-host
make: Entering directory '/__w/M2-workflows/M2-workflows/M2/M2/BUILD/libraries/mpsolve/build/mpsolve-3.2.1'
make[3]: Entering directory '/__w/M2-workflows/M2-workflows/M2/M2/BUILD/libraries/mpsolve/build/mpsolve-3.2.1'
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh /__w/M2-workflows/M2-workflows/M2/M2/BUILD/libraries/mpsolve/build/mpsolve-3.2.1/missing aclocal-1.16 -I m4
/__w/M2-workflows/M2-workflows/M2/M2/BUILD/libraries/mpsolve/build/mpsolve-3.2.1/missing: line 81: aclocal-1.16: command not found
WARNING: 'aclocal-1.16' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <https://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <https://www.gnu.org/software/autoconf>
         <https://www.gnu.org/software/m4/>
make[3]: Leaving directory '/__w/M2-workflows/M2-workflows/M2/M2/BUILD/libraries/mpsolve/build/mpsolve-3.2.1'
         <https://www.perl.org/>
make[3]: *** [Makefile:458: aclocal.m4] Error 127
```