### PR TITLE
Minimize filename during TestInput tests (take 2)

### DIFF
--- a/M2/Macaulay2/tests/normal/testing.m2
+++ b/M2/Macaulay2/tests/normal/testing.m2
@@ -1,4 +1,4 @@
-testpkg = temporaryFileName() | ".m2"
+testpkg = minimizeFilename(temporaryFileName() | ".m2")
 testpkg << ///newPackage("TestPackage")
 beginDocumentation()
 TEST "assert Equation(1 + 1, 2)"
@@ -12,7 +12,7 @@ assert Equation(toString pkgtest, "assert Equation(1 + 1, 2)")
 assert Equation(net pkgtest, "TestInput[" | testpkg | ":3:5-3:32]")
 beginDocumentation()
 expectedCode = DIV{
-    new FilePosition from (minimizeFilename testpkg, 3, 5, 3, 32, 3, 5),
+    new FilePosition from (testpkg, 3, 5, 3, 32, 3, 5),
     ": --source code:",
     PRE{CODE{"class" => "language-macaulay2",
 	    "TEST \"assert Equation(1 + 1, 2)\""}}}


### PR DESCRIPTION
The filename appears in several different checks, so we minimize it at the beginning.

This *should* fix https://github.com/Macaulay2/M2/pull/3530#issuecomment-2427876700.  Previously, if I ran M2 from `/tmp` (so the relative path to the temporary file would be missing the "/tmp"), it would fail, but after this change, it passes.