### PR TITLE
just some typos in packages

### DIFF
--- a/M2/Macaulay2/packages/HolonomicSystems/DOC/Dsystems.m2
+++ b/M2/Macaulay2/packages/HolonomicSystems/DOC/Dsystems.m2
@@ -11,7 +11,7 @@ doc ///
     D:PolynomialRing  
   Outputs
      :Ideal
-      the toric ideal of the matrix $A$ in the polynomial ring of the partials inside of the Weyl algerba $D$.
+      the toric ideal of the matrix $A$ in the polynomial ring of the partials inside of the Weyl algebra $D$.
   Description
     Text 
       A $d \times n$ integer matrix $A$ determines a GKZ hypergeometric system of PDEs 

--- a/M2/Macaulay2/packages/LLLBases.m2
+++ b/M2/Macaulay2/packages/LLLBases.m2
@@ -946,9 +946,9 @@ document {
      },
      SUBSECTION "Orthogonalization Strategy",
      UL {
-  	  {"default -- Classical Gramm-Schmidt Orthogonalization, ",
+  	  {"default -- Classical Gram-Schmidt Orthogonalization, ",
      "This choice uses classical methods for computing
-     the Gramm-Schmidt othogonalization.
+     the Gram-Schmidt orthogonalization.
      It is fast but prone to stability problems.
      This strategy was first proposed by Schnorr and Euchner in the paper
      mentioned above.

--- a/M2/Macaulay2/packages/MatchingFields.m2
+++ b/M2/Macaulay2/packages/MatchingFields.m2
@@ -978,7 +978,7 @@ matchingFieldFromPermutationNoScaling(ZZ, ZZ, List) := opts -> (Lk, Ln, S) -> (
 -- 7) if not then d = d+1 and go back to step 2
 -- 8) reduce the matching field ideal gens modulo the full GB and check if the result is zero
 --
--- In the homgeneous case, it suffices to compute a GB up to degree limit d (step 1)
+-- In the homogeneous case, it suffices to compute a GB up to degree limit d (step 1)
 -- so we can forgo the while loop
 
 isToricDegeneration = method ()

--- a/M2/Macaulay2/packages/MonodromySolver/under-construction-examples/deprecated-examples/example-trace.m2
+++ b/M2/Macaulay2/packages/MonodromySolver/under-construction-examples/deprecated-examples/example-trace.m2
@@ -109,7 +109,7 @@ R = C[x_1..x_n]
 F = apply(n-m, i->sub(random(d,CC[x_1..x_n]),R)) -- V(F) = intersection of n-m hypersurfaces of degree d
 A = genericMatrix(C,n,m)
 B = genericMatrix(C,b_1,1,m)
-L = flatten entries (vars R * A + B) -- slice of complimentary dimension 
+L = flatten entries (vars R * A + B) -- slice of complementary dimension 
 G = polySystem(F|L)
 
  clearAll()

--- a/M2/Macaulay2/packages/NumericalSemigroups.m2
+++ b/M2/Macaulay2/packages/NumericalSemigroups.m2
@@ -2097,7 +2097,7 @@ Outputs
   degrees of a basis of T^1(semigroupRing L)
 Description
   Text
-   T^1(B) is the tangent space to the versal deformaion of
+   T^1(B) is the tangent space to the versal deformation of
    the ring B, and is finite dimensional when B has isolated
    singularity. If B = S/I is a Cohen presentation, then
    T^1(B) = coker Hom(Omega_S, B) -> Hom(I/I^2, B).

--- a/M2/Macaulay2/packages/PlaneCurveLinearSeries.m2
+++ b/M2/Macaulay2/packages/PlaneCurveLinearSeries.m2
@@ -479,7 +479,7 @@ Outputs
 Description
   Text
    Implements the additive inverse in the group law on the smooth points of
-   a plane curve E of genus 1, represented by its homogeneouos coordinate ring,
+   a plane curve E of genus 1, represented by its homogeneous coordinate ring,
    with chosen zero point o.
   Example
    S = QQ[x,y,z]

--- a/M2/Macaulay2/packages/TateOnProducts.m2
+++ b/M2/Macaulay2/packages/TateOnProducts.m2
@@ -856,7 +856,7 @@ viewHelp TateOnProducts
 
 lastQuadrantComplex=method()
 lastQuadrantComplex(ChainComplex,List) := (C,c) -> (
-    -- c index of the lower corner of the complentary first quadrant
+    -- c index of the lower corner of the complementary first quadrant
     lastQuadrantComplex1(C,c-toList(#c:1)))
 
 

--- a/M2/Macaulay2/packages/TropicalToric/ToricCycleDoc.m2
+++ b/M2/Macaulay2/packages/TropicalToric/ToricCycleDoc.m2
@@ -326,7 +326,7 @@ doc ///
         The set of torus-invariant cycles forms an abelian group
         under addition.  The basic operations arising from this structure,
         including addition, subtraction, negation, and scalar
-        multplication by integers, are available.
+        multiplication by integers, are available.
     Text
         We illustrate a few of the possibilities on one variety.
     Example

--- a/M2/Macaulay2/packages/TropicalToric/TropicalToricCode.m2
+++ b/M2/Macaulay2/packages/TropicalToric/TropicalToricCode.m2
@@ -31,7 +31,7 @@ refineMultiplicity (TropicalCycle, NormalToricVariety) := (T,X) ->(
 
 --input: normal toric varieties X,X' such that the identity on the lattices induces
 --       a toric map phi:X' -> X,
---       list mult of multiplcities of cones of X' of dimension k
+--       list mult of multiplicities of cones of X' of dimension k
 --output: list of degrees deg([Y'] * phi^*(V(sigma)), where [Y'] is the class of the cycle
 --        Y' in X' corresponding to the Minkowski weight given by mult.
 -- Note that here [Y'] * V(sigma') = mult_sigma' for every cone sigma' of X'.


### PR DESCRIPTION
This is fixing some typos found using `codespell` and commands like

```
 egrep -Rw --no-filename -o 'multi[a-z]+' M2/Macaulay2/ | sort | uniq -c | sort -rn
```