### PR TITLE
changed interiorVector to work for cones with no rays, and added a test

### DIFF
--- a/M2/Macaulay2/packages/Polyhedra/core/cone/methods.m2
+++ b/M2/Macaulay2/packages/Polyhedra/core/cone/methods.m2
@@ -64,14 +64,13 @@ minFace (Matrix,Cone) := (v,C) -> (
 --  OUTPUT : 'p',  a point given as a matrix 
 interiorVector = method(TypicalValue => Matrix)
 interiorVector Cone := C -> (
-     if dim C == 0 then map(ZZ^(ambDim C),ZZ^1,0)
+     Rm := rays C;
+     if numColumns Rm == 0 then map(ZZ^(ambDim C),ZZ^1,0)
      else (
-	  Rm := rays C;
 	  ones := matrix toList(numColumns Rm:{1});
 	  -- Take the sum of the rays
 	  iv := Rm * ones;
 	  transpose matrix apply(entries transpose iv, w -> (g := abs gcd w; apply(w, e -> e//g)))));
-
 
 --   INPUT : '(p,C)',  where 'p' is a point given by a matrix and 'C' is a Cone
 --  OUTPUT : 'true' or 'false'

--- a/M2/Macaulay2/packages/Polyhedra/tests/core/cone_basics.m2
+++ b/M2/Macaulay2/packages/Polyhedra/tests/core/cone_basics.m2
@@ -121,3 +121,9 @@ TEST ///
 P = convexHull transpose matrix {{0,0},{2,0},{2,3},{-1,4}}
 assert(isSimplicial P)
 ///
+
+--Test for interiorVector for cone without rays
+TEST ///
+C = coneFromVData(map(ZZ^(4),ZZ^1,0), matrix{{1},{1},{1},{1}})
+assert(interiorVector C==matrix{{0},{0},{0},{0}})
+///


### PR DESCRIPTION
At the Macaulay2 in the Sciences we observed that the interiorVector function in the Polyhedral package does not give an point inside the cone for a cone that has no rays.