### PR TITLE
Update MonomialIntegerPrograms.m2

### DIFF
--- a/M2/Macaulay2/packages/MonomialIntegerPrograms.m2
+++ b/M2/Macaulay2/packages/MonomialIntegerPrograms.m2
@@ -135,7 +135,7 @@ oldCodim = lookup(codim, MonomialIdeal);
 oldDegree = lookup(degree, MonomialIdeal);
 loadSCIPCodimAndDegree = method();
 installMethod(loadSCIPCodimAndDegree,() -> (
-  codim MonomialIdeal := {} >> opts -> m -> ((cacheValue symbol codim) codimensionIP) m;
+  codim MonomialIdeal := options oldCodim >> opts -> m -> ((cacheValue symbol codim) codimensionIP) m;
   degree MonomialIdeal := m -> ((cacheValue symbol degree) degreeIP) m;
 ));
 loadBuiltinCodimAndDegree = method();


### PR DESCRIPTION
Corrected options for (codim,MonomialIdeal)

The package overwrite codim when scip is present on a system.  The new codim had different options from the old codim, this caused the package examples to produce errors on calls to associatedPrimes