### PR TITLE
Run autogen.sh for re-generating configure script from Makefile

### DIFF
--- a/M2/Makefile.in
+++ b/M2/Makefile.in
@@ -67,7 +67,7 @@ clean:
 	if [ -f Makefile ] ; then $(MAKE) -f Makefile clean-tools ; fi
 
 install: configured; $(MAKE) -C distributions $@
-@srcdir@/configure : @srcdir@/configure.ac @srcdir@/m4/files; $(MAKE) -C @srcdir@ -f Makefile
+@srcdir@/configure : @srcdir@/configure.ac @srcdir@/m4/files; @srcdir@/autogen.sh
 recheck config.status: @srcdir@/configure @srcdir@/Macaulay2/packages/=distributed-packages
 	$(WHY)
 	./config.status --recheck


### PR DESCRIPTION
I've run into this bug a few times in the last day or so.  Whenever make thinks that `configure` needs to be updated, it tries to regenerate it the old-fashioned way instead of running autogen.sh.  I missed this change back in #3520.