### PR TITLE
Always exit when running "M2 --check X"

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -176,9 +176,9 @@ jobs:
         if: matrix.build-system == 'cmake' && runner.os == 'macOS'
         run: |
           set -xe
-          ./M2 -q --check 1 -e 'exit 0'
-          ./M2 -q --check 2 -e 'exit 0'
-          ./M2 -q --check 3 -e 'exit 0'
+          ./M2 -q --check 1
+          ./M2 -q --check 2
+          ./M2 -q --check 3
           cmake --build . --target M2-tests
           cmake --build . --target M2-unit-tests
           cmake --build . --target memtailor-unit-tests mathic-unit-tests mathicgb-unit-tests

--- a/M2/BUILD/docker/Makefile
+++ b/M2/BUILD/docker/Makefile
@@ -32,9 +32,9 @@ run-emacs-tui:;	docker run $(VOLUME) -it --entrypoint emacs $(TAG)
 run-emacs:;	docker run $(VOLUME) --entrypoint emacs --net=host --env="DISPLAY" $(TAG)
 
 check: check-1
-check-1:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 1 -e 'exit 0'
-check-2:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 2 -e 'exit 0'
-check-3:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 3 -e 'exit 0'
+check-1:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 1
+check-2:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 2
+check-3:;	docker run $(VOLUME) -it --entrypoint M2 $(TAG) -q --no-preload --check 3
 
 ###############################################################################
 # Terminal targets

--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -50,7 +50,7 @@ relink:
 foo : ; : @libdir@ $(BUILTLIBPATH)
 
 check: $(EXEFILE)
-	LD_LIBRARY_PATH="$(BUILTLIBPATH)/lib:$$LD_LIBRARY_PATH" $< --check 1 -q --stop -E "exit 0"
+	LD_LIBRARY_PATH="$(BUILTLIBPATH)/lib:$$LD_LIBRARY_PATH" $< --check 1 -q
 
 ifeq (@OS@,Darwin)
 # We specify the search path for finding shareable libraries, in case there are any,

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -492,11 +492,13 @@ action2 := hashTable {
      "--debug" => arg -> debugWarningHashcode = value' arg,
      "--prefix" => arg -> if phase == 1 or phase == 3 then (
 	  prefixPath = { prefixDirectory = concatPath(arg, "") }),
-	  else if phase == 1 and arg == "1" then
-	       runBasicTests()
      "--check" => arg -> if arg != "1" and arg != "2" and arg != "3" then (
 	       stopIfError = true;
 	       error ("--check ",arg,": expected 1, 2, or 3"))
+	  else if phase == 1 and arg == "1" then (
+	       stopIfError = true;
+	       runBasicTests();
+	       exit 0)
 	  -- FIXME: doesn't work with --no-core
 	  else if phase == 4 and arg == "2" then (
 	       argumentMode = defaultMode - SetCaptureErr - SetUlimit -

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -492,10 +492,11 @@ action2 := hashTable {
      "--debug" => arg -> debugWarningHashcode = value' arg,
      "--prefix" => arg -> if phase == 1 or phase == 3 then (
 	  prefixPath = { prefixDirectory = concatPath(arg, "") }),
-     "--check" => arg -> if arg != "1" and arg != "2" and arg != "3" then
-	       error ("--check ",arg,": expected 1, 2, or 3")
 	  else if phase == 1 and arg == "1" then
 	       runBasicTests()
+     "--check" => arg -> if arg != "1" and arg != "2" and arg != "3" then (
+	       stopIfError = true;
+	       error ("--check ",arg,": expected 1, 2, or 3"))
 	  -- FIXME: doesn't work with --no-core
 	  else if phase == 4 and arg == "2" then (
 	       argumentMode = defaultMode - SetCaptureErr - SetUlimit -


### PR DESCRIPTION
We already exited when running `M2 --check 2` and `M2 --check 3` after running the corresponding tests.  With this PR, we propose exiting after `M2 --check 1` and also when the `--check` option gets an unknown argument.

Closes: #3488