### PR TITLE
Fix realPart/imaginaryPart/conjugate bugs

### DIFF
--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -237,6 +237,8 @@ imaginaryPart InexactNumber := imaginaryPart0
 imaginaryPart Number := imaginaryPart0 @@ numeric
 
 conjugate CC := z -> toCC(precision z, realPart z, - imaginaryPart z)
+conjugate Constant := conjugate @@ numeric
+
 isConstant Number := i -> true
 
 round RR := round CC := round0

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -226,8 +226,16 @@ CC // RR := (x,y) -> x // y_CC;
 CC % RR := (x,y) -> x % y_CC;
 
 -- functions
-realPart Number := realPart0
-imaginaryPart Number := imaginaryPart0
+realPart ZZ :=
+realPart QQ :=
+realPart InexactNumber := realPart0
+realPart Number := realPart0 @@ numeric
+
+imaginaryPart ZZ :=
+imaginaryPart QQ :=
+imaginaryPart InexactNumber := imaginaryPart0
+imaginaryPart Number := imaginaryPart0 @@ numeric
+
 conjugate CC := z -> toCC(precision z, realPart z, - imaginaryPart z)
 isConstant Number := i -> true
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_arithmetic.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_arithmetic.m2
@@ -35,7 +35,8 @@ document {
      "See also ", TO "odd", "."}
 
 document {
-     Key => {realPart, (realPart,Number)},
+     Key => {realPart, (realPart,Number), (realPart,QQ), (realPart,ZZ),
+	 (realPart,InexactNumber)},
      Headline => "real part",
      Usage => "realPart z",
      Inputs => {"z" => "an integer, rational, real or complex number"},
@@ -44,10 +45,11 @@ document {
 	  "realPart(3/4)",
 	  "realPart(1.5+2*ii)"
 	  },
-     SeeAlso => {CC}
+     SeeAlso => {CC, imaginaryPart}
      }
 document {
-     Key => {imaginaryPart,(imaginaryPart,Number)},
+     Key => {imaginaryPart,(imaginaryPart,Number), (imaginaryPart,QQ),
+	 (imaginaryPart,ZZ), (imaginaryPart,InexactNumber)},
      Headline => "imaginary part",
      Usage => "imaginaryPart z",
      Inputs => {"z" => "an integer, rational, real or complex number"},
@@ -56,15 +58,11 @@ document {
 	  "imaginaryPart(3/4)",
 	  "imaginaryPart(1.5+2*ii)"
 	  },
-     SeeAlso => {CC}
+     SeeAlso => {CC, realPart}
      }
 
 document {
-     Key => conjugate,
-     Headline => "complex conjugate",
-     TT "conjugate z", " -- the complex conjugate of the complex number z."}
-document {
-     Key => {(conjugate,CC),(conjugate,Number)},
+     Key => {conjugate,(conjugate,CC),(conjugate,Number),(conjugate,Constant)},
      Headline => "complex conjugate",
      Usage => "conjugate z",
      Inputs => {"z"},

--- a/M2/Macaulay2/tests/normal/numbers.m2
+++ b/M2/Macaulay2/tests/normal/numbers.m2
@@ -79,6 +79,9 @@ assert( hash (1p111*ii) =!= hash (1p110*ii) )
 assert( hash (1p111*ii) === hash (1p111*ii) )
 assert( realPart toCC 1. === 1. )
 assert( imaginaryPart toCC 1. === 0. )
+assert( realPart ii === 0. )
+assert( imaginaryPart ii === 1. )
+assert( conjugate ii == -ii )
 
 assert try (lift(1.3,ZZ); false) else true
 assert not liftable(1.3,ZZ)


### PR DESCRIPTION
`realPart` and `imaginaryPart` expected one of the `Number` types defined in the interpreter, so failed when given one of the `Number` types defined at top-level (`Constant`, `InfiniteNumber`, `IndeterminateNumber`).

`conjugate` assumed that every non-`CC` `Number` object was real, and so gave the wrong output when given `ii`, which is complex but is a `Constant` object.

We also update the docs and add unit tests.

### Before
```m2
i1 : realPart ii
stdio:2:8:(3): error: expected a number

i2 : imaginaryPart ii
stdio:3:13:(3): error: expected a number

i3 : conjugate ii

o3 = ii

o3 : Constant
```

### After
```m2
i1 : realPart ii

o1 = 0

o1 : RR (of precision 53)

i2 : imaginaryPart ii

o2 = 1

o2 : RR (of precision 53)

i3 : conjugate ii

o3 = -ii

o3 : CC (of precision 53)
```