### PR TITLE
Update Fedora docker files

### DIFF
--- a/M2/BUILD/docker/fedora/Dockerfile
+++ b/M2/BUILD/docker/fedora/Dockerfile
@@ -2,7 +2,9 @@
 # Net usage:  54+124+
 # Disk usage: ??
 
-FROM registry.fedoraproject.org/fedora-minimal:32
+ARG RELEASE=latest
+
+FROM quay.io/fedora/fedora-minimal:$RELEASE
 
 # Programs we require to build
 #  kernel-devel rpm-build rpm-sign rpmdevtools

--- a/M2/BUILD/docker/fedora/Dockerfile
+++ b/M2/BUILD/docker/fedora/Dockerfile
@@ -28,7 +28,7 @@ RUN microdnf install -y cddlib-devel 4ti2 gfan normaliz csdp-tools nauty \
     lrslib-utils cohomCalg msolve
 
 # Optional packages
-RUN microdnf install -y mlocate bash-completion R
+RUN microdnf install -y plocate bash-completion R
 
 # Add non-root user for building and running Macaulay2
 RUN useradd -G wheel -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/M2/BUILD/docker/fedora/Dockerfile
+++ b/M2/BUILD/docker/fedora/Dockerfile
@@ -8,23 +8,27 @@ FROM quay.io/fedora/fedora-minimal:$RELEASE
 
 # Programs we require to build
 #  kernel-devel rpm-build rpm-sign rpmdevtools
-RUN microdnf install -y autoconf bison ccache cmake curl diffutils file gcc-c++ git \
-	gnupg libtool make ninja-build patch yasm rpm-build rpmlint which
+RUN microdnf install -y autoconf bison ccache cmake curl diffutils file     \
+    gcc-c++ git gnupg libtool make ninja-build patch yasm rpm-build rpmlint \
+    which flex gcc-gfortran
 
 # Libraries we require
 RUN microdnf install -y openblas-devel libxml2-devel readline-devel gdbm-devel \
-	boost-devel libomp-devel tbb-devel
+    boost-devel libomp-devel tbb-devel python3-devel libffi-devel
 
 # Libraries we can build (factory not available on ubuntu)
 RUN microdnf install -y eigen3-devel glpk-devel gmp-devel mpfr-devel ntl-devel \
-	libnauty-devel libnormaliz-devel libfrobby-devel gc-devel
+    libnauty-devel libnormaliz-devel libfrobby-devel gc-devel mpfi-devel       \
+    factory-devel mpsolve-devel fflas-ffpack-devel memtailor-devel             \
+    mathic-devel mathicgb-devel
 
 # Programs we can build
-# TODO: cohomcalg available soon. Polymake requires firefox???
-RUN microdnf install -y cddlib-devel 4ti2 gfan normaliz csdp-tools nauty lrslib
+# TODO: Polymake requires firefox???
+RUN microdnf install -y cddlib-devel 4ti2 gfan normaliz csdp-tools nauty \
+    lrslib-utils cohomCalg msolve
 
 # Optional packages
-RUN microdnf install -y mlocate bash-completion
+RUN microdnf install -y mlocate bash-completion R
 
 # Add non-root user for building and running Macaulay2
 RUN useradd -G wheel -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/M2/BUILD/docker/fedora/Dockerfile
+++ b/M2/BUILD/docker/fedora/Dockerfile
@@ -8,23 +8,23 @@ FROM quay.io/fedora/fedora-minimal:$RELEASE
 
 # Programs we require to build
 #  kernel-devel rpm-build rpm-sign rpmdevtools
-RUN microdnf install autoconf bison ccache cmake curl diffutils file gcc-c++ git \
+RUN microdnf install -y autoconf bison ccache cmake curl diffutils file gcc-c++ git \
 	gnupg libtool make ninja-build patch yasm rpm-build rpmlint which
 
 # Libraries we require
-RUN microdnf install openblas-devel libxml2-devel readline-devel gdbm-devel \
-	boost-devel libomp-dev libtbb-dev
+RUN microdnf install -y openblas-devel libxml2-devel readline-devel gdbm-devel \
+	boost-devel libomp-devel tbb-devel
 
 # Libraries we can build (factory not available on ubuntu)
-RUN microdnf install eigen3-devel glpk-devel gmp-devel mpfr-devel ntl-devel \
+RUN microdnf install -y eigen3-devel glpk-devel gmp-devel mpfr-devel ntl-devel \
 	libnauty-devel libnormaliz-devel libfrobby-devel gc-devel
 
 # Programs we can build
 # TODO: cohomcalg available soon. Polymake requires firefox???
-#RUN microdnf install libcdd-devel 4ti2 gfan normaliz coinor-csdp nauty lrslib
+RUN microdnf install -y cddlib-devel 4ti2 gfan normaliz csdp-tools nauty lrslib
 
 # Optional packages
-RUN microdnf install mlocate bash-completion
+RUN microdnf install -y mlocate bash-completion
 
 # Add non-root user for building and running Macaulay2
 RUN useradd -G wheel -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/M2/BUILD/docker/fedora/Makefile
+++ b/M2/BUILD/docker/fedora/Makefile
@@ -1,7 +1,9 @@
 include ../ubuntu/Makefile
 
 ## Parameters
-TAG = m2-fedora-build
+RELEASE = latest
+BUILD_ARGS = --build-arg RELEASE=$(RELEASE)
+TAG = m2-fedora-$(RELEASE)-build
 BUILD_DIR = M2/BUILD/build-docker
 BUILD_OPT = -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
 

--- a/M2/BUILD/docker/fedora/Makefile
+++ b/M2/BUILD/docker/fedora/Makefile
@@ -10,3 +10,24 @@ BUILD_OPT = -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
 rpm:;       docker run $(VOLUME) -it --entrypoint "" $(TAG) bash -c "cd M2/$(BUILD_DIR); cpack -G RPM"
 
 rpmlint:;   docker run $(VOLUME) -it --entrypoint "" $(TAG) bash -c "rpmlint M2/$(BUILD_DIR)/Macaulay2-*.rpm"
+
+## autotools build
+## TODO: generalize this to other distros, move to toplevel Makefile
+
+CONFIG_OPT = --with-system-gc --with-system-memtailor --with-system-mathic \
+	--with-system-mathicgb --enable-download --enable-rpm --prefix=/usr
+
+define M2_BUILD_SCRIPT_autotools
+set -xe
+
+mkdir -p M2/$(BUILD_DIR)
+cd M2/$(BUILD_DIR)
+$(M2_HOME)/M2/M2/autogen.sh
+$(M2_HOME)/M2/M2/configure $(CONFIG_OPT)
+make
+endef
+export M2_BUILD_SCRIPT_autotools
+
+build-autotools: build-image
+	docker run $(VOLUME) -it --entrypoint="" $(TAG) \
+		bash -c "$$M2_BUILD_SCRIPT_autotools"

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -120,7 +120,7 @@ then if test -f /usr/bin/sw_vers
 	 "debian"|"Debian"*) ISSUE_FLAVOR=Debian ;;
          "ubuntu"|"Ubuntu") ISSUE_FLAVOR=Ubuntu ;;
 	 "FedoraCore"*) ISSUE_FLAVOR=FedoraCore ;;
-	 "Fedora"*) ISSUE_FLAVOR=Fedora ;;
+	 "fedora"|"Fedora"*) ISSUE_FLAVOR=Fedora ;;
 	 "RedHatEnterprise"*) ISSUE_FLAVOR=RedHatEnterprise ;;
 	 "RedHat"*) ISSUE_FLAVOR=RedHat ;;
 	 "Scientific"*) ISSUE_FLAVOR="ScientificLinux" ;;


### PR DESCRIPTION
We make several updates to the files used to build Macaulay2 on Fedora using docker.  In particular, we:

* bump the release from the hardcoded 32 to "latest" (currently 41, but using this alias will ease maintenance going forward).
* alow specifying a particular release by setting the RELEASE variable.
* update the list of packages to install.
* add a "build-autotools" target to use the autotools build.

I successfully used these changes to build the 1.24.11 Fedora 40 and 41 packages now on the website.