### PR TITLE
Include bison-generated header files first in html-check-links

### DIFF
--- a/M2/Macaulay2/html-check-links/Makefile.in
+++ b/M2/Macaulay2/html-check-links/Makefile.in
@@ -2,7 +2,7 @@
 # FULLDEBUG = TRUE
 include ../../include/config.Makefile
 VPATH = @srcdir@
-CPPFLAGS += -I@srcdir@ -I.
+CPPFLAGS := -I@srcdir@ -I. $(CPPFLAGS)
 YACC = @YACC@
 %.tab.c %.tab.h: %.y; $(YACC.y) $< && mv y.tab.c $*.tab.c && mv y.tab.h $*.tab.h
 %.fixed.c : %.tab.c


### PR DESCRIPTION
Otherwise, we may end up including them from elsewhere (e.g., there's a "grammar.h" distributed with some versions of Python).

Closes: #2398

(Draft for now -- this works locally but I'd also like to check on a RHEL 9 GitHub build.)