### PR TITLE
Use brew's readline in macOS autotools GitHub builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -157,8 +157,12 @@ jobs:
           ../../autogen.sh
           export PYVERSION=`python3 -c "from sys import version_info; \
             print(f'{version_info.major}.{version_info.minor}')"`
-          export CPPFLAGS="-I`brew --prefix`/include -I`brew --prefix libomp`/include"
-          export  LDFLAGS="-L`brew --prefix`/lib -L`brew --prefix libomp`/lib \
+          export CPPFLAGS="-I`brew --prefix`/include \
+            -I`brew --prefix libomp`/include         \
+            -I`brew --prefix readline`/include"
+          export  LDFLAGS="-L`brew --prefix`/lib \
+            -L`brew --prefix libomp`/lib         \
+            -L`brew --prefix readline`/lib       \
             -L/Library/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
           export F77=gfortran-14
           ../../configure --enable-download --with-system-gc


### PR DESCRIPTION
It's keg-only to avoid conflicting with libedit provided by the system, so we need to specify the paths in order for it to be detected.  Otherwise, we end up building it every time!

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
