### PR TITLE
leadTerm Ideal returning an Ideal

### DIFF
--- a/M2/Macaulay2/m2/gb.m2
+++ b/M2/Macaulay2/m2/gb.m2
@@ -202,6 +202,7 @@ syz = method(TypicalValue => Matrix, Options => syzDefaults)
 -- rawGBSyzygies doesn't sort its columns, so we do that here
 syz              GroebnerBasis  := Matrix => o -> G -> map(ring G, rawsort rawGBSyzygies G.RawComputation)
 leadTerm         GroebnerBasis  := Matrix =>      G -> map(ring G, rawGBGetLeadTerms(raw G, -1))
+leadTerm     (ZZ,GroebnerBasis) := Matrix =>   (i,G)-> map(ring G, rawGBGetLeadTerms(raw G, i))
 getChangeMatrix  GroebnerBasis  := Matrix =>      G -> map(ring G, rawGBChangeOfBasis G.RawComputation)
 generators       GroebnerBasis  := Matrix => o -> G -> map(target unbag G.matrix, , rawGBGetMatrix G.RawComputation)
 -- rawGBMinimalGenerators doesn't sort its columns, so we do that here

--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -431,6 +431,7 @@ Ideal = new Type of HashTable
 Ideal.synonym = "ideal"
 
 ideal = method(Dispatch => Thing, TypicalValue => Ideal)
+ideal Ideal := identity
 
 expression Ideal := (I) -> (expression ideal) unsequence apply(toSequence first entries generators I, expression)
 net Ideal := (I) -> net expression I
@@ -514,8 +515,8 @@ Matrix % Ideal := Matrix => ((f,I) ->
      ) @@ samering
 Vector % Ideal := (v,I) -> new class v from {v#0%I}
 numgens Ideal := (I) -> numgens source generators I
-leadTerm Ideal := Matrix => (I) -> leadTerm generators gb I
-leadTerm(ZZ,Ideal) := Matrix => (n,I) -> leadTerm(n,generators gb I)
+leadTerm Ideal := Ideal => (I) -> ideal leadTerm gb I
+leadTerm(ZZ,Ideal) := Matrix => (n,I) -> ideal leadTerm(n,gb I)
 jacobian Ideal := Matrix => (I) -> jacobian generators I
 Ideal _ List := (I,w) -> (module I)_w
 

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -98,6 +98,7 @@ Vector#AfterPrint = Vector#AfterNoPrint = v -> moduleAbbrv(module v, Vector)
 ring Vector := v -> ring class v
 module Vector := v -> target v#0
 leadTerm Vector := v -> new class v from leadTerm v#0
+leadTerm (ZZ, Vector) := (n,v) -> new class v from leadTerm(n,v#0)
 degree Vector := v -> (
      f := ambient v#0;
      first degrees source map(target f,,f))

--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -86,6 +86,7 @@ Set.synonym = "set"
 -- constructors, both compiled functions defined in d/sets.dd
 set VisibleList := Set => set
 new Set from List := Set => (X,x) -> set x
+set Set := identity
 
 -- set operations
 elements Set := List => keys

--- a/M2/Macaulay2/packages/AlgebraicSplines.m2
+++ b/M2/Macaulay2/packages/AlgebraicSplines.m2
@@ -928,7 +928,7 @@ orient = method()
 
 orient(Ideal):=List=> I->(
     LT:= leadTerm I;
-    reverse sort flatten apply(flatten entries LT,f-> support f)
+    reverse sort flatten apply(LT_*,f-> support f)
     )
 
 ------------------------------------------

--- a/M2/Macaulay2/packages/ExteriorIdeals.m2
+++ b/M2/Macaulay2/packages/ExteriorIdeals.m2
@@ -377,7 +377,7 @@ minimalBettiNumbers Ideal := I -> betti res ideal flatten entries mingens I
 -- Computes the initial ideal of an ideal
 ----------------------------------------------------------------------------------------------
 initialIdeal = method(TypicalValue=>Ideal)
-initialIdeal Ideal := I -> ideal rsort leadTerm I
+initialIdeal Ideal := I -> ideal rsort leadTerm gb I
 
 
 beginDocumentation()

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc5.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc5.m2
@@ -179,7 +179,8 @@ document {
      }
 
 undocumented {
-     (NewFromMethod, Set, List)
+     (NewFromMethod, Set, List),
+     (set, Set)
      }
 
 document {

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc7.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc7.m2
@@ -165,7 +165,7 @@ document {
      }
 
 document {
-     Key => (leadTerm, ZZ, Matrix),
+     Key => {(leadTerm, ZZ, Matrix), (leadTerm, ZZ, GroebnerBasis), (leadTerm, ZZ, Vector)},
      Headline => "get the matrix of lead polynomials of each column",
      Usage => "leadTerm(n,f)",
      Inputs => {"n", "f" => "in a polynomial ring"},

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/ideal-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/ideal-doc.m2
@@ -4,6 +4,8 @@
 
 -- in Classic: (ideal, String)
 
+undocumented (ideal,Ideal)
+
 document { 
      Key => ideal,
      Headline => "make an ideal",

--- a/M2/Macaulay2/packages/MinimalPrimes/radical.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes/radical.m2
@@ -149,7 +149,7 @@ unmixedradical = I -> (
 	    J := minors(size,dR);
 	    --
 	    g1 := leadTerm generators gb presentation R;
-	    g1 = g1 | lift(leadTerm J, B);
+	    g1 = g1 | lift(generators leadTerm J, B);
 	    --
 	    if c < codim ideal g1 then size = size + 1 else (
 		-- we would like the next line to read:

--- a/M2/Macaulay2/packages/OldPolyhedra.m2
+++ b/M2/Macaulay2/packages/OldPolyhedra.m2
@@ -3439,7 +3439,7 @@ statePolytope Ideal := I -> (
 	  -- map 'I' into 'S' and compute Groebner basis and leadterm
 	  I1 := f I;
 	  g := gb I1;
-	  lt := leadTerm I1;
+	  lt := generators leadTerm I1;
 	  gbRemove I1;
 	  (g,lt));
      makePositive := (w,posv) -> (
@@ -3455,7 +3455,7 @@ statePolytope Ideal := I -> (
      if not noError then error("The ideal must be homogeneous w.r.t. some strictly positive grading");
      -- Compute a first Groebner basis to start with
      g := gb I;
-     lt := leadTerm I;
+     lt := generators leadTerm I;
      -- Compute the Groebner cone
      C := gCone(g,lt);
      gbRemove I;

--- a/M2/Macaulay2/packages/Polyhedra/extended/not_refactored.m2
+++ b/M2/Macaulay2/packages/Polyhedra/extended/not_refactored.m2
@@ -47,7 +47,7 @@ statePolytope Ideal := I -> (
       -- map 'I' into 'S' and compute Groebner basis and leadterm
       I1 := f I;
       g := gb I1;
-      lt := leadTerm I1;
+      lt := generators leadTerm I1;
       gbRemove I1;
       (g,lt)
    );
@@ -65,7 +65,7 @@ statePolytope Ideal := I -> (
    if not noError then error("The ideal must be homogeneous w.r.t. some strictly positive grading");
    -- Compute a first Groebner basis to start with
    g := gb I;
-   lt := leadTerm I;
+   lt := generators leadTerm I;
    -- Compute the Groebner cone
    C := gCone(g,lt);
    gbRemove I;

--- a/M2/Macaulay2/packages/SegreClasses.m2
+++ b/M2/Macaulay2/packages/SegreClasses.m2
@@ -293,7 +293,7 @@ chowClass Scheme := opts -> X -> (
                     Ls=Ls+sum(wDims_i,j->ideal(random(OneAti(degreeLength R,i),R)));
                 );
             );
-            ZeroDimGB=ideal groebnerBasis(saturate(X)+Ls+LA, Strategy=>"F4");
+            ZeroDimGB=groebnerBasis(saturate(X)+Ls+LA, Strategy=>"F4");
             classI=classI+(numColumns basis(cokernel leadTerm ZeroDimGB))*w;
         );
     );

--- a/M2/Macaulay2/packages/TSpreadIdeals.m2
+++ b/M2/Macaulay2/packages/TSpreadIdeals.m2
@@ -652,7 +652,7 @@ else error "expected a graded ideal";
 -- returns the initial ideal of an ideal
 ----------------------------------------------------------------------------------------------
 initialIdeal = method(TypicalValue=>Ideal)
-initialIdeal Ideal := I -> ideal rsort leadTerm I
+initialIdeal Ideal := I -> ideal rsort leadTerm gb I
 
 -------------------------------------------------------------------------------------------
 -- returns the minimal Betti numbers of the quotient S/I

--- a/M2/Macaulay2/tests/slow/isSubset.m2
+++ b/M2/Macaulay2/tests/slow/isSubset.m2
@@ -44,7 +44,7 @@ f = J_(numgens J - 1);
 m = a*b*c^6
 assert( m % leadTerm K == 0 )
 assert( m % K != m )
-s = select( flatten entries leadTerm K, n -> m % leadMonomial n == 0 )
+s = select( (leadTerm K)_*, n -> m % leadMonomial n == 0 )
 assert( m % ideal s == 0 )
 assert( f % K == 0 )
 assert isSubset(J,K)


### PR DESCRIPTION
This one has been bothering me for a long time.
`leadTerm RingElement` returns a `RingElement`, `leadTerm Matrix` returns a `Matrix`, `leadTerm Vector` returns a `Vector`, but `leadTerm Ideal` ... returns a `Matrix`. Despite the documentation saying it should return an `Ideal`. This obviously needs fixing, but the problem is, a lot of existing code relies on this current incorrect implementation.

I decided to finally take a look at this and fix it the best I could:
- As suggested in the comments of #1499, I added `ideal Ideal := identity` which should mitigate most issues of upwards compatibility.
- I corrected some of the existing code in packages when this wasn't enough.
Incidentally, packages `ExteriorIdeals` and `TSpreadIdeals` define a method `initialIdeal` which by now is strictly equivalent to `leadTerm`. I believe these methods should be deprecated.
- I took this opportunity to also implement the suggestion of #2467.