### PR TITLE
Add scalar division methods

### DIFF
--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -85,6 +85,8 @@ Matrix * Number :=
 Matrix * RingElement := (m,r) -> (
     if ring r =!= ring m then try r = promote(r,ring m) else m = promote(m,ring r);
      map(target m, source m, reduce(target m, raw m * raw r)))
+Matrix / Number      :=
+Matrix / RingElement := (m,r) -> m * (1/r)
 
 toSameRing = (m,n) -> (
      if ring m =!= ring n then (

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -132,6 +132,7 @@ lift(Vector,Number) := Vector => o -> (v,S) -> vector (lift(v#0,S))
 - Vector := Vector => v -> new class v from {-v#0}
 Number * Vector := RingElement * Vector := Vector => (r,v) -> vector(r * v#0)
 Vector * Number := Vector * RingElement := Vector => (v,r) -> vector(v#0 * r)
+Vector / Number := Vector / RingElement := Vector => (v,r) -> vector(v#0 / r)
 Vector + Vector := Vector => (v,w) -> vector(v#0+w#0)
 Vector - Vector := Vector => (v,w) -> vector(v#0-w#0)
 Vector ** Vector := Vector => (v,w) -> vector(v#0**w#0)

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc.m2
@@ -403,6 +403,33 @@ document {
      SeeAlso => { "//"}
      }
 
+doc ///
+  Key
+    (symbol /, Matrix, Number)
+    (symbol /, Matrix, RingElement)
+    (symbol /, Vector, Number)
+    (symbol /, Vector, RingElement)
+  Headline
+    scalar division
+  Usage
+    v / c
+  Inputs
+    v:{Matrix, Vector}
+    c:{Number, RingElement}
+  Outputs
+    :{Matrix, Vector}
+  Description
+    Text
+      This operation is equivalent to right scalar multiplication by the
+      multiplicative inverse of @CODE "c"@, i.e., @CODE "v * (1/c)"@.
+    Example
+      R = QQ[a,b,c,d]
+      matrix {{d, -b}, {-c, a}} / (a * d - b * c)
+  Caveat
+    The base ring of the output will be a field containing the base ring
+    of @CODE "v"@.
+///
+
 document {
      Key => {symbol %,
 	  (symbol %, CC, CC),

--- a/M2/Macaulay2/tests/normal/vector.m2
+++ b/M2/Macaulay2/tests/normal/vector.m2
@@ -23,3 +23,7 @@ assert Equation(2 * v, vector(N, {2, 4, 6}))
 assert Equation(x * v, vector map(N, R^{-1}, {{x}, {2*x}, {3*x}}))
 assert Equation(v * 2, vector(N, {2, 4, 6}))
 assert Equation(v * x, vector map(N, R^{-1}, {{x}, {2*x}, {3*x}}))
+assert Equation(v / 2, vector(N, {1/2, 1, 3/2}))
+v = vector {x, y, z}
+kk = frac R
+assert Equation(v / x, vector map(kk^3, kk^{-1}, {{1}, {y/x}, {z/x}}))


### PR DESCRIPTION
I was using M2 to double-check some computations while grading calculus homework and was surprised to get the following error:

```m2
i1 : vector {1, 2, 3} / 4
stdio:1:17:(3): error: no method for binary operator / applied to objects:
                              3
            | 1 | (of class ZZ )
            | 2 |
            | 3 |
      /     4 (of class ZZ)
```

We add scalar division methods for vectors and matrices by numbers and ring elements.  So afterward:

```m2
i1 : vector {1, 2, 3} / 4

o1 = | 1/4 |
     | 1/2 |
     | 3/4 |

       3
o1 : QQ
```