### PR TITLE
Add "vector" constructor methods taking ring as input

### DIFF
--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -172,6 +172,14 @@ new Module from Sequence := (Module,x) -> (
 vector(Module, Matrix) := (M, f) -> vector map(M,,entries f)
 vector(Module, List)   := (M, v) -> vector map(M,,apply(splice v, i -> {i}))
 vector(Module, RingElement) := vector(Module, Number) := (M, x) -> vector(M, {x})
+vector(Ring,       Matrix)      :=
+vector(RingFamily, Matrix)      := (R, f) -> vector(R^(numRows f), f)
+vector(Ring,       List)        :=
+vector(RingFamily, List)        := (R, v) -> vector(R^(#v), v)
+vector(Ring,       Number)      :=
+vector(Ring,       RingElement) :=
+vector(RingFamily, Number)      :=
+vector(RingFamily, RingElement) := (R, x) -> vector(R^1, {x})
 
 Module#id = M -> map(M, M, 1)
 raw Module := M -> M.RawFreeModule

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_module.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_module.m2
@@ -50,6 +50,14 @@ doc ///
     (vector, Matrix)
     (vector, Number)
     (vector, RingElement)
+    (vector, Ring, List)
+    (vector, Ring, Matrix)
+    (vector, Ring, Number)
+    (vector, Ring, RingElement)
+    (vector, RingFamily, List)
+    (vector, RingFamily, Matrix)
+    (vector, RingFamily, Number)
+    (vector, RingFamily, RingElement)
   Headline
     make a vector
   Usage
@@ -95,6 +103,14 @@ doc ///
       vector {1, 2, 3}
       vector {1, x, y}
       vector(R^3, {1, 2, 3})
+    Text
+      Alternatively, the ring $R$ may be provided instead of $M$, and the
+      resulting vector will be an element of the appropriate free module over
+      $R$.
+    Example
+      vector(QQ, {1, 2, 3})
+      vector(R, {1, 2, 3})
+      vector(R, 2)
 ///
 
 document {

--- a/M2/Macaulay2/tests/normal/vector.m2
+++ b/M2/Macaulay2/tests/normal/vector.m2
@@ -6,6 +6,12 @@ R = QQ[x,y,z]
 assert Equation(vector x, vector matrix {{x}})
 assert Equation(vector {x, y, z}, vector matrix {{x}, {y}, {z}})
 
+v = vector matrix {{1_R}}
+assert Equation(vector(R, matrix {{1}}), v)
+assert Equation(vector(R, {1}), v)
+assert Equation(vector(R, 1), v)
+assert Equation(vector(R, 1_R), v)
+
 M = image transpose vars R
 assert Equation(vector(M, 1), vector map(M,, {{1}}))
 


### PR DESCRIPTION
Currently, we can do the following for matrices and it works as expected:

```m2
i1 : matrix(QQ, {{1, 2}, {3, 4}})

o1 = | 1 2 |
     | 3 4 |

              2       2
o1 : Matrix QQ  <-- QQ
```

But it doesn't work for vectors:

```m2
i2 : vector(QQ, {1, 2, 3})
stdio:2:6:(3): error: no method found for applying vector to:
     argument 1 :  QQ (of class Ring)
     argument 2 :  {1, 2, 3} (of class List)
```

We add this functionality.  In particular, given a `Ring` (or `RingFamily`, so we catch `RR`, `CC`, and `RRi`) and a matrix, list, number, or ring element, we construct an element of the appropriate free module over that ring:

```m2
i1 : vector(QQ, {1, 2, 3})

o1 = | 1 |
     | 2 |
     | 3 |

       3
o1 : QQ
```
