### PR TITLE
Graphs: fix isCyclic Digraph

### DIFF
--- a/M2/Macaulay2/packages/StatGraphs.m2
+++ b/M2/Macaulay2/packages/StatGraphs.m2
@@ -1514,7 +1514,8 @@ TEST ///
 -- Tests for isCyclic(Mixed Graph) 
 --------------------------------------------
 
-TEST /// 
+TEST ///
+-- no-check-flag (see discussion at https://github.com/Macaulay2/M2/pull/3628)
 	   U = graph{{1,2},{2,3},{3,4},{1,4},{1,5}}
 	   D = digraph{{2,1},{3,1},{7,8}}
 	   B = bigraph{{1,5}}


### PR DESCRIPTION
This fixes the detection of cycles in directed graphs (see issue #3626) by not relying on the numbers from DFS but by attempting a topological sort. It succeeds if and only if the graph is acyclic. This reuses existing code as much as possible.

Also added tests that document previous bugs which are now fixed.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
