### PR TITLE
Augmented assignment updates

### DIFF
--- a/M2/Macaulay2/d/convertr.d
+++ b/M2/Macaulay2/d/convertr.d
@@ -298,7 +298,7 @@ export convert0(e:ParseTree):Code := (
 	      is t:Token do Code(augmentedAssignmentCode(
 		      b.Operator.entry, convert(b.lhs), convert(b.rhs), t.entry, pos))
 	      else Code(augmentedAssignmentCode(
-		      b.Operator.entry, dummyCode, dummyCode, dummySymbol, dummyPosition)) -- CHECK
+		      b.Operator.entry, convert(b.lhs), convert(b.rhs), dummySymbol, pos))
 		      )
 	  else Code(binaryCode(b.Operator.entry.binary, convert(b.lhs), convert(b.rhs), pos))
 	  )

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1268,21 +1268,20 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	    is Nothing do nothing
 	    else return e)
 	else lexpr = eval(x.lhs);
-	left := evaluatedCode(lexpr, dummyPosition);
-	when left.expr is e:Error do return Expr(e) else nothing;
+	when lexpr is e:Error do return lexpr else nothing;
 	-- check if user-defined method exists
-	meth := lookup(Class(left.expr),
-	    Expr(SymbolClosure(globalFrame, x.oper)));
+	meth := lookup(Class(lexpr), Expr(SymbolClosure(globalFrame, x.oper)));
 	if meth != nullE then (
-	    rightexpr := eval(x.rhs);
-	    when rightexpr is e:Error do return(e) else nothing;
-	    r := applyEEE(meth, left.expr, rightexpr);
+	    rexpr := eval(x.rhs);
+	    when rexpr is e:Error do return rexpr else nothing;
+	    r := applyEEE(meth, lexpr, rexpr);
 	    when r
 	    is s:SymbolClosure do (
 		if s.symbol.word.name === "Default" then nothing
 		else return r)
 	    else return r);
 	-- if not, use default behavior
+	left := evaluatedCode(lexpr, codePosition(x.lhs));
 	when x.lhs
 	is y:globalMemoryReferenceCode do (
 	    r := s.binary(Code(left), x.rhs);

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1296,17 +1296,17 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	    when r is e:Error do r
 	    else globalAssignment(y.frameindex, x.info, r))
 	is y:binaryCode do (
-	    r := Code(binaryCode(s.binary, Code(left), x.rhs, dummyPosition));
+	    r := Code(binaryCode(s.binary, Code(left), x.rhs, x.position));
 	    if y.f == DotS.symbol.binary || y.f == SharpS.symbol.binary
 	    then AssignElemFun(y.lhs, y.rhs, r)
 	    else InstallValueFun(CodeSequence(
 		    convertGlobalOperator(x.info), y.lhs, y.rhs, r)))
 	is y:adjacentCode do (
-	    r := Code(binaryCode(s.binary, Code(left), x.rhs, dummyPosition));
+	    r := Code(binaryCode(s.binary, Code(left), x.rhs, x.position));
 	    InstallValueFun(CodeSequence(
 		    convertGlobalOperator(AdjacentS.symbol), y.lhs, y.rhs, r)))
 	is y:unaryCode do (
-	    r := Code(binaryCode(s.binary, Code(left), x.rhs, dummyPosition));
+	    r := Code(binaryCode(s.binary, Code(left), x.rhs, x.position));
 	    UnaryInstallValueFun(convertGlobalOperator(x.info), y.rhs, r))
 	else buildErrorPacket(
 	    "augmented assignment not implemented for this code")));

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1285,15 +1285,15 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 	when x.lhs
 	is y:globalMemoryReferenceCode do (
 	    r := s.binary(Code(left), x.rhs);
-	    when r is e:Error do Expr(e)
+	    when r is e:Error do r
 	    else globalAssignment(y.frameindex, x.info, r))
 	is y:localMemoryReferenceCode do (
 	    r := s.binary(Code(left), x.rhs);
-	    when r is e:Error do Expr(e)
+	    when r is e:Error do r
 	    else localAssignment(y.nestingDepth, y.frameindex, r))
 	is y:threadMemoryReferenceCode do (
 	    r := s.binary(Code(left), x.rhs);
-	    when r is e:Error do Expr(e)
+	    when r is e:Error do r
 	    else globalAssignment(y.frameindex, x.info, r))
 	is y:binaryCode do (
 	    r := Code(binaryCode(s.binary, Code(left), x.rhs, dummyPosition));


### PR DESCRIPTION
This fixes the weird error message @mahrud pointed out in https://github.com/Macaulay2/M2/pull/3614#issuecomment-2549027711.  Now we have:

```m2
i1 : (a,b) ??= (1,2)
stdio:1:6:(3): error: augmented assignment not implemented for this code
```

Also a few other small updates that I noticed while looking at the code.