### PR TITLE
Fix a couple small "code" bugs

### DIFF
--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -57,7 +57,7 @@ code FilePosition := x -> (
      (
 	  wp := set characters " \t\r);";
 	  file := (
-	       if match("startup.m2.in$", filename) then startupString
+	       if match("startup\\.m2\\.in$", filename) then startupString
 	       else if filename === "currentString" then (
 		    if currentString === null
 		    then error "code no longer available"

--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -53,7 +53,7 @@ dedupMethods = L -> (
 code = method(Dispatch => Thing)
 code Nothing    := identity
 code FilePosition := x -> (
-    filename := x#0; start := x#1; stop := x#3;
+    filename := x#0; start := x#1; stop := x#3 ?? x#1;
      (
 	  wp := set characters " \t\r);";
 	  file := (
@@ -64,8 +64,8 @@ code FilePosition := x -> (
 		    else currentString)
 	       else if filename === "stdio" then (
 		    start = 1;
-		    stop = x#3 - x#1 + 1;
-		    toString stack apply(x#1..x#3,
+		    stop += 1 - x#1;
+		    toString stack apply(x#1..x#1+stop-1,
 			i -> getHistory(i + historyOffset)))
 	       else (
 		    if not fileExists filename then error ("couldn't find file ", filename);


### PR DESCRIPTION
We fix two little `code` bugs I noticed:

First, we previously assumed that the given `FilePosition` object would include a stopping position, which isn't the case for some things (like outputs of `locate(DocumentTag)`:

```m2
i1 : locate makeDocumentTag (ideal, List)

o1 = /usr/share/Macaulay2/Macaulay2Doc/functions/ideal-doc.m2:42:0

o1 : FilePosition

i2 : code oo
stdio:2:4:(3): error: array index 3 out of bounds 0 .. 2
```
So we assume that the stopping is the same as the starting position, which maybe isn't great, but at least there's no more error:

```m2
i1 : locate makeDocumentTag (ideal, List)

o1 = src/macaulay2/M2/M2/Macaulay2/packages/Macaulay2Doc/functions/ideal-doc.m2:42:0

o1 : FilePosition

i2 : code oo

o2 = src/macaulay2/M2/M2/Macaulay2/packages/Macaulay2Doc/functions/ideal-doc.m2:42:0: --source code:
     document { 
```

The other bug is very very minor.  Suppose, for some crazy reason, we write some Macaulay2 code in a file named something that matches the regex "startup.m2.in$", e.g., "startupxm2xin".  If we load it and call `code` on something from it, then it will give us something from the actual startup.m2.in:

```m2
i1 : get "startupxm2xin"

o1 = f = x -> x^2

i2 : load "startupxm2xin"

i3 : code f

o3 = startupxm2xin:1:4-1:12: --source code:
     -- -*- coding: utf-8 -*-
```

If we properly escape the dots, then it works as expected:

```m2
i3 : code f

o3 = startupxm2xin:1:4-1:12: --source code:
     f = x -> x^2
```




