### PR TITLE
Add language server package

### DIFF
--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -295,5 +295,7 @@ MRDI
 EliminationTemplates
 WittVectors
 Padic
+EuclideanDistanceDegree
 NeuralIdeals
 TestAudit
+LanguageServer

--- a/M2/Macaulay2/packages/CMakeLists.txt
+++ b/M2/Macaulay2/packages/CMakeLists.txt
@@ -141,6 +141,7 @@ foreach(package IN LISTS PACKAGES)
     file(COPY ${package}  DESTINATION ${M2_DIST_PREFIX}/${M2_INSTALL_DATADIR})
   endif()
 
+
   ## Configuring the command strings
   _M2_STRING_CONFIGURE(M2_INSTALL_TEMPLATE M2_INSTALL_STRING TRUE)
   _M2_STRING_CONFIGURE(M2_CHECK_TEMPLATE   M2_CHECK_STRING)
@@ -252,3 +253,6 @@ foreach(package IN LISTS PACKAGES)
     DEPENDS M2-core
     )
 endforeach()
+
+file(COPY LanguageServer/M2-language-server
+     DESTINATION ${M2_DIST_PREFIX}/${M2_INSTALL_BINDIR})

--- a/M2/Macaulay2/packages/LanguageServer.m2
+++ b/M2/Macaulay2/packages/LanguageServer.m2
@@ -1,0 +1,216 @@
+newPackage("LanguageServer",
+    Headline => "language server",
+    Version => "0.1",
+    Date => "May 30, 2026",
+    Authors => {{
+            Name => "Doug Torrance",
+            Email => "dtorrance9@gatech.edu",
+            HomePage => "https://d-torrance.github.io"}},
+    AuxiliaryFiles => true,
+    Keywords => {"System"},
+    PackageImports => {"JSONRPC", "Parsing"})
+
+export {
+    -- classes
+    "LSPServer",
+
+    -- methods
+    "start",
+    }
+
+exportFrom(JSONRPC, "setLogger")
+
+importFrom(Core, {
+        "markdown",
+        "nonnull",
+        "toURL",
+        })
+
+------------------------------------
+-- add header to outgoing message --
+------------------------------------
+addHeader = msg -> concatenate(
+    "Content-Length: ", toString length msg, "\r\n",
+    "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n",
+    msg)
+
+----------------------------------------------------------------------
+-- remove (and extract content length) header from incoming message --
+----------------------------------------------------------------------
+
+-- parse using http grammar from
+-- https://www.rfc-editor.org/rfc/rfc7230#section-3.2
+owsP = *orP(" ", "\t")
+fieldVCharP = Parser(c -> if c === null then null else (
+        x := first ascii c;
+        if x < 0x21 or x == 0x7f then null
+        else terminalParser c))
+fieldValueP = *andP(fieldVCharP, optP(+orP(" ", "\t") @ fieldVCharP))
+
+headerP = (-* extract content length *- x -> x#2) % andP(
+    "Content-Length:", owsP, NNParser, owsP, "\r\n",
+    optP(andP("Content-Type:", owsP, fieldValueP, owsP)),"\r\n")
+
+contentP = concatenate % *Parser(c ->
+    if c === null then null else terminalParser c)
+
+parseLSP = (headerP @ contentP) : charAnalyzer
+
+-----------------
+-- LSP methods --
+-----------------
+
+-- mutable hash table containing text of open files
+-- keys: uri, values: list of strings (lines of text in file)
+openDocuments = new MutableHashTable
+
+getWord = (txtdoc, pos) -> (
+    line := openDocuments#(txtdoc#"uri")#(pos#"line");
+    start := stop := pos#"character";
+    while start > 0 and match("\\w", line#(start - 1)) do start -= 1;
+    while stop < #line - 1 and match("\\w", line#(stop + 1)) do stop += 1;
+    substring(line, start, stop - start + 1))
+
+toLocation = method()
+toLocation FilePosition := pos -> hashTable {
+    "uri" => toURL toAbsolutePath pos#0,
+    "range" => hashTable {
+        "start" => hashTable {
+            "line" => pos#1 - 1, -- LSP uses 0-based line numbers
+            "character" => pos#2},
+        "end" => hashTable {
+            "line" => pos#3 - 1,
+            "character" => pos#4}}}
+toLocation VisibleList := L -> apply(L, toLocation)
+
+getLocation = method()
+getLocation Thing := x -> (
+    loc := lookup(locate, class x);
+    if loc =!= null then toLocation loc x)
+
+getLocation MethodFunction            :=
+getLocation MethodFunctionBinary      :=
+getLocation MethodFunctionSingle      :=
+getLocation MethodFunctionWithOptions := f -> (
+    toLocation unique nonnull locate methods f)
+
+LSPmethods = hashTable {
+    "textDocument/didOpen" => (
+        {"textDocument"},
+        txtdoc -> (
+            openDocuments#(txtdoc#"uri") = lines txtdoc#"text";)),
+    "textDocument/didClose" => (
+        {"textDocument"},
+        txtdoc -> (remove(openDocuments, txtdoc#"uri");)),
+    -- TODO: use incremental changes
+    "textDocument/didChange" => (
+        {"textDocument", "contentChanges"},
+        (txtdoc, changes) -> scan(changes, change ->
+            openDocuments#(txtdoc#"uri") = lines change#"text")) ,
+    "textDocument/hover" => (
+        {"textDocument", "position"},
+        (txtdoc, pos) -> (
+            word := getWord(txtdoc, pos);
+            hoverdoc := ??(? value word);
+            if hoverdoc =!= null then hashTable {
+                "contents" => hashTable {
+                    "kind" => "markdown",
+                    "value" => markdown hoverdoc}})),
+    "textDocument/definition" => (
+        {"textDocument", "position"},
+        (txtdoc, pos) -> (
+            word := getWord(txtdoc, pos);
+            ??(getLocation value word))),
+    "textDocument/completion" => (
+        {"textDocument", "position"},
+        (txtdoc, pos) -> (
+            word := getWord(txtdoc, pos);
+            completions := apropos("^" | regexQuote word);
+            if #completions > 0 then apply(completions,
+                completion -> hashTable {"label" => completion}))),
+    }
+
+---------------------
+-- LSPServer class --
+---------------------
+
+LSPServer = new Type of MutableHashTable
+LSPServer.synonym = "LSP server"
+globalAssignment LSPServer
+
+exitCode = 1
+new LSPServer := T -> (
+    jserver := new JSONRPCServer;
+    -- install dummy methods
+    scanKeys(LSPmethods, key ->
+        registerMethod(jserver, key,
+            x -> JSONRPCError(-32002, "Server Not Initialized")));
+    registerMethod(jserver, "initialize", () -> (
+            -- now install actual methods
+            scanPairs(LSPmethods, (key, val) ->
+                registerMethod(jserver, key, val#0, val#1));
+            hashTable {
+                "capabilities" => hashTable {
+                    "textDocumentSync" => 1,
+                    "hoverProvider" => true,
+                    "definitionProvider" => true,
+                    "completionProvider" => hashTable {},
+                    },
+                "serverInfo" => hashTable {
+                    "name" => "Macaulay2 Language Server",
+                    "version" => LanguageServer.Options.Version}}));
+    registerMethod(jserver, "shutdown", () -> (
+            invalidRequest := x -> JSONRPCError(-32600, "Invalid Request");
+            scanKeys(LSPmethods,
+                key -> registerMethod(jserver, key, invalidRequest));
+            registerMethod(jserver, "shutdown", invalidRequest);
+            exitCode = 0;));
+    registerMethod(jserver, "exit", () -> exit exitCode);
+    new T from {
+        "JSON-RPC server" => jserver,
+        "logger" => x -> null})
+
+setLogger(LSPServer, Function) := (server, logger) -> (
+    setLogger(server#"JSON-RPC server", logger);
+    server#"logger" = logger)
+
+start = method()
+start LSPServer := server -> (
+    server#"logger" "starting server";
+    (len, stream) := (0, "");
+    while true do (
+        if #stream == 0 then (
+            wait stdio;
+            stream = read stdio);
+        (len, stream) = try parseLSP stream else (
+            server#"logger" "Content-Length missing; exiting";
+            exit 1);
+        while #stream < len do (
+            wait stdio;
+            stream |= read stdio);
+        request := substring(stream, 0, len);
+        stream = substring(stream, len);
+        server#"logger"("client request:" | request);
+        response := handleRequest(server#"JSON-RPC server", request);
+        if response =!= null then (
+            response = addHeader response;
+            server#"logger"("server response: " | response);
+            stdio << response << flush)))
+
+beginDocumentation()
+
+load "./LanguageServer/doc.m2"
+
+end
+
+-- to get working in Emacs:
+(require 'eglot)
+(add-to-list 'eglot-server-programs '(M2-mode "M2-language-server"))
+
+-- or lsp-mode:
+(require 'lsp-mode)
+(add-to-list 'lsp-language-id-configuration '(M2-mode . "M2"))
+(lsp-register-client (make-lsp-client
+        :new-connection (lsp-stdio-connection "M2-language-server")
+        :activation-fn (lsp-activate-on "M2")
+        :server-id 'M2))

--- a/M2/Macaulay2/packages/LanguageServer/M2-language-server
+++ b/M2/Macaulay2/packages/LanguageServer/M2-language-server
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+M2 --silent --stop                    \
+   -e 'clearEcho stdio'               \
+   -e 'needsPackage "LanguageServer"' \
+   -e 'server = new LSPServer'        \
+   -e 'setLogger(server, printerr)'   \
+   -e 'start server'

--- a/M2/Macaulay2/packages/LanguageServer/doc.m2
+++ b/M2/Macaulay2/packages/LanguageServer/doc.m2
@@ -1,0 +1,85 @@
+doc ///
+  Key
+    LanguageServer
+  Headline
+    language server
+  Description
+    Text
+      This package provides a language server for Macaulay2 implementing the
+      @HREF("https://microsoft.github.io/language-server-protocol/",
+          "Language Server Protocol (LSP)")@.
+      It is used via the @CODE "M2-language-server"@ script, which is
+      distributed with Macaulay2 and starts the server with standard input and
+      output as the communication channel.
+
+      The language server is supported out of the box by the following editors:
+    Code
+      UL {
+          LI {"the Macaulay2 major mode for ",
+              HREF("https://github.com/Macaulay2/M2-emacs", "Emacs"),
+              ", using eglot or lsp-mode"},
+          LI {"the Macaulay2 extension for ",
+              HREF("https://github.com/Macaulay2/vscode-macaulay2", "VS Code")},
+          LI {"the Macaulay2 plugin for ",
+              HREF("https://github.com/Macaulean/macaulay2.nvim", "Neovim")}}
+  Subnodes
+    LSPServer
+///
+
+doc ///
+  Key
+     LSPServer
+    (NewMethod, LSPServer)
+  Headline
+    LSP server class
+  Usage
+    new LSPServer
+  Description
+    Text
+      @CODE "LSPServer"@ is the main class of the package.  It wraps a
+      JSON-RPC server and handles the LSP lifecycle: initialize, text document
+      synchronization, and shutdown.
+    Example
+      server = new LSPServer
+  Subnodes
+    start
+    (setLogger, LSPServer, Function)
+///
+
+doc ///
+  Key
+     start
+    (start, LSPServer)
+  Headline
+    start the language server
+  Usage
+    start server
+  Inputs
+    server:LSPServer
+  Description
+    Text
+      Starts the language server, reading LSP messages from @TO stdio@ and
+      writing responses back to @TO stdio@.  This is called automatically
+      by the @CODE "M2-language-server"@ script and is not typically
+      invoked directly by the user.
+///
+
+doc ///
+  Key
+    (setLogger, LSPServer, Function)
+  Headline
+    set up logging for an LSP server
+  Usage
+    setLogger(server, f)
+  Inputs
+    server:LSPServer
+    f:Function
+  Description
+    Text
+      Sets a custom logging function for @CODE "server"@.  The function
+      @CODE "f"@ should accept a single string.  For example, to log
+      to standard error:
+    Example
+      server = new LSPServer
+      setLogger(server, printerr)
+///

--- a/M2/Macaulay2/packages/LanguageServer/tests/completion.m2
+++ b/M2/Macaulay2/packages/LanguageServer/tests/completion.m2
@@ -1,0 +1,38 @@
+needsPackage "JSONRPC"
+needsPackage "JSON"
+
+server = (new LSPServer)#"JSON-RPC server"
+handleRequest(server, makeRequest("initialize", {}, 1))
+uri = "test.m2"
+handleRequest(server, makeRequest("textDocument/didOpen",
+        hashTable {"textDocument" => hashTable {
+                "uri" => uri, "text" => "ring\n"}}))
+response = fromJSON handleRequest(server, makeRequest("textDocument/completion",
+        hashTable {
+            "textDocument" => hashTable {"uri" => uri},
+            "position" => hashTable {"line" => 0, "character" => 2}}, 1))
+completions = response#"result"
+assert BinaryOperation(symbol >, #response#"result", 0)
+assert all(response#"result", completion -> match("^ring", completion#"label"))
+
+-- after textDocument/didChange
+handleRequest(server, makeRequest("textDocument/didChange",
+        hashTable {
+            "textDocument" => hashTable {"uri" => uri},
+            "contentChanges" => {hashTable {"text" => "ideal\n"}}}))
+response = fromJSON handleRequest(server, makeRequest("textDocument/completion",
+        hashTable {
+            "textDocument" => hashTable {"uri" => uri},
+            "position" => hashTable {"line" => 0, "character" => 2}}, 2))
+completions = response#"result"
+assert BinaryOperation(symbol >, #response#"result", 0)
+assert all(response#"result", completion -> match("^ideal", completion#"label"))
+
+-- after textDocument/didClose
+handleRequest(server, makeRequest("textDocument/didClose",
+        hashTable {"textDocument" => hashTable {"uri" => uri}}))
+response = fromJSON handleRequest(server, makeRequest("textDocument/completion",
+        hashTable {
+            "textDocument" => hashTable {"uri" => uri},
+            "position" => hashTable {"line" => 0, "character" => 2}}, 3))
+assert response#?"error"

--- a/M2/Macaulay2/packages/LanguageServer/tests/definition.m2
+++ b/M2/Macaulay2/packages/LanguageServer/tests/definition.m2
@@ -1,0 +1,16 @@
+needsPackage "JSONRPC"
+needsPackage "JSON"
+
+server = (new LSPServer)#"JSON-RPC server"
+handleRequest(server, makeRequest("initialize", {}, 1))
+uri = "test.m2"
+handleRequest(server, makeRequest("textDocument/didOpen",
+        hashTable {"textDocument" => hashTable {
+                "uri" => uri, "text" => "ring\n"}}))
+response = fromJSON handleRequest(server, makeRequest("textDocument/definition",
+        hashTable {
+            "textDocument" => hashTable {"uri" => uri},
+            "position" => hashTable {"line" => 0, "character" => 0}}, 1))
+locs = response#"result"
+assert BinaryOperation(symbol >, #locs, 0)
+assert all(locs, loc -> loc#?"uri" and loc#?"range")

--- a/M2/Macaulay2/packages/LanguageServer/tests/hover.m2
+++ b/M2/Macaulay2/packages/LanguageServer/tests/hover.m2
@@ -1,0 +1,14 @@
+needsPackage "JSONRPC"
+needsPackage "JSON"
+
+server = (new LSPServer)#"JSON-RPC server"
+handleRequest(server, makeRequest("initialize", {}, 1))
+uri = "test.m2"
+handleRequest(server, makeRequest("textDocument/didOpen",
+        hashTable {"textDocument" => hashTable {
+                "uri" => uri, "text" => "ring\n"}}))
+response = fromJSON handleRequest(server, makeRequest("textDocument/hover",
+        hashTable {
+            "textDocument" => hashTable {"uri" => uri},
+            "position" => hashTable {"line" => 0, "character" => 2}}, 1))
+assert Equation(response#"result"#"contents"#"kind", "markdown")

--- a/M2/Macaulay2/packages/LanguageServer/tests/lifecycle.m2
+++ b/M2/Macaulay2/packages/LanguageServer/tests/lifecycle.m2
@@ -1,0 +1,29 @@
+needsPackage "JSON"
+needsPackage "JSONRPC"
+
+server = (new LSPServer)#"JSON-RPC server"
+
+-- before initialize, LSP methods return "Server Not Initialized" (-32002)
+response = fromJSON handleRequest(server, makeRequest("textDocument/hover",
+        hashTable {
+            "textDocument" => hashTable {"uri" => "test.m2"},
+            "position" => hashTable {"line" => 0, "character" => 0}}, 1))
+assert Equation(response#"error"#"code", -32002)
+
+-- initialize
+response = fromJSON handleRequest(server, makeRequest("initialize", {}, 2))
+capabilities = response#"result"#"capabilities"
+assert capabilities#?"hoverProvider"
+assert capabilities#?"definitionProvider"
+assert capabilities#?"completionProvider"
+assert Equation(capabilities#"textDocumentSync", 1)
+assert Equation(response#"result"#"serverInfo"#"name",
+    "Macaulay2 Language Server")
+
+-- shutdown disables LSP methods (-32600)
+handleRequest(server, makeRequest("shutdown", 3))
+response = fromJSON handleRequest(server, makeRequest("textDocument/hover",
+        hashTable {
+            "textDocument" => hashTable {"uri" => "test.m2"},
+            "position" => hashTable {"line" => 0, "character" => 0}}, 4))
+assert Equation(response#"error"#"code", -32600)

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -113,6 +113,11 @@ $(foreach i, $(patsubst Style,,$(ALL_PACKAGES)), $(eval @pre_libm2dir@/$i/.insta
 $(foreach i, $(patsubst FirstPackage,,$(patsubst Style,,$(ALL_PACKAGES))), $(eval @pre_libm2dir@/$i/.installed: | @pre_libm2dir@/FirstPackage/.installed))
 $(foreach i, $(patsubst Macaulay2Doc,,$(patsubst FirstPackage,,$(patsubst Style,,$(ALL_PACKAGES)))), $(eval @pre_libm2dir@/$i/.installed: | @pre_libm2dir@/Macaulay2Doc/.installed))
 
+all: @pre_bindir@/M2-language-server
+
+@pre_bindir@/M2-language-server: LanguageServer/M2-language-server
+	cp $< $@
+
 # the Info-validate function doesn't work well enough to be useful:
 # check::check-info
 


### PR DESCRIPTION
This is a (very very very) early draft of a `LanguageServer` package that implements Microsoft's [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) (LSP), which is used by multiple editors (Emacs, VSCode, etc.)