### PR TITLE
toExternalString for nonreal RR objects

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1525,7 +1525,7 @@ toCC(e:Expr):Expr := (
 		    -- # typical value: toCC, ZZ, RR, QQ, CC
 		    -- # typical value: toCC, ZZ, RR, RR, CC
 		    if !isULong(prec.v) then WrongArgSmallUInteger(1)
-		    else toExpr(CC(
+		    else toExpr(toCC(
 			      when s.1
 			      is x:QQcell do toRR(x.v,toULong(prec.v))
 			      is x:ZZcell do toRR(x.v,toULong(prec.v))

--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -1128,29 +1128,29 @@ export nanRR(prec:ulong):RR := (
                                     
 export nanRRi(prec:ulong):RRi := toRRi(nanRR(prec));
 
+export infinityCC(prec:ulong):CC := (x := infinityRR(prec,1); CC(x,x));
+
+export nanCC(prec:ulong):CC := (x := nanRR(prec); CC(x,x));
+
 export toCC(x:RR,y:RR):CC := (
-     if ( isnan0(x) || isnan0(y) ) then (prec := precision0(x); z := nanRR(prec); CC(z,z))
-     else if ( isinf0(x) || isinf0(y) ) then (prec := precision0(x); z := infinityRR(prec,1); CC(z,z))
+     if ( isnan0(x) || isnan0(y) ) then nanCC(min(precision0(x), precision0(y)))
+     else if ( isinf0(x) || isinf0(y) ) then infinityCC(min(precision0(x), precision0(y)))
      else if precision0(x) == precision0(y) then CC(x,y)
      else if precision0(x) < precision0(y) then CC(x,toRR(y,precision0(x)))
      else CC(toRR(x,precision0(y)),y)
     );
 
-export infinityCC(prec:ulong):CC := (x := infinityRR(prec,1); toCC(x,x));
+export toCC(x:RR):CC := toCC(x,toRR(0,precision0(x)));
 
-export nanCC(prec:ulong):CC := (x := nanRR(prec); toCC(x,x));
+export toCC(x:int,y:RR):CC := toCC(toRR(x,precision0(y)),y);
 
-export toCC(x:RR):CC := CC(x,toRR(0,precision0(x)));
-
-export toCC(x:int,y:RR):CC := CC(toRR(x,precision0(y)),y);
-
-export toCC(x:RR,prec:ulong):CC := CC(toRR(x,prec),toRR(0,prec));
+export toCC(x:RR,prec:ulong):CC := toCC(toRR(x,prec),toRR(0,prec));
 
 export toCC(x:CC,prec:ulong):CC := (
      if precision0(x.re) == prec then x
      else CC(toRR(x.re,prec),toRR(x.im,prec)));
 
-export toCC(x:RR,y:RR,prec:ulong):CC := CC(toRR(x,prec),toRR(y,prec));
+export toCC(x:RR,y:RR,prec:ulong):CC := toCC(toRR(x,prec),toRR(y,prec));
 
 export toCC(x:QQ,prec:ulong):CC := CC(toRR(x,prec),toRR(0,prec));
 

--- a/M2/Macaulay2/d/gmp1.d
+++ b/M2/Macaulay2/d/gmp1.d
@@ -78,7 +78,7 @@ export format(
      ) : array(string) := (	   -- return: ("-","132.456") or ("","123.456")
      ng := signbit(x);
      if isinf(x) then return array(string)(if ng then "-" else "","infinity");
-     if isnan(x) then return array(string)(if ng then "-" else "","NotANumber");
+     if isnan(x) then return array(string)("NotANumber");
      meaningful := int(floor(precision(x) / log2ten)) + 1;
      if s == 0 || s > meaningful then s = meaningful; -- print at most the "meaningful" digits
      sgn := "";
@@ -175,11 +175,13 @@ export tostringRRi(x:RRi):string := concatenate(
        	));  
 tostringRRipointer = tostringRRi;  
 
+numericstr(prec:ulong, str:string, ng:bool):string := (
+    "numeric(" + tostring(prec) + ", " + if ng then "-" else "" + str + ")");
 
 export toExternalString(x:RR):string := (
      ng := signbit(x);
-     if isinf(x) then return if ng then "-infinity" else "infinity";
-     if isnan(x) then return if ng then "-NotANumber" else "NotANumber";
+     if isinf(x) then return numericstr(precision(x), "infinity", ng);
+     if isnan(x) then return numericstr(precision(x), "NotANumber", false);
      if ng then x = -x;
      ex := long(0);
      s := getstr(ex, base, 0, x);

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1283,6 +1283,7 @@ export {
 	"member" => "isMember",
         "minPres" => "minimalPresentation",
         "mutable" => "isMutable",
+	"NotANumber" => "indeterminate",
         "numcols" => "numColumns",
         "numrows" => "numRows",
         "sub" => "substitute",

--- a/M2/Macaulay2/tests/normal/numbers.m2
+++ b/M2/Macaulay2/tests/normal/numbers.m2
@@ -70,12 +70,32 @@ assert ch( -ii*.73249827349273948274398273498273p100e0)
 assert ch( -ii*.92837938475938759387539847539847p100e0)
 assert ch numeric infinity
 assert ch numeric(100, infinity)
+assert ch toCC numeric infinity
+assert ch toCC numeric(100, infinity)
+
+CCinf = toCC numeric infinity
+assert(CCinf === -CCinf)
+scan({5, 5/1, 5.0}, x -> (
+	y := toCC(53, x, numeric infinity);
+	assert ch y;
+	assert(y === CCinf);
+	y = toCC(53, numeric infinity);
+	assert ch y;
+	assert(y === CCinf)))
 
 chnan = x -> (
     y := value toExternalString x;
     precision y === precision x and not isANumber y)
 assert chnan numeric NotANumber
 assert chnan numeric(100, NotANumber)
+
+nan = numeric NotANumber
+CCnan = toCC nan
+chCCnan = chnan @@ realPart and chnan @@ imaginaryPart
+assert chCCnan CCnan
+scan({5, 5/1, 5.0}, x -> (
+	assert chCCnan toCC(53, x, nan);
+	assert chCCnan toCC(53, nan, x)))
 
 assert( 1. === 1. )
 assert( 1. =!= .1 )

--- a/M2/Macaulay2/tests/normal/numbers.m2
+++ b/M2/Macaulay2/tests/normal/numbers.m2
@@ -68,6 +68,14 @@ assert ch( +ii*.73249827349273948274398273498273p100e0)
 assert ch( +ii*.92837938475938759387539847539847p100e0)
 assert ch( -ii*.73249827349273948274398273498273p100e0)
 assert ch( -ii*.92837938475938759387539847539847p100e0)
+assert ch numeric infinity
+assert ch numeric(100, infinity)
+
+chnan = x -> (
+    y := value toExternalString x;
+    precision y === precision x and not isANumber y)
+assert chnan numeric NotANumber
+assert chnan numeric(100, NotANumber)
 
 assert( 1. === 1. )
 assert( 1. =!= .1 )


### PR DESCRIPTION
The following behavior of `toExternalString` isn't quite right:

```m2
i1 : x = numeric infinity

o1 = infinity

o1 : RR (of precision 53)

i2 : toExternalString oo

o2 = infinity

i3 : value oo

o3 = infinity

o3 : InfiniteNumber

i4 : x = numeric indeterminate

o4 = NotANumber

o4 : RR (of precision 53)

i5 : toExternalString oo

o5 = NotANumber

i6 : value oo

o6 = NotANumber

o6 : Symbol
```
Ideally, `value @@ toExternalString` should act like `identity`, and in both cases, we're ending up with instances of a completely different class!

To solve this, we:

* Introduce `NotANumber`, a new instance of `IndeterminateNumber`.
* Introduce the `Number_ZZ` syntactic sugar for `numeric`.
* Modify `toExternalString` to take advantage of these changes. 

So now we have:

```m2
i1 : toExternalString numeric infinity

o1 = infinity_53

i2 : value oo

o2 = infinity

o2 : RR (of precision 53)

i3 : toExternalString numeric indeterminate

o3 = NotANumber_53

i4 : value oo

o4 = NotANumber

o4 : RR (of precision 53)
```

This is a draft for now since there are conflicts with #3630 and I should add tests and docs.