### PR TITLE
Remove emacs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,3 @@
 [submodule "M2/submodules/googletest"]
 	path = M2/submodules/googletest
 	url = https://github.com/google/googletest.git
-[submodule "M2/Macaulay2/editors/emacs"]
-	path = M2/Macaulay2/editors/emacs
-	url = https://github.com/Macaulay2/M2-emacs.git

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -4,10 +4,9 @@ ARGS = --script
 .NOTPARALLEL:
 
 MADEFILES = M2-symbols.el M2-emacs-help.txt M2-emacs.m2
-SRCFILES = M2-init.el M2-mode.el M2.el README.md
 
-all: @pre_emacsdir@ $(addprefix @pre_emacsdir@/, $(SRCFILES) $(MADEFILES))
-verify: $(addprefix @pre_emacsdir@/, $(SRCFILES) $(MADEFILES)) $(addprefix emacs/, $(SRCFILES) $(MADEFILES)); ls -lrt $^
+all: @pre_emacsdir@ $(addprefix @pre_emacsdir@/, $(MADEFILES))
+verify: $(addprefix @pre_emacsdir@/, $(MADEFILES)) $(addprefix emacs/, $(MADEFILES)); ls -lrt $^
 Makefile: @srcdir@/Makefile.in; cd ../..; ./config.status Macaulay2/editors/Makefile
 
 @pre_emacsdir@ :; @INSTALL@ -d "$@"

--- a/M2/Macaulay2/editors/emacs/M2-symbols.el.in
+++ b/M2/Macaulay2/editors/emacs/M2-symbols.el.in
@@ -1,0 +1,39 @@
+;; use this function with C-h f to discover which instance and version of this file is loaded
+(defun M2-version () "@M2VERSION@" "The corresponding Macaulay2 version number for the loaded Macaulay2 major mode.")
+
+(defconst M2-symbols
+  '( @M2SYMBOLS@ )
+  "A list of the symbols available in Macaulay2, for use with dynamic completion." )
+
+(let ((max-specpdl-size 1000)) ; needed for passing long long lists to regexp-opt
+  (defconst M2-keyword-regexp  (regexp-opt '( @M2KEYWORDS@  ) 'words)
+      "Regular expression for Macaulay2 keywords")
+  (defconst M2-type-regexp     (regexp-opt '( @M2DATATYPES@ ) 'words)
+      "Regular expression for Macaulay2 types")
+  (defconst M2-function-regexp (regexp-opt '( @M2FUNCTIONS@ ) 'words)
+      "Regular expression for Macaulay2 functions")
+  (defconst M2-constant-regexp (regexp-opt '( @M2CONSTANTS@ ) 'words)
+      "Regular expression for Macaulay2 constants"))
+
+(defconst M2-comint-prompt-regexp "^\\([ \t]*\\(i*[1-9][0-9]* :\\|o*[1-9][0-9]* =\\) \\)?"
+  "Regular expression for the Macaulay2 prompt")
+
+(defconst M2-mode-font-lock-keywords
+  (list
+   (cons M2-keyword-regexp  'font-lock-keyword-face)
+   (cons M2-type-regexp     'font-lock-type-face)
+   (cons M2-function-regexp 'font-lock-function-name-face)
+   (cons M2-constant-regexp 'font-lock-constant-face)))
+
+; TODO:
+; font-lock-warning-face
+; font-lock-variable-name-face
+; font-lock-builtin-face
+; font-lock-preprocessor-face
+; font-lock-doc-face
+; font-lock-negation-char-face
+
+(if (fboundp 'font-lock-add-keywords)
+    (font-lock-add-keywords 'M2-mode M2-mode-font-lock-keywords 'set))
+
+(provide 'M2-symbols)

--- a/M2/Macaulay2/editors/emacs/make-M2-emacs-help.m2
+++ b/M2/Macaulay2/editors/emacs/make-M2-emacs-help.m2
@@ -1,0 +1,21 @@
+
+printWidth = 79;
+frontmatter := "-- Auto-generated for Macaulay2-" | version#"VERSION" | ". Do not modify this file manually. --\n\n";
+
+(
+"M2-emacs.m2"
+<< frontmatter
+<< "                       Editing Macaulay2 code with emacs"                        << endl << endl
+<< help                   "editing Macaulay2 code with emacs"                        << endl << close
+)
+
+(
+"M2-emacs-help.txt"
+<< frontmatter
+<< "                          Running Macaulay2 in Emacs"                            << endl << endl
+<< help                      "running Macaulay2 in emacs"                            << endl << close
+)
+
+-- Local Variables:
+-- compile-command: "make -C $M2BUILDDIR/Macaulay2/emacs M2-emacs.m2"
+-- End:


### PR DESCRIPTION
As discussed at Fields earlier, we remove the M2-emacs submodule.  This will prevent the common occurrence of accidentally updating the submodule hash in a commit.

 The sources for the generated files are restored to `M2/Macaulay2/editors/emacs`.  The generated files can then be copied to the M2-emacs repository at each release.

Another question is distribution.  If the M2-emacs files are no longer included in the main source repository, then what's the best way to get them to users?  Maybe this is more of a package maintainer issue for the various distributions (e.g., I would need to make a few updates to how the Debian/Ubuntu elpa-macaulay2 package is built.)  But I suppose `setupEmacs` could be modified to say, download a tarball of the M2-emacs repo from GitHub and install it. 