### PR TITLE
Recognize several more unicode characters as math operators

### DIFF
--- a/M2/Macaulay2/d/ctype.d
+++ b/M2/Macaulay2/d/ctype.d
@@ -53,14 +53,14 @@ export isquote    (c:char):bool := (chartype(c) & QUOTE    ) != 0;
 
 -- c = two bytes concatenated
 export ismathoperator(c:int):bool := (
-    (c & 0xffe0) == 0xc2a0 || -- latin-1 punctuation/symbols
-    c == 0xc397            || -- multiplication sign
-    c == 0xc3b7            || -- division sign
-    (c & 0xfffc) == 0xe288 || -- mathematical operators
-    (c & 0xfffc) == 0xe2a8 || -- supplemental mathematical operators
-    c == 0xe29f            || -- misc. mathematical symbols A
-    (c & 0xfffe) == 0xe2a6 || -- misc. mathematical symbols B
-    (c & 0xfffc) == 0xe28c    -- misc. technical
+    (c & 0xffe0) == 0xc2a0 || -- latin-1 punctuation/symbols     (U+00A0-U+00BF)
+    c == 0xc397            || -- multiplication sign             (U+00D7)
+    c == 0xc3b7            || -- division sign                   (U+00F7)
+    (c & 0xfffe) == 0xe286 || -- arrows                          (U+2190-U+21FF)
+    (c & 0xfff8) == 0xe288 || -- math operators/misc technical   (U+2200-U+23FF)
+    c == 0xe29f            || -- misc math symbols/supp arrows A (U+27C0-U+27FF)
+    (c & 0xfffc) == 0xe2a4 || -- misc math symbols/supp arrows B (U+2900-U+29FF)
+    (c & 0xfff8) == 0xe2a8    -- supp math ops/misc sym & arrows (U+2A00-U+2BFF)
     );
 
 ismathoperator(c1:char, c2:char):bool := (

--- a/M2/Macaulay2/tests/normal/unicode.m2
+++ b/M2/Macaulay2/tests/normal/unicode.m2
@@ -7,3 +7,5 @@ assert(v·w == 11)
 
 -- should get "invalid symbol" error
 assert try getSymbol "⟎⟎" then false else true
+
+assert((a⇒b) === (a => b))


### PR DESCRIPTION
This is a quick follow up to #3584 adding a few more unicode blocks to the list of characters recognized as mathematical operators.  In particular:

* Arrows (U+2190-U+21FF)
* Supplementary arrows A (U+27F0-U+27FF)
* Supplementary arrows B (U+2900-U+297F)
* Miscellaneous symbols & arrows (U+2B00-U+2BFF)

This fixes the bug pointed out in https://github.com/Macaulay2/M2/pull/3584#issuecomment-2511393699