### PR TITLE
Don't try to get typical values from nonexistent files

### DIFF
--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -110,8 +110,9 @@ generateTypicalValues = (srcdir) -> (
     printerr("Generating typical values in ", relativizeFilename typicalValuesSource);
     outfile := openOut typicalValuesSource;
     for file in sort ddfiles do (
+	try src := get(srcdir | file) else continue;
 	comment := "-- typical values extracted from " | file;
-	srcstring := stack apply(pairs lines get(srcdir | file), (num, line) -> line | " -- " | file | ":" | num);
+	srcstring := stack apply(pairs lines src, (num, line) -> line | " -- " | file | ":" | num);
 	-- TODO: separate method key (\\1) and output type (\\2)
 	extracted := select(typicalValuesFormat | " -- (.*)$", "typval(\\1, \\2) -- \\3", toString srcstring);
 	extracted  = apply(extracted, line -> first select("(.*?)--(.*?)$", "\\1" | pad_(91-#line) "\t-- \\2", line));


### PR DESCRIPTION
This fixes a strange bug I ran into.

On my laptop, somehow I ended up with a .d file that was a symlink to a nonexistent file.  When building Macaulay2 for the first time, it tried to generate `tvalues.m2`.  By default, it calls `get` on all the .d and .dd files in the d directory and writes some things to `tvalues.m2`.  But in my case, `get` failed, and so we got an error but ended up with an empty `tvalues.m2`.

Then when loading M2 the next time, it saw that `tvalues.m2` existed (even though it was empty), and proceeded on its merry way.  But none of  the methods that should have been defined from compiled functions were defined!  This ended up leading to a bunch of errors in Macaulay2Doc for documentation keys with no corresponding methods.

A simple fix is to just skip over files where `fileExists` fails.  (I think -- is there any edge case where `fileExists` will return true but `get` fails?)