### PR TITLE
Properly display degrees in mathML(MatrixExpression)

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -551,7 +551,7 @@ toString'(Function, SparseMonomialVectorExpression) := (fmt,v) -> toString (
 MatrixExpression = new HeaderType of Expression
 MatrixExpression.synonym = "matrix expression"
 matrixOpts1 := new OptionTable from {Blocks=>null,Degrees=>null,MutableMatrix=>false};
-matrixOpts := m -> ( -- helper function
+matrixOpts = m -> ( -- helper function
     (opts,x) := override(matrixOpts1,toSequence m);
     (opts, if #x > 0 and class x#0 =!= List then { x } else toList x) -- because of #1548
     )

--- a/M2/Macaulay2/m2/mathml.m2
+++ b/M2/Macaulay2/m2/mathml.m2
@@ -11,7 +11,7 @@ nest := (tag,s) -> concatenate("<",tag,">",s,"</",tag,">")
 mo   := s -> nest("mo",s)
 mrow := s -> nest("mrow",s)
 mtable := x -> concatenate(
-     "<mtable align=\"baseline1\">", newline,
+     "<mtable columnalign=\"center\">", newline,
      apply(x, row -> ( "<mtr>", apply(row, e -> ("<mtd>",e,"</mtd>",newline)), "</mtr>", newline ) ),
      "</mtable>", newline )
 mtableML := x -> mtable applyTable(x,mathML)

--- a/M2/Macaulay2/m2/mathml.m2
+++ b/M2/Macaulay2/m2/mathml.m2
@@ -59,7 +59,29 @@ mathML FunctionApplication := m -> (
      then concatenate (mfun, bigParenthesize margs)
      else concatenate (bigParenthesize mfun, bigParenthesize margs)
      )
-mathML MatrixExpression := x -> concatenate( "<mrow><mo>(</mo>", mtableML x, "<mo>)</mo></mrow>", newline )
+
+-- zero-width "phantom" element to make sure that degrees line up
+mphantom := x -> concatenate(
+    "<mpadded width=\"0px\"><mphantom>",
+    x,
+    "</mphantom></mpadded>")
+mathML MatrixExpression := x -> (
+    (opts, m) := matrixOpts x;
+    if all(m, r -> all(r, i -> class i === ZeroExpression))
+    then return mathML 0;
+    m = applyTable(m, mathML);
+    concatenate(
+	if opts.Degrees =!= null then (
+	    degs := mathML \ opts.Degrees#0;
+	    mtable apply(#m, i -> {degs#i | mphantom m#i})),
+	"<mo>(</mo>",
+	mtable (
+	    if opts.Degrees =!= null
+	    then apply(#m, i -> prepend(mphantom degs#i, m#i))
+	    else m),
+	"<mo>)</mo>",
+	newline))
+
 mathML Minus := v -> concatenate( "<mrow><mo>-</mo>", mathML v#0, "</mrow>")
 mathML Divide := x -> concatenate("<mfrac>", mathML x#0, mathML x#1, "</mfrac>")
 mathML OneExpression := x -> "<mn>1</mn>"


### PR DESCRIPTION
@mikestillman - this fixes the matrix display bug we were seeing in Jupyter in texmacs mode.

### Before
![image](https://github.com/user-attachments/assets/d83f9d4d-ce8e-4399-9eeb-e07ad64003c4)

### After
![image](https://github.com/user-attachments/assets/7a496584-b13d-4a79-9610-36cb023432a0)

We also replace the *'s with ·'s when displaying products:
![image](https://github.com/user-attachments/assets/29768b1f-ecf7-40de-89d4-ed6787f61f5c)
