### PR TITLE
Update behavior of augmented null coalescing operator

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_augmented_assignment.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_augmented_assignment.m2
@@ -112,7 +112,10 @@ doc ///
       The null coalescing operator can be combined with
       @TO "augmented assignment"@ as a shortcut for
       @M2CODE "if x === null then x = y"@ and
-      @M2CODE "if not x#?i then x#i = y"@.
+      @M2CODE "if not x#?i then x#i = y"@.  Note that it behaves
+      slightly differently than other augmented assignment operators,
+      as @CODE "x ??= y"@ is treated like @CODE "x ?? (x = y)"@ rather
+      than @CODE "x = x ?? y"@.
     Example
       x = null
       x ??= 2

--- a/M2/Macaulay2/tests/normal/augmented-assignment.m2
+++ b/M2/Macaulay2/tests/normal/augmented-assignment.m2
@@ -157,3 +157,7 @@ assert BinaryOperation(symbol ===, y ?? x, y)
 assert BinaryOperation(symbol ===, x ?? y, y)
 x ??= y
 assert BinaryOperation(symbol ===, x, y)
+
+-- issue #3612
+h = new HashTable from { symbol cache => new CacheTable };
+h.cache ??= new CacheTable


### PR DESCRIPTION
`x ??= y` now behaves like `x ?? (x = y)` rather than `x = x ?? y`.

These are equivalent when x is null.

When x is non-null, we avoid an unnecessary re-assignment step, which also allows for the possibility of using this operator with immutable hash tables without raising errors when keys already exist.

Closes: #3612

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
