### PR TITLE
Skip multiline comments when checking if test/example is capturable

### DIFF
--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -130,8 +130,8 @@ isCapturable = (inputs, pkg, isTest) -> (
     -- alternatively, no-capture-flag can be used with an example or test
     if argumentMode & NoCapture =!= 0 or match("no-capture-flag", inputs) then return false;
     -- strip commented segments first
-    inputs = replace("--.*$", "",       inputs);
-    inputs = replace("-\\*.*?\\*-", "", inputs);
+    inputs = replace("--.*$", "",            inputs);
+    inputs = replace("-\\*(.|\n)*?\\*-", "", inputs);
     -- TODO: remove this when the effects of capture on other packages is reviewed
     (isTest or match({"FirstPackage", "Macaulay2Doc"},            pkg#"pkgname"))
     and not match({


### PR DESCRIPTION
As discussed in M2internals this afternoon.

### Before

```m2
i1 : TEST ///
-*
gbTrace
notify
*-
assert true
///

                              
i2 : check User
 -- running   check(0, "User")                  -- .860631s elapsed
```

### After
```m2
i1 : TEST ///
-*
gbTrace
notify
*-
assert true
///

                              
i2 : check User
 -- capturing check(0, "User") -- .0826772s elapsed
```