### PR TITLE
Add lastError function

### DIFF
--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -472,14 +472,8 @@ lookup(t:Token,forcedef:bool,thread:bool):void := (
      	  is entry:Symbol do (
 	       t.entry = entry;
 	       if entry.position == tempPosition then entry.position = t.position;
-	       if entry.flagLookup then (
-		    printErrorMessage(t,"flagged symbol encountered");
-		    HadError=true;
-		    );
-	       if thread && !entry.thread then (
-		    printErrorMessage(t,"symbol already present, but not thread local");
-		    HadError=true;
-		    );
+	       if entry.flagLookup then makeErrorTree(t,"flagged symbol encountered");
+	       if thread && !entry.thread then makeErrorTree(t,"symbol already present, but not thread local");
 	       )
      	  else (
 	       if forcedef
@@ -495,9 +489,7 @@ lookup(t:Token,forcedef:bool,thread:bool):void := (
 		    t.dictionary = globalDictionary; -- undefined variables are defined as global
 		    t.entry = makeSymbol(t.word,t.position,globalDictionary,thread,locallyCreated);
 		    )
-	       else (
-	       	    printErrorMessage(t,"undefined symbol " + t.word.name);
-	       	    HadError=true;))));
+	       else makeErrorTree(t,"undefined symbol " + t.word.name))));
 lookup(t:Token):void := lookup(t,true,false);
 lookuponly(t:Token):void := lookup(t,false,false);
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -415,10 +415,12 @@ export makeSymbol(t:Token):Symbol := (
 export makeErrorTree(e:ParseTree,message:string):void := (
      HadError = true;
      printErrorMessage(treePosition(e),message);
+     setLastErrorpointer(treePosition(e), message);
      );
 export makeErrorTree(e:Token,message:string):void := (
      HadError = true;
      printErrorMessage(e,message);
+     setLastErrorpointer(e.position, message);
      );
 makeSymbol(e:ParseTree,dictionary:Dictionary):void := (
      when e

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1343,8 +1343,9 @@ steppingFurther(c:Code):bool := steppingFlag && (
 
 handleError(c:Code,e:Expr):Expr := (
      when e is err:Error do (
-	  if SuppressErrors then return e;
-	  if err.message == returnMessage
+	  p := codePosition(c);
+	  if SuppressErrors
+	  || err.message == returnMessage
 	  || err.message == continueMessage || err.message == continueMessageWithArg
 	  || err.message == stepMessage || err.message == stepMessageWithArg
 	  || err.message == breakMessage
@@ -1353,10 +1354,9 @@ handleError(c:Code,e:Expr):Expr := (
 	  then (
 	       -- an error message that is really being used to transfer control must be passed up the line
 	       -- the position is plugged in just in case it's unhandled
-	       if err.position == dummyPosition then err.position = codePosition(c);
+	       if err.position == dummyPosition then err.position = p;
 	       return e;
 	       );
-	  p := codePosition(c);
 	  clearAllFlags();
 	  clearAlarm();
 	  if p.loadDepth >= errorDepth && !err.position === p then (

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1585,7 +1585,14 @@ export evalraw(c:Code):Expr := (
 	       	    tmp)
 	       else AngleBarList(r)
 	       ));
-     when e is Error do handleError(c,e) else e);
+     when e is Error
+     do (
+	 f := handleError(c,e);
+	 when f is err:Error
+	 do setLastErrorpointer(err.position, err.message)
+	 else nothing;
+	 f)
+     else e);
 
 export evalexcept(c:Code):Expr := (
      -- printErrorMessage(codePosition(c),"--evaluating: "+present(tostring(c)));

--- a/M2/Macaulay2/d/lex.d
+++ b/M2/Macaulay2/d/lex.d
@@ -82,8 +82,14 @@ export install(name:string,word:Word):Word := (
      foreach ch in name do node = install(node,int(ch));     
      node.word = word;
      word);
+
+-- setLastError defined in actors5.d
+dummysetLastError(position:Position, message:string):void := nothing;
+export setLastErrorpointer := dummysetLastError;
+
 makeLexError(position:Position, message:string):void := (
     printErrorMessage(position, message);
+    setLastErrorpointer(position, message);
     empty(tokenbuf));
 
 newPosition(file:PosFile, line:ushort, column:ushort):Position := Position(

--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -184,6 +184,7 @@ accumulate(e:ParseTree,file:TokenFile,prec:int,obeylines:bool):ParseTree := (
      );
 makeParseError(token:Token, message:string):ParseTree := (
      printErrorMessage(token, message);
+     setLastErrorpointer(token.position, message);
      errorTree);
 export errorunary(token1:Token,file:TokenFile,prec:int,obeylines:bool):ParseTree := (
      makeParseError(token1,"syntax error at '" + token1.word.name + "'"));

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1340,6 +1340,7 @@ exportMutable {
 	"handleInterrupts",
 	"homeDirectory",
 	"interpreterDepth",
+	"lastError",
 	"lastMatch",
 	"lineNumber",
 	"loadDepth",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_debugging.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_debugging.m2
@@ -327,6 +327,32 @@ document {
 	  }
      }
 
+doc ///
+  Key
+    symbol lastError
+  Headline
+    information about the last error
+  Usage
+    lastError
+  Outputs
+    :Sequence
+      of two elements, the @TO FilePosition@ of the code that generated
+      the last error and a string containing the error message
+  Description
+    Example
+      try 1/0
+      lastError
+    Text
+      The last error is local to each thread.
+    Example
+      taskResult schedule(() -> try error "foo" else lastError)
+      lastError
+    Text
+      Clear the value by assigning null.
+    Example
+      lastError = null
+///
+
 
 document {
      Key => "recursionLimit",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2
@@ -699,6 +699,7 @@ document {
 	  TO "error",
 	  TO "try",
 	  TO "throw",
+	  TO "Macaulay2Doc::lastError" -- TODO: why do we need to specify pkg?
 	  }
      }
 

--- a/M2/Macaulay2/tests/normal/error-messages.m2
+++ b/M2/Macaulay2/tests/normal/error-messages.m2
@@ -1,3 +1,7 @@
+assert(try 1/0 else lastError#1 == "division by zero")
+lastError = null
+assert(lastError === null)
+
 stderr << "--testing the error messages must be done manually" << endl
 end
 


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->

This returns a sequence containing the location and message string for the last error (at least most of the time, e.g., not for syntax errors).

The eventual goal is to use this in the MPI package (see #2129) for handling errors gracefully, e.g., doing something like `try x else lastError()`.