### PR TITLE
Add `part` for graded objects and other improvements

### DIFF
--- a/M2/Macaulay2/m2/basis.m2
+++ b/M2/Macaulay2/m2/basis.m2
@@ -180,7 +180,7 @@ inducedBasisMap = (G, F, f) -> (
     -- this helper routine is useful for computing basis of a pair of composable
     -- matrices or a chain complex, when target f is the source of a matrix which
     -- we previously computed basis for.
-    psi := f * inducedMap(source f, , generators F);
+    psi := f * F.cache.Monomials; -- equivalent to f * inducedMap(source f, , gens F)
     phi := last coefficients(ambient psi, Monomials => generators G);
     map(G, F, phi, Degree => degree f))
     -- TODO: benchmark against inducedTruncationMap in Truncations.m2

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -643,11 +643,28 @@ isSubquotient(Module,Module) := (M,N) -> (
      relations N % relations M == 0
      )
 
+-----------------------------------------------------------------------------
+-- inducedMap
+-----------------------------------------------------------------------------
+
 inducedMap = method (
      Options => {
 	  Verify => true,
 	  Degree => null 
 	  })
+-- TODO: hookify this, so people can add more application specific induced maps
+inducedMap(Module, Module)          := Matrix => opts -> (M, N) -> (
+    if ambient M =!= ambient N then error "inducedMap: expected modules with same ambient free module";
+    -- e.g. avoid a gb computation for inducedMap(M, image basis(d, M))
+    if N.cache.?Monomials and M === target N.cache.Monomials
+    then map(M, N, N.cache.Monomials, Degree => opts.Degree)
+    else inducedMap(M, N, id_(ambient N), opts))
+inducedMap(Module, Nothing, Matrix) := Matrix => opts -> (M, N, f) -> (
+    B := image f;
+    -- e.g. avoid a gb computation for inducedMap(image f, , f)
+    if M === target B.cache.Monomials
+    then map(M, source B.cache.Monomials, B.cache.Monomials, Degree => opts.Degree)
+    else inducedMap(M, source f, f, opts))
 inducedMap(Module,Module,Matrix) := Matrix => opts -> (N',M',f) -> (
      N := target f;
      M := source f;
@@ -669,7 +686,6 @@ inducedMap(Module,Module,Matrix) := Matrix => opts -> (N',M',f) -> (
 	  if not isWellDefined f' then error "inducedMap: expected matrix to induce a well-defined map";
 	  );
      f')
-inducedMap(Module,Nothing,Matrix) := o -> (M,N,f) -> inducedMap(M,source f, f,o)
 inducedMap(Nothing,Module,Matrix) := o -> (M,N,f) -> inducedMap(target f,N, f,o)
 inducedMap(Nothing,Nothing,Matrix) := o -> (M,N,f) -> inducedMap(target f,source f, f,o)
 
@@ -682,10 +698,6 @@ addHook((inducedMap, Module, Module, Matrix), Strategy => Default, (opts, N', M'
      f' := g // gbN';
      f' = map(N',M',f',Degree => if opts.Degree === null then degree f else opts.Degree);
      (f', g, gbN', gbM)))
-
-inducedMap(Module,Module) := Matrix => o -> (M,N) -> (
-    if ambient M =!= ambient N then error "inducedMap: expected modules with same ambient free module";
-     inducedMap(M,N,id_(ambient N),o))
 
 -- TODO: deprecate this in favor of isWellDefined
 inducesWellDefinedMap = method(TypicalValue => Boolean)
@@ -702,6 +714,8 @@ inducesWellDefinedMap(Module,Module,Matrix) := (M,N,f) -> (
 inducesWellDefinedMap(Module,Nothing,Matrix) := (M,N,f) -> inducesWellDefinedMap(M,source f,f)
 inducesWellDefinedMap(Nothing,Module,Matrix) := (M,N,f) -> inducesWellDefinedMap(target f,N,f)
 inducesWellDefinedMap(Nothing,Nothing,Matrix) := (M,N,f) -> true
+
+-----------------------------------------------------------------------------
 
 vars Ring := Matrix => R -> (
      g := generators R;

--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -311,14 +311,15 @@ subquotient(Nothing,Matrix) := (null,relns) -> (
 	  Mparts = append(Mparts, symbol relations => relns);
 	  );
      new Module of Vector from hashTable Mparts)
-subquotient(Matrix,Nothing) := (subgens,null) -> (
-     R := ring subgens;
-     E := target subgens;
-     rE := E.RawFreeModule;
-     subgens = align matrix subgens;
+subquotient(Matrix, Nothing) := (subgens0, null) -> (
+    R := ring subgens0;
+    E := target subgens0;
+    rE := E.RawFreeModule;
+    subgens := align matrix subgens0;
      if E.?generators then subgens = E.generators * subgens;
      Mparts := {
 	  symbol cache => new CacheTable from { 
+	    symbol Monomials => subgens0,
 	       cache => new MutableHashTable	    -- this hash table is mutable, hence has a hash number that can serve as its age
 	       },
 	  symbol RawFreeModule => rE,
@@ -330,16 +331,16 @@ subquotient(Matrix,Nothing) := (subgens,null) -> (
 	  Mparts = append(Mparts, symbol relations => E.relations);
 	  );
      new Module of Vector from hashTable Mparts)
-subquotient(Matrix,Matrix) := (subgens,relns) -> (
-     R := ring relns;
-     E := target subgens;
+subquotient(Matrix, Matrix) := (subgens0, relns) -> (
+    R := ring relns;
+    E := target subgens0;
      if E =!= target relns then error "expected maps with the same target";
      rE := E.RawFreeModule;
      n := rawRank rE;
      if n == 0 then new Module from (R,rE)
      else (
 	  relns = align matrix relns;
-	  subgens = align matrix subgens;
+	subgens := align matrix subgens0;
 	  if E.?generators then (
 	       relns = E.generators * relns;
 	       subgens = E.generators * subgens;
@@ -347,6 +348,7 @@ subquotient(Matrix,Matrix) := (subgens,relns) -> (
 	  if E.?relations then relns = relns | E.relations;
 	  Mparts := {
 	       symbol cache => new CacheTable from { 
+		symbol Monomials => subgens0,
 		    cache => new MutableHashTable	    -- this hash table is mutable, hence has a hash number that can serve as its age
 		    },
 	       symbol RawFreeModule => rE,

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -750,16 +750,24 @@ truncate(ZZ, Complex) := Complex => {} >> opts -> (e, C) -> truncate({e}, C)
 --------------------------------------------------------------------
 -- basis -----------------------------------------------------------
 --------------------------------------------------------------------
+importFrom_Core { "inducedBasisMap" }
+
 -- returns the graded component of the complex in the given degree
 -- as a complex over the same ring (as opposed to the coefficient ring)
 -- TODO: also define basis given a degree range and infinite ranges
--- TODO: also define for ComplexMap
 basis(ZZ,   Complex) :=
 basis(List, Complex) := Complex => opts -> (deg, C) -> (
     (lo, hi) := C.concentration;
     if lo == hi
     then complex(image basis(deg, C_lo, opts), Base => lo)
-    else complex applyValues(C.dd.map, f -> basis(deg, f, opts)))
+    -- this is the simplest way to take the basis of the whole complex:
+    -- else complex applyValues(C.dd.map, f -> basis(deg, f, opts)))
+    else (
+	-- this construction requires ~half as many basis computations
+	f := basis(deg, dd^C_lo, opts);
+	complex hashTable for i from lo+1 to hi list i => (
+	    f = inducedBasisMap(source f, image basis(deg, C_i, opts), dd^C_i))
+    ))
 
 --------------------------------------------------------------------
 -- part ------------------------------------------------------------

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -779,10 +779,7 @@ cover' ComplexMap := ComplexMap => f -> (
 -- returns the graded component of the complex in the given degree
 -- but as a complex over the coefficient ring instead
 part(ZZ,   Complex) :=
-part(List, Complex) := Complex => (deg, C) -> (
-    D := basis(deg, C);
-    psi := residueMap ring C;
-    complex applyValues(D.dd.map, f -> psi cover f))
+part(List, Complex) := Complex => (deg, C) -> (residueMap ring C) cover' basis(deg, C)
 
 --------------------------------------------------------------------
 -- homology --------------------------------------------------------

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -766,6 +766,20 @@ truncate(List, Complex) := Complex => {} >> opts -> (e, C) -> (
 truncate(ZZ, Complex) := Complex => {} >> opts -> (e, C) -> truncate({e}, C)
 
 --------------------------------------------------------------------
+-- basis -----------------------------------------------------------
+--------------------------------------------------------------------
+-- returns the graded component of the complex in the given degree
+-- as a complex over the same ring (as opposed to the coefficient ring)
+-- TODO: also define basis given a degree range and infinite ranges
+-- TODO: also define for ComplexMap
+basis(ZZ,   Complex) :=
+basis(List, Complex) := Complex => opts -> (deg, C) -> (
+    (lo, hi) := C.concentration;
+    if lo == hi
+    then complex(image basis(deg, C_lo, opts), Base => lo)
+    else complex applyValues(C.dd.map, f -> basis(deg, f, opts)))
+
+--------------------------------------------------------------------
 -- homology --------------------------------------------------------
 --------------------------------------------------------------------
 homology Complex := Complex => opts -> C -> (

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -740,24 +740,6 @@ canonicalTruncation(Complex,InfiniteNumber,InfiniteNumber) :=
 canonicalTruncation(Complex,ZZ,Nothing) := 
 canonicalTruncation(Complex,Nothing,ZZ) := Complex => (C,lo,hi) -> canonicalTruncation(C, (lo,hi))
 
-part(List, Complex) := Complex => (deg, C) -> (
-    -- return a Complex over the coefficient ring
-    R := ring C;
-    A := coefficientRing R;
-    psi := map(A,R, DegreeMap => degR -> take(degR, - degreeLength A));
-    (lo, hi) := concentration C;
-    if lo === hi 
-    then complex(psi source basis(deg, C_lo), Base => lo)
-    else (
-        maps := hashTable for i from lo+1 to hi list (
-            f := psi matrix basis(deg, dd^C_i);
-            if source f == 0 then continue else i => f
-            );
-        if # keys maps === 0 then complex(psi source basis(deg, C_lo), Base => lo)  else complex maps
-        )
-    )
-part(ZZ, Complex) := Complex => (deg, C) -> part({deg}, C)
-
 truncate(List, Complex) := Complex => {} >> opts -> (e, C) -> (
     (lo, hi) := concentration C;
     if lo === hi then return complex truncate(e, C_lo);
@@ -778,6 +760,19 @@ basis(List, Complex) := Complex => opts -> (deg, C) -> (
     if lo == hi
     then complex(image basis(deg, C_lo, opts), Base => lo)
     else complex applyValues(C.dd.map, f -> basis(deg, f, opts)))
+
+--------------------------------------------------------------------
+-- part ------------------------------------------------------------
+--------------------------------------------------------------------
+importFrom_Core "residueMap" -- gives a map back to the coefficient ring
+
+-- returns the graded component of the complex in the given degree
+-- but as a complex over the coefficient ring instead
+part(ZZ,   Complex) :=
+part(List, Complex) := Complex => (deg, C) -> (
+    D := basis(deg, C);
+    psi := residueMap ring C;
+    complex applyValues(D.dd.map, f -> psi cover f))
 
 --------------------------------------------------------------------
 -- homology --------------------------------------------------------

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -766,6 +766,16 @@ basis(List, Complex) := Complex => opts -> (deg, C) -> (
 --------------------------------------------------------------------
 importFrom_Core "residueMap" -- gives a map back to the coefficient ring
 
+-- this may not always be well-defined, so it is not exported
+cover' = method()
+cover' Complex := Complex => C -> (
+    (lo, hi) := concentration C;
+    if lo == hi
+    then complex(cover C_lo, Base => lo)
+    else complex applyValues(C.dd.map, cover))
+cover' ComplexMap := ComplexMap => f -> (
+    map(cover' target f, cover' source f, i -> cover f_i, Degree => degree f))
+
 -- returns the graded component of the complex in the given degree
 -- but as a complex over the coefficient ring instead
 part(ZZ,   Complex) :=

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -740,12 +740,22 @@ canonicalTruncation(Complex,InfiniteNumber,InfiniteNumber) :=
 canonicalTruncation(Complex,ZZ,Nothing) := 
 canonicalTruncation(Complex,Nothing,ZZ) := Complex => (C,lo,hi) -> canonicalTruncation(C, (lo,hi))
 
-truncate(List, Complex) := Complex => {} >> opts -> (e, C) -> (
-    (lo, hi) := concentration C;
-    if lo === hi then return complex truncate(e, C_lo);
-    complex hashTable for i from lo+1 to hi list i => truncate(e, dd^C_i)
-    )
-truncate(ZZ, Complex) := Complex => {} >> opts -> (e, C) -> truncate({e}, C)
+importFrom_Truncations { "inducedTruncationMap" }
+
+truncateModuleOpts := options(truncate, List, Module)
+truncate(ZZ,   Complex) :=
+truncate(List, Complex) := Complex => truncateModuleOpts >> opts -> (degs, C) -> (
+    (lo, hi) := C.concentration;
+    if lo == hi
+    then complex(truncate(degs, C_lo, opts), Base => lo)
+    -- this is the simplest way to truncate the whole complex:
+    -- else complex applyValues(C.dd.map, f -> truncate(degs, f, opts)))
+    else (
+	-- this construction requires ~half as many truncations
+	f := truncate(degs, dd^C_lo, opts);
+	complex hashTable for i from lo+1 to hi list i => (
+	    f = inducedTruncationMap(source f, truncate(degs, C_i, opts), dd^C_i))
+    ))
 
 --------------------------------------------------------------------
 -- basis -----------------------------------------------------------

--- a/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
@@ -538,6 +538,20 @@ truncate(List, ComplexMap) := ComplexMap => {} >> opts -> (e, f) -> (
 truncate(ZZ, ComplexMap) := ComplexMap => {} >> opts -> (e, f) -> truncate({e}, f)
 
 --------------------------------------------------------------------
+-- basis -----------------------------------------------------------
+--------------------------------------------------------------------
+-- returns the induced complex map between the graded components of
+-- the source and target complexes in the given degree, over the
+-- same ring as the input (as opposed to its coefficient ring)
+-- TODO: also define basis given a degree range and infinite ranges
+basis(ZZ,   ComplexMap) :=
+basis(List, ComplexMap) := ComplexMap => opts -> (deg, f) -> (
+    d := degree f;
+    C := basis(deg, source f, opts);
+    D := if source f === target f then C else basis(deg, target f, opts);
+    map(D, C, i -> inducedBasisMap(D_(i+d), C_i, f_i), Degree => d))
+
+--------------------------------------------------------------------
 -- homology --------------------------------------------------------
 --------------------------------------------------------------------
 minimalPresentation ComplexMap := 

--- a/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
@@ -547,13 +547,7 @@ basis(List, ComplexMap) := ComplexMap => opts -> (deg, f) -> (
 -- the source and target complexes in the given degree, but as a map
 -- over the coefficient ring instead
 part(ZZ,   ComplexMap) :=
-part(List, ComplexMap) := ComplexMap => (deg, f) -> (
-    psi := residueMap ring f;
-    g := basis(deg, f);
-    C := psi cover source g;
-    D := psi cover target g;
-    d := degree f;
-    map(D, C, i -> map(D_(i+d), C_i, psi cover g_i), Degree => d))
+part(List, ComplexMap) := ComplexMap => (deg, f) -> (residueMap ring f) cover' basis(deg, f)
 
 --------------------------------------------------------------------
 -- homology --------------------------------------------------------

--- a/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
@@ -518,13 +518,13 @@ canonicalTruncation(ComplexMap,InfiniteNumber,InfiniteNumber) :=
 canonicalTruncation(ComplexMap,ZZ,Nothing) := 
 canonicalTruncation(ComplexMap,Nothing,ZZ) := ComplexMap => (f,lo,hi) -> canonicalTruncation(f, (lo,hi))
 
-truncate(List, ComplexMap) := ComplexMap => {} >> opts -> (e, f) -> (
-    C := truncate(e, source f);
-    D := truncate(e, target f);
+truncateMatrixOpts := options(truncate, List, Matrix)
+truncate(ZZ,   ComplexMap) :=
+truncate(List, ComplexMap) := ComplexMap => truncateMatrixOpts >> opts -> (degs, f) -> (
     d := degree f;
-    map(D, C, i -> map(D_(i+d), C_i, truncate(e, f_i)), Degree => d)
-    )
-truncate(ZZ, ComplexMap) := ComplexMap => {} >> opts -> (e, f) -> truncate({e}, f)
+    C := truncate(degs, source f, opts);
+    D := if source f === target f then C else truncate(degs, target f, opts);
+    map(D, C, i -> inducedTruncationMap(D_(i+d), C_i, f_i), Degree => d))
 
 --------------------------------------------------------------------
 -- basis -----------------------------------------------------------

--- a/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplexMap.m2
@@ -518,17 +518,6 @@ canonicalTruncation(ComplexMap,InfiniteNumber,InfiniteNumber) :=
 canonicalTruncation(ComplexMap,ZZ,Nothing) := 
 canonicalTruncation(ComplexMap,Nothing,ZZ) := ComplexMap => (f,lo,hi) -> canonicalTruncation(f, (lo,hi))
 
-part(List, ComplexMap) := ComplexMap => (deg, f) -> (
-    R := ring f;
-    A := coefficientRing R;
-    psi := map(A,R, DegreeMap => degR -> take(degR, - degreeLength A));
-    C := part(deg, source f);
-    D := part(deg, target f);
-    d := degree f;
-    map(D, C, i -> map(D_(i+d), C_i, psi matrix basis(deg, f_i)), Degree => d)
-    )
-part(ZZ, ComplexMap) := ComplexMap => (deg, f) -> part({deg}, f)
-
 truncate(List, ComplexMap) := ComplexMap => {} >> opts -> (e, f) -> (
     C := truncate(e, source f);
     D := truncate(e, target f);
@@ -550,6 +539,21 @@ basis(List, ComplexMap) := ComplexMap => opts -> (deg, f) -> (
     C := basis(deg, source f, opts);
     D := if source f === target f then C else basis(deg, target f, opts);
     map(D, C, i -> inducedBasisMap(D_(i+d), C_i, f_i), Degree => d))
+
+--------------------------------------------------------------------
+-- part ------------------------------------------------------------
+--------------------------------------------------------------------
+-- returns the induced complex map between the graded component of
+-- the source and target complexes in the given degree, but as a map
+-- over the coefficient ring instead
+part(ZZ,   ComplexMap) :=
+part(List, ComplexMap) := ComplexMap => (deg, f) -> (
+    psi := residueMap ring f;
+    g := basis(deg, f);
+    C := psi cover source g;
+    D := psi cover target g;
+    d := degree f;
+    map(D, C, i -> map(D_(i+d), C_i, psi cover g_i), Degree => d))
 
 --------------------------------------------------------------------
 -- homology --------------------------------------------------------

--- a/M2/Macaulay2/packages/Complexes/ChainComplexTests.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplexTests.m2
@@ -2073,7 +2073,7 @@ needsPackage "Complexes"
 ///
 
 TEST ///
-  -- example of computing part.
+  -- example of computing basis and part.
 -*
   restart
   needsPackage "Complexes" 
@@ -2094,16 +2094,19 @@ TEST ///
   assert isWellDefined part(2, F)
   assert(ring part(2, F) === kk)
 
-  assert (C = part(6, F); 
-      (for i from 0 to length C list rank C_i) == {84, 125, 54, 1})
-  assert isWellDefined part(6, F)
+  C = part(6, F)
+  D = basis(6, F)
+  assert isWellDefined C
+  assert isWellDefined D
+  assert({84, 125, 54, 1} == apply(length C + 1, i -> rank C_i))
+  assert({84, 125, 54, 1} == apply(length D + 1, i -> rank cover D_i))
 
   kk = ZZ/32003[s,t]
   S = kk[a..d]
   psi = map(kk, S)
   I = ideal"sab, tad, (s-t)bc, tc3"
 
-  isHomogeneous I
+  assert isHomogeneous I
   F = freeResolution comodule I
 
   assert(part(-10, F) == 0)
@@ -2126,8 +2129,19 @@ TEST ///
   assert(ring part(6, F) === kk)
 
   C = part(2, F)
-  dd^C
-  isHomogeneous dd^C_1 -- want this to be true.
+  D = basis(2, F)
+  assert isHomogeneous C
+  assert isHomogeneous D
+  assert isHomogeneous dd^C
+  assert isHomogeneous dd^D
+
+  f = id_F;
+  g = part(2, f)
+  h = basis(2, f)
+  assert isHomogeneous g
+  assert isHomogeneous h
+  assert isCommutative g
+  assert isCommutative h
 ///
 
 TEST ///  

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -292,6 +292,10 @@ truncate(InfiniteNumber, Thing) := truncateModuleOpts >> o -> (d, M) -> (
 truncate(Nothing,        InfiniteNumber, Matrix) :=
 truncate(InfiniteNumber, InfiniteNumber, Matrix) := lookup(truncate, List, List, Matrix)
 
+-- TODO: implement union types in M2 and simplify stuff like this
+truncate(Nothing,        InfiniteNumber, Matrix) :=
+truncate(InfiniteNumber, InfiniteNumber, Matrix) := lookup(truncate, List, List, Matrix)
+
 --------------------------------------------------------------------
 -- basis using basisPolyhedron (experimental)
 --------------------------------------------------------------------

--- a/M2/Macaulay2/packages/Truncations/tests.m2
+++ b/M2/Macaulay2/packages/Truncations/tests.m2
@@ -394,6 +394,11 @@ TEST /// -- test of truncation of complexes
   truncate(3, C)
 ///
 
+TEST /// -- test of subtruncate
+  M = module(QQ[x,y])
+  assert(truncate(1, 2, id_M) == map(truncate(1, M), truncate(2, M), {{y, 0, 0}, {0, y, x}}))
+///
+
 end--
 
 restart

--- a/M2/Macaulay2/packages/Truncations/tests.m2
+++ b/M2/Macaulay2/packages/Truncations/tests.m2
@@ -387,6 +387,13 @@ TEST /// -- test of subtruncate
   assert(truncate(1, 2, id_M) == map(truncate(1, M), truncate(2, M), {{y, 0, 0}, {0, y, x}}))
 ///
 
+TEST /// -- test of truncation of complexes
+  needsPackage "Complexes"
+  S = QQ[x,y,z]
+  C = koszulComplex vars S
+  truncate(3, C)
+///
+
 end--
 
 restart


### PR DESCRIPTION
Summary of changes:
- **added part for modules, matrices, ideals, and rings**
  - this is the same as `part(ZZ, Complex)`, but for other graded objects
- **added basis(ZZ, Complex)**
- **added basis(ZZ, ComplexMap)**
  - this is a similar to `part(ZZ, Complex)`, but the base ring is the original ring, not its coefficient ring
- **simplified part(ZZ, Complex)**
  - also fixes https://github.com/Macaulay2/M2/issues/3345
- **simplified part(ZZ, ComplexMap)**
- **added better algorithm for basis(ZZ, Complex)**
- **added better algorithm for truncate(ZZ, Complex)**
- **added better algorithm for truncate(ZZ, ComplexMap)**
  - this is way faster for large enough complexes
- **added tests for basis of Complex and ComplexMap**
- **added method for truncating source of map more than target**
  - we use this frequently in Varieties

The rest are optimizations in line with https://github.com/Macaulay2/M2/issues/3352 to eliminate unnecessary gb computations, though there's more work left.
- **cached subquotient gens in M.cache.Monomial**
- **optimized basis(ZZ, Matrix)**
- **used ??= to cache image, coker, coimage**
- **added ways to avoid gb calls in inducedMap**