### PR TITLE
Fixes in CMake and Bertini

### DIFF
--- a/M2/Macaulay2/e/newdelete.hpp
+++ b/M2/Macaulay2/e/newdelete.hpp
@@ -1,8 +1,6 @@
 #ifndef NEWDELETE_H
 #define NEWDELETE_H 1
 
-#define GC_REDIRECT_TO_LOCAL // enable thread-local allocation
-
 #include "M2mem.h"  // for freemem, getmem, outofmem2
 #include "debug.h"  // for TRAPCHK, TRAPCHK_SIZE
 

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -134,7 +134,10 @@ isCapturable = (inputs, pkg, isTest) -> (
     inputs = replace("-\\*.*?\\*-", "", inputs);
     -- TODO: remove this when the effects of capture on other packages is reviewed
     (isTest or match({"FirstPackage", "Macaulay2Doc"},            pkg#"pkgname"))
-    and not match({"MultiprojectiveVarieties", "EngineTests","ThreadedGB","RunExternalM2","SpecialFanoFourfolds"}, pkg#"pkgname")
+    and not match({
+	    "FastMinors", "TerraciniLoci",
+	    "MultiprojectiveVarieties", "SpecialFanoFourfolds",
+	    "EngineTests", "ThreadedGB", "RunExternalM2"}, pkg#"pkgname")
     and not (match({"Cremona"}, pkg#"pkgname") and version#"pointer size" == 4)
     -- FIXME: these are workarounds to prevent bugs, in order of priority for being fixed:
     and not match("(gbTrace|NAGtrace)",                       inputs) -- cerr/cout directly from engine isn't captured

--- a/M2/Macaulay2/packages/Bertini.m2
+++ b/M2/Macaulay2/packages/Bertini.m2
@@ -2115,7 +2115,7 @@ importParameterFile(String) := o ->(aString)->(
     if o.NameParameterFile===3 then NPF="random_values";
     aString=aString|NPF;
     if false===fileExists aString
-    then error"The file "|NPF|" does not exist at "|aString|". ";
+    then error("The file "|NPF|" does not exist at "|aString|".");
     getLines:=apply(lines get (aString),i->select("[0-9e.+-]+",i)); -- grabs all lines of the solution file and selects desired words
     expectedNumberOfParameters:=value (getLines_0_0);
     getLines=drop(getLines,2);

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -331,7 +331,7 @@ else()
 endif()
 
 if(FLINT_FOUND)
-  set(CMAKE_REQUIRED_INCLUDES "${FLINT_INCLUDE_DIR}")
+  set(CMAKE_REQUIRED_INCLUDES "${FLINT_INCLUDE_DIR};${GMP_INCLUDE_DIRS}")
   check_include_files(flint/nmod.h HAVE_FLINT_NMOD_H)
   check_include_files(flint/arb.h  HAVE_FLINT_ARB_H)
 else()


### PR DESCRIPTION
I may add more quickfixes to this PR.

- **added GMP include path when searching for flint headers**
- **fixed a bug in Bertini**
