### PR TITLE
Bump normaliz to 3.10.4

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -224,6 +224,7 @@ jobs:
            path: |
              # Autotools
              M2/BUILD/build/config.log
+             M2/BUILD/build/check-configure/tmp/config.log
              M2/BUILD/build/include/*
              M2/BUILD/build/libraries/*/build/*/config.log
              # CMake

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -966,8 +966,8 @@ _ADD_COMPONENT_DEPENDENCY(libraries nauty "" NAUTY_FOUND)
 # https://www.normaliz.uni-osnabrueck.de/
 # normaliz needs libgmp, libgmpxx, boost, and openmp, and is used by the package Normaliz
 ExternalProject_Add(build-normaliz
-  URL               https://github.com/Normaliz/Normaliz/releases/download/v3.10.2/normaliz-3.10.2.tar.gz
-  URL_HASH          SHA256=0f649a8eae5535c18df15e8d35fc055fd0d7dbcbdd451e8876f4a47061481f07
+  URL               https://github.com/Normaliz/Normaliz/releases/download/v3.10.4/normaliz-3.10.4.tar.gz
+  URL_HASH          SHA256=9b424f966d553ae32e710b8ab674c7887ddcbf0e5ea08af7f8bc1b587bcbb2aa
   PREFIX            libraries/normaliz
   SOURCE_DIR        libraries/normaliz/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -982,7 +982,7 @@ ExternalProject_Add(build-normaliz
 		      --without-e-antic
                       "CPPFLAGS=${CPPFLAGS} -I${GMP_INCLUDE_DIRS}"
                       CFLAGS=${CFLAGS}
-                      CXXFLAGS=${CXXFLAGS}
+                      "CXXFLAGS=${CXXFLAGS} -std=gnu++14"
                       "LDFLAGS=${LDFLAGS}  -L${GMP_LIBRARY_DIRS}"
                       CC=${CMAKE_C_COMPILER}
                       CXX=${CMAKE_CXX_COMPILER}

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -979,6 +979,7 @@ ExternalProject_Add(build-normaliz
                       --without-flint # ${FLINT_ROOT}
 		      --without-nauty
 		      --without-cocoalib
+		      --without-e-antic
                       "CPPFLAGS=${CPPFLAGS} -I${GMP_INCLUDE_DIRS}"
                       CFLAGS=${CFLAGS}
                       CXXFLAGS=${CXXFLAGS}

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -232,7 +232,8 @@ foreach(_library IN LISTS LIBRARY_OPTIONS)
     elseif(BUILD_LIBRARIES MATCHES "(ALL|ON)" OR "${_name}" IN_LIST BUILD_LIBRARIES)
       # exists on the system, but we want to build it
       unset(${_library}_DIR CACHE) # for Eigen3
-      unset(${_name}_FOUND CACHE)
+      unset(${_name}_FOUND CACHE)  # for fflas_ffpack and givaro
+      unset(${_name}_FOUND)        # for everything else
       unset(${_name}_LIBDIR CACHE)
       unset(${_name}_LIBRARY CACHE)
       unset(${_name}_LIBRARIES CACHE)

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -154,7 +154,7 @@ pkg_search_module(GIVARO	IMPORTED_TARGET	givaro>=4.1.1)
 
 set(LIBRARY_OPTIONS
   Eigen3 BDWGC MPFR MPFI NTL Flint Factory Frobby cddlib MPSolve
-  GTest GLPK Givaro FFLAS_FFPACK)
+  GTest GLPK Givaro FFLAS_FFPACK Normaliz)
 
 ###############################################################################
 ## Optional libraries:

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -139,7 +139,7 @@ set(ENV{PKG_CONFIG_PATH}	${M2_HOST_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
 
 ## Setting the prefixes where CMake will look for headers, libraries, and programs
 set(CMAKE_SYSTEM_PREFIX_PATH	${M2_HOST_PREFIX} ${CMAKE_SYSTEM_PREFIX_PATH})
-set(CMAKE_PREFIX_PATH		${CMAKE_PREFIX_PATH} ${M2_HOST_PREFIX})
+set(CMAKE_PREFIX_PATH		${M2_HOST_PREFIX} ${CMAKE_PREFIX_PATH})
 
 ## Setting the folder for Macaulay2 Core and packages
 set(CMAKE_INSTALL_DATADIR	share/Macaulay2)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1043,7 +1043,7 @@ AS_IF([test $BUILD_normaliz = no],
 	       AC_MSG_CHECKING([for libnormaliz])
 	       AC_LANG(C++)
 	       SAVELIBS=$LIBS
-	       LIBS="$LIBS -lnormaliz -lgmp"
+	       LIBS="$LIBS -lnormaliz -lgmp -lgmpxx"
 	       CHECK_NMZ_PACKAGE([ENFNORMALIZ], [-leantic -leanticxx])
 	       CHECK_NMZ_PACKAGE([NMZ_COCOA], [-lcocoa])
 	       CHECK_NMZ_PACKAGE([NMZ_NAUTY], [-lnauty])

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1063,7 +1063,7 @@ AS_IF([test $BUILD_normaliz = no],
          BUILD_normaliz=yes])])
 
 AS_IF([test $BUILD_normaliz = yes],
-    [BUILTLIBS="-lnormaliz -fopenmp $BUILTLIBS"])
+    [BUILTLIBS="-lnormaliz $OPENMP_CXXFLAGS $OPENMP_LIBS $BUILTLIBS"])
 
 if test "$BUILD_nauty" = no
 then dnl debian/fedora: nauty-

--- a/M2/libraries/normaliz/Makefile.in
+++ b/M2/libraries/normaliz/Makefile.in
@@ -33,7 +33,7 @@ NORMFLAGS =
 CXXFLAGS1 = $(CPPFLAGS) -Wall -O3 -Wno-unknown-pragmas -I .. -I . $(CXXFLAGS0)
 BUILDOPTIONS =  CXX="$(CXX)" \
 		NORMFLAGS="$(NORMFLAGS)" \
-		CXXFLAGS="$(CXXFLAGS1)" \
+		CXXFLAGS="$(CXXFLAGS1) -std=c++14" \
 		RANLIB="@RANLIB@" \
 		GMPFLAGS="$(LDFLAGS) -lgmpxx -lgmp"
 PROGRAMS = source/normaliz

--- a/M2/libraries/normaliz/Makefile.in
+++ b/M2/libraries/normaliz/Makefile.in
@@ -1,6 +1,6 @@
 HOMEPAGE = https://www.normaliz.uni-osnabrueck.de/
 # get releases from https://github.com/Normaliz/Normaliz/releases
-VERSION = 3.10.3
+VERSION = 3.10.4
 #PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 
 URL = https://github.com/Normaliz/Normaliz/releases/download/v$(VERSION)


### PR DESCRIPTION
[Normaliz 3.10.4](https://github.com/Normaliz/Normaliz/releases/tag/v3.10.4) was released earlier today, so we update the version when building it ourselves.

This is a draft for now -- I plan on removing the second commit (which forces building normaliz on GitHub) if the builds are successful.