### PR TITLE
Update JSON package to version 0.4

### DIFF
--- a/M2/Macaulay2/c/readfile.c
+++ b/M2/Macaulay2/c/readfile.c
@@ -108,11 +108,15 @@ static bool doubleq(char *p, unsigned int n) {
 
 static char escaped(char c){
      switch(c){
-     	  case 'b': return '\b';
-     	  case 't': return '\t';
-	  case 'n': return '\n';
+	  case '0': return '\0';
+	  case 'a': return '\a';
+	  case 'b': return '\b';
+	  case 'e': return '\e';
 	  case 'f': return '\f';
+	  case 'n': return '\n';
 	  case 'r': return '\r';
+	  case 't': return '\t';
+	  case 'v': return '\v';
 	  default : return c;
 	  }
      }

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -656,21 +656,34 @@ export present(x:string):string := (
      fixesneeded := 0;
      foreach cc in x do (
 	  c := cc; 
-	  if c == char(0) || c == '\t' || c == '\b' || c == '\r' || c == '\"' || c == '\\' 
+	  if (c == '\0' ||
+	      c == '\"' ||
+	      c == '\\' ||
+	      c == '\a' ||
+	      c == '\b' ||
+	      c == '\e' ||
+	      c == '\f' ||
+	      c == '\n' ||
+	      c == '\r' ||
+	      c == '\t' ||
+	      c == '\v' )
 	  then fixesneeded = fixesneeded + 1 
 	  );
      if fixesneeded != 0 then (
 	  new string len length(x)+fixesneeded do foreach cc in x do (
 	       c := cc;
-	       if c == char(0) then (provide '\\'; provide '0';)
-	       else if c == '\r' then (provide '\\'; provide 'r';)
-	       else if c == '\b' then (provide '\\'; provide 'b';)
-	       else if c == '\t' then (provide '\\'; provide 't';)
+	       if      c == '\0' then (provide '\\'; provide '0')
+	       else if c == '\a' then (provide '\\'; provide 'a')
+	       else if c == '\b' then (provide '\\'; provide 'b')
+	       else if c == '\e' then (provide '\\'; provide 'e')
+	       else if c == '\f' then (provide '\\'; provide 'f')
+	       else if c == '\n' then (provide '\\'; provide 'n')
+	       else if c == '\r' then (provide '\\'; provide 'r')
+	       else if c == '\t' then (provide '\\'; provide 't')
+	       else if c == '\v' then (provide '\\'; provide 'v')
 	       else (
 		    if c == '\"' || c == '\\' then provide '\\';
-	       	    provide c;
-		    )
-	       ))
+		    provide c)))
      else x);
 
 export presentn(x:string):string := ( -- fix newlines and other special chars, also

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -365,9 +365,9 @@ outfile = openOut(outdir | "/test-parse.m2")
 outfile << commentize  copyrightBanner << endl
 for tst in sort select(tsts, f -> match("^y_", f)) do (
     outfile << endl << commentize tst << endl;
-    json = get(testdir | "/" | tst);
+    testjson = get(testdir | "/" | tst);
     outfile << "assert BinaryOperation(symbol ===, fromJSON " <<
-    format json << ", " << toExternalString fromJSON json << ")" << endl)
+    format testjson << ", " << toExternalString fromJSON testjson << ")" << endl)
 close outfile
 ///
 

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -85,9 +85,13 @@ unescapedP = Parser(c -> if c === null then null else (
 	if x < 0x20 or x == 0x22 or x == 0x5c or x > 0x10ffff
 	then null
 	else terminalParser c))
-charP = unescapedP | ("\\" @
+deformat = x -> (
+    if last x === "/" then "/"
+    else value concatenate("\"", x, "\""))
+escapedP = deformat % ("\\" @
     orP("\"", "\\", "/", "b", "f", "n", "r", "t",
 	andP("u", hexDigitP, hexDigitP, hexDigitP, hexDigitP)))
+charP = unescapedP | escapedP
 stringP = ((l, x, r) -> concatenate x) % andP("\"", *charP, "\"")
 
 -- objects

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -129,7 +129,9 @@ fromJSON File   := fromJSON @@ get
 -- encoding --
 --------------
 
-toJSON = method(Options => {
+toJSON = method(
+    Dispatch => Thing,
+    Options => {
 	Indent         => null,
 	IndentLevel    => 0,
 	NameSeparator  => ": ",

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -1,8 +1,8 @@
 newPackage(
     "JSON",
     Headline => "JSON encoding and decoding",
-    Version => "0.3",
-    Date => "September 14, 2024",
+    Version => "0.4",
+    Date => "February 24, 2025",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
@@ -17,6 +17,12 @@ newPackage(
 ---------------
 
 -*
+0.4 (2025-02-24, M2 1.25.05)
+* add "json" synonym for "toJSON"
+* remove JSONEncoder class
+* add several new toJSON methods (Thing, MutableHashTable, Hypertext)
+* set toJSON to Dispatch => Thing so it will work for short sequences
+* properly deal w/ escaped characters in fromJSON
 
 0.3 (2024-09-14, M2 1.24.11)
 * remove redundant Constant methods now that we can use inheritance

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -138,6 +138,7 @@ toJSON = method(
 	ValueSeparator => null,
 	Sort           => false})
 
+toJSON Thing   := toJSON MutableHashTable := o -> format @@ toString
 toJSON String  := o -> format
 toJSON RR      := o -> format_0
 toJSON Number  := o -> format_0 @@ numeric
@@ -145,7 +146,7 @@ toJSON ZZ      :=
 toJSON Boolean :=
 toJSON Nothing := o -> toString
 toJSON Symbol  := o -> x -> (
-    if x === nil then "null" else error("unknown symbol"))
+    if x === nil then "null" else format toString x)
 
 maybeNewline = o -> if o.Indent === null then "" else newline
 
@@ -206,11 +207,13 @@ doc ///
     toJSON
     (toJSON,Boolean)
     (toJSON,HashTable)
+    (toJSON,MutableHashTable)
     (toJSON,Nothing)
     (toJSON,Number)
     (toJSON,RR)
     (toJSON,String)
     (toJSON,Symbol)
+    (toJSON,Thing)
     (toJSON,VisibleList)
     (toJSON,ZZ)
     [toJSON,Indent]

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -9,6 +9,7 @@ newPackage(
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
     Keywords => {"System"},
     PackageImports => {"Parsing"},
+    PackageExports => {"Text"},
     AuxiliaryFiles => true)
 
 ---------------
@@ -147,6 +148,7 @@ toJSON Boolean :=
 toJSON Nothing := o -> toString
 toJSON Symbol  := o -> x -> (
     if x === nil then "null" else format toString x)
+toJSON Hypertext := o -> format @@ html
 
 maybeNewline = o -> if o.Indent === null then "" else newline
 
@@ -207,6 +209,7 @@ doc ///
     toJSON
     (toJSON,Boolean)
     (toJSON,HashTable)
+    (toJSON,Hypertext)
     (toJSON,MutableHashTable)
     (toJSON,Nothing)
     (toJSON,Number)

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -35,6 +35,7 @@ export {
     -- methods
     "toJSON",
     "fromJSON",
+    "json" => "toJSON",
 
     -- symbols
     "Indent",
@@ -233,7 +234,8 @@ doc ///
     :String -- containing JSON data
   Description
     Text
-      This method returns a string containing JSON data corresponding to the
+      This method (which is also available using its synonym @CODE "json"@)
+      returns a string containing JSON data corresponding to the
       given Macaulay2 thing.  If the @TT "Indent"@ option is @TT "null"@
       (the default), then there are no newlines or indentation.
     Example

--- a/M2/Macaulay2/packages/JSON/test-encode.m2
+++ b/M2/Macaulay2/packages/JSON/test-encode.m2
@@ -59,3 +59,15 @@ assert Equation(toJSON(hashTable{"a" => 1, "b" => 2, "c" => 3}, Sort => true,
 	ValueSeparator => " , "), "{\"a\": 1 , \"b\": 2 , \"c\": 3}")
 assert Equation(toJSON(hashTable{"a" => 1, "b" => 2, "c" => 3}, Sort => true,
 	NameSeparator => " : "), "{\"a\" : 1, \"b\" : 2, \"c\" : 3}")
+
+-- Dispatch => Thing
+assert Equation(toJSON(1, 2), "[1, 2]")
+
+-- converting other types to strings
+assert Equation(toJSON foo, "\"foo\"")
+assert Equation(toJSON ZZ, "\"ZZ\"")
+assert Equation(toJSON Core, "\"Core\"")
+
+-- hypertext
+assert Equation(toJSON HREF("foo.html", "foo"),
+    ///"<a href=\"foo.html\">foo</a>"///)

--- a/M2/Macaulay2/packages/JSON/test-parse.m2
+++ b/M2/Macaulay2/packages/JSON/test-parse.m2
@@ -25,8 +25,7 @@ assert BinaryOperation(symbol ===, fromJSON "[null, 1, \"1\", {}]", {nil,1,"1",n
 assert BinaryOperation(symbol ===, fromJSON "[null]", {nil})
 
  -- y_array_with_1_and_newline.json
-assert BinaryOperation(symbol ===, fromJSON "[1
-]", {1})
+assert BinaryOperation(symbol ===, fromJSON "[1\n]", {1})
 
  -- y_array_with_leading_space.json
 assert BinaryOperation(symbol ===, fromJSON " [1]", {1})
@@ -50,8 +49,7 @@ assert BinaryOperation(symbol ===, fromJSON "[0e1]", {.0p53})
 assert BinaryOperation(symbol ===, fromJSON "[ 4]", {4})
 
  -- y_number_double_close_to_zero.json
-assert BinaryOperation(symbol ===, fromJSON "[-0.000000000000000000000000000000000000000000000000000000000000000000000000000001]
-", {-.1p53e-77})
+assert BinaryOperation(symbol ===, fromJSON "[-0.000000000000000000000000000000000000000000000000000000000000000000000000000001]\n", {-.1p53e-77})
 
  -- y_number_int_with_exp.json
 assert BinaryOperation(symbol ===, fromJSON "[20e1]", {.2p53e3})
@@ -114,7 +112,7 @@ assert BinaryOperation(symbol ===, fromJSON "{}", new HashTable from {})
 assert BinaryOperation(symbol ===, fromJSON "{\"\":0}", new HashTable from {"" => 0})
 
  -- y_object_escaped_null_in_key.json
-assert BinaryOperation(symbol ===, fromJSON "{\"foo\\u0000bar\": 42}", new HashTable from {"foo\\u0000bar" => 42})
+assert BinaryOperation(symbol ===, fromJSON "{\"foo\\u0000bar\": 42}", new HashTable from {"foo\0bar" => 42})
 
  -- y_object_extreme_numbers.json
 assert BinaryOperation(symbol ===, fromJSON "{ \"min\": -1.0e+28, \"max\": 1.0e+28 }", new HashTable from {"max" => .99999999999999996p53e28, "min" => -.99999999999999996p53e28})
@@ -126,45 +124,43 @@ assert BinaryOperation(symbol ===, fromJSON "{\"x\":[{\"id\": \"xxxxxxxxxxxxxxxx
 assert BinaryOperation(symbol ===, fromJSON "{\"a\":[]}", new HashTable from {"a" => {}})
 
  -- y_object_string_unicode.json
-assert BinaryOperation(symbol ===, fromJSON "{\"title\":\"\\u041f\\u043e\\u043b\\u0442\\u043e\\u0440\\u0430 \\u0417\\u0435\\u043c\\u043b\\u0435\\u043a\\u043e\\u043f\\u0430\" }", new HashTable from {"title" => "\\u041f\\u043e\\u043b\\u0442\\u043e\\u0440\\u0430 \\u0417\\u0435\\u043c\\u043b\\u0435\\u043a\\u043e\\u043f\\u0430"})
+assert BinaryOperation(symbol ===, fromJSON "{\"title\":\"\\u041f\\u043e\\u043b\\u0442\\u043e\\u0440\\u0430 \\u0417\\u0435\\u043c\\u043b\\u0435\\u043a\\u043e\\u043f\\u0430\" }", new HashTable from {"title" => "–ü–æ–ª—Ç–æ—Ä–∞ –ó–µ–º–ª–µ–∫–æ–ø–∞"})
 
  -- y_object_with_newlines.json
-assert BinaryOperation(symbol ===, fromJSON "{
-\"a\": \"b\"
-}", new HashTable from {"a" => "b"})
+assert BinaryOperation(symbol ===, fromJSON "{\n\"a\": \"b\"\n}", new HashTable from {"a" => "b"})
 
  -- y_string_1_2_3_bytes_UTF-8_sequences.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0060\\u012a\\u12AB\"]", {"\\u0060\\u012a\\u12AB"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0060\\u012a\\u12AB\"]", {"`ƒ™·ä´"})
 
  -- y_string_accepted_surrogate_pair.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uD801\\udc37\"]", {"\\uD801\\udc37"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD801\\udc37\"]", {"Ì†ÅÌ∞∑"})
 
  -- y_string_accepted_surrogate_pairs.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\ud83d\\ude39\\ud83d\\udc8d\"]", {"\\ud83d\\ude39\\ud83d\\udc8d"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\ud83d\\ude39\\ud83d\\udc8d\"]", {"Ì†ΩÌ∏πÌ†ΩÌ≤ç"})
 
  -- y_string_allowed_escapes.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"]", {"\\\"\\\\\\/\\b\\f\\n\\r\\t"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"]", {"\"\\/\b\f\n\r\t"})
 
  -- y_string_backslash_and_u_escaped_zero.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\\\u0000\"]", {"\\\\u0000"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\\u0000\"]", {"\\u0000"})
 
  -- y_string_backslash_doublequotes.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\\"\"]", {"\\\""})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\"\"]", {"\""})
 
  -- y_string_comments.json
 assert BinaryOperation(symbol ===, fromJSON "[\"a/*b*/c/*d//e\"]", {"a/*b*/c/*d//e"})
 
  -- y_string_double_escape_a.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\\\a\"]", {"\\\\a"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\\a\"]", {"\\a"})
 
  -- y_string_double_escape_n.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\\\n\"]", {"\\\\n"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\\\n\"]", {"\\n"})
 
  -- y_string_escaped_control_character.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0012\"]", {"\\u0012"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0012\"]", {""})
 
  -- y_string_escaped_noncharacter.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uFFFF\"]", {"\\uFFFF"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uFFFF\"]", {"Ôøø"})
 
  -- y_string_in_array.json
 assert BinaryOperation(symbol ===, fromJSON "[\"asd\"]", {"asd"})
@@ -173,10 +169,10 @@ assert BinaryOperation(symbol ===, fromJSON "[\"asd\"]", {"asd"})
 assert BinaryOperation(symbol ===, fromJSON "[ \"asd\"]", {"asd"})
 
  -- y_string_last_surrogates_1_and_2.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFF\"]", {"\\uDBFF\\uDFFF"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFF\"]", {"ÌØøÌøø"})
 
  -- y_string_nbsp_uescaped.json
-assert BinaryOperation(symbol ===, fromJSON "[\"new\\u00A0line\"]", {"new\\u00A0line"})
+assert BinaryOperation(symbol ===, fromJSON "[\"new\\u00A0line\"]", {"new¬†line"})
 
  -- y_string_nonCharacterInUTF-8_U+10FFFF.json
 assert BinaryOperation(symbol ===, fromJSON "[\"Ùèøø\"]", {"Ùèøø"})
@@ -185,10 +181,10 @@ assert BinaryOperation(symbol ===, fromJSON "[\"Ùèøø\"]", {"Ùèøø"})
 assert BinaryOperation(symbol ===, fromJSON "[\"Ôøø\"]", {"Ôøø"})
 
  -- y_string_null_escape.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0000\"]", {"\\u0000"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0000\"]", {"\0"})
 
  -- y_string_one-byte-utf-8.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u002c\"]", {"\\u002c"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u002c\"]", {","})
 
  -- y_string_pi.json
 assert BinaryOperation(symbol ===, fromJSON "[\"œÄ\"]", {"œÄ"})
@@ -203,13 +199,13 @@ assert BinaryOperation(symbol ===, fromJSON "[\"asd \"]", {"asd "})
 assert BinaryOperation(symbol ===, fromJSON "\" \"", " ")
 
  -- y_string_surrogates_U+1D11E_MUSICAL_SYMBOL_G_CLEF.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uD834\\uDd1e\"]", {"\\uD834\\uDd1e"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD834\\uDd1e\"]", {"Ì†¥Ì¥û"})
 
  -- y_string_three-byte-utf-8.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0821\"]", {"\\u0821"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0821\"]", {"‡†°"})
 
  -- y_string_two-byte-utf-8.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0123\"]", {"\\u0123"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0123\"]", {"ƒ£"})
 
  -- y_string_u+2028_line_sep.json
 assert BinaryOperation(symbol ===, fromJSON "[\"‚Ä®\"]", {"‚Ä®"})
@@ -218,43 +214,43 @@ assert BinaryOperation(symbol ===, fromJSON "[\"‚Ä®\"]", {"‚Ä®"})
 assert BinaryOperation(symbol ===, fromJSON "[\"‚Ä©\"]", {"‚Ä©"})
 
  -- y_string_uEscape.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0061\\u30af\\u30EA\\u30b9\"]", {"\\u0061\\u30af\\u30EA\\u30b9"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0061\\u30af\\u30EA\\u30b9\"]", {"a„ÇØ„É™„Çπ"})
 
  -- y_string_uescaped_newline.json
-assert BinaryOperation(symbol ===, fromJSON "[\"new\\u000Aline\"]", {"new\\u000Aline"})
+assert BinaryOperation(symbol ===, fromJSON "[\"new\\u000Aline\"]", {"new\nline"})
 
  -- y_string_unescaped_char_delete.json
 assert BinaryOperation(symbol ===, fromJSON "[\"\"]", {""})
 
  -- y_string_unicode.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uA66D\"]", {"\\uA66D"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uA66D\"]", {"Íô≠"})
 
  -- y_string_unicode_2.json
 assert BinaryOperation(symbol ===, fromJSON "[\"‚çÇ„à¥‚çÇ\"]", {"‚çÇ„à¥‚çÇ"})
 
  -- y_string_unicode_escaped_double_quote.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0022\"]", {"\\u0022"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0022\"]", {"\""})
 
  -- y_string_unicode_U+1FFFE_nonchar.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uD83F\\uDFFE\"]", {"\\uD83F\\uDFFE"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD83F\\uDFFE\"]", {"Ì†øÌøæ"})
 
  -- y_string_unicode_U+10FFFE_nonchar.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFE\"]", {"\\uDBFF\\uDFFE"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFE\"]", {"ÌØøÌøæ"})
 
  -- y_string_unicode_U+200B_ZERO_WIDTH_SPACE.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u200B\"]", {"\\u200B"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u200B\"]", {"‚Äã"})
 
  -- y_string_unicode_U+2064_invisible_plus.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u2064\"]", {"\\u2064"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u2064\"]", {"‚Å§"})
 
  -- y_string_unicode_U+FDD0_nonchar.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uFDD0\"]", {"\\uFDD0"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uFDD0\"]", {"Ô∑ê"})
 
  -- y_string_unicode_U+FFFE_nonchar.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uFFFE\"]", {"\\uFFFE"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uFFFE\"]", {"Ôøæ"})
 
  -- y_string_unicodeEscapedBackslash.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u005C\"]", {"\\u005C"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u005C\"]", {"\\"})
 
  -- y_string_utf8.json
 assert BinaryOperation(symbol ===, fromJSON "[\"‚Ç¨ùÑû\"]", {"‚Ç¨ùÑû"})
@@ -284,8 +280,7 @@ assert BinaryOperation(symbol ===, fromJSON "true", true)
 assert BinaryOperation(symbol ===, fromJSON "\"\"", "")
 
  -- y_structure_trailing_newline.json
-assert BinaryOperation(symbol ===, fromJSON "[\"a\"]
-", {"a"})
+assert BinaryOperation(symbol ===, fromJSON "[\"a\"]\n", {"a"})
 
  -- y_structure_true_in_array.json
 assert BinaryOperation(symbol ===, fromJSON "[true]", {true})


### PR DESCRIPTION
We ~~export~~ *remove* the `JSONEncoder` class so that developers can write their own `toJSON` methods.  Thanks @mahrud for the suggestion!