### PR TITLE
Raise an error when creating a task but M2 was called w/ --no-threads

### DIFF
--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -97,8 +97,12 @@ nextTaskSerialNumber():int := (
      taskSerialNumber = taskSerialNumber+1;		    -- race condition here, solve later
      taskSerialNumber);
 
+NoThreadsError() ::= buildErrorPacket("thread support has been disabled");
+
 createTask2(fun:Expr,arg:Expr):Expr :=(
      if !isFunction(fun) then return WrongArg(1,"a function");
+     if Ccode(bool, "!isThreadSupervisorInitialized()")
+     then return NoThreadsError();
      tc := TaskCell(TaskCellBody(nextHash(),nextTaskSerialNumber(),Ccode(taskPointer,"((void *)0)"), false, fun, arg, nullE ));
      blockingSIGINT();
      -- we are careful not to give the new thread the pointer tc, which we finalize:
@@ -170,6 +174,8 @@ setupfun("addCancelTask",addCancelTaskM2);
 
 schedule2(fun:Expr,arg:Expr):Expr := (
      if !isFunction(fun) then return WrongArg(1,"a function");
+     if Ccode(bool, "!isThreadSupervisorInitialized()")
+     then return NoThreadsError();
      tc := TaskCell(TaskCellBody(nextHash(),nextTaskSerialNumber(),Ccode(taskPointer,"((void *)0)"), false, fun, arg, nullE ));
      blockingSIGINT();
      -- we are careful not to give the new thread the pointer tc, which we finalize:

--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -209,6 +209,8 @@ setupfun("schedule",schedule);
 taskResult(e:Expr):Expr := (
      when e is c:TaskCell do
      if c.body.resultRetrieved then buildErrorPacket("task result already retrieved")
+     else if !taskReady(c.body.task)
+     then buildErrorPacket("task not scheduled yet")
      else if !taskKeepRunning(c.body.task) then buildErrorPacket("task canceled")
      else if !taskDone(c.body.task) then (
 	  Ccode(voidPointer, "waitOnTask(",c.body.task,")");

--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -12,6 +12,7 @@ taskCreate(f:function(TaskCellBody):null,tb:TaskCellBody) ::=  Ccode(taskPointer
 
 export taskDone(tp:taskPointer) ::= Ccode(int, "taskDone(",tp,")")==1;
 export taskStarted(tp:taskPointer) ::=Ccode(int, "taskStarted(",tp,")")==1;
+export taskReady(tp:taskPointer) ::= Ccode(int, "taskReady(", tp, ")") == 1;
 pushTask(tp:taskPointer) ::=Ccode(void, "pushTask(",tp,")");
 taskResult(tp:taskPointer) ::=Ccode(voidPointer, "taskResult(",tp,")");
 export taskKeepRunning(tp:taskPointer) ::= Ccode(int, "taskKeepRunning(",tp,")")==1;

--- a/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/threads.m2
@@ -329,6 +329,7 @@ Node
      for i to 5 do t_i = createTask(() -> i)
      for i from 1 to 5 do addDependencyTask(t_i, t_(i - 1))
      schedule t_0
+     sleep 1
      taskResult t_5
 Node
  Key

--- a/M2/Macaulay2/system/supervisor.cpp
+++ b/M2/Macaulay2/system/supervisor.cpp
@@ -141,6 +141,13 @@ extern "C" {
 	// synchronizes-with the task's thread, avoids data races
     return task->m_Started;
   }
+  int taskReady(struct ThreadTask *task)
+  {
+    if (!task)
+      return false;
+    lock_guard<pthreadMutex> lock(task->m_Mutex);
+    return task->m_ReadyToRun;
+  }
   void* taskResult(struct ThreadTask* task)
   {
     lock_guard<pthreadMutex> lock(task->m_Mutex);

--- a/M2/Macaulay2/system/supervisor.cpp
+++ b/M2/Macaulay2/system/supervisor.cpp
@@ -78,6 +78,10 @@ extern "C" {
     threadSupervisor->m_TargetNumThreads=maxNumThreads;
     threadSupervisor->initialize();
   }
+  char isThreadSupervisorInitialized(void)
+  {
+    return threadSupervisor->is_initialized;
+  }
   void pushTask(struct ThreadTask* task)
   {
     lock_guard<pthreadMutex> supLock(threadSupervisor->m_Mutex);
@@ -272,6 +276,7 @@ void ThreadSupervisor::initialize()
       m_Threads.push_back(thread);
       thread->start();
     }
+  is_initialized = true;
 }
 // done or canceled; task's mutex is locked by caller
 void ThreadSupervisor::_i_finished(struct ThreadTask* task)

--- a/M2/Macaulay2/system/supervisor.hpp
+++ b/M2/Macaulay2/system/supervisor.hpp
@@ -143,6 +143,7 @@ struct ThreadSupervisor
   gc_set(int*) m_ThreadLocalIdPtrSet;
   ///initialize
   void initialize();
+  bool is_initialized = false;
   ///thread local id's
   int m_ThreadLocalIdCounter;
   void* m_LocalThreadMemory;

--- a/M2/Macaulay2/system/supervisorinterface.h
+++ b/M2/Macaulay2/system/supervisorinterface.h
@@ -71,6 +71,7 @@ extern "C" {
   void createThreadGCMemory();
   extern void delThread(pthread_t thread);
   extern void initializeThreadSupervisor();
+  extern char isThreadSupervisorInitialized(void);
   /**
      Set the maximum number of allowable threads
   **/

--- a/M2/Macaulay2/system/supervisorinterface.h
+++ b/M2/Macaulay2/system/supervisorinterface.h
@@ -45,6 +45,10 @@ extern "C" {
   **/
   extern int taskStarted(struct ThreadTask* task);
   /**
+     Returns 1 if the task is ready to run, 0 otherwise
+  **/
+  extern int taskReady(struct ThreadTask* task);
+  /**
      Returns the taskResult if finished, NULL otherwise
   **/
   extern void* taskResult(struct ThreadTask* task);


### PR DESCRIPTION
### Before

We could create tasks, but they'd never be run:

```m2
$ M2 --silent --no-threads

i1 : t = schedule(() -> 3);

i2 : sleep 5

o2 = 0

i3 : isReady t

o3 = false
```

### After

```m2
$ M2 --silent --no-threads

i1 : t = schedule(() -> 3);
stdio:1:12:(3): error: thread support has been disabled
```

Closes: #3570 

---
I also noticed another bug while working on this.  Previously, if we call `taskResult` on a `Task` object that was created with `taskResult` but we never called `schedule`, then Macaulay2 would hang:

```m2
i1 : t = createTask(() -> 3);

i2 : taskResult t
^C^C
Exit (y=yes/n=no/a=abort/b=backtrace)? b
-* stack trace, pid: 3305389
 0# stack_trace(std::ostream&, bool) at /usr/src/macaulay2-1.24.05+git202410290107-0ppa202410281907~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:136
 1# interrupt_handler at /usr/src/macaulay2-1.24.05+git202410290107-0ppa202410281907~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:300
 2# 0x00007CA6F4A45320 in /lib/x86_64-linux-gnu/libc.so.6
 3# __GI___futex_abstimed_wait_cancelable64 at ./nptl/futex-internal.c:139
 4# pthread_cond_wait at ./nptl/pthread_cond_wait.c:627
 5# ThreadTask::waitOn() at /usr/src/macaulay2-1.24.05+git202410290107-0ppa202410281907~ubuntu24.04.1/M2/Macaulay2/system/supervisor.cpp:211
 6# taskResult_1 at /usr/src/macaulay2-1.24.05+git202410290107-0ppa202410281907~ubuntu24.04.1/M2/Macaulay2/d/pthread-tmp.c:465
```

Now we raise an error instead:

```m2
i1 : t = createTask(() -> 3);

i2 : taskResult t
stdio:2:10:(3): error: task not scheduled yet
```