### PR TITLE
Define gcd & lcm of single element

### DIFF
--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -37,6 +37,7 @@ gcd(RingElement,RingElement) := RingElement => (r,s) -> (
 	       if s%a != 0 then error "can't find gcd in this ring";
 	       s // a))
      else notImplemented()))
+gcd RingElement := identity
 
 gcdCoefficients(RingElement,RingElement) := (f,g) -> (	    -- ??
      R := ring f;
@@ -52,6 +53,7 @@ lcm(RingElement,RingElement) := (f,g) -> (
     d := gcd(f, g);
     if d == 0 then d
     else f * (g // d))
+lcm RingElement := identity
 
 -----------------------------------------------------------------------------
 

--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -51,6 +51,7 @@ gcd(QQ,ZZ) := QQ => (y,x) -> gcd(x * denominator y, numerator y) / denominator y
 gcd(QQ,QQ) := QQ => (x,y) -> (
      d := denominator x * (denominator y // gcd(denominator x, denominator y));
      gcd(numerator (x * d), numerator (y * d)) / d)
+gcd ZZ := gcd QQ := identity
 
 abs = method()
 abs ZZ := abs RR := abs RRi := abs CC := abs QQ := abs0
@@ -68,6 +69,7 @@ lcm(QQ,QQ) := (f,g) -> (
     d := gcd(f, g);
     if d == 0 then 0_QQ
     else abs f * (abs g / d))
+lcm ZZ := lcm QQ := identity
 
 odd  = x -> 1 === x%2
 even = x -> 0 === x%2

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
@@ -148,7 +148,11 @@ document {
 	  (gcd, QQ, ZZ),
 	  (gcd, ZZ, ZZ),
 	  (gcd,RingElement,ZZ),
-	  (gcd,ZZ,RingElement)},
+	  (gcd,ZZ,RingElement),
+	  (gcd, ZZ),
+	  (gcd, QQ),
+	  (gcd, RingElement)
+	  },
      Headline => "greatest common divisor",
      Usage => "gcd(x,y,...)",
      Inputs => { "x" => ZZ, ", or ", ofClass QQ, ", or ",ofClass RingElement },
@@ -175,6 +179,9 @@ doc ///
     (lcm, ZZ, ZZ)
     (lcm,RingElement,ZZ)
     (lcm,ZZ,RingElement)
+    (lcm, ZZ)
+    (lcm, QQ)
+    (lcm, RingElement)
   Headline
     least common multiple
   Usage

--- a/M2/Macaulay2/tests/normal/gcd.m2
+++ b/M2/Macaulay2/tests/normal/gcd.m2
@@ -3,17 +3,21 @@ assert( gcd(2*3*5,2*3*7,2*5*7,3*5*7) == 1 )
 assert( gcd(1000:2) == 2 )
 assert( gcd splice(1000:2,3) == 1 )
 assert( gcd {} == 0 )
+assert( gcd 2 == 2 )
 assert( lcm(2,3,5,7) == 210 )
 assert( lcm(1000:2) == 2 )
 assert( lcm(0, 0) == 0 )
 assert( lcm(0/1, 0/1) == 0 )
 assert( lcm {} == 1 )
+assert( lcm 2 == 2 )
 
 R = ZZ/32003[x,y]
 f = (x+y)^3*(x-y^2)
 g = (x+y)^2*(x^3-x*y+y^3)^4
 assert ( gcd(f,g) == (x+y)^2 )
 assert ( lcm(0_R, 0_R) == 0 )
+assert ( gcd f == f )
+assert ( lcm f == f )
 
 GF 729[x, y, z]
 assert( gcd((x^5+y^3+a+1)*(y-1),(x^5+y^3+a+1)*(z+1)) == x^5+y^3+a+1 )


### PR DESCRIPTION
Previously, `gcd` and `lcm` raised an error if we passed a single element.  This seems a bit odd, especially when we use parentheses, since it works with any other number of arguments:

```m2
i1 : gcd()

o1 = 0

i2 : gcd(3)
stdio:2:3:(3): error: no method found for applying gcd to:
     argument   :  3 (of class ZZ)

i3 : gcd(3, 6)

o3 = 3

i4 : gcd(3, 6, 9)

o4 = 3
```

After defining `gcd(ZZ)`:

```m2
i1 : gcd(3)

o1 = 3
```

