### PR TITLE
Check that list is nonempty before calling factory function

### DIFF
--- a/M2/Macaulay2/e/interface/factory.cpp
+++ b/M2/Macaulay2/e/interface/factory.cpp
@@ -785,6 +785,11 @@ M2_arrayintOrNull rawIdealReorder(const Matrix *M)
             }
         }
 
+      if (I.length() == 0) {
+        ERROR("expected at least one generator");
+        return nullptr;
+      }
+
       List<int> t = neworderint(I);
 
       int n = t.length();


### PR DESCRIPTION
Otherwise we get a segfault

### Before
```m2
i1 : debug Core

i2 : R = QQ[x];

i3 : rawIdealReorder raw matrix(R, {})
-- SIGSEGV
-* stack trace, pid: 1478018
 0# stack_trace(std::ostream&, bool) at /usr/src/macaulay2-1.24.05+git202409121006-0ppa202409120131~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:132
 1# segv_handler at /usr/src/macaulay2-1.24.05+git202409121006-0ppa202409120131~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:249
 2# 0x00007021FB445320 in /usr/lib/x86_64-linux-gnu/libc.so.6
 3# get_max_var(List<CanonicalForm> const&) in /usr/lib/x86_64-linux-gnu/libsingular-factory-4.3.2.so
 4# neworder(List<CanonicalForm> const&) in /usr/lib/x86_64-linux-gnu/libsingular-factory-4.3.2.so
 5# neworderint(List<CanonicalForm> const&) in /usr/lib/x86_64-linux-gnu/libsingular-factory-4.3.2.so
 6# rawIdealReorder at interface/factory.cpp:790
 7# interface_rawIdealReorder at /usr/src/macaulay2-1.24.05+git202409121006-0ppa202409120131~ubuntu24.04.1/M2/Macaulay2/d/interface.dd:1475
```

### After
```m2
i3 : rawIdealReorder raw matrix(R, {})
stdio:3:15:(3): error: expected at least one generator
```

This is the underlying segfault behind #3497.  I'm not sure if this is enough to fix the issue.

@pzinn: does the zero ideal have an irreducible characteristic series?