### PR TITLE
Fix --srcdir option when running examples/tests

### DIFF
--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -120,7 +120,8 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
      cmd = cmd | readmode(ArgSilent,      "--silent");
      cmd = cmd | readmode(ArgStop,        "--stop");
      cmd = cmd | readmode(ArgPrintWidth,  "--print-width " | ArgPrintWidthN);
-     cmd = cmd | concatenate apply(srcdirs, d -> (" --srcdir ", format d));
+     cmd = cmd | concatenate apply(srcdirs, d -> (" --srcdir ",
+	     format relativizeFilename(rundir, d)));
      -- TODO: fix capture, add preloaded packages to Macaulay2Doc, then delete the following two lines
      needsline := concatenate(" -e 'needsPackage(",format pkgname,",Reload=>true,FileName=>",format pkg#"source file",")'");
      cmd = cmd | if not isMember(pkgname, {"Macaulay2Doc", "Core", "User"}) then needsline else "";


### PR DESCRIPTION
We cd into a temporary directory when doing this, so if any --srcdir options were given using relative paths, then we weren't looking in the right place.

Previously, this was silently ignored, but now that we raise an error when the Macaulay2 subdirectory doesn't exist (see #3644), we were getting errors.

We fix this by relativizing the filename from the run directory to the source directory.

### Before
```m2
$ M2 --srcdir M2
Macaulay2, version 1.24.11-156-ge1109a787b (development)
with packages: ConwayPolynomials, Elimination, IntegralClosure, InverseSystems,
               Isomorphism, LLLBases, MinimalPrimes, OnlineLookup,
               PackageCitations, Polyhedra, PrimaryDecomposition, ReesAlgebra,
               Saturation, TangentCone, Truncations, Varieties


i1 : check(0, "TerraciniLoci")
 -- running   check(0, "TerraciniLoci")         
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-3476369-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --no-randomize --no-readline --silent --stop --print-width 77 --srcdir "M2" -e 'needsPackage("TerraciniLoci",Reload=>true,FileName=>"/home/profzoom/src/macaulay2/M2/M2/Macaulay2/packages/TerraciniLoci.m2")' <"/tmp/M2-3476369-0/0.m2" >>"/tmp/M2-3476369-0/0.tmp" 2>&1
/tmp/M2-3476369-0/0.tmp:0:1:(3):[12]: (output file) error: Macaulay2 exited with status code 1
/usr/share/Macaulay2/Core/startup.m2:544:36:(0):[1]: --srcdir should contain a 'Macaulay2' subdirectory
/usr/share/Macaulay2/Core/startup.m2:594:25:(0): --back trace--
/tmp/M2-3476369-0/0.m2:0:1: (input file)
M2: *** Error 1
 -- .0739986s elapsed
stdio:1:5:(3): error: test(s) #0 of package TerraciniLoci failed.
```

### After
```m2
$ M2 --srcdir M2
Macaulay2, version 1.24.11-156-ge1109a787b (development)
with packages: ConwayPolynomials, Elimination, IntegralClosure, InverseSystems,
               Isomorphism, LLLBases, MinimalPrimes, OnlineLookup,
               PackageCitations, Polyhedra, PrimaryDecomposition, ReesAlgebra,
               Saturation, TangentCone, Truncations, Varieties

i1 : debugLevel = 1; check(0, "TerraciniLoci")
 -- running   check(0, "TerraciniLoci")         
 ulimit -c unlimited; ulimit -t 700; ulimit -m 850000; ulimit -s 8192; ulimit -n 512;  cd /tmp/M2-3477742-0/1-rundir/; GC_MAXIMUM_HEAP_SIZE=400M "/usr/bin/M2-binary" --no-randomize --no-readline --silent --stop --print-width 77 --srcdir "../../../home/profzoom/src/macaulay2/M2/M2" -e 'needsPackage("TerraciniLoci",Reload=>true,FileName=>"/home/profzoom/src/macaulay2/M2/M2/Macaulay2/packages/TerraciniLoci.m2")' <"/tmp/M2-3477742-0/0.m2" >>"/tmp/M2-3477742-0/0.tmp" 2>&1
 -- 1.52943s elapsed

i3 : 
```
