### PR TITLE
Specify doc nodes from Varieties package

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc.m2
@@ -12,7 +12,6 @@ newPackage ("Macaulay2Doc",
 	  {Name => "Michael E. Stillman", Email => "mike@math.cornell.edu", HomePage => "http://www.math.cornell.edu/People/Faculty/stillman.html"}
 	  },
      Keywords => {"Documentation"},
-     PackageExports => Core#"preloaded packages",
      HomePage => "https://macaulay2.com/",
      Version => version#"VERSION")
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -357,7 +357,7 @@ document {
 		    LI { "Raising a matrix to the 0th power will now raise an error if the ", TO source, " and ", TO target, " do not agree."},
 		    LI { "The value of a class's ", TT "1", " key (used internally for getting multiplicative identities) should now be a function that takes ",
 			 "an instance of the class and returns the multiplicative identity rather than the multiplicative identity itself."},
-		    LI { "The function ", TO urlEncode, " has been moved from the ", TO OnlineLookup, " package to ", TO Core, ", and its behavior has been ",
+		    LI { "The function ", TO urlEncode, " has been moved from the ", TO "OnlineLookup::OnlineLookup", " package to ", TO Core, ", and its behavior has been ",
 			 "slightly modified."}
 	       }
 	  },

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/betti-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/betti-doc.m2
@@ -198,7 +198,7 @@ Node
         betti coker matrix{{x^3, x*y^2}, {y*x^2, y^3}}
         betti coker map(S^{0,-1}, , matrix{{x^2, y}, {y^3, x^2}})
       Text
-        Also see @TO (betti, CoherentSheaf)@.
+        Also see @TO "Varieties::betti(CoherentSheaf)"@.
   Synopsis
     Heading
       Betti diagram showing the degrees of generators of a homogeneous ideal

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/cohomology-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/cohomology-doc.m2
@@ -78,7 +78,9 @@ document {
 	  },
      Caveat => {"There is no check made if the given module 
 	  is graded over the base polynomial ring"},
-     SeeAlso => {"Dmodules::Dmodules",(cohomology,ZZ,SumOfTwists),(cohomology,ZZ,CoherentSheaf)}
+     SeeAlso => {"Dmodules::Dmodules",
+	 "Varieties::HH^ZZ SumOfTwists",
+	 "Varieties::HH^ZZ CoherentSheaf"}
      }
 
 document { 

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/degree-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/degree-doc.m2
@@ -34,7 +34,7 @@ document {
 	  TO (degree,Ideal),
 	  TO (degree,Ring),
 	  TO (degree,Module),
-	  TO (degree,ProjectiveVariety)
+	  TO "Varieties::degree(ProjectiveVariety)"
 	  },
 	  HEADER3 "Degree of homomorphisms",
 	  UL {

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/document-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/document-doc.m2
@@ -435,7 +435,7 @@ Node
       This option inserts the source code of the listed functions into a documentation page.
 
       As an example, here is the code for the @TT "SourceCode"@ part
-      of the documentation node for @TO (variety, SheafOfRings)@.
+      of the documentation node for @TO "Varieties::variety(SheafOfRings)"@.
     Code
       EXAMPLE { PRE ////SourceCode => {(variety, SheafOfRings)}//// }
   SeeAlso


### PR DESCRIPTION
Currently, Macaulay2Doc exports `Core#"preloaded packages"`, but the user can change that in `init.m2` since #3312.  So it's not guaranteed that any particular package is preloaded.

However, there were several links in Macaluay2Doc that pointed to Varieties doc nodes.  So loading Macaulay2Doc was failing when Varieties wasn't preloaded.

We add `"Varieties::"` in front of these links to fix this.  We also drop the `PackageExports` option from Macaulay2Doc since it isn't necessary and was unpredictable.

Note that `(betti, CoherentSheaf)` is linked to from [`betti`](https://www.macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_betti.html) but is undocumented.  I went ahead and updated it like the others so that it should work whenever it is eventually documented.



