### PR TITLE
Stop trying to run clean-tools target in "make clean"

### DIFF
--- a/M2/Makefile.in
+++ b/M2/Makefile.in
@@ -64,7 +64,6 @@ clean:
 	rm -f M2 srcdir .link-test srcdir confdefs.h configure.lineno conftest.* include/config.h
 	rm -rf usr-dist conf_* usr-host
 	rm -f pre-install.sh post-install.sh normal-install.sh
-	if [ -f Makefile ] ; then $(MAKE) -f Makefile clean-tools ; fi
 
 install: configured; $(MAKE) -C distributions $@
 @srcdir@/configure : @srcdir@/configure.ac @srcdir@/m4/files; @srcdir@/autogen.sh


### PR DESCRIPTION
No longer exists after the switch to autogen.sh

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
