### PR TITLE
Probability package updates

### DIFF
--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -63,6 +63,12 @@ export rawRandomRR(e:Expr):Expr := (
      else toExpr(Ccode(RR, "rawRandomRR(", toULong(prec.v), ")"))
      else WrongArgZZ());
 setupfun("rawRandomRR",rawRandomRR);
+export rawRandomRRNormal(e:Expr):Expr := (
+     when e
+     is prec:ZZcell do if !isULong(prec.v) then WrongArgSmallInteger()
+     else toExpr(Ccode(RR, "rawRandomRRNormal(", toULong(prec.v), ")"))
+     else WrongArgZZ());
+setupfun("rawRandomRRNormal",rawRandomRRNormal);
 export rawRandomCC(e:Expr):Expr := (
      when e
      is prec:ZZcell do if !isULong(prec.v) then WrongArgSmallInteger() 

--- a/M2/Macaulay2/e/interface/random.cpp
+++ b/M2/Macaulay2/e/interface/random.cpp
@@ -104,6 +104,15 @@ gmp_RR rawRandomRR(unsigned long precision)
   return moveTo_gmpRR(result);
 }
 
+gmp_RR rawRandomRRNormal(unsigned long precision)
+/* returns a normally distributed random real with the given precision */
+{
+  mpfr_ptr result = getmemstructtype(mpfr_ptr);
+  mpfr_init2(result, precision);
+  mpfr_nrandom(result, state, MPFR_RNDN);
+  return moveTo_gmpRR(result);
+}
+
 gmp_CC rawRandomCC(unsigned long precision)
 /* returns a uniformly distributed random complex in the box [0.0,0.0],
  * [1.0,1.0] */

--- a/M2/Macaulay2/e/interface/random.h
+++ b/M2/Macaulay2/e/interface/random.h
@@ -40,6 +40,9 @@ gmp_RR rawRandomRR(unsigned long prec);
 /* returns a uniformly distributed random real with the given precision, in
  * range [0.0,1.0] */
 
+gmp_RR rawRandomRRNormal(unsigned long prec);
+/* returns a normally distributed random real with the given precision */
+
 gmp_CC rawRandomCC(unsigned long prec);
 
 void randomMpfr(mpfr_t result);

--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -18,8 +18,8 @@
 
 newPackage("Probability",
     Headline => "basic probability functions",
-    Version => "0.4",
-    Date => "January 23, 2024",
+    Version => "0.5",
+    Date => "September 13, 2024",
     Authors => {{
 	    Name     => "Doug Torrance",
 	    Email    => "dtorrance@piedmont.edu",
@@ -46,6 +46,13 @@ newPackage("Probability",
 ---------------
 
 -*
+
+0.5 (2024-09-13, M2 1.24.11)
+* add JSAG info
+* remove Constant methods now that we can use inheritance
+* adjust tests now that we use flint instead of boost for some special functions
+* use mpfr's built-in function for generating normally distributed variates
+* add subnodes to improve docs
 
 0.4 (2024-01-23, M2 1.23)
 * release under GPL

--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -332,6 +332,7 @@ exponentialDistribution Number := lambda -> (
 	QuantileFunction => p -> -log(1 - p) / lambda,
 	Description => "Exp(" | toString lambda | ")"))
 
+importFrom(Core, "rawRandomRRNormal")
 normalDistribution = method()
 normalDistribution(Number, Number) := (mu, sigma) -> (
     checkReal mu;
@@ -342,9 +343,9 @@ normalDistribution(Number, Number) := (mu, sigma) -> (
 	    1/2 * (1 + erf((x - mu) / (sigma * sqrt 2))),
 	QuantileFunction => p ->
 	    mu + sigma * sqrt 2 * inverseErf(2 * p - 1),
-	-- box muller transform
-	RandomGeneration => () ->
-	    mu + sigma * sqrt(-2 * log random 1.) * cos (2 * pi * random 1.),
+	RandomGeneration => (
+	    p := min(precision numeric mu, precision numeric sigma);
+	    () -> mu + sigma * rawRandomRRNormal p),
 	Support => (-infinity, infinity),
 	Description => "N" | toString (mu, sigma)))
 

--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -461,6 +461,8 @@ doc ///
     As is always the case when working with real numbers in Macaulay2,
     unexpected results may occur due to the limitations of floating
     point arithmetic.
+  Subnodes
+    ProbabilityDistribution
 ///
 
 doc ///
@@ -514,6 +516,16 @@ doc ///
       constructor methods, @TO discreteProbabilityDistribution@,
       @TO continuousProbabilityDistribution@, or any of the various built-in
       methods for common distributions.
+  Subnodes
+    :Keys
+    DensityFunction
+    DistributionFunction
+    QuantileFunction
+    RandomGeneration
+    Support
+    :Constructor methods
+    discreteProbabilityDistribution
+    continuousProbabilityDistribution
 ///
 
 doc ///
@@ -527,6 +539,8 @@ doc ///
       @TO discreteProbabilityDistribution@ and
       @TO continuousProbabilityDistribution@ for setting the probability
       density/mass function to be used by @TO density@.
+  Subnodes
+    density
 ///
 
 doc ///
@@ -540,6 +554,8 @@ doc ///
       @TO discreteProbabilityDistribution@ and
       @TO continuousProbabilityDistribution@ for setting the cumulative
       distribution function to be used by @TO probability@.
+  Subnodes
+    probability
 ///
 
 doc ///
@@ -553,6 +569,8 @@ doc ///
       @TO discreteProbabilityDistribution@ and
       @TO continuousProbabilityDistribution@ for setting the quantile function
       to be used by @TO quantile@.
+  Subnodes
+    quantile
 ///
 
 doc ///
@@ -566,6 +584,8 @@ doc ///
       @TO discreteProbabilityDistribution@ and
       @TO continuousProbabilityDistribution@ for setting the random generation
       function to be used by @TO (random, ProbabilityDistribution)@.
+  Subnodes
+    (random, ProbabilityDistribution)
 ///
 
 doc ///
@@ -656,6 +676,8 @@ doc ///
       probability \(S_X(x) = P(X > x)\).
     Example
       probability_Z(1.96, LowerTail => false)
+  Subnodes
+    LowerTail
 ///
 
 doc ///
@@ -793,6 +815,12 @@ doc ///
     When defining a probability mass function, the user must be careful that
     it satisfies the definition, i.e., it must be nonnegative and its values
     must sum to 1 on its support.
+  Subnodes
+    binomialDistribution
+    poissonDistribution
+    geometricDistribution
+    negativeBinomialDistribution
+    hypergeometricDistribution
 ///
 
 doc ///
@@ -861,6 +889,15 @@ doc ///
     When defining a probability density function, the user must be careful that
     it satisfies the definition, i.e., it must be nonnegative and it must
     integrate to 1 on its support.
+  Subnodes
+    uniformDistribution
+    exponentialDistribution
+    normalDistribution
+    gammaDistribution
+    chiSquaredDistribution
+    tDistribution
+    fDistribution
+    betaDistribution
 ///
 
 doc ///

--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -547,7 +547,7 @@ doc ///
   Key
     DistributionFunction
   Headline
-    cumulative density function
+    cumulative distribution function
   Description
     Text
       A key in @TO ProbabilityDistribution@ objects and an option for


### PR DESCRIPTION
Currently, the probability distribution of `random(QQ)` is kind of unusual.  If _X_ and _Y_ both have the discrete uniform distribution on {1,...,_h_} for some positive integer _h_, then we get a sample from the distribution of _X_/_Y_.   This maybe isn't great.  For example, _P_(_X_/_Y_ = 1) = 1/_h_.  Indeed:

```m2
i1 : tally apply(100, i -> random(QQ, Height => 3))

o1 = Tally{1 => 29}
           2 => 12
           3 => 11
           1
           - => 9
           3
           1
           - => 12
           2
           2
           - => 14
           3
           3
           - => 13
           2
```

Instead, we propose sampling from the standard normal distribution and rounding the results to the nearest rational number with denominator bounded by _h_ (using the [Farey sequence](https://en.wikipedia.org/wiki/Farey_sequence)).  I think I mentioned this idea recently in some discussion, but I can't find it.  After the change:

```m2
i1 : tally apply(100, i -> random(QQ, Height => 3))

o1 = Tally{-1 => 10 }
           -2 => 1
           0 => 12
           1 => 6
           2 => 2
             1
           - - => 5
             3
             1
           - - => 8
             2
             2
           - - => 12
             3
             3
           - - => 3
             2
             4
           - - => 6
             3
             5
           - - => 3
             3
             7
           - - => 1
             3
           1
           - => 6
           2
           1
           - => 15
           3
           2
           - => 3
           3
           3
           - => 3
           2
           4
           - => 2
           3
           7
           - => 1
           2
           7
           - => 1
           3
```

This PR also has a few other related changes:

* Make the Farey sequence approximation routine available at top-level (but unexported).
* Add a function to the engine that returns a random `RR` from the standard normal distribution and use it in the `Probability` package.
* Improve the `Probability` package documentation.

This possibly closes #999, although that suggests using a uniform distribution.