### PR TITLE
Don't use robust "key not found" error when errors are suppressed

### DIFF
--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -318,10 +318,11 @@ lookup(object:HashTable, key:Expr):Expr; -- forward declaration
 KeyNotFound(object:string, key:Expr):Expr := (
     -- TODO: implement a similar trick to call synonym(object)
     msg := "key not found in " + object;
-    see := lookup(Class(key), RobustPrintE);
-    if see != notfoundE then
-    when applyEEEpointer(see, toExpr(msg), key)
-    is str:stringCell do msg = str.v else nothing;
+    if !SuppressErrors then (
+	see := lookup(Class(key), RobustPrintE);
+	if see != notfoundE then
+	when applyEEEpointer(see, toExpr(msg), key)
+	is str:stringCell do msg = str.v else nothing);
     buildErrorPacket(msg));
 
 export lookup1(object:HashTable,key:Expr,keyhash:hash_t):Expr := (


### PR DESCRIPTION
The robust error message involves calling `alarm`, which will cancel any alarms we might be trying to catch using `try` or `??`.

Closes: #3524

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
