### PR TITLE
Switched to null-coalescing notation

### DIFF
--- a/M2/Macaulay2/m2/Hom.m2
+++ b/M2/Macaulay2/m2/Hom.m2
@@ -62,7 +62,7 @@ Hom(Matrix, Matrix) := Matrix => o -> (f, g) -> Hom(source f, g, o) * Hom(f, sou
 -----------------------------------------------------------------------------
 
 -- TODO: compare speed with Hom(M, R^1)
-dual Module := Module => {} >> o -> F -> if F.cache.?dual then F.cache.dual else F.cache.dual = (
+dual Module := Module => {} >> o -> F -> F.cache.dual ??= (
      if not isFreeModule F then kernel transpose presentation F
      else new Module from (ring F,rawDual raw F))
 

--- a/M2/Macaulay2/m2/computations.m2
+++ b/M2/Macaulay2/m2/computations.m2
@@ -60,14 +60,11 @@ new Computation from HashTable := (C, T) -> new C from { Result => null }
 -- if there is a compatible computation stored in T.cache,
 -- returns the computation container, otherwise creates the entry:
 --   Context => Computation
+-- TODO: how should one look for other compatible contexts as well?
 fetchComputation = method(Options => true)
 fetchComputation(Type, HashTable,            Context) := Computation => true >> opts -> (C, T,    context) -> fetchComputation(C, T, T, context)
 fetchComputation(Type, HashTable, Sequence,  Context) :=
-fetchComputation(Type, HashTable, HashTable, Context) := Computation => true >> opts -> (C, T, X, context) -> (
-    -- TODO: look for other compatible contexts as well
-    -- TODO: use https://github.com/Macaulay2/M2/issues/1596 when it is implemented
-    if T.cache#?context then T.cache#context
-    else T.cache#context = new C from X)
+fetchComputation(Type, HashTable, HashTable, Context) := Computation => true >> opts -> (C, T, X, context) -> T.cache#context ??= new C from X
 
 -----------------------------------------------------------------------------
 -- isComputationDone

--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -42,7 +42,7 @@ on = { CallLimit => 100000, Name => null, GenerateAssertions => false } >> opts 
      fb := functionBody f;
      calldepth := 0;
      totaltime := 0.;
-     if not callCount#?fb then callCount#fb = 0;
+     callCount#fb ??= 0;
      limit := opts.CallLimit;
      if not instance(f, Function) then error("expected a function");
      fn := if opts.Name =!= null then opts.Name else try toString f else "-*function*-";
@@ -135,7 +135,7 @@ show1(Sequence,Function) := show1(List,Function) := (types,pfun) -> (
 --	  if hasAttribute(v,PrintNet) then v = getAttribute(v,PrintNet) else
 --	  if hasAttribute(v,PrintNames) then v = getAttribute(v,PrintNames) else
 --	  if hasAttribute(v,ReverseDictionary) then v = getAttribute(v,ReverseDictionary);
-	  if w#?v then w#v else w#v = new Descent
+	  w#v ??= new Descent
 	  );
      scan(types, install);
      world)

--- a/M2/Macaulay2/m2/gb.m2
+++ b/M2/Macaulay2/m2/gb.m2
@@ -312,7 +312,7 @@ gb = method(TypicalValue => GroebnerBasis, Options => gbDefaults)
 gb Ideal  := GroebnerBasis => opts -> I -> gb (module I, opts)
 gb Module := GroebnerBasis => opts -> M -> (
     if M.?relations then (
-	if not M.cache#?"full gens" then M.cache#"full gens" = generators M | relations M;
+	M.cache#"full gens" ??= generators M | relations M;
 	gb(M.cache#"full gens", opts, SyzygyRows => numgens source generators M))
     else gb(generators M, opts))
 gb Matrix := GroebnerBasis => opts -> m -> (

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -96,7 +96,7 @@ redoMENU = contents -> (
 reverseOptionTable := null
 
 addro := (sym, meth) -> (
-    if not reverseOptionTable#?sym then reverseOptionTable#sym = new MutableHashTable;
+    reverseOptionTable#sym ??= new MutableHashTable;
     reverseOptionTable#sym#meth = true;)
 
 initializeReverseOptionTable := () -> (

--- a/M2/Macaulay2/m2/hilbert.m2
+++ b/M2/Macaulay2/m2/hilbert.m2
@@ -316,7 +316,7 @@ hilbertSeries Module := opts -> M -> (
 	    if ord == ord2 then return ser else
 	    if ord  < ord2 then return part(, ord-1, hft, ser));
 	if M.cache#?exactKey or M.cache#?reducedKey then (
-	    if not M.cache#?reducedKey then M.cache#reducedKey = reduceHilbert M.cache#exactKey;
+	    M.cache#reducedKey ??= reduceHilbert M.cache#exactKey;
 	    return last(M.cache#approxKey = (ord, truncateSeries(ord, hft, M.cache#reducedKey))))
 	    )
     else error "hilbertSeries: option Order expected infinity or an integer";

--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -414,15 +414,13 @@ Matrix#AfterPrint = Matrix#AfterNoPrint = f -> (
 
 -- precedence Matrix := x -> precedence symbol x
 
-image Matrix := Module => f -> (
-     if f.cache.?image then f.cache.image else f.cache.image = subquotient(f,)
-     )
-coimage Matrix := Module => f -> (
-     if f.cache.?coimage then f.cache.coimage else f.cache.coimage = cokernel inducedMap(source f, kernel f)
-     )
-cokernel Matrix := Module => m -> (
-     if m.cache.?cokernel then m.cache.cokernel else m.cache.cokernel = subquotient(,m)
-     )
+-- source and target are defined in modules.m2
+-- image caches f in M.cache.Monomials
+image    Matrix := Module => f -> f.cache.image    ??= subquotient(f, null)
+cokernel Matrix := Module => f -> f.cache.cokernel ??= subquotient(null, f)
+-- kernel is defined in pushforward.m2
+coimage  Matrix := Module => f -> f.cache.coimage  ??= cokernel inducedMap(source f, kernel f)
+-- homology is defined further down
 
 cokernel RingElement := Module => f -> cokernel matrix {{f}}
 image RingElement := Module => f -> image matrix {{f}}

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -357,10 +357,7 @@ addHook((quotient, Matrix, Matrix), Strategy => Default, (opts, f, g) -> (
      -- now M is a quotient module, without explicit generators
      f' := matrix f;
      g' := matrix g;
-     G := (
-	  if g.cache#?"gb for quotient"
-	  then g.cache#"gb for quotient"
-	  else g.cache#"gb for quotient" = (
+     G := ( g.cache#"gb for quotient" ??= (
 	       if M.?relations 
 	       then gb(g' | relations M, ChangeMatrix => true, SyzygyRows => rank source g')
 	       else gb(g',               ChangeMatrix => true)));

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -618,7 +618,7 @@ addHook(Symbol,                  Function) := opts -> (key,        hook) -> addH
 addHook(Sequence,                Function) := opts -> (key,        hook) -> addHook(getHookStore(key, true), key, hook, opts)
 addHook(MutableHashTable, Thing, Function) := opts -> (store, key, hook) -> (
     -- this is the hashtable of Hooks for a specific key, which stores HookAlgorithms and HookPriority
-    if not store#?key then store#key = new MutableHashTable from {
+    store#key ??= new MutableHashTable from {
 	HookAlgorithms => new MutableHashTable, -- a mutable hash table "strategy key" => "strategy code"
 	HookPriority   => new MutableList};     -- a mutable list of strategy keys, in order
     store = store#key;

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -15,6 +15,7 @@ ring Matrix := f -> (
      if R =!= S then error "expected module map with source and target over the same ring";
      if f.?RingMap then error "expected module map with no ring map";
      R)
+-- FIXME: can't set the typical output type because Module isn't defined yet!
 source Matrix := f -> f.source
 target Matrix := f -> f.target
 

--- a/M2/Macaulay2/m2/modules2.m2
+++ b/M2/Macaulay2/m2/modules2.m2
@@ -113,12 +113,12 @@ Ideal == ZZ := (I,n) -> (
 
 -----------------------------------------------------------------------------
 
-presentation(Module) := Matrix => M -> (
-     if M.cache.?presentation then M.cache.presentation else M.cache.presentation = (
+presentation Module := Matrix => M -> M.cache.presentation ??= (
 	  if M.?generators then (
 	       modulo( M.generators, if M.?relations then M.relations)
 	       )
-	  else relations M))
+    else relations M)
+
 -----------------------------------------------------------------------------  
 
 minimalPresentation(Module) := prune(Module) := Module => opts -> (cacheValue (symbol minimalPresentation => opts)) (M -> (
@@ -303,7 +303,7 @@ Module ^ Array := Matrix => (M,w) -> if M.cache#?(symbol ^,w) then M.cache#(symb
      if oldw =!= null then newcomps = apply(oldw,newcomps,(i,M) -> i => M); -- warning: duplicate entries in oldw will lead to inaccessible components
      map(directSum newcomps, M, (cover M)^(splice apply(w, i -> v#i))))
 
-Module _ Array := Matrix => (M,w) -> if M.cache#?(symbol _,w) then M.cache#(symbol _,w) else M.cache#(symbol _,w) = (
+Module _ Array := Matrix => (M, w) -> M.cache#(symbol _, w) ??= (
      -- we don't splice any more because natural indices include pairs (i,j).
      w = toList w;
      if not M.cache.?components then error "expected a direct sum module";

--- a/M2/Macaulay2/m2/multilin.m2
+++ b/M2/Macaulay2/m2/multilin.m2
@@ -43,7 +43,7 @@ rep := (meth, opts, args) -> prepend_opts nonnull apply(args, arg ->
     else arg)
 
 symmetricAlgebra = method( Options => monoidDefaults )
-symmetricAlgebra Module := Ring => opts -> (cacheValue (symmetricAlgebra => opts)) (M -> (
+symmetricAlgebra Module := Ring => opts -> M -> M.cache#(symmetricAlgebra, opts) ??= (
 	k := ring M;
 	N := monoid rep(symmetricAlgebra, opts, [
 		Variables => () -> numgens M,
@@ -52,14 +52,13 @@ symmetricAlgebra Module := Ring => opts -> (cacheValue (symmetricAlgebra => opts
 	S := k N;
 	S  = S / ideal(vars S * promote(presentation M, S));
 	S.Module = M;
-	S))
+    S)
 
-symmetricAlgebra(Ring, Ring, Matrix) := RingMap => o -> (T, S, f) -> (
-    if f.cache#?(key := (symmetricAlgebra, T, S, f)) then f.cache#key else f.cache#key = (
+symmetricAlgebra(Ring, Ring, Matrix) := RingMap => o -> (T, S, f) -> f.cache#(symmetricAlgebra, T, S, f) ??= (
 	p := map(T, S, vars T * promote(cover f, T));
 	if f.cache.?inverse then p.cache.inverse = (
 	    map(S, T, vars S * promote(cover inverse f, S)));
-	p))
+    p)
 symmetricAlgebra                   Matrix  := RingMap => o ->        f  -> symmetricAlgebra(symmetricAlgebra target f, symmetricAlgebra source f, f)
 symmetricAlgebra(Nothing, Nothing, Matrix) := RingMap => o -> (T, S, f) -> symmetricAlgebra(symmetricAlgebra target f, symmetricAlgebra source f, f)
 symmetricAlgebra(Nothing, Ring,    Matrix) := RingMap => o -> (T, S, f) -> symmetricAlgebra(symmetricAlgebra target f, S, f)
@@ -70,8 +69,7 @@ symmetricAlgebra(Ring,    Nothing, Matrix) := RingMap => o -> (T, S, f) -> symme
 -----------------------------------------------------------------------------
 
 symmetricPower = method()
-symmetricPower(ZZ, Module) := Module => (p, M) -> (
-    if M.cache#?(key := (symmetricPower, p)) then M.cache#key else M.cache#key = (
+symmetricPower(ZZ, Module) := Module => (p, M) -> M.cache#(symmetricPower, p) ??= (
 	R := ring M;
 	if p   < 0 then R^0 else
 	if p === 0 then R^1 else
@@ -79,12 +77,11 @@ symmetricPower(ZZ, Module) := Module => (p, M) -> (
 	if isFreeModule M   then new Module from (R, rawSymmetricPower(p, raw M))
 	else coimage basis(p, symmetricAlgebra M,
 	    SourceRing => ring M, Degree => {p, degreeLength R:0})
-    ))
+    )
 symmetricPower(ZZ, Matrix) := Matrix => (i, m) -> map(ring m, rawSymmetricPower(i, raw m))
 
 exteriorPower = method(Options => { Strategy => null })
-exteriorPower(ZZ, Module) := Module => opts -> (p, M) -> (
-    if M.cache#?(exteriorPower, p) then M.cache#(exteriorPower, p) else M.cache#(exteriorPower, p) = (
+exteriorPower(ZZ, Module) := Module => opts -> (p, M) -> M.cache#(exteriorPower, p) ??= (
 	R := ring M;
 	if p   < 0 then R^0 else
 	if p === 0 then R^1 else
@@ -97,7 +94,7 @@ exteriorPower(ZZ, Module) := Module => opts -> (p, M) -> (
 	    h1 := m ** id_Fp1;
 	    h2 := wedgeProduct(1,p-1,F);
 	    cokernel(h2 * h1))
-    ))
+    )
 
 exteriorPower(ZZ, Matrix) := Matrix => opts -> (p, m) -> (
     R := ring m;

--- a/M2/Macaulay2/m2/newring.m2
+++ b/M2/Macaulay2/m2/newring.m2
@@ -16,7 +16,7 @@ nothing := symbol nothing
 newRing = method( Options => applyValues(monoidDefaults, x -> nothing), TypicalValue => Ring )
 newRing PolynomialRing := opts -> (R) -> (
      opts = new MutableHashTable from select(new HashTable from opts, v -> v =!= nothing);
-     nullify := k -> if not opts#?k then opts#k = monoidDefaults#k;
+    nullify := k -> opts#k ??= monoidDefaults#k;
     if opts.?DegreeRank  then nullify \ {Heft, Degrees,    DegreeGroup};
     if opts.?Degrees     then nullify \ {Heft, DegreeRank, DegreeGroup};
     if opts.?DegreeGroup then nullify \ {Heft, DegreeRank};

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -232,8 +232,7 @@ Ring / List := Ring / Sequence := QuotientRing => (R,f) -> R / promote(ideal f, 
 -----------------------------------------------------------------------------
 
 presentation PolynomialRing := Matrix => R -> map(R^1, R^0, 0)
-presentation QuotientRing   := Matrix => R -> (
-     if R.?presentation then R.presentation else R.presentation = (
+presentation QuotientRing   := Matrix => R -> R.presentation ??= (
 	  S := ambient R;
 	  f := generators ideal R;
 	  while class S === QuotientRing do (		    -- untested code
@@ -241,8 +240,7 @@ presentation QuotientRing   := Matrix => R -> (
 	       S = ambient S;
 	       );
 	  f
-	  )
-     )
+    )
 
 presentation(QuotientRing,   QuotientRing)   :=
 presentation(QuotientRing,   PolynomialRing) :=

--- a/M2/Macaulay2/m2/remember.m2
+++ b/M2/Macaulay2/m2/remember.m2
@@ -8,7 +8,7 @@ memoize(Function,List) := (f,initialValues) -> (
      values := new MutableHashTable from initialValues;
      x -> (
 	  -- This code is common to any function that has been memoized with initial values.
-	  if not values#?x then values#x = f(x) else values#x
+	  values#x ??= f(x)
 	  )
      )
 memoize Function := f -> memoize(f,{})

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -161,9 +161,7 @@ if firstTime then (
 
      Attributes = new MutableHashTable;
      -- values are hash tables with keys Symbol, String, Net (as symbols); replaces ReverseDictionary and PrintNames
-     setAttribute = (val,attr,x) -> (
-	  if Attributes#?val then Attributes#val else Attributes#val = new MutableHashTable
-	  )#attr = x;
+     setAttribute = (val,attr,x) -> ( Attributes#val ??= new MutableHashTable )#attr = x;
      hasAnAttribute = (val) -> Attributes#?val;
      hasAttribute = (val,attr) -> Attributes#?val and Attributes#val#?attr;
      getAttribute = (val,attr) -> Attributes#val#attr;

--- a/M2/Macaulay2/m2/variables.m2
+++ b/M2/Macaulay2/m2/variables.m2
@@ -29,7 +29,7 @@ IndexedVariableTable _ Thing := (x,i) -> (
 IndexedVariableTable _ Thing  = (x,i,e) -> (checkValue x; x#i = e)
 IndexedVariableTable.GlobalAssignHook = (X,x) -> (
      globalAssignFunction(X,x);
-     if not x#?symbol$ then x#symbol$ = X;
+     x#symbol$ ??= X;
      )
 IndexedVariableTable.GlobalReleaseHook = (X,x) -> (
      globalReleaseFunction(X,x);

--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -604,7 +604,7 @@ poincare Complex := C -> (
 
 poincareN Complex := C -> (
     S := degreesRing ring C;
-    if not S.?poincareN then S.poincareN = (
+    R := S.poincareN ??= (
         s := getSymbol "S";
         t := getSymbol "T";
         ZZ (monoid[s, t_0 .. t_(degreeLength ring C - 1), 
@@ -612,7 +612,6 @@ poincareN Complex := C -> (
                 MonomialOrder => RevLex, 
                 Global => false])
         );
-    R := S.poincareN;
     (lo,hi) := concentration C;
     f := 0_R;
     for i from lo to hi do (
@@ -1089,7 +1088,7 @@ Ext(ZZ, Module, Module) := Module => opts -> (i,M,N) -> (
     liftmap := null; -- given f : R^1 --> H, returns g : R^1 --> Hom(FM_i, N)
     invmap := null; -- given g : R^1 --> Hom(FM_i, N), returns f : R^1 --> H = Ext^i(M,N)
     Y := youngest(M.cache.cache,N.cache.cache);
-    if not Y#?(Ext,i,M,N) then Y#(Ext,i,M,N) = (
+    Y#(Ext,i,M,N) ??= (
         R := ring M;
         if not isCommutative R then error "'Ext' not implemented yet for noncommutative rings.";
         if R =!= ring N then error "expected modules over the same ring";
@@ -1134,8 +1133,7 @@ Ext(ZZ, Module, Module) := Module => opts -> (i,M,N) -> (
         H.cache.formation = FunctionApplication { Ext, (i, M, N) };
         H.cache.Ext = (i,M,N);
         H
-        );
-    Y#(Ext,i,M,N)
+	)
     )
 
 yonedaExtension = method()

--- a/M2/Macaulay2/packages/MinimalPrimes/AnnotatedIdeal.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes/AnnotatedIdeal.m2
@@ -145,7 +145,7 @@ ideal AnnotatedIdeal := Ideal => (cacheValue "CachedIdeal") (I -> (
 -- TODO: is this still needed?
 ideal AnnotatedIdeal := (I) -> (
     --F := product unique join(I.Linears / (x -> x#1),I.Inverted);
-    if not I#?"CachedIdeal" then I#"CachedIdeal" = (
+    I#"CachedIdeal" ??= (
        F := product unique (I.Linears / (x -> x#1));
        I1 := ideal(I.Linears/last);
        I2 := if I.?IndependentSet then (
@@ -158,9 +158,7 @@ ideal AnnotatedIdeal := (I) -> (
        I3 := if numgens I1 === 0 then I2 else if numgens I2 === 0 then I1 else I1+I2;
        --if F == 1 then I3 else saturate(I3, F)
        if F == 1 then I3 else mySat(I3, F)
-    );
-    I#"CachedIdeal"
-)
+    ))
 *-
 
 isSubset(Ideal, AnnotatedIdeal) := (I, J) -> isSubset(I, ideal J) -- naive attempt first...

--- a/M2/Macaulay2/packages/MinimalPrimes/decompose2-test.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes/decompose2-test.m2
@@ -1,4 +1,4 @@
-decompose Ideal := (I) -> if I.cache.?decompose then I.cache.decompose else I.cache.decompose = (
+decompose Ideal := (I) -> I.cache.decompose ??= (
      R := ring I;
      if isQuotientRing R then (
 	  A := ultimate(ambient, R);

--- a/M2/Macaulay2/packages/NumericalSemigroups.m2
+++ b/M2/Macaulay2/packages/NumericalSemigroups.m2
@@ -461,7 +461,7 @@ apery List := HashTable => L -> (
     a := 0; -- number of keys already filled in A
     S := set L + set{0}; -- S will hold all the semigroup elmeents found, including 0
 
-    --now look for new Apery set elememts and semigroup elements until
+    --now look for new Apery set elements and semigroup elements until
     --all the keys have been filled.
     s := m;
     while a < m-1 do(
@@ -2797,7 +2797,7 @@ Inputs
  g:ZZ
   genus
  m:ZZ
-  mutiplicity
+  multiplicity
  c:ZZ
   conductor
 Outputs

--- a/M2/Macaulay2/packages/PencilsOfQuadrics.m2
+++ b/M2/Macaulay2/packages/PencilsOfQuadrics.m2
@@ -2803,7 +2803,7 @@ doc ///
     Text
      A vector bundle on a hyperelliptic curve E with
      equation y^2 - (-1)^g * f
-     can be represeted by it's pushforward V to PP^1,
+     can be represented by it's pushforward V to PP^1,
      under the degree 2 map, 
      which will be a vector bundle of twice the rank,
      together with a matrix 

--- a/M2/Macaulay2/packages/Permutations/docs.m2
+++ b/M2/Macaulay2/packages/Permutations/docs.m2
@@ -972,7 +972,7 @@ doc ///
     extend
     (extend, Permutation, ZZ)
   Headline
-    rewrites a permutation as a permution on more symbols
+    rewrites a permutation as a permutation on more symbols
   Usage
     extend(w,n)
   Inputs

--- a/M2/Macaulay2/packages/Polyhedra/extended/legacy.m2
+++ b/M2/Macaulay2/packages/Polyhedra/extended/legacy.m2
@@ -112,14 +112,13 @@ imageFan (Matrix,Cone) := (M,C) -> (
 --  OUTPUT : 'C',  a Cone, the inner normal cone of P in the face Q
 -- COMMENT : 'Q' must be a face of P
 normalCone (Polyhedron,Polyhedron) := Cone => {} >> opts -> (P,Q) -> (
-     if not P.cache.?normalCone then P.cache.normalCone = new MutableHashTable;
-     if not P.cache.normalCone#?Q then (
+    P.cache.normalCone ??= new MutableHashTable;
+    P.cache.normalCone#Q ??= (
 	  -- Checking for input errors
 	  if not isFace(Q,P) then error("The second polyhedron must be a face of the first one");
 	  p := interiorPoint Q;
-	  P.cache.normalCone#Q = dualCone coneFromVData affineImage(P,-p));
-     P.cache.normalCone#Q)
-
+	dualCone coneFromVData affineImage(P, -p))
+    )
 
 
 --   INPUT : 'M',  a Matrix

--- a/M2/Macaulay2/packages/PrimaryDecomposition.m2
+++ b/M2/Macaulay2/packages/PrimaryDecomposition.m2
@@ -261,9 +261,7 @@ ass0 = I -> (
     J := dual I;
     M := first entries generators J;
     H := new MutableHashTable;
-    scan(M, m -> (
-	    s := rawIndices raw m;
-	    if not H#?s then H#s = true));
+    scan(M, m -> H#(rawIndices raw m) ??= true);
     inds := sort apply(keys H, ind -> (#ind, ind));
     apply(inds, s -> s#1))
 


### PR DESCRIPTION
- **switched to new ??= notation in Core**
- **switched to new ??= notation in a few packages**

We should get rid of `cacheValue` and `stashValue`, the main motivation being that this is ugly:
```m2
i1 : code(module, Ring)

o1 = -- code for method: module(Ring)
     ../linuxbrew/.linuxbrew/share/Macaulay2/Core/methods.m2:685:49-694:27:
     --source code:
     cacheValue = key -> f -> new CacheFunction from (x -> (
               c := try x.cache else x.cache = new CacheTable;
               if c#?key then (
                    val := c#key;
                    if class val === CacheFunction then (
                         remove(c,key);
                         c#key = val x)
                    else val
                    )
               else c#key = f x))
     | symbol  class            value                                                    location of symbol
     | ------  -----            -----                                                    ------------------
     | f       FunctionClosure  FunctionClosure[../linuxbrew/.linuxbrew/share/Macaulay.  ../linuxbrew/.linuxbrew/share/Macaulay2/Core/methods.m2:685:20-685:21
     | key     Symbol           module                                                   ../linuxbrew/.linuxbrew/share/Macaulay2/Core/methods.m2:685:13-685:16
     | -- function f:
     | ../linuxbrew/.linuxbrew/share/Macaulay2/Core/matrix1.m2:21:52-21:60:
     | --source code:
     | module Ring := Module => (cacheValue symbol module)(R -> R^1)
```