### PR TITLE
Print stack trace when flint aborts

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <flint/flint.h> // for flint_set_abort
 
 /* ######################################################################### */
 
@@ -54,6 +55,7 @@ bool interrupts_interruptShield;
 void* interpFunc(ArgCell* vargs);
 void* profFunc(ArgCell* p);
 void* testFunc(ArgCell* p);
+void  M2_flint_abort(void);
 
 static void * GC_start_performance_measurement_0(void *) {
 #ifdef GC_start_performance_measurement /* added in bdwgc 8 */
@@ -89,6 +91,8 @@ int main(/* const */ int argc, /* const */ char *argv[], /* const */ char *env[]
   interrupt_jmp.is_set = FALSE;
 
   signal(SIGPIPE,SIG_IGN); /* ignore the broken pipe signal */
+
+  flint_set_abort(M2_flint_abort);
 
   static struct ArgCell* M2_vargs;
   M2_vargs = (ArgCell*) GC_MALLOC_UNCOLLECTABLE(sizeof(struct ArgCell));
@@ -132,6 +136,11 @@ void stack_trace(std::ostream &stream, bool M2) {
     stream << boost::stacktrace::stacktrace();
     stream << "-- end stack trace *-" << std::endl;
   }
+}
+
+void M2_flint_abort(void) {
+  stack_trace(std::cerr, false);
+  abort();
 }
 
 extern "C" {


### PR DESCRIPTION
This is a partial response to #3518.

Flint has a function `flint_set_abort` that allows us to override its `flint_abort` function.  We still end up calling `abort()` (if we don't, then we just end up segfaulting, at least for this particular bug), but we take the opportunity to print a stack trace for debugging.

```m2
i3 : factor f 15
Flint exception (General error):
    lenP < 2 in n_poly_mod_invmod
-* stack trace, pid: 3833436
 0# stack_trace(std::ostream&, bool) at ../../../../Macaulay2/d/main.cpp:136
 1# M2_flint_abort() at ../../../../Macaulay2/d/main.cpp:143
 2# 0x000075E0EB0DF95F at src/generic_files/exception.c:49
 3# flint_throw at src/generic_files/exception.c:63
 4# 0x000075E0EB528727 at src/n_poly/n_poly_mod.c:463
 5# n_bpoly_mod_make_monic_mod at src/nmod_mpoly_factor/n_bpoly_mod_factor_lgprime.c:57
 6# n_bpoly_mod_factor_lgprime at src/nmod_mpoly_factor/n_bpoly_mod_factor_lgprime.c:902
 7# _factor_irred_compressed at src/nmod_mpoly_factor/factor.c:368
 8# _factor_irred at src/nmod_mpoly_factor/factor.c:729
 9# nmod_mpoly_factor_irred at src/nmod_mpoly_factor/factor.c:832
10# nmod_mpoly_factor_algo at src/nmod_mpoly_factor/factor.c:979
11# factorize(CanonicalForm const&, bool) at /build/singular-HDHwVv/singular-4.3.2-p10+ds/factory/cf_factor.cc:592
12# factorize(CanonicalForm const&, bool) at /build/singular-HDHwVv/singular-4.3.2-p10+ds/factory/cf_factor.cc:428
13# rawFactorBase(RingElement const*, engine_RawRingElementArray_struct**, M2_arrayint_struct**, RingElement const*) at ../../../../Macaulay2/e/interface/factory.cpp:711
14# interface_rawFactor at ../../../../Macaulay2/d/interface.dd:1435
15# evaluate_evalraw at ../../../../Macaulay2/d/evaluate.d:1429
16# evaluate_applyFCS at ../../../../Macaulay2/d/evaluate.d:568

.
.
.

75# SupervisorThread::threadEntryPoint() at ../../../../Macaulay2/system/supervisor.cpp:404
76# SupervisorThread::threadEntryPoint(void*) at ../../../../Macaulay2/system/supervisor.hpp:89
77# 0x000075E0EAADC684 in /usr/lib/x86_64-linux-gnu/libgc.so.1
78# GC_call_with_stack_base in /usr/lib/x86_64-linux-gnu/libgc.so.1
79# start_thread at ./nptl/pthread_create.c:447
80# clone3 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:80
-- end stack trace *-
Aborted (core dumped)

Process M2 exited abnormally with code 134
```