### PR TITLE
Revert "Set default URL for downloading library tarballs (autotools)"

### DIFF
--- a/M2/libraries/Makefile.library.in
+++ b/M2/libraries/Makefile.library.in
@@ -12,7 +12,6 @@ PREFIX = $(BUILTLIBPATH)
 ifneq ($(PARALLEL),yes)
 NOTPARALLEL = -j1
 endif
-URL = https://macaulay2.com/Downloads/OtherSourceCode
 LIBNAME ?= $(shell basename `pwd`)
 UNTARDIR = build
 OLDUNTARDIR = build-old

--- a/M2/libraries/cddlib/Makefile.in
+++ b/M2/libraries/cddlib/Makefile.in
@@ -7,6 +7,7 @@ VERSION = 0.94m
 # cddlib is now available on github, so we could switch this library to a submodule
 # https://github.com/cddlib/cddlib
 # https://www.inf.ethz.ch/personal/fukudak/cdd_home/
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 ALLOPTIONS     = SUBDIRS="lib-src" gmpdir=/nowhere
 CONFIGOPTIONS  = $(ALLOPTIONS)
 

--- a/M2/libraries/cddplus/Makefile.in
+++ b/M2/libraries/cddplus/Makefile.in
@@ -1,6 +1,7 @@
 LIBNAME = cdd+
 HOMEPAGE = http://www.ifor.math.ethz.ch/~fukuda/cdd_home/
 # URL = ftp://ftp.ifor.math.ethz.ch/pub/fukuda/cdd/
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 VERSION = 077a
 TARFILE = cdd+-$(VERSION).tar.gz
 PATCHFILE = @abs_srcdir@/patch-$(VERSION)

--- a/M2/libraries/cohomcalg/Makefile.in
+++ b/M2/libraries/cohomcalg/Makefile.in
@@ -4,6 +4,7 @@ HOMEPAGE = https://github.com/BenjaminJurke/cohomCalg/
 # Note: download https://github.com/BenjaminJurke/cohomCalg/archive/v0.32.tar.gz but rename the file to cohomCalg-0.32.tar.gz
 # Warning: this no longer compiles with gcc version 4.8.5, and it doesn't help with
 #   https://github.com/Macaulay2/M2/issues/977, so we may want to go back to the old version.
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 VERSION = 0.32
 TARFILE = cohomCalg-$(VERSION).tar.gz
 LICENSEFILES = LICENSE

--- a/M2/libraries/csdp/Makefile.in
+++ b/M2/libraries/csdp/Makefile.in
@@ -3,6 +3,7 @@ LIBNAME = Csdp
 VERSION = $(CSDP_VERSION)
 PATCHFILE = @abs_srcdir@/patch-$(CSDP_VERSION)
 #URL = http://www.coin-or.org/download/source/Csdp
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 TARFILE = Csdp-$(VERSION).tgz
 
 CONFIGURECMD = true

--- a/M2/libraries/gdbm/Makefile.in
+++ b/M2/libraries/gdbm/Makefile.in
@@ -1,6 +1,7 @@
 LICENSEFILES = COPYING
 
 # URL = ftp://ftp.gnu.org/gnu/gdbm
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 VERSION = 1.9.1
 
 ifeq (@SHARED@,no)

--- a/M2/libraries/gfan/Makefile.in
+++ b/M2/libraries/gfan/Makefile.in
@@ -2,6 +2,7 @@ GFAN_VERSION = 0.6.2
 VERSION = $(GFAN_VERSION)
 PATCHFILE = @abs_srcdir@/patch-$(GFAN_VERSION)
 # URL = http://home.imf.au.dk/jensen/software/gfan/gfan.html
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 TARFILE = gfan$(VERSION).tar.gz
 TARDIR = gfan$(VERSION)
 CONFIGURECMD = true

--- a/M2/libraries/gftables/Makefile.in
+++ b/M2/libraries/gftables/Makefile.in
@@ -1,6 +1,7 @@
 # this pseudo-library fetches the precomputed finite field addition tables used by factory and puts them in the right place
 
 # URL = ftp://www.mathematik.uni-kl.de/pub/Math/Singular/Factory
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 VERSION=1.1
 #TARFILE = factory-gftables.tar.gz
 TARFILE = factory.4.0.1-gftables.tar.gz

--- a/M2/libraries/glpk/Makefile.in
+++ b/M2/libraries/glpk/Makefile.in
@@ -1,6 +1,7 @@
 # URL = ftp://ftp.gnu.org/gnu/glpk
 # we link it with 4ti2, but not with Macaulay2
 VERSION = 4.59
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 HOMEPAGE = http://www.gnu.org/software/glpk/
 
 ifeq (@SHARED@,no)

--- a/M2/libraries/gtest/Makefile.in
+++ b/M2/libraries/gtest/Makefile.in
@@ -6,6 +6,7 @@ CONFIGURECMD = :
 BUILDCMD = :
 
 LICENSEFILES = LICENSE
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 MLIMIT = 1400000
 VLIMIT = 1400000
 TLIMIT = 400

--- a/M2/libraries/lapack/Makefile.in
+++ b/M2/libraries/lapack/Makefile.in
@@ -1,6 +1,7 @@
 # http://www.netlib.org/lapack/
 # documentation: http://www.netlib.org/lapack/lug/
 #URL = http://www.netlib.org/lapack
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 
 VERSION = 3.9.0
 

--- a/M2/libraries/libtool/Makefile.in
+++ b/M2/libraries/libtool/Makefile.in
@@ -1,4 +1,5 @@
 # URL = ftp://ftp.gnu.org/gnu/libtool
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 VERSION = 2.4.2
 ifeq (@SHARED@,no)
 CONFIGOPTIONS += --disable-shared

--- a/M2/libraries/linbox/Makefile.in
+++ b/M2/libraries/linbox/Makefile.in
@@ -3,6 +3,7 @@ VERSION = 1.7.0
 URL = https://github.com/linbox-team/linbox/archive/refs/tags
 TARFILE = v$(VERSION).tar.gz
 
+#URL = https://macaulay2.com/Downloads/OtherSourceCode
 PRECONFIGURE = autoreconf -i
 
 #PATCHFILE = @abs_srcdir@/patch-$(VERSION)

--- a/M2/libraries/lrslib/Makefile.in
+++ b/M2/libraries/lrslib/Makefile.in
@@ -5,6 +5,7 @@
 # reconfigure in the build directory
 HOMEPAGE = http://www-cgrl.cs.mcgill.ca/~avis/C/lrs.html
 # URL = http://cgm.cs.mcgill.ca/~avis/C/lrslib/archive
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 VERSION = 071a
 PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 TARFILE = lrslib-$(VERSION).tar.gz

--- a/M2/libraries/mpfi/Makefile.in
+++ b/M2/libraries/mpfi/Makefile.in
@@ -11,6 +11,7 @@ CONFIGOPTIONS += --disable-thread-safe
 
 RELAX = yes
 # shut down Oct, 2021 -- URL = https://gforge.inria.fr/frs/download.php/file/37331
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 
 ifeq (@DEBUG@,yes)
 CONFIGOPTIONS += --enable-assert

--- a/M2/libraries/mpsolve/Makefile.in
+++ b/M2/libraries/mpsolve/Makefile.in
@@ -1,6 +1,7 @@
 VPATH = @srcdir@
 HOMEPAGE = https://numpi.dm.unipi.it/software/mpsolve 
 VERSION = 3.2.1
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 
 # obtained from https://numpi.dm.unipi.it/_media/software/mpsolve
 #               https://numpi.dm.unipi.it/_media/software/mpsolve/mpsolve-3.2.1.tar.gz

--- a/M2/libraries/pari/Makefile.in
+++ b/M2/libraries/pari/Makefile.in
@@ -10,6 +10,7 @@ VPATH = @srcdir@
 
 VERSION = 2.11.2
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 
 # uname gives a strange answer on the second command line below, under mac os x.  Pari's configure
 # script uses "uname -p", but I'm not sure whether it causes any problems.

--- a/M2/libraries/readline/Makefile.in
+++ b/M2/libraries/readline/Makefile.in
@@ -6,6 +6,7 @@ PATCHES = 001
 RELAX = yes
 # URL = ftp://ftp.gnu.org/gnu/readline
 # PATCHURL = $(URL)/readline-$(VERSION)-patches
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 PATCHURL = $(URL)
 
 BUILDTARGET = all -o install-examples

--- a/M2/libraries/topcom/Makefile.in
+++ b/M2/libraries/topcom/Makefile.in
@@ -1,5 +1,6 @@
 # http://www.rambau.wm.uni-bayreuth.de/Software/
 HOMEPAGE = http://www.rambau.wm.uni-bayreuth.de/TOPCOM/
+URL = https://macaulay2.com/Downloads/OtherSourceCode
 VERSION = 0.17.8
 PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 TARFILE = TOPCOM-$(VERSION).tar.gz


### PR DESCRIPTION
This reverts commit 6fe4ac6063c830bc61b11d780b3abce1a58a1f65.

Setting a default `URL` in the top level `libraries` Makefile was a mistake, since it can be included after the library-specific `URL` is defined, overwriting the variable.  This was causing a problem for at least once library (tbb), which tried downloading a non-existent tarball from the M2 webpage instead of getting it from GitHub.