### PR TITLE
Detect TOPCOM package on Arch Linux

### DIFF
--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -77,10 +77,12 @@ topcomPoints Matrix := opts -> (A) -> (
 callTopcom = method()
 callTopcom(String, List) := (command, inputs) -> (
     if topcomProgram === null then
-	topcomProgram = findProgram("topcom","cube 3", Prefix => {
+	topcomProgram = findProgram("topcom", {"cube 3", "B_A 3"}, Prefix => {
 	    (".*", "topcom-"), -- debian
 	    ("^(cross|cube|cyclic|hypersimplex|lattice)$", "TOPCOM-"), --fedora
-	    ("^cube$", "topcom_")}); --gentoo
+	    ("^cube$", "topcom_"), --gentoo
+	    ("^(binomial|cross|cube|cyclic|lattice)$", "topcom-") --arch
+	    });
     filename := temporaryFileName();
     infile := filename|".in";
     -- now create the output file


### PR DESCRIPTION
It prepends "topcom-" to just some of the binaries.  This means we need to check two binaries (one with the prefix and one without) to distinguish the Arch package from the Debian one (which prepends "topcom-" to everything).

From https://gitlab.archlinux.org/archlinux/packaging/packages/topcom/-/blob/main/PKGBUILD?ref_type=heads:

```shell
  for _prog in binomial cross cube cyclic lattice; do
    mv "$pkgdir"/usr/bin/{,topcom-}$_prog
  done
```
