### PR TITLE
TeXmacs fixes

### DIFF
--- a/M2/Macaulay2/m2/mathml.m2
+++ b/M2/Macaulay2/m2/mathml.m2
@@ -59,7 +59,7 @@ mathML FunctionApplication := m -> (
      then concatenate (mfun, bigParenthesize margs)
      else concatenate (bigParenthesize mfun, bigParenthesize margs)
      )
-mathML MatrixExpression := x -> concatenate( "<mrow><mo>(</mo>", mtableML x#0, "<mo>)</mo></mrow>", newline )
+mathML MatrixExpression := x -> concatenate( "<mrow><mo>(</mo>", mtableML x, "<mo>)</mo></mrow>", newline )
 mathML Minus := v -> concatenate( "<mo>-</mo>", mathML v#0)
 mathML Divide := x -> concatenate("<mfrac>", mathML x#0, mathML x#1, "</mfrac>")
 mathML OneExpression := x -> "<mn>1</mn>"

--- a/M2/Macaulay2/m2/mathml.m2
+++ b/M2/Macaulay2/m2/mathml.m2
@@ -144,6 +144,7 @@ mathML ChainComplex := C -> (
      s := sort spots C;
      if #s === 0 then mathML "0"
      else mtable transpose between({leftarrow,"",""}, toList apply(s#0 .. s#-1,i -> {mathML C_i,"",mathML i})))
+mathML MapExpression := x -> mrow {mathML x#0, leftarrow, mathML x#1}
 mathML Option := s -> concatenate("<mrow>",mathML s#0, doublerightarrow, mathML s#1, "</mrow>")
 mathML Type :=
 mathML ImmutableType := R -> if R.?mathML then R.mathML else mathML expression R

--- a/M2/Macaulay2/m2/texmacs.m2
+++ b/M2/Macaulay2/m2/texmacs.m2
@@ -15,11 +15,28 @@ mtable := x -> concatenate(
      apply(x, row -> ( "<mtr>", apply(row, e -> ("<mtd>",e,"</mtd>",newline)), "</mtr>", newline ) ),
      "</mtable>", newline )
 fmt := x -> concatenate lines try mathML x else mathML toString x;
+po := () -> red concatenate("<mi>", interpreterDepth:"o", toString lineNumber,"</mi>")
 Thing#{TeXmacs,Print} = send := v -> (
-     po := red concatenate("<mi>o",toString lineNumber,"</mi>");
-     << tmhtml fixn mathMode mtable {{po,red "<mo>=</mo>",fmt v},{},{po,red "<mo>:</mo>",fmt class v}})
+     << tmhtml fixn mathMode mtable {{po(), red "<mo>=</mo>",fmt v}})
 Nothing#{TeXmacs,Print} = identity
 InexactNumber#{TeXmacs,Print} = v -> withFullPrecision ( () -> send v )
+
+tmAfterPrint = x -> (
+    << endl
+    << tmhtml fixn mathMode mtable {{po(), red "<mo>:</mo>",
+	    concatenate apply(deepSplice sequence x,
+		y -> if y =!= null then fmt y)}})
+
+Thing#{TeXmacs,AfterPrint} = x -> (
+    l := lookup(AfterPrint, class x);
+    if l === null then return;
+    s := l x;
+    if s =!= null then tmAfterPrint s)
+Thing#{TeXmacs,AfterNoPrint} = x -> (
+    l := lookup(AfterNoPrint, class x);
+    if l === null then return;
+    s := l x;
+    if s =!= null then tmAfterPrint s)
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "

--- a/M2/Macaulay2/m2/texmacs.m2
+++ b/M2/Macaulay2/m2/texmacs.m2
@@ -5,7 +5,7 @@ needs "reals.m2"
 TeXmacsBegin = "\2"
 TeXmacsEnd   = "\5"
 fix := s -> replace("\2|\5","\33\\0",s)
-fixn := s -> concatenate between("\0", apply(separate("\0", s), fix))
+fixn := s -> concatenate between("\0", apply(separate("\\0", s), fix))
 red := p -> concatenate("<mstyle color=\"red\">",concatenate p,"</mstyle>")
 mathMode := s -> concatenate("<math xmlns=\"http://www.w3.org/1998/Math/MathML\">",concatenate s,"</math>")
 para := p -> concatenate("<p>",concatenate p,"</p>")


### PR DESCRIPTION
This includes @mgubi's [proposed fix](http://forum.texmacs.cn/t/macaulay-does-not-advance/1942/12) for #2534 and also fixes the reported matrix display issue.  This was a small bug in `mathML(MatrixExpression)` where we were trying to just display the first row.

### Before
![image](https://github.com/user-attachments/assets/bfc7e4f9-1c84-4c78-9b20-c5b9e7478264)

### After
![image](https://github.com/user-attachments/assets/5e0b3fd6-1a58-4281-9911-89c6703d8a71)

@mgubi, @bztd:  Thoughts?


 