### PR TITLE
Build with Python support by default

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -130,7 +130,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release -DBUILD_NATIVE=OFF \
             -DCMAKE_PREFIX_PATH="`brew --prefix`;`brew --prefix libffi`" \
             -DCMAKE_INSTALL_PREFIX=/usr \
-            -DWITH_PYTHON=ON \
             --debug-trycompile
 
       - name: Build libraries using Ninja
@@ -161,7 +160,7 @@ jobs:
           export CPPFLAGS="-I`brew --prefix`/include -I`brew --prefix libomp`/include"
           export  LDFLAGS="-L`brew --prefix`/lib -L`brew --prefix libomp`/lib \
             -L/Library/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
-          ../../configure --enable-download --with-python --with-system-gc
+          ../../configure --enable-download --with-system-gc
 
       - name: Build Macaulay2 using Make
         if: matrix.build-system == 'autotools'

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -30,8 +30,7 @@ option(WITH_TBB		"Link with the TBB library"		ON)
 option(WITH_FFI		"Link with the FFI library"		ON)
 # TODO: parse.d expr.d tokens.d actors4.d actors5.d still need xml
 option(WITH_XML		"Link with the libxml2 library"		ON)
-# TODO: still not operational
-option(WITH_PYTHON	"Link with the Python library"		OFF)
+option(WITH_PYTHON	"Link with the Python library"		ON)
 option(WITH_MYSQL	"Link with the MySQL library"		OFF)
 
 set(BUILD_PROGRAMS  "" CACHE STRING "Build programs, even if found")

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1324,10 +1324,13 @@ else
 fi
 AC_SUBST(GTEST_PATH)
 
-AC_SUBST(PYTHON,no)
+AC_SUBST([PYTHON])
 AC_ARG_WITH(python, AS_HELP_STRING(--with-python@<:@=3.x@:>@.,
     [link with libpython. If the version number is not specified, then the
-     system's default version will be detected.]), PYTHON=$withval)
+     system's default version will be detected.  Use --without-python to turn
+     off Python support.]),
+    [PYTHON=$withval],
+    [PYTHON=yes])
 if test $PYTHON != no
 then AC_DEFINE(WITH_PYTHON,1,[whether we are linking with the python library])
     if test $PYTHON = yes


### PR DESCRIPTION
The Python package is pretty stable, and I think it might be useful to some users for it to be more widely available (there was a recent question about using numpy in Zulip, for example), so I'm proposing that we build with Python support by default.  It would still be possible to turn this off using `--without-python` (autotools) or `-DWITH_PYTHON=OFF` (cmake).