### PR TITLE
Add examples(ZZ) to see examples for the doc nodes from "about"

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -416,13 +416,12 @@ isSecondaryTag   = tag -> ( d := fetchRawDocumentation tag; d =!= null and d#?Pr
 isUndocumented   = tag -> ( d := fetchRawDocumentation tag; d =!= null and d#?"undocumented" and d#"undocumented" === true )
 hasDocumentation = key -> null =!= fetchAnyRawDocumentation makeDocumentTag(key, Package => null)
 
--- TODO: is it possible to expand to (filename, start,startcol, stop,stopcol, pos,poscol)?
 locate DocumentTag := tag -> new FilePosition from (
-    if (rawdoc := fetchAnyRawDocumentation tag) =!= null
-    then (
-	minimizeFilename((package rawdoc.DocumentTag)#"source directory" |
-	    rawdoc#"filename"),
-	rawdoc#"linenum", 0)
+    rawdoc := fetchAnyRawDocumentation tag;
+    if rawdoc =!= null then (
+	pkg := package rawdoc.DocumentTag;
+	src := minimizeFilename(pkg#"source directory" | rawdoc#"filename");
+	src, rawdoc#"linenum", 0)
     else (currentFileName, currentRowNumber(), currentColumnNumber()))
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -188,6 +188,16 @@ examples DocumentTag := tag -> (
 	"-- " | net locate tag,
 	ex))
 
+examples List := L -> (
+    L = splice \ pairs apply(L, key ->
+	(tag := makeDocumentTag key, locate tag));
+    n := #L;
+    stack apply(L, (i, tag, loc) -> (
+	    ex := examples tag;
+	    -- deduplicate tags w/ same location
+	    if i < n - 1 and loc === L#(i + 1)#2 then ex#0
+	    else if i < n - 1 then ex || net HR() else ex)))
+
 -----------------------------------------------------------------------------
 -- storeExampleOutput
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -7,11 +7,11 @@
  * examples
  *-
 
+processExamplesStrict = true
+
 needs "hypertext.m2"
 needs "run.m2"
 needs "document.m2" -- for DocumentTag
-
-processExamplesStrict = true
 
 -----------------------------------------------------------------------------
 -- local utilities

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -34,11 +34,13 @@ operator := binary + prefix + postfix + augmented
 -- Local utilities
 -----------------------------------------------------------------------------
 
--- used by help, viewHelp, and infoHelp
+-- used by help, viewHelp, infoHelp, and examples
 seeAbout := (f, i) -> (
     if     lastabout === null then error "no previous 'about' response";
     if not lastabout#?i       then error("previous 'about' response contains no entry numbered ", i);
     f lastabout#i)
+
+examples ZZ := seeAbout_examples
 
 -----------------------------------------------------------------------------
 -- these menus have to get sorted, so optTO and optTOCLASS return sequence:

--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -39,6 +39,7 @@ addStartFunction(
 		   Headline       => "default package for interpreter interactions",
 		   DebuggingMode  => true);
 	       User.PackageIsLoaded = true;
+	       User#"source directory" = "";
 	       path = prepend("./",path); -- now we search also the user's current directory, since our files have already been loaded
 	       path = unique apply( path, minimizeFilename);	    -- beautify
 	       allowLocalCreation User#"private dictionary";

--- a/M2/Macaulay2/m2/loadsequence
+++ b/M2/Macaulay2/m2/loadsequence
@@ -85,8 +85,8 @@ schubert.m2
 local.m2
 
 packages.m2
-examples.m2
 document.m2
+examples.m2
 installPackage.m2
 testing.m2
 help.m2

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/examples-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/examples-doc.m2
@@ -56,6 +56,7 @@ Node
      examples
     (examples, Thing)
     (examples, ZZ)
+    (examples, List)
   Headline
     list the examples in documentation
   Usage
@@ -83,6 +84,11 @@ Node
     Example
       about firstFunction
       examples 0
+    Text
+      If the input is a list, then the examples for all of its elements will be
+      gathered into a single net.
+    Example
+      examples about firstFunction
   SeeAlso
     "reading the documentation"
     capture

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/examples-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/examples-doc.m2
@@ -55,6 +55,7 @@ Node
   Key
      examples
     (examples, Thing)
+    (examples, ZZ)
   Headline
     list the examples in documentation
   Usage
@@ -76,6 +77,12 @@ Node
       Alternatively, one could use @TO "print"@ to display them with no indentation.
     Example
       print ex
+    Text
+      If the input is an integer, then the examples will correspond to the
+      documentation node with that index in the last call to @TO about@.
+    Example
+      about firstFunction
+      examples 0
   SeeAlso
     "reading the documentation"
     capture

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
@@ -258,6 +258,7 @@ Node
     headlines
     findSynonyms
     "regular expressions"
+    (examples, ZZ)
 
 Node
   Key

--- a/M2/Macaulay2/packages/Text.m2
+++ b/M2/Macaulay2/packages/Text.m2
@@ -920,7 +920,6 @@ scan({peek', show, validate, html, net, info, tex, texMath, mathML, NewFromMetho
 	    x.Package === "Text" and (isMissingDoc x or isUndocumented x)))
 
 undocumented {
-    (examples, Hypertext),
     (hypertext, Hypertext)
     }
 

--- a/M2/Macaulay2/tests/normal/examples.m2
+++ b/M2/Macaulay2/tests/normal/examples.m2
@@ -1,3 +1,4 @@
 document { Key => "foo", "hi there", EXAMPLE "a", "ho there", EXAMPLE "b" }
-examples "foo"
-assert( oo == "a\nb"^-1)
+ex = examples "foo"
+assert( ex#-2 == "a" )
+assert( ex#-1 == "b" )


### PR DESCRIPTION
We also add some informative comments to the output.  For example:

```m2
i1 : about rank

o1 = {0 => Chordal :: rank(ChordalNetNode)                   }
     {1 => DiffAlg :: rank(DiffAlgDistribution)              }
     {2 => HyperplaneArrangements :: rank(CentralArrangement)}
     {3 => HyperplaneArrangements :: rank(Flat)              }
     {4 => InvariantRing :: rank(DiagonalAction)             }
     {5 => LieTypes :: rank(LieAlgebra)                      }
     {6 => Macaulay2Doc :: rank                              }
     {7 => Macaulay2Doc :: rank of a matrix                  }
     {8 => Macaulay2Doc :: rank(GradedModule)                }
     {9 => Macaulay2Doc :: rank(Matrix)                      }
     {10 => Macaulay2Doc :: rank(Module)                     }
     {11 => Macaulay2Doc :: rank(MutableMatrix)              }
     {12 => Matroids :: rank(Matroid)                        }
     {13 => Matroids :: rank(Matroid,List)                   }
     {14 => Matroids :: rank(Matroid,Set)                    }
     {15 => OldToricVectorBundles :: rank(ToricVectorBundle) }
     {16 => Posets :: rank(Poset)                            }
     {17 => Schubert2 :: rank(AbstractSheaf)                 }
     {18 => SparseResultants :: rank(MultidimensionalMatrix) }
     {19 => ToricVectorBundles :: rank(ToricVectorBundle)    }
     {20 => WeylGroups :: rank(DynkinDiagram)                }
     {21 => WeylGroups :: rank(RootSystem)                   }

o1 : NumberedVerticalList

i2 : examples 6

o2 = -- examples for tag: rank
     -- ../src/macaulay2/M2/M2/Macaulay2/packages/Macaulay2Doc/functions/rank-doc.m2:32:0
     R = ZZ/101[x,y,z]
     p = vars R;
     rank kernel p
     rank cokernel p
     C = res cokernel p
     rank C
```