### PR TITLE
Fixing ring maps from WeylAlgebra to AssociativeAlgebra

### DIFF
--- a/M2/Macaulay2/e/M2FreeAlgebra.hpp
+++ b/M2/Macaulay2/e/M2FreeAlgebra.hpp
@@ -50,6 +50,7 @@ public:
   virtual const M2FreeAlgebraOrQuotient * cast_to_M2FreeAlgebraOrQuotient()  const { return this; }
   virtual       M2FreeAlgebraOrQuotient * cast_to_M2FreeAlgebraOrQuotient()        { return this; }
 
+  bool is_commutative_ring() const { return false; }
 };
 
 class M2FreeAlgebra : public M2FreeAlgebraOrQuotient

--- a/M2/Macaulay2/e/M2FreeAlgebraQuotient.hpp
+++ b/M2/Macaulay2/e/M2FreeAlgebraQuotient.hpp
@@ -45,7 +45,9 @@ public:
   
   int numVars() const { return monoid().numVars(); }
   int n_vars() const { return numVars(); }
-  
+
+  bool is_quotient_ring() const { return true; }
+
   // these are all the functions from Ring that must exist for M2FreeAlgebraQuotient to be instantiated
   virtual int index_of_var(const ring_elem a) const;
   

--- a/M2/Macaulay2/tests/normal/ringmap7.m2
+++ b/M2/Macaulay2/tests/normal/ringmap7.m2
@@ -1,0 +1,13 @@
+needsPackage "WeylAlgebras"
+needsPackage "AssociativeAlgebras"
+
+D = ZZ/101[x,dx, WeylAlgebra => {x => dx}]
+R = ZZ/101<|dy,y|>/(dy*y - 1 - y*dy)
+
+f = map(R, D, {y,dy})
+
+assert(f(dx*x) == y*dy+1)
+assert(f(x*dx) == y*dy)
+
+assert(f(dx*x^2) == y^2*dy+2*y)
+assert(f(x^2*dx) == y^2*dy)


### PR DESCRIPTION
@mikestillman this is the change suggested in https://github.com/Macaulay2/M2/issues/2907#issuecomment-1741490215 by @mdebellevue. Could you have a look at why it's not working?

I emailed you two weeks ago that we need to have #2907 fixed before the upcoming workshop. If that's not possible, we need to know so we can change plans.