### PR TITLE
Improvements to Simplicial Toric Varieties

### DIFF
--- a/M2/Macaulay2/m2/basis.m2
+++ b/M2/Macaulay2/m2/basis.m2
@@ -320,7 +320,7 @@ algorithms#(basis, List, List, Module) = new MutableHashTable from {
 	G := degreeGroup(R := ring M);
 	if G == 0 or isFreeModule G then return null;
 	(S, phi, psi, p, f) := permuteDegreeGroup R;
-	B := psi map_S basisDefaultStrategy(opts, f lo, f hi, phi M);
+	B := psi map_S basisDefaultStrategy(opts, f lo, f hi, phi ** M);
 	L := positions(degrees source B, deg -> lo <= deg and deg <= hi);
 	raw submatrix(B, , L)),
     -- TODO: add separate strategies for skew commutative rings, vector spaces, and ZZ-modules

--- a/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
@@ -505,8 +505,8 @@ isVeryAmple ToricDivisor := {} >> o -> D -> (
 	)
     );
      
-isFano = method ()
-isFano NormalToricVariety := Boolean => X -> isAmple (- toricDivisor X)
+isFano = method()
+isFano NormalToricVariety := Boolean => X -> X.cache.isFano ??= isAmple(- toricDivisor X)
 
 
 ------------------------------------------------------------------------------

--- a/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Divisors.m2
@@ -518,8 +518,8 @@ vertices ToricDivisor := Matrix => D -> (
     X := variety D;
     if not isComplete X then 
     	error "-- expected a divisor on a complete toric variety";
-    if not isEffective D then return null;
     d := dim X;
+    if not isEffective D then return map(ZZ^d, ZZ^0, 0);
     V := transpose (matrix vector D | matrix rays variety D);
     V = V | transpose matrix {{1} | toList(d:0)};
     -( (fourierMotzkin V)#0)^{1..d} 
@@ -527,7 +527,7 @@ vertices ToricDivisor := Matrix => D -> (
 
 latticePoints ToricDivisor := Matrix => D -> (
     V := vertices D;
-    if V === null then return null;
+    if numColumns V <= 1 then return V;
     c := matrix(vector \ latticePoints convexHull V);
     c_(sortColumns c) 
     );

--- a/M2/Macaulay2/packages/NormalToricVarieties/DivisorsDocumentation.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/DivisorsDocumentation.m2
@@ -1967,8 +1967,7 @@ doc ///
             Cartier divisor is a lattice polytope.  Given a torus-invariant
             Cartier divisor on a normal toric variety, this method returns an
             integer matrix whose columns correspond to the vertices of the
-            associated lattice polytope.  For a non-effective Cartier divisor,
-            this methods returns @TO null@.  When the divisor is ample,
+	    associated lattice polytope. When the divisor is ample,
             the normal fan the corresponding polytope equals the fan
             associated to the normal toric variety.
         Text
@@ -1976,7 +1975,7 @@ doc ///
 	    a point, or a triangle.
         Example  
     	    PP2 = toricProjectiveSpace 2;
-    	    assert (null === vertices (-PP2_0))
+	    assert (vertices (-PP2_0) == 0)
     	    vertices (0*PP2_0)
     	    assert isAmple PP2_0
     	    V1 = vertices (PP2_0)
@@ -2031,14 +2030,13 @@ doc ///
   	    Cartier divisor is a lattice polytope.  Given a torus-invariant
   	    Cartier divisor on a normal toric variety, this method returns an
   	    integer matrix whose columns correspond to the lattices points
-  	    contained in the associated polytope.  For a non-effective Cartier
-  	    divisor, this method returns @TO null@.
+	    contained in the associated polytope.
         Text  
             On the projective plane, the associate polytope is either empty, a
    	    point, or a triangle.
         Example
             PP2 = toricProjectiveSpace 2;
-    	    assert (null === vertices (-PP2_0))
+	    assert (vertices (-PP2_0) == 0)
     	    latticePoints (0*PP2_0)
     	    assert isAmple PP2_0
     	    V1 = latticePoints (PP2_0)

--- a/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
@@ -104,6 +104,17 @@ cotangentSheaf(List, NormalToricVariety) := CoherentSheaf => opts -> (a, X) -> (
     then X#(cotangentSheaf, a)
     else X#(cotangentSheaf, a) = tensor apply(#a, i -> pullback(X^[i], cotangentSheaf(a#i, Xs#i))))
 
+-- This additional hook is valid beyond toric varieties, but for toric varieties
+-- it essentially builds on `monomials ToricDivisor` for basis of the Cox ring.
+-- basis' calls rawHilbertBasis which uses a parallelized algorithm from Normaliz,
+-- hence is significantly faster than the standard algorithm in the engine.
+-- Note: this computation can't be interrupted without restarting M2,
+-- and the order of resulting monomials may be different.
+importFrom_Core "raw"
+importFrom_Truncations "basis'"
+addHook((basis, List, List, Module), Strategy => Toric,
+    (opts, lo, hi, M) -> if degreeLength ring M > 1 and lo === hi
+    and instance(variety ring M, NormalToricVariety) then raw basis'(lo, M, opts))
 
 -- THIS FUNCTION IS NOT EXPORTED.  Given a normal toric variety, this function
 -- creates a HashTable describing the cohomology of all twists of the

--- a/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
@@ -135,6 +135,7 @@ setupHHOO = X -> (
 	);
     -- create rings
     degS := degrees S; 
+    ClX := classGroup X;
     X.cache.rawHHOO = new HashTable from apply(d+1, 
 	i -> {i, apply(sigma#i, s -> (
 	  	    v := - degree product(n, 
@@ -143,7 +144,7 @@ setupHHOO = X -> (
 	  	    degT := apply(n, 
 	    		j -> if member(j,s#0) then -degS#j else degS#j
 			);
-	  	    T := (ZZ/2)(monoid [gens S, Degrees => degT]);
+		    T := (ZZ/2)(monoid [gens S, Degrees => degT, DegreeGroup => ClX]);
 	  	    {v,T,s#0,s#1}
 		    )
 		)

--- a/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Sheaves.m2
@@ -110,11 +110,12 @@ cotangentSheaf(List, NormalToricVariety) := CoherentSheaf => opts -> (a, X) -> (
 -- hence is significantly faster than the standard algorithm in the engine.
 -- Note: this computation can't be interrupted without restarting M2,
 -- and the order of resulting monomials may be different.
-importFrom_Core "raw"
-importFrom_Truncations "basis'"
-addHook((basis, List, List, Module), Strategy => Toric,
-    (opts, lo, hi, M) -> if degreeLength ring M > 1 and lo === hi
-    and instance(variety ring M, NormalToricVariety) then raw basis'(lo, M, opts))
+-- TODO: this is temporarily disabled, for now
+-- importFrom_Core "raw"
+-- importFrom_Truncations "basis'"
+-- addHook((basis, List, List, Module), Strategy => Toric,
+--     (opts, lo, hi, M) -> if degreeLength ring M > 1 and lo === hi
+--     and instance(variety ring M, NormalToricVariety) then raw basis'(lo, M, opts))
 
 -- THIS FUNCTION IS NOT EXPORTED.  Given a normal toric variety, this function
 -- creates a HashTable describing the cohomology of all twists of the

--- a/M2/Macaulay2/packages/NormalToricVarieties/Tests.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Tests.m2
@@ -686,10 +686,20 @@ TEST ///
   P = convexHull matrix {0_N, N_0, N_1, N_0 + N_1 + 2*N_2}
   D = toricDivisor P
   X = variety D
+  assert(11 == # monomials(2*D))
+  assert(11 == rank HH^0(X, OO(2*D)))
+  assert(11 == numcols latticePoints(2*D))
+  assert(4  == numcols vertices(2*D))
   Y = toricProjectiveSpace 3
   f = map(Y, X, matrix {{1, -1, 0}, {0, -1, 0}, {1, 0, 2}})
   assert(classGroup f == map(classGroup X, classGroup Y, {{0}, {0}, {2}}))
   -- TODO: ideally this shouldn't be -1
   -- c.f. https://github.com/Macaulay2/M2/issues/2261
   assert(picardGroup f == map(picardGroup X, picardGroup Y, {{-1}}))
+  -- c.f. https://github.com/Macaulay2/M2/issues/3575
+  D' = 2*X_0-2*X_1+2*X_2;
+  assert(11 == # monomials(2*D'))
+  assert(11 == rank HH^0(X, OO(2*D')))
+  assert(0  == numcols latticePoints(2*D'))
+  assert(0  == numcols vertices(2*D'))
 ///

--- a/M2/Macaulay2/packages/NormalToricVarieties/Tests.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/Tests.m2
@@ -679,3 +679,17 @@ f = diagonalToricMap (P,2)
 assert isWellDefined f
 assert (codim ideal f == n)
 ///
+
+-- test 18
+TEST ///
+  N = ZZ^3
+  P = convexHull matrix {0_N, N_0, N_1, N_0 + N_1 + 2*N_2}
+  D = toricDivisor P
+  X = variety D
+  Y = toricProjectiveSpace 3
+  f = map(Y, X, matrix {{1, -1, 0}, {0, -1, 0}, {1, 0, 2}})
+  assert(classGroup f == map(classGroup X, classGroup Y, {{0}, {0}, {2}}))
+  -- TODO: ideally this shouldn't be -1
+  -- c.f. https://github.com/Macaulay2/M2/issues/2261
+  assert(picardGroup f == map(picardGroup X, picardGroup Y, {{-1}}))
+///

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricMaps.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricMaps.m2
@@ -310,9 +310,8 @@ classGroup ToricMap := Matrix => (cacheValue symbol classGroup) (f -> (
     	X := source f;
     	Y := target f;
     	divisorMap := weilDivisorGroup f;
-    	map(classGroup X, classGroup Y, transpose (
-	    	(transpose (fromWDivToCl(X) * divisorMap)) // transpose fromWDivToCl(Y)
-	    	))
+	map(classGroup X, classGroup Y,
+	    fromWDivToCl Y \\ (fromWDivToCl X * divisorMap))
     	)
     )
 
@@ -332,9 +331,8 @@ picardGroup ToricMap := Matrix => (cacheValue symbol picardGroup) (f -> (
     	X := source f;
     	Y := target f;
     	divisorMap := cartierDivisorGroup f;
-    	map(classGroup X, classGroup Y, transpose (
-	    	(transpose (fromCDivToPic(X) * divisorMap)) // transpose fromCDivToPic(Y)
-	    	))
+	map(classGroup X, classGroup Y,
+	    fromCDivToPic Y \\ (fromCDivToPic X * divisorMap))
     	)
     )
 

--- a/M2/Macaulay2/packages/NormalToricVarieties/ToricMaps.m2
+++ b/M2/Macaulay2/packages/NormalToricVarieties/ToricMaps.m2
@@ -331,7 +331,7 @@ picardGroup ToricMap := Matrix => (cacheValue symbol picardGroup) (f -> (
     	X := source f;
     	Y := target f;
     	divisorMap := cartierDivisorGroup f;
-	map(classGroup X, classGroup Y,
+	map(picardGroup X, picardGroup Y,
 	    fromCDivToPic Y \\ (fromCDivToPic X * divisorMap))
     	)
     )

--- a/M2/Macaulay2/packages/Polyhedra/core/cone/constructors.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/cone/constructors.m2
@@ -74,6 +74,10 @@ coneFromVData = method(TypicalValue => Cone)
 --  OUTPUT : 'C'  a Cone
 -- COMMENT : The description by rays and lineality space is stored in C as well 
 --		 as the description by defining half-spaces and hyperplanes.
+coneFromVData Matrix := Mrays -> Mrays.cache.cone ??= (
+    -- the default lineality space is zero
+    coneFromVData(Mrays, map(target Mrays, (ring Mrays)^0, 0)))
+
 coneFromVData(Matrix,Matrix) := (Mrays,LS) -> (
    if numRows Mrays =!= numRows LS then error("rays and linSpace generators must lie in the same space");
    result := new HashTable from {
@@ -100,16 +104,6 @@ coneFromHData(Matrix, Matrix) := (ineq, eq) -> (
    };
    return internalConeConstructor result
 
-)
-
-
-
---   INPUT : 'R'  a Matrix containing the generating rays as column vectors
-coneFromVData Matrix := R -> (
-   r := ring R;
-   -- Generating the zero lineality space LS
-   LS := map(target R, r^0,0);
-   coneFromVData(R,LS)
 )
 
 

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -304,18 +304,21 @@ truncate(InfiniteNumber, InfiniteNumber, Matrix) := lookup(truncate, List, List,
 -- add partial multidegree support
 -- ensure the output is a module over the degree 0 of R
 
-basisMonomials = method()
-basisMonomials(List, Module) := (degs, F) -> (
+basisMonomials = method(Options => {"partial degrees" => null})
+basisMonomials(List, Module) := opts -> (degs, F) -> (
     -- inputs: a list of multidegrees, a free module
     -- assume checkOrMakeDegreeList has already been called on degs
     -- TODO: either figure out a way to use cached results or do this in parallel
-    R := ring F; directSum apply(degrees F, a -> concatCols apply(degs, d -> basisMonomials(d - a, R))))
-basisMonomials(List, Ring) := (d, R) -> R#(symbol basis', d) ??= (
+    R := ring F; directSum apply(degrees F, a -> concatCols apply(degs, d -> basisMonomials(d - a, R, opts))))
+basisMonomials(List, Ring) := opts -> (d, R) -> (
     -- inputs: a single multidegree, a graded ring
     -- valid for total coordinate ring of any simplicial toric variety
     -- or any polynomial ring, quotient ring, or exterior algebra.
-    -- TODO: we should accept _any_ cached truncation as a hint
-    if R#?(symbol truncate, d, null) then (
+    partialdegs := opts#"partial degrees";
+    if  R#?(symbol basis', d) and partialdegs === null
+    then R#(symbol basis', d)
+    else if R#?(symbol truncate, d) and partialdegs === null
+    then R#(symbol basis', d) = (
         -- opportunistically use cached truncation results
         -- TODO: is this always correct? with negative degrees?
         truncgens := R#(symbol truncate, d, null);
@@ -325,11 +328,18 @@ basisMonomials(List, Ring) := (d, R) -> R#(symbol basis', d) ??= (
         (R1, phi1) := flattenRing R;
         -- generates the effective cone
         A := effGenerators R1;
+        -- TODO: would be better if basisPolyhedron could also account for torsion
         F := freeComponents target A;
         b := transpose matrix{d_F};
-        -- TODO: would be better if basisPolyhedron could account for torsion
+	-- select partial degree rows
+	if instance(partialdegs, List) then (
+	    varlist := select(#gens R1, i -> not member(i, partialdegs));
+	    A = A^varlist;
+	    d = d^varlist;
+	    );
         P := basisPolyhedron(A^F, b,
             Exterior => (options R1).SkewCommutative);
+        if isCompact P and volume P === 0 then return map(R^1, R^0, 0);
         H := entries map(ZZ, rawHilbertBasis raw transpose rays cone P); -- ~40% of computation
         J := leadTerm ideal R1;
         ambR := ring J;
@@ -343,13 +353,13 @@ basisMonomials(List, Ring) := (d, R) -> R#(symbol basis', d) ??= (
         submatrix(result, , psrc)))
 
 -- FIXME: when M has relations, it should be pruned
-basis' = method(Options => options basis)
+basis' = method(Options => options basis ++ {"partial degrees" => null})
 basis'(List, Module) := Matrix => opts -> (degs, M) -> (
     if M == 0 then return M;
     if not truncateImplemented(R := ring M) then error "cannot use basis' with this ring type";
     degs = checkOrMakeDegreeList(degs, degreeLength R);
     if isFreeModule M
-    then map(M, , basisMonomials(degs, M))
+    then map(M, , basisMonomials(degs, M, "partial degrees" => opts#"partial degrees"))
     else map(M, , basis'(degs, target presentation M, opts)))
 
 --------------------------------------------------------------------

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -357,7 +357,7 @@ basisMonomials(List, Ring) := opts -> (d, R) -> (
 -- FIXME: when M has relations, it should be pruned
 basis' = method(Options => options basis ++ {"partial degrees" => null})
 basis'(List, Module) := Matrix => opts -> (degs, M) -> (
-    if M == 0 then return M;
+    if M == 0 then return gens M;
     if not truncateImplemented(R := ring M) then error "cannot use basis' with this ring type";
     degs = checkOrMakeDegreeList(degs, degreeLength R);
     if isFreeModule M

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -330,7 +330,7 @@ basisMonomials(List, Ring) := opts -> (d, R) -> (
         truncgens := R#(symbol truncate, d, null);
 	psrc := selectByDegrees(source truncgens, d, d);
         submatrix(truncgens, , psrc))
-    else (
+    else R#(symbol basis', d) = (
         (R1, phi1) := flattenRing R;
         -- generates the effective cone
         A := effGenerators R1;

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -176,8 +176,9 @@ truncationMonomials(List, Ring) := opts -> (d, R) -> (
     -- inputs: a single multidegree, a graded ring
     -- valid for total coordinate ring of any simplicial toric variety
     -- or any polynomial ring, quotient ring, or exterior algebra.
-    R#(symbol truncate, d, if opts#Cone =!= null then rays opts#Cone) ??= (
-        (R1, phi1) := flattenRing R;
+    C := if opts#Cone =!= null then rays opts#Cone else id_(degreeGroup R);
+    R#(symbol truncate, d, C) ??= (
+	(R1, phi1) := flattenRing R;
         -- generates the effective cone
         A := effGenerators R1;
         F := freeComponents target A;
@@ -317,7 +318,8 @@ basisMonomials(List, Ring) := opts -> (d, R) -> (
     partialdegs := opts#"partial degrees";
     if  R#?(symbol basis', d) and partialdegs === null
     then R#(symbol basis', d)
-    else if R#?(symbol truncate, d) and partialdegs === null
+    -- TODO: we should accept _any_ cached truncation as a hint
+    else if R#?(symbol truncate, d, null) and partialdegs === null
     then R#(symbol basis', d) = (
         -- opportunistically use cached truncation results
         -- TODO: is this always correct? with negative degrees?

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -363,11 +363,15 @@ basis'(List, Module) := Matrix => opts -> (degs, M) -> (
     if M == 0 then return map(M, 0, 0);
     if not truncateImplemented(R := ring M) then error "cannot use basis' with this ring type";
     degs = checkOrMakeDegreeList(degs, degreeLength R);
-    -- TODO: "mingens image" seems silly ...
-    B := map(M, , if not M.?relations
-    then basisMonomials(degs, M, "partial degrees" => opts#"partial degrees")
-    else reduce(super M, raw basis'(degs, image generators M, opts)));
-    inducedMap(M, , mingens image B))
+    B := if isFreeModule M then (
+	map(M, , basisMonomials(degs, M, "partial degrees" => opts#"partial degrees")))
+    else if not M.?relations then (
+	map(M, , basisMonomials(degs, cover M, "partial degrees" => opts#"partial degrees")))
+    else inducedMap(M, ,
+	-- TODO: "mingens image" seems silly ...
+	mingens image map(ambient M, ,
+	    reduce(super M, raw gens image basis'(degs, image generators M))))
+    )
 
 --------------------------------------------------------------------
 ----- Tests section

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -72,6 +72,9 @@ checkOrMakeDegreeList(List, ZZ) := (L, degrank) -> (
         then sort L else error("expected a list of multidegrees, each of length " | degrank))
     )
 
+-- c.f. https://github.com/Macaulay2/M2/issues/3578
+selectByDegrees = (M, lo, hi) -> rawSelectByDegrees(raw (ring M)^(-degrees M), lo, hi)
+
 --------------------------------------------------------------------
 -- Divisorial information
 --------------------------------------------------------------------
@@ -324,7 +327,7 @@ basisMonomials(List, Ring) := opts -> (d, R) -> (
         -- opportunistically use cached truncation results
         -- TODO: is this always correct? with negative degrees?
         truncgens := R#(symbol truncate, d, null);
-	psrc := rawSelectByDegrees(raw source truncgens, d, d);
+	psrc := selectByDegrees(source truncgens, d, d);
         submatrix(truncgens, , psrc))
     else (
         (R1, phi1) := flattenRing R;
@@ -351,7 +354,7 @@ basisMonomials(List, Ring) := opts -> (d, R) -> (
         result := mingens ideal(mongens % J); -- ~40% of computation
         if R1 =!= ambR then result = result ** R1;
         if R =!= R1 then result = phi1^-1 result;
-        psrc = rawSelectByDegrees(raw source result, d, d);
+	psrc = selectByDegrees(source result, d, d);
         submatrix(result, , psrc)))
 
 -- FIXME: when M has relations, it should be pruned

--- a/M2/Macaulay2/packages/Truncations.m2
+++ b/M2/Macaulay2/packages/Truncations.m2
@@ -31,6 +31,7 @@ importFrom_Core {
     "freeComponents",
     "raw", "rawHilbertBasis", "rawSelectByDegrees",
     "tryHooks",
+    "reduce",
     }
 
 -- "truncate" is exported by Core
@@ -357,15 +358,16 @@ basisMonomials(List, Ring) := opts -> (d, R) -> (
 	psrc = selectByDegrees(source result, d, d);
         submatrix(result, , psrc)))
 
--- FIXME: when M has relations, it should be pruned
 basis' = method(Options => options basis ++ {"partial degrees" => null})
 basis'(List, Module) := Matrix => opts -> (degs, M) -> (
-    if M == 0 then return gens M;
+    if M == 0 then return map(M, 0, 0);
     if not truncateImplemented(R := ring M) then error "cannot use basis' with this ring type";
     degs = checkOrMakeDegreeList(degs, degreeLength R);
-    if isFreeModule M
-    then map(M, , basisMonomials(degs, M, "partial degrees" => opts#"partial degrees"))
-    else map(M, , basis'(degs, target presentation M, opts)))
+    -- TODO: "mingens image" seems silly ...
+    B := map(M, , if not M.?relations
+    then basisMonomials(degs, M, "partial degrees" => opts#"partial degrees")
+    else reduce(super M, raw basis'(degs, image generators M, opts)));
+    inducedMap(M, , mingens image B))
 
 --------------------------------------------------------------------
 ----- Tests section

--- a/M2/Macaulay2/packages/Truncations/basis-tests.m2
+++ b/M2/Macaulay2/packages/Truncations/basis-tests.m2
@@ -1,0 +1,66 @@
+TEST ///
+  A = QQ[x,y]
+  assert(basis_-2 A == map(A^1,A^0,0))
+  assert(basis_0 A  == map(A^1,A^1,1))
+  assert try (basis A; false) else true
+  assert(basis_2 A  == matrix"x2,xy,y2")
+
+  B = A/ideal"x2,xy,y2"
+  assert(basis_-2 B == map(B^1,B^0,0))
+  assert(basis_0 B  == map(B^1,B^1,1))
+  assert(basis   B  == matrix"1,x,y")
+  assert(basis_1 B  == matrix"x,y")
+
+  C = QQ[x,y, Degrees => {1,0}]
+  assert(basis_-2 C == map(C^1,C^0,0))
+  assert(basis_0 C  == map(C^1,C^1,1))
+  assert try (basis C; false) else true
+  assert(basis_2 C  == matrix"x2")
+
+  D = QQ[x,y, Degrees => {0,1}]
+  assert(basis_-2 D == map(D^1,D^0,0))
+  assert(basis_0 D  == map(D^1,D^1,1))
+  assert try (basis D; false) else true
+  assert(basis_2 D  == matrix"y2")
+///
+
+TEST ///
+  A = QQ[x,y, DegreeRank => 2]
+  assert(basis_-2 A == map(A^1,A^0,0))
+  assert(basis_0 A  == map(A^1,A^1,1))
+  assert try (basis A; false) else true
+  assert(basis_2 A  == matrix"x2")
+  assert(basis_{0,0} A  == map(A^1,A^1,1))
+  assert(basis_{0,2} A  == matrix"y2")
+
+  debug needsPackage "Truncations"
+  B = A[w,z]
+  -- FIXME in feature/hilbert
+  -- basis(1, B)
+  -- basis({1,0,0}, B)
+  -- hilbertFunction({1,0,0}, B)
+  basis'({1,0,0}, module B)
+  basis({1,0,0}, first flattenRing B)
+  hilbertFunction({1,0,0}, first flattenRing B)
+  basis'({0,1,0}, module B)
+  basis({0,1,0}, first flattenRing B)
+  hilbertFunction({0,1,0}, first flattenRing B)
+  basis'({0,0,1}, module B)
+  basis({0,0,1}, first flattenRing B)
+  hilbertFunction({0,0,1}, first flattenRing B)
+///
+
+TEST ///
+  debug needsPackage "Truncations"
+  A = QQ[x,y, Degrees => {{1,1},{1,2}}]
+  basis({3}, A)
+  basis'({3,2}, module A, "partial degrees" => {})
+  basis'({3,2}, module A, "partial degrees" => {0})
+  basis'({3,2}, module A, "partial degrees" => {1})
+  basis'({3,2}, module A, "partial degrees" => {0,1})
+  -- FIXME: caching is broken
+  basis'({3,2}, module A)
+  truncate({3,0}, module A)
+  -- TODO: can we do partial multidegrees for hilbertFunction?
+  sum apply(7, i -> hilbertFunction({3,i}, A))
+///

--- a/M2/Macaulay2/packages/Truncations/basis-tests.m2
+++ b/M2/Macaulay2/packages/Truncations/basis-tests.m2
@@ -85,3 +85,10 @@ TEST ///
   (t, B) = toSequence elapsedTiming basis(degree D, S^1);
   assert(numcols B == 11 and t < 10)
 ///
+
+TEST ///
+  needsPackage "NormalToricVarieties"
+  X = hirzebruchSurface 2
+  M = cotangentSheaf X
+  assert(HH^1(X, M) == QQ^2)
+///

--- a/M2/Macaulay2/packages/Truncations/basis-tests.m2
+++ b/M2/Macaulay2/packages/Truncations/basis-tests.m2
@@ -64,3 +64,24 @@ TEST ///
   -- TODO: can we do partial multidegrees for hilbertFunction?
   sum apply(7, i -> hilbertFunction({3,i}, A))
 ///
+
+TEST ///
+  needsPackage "NormalToricVarieties"
+  -- Bruns and Gubeladze Example 5.1
+  P = convexHull matrix transpose {
+      {1,1,1,0,0,0}, {0,1,1,0,0,1},
+      {1,1,0,1,0,0}, {0,1,0,1,1,0},
+      {1,0,1,0,1,0}, {0,1,0,0,1,1},
+      {1,0,0,1,0,1}, {0,0,1,1,1,0},
+      {1,0,0,0,1,1}, {0,0,1,1,0,1}}
+  N = ZZ^5
+  P = affineImage(id_N | transpose matrix {{-1,-1,-1,-1,-1}}, P)
+
+  D = toricDivisor P
+  X = variety D
+  S = ring X
+
+  -- tests the basis' which is added as a hook in NormalToricVarieties
+  (t, B) = toSequence elapsedTiming basis(degree D, S^1);
+  assert(numcols B == 11 and t < 10)
+///

--- a/M2/Macaulay2/packages/Truncations/tests.m2
+++ b/M2/Macaulay2/packages/Truncations/tests.m2
@@ -394,9 +394,32 @@ TEST /// -- test of truncation of complexes
   truncate(3, C)
 ///
 
-TEST /// -- test of subtruncate
-  M = module(QQ[x,y])
-  assert(truncate(1, 2, id_M) == map(truncate(1, M), truncate(2, M), {{y, 0, 0}, {0, y, x}}))
+TEST /// -- test of truncationPolyhedron with torsion in class group
+  debug needsPackage "Truncations"
+  needsPackage "NormalToricVarieties"
+  needsPackage "Polyhedra"
+  B = matrix {{2, -1}, {-1, 2}, {-1,-1}}
+  Y = normalToricVariety(entries B,
+      {{0, 1}, {1, 2}, {2, 0}})
+  S = ring Y
+  D = 3 * Y_0
+  deg = degree D
+
+  -- TODO: is this correct?
+  -- I = truncate(deg, S)
+  -- assert(I == ideal {x_2^3, x_0*x_1*x_2, x_1^3, x_0^3})
+  -- assert(degrees I == {{0, 3}, {0, 3}, {0, 3}, {0, 3}})
+
+  assert same { set monomials D,
+      set first entries basis(deg, module S, Strategy => Torsion),
+      set first entries basis(deg, module S, Strategy => Toric),
+      set first entries basis(deg, module S) }
+
+  -- TODO
+  --X = normalToricVariety (id_(ZZ^3) | -id_(ZZ^3));
+  --Y = makeSimplicial X;
+  --Bl1 = toricBlowup({0}, X);
+  --Y = toricBlowup({7}, Bl1);
 ///
 
 end--

--- a/M2/Macaulay2/packages/Truncations/tests.m2
+++ b/M2/Macaulay2/packages/Truncations/tests.m2
@@ -412,7 +412,7 @@ TEST /// -- test of truncationPolyhedron with torsion in class group
 
   assert same { set monomials D,
       set first entries basis(deg, module S, Strategy => Torsion),
-      set first entries basis(deg, module S, Strategy => Toric),
+      --set first entries basis(deg, module S, Strategy => Toric),
       set first entries basis(deg, module S) }
 
   -- TODO

--- a/M2/Macaulay2/packages/Truncations/tests.m2
+++ b/M2/Macaulay2/packages/Truncations/tests.m2
@@ -422,6 +422,30 @@ TEST /// -- test of truncationPolyhedron with torsion in class group
   --Y = toricBlowup({7}, Bl1);
 ///
 
+TEST ///
+  needsPackage "NormalToricVarieties"
+  needsPackage "Complexes"
+  N = ZZ^3
+  D = toricDivisor convexHull matrix {0_N, N_0, N_1, N_0 + N_1 + 2*N_2}
+  X = variety D
+  X.cache.nefCone = coneFromVData map(coker matrix {{2, 0}, {0, 2}, {0, 0}}, , transpose{{0,0,1}})
+  S = ring X
+
+  -- TODO: are these correct?
+  -- C = complex gens truncate(degree D, S)
+  -- part(degree(2*D), C) -- TODO: add an assertion
+  -- assert(part(degree(2*D), HH_0 C) == 0)
+  -- assert(part(degree(2*D), HH_1 C) == QQ^5)
+  -- assert(part(degree(2*D), HH C) == complex map(QQ^0, QQ^5, 0))
+  -- assert(part(degree(2*D), HH C) == prune HH part(degree(2*D), C))
+
+  M = coker basis({0,0,2}, S)
+  assert(basis({0,0,1}, M) == x_3)
+  assert(basis({0,0,2}, M) == 0)
+  assert(basis({0,0,3}, M) == x_0*x_1*x_2)
+  assert(basis({0,0,4}, M) == x_0*x_1*x_2*x_3)
+///
+
 end--
 
 restart

--- a/M2/Macaulay2/tests/normal/basis3.m2
+++ b/M2/Macaulay2/tests/normal/basis3.m2
@@ -144,3 +144,14 @@ K = image map(source b, , gens ker b)
 -- assert isSubset(ker b, source b)
 assert isSubset(K, source b)
 assert(ker f == K)
+
+-- testing basis in presence of torsion in the degree group
+needsPackage "Complexes"
+B = map(ZZ^1/ideal 2 ++ ZZ^1/ideal 2 ++ ZZ^1, ,
+    matrix transpose {{1,1,1}, {0,1,1}, {1,0,1}, {0,0,1}})
+S = QQ[x_0..x_3, Degrees => B]
+m = basis({0,0,2}, S)
+C = complex m
+assert(4 == numcols m)
+assert(0 == part({0,0,2}, HH C))
+assert(0 == HH part({0,0,2}, C))


### PR DESCRIPTION
~This is on top of #3567, and hence also #3550.~ Both dependencies are merged now.

#### Changes in Truncations
- added test for truncation in presence of torsion
- added support for partial multidegrees in basis'
- added test for basis'
- fixed caching in Truncations
- added caching for coneFromVData(Matrix)
- added test for basis' in Truncations
- added temporary workaround for rawSelectByDegrees bug
- added tests for basis in presense of torsion
- fixed minor bug in basis with torsion degrees
- fixed a couple of bugs in basis'

#### Changes in NormalToricVarieties
- ~added isQQFano in NormalToricVarieties~ (removed for now)
- cached isFano for NormalToricVariety
- simplified classGroup and picardGroup for ToricMap
- fixed a bug in picardGroup ToricMap
- added test for classGroup and picardGroup for ToricMap
- ~fixed a bug in inducedMap for simplicial toric varieties~ (removed for now)
- changed vertices ToricDivisor to always return a matrix
- fixed cohomology for simplicial toric varieties
- ~added basis' as new basis strategy over toric varieties~ (disabled for now)
