### PR TITLE
Remove old atan/atan2 error message

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -1060,8 +1060,6 @@ atan(e:Expr):Expr := (
      is x:CCcell do toExpr(atan(x.v))				    -- # typical value: atan, CC, CC
      is x:RRcell do toExpr(atan(x.v))				    -- # typical value: atan, RR, RR
      is x:RRicell do toExpr(atan(x.v))				    -- # typical value: atan, RRi, RRi
-     is a:Sequence do if length(a) == 2 then buildErrorPacket("atan(x,y) has been replaced by atan2(y,x)")
-     else WrongNumArgs(1)
      else WrongArgRRorCC()
      );
 setupfun("atan",atan).Protected=false;


### PR DESCRIPTION
Unnecessary since calling `atan(x,y)` will raise a "no method found" error anyway and we'll never reach this code.

You have to try pretty hard to get this error:

```m2
i1 : (lookup(atan, RR))(2, 3)
stdio:1:18:(3): error: atan(x,y) has been replaced by atan2(y,x)
```

As suggested in https://github.com/Macaulay2/M2/pull/3498#discussion_r1775992378