### PR TITLE
Move grammar generation to Style package

### DIFF
--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -774,6 +774,7 @@ logorfun(lhs:Code,rhs:Code):Expr := (
      when left
      is Error do left
      else (
+	  -- # typical value: symbol or, Boolean, Boolean, Boolean
 	  if left == True then True
 	  else if left == False then (
 	       right := eval(rhs);
@@ -794,6 +795,7 @@ logandfun(lhs:Code,rhs:Code):Expr := (
      when a
      is Error do a
      else (
+	  -- # typical value: symbol and, Boolean, Boolean, Boolean
 	  if a == False then False
 	  else if a == True then (
 	       b := eval(rhs);
@@ -809,6 +811,7 @@ export notFun(rhs:Code):Expr := (
      a := eval(rhs);
      when a
      is Error do a
+     -- # typical value: symbol not, Boolean, Boolean
      else if a == True then False
      else if a == False then True
      else unarymethod(a,notS));

--- a/M2/Macaulay2/editors/Macaulay2Web/M2-symbols.ts.in
+++ b/M2/Macaulay2/editors/Macaulay2Web/M2-symbols.ts.in
@@ -1,1 +1,3 @@
+// @M2BANNER@
+
 export default [@M2SYMBOLS@];

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -38,7 +38,8 @@ highlightjs/%: @srcdir@/highlightjs/% highlightjs
 	cp $< $@
 
 clean:
-	rm -rf @pre_emacsdir@/* atom emacs highlightjs prism pygments vim
+	rm -rf @pre_emacsdir@/* atom emacs highlightjs prism pygments vim \
+		Macaulay2Web textmate
 
 else
 clean:

--- a/M2/Macaulay2/editors/atom/macaulay2.cson.in
+++ b/M2/Macaulay2/editors/atom/macaulay2.cson.in
@@ -1,3 +1,5 @@
+## @M2BANNER@
+
 # If this is your first time writing a language grammar, check out:
 #   - https://flight-manual.atom.io/hacking-atom/sections/creating-a-grammar/
 #   - https://flight-manual.atom.io/hacking-atom/sections/creating-a-legacy-textmate-grammar/

--- a/M2/Macaulay2/editors/make-M2-symbols.m2
+++ b/M2/Macaulay2/editors/make-M2-symbols.m2
@@ -3,201 +3,35 @@
 -- as keywords, types, etc. and substituting them in grammar files for various
 -- editors and syntax highlighting engines. Grammar file templates are assumed
 -- to be located in the same directory as this script.
--- Currently:
---  - Emacs
---  - Atom & Linguist: https://github.com/Macaulay2/language-macaulay2
---  - Rouge
---  - Pygments
---  - highlight.js
-
 -------------------------------------------------------------------------------
-exportFrom_Core "sortBy"
 
--- TODO: Move these two elsewhere:
-Function and Function := (f, g) -> s -> f s and g s
-Function or  Function := (f, g) -> s -> f s or  g s
-
-is := X -> (name, symb) -> instance(value symb, X)
-
-isAlpha        := s -> match("^[[:alpha:]]+$", s)
-isAlphaNumeric := s -> match("^[[:alnum:]]+$", s)
-
--- Things we want to highlight:
-isType     := is Type
-isKeyword  := is Keyword
-isFunction := is Function
-isConst    := (name, symb) -> (isAlphaNumeric name
-    and not (isFunction or isType or isKeyword) (name, symb)
-    and (symb === symbol null or value symb =!= null))
-
-okay := method()
-okay(String, Keyword) :=
-okay(String, Symbol)  := (name, pkg) -> length name > 1 and isAlphaNumeric name
-
--------------------------------------------------------------------------------
--- Get a list of all symbols visible just after loading preloaded packages
-allPkgNames := separate(" ", version#"packages") | {"Core"}
-loadedPkgNames := Core#"preloaded packages" | {"Core", "Text", "Parsing", "SimpleDoc"}
-symbols := unique (sortBy ascii @@ first) join(
-    apply(allPkgNames, pkgname -> (pkgname, symbol Core)),
-    flatten apply(loadedPkgNames, pkgname -> (
-	    pkg := needsPackage pkgname;
-	    select(pairs pkg.Dictionary, okay))))
-
-if length symbols < 1500 then error "expected more entries for M2-symbols"
-
--- Check for invalid symbols
-bad := select(symbols, (name, symb) -> not okay(name, symb))
-if #bad > 0 then error(
-    "encountered symbol(s) that are not alphanumeric or have less than 2 characters:",
-    concatenate apply(bad, (name, symb) ->
-	{"\n\t", -* TODO: symbolLocation name, ": here is the first use of ", *- toString name}))
-
--------------------------------------------------------------------------------
--- Put the symbols into bins
-SYMBOLS   = first \ select(symbols, (name, symb) -> isAlphaNumeric name)
-KEYWORDS  = first \ select(symbols, isKeyword)
-DATATYPES = first \ select(symbols, isType)
-FUNCTIONS = first \ select(symbols, isFunction)
-CONSTANTS = first \ select(symbols, isConst)
-CONSTANTS = CONSTANTS | {"Node", "Item", "Example", "CannedExample", "Pre", "Code", "Tree", "Synopsis"} -- SimpleDoc words
-CONSTANTS = sort CONSTANTS
-STRINGS   = format "///\\\\(/?/?[^/]\\\\|\\\\(//\\\\)*////[^/]\\\\)*\\\\(//\\\\)*///"
-
--------------------------------------------------------------------------------
--- Substitute symbols, keywords, types, functions, and constants
-
--- This banner is added to the top of generated grammars
-banner := "Auto-generated for Macaulay2-@M2VERSION@. Do not modify this file manually."
-
-symbolsForVim = template -> (
-    output := concatenate("\"\" ", banner, newline, newline, template);
-    output = replace("@M2VERSION@",   version#"VERSION",      output);
-    output = replace("@M2SYMBOLS@",   demark(" ", SYMBOLS),   output);
-    output = replace("@M2KEYWORDS@",  demark(" ", KEYWORDS),  output);
-    output = replace("@M2DATATYPES@", demark(" ", DATATYPES), output);
-    output = replace("@M2FUNCTIONS@", demark(" ", FUNCTIONS), output);
-    output = replace("@M2CONSTANTS@", demark(" ", CONSTANTS), output);
-    output = replace("@M2STRINGS@",               STRINGS,    output);
-    output)
-
-symbolsForEmacs = template -> (
-    output := concatenate(";; ", banner, newline, newline, template);
-    output = replace("@M2VERSION@",   version#"VERSION",               output);
-    output = replace("@M2SYMBOLS@",   demark(" ", format \ SYMBOLS),   output);
-    output = replace("@M2KEYWORDS@",  demark(" ", format \ KEYWORDS),  output);
-    output = replace("@M2DATATYPES@", demark(" ", format \ DATATYPES), output);
-    output = replace("@M2FUNCTIONS@", demark(" ", format \ FUNCTIONS), output);
-    output = replace("@M2CONSTANTS@", demark(" ", format \ CONSTANTS), output);
-    output = replace("@M2STRINGS@",                        STRINGS,    output);
-    output)
-
-symbolsForAtom = template -> (
-    output := concatenate("## ", banner, newline, newline, template);
-    output = replace("@M2VERSION@",   version#"VERSION",      output);
-    --output = replace("@M2SYMBOLS@",   demark("|", SYMBOLS),   output);
-    output = replace("@M2KEYWORDS@",  demark("|", KEYWORDS),  output);
-    output = replace("@M2DATATYPES@", demark("|", DATATYPES), output);
-    output = replace("@M2FUNCTIONS@", demark("|", FUNCTIONS), output);
-    output = replace("@M2CONSTANTS@", demark("|", CONSTANTS), output);
-    output = replace("@M2STRINGS@",               STRINGS,    output);
-    output)
-
-symbolsForPrism = template -> (
-    output := concatenate("// ", banner, newline, newline, template);
-    output = replace("@M2VERSION@",   version#"VERSION",      output);
-    output = replace("@M2SYMBOLS@",   demark(",", format \ SYMBOLS), output);
-    output = replace("@M2KEYWORDS@",  demark("|", KEYWORDS),  output);
-    output = replace("@M2DATATYPES@", demark("|", DATATYPES), output);
-    output = replace("@M2FUNCTIONS@", demark("|", FUNCTIONS), output);
-    output = replace("@M2CONSTANTS@", demark("|", CONSTANTS), output);
-    output = replace("@M2STRINGS@",               STRINGS,    output);
-    output)
-
-symbolsForRouge = template -> (
-    output := concatenate("## ", banner, newline, newline, template);
-    output = replace("@M2VERSION@",   version#"VERSION",      output);
-    --output = replace("@M2SYMBOLS@",   demark("|", SYMBOLS),   output);
-    output = replace("@M2KEYWORDS@",  demark(" ", KEYWORDS),  output);
-    output = replace("@M2DATATYPES@", demark("|", DATATYPES), output);
-    output = replace("@M2FUNCTIONS@", demark("|", FUNCTIONS), output);
-    output = replace("@M2CONSTANTS@", demark("|", CONSTANTS), output);
-    output = replace("@M2STRINGS@",               STRINGS,    output);
-    output)
-
-pygmentsformat = symlist -> demark("," | newline | "    ", format \ symlist)
-symbolsForPygments = template -> (
-    output := replace("@M2BANNER@", "# " | banner, template);
-    output = replace("@M2VERSION@",   version#"VERSION",        output);
-    output = replace("@M2KEYWORDS@",  pygmentsformat KEYWORDS,  output);
-    output = replace("@M2DATATYPES@", pygmentsformat DATATYPES, output);
-    output = replace("@M2FUNCTIONS@", pygmentsformat FUNCTIONS, output);
-    output = replace("@M2CONSTANTS@", pygmentsformat CONSTANTS, output);
-    output = replace("@M2STRINGS@",                  STRINGS,   output);
-    output)
-
-hljsformat = symlist -> demark("," | newline | "	", format \ symlist)
-symbolsForHighlightJS = template -> (
-    output := replace("@M2BANNER@",   banner,               template);
-    output = replace("@M2VERSION@",   version#"VERSION",    output);
-    output = replace("@M2KEYWORDS@",  hljsformat KEYWORDS,  output);
-    output = replace("@M2DATATYPES@", hljsformat DATATYPES, output);
-    output = replace("@M2FUNCTIONS@", hljsformat FUNCTIONS, output);
-    output = replace("@M2CONSTANTS@", hljsformat CONSTANTS, output);
-    output)
-
-symbolsForTextMate = template -> (
-    output = replace("@M2KEYWORDS@",  demark("|", KEYWORDS),  template);
-    output = replace("@M2DATATYPES@", demark("|", DATATYPES), output);
-    output = replace("@M2FUNCTIONS@", demark("|", FUNCTIONS), output);
-    output = replace("@M2CONSTANTS@", demark("|", CONSTANTS), output);
-    output)
-
-symbolsForMacaulay2Web = template -> (
-    output := concatenate("// ", banner, newline, newline, template);
-    output = replace("@M2VERSION@",   version#"VERSION",    output);
-    output = replace("@M2SYMBOLS@",   demark(",", format \ SYMBOLS), output);
-    output)
-
--------------------------------------------------------------------------------
--- Generate syntax files from templates in the same directory
-
-generateGrammar := (grammarFile, grammarFunction) -> (
-    template := currentFileDirectory | grammarFile | ".in";
-    if fileExists template then (
-        stdio << "-- Generating " << grammarFile << endl;
-        directory := replace("/[^/].*$", "", grammarFile);
-        if not isDirectory directory then makeDirectory directory;
-        grammarFile << grammarFunction get(template) << close)
-    else stderr << "Skipping generation of " << grammarFile << " as it does not exist." << endl;)
+needsPackage "Style"
 
 -- Emacs: Write M2-symbols.el
-generateGrammar("emacs/M2-symbols.el", symbolsForEmacs)
+generateGrammar("emacs/M2-symbols.el", x -> demark(" ", format \ x))
 
 -- Atom & Linguist: Write macaulay2.cson
-generateGrammar("atom/macaulay2.cson", symbolsForAtom);
+generateGrammar("atom/macaulay2.cson", x -> demark("|", x))
 
 -- Prism: Write macaulay2.js
-generateGrammar("prism/macaulay2.js", symbolsForPrism);
+generateGrammar("prism/macaulay2.js", x -> demark("|", x))
 
 -- Vim: Write m2.vim.syntax and m2.vim.dict
-generateGrammar("vim/m2.vim.syntax", symbolsForVim);
-generateGrammar("vim/m2.vim.dict", symbolsForVim); -- TODO: is this necessary?
-
--- Rouge: Write macaulay2.rb
---generateGrammar("rouge/macaulay2.rb", symbolsForRouge);
+generateGrammar("vim/m2.vim.syntax", x -> demark(" ", x))
+generateGrammar("vim/m2.vim.dict", x -> demark(" ", x)) -- TODO: is this necessary?
 
 -- Pygments: Write macaulay2.py
-generateGrammar("pygments/macaulay2.py", symbolsForPygments)
+generateGrammar("pygments/macaulay2.py",
+    x -> demark("," | newline | "    ", format \ x))
 
 -- highlight.js: Write macaulay2.js
-generateGrammar("highlightjs/macaulay2.js", symbolsForHighlightJS)
+generateGrammar("highlightjs/macaulay2.js",
+    x -> demark("," | newline | "	", format \ x))
 
-generateGrammar("textmate/macaulay2.tmLanguage.json", symbolsForTextMate)
+generateGrammar("textmate/macaulay2.tmLanguage.json", x -> demark("|", x))
 
 -- Macaulay2Web: Write M2-symbols.ts
-generateGrammar("Macaulay2Web/M2-symbols.ts", symbolsForMacaulay2Web)
-
+generateGrammar("Macaulay2Web/M2-symbols.ts", x -> demark(",", format \ x))
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/emacs M2-symbols "

--- a/M2/Macaulay2/editors/prism/macaulay2.js.in
+++ b/M2/Macaulay2/editors/prism/macaulay2.js.in
@@ -1,3 +1,5 @@
+// @M2BANNER@
+
 Prism.languages.m2 =
 Prism.languages.macaulay2 = {
     'comment': [

--- a/M2/Macaulay2/editors/vim/m2.vim.dict.in
+++ b/M2/Macaulay2/editors/vim/m2.vim.dict.in
@@ -1,3 +1,5 @@
+"" @M2BANNER@
+
 " Vim dictionary file
 " Language: Macaulay2
 

--- a/M2/Macaulay2/editors/vim/m2.vim.syntax.in
+++ b/M2/Macaulay2/editors/vim/m2.vim.syntax.in
@@ -1,3 +1,5 @@
+"" @M2BANNER@
+
 " Vim syntax file
 " Language: Macaulay2
 

--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -92,6 +92,11 @@ ZZ & ZZ := ZZ => lookup(symbol &, ZZ, ZZ)
 ZZ ^^ ZZ := bitxorfun
 Boolean xor Boolean := (x, y) -> x and not y or not x and y
 
+Function and Function := (f, g) -> s -> f s and g s
+Function or  Function := (f, g) -> s -> f s or  g s
+Function xor Function := (f, g) -> s -> f s xor g s
+not Function := f -> s -> not f s
+
 ZZ~ := bitnotfun
 
 changeBase = method()

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
@@ -212,15 +212,42 @@ document {
      }
 
 -- TODO: implement or/and for ZZ
-document {
-     Key => "or",
-     Headline => "disjunction",
-     TT "t or u", " -- returns true if ", TT "t", " is true or ", TT "u", "
-     is true.",
-     PARA{},
-     "If ", TT "t", " is true, then the code in ", TT "u", " is not evaluated.",
-     SeeAlso =>{ "and", "not", "xor" }
-     }
+doc ///
+  Key
+     symbol or
+    (symbol or, Boolean, Boolean)
+    (symbol or, Function, Function)
+  Headline
+    disjunction
+  Usage
+    t or u
+  Inputs
+    t:{Boolean, Function}
+    u:{Boolean, Function}
+  Outputs
+    :{Boolean, Function}
+  Description
+    Text
+      If @CODE "t"@ or @CODE "u"@ are booleans, then @M2CODE "t or u"@
+      returns true if either is true.
+    Example
+      even 7 or isPrime 7
+    Text
+      If @CODE "t"@ is true, then the code in @CODE "u"@ is not evaluated.
+    Example
+      even 6 or 1/0
+    Text
+      If they are both functions that return booleans, then the return value is
+      also a function.
+    Example
+      isEvenOrPrime = even or isPrime
+      isEvenOrPrime 7
+      isEvenOrPrime 9
+  SeeAlso
+    symbol and
+    symbol not
+    symbol xor
+///
 
 document {
     Key => symbol |,
@@ -240,15 +267,38 @@ document {
     SeeAlso => {(symbol &,ZZ,ZZ),(symbol ^^,ZZ,ZZ), (symbol ~, ZZ)}
 }
 
-document {
-     Key => "and",
-     Headline => "conjunction",
-     TT "t and u", " -- returns true if ", TT "t", " is true and ", TT "u", "
-     is true.",
-     PARA{},
-     "If ", TT "t", " is false, then the code in ", TT "u", " is not evaluated.",
-     SeeAlso =>{ "or", "not", "xor" }
-     }
+doc ///
+  Key
+     symbol and
+    (symbol and, Boolean, Boolean)
+    (symbol and, Function, Function)
+  Headline
+    conjunction
+  Usage
+    t and u
+  Inputs
+    t:{Boolean, Function}
+    u:{Boolean, Function}
+  Outputs
+    :{Boolean, Function}
+  Description
+    Text
+      If both @CODE "t"@ and @CODE "u"@ are booleans, then @M2CODE "t and u"@
+      returns true if both are true.
+    Example
+      even 2 and isPrime 2
+    Text
+      If they are both functions that return booleans, then the return value is
+      also a function.
+    Example
+      isEvenPrime = isPrime and even
+      isEvenPrime 2
+      isEvenPrime 3
+  SeeAlso
+    symbol or
+    symbol not
+    symbol xor
+///
 
 document {
      Key => symbol &,
@@ -268,30 +318,67 @@ document {
      SeeAlso => {(symbol |,ZZ,ZZ),(symbol ^^,ZZ,ZZ), (symbol ~, ZZ)}
      }
 
-document {
-     Key => "not",
-     Headline => "negation",
-     TT "not x", " -- yields the negation of x, which must be true or false.",
-     SeeAlso =>{ "and", "or" }
-     }
+doc ///
+  Key
+    symbol not
+  Headline
+    negation
+  Usage
+    not x
+  Inputs
+    x:{Boolean, Function}
+  Outputs
+    :{Boolean, Function}
+  Description
+    Text
+      If @CODE "x"@ is a boolean, then @M2CODE "not x"@ returns true
+      if @CODE "x"@ is false and vice versa.
+    Example
+      not isPrime 4
+    Text
+      If @CODE "x"@ is a function that returns a boolean, then the return value
+      is also a function.
+    Example
+      isNotPrime = not isPrime
+      isNotPrime 4
+      isNotPrime 5
+  SeeAlso
+    symbol and
+    symbol or
+    symbol xor
+///
 
 doc ///
   Key
-    symbol xor
+     symbol xor
     (symbol xor, Boolean, Boolean)
+    (symbol xor, Function, Function)
   Headline
     exclusive disjunction
   Usage
     t xor u
   Inputs
-    t:Boolean
-    u:Boolean
+    t:{Boolean, Function}
+    u:{Boolean, Function}
   Outputs
-    :Boolean
-      equivalent to @TT "t and not u or not t and u"@
+    :{Boolean, Function}
+  Description
+    Text
+      If @CODE "t"@ and @CODE "u"@ are booleans, then @M2CODE "t xor u"@
+      returns true if exactly one of them is true.
+    Example
+      even 7 xor isPrime 7
+    Text
+      If they are both functions than return booleans, then the return value is
+      also a function.
+    Example
+      isEvenXorPrime = even xor isPrime
+      isEvenXorPrime 7
+      isEvenXorPrime 2
   SeeAlso
     symbol and
     symbol or
+    symbol not
 ///
 
 document {

--- a/M2/Macaulay2/packages/SimpleDoc.m2
+++ b/M2/Macaulay2/packages/SimpleDoc.m2
@@ -66,6 +66,8 @@ applySplit = (functionTable, textlines) -> apply(splitByIndent(textlines, false)
 	functionTable#key(textlines_{s+1..e}, getLinenum textlines#s)))
 
 -- Mapping tables for evaluating docstring keywords
+-- When adding a new keyword that isn't already an exported symbol,
+-- add it to the list of constants for syntax highlighting in Style.m2
 NodeFunctions = new HashTable from {
     "Node"            => (textlines, keylinenum) -> new Node from nodeCheck(applySplit(NodeFunctions, textlines), keylinenum),
     "Key"             => (textlines, keylinenum) -> Key             => getKeys(textlines, keylinenum),

--- a/M2/Macaulay2/packages/Style.m2
+++ b/M2/Macaulay2/packages/Style.m2
@@ -60,9 +60,20 @@ generateSymbols = () -> (
     cachedSymbols.Type     = first \ select(symbols, isType);
     cachedSymbols.Function = first \ select(symbols, isFunction);
     cachedSymbols.Constant = sort join(
-	first \ select(symbols, isConst),
-	{"Node", "Item", "Example", "CannedExample", "Pre", "Code", "Tree",
-	    "Synopsis"}); -- SimpleDoc words
+	first \ select(symbols, isConst), {
+	    -- SimpleDoc docstring keywords -- keep updated
+	    -- NodeFunctions
+	    "Node",
+	    "Synopsis",
+	    -- DescriptionFunctions
+	    "CannedExample",
+	    "Code",
+	    "Example",
+	    "Pre",
+	    "Tree",
+	    -- ConsequenceFunctions
+	    "Item"
+	    });
     )
 
 -------------------------------------------------------------------------------

--- a/M2/Macaulay2/packages/Style.m2
+++ b/M2/Macaulay2/packages/Style.m2
@@ -52,15 +52,6 @@ generateSymbols = () -> (
 
     if length symbols < 1500 then error "expected more entries for M2-symbols";
 
-    -- Check for invalid symbols
-    bad := select(symbols, (name, symb) -> not okay(name, symb));
-    if #bad > 0 then error(
-	"encountered symbol(s) that are not alphanumeric or have less than 2 characters:",
-	concatenate apply(bad, (name, symb) -> {
-		"\n\t",
-		-* TODO: symbolLocation name, ": here is the first use of ", *-
-		toString name}));
-
     -------------------------------------------------------------------------------
     -- Put the symbols into bins
     cachedSymbols.Symbol   = first \ select(symbols,

--- a/M2/Macaulay2/packages/Style.m2
+++ b/M2/Macaulay2/packages/Style.m2
@@ -3,16 +3,184 @@ newPackage( "Style",
      AuxiliaryFiles => true,
      Headline => "style sheets and images for the documentation",
      Keywords => {"Documentation"},
-     Version => "1.0"
+     Version => "1.1"
      )
+
+---------------------------------------------
+-- grammar generation code adapted from    --
+-- M2/Macaulay2/editors/make-M2-symbols.m2 --
+---------------------------------------------
+
+export {"generateGrammar"}
+
+importFrom(Core, "sortBy")
+
+-- TODO: Move these two elsewhere:
+Function and Function := (f, g) -> s -> f s and g s
+Function or  Function := (f, g) -> s -> f s or  g s
+
+is := X -> (name, symb) -> instance(value symb, X)
+
+isAlpha        := s -> match("^[[:alpha:]]+$", s)
+isAlphaNumeric := s -> match("^[[:alnum:]]+$", s)
+
+-- Things we want to highlight:
+isType     := is Type
+isKeyword  := is Keyword
+isFunction := is Function
+isConst    := (name, symb) -> (isAlphaNumeric name
+    and not (isFunction or isType or isKeyword) (name, symb)
+    and (symb === symbol null or value symb =!= null))
+
+okay := method()
+okay(String, Keyword) :=
+okay(String, Symbol)  := (name, pkg) -> length name > 1 and isAlphaNumeric name
+
+cachedSymbols = new CacheTable
+STRINGS = format "///\\\\(/?/?[^/]\\\\|\\\\(//\\\\)*////[^/]\\\\)*\\\\(//\\\\)*///"
+
+-- This banner is added to the top of generated grammars
+banner := "Auto-generated for Macaulay2-@M2VERSION@. Do not modify this file manually."
+
+generateSymbols = () -> (
+    ----------------------------------------------------------------------------
+    -- Get a list of all symbols visible just after loading preloaded packages
+    allPkgNames := separate(" ", version#"packages") | {"Core"};
+    loadedPkgNames := join(Core#"preloaded packages",
+	{"Core", "Text", "Parsing", "SimpleDoc"});
+    symbols := unique (sortBy ascii @@ first) join(
+	apply(allPkgNames, pkgname -> (pkgname, symbol Core)),
+	flatten apply(loadedPkgNames, pkgname -> (
+		pkg := needsPackage pkgname;
+		select(pairs pkg.Dictionary, okay))));
+
+    if length symbols < 1500 then error "expected more entries for M2-symbols";
+
+    -- Check for invalid symbols
+    bad := select(symbols, (name, symb) -> not okay(name, symb));
+    if #bad > 0 then error(
+	"encountered symbol(s) that are not alphanumeric or have less than 2 characters:",
+	concatenate apply(bad, (name, symb) -> {
+		"\n\t",
+		-* TODO: symbolLocation name, ": here is the first use of ", *-
+		toString name}));
+
+    -------------------------------------------------------------------------------
+    -- Put the symbols into bins
+    cachedSymbols.Symbol   = first \ select(symbols,
+	(name, symb) ->isAlphaNumeric name);
+    cachedSymbols.Keyword  = first \ select(symbols, isKeyword);
+    cachedSymbols.Type     = first \ select(symbols, isType);
+    cachedSymbols.Function = first \ select(symbols, isFunction);
+    cachedSymbols.Constant = sort join(
+	first \ select(symbols, isConst),
+	{"Node", "Item", "Example", "CannedExample", "Pre", "Code", "Tree",
+	    "Synopsis"}); -- SimpleDoc words
+    )
+
+-------------------------------------------------------------------------------
+-- Generate syntax files from templates in the same directory
+
+generateGrammar = method()
+generateGrammar(String, String, Function) := (template, outfile, demarkf) -> (
+    if not fileExists template
+    then (
+	printerr("warning: ", template,
+	    " does not exist; skipping generation of ", outfile);
+	return);
+    printerr("generating ", outfile);
+    directory := replace("/[^/].*$", "", outfile);
+    if not isDirectory directory then makeDirectory directory;
+    output := get template;
+    if #cachedSymbols == 0 then generateSymbols();
+    output = replace("@M2BANNER@",    banner,                         output);
+    output = replace("@M2VERSION@",   version#"VERSION",              output);
+    output = replace("@M2SYMBOLS@",   demarkf cachedSymbols.Symbol,   output);
+    output = replace("@M2KEYWORDS@",  demarkf cachedSymbols.Keyword,  output);
+    output = replace("@M2DATATYPES@", demarkf cachedSymbols.Type,     output);
+    output = replace("@M2FUNCTIONS@", demarkf cachedSymbols.Function, output);
+    output = replace("@M2CONSTANTS@", demarkf cachedSymbols.Constant, output);
+    output = replace("@M2STRINGS@",   STRINGS,                        output);
+    outfile << output << close;)
+generateGrammar(String, Function) := (outfile, demarkf) -> (
+    generateGrammar(currentFileDirectory | outfile | ".in", outfile, demarkf))
 
 beginDocumentation()
 
-document { Key => "Style",
-     Headline => "style sheets and images for the documentation",
-     "This package is simply a repository for the style sheets and images used by the
-     html pages in the documentation."
-     }
+doc ///
+  Key
+    Style
+  Headline
+    style sheets and images for the documentation
+  Description
+    Text
+      This package is primarily a repository for the style sheets and images
+      used by the html pages in the documentation.
+
+      It exports one method, @TO generateGrammar@, for generating grammar files
+      used for syntax highlighting and/or auto-completion in Macaulay2 code
+      editors and in the html documentation.
+///
+
+doc ///
+  Key
+    generateGrammar
+    (generateGrammar, String, Function)
+    (generateGrammar, String, String, Function)
+  Headline
+    generate a grammar file from a template
+  Usage
+    generateGrammar(template, outfile, demarkf)
+    generateGrammar(outfile, demarkf)
+  Inputs
+    template:String -- the filename of the template file
+    outfile:String -- the filename of the output file
+    demarkf:Function -- how to demark a list of symbols
+  Description
+    Text
+      This method generates a grammar file for use in syntax highlighting
+      Macaulay2 code in a text editor or web browser.
+
+      The file @SAMP "template"@ may contain any of the following special
+      strings:
+
+      @UL {
+	  LI {SAMP "\100M2BANNER\100", ", for placing a banner mentioning that
+	      the resulting file was automatically generated."},
+	  LI {SAMP "\100M2VERSION\100", ", for the current version of ",
+	      "Macaulay2."},
+	  LI {SAMP "\100M2SYMBOLS\100", ", for a list of all Macaulay2 symbols",
+	      ", e.g., for automatic completion."},
+	  LI {SAMP "\100M2KEYWORDS\100", ", for a list of Macaulay2 keywords."},
+	  LI {SAMP "\100M2DATATYPES\100", ", for a list of Macaulay2 types."},
+	  LI {SAMP "\100M2FUNCTIONS\100", ", for a list of Macaulay2 ",
+	      "functions."},
+	  LI {SAMP "\100M2CONSTANTS\100", ", for a list of Macaulay2 symbols ",
+	      "and packages."},
+	  LI {SAMP "\100M2STRINGS\100", ", for a regular expression that ",
+	      "matches Macaulay2 strings."}}@
+
+      The function @SAMP "demarkf"@ indicates how the elements of each of the
+      lists will be demarked in the resulting file.   The file @SAMP "outfile"@
+      will then be generated, replacing each of these strings as indicated
+      above.
+    Example
+      outfile = temporaryFileName()
+      template = outfile | ".in"
+      template << "@M2BANNER@" << endl << endl;
+      template << "This is an example file for the generateGrammar method!";
+      template << endl;
+      template << "String regex: @M2STRINGS@" << endl;
+      template << "List of keywords: {" << endl;
+      template << "    @M2KEYWORDS@" << endl;
+      template << "}" << endl << close;
+      get template
+      generateGrammar(template, outfile, x -> demark(",\n    ", x))
+      get outfile
+    Text
+      If @SAMP "template"@ is omitted, then it defaults to
+      @M2CODE "currentFileDirectory | outfile | \".in\""@.
+///
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages PACKAGES=Style "

--- a/M2/Macaulay2/packages/Style.m2
+++ b/M2/Macaulay2/packages/Style.m2
@@ -15,10 +15,6 @@ export {"generateGrammar"}
 
 importFrom(Core, "sortBy")
 
--- TODO: Move these two elsewhere:
-Function and Function := (f, g) -> s -> f s and g s
-Function or  Function := (f, g) -> s -> f s or  g s
-
 is := X -> (name, symb) -> instance(value symb, X)
 
 isAlpha        := s -> match("^[[:alpha:]]+$", s)

--- a/M2/Macaulay2/tests/normal/boolean.m2
+++ b/M2/Macaulay2/tests/normal/boolean.m2
@@ -48,3 +48,23 @@ assert Equation((-1139)~, 1138)
 -----------------
 assert Equation(value BinaryOperation(symbol xor, true, true), false)
 assert Equation(value BinaryOperation(symbol ^^, 1, 1), 0)
+
+---------------
+-- functions --
+---------------
+T = x -> true
+F = x -> false
+assert Equation((T and T)(), true)
+assert Equation((T and F)(), false)
+assert Equation((F and T)(), false)
+assert Equation((F and F)(), false)
+assert Equation((T or T)(), true)
+assert Equation((T or F)(), true)
+assert Equation((F or T)(), true)
+assert Equation((F or F)(), false)
+assert Equation((T xor T)(), false)
+assert Equation((T xor F)(), true)
+assert Equation((F xor T)(), true)
+assert Equation((F xor F)(), false)
+assert Equation((not T)(), false)
+assert Equation((not F)(), true)


### PR DESCRIPTION
As suggested by @mahrud in https://github.com/Macaulay2/M2/pull/3298#issuecomment-2183065149), we move the `generateGrammar` function from a build script to a method exported by the `Style` packagee.