### PR TITLE
Allow 2 or 3 inputs to "new ... from" methods

### DIFF
--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -925,7 +925,30 @@ assignNewFromFun(newclass:Code,newinitializer:Code,rhs:Code):Expr := (
 	  i := eval(newinitializer);
 	  when i is Error do i
 	  is ii:HashTable do installMethod(NewFromE,cc,ii,eval(rhs))
-     	  else printErrorMessageE(newinitializer,"expected a hash table"))
+	  is a:Sequence do (
+	      if length(a) == 2
+	      then (
+		  when a.0
+		  is T1:HashTable do
+		  when a.1
+		  is T2:HashTable do (
+		      installMethod(NewFromE, cc, T1, T2, eval(rhs)))
+		  else WrongArgHashTable(2)
+		  else WrongArgHashTable(1))
+	      else if length(a) == 3
+	      then (
+		  when a.0
+		  is T1:HashTable do
+		  when a.1
+		  is T2:HashTable do
+		  when a.2
+		  is T3:HashTable do (
+		      installMethod(NewFromE, cc, T1, T2, T3, eval(rhs)))
+		  else WrongArgHashTable(3)
+		  else WrongArgHashTable(2)
+		  else WrongArgHashTable(1))
+	      else WrongNumArgs(1, 3))
+     	  else printErrorMessageE(newinitializer,"expected 1 to 3 hash tables"))
      else printErrorMessageE(newclass,"expected a hash table as prospective class"));
 AssignNewFromFun = assignNewFromFun;
 setup(NewFromS,AssignNewFromFun);

--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -347,7 +347,34 @@ newfromfun(newClassCode:Code,newInitCode:Code):Expr := (
 	       then newClass(applyEEE(method,Expr(classs),newInitExpr),classs,true)
 	       else (
 		    when newInitExpr
-		    is s:Sequence do newClass(newInitExpr,classs,false)
+		    is s:Sequence do (
+			if length(s) == 2
+			then (
+			    method = lookupTernaryMethod(
+				classs,
+				Class(s.0),
+				Class(s.1),
+				NewFromE);
+			    if method != nullE
+			    then newClass(
+				applyEEEE(method, Expr(classs), s.0, s.1),
+				classs, true)
+			    else newClass(newInitExpr, classs, false))
+			else if length(s) == 3
+			then (
+			    method = lookupQuaternaryMethod(
+				classs,
+				Class(s.0),
+				Class(s.1),
+				Class(s.2),
+				NewFromE);
+			    if method != nullE
+			    then newClass(
+				applyES(method,
+				    Sequence(Expr(classs), s.0, s.1, s.2)),
+				classs, true)
+			    else newClass(newInitExpr, classs, false))
+			else newClass(newInitExpr,classs,false))
 		    is p:List do (
 			 if p.Class == classs
 			 then Expr(if p.Mutable then copy(p) else p)

--- a/M2/Macaulay2/m2/gb.m2
+++ b/M2/Macaulay2/m2/gb.m2
@@ -147,19 +147,12 @@ GroebnerBasis.synonym = "Gröbner basis"
 GroebnerBasisOptions = new Type of OptionTable
 GroebnerBasisOptions.synonym = "Gröbner basis options"
 
--- m:    a Matrix
--- type: an GroebnerBasisOptions
--- opts: an OptionTable
 -- TODO: document this
-new GroebnerBasis from Sequence := (GB, S) -> (
-    (m, type, opts) := if #S === 3 then S else error "GroebnerBasis: expected three initial values";
-    -- TODO: implement recursive type checking
-    if not instance(m, Matrix) or not instance(type, GroebnerBasisOptions) or not instance(opts, OptionTable)
-    then error "GroebnerBasis: expected a sequence of type (Matrix, GroebnerBasisOptions, OptionTable)";
+new GroebnerBasis from (Matrix, GroebnerBasisOptions, OptionTable) := (GB, m, type, opts) -> (
     if flagInhomogeneity and not isHomogeneous m then error "internal error: gb: inhomogeneous matrix flagged";
     -- initialize the toplevel container
     G := new GroebnerBasis;
-    if debugLevel > 5 then registerFinalizer(G, "gb (new GroebnerBasis from Sequence)");
+    if debugLevel > 5 then registerFinalizer(G, "gb (new GroebnerBasis from (Matrix, GroebnerBasisOptions, OptionTable))");
     G.ring = ring m;
     G.matrix = Bag {m};
     G.target = target m;

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -156,18 +156,15 @@ isHomogeneous Vector := (v) -> isHomogeneous v#0
 Module = new Type of ImmutableType
 Module.synonym = "module"
 new Module from List := (Module,v) -> new Module of Vector from hashTable v
-new Module from Sequence := (Module,x) -> (
-     (R,rM) -> (
-	  assert instance(R,Ring);
-	  assert instance(rM,RawFreeModule);
-	  new Module of Vector from hashTable {
-     	       symbol cache => new CacheTable from { 
-		    cache => new MutableHashTable	    -- this hash table is mutable, hence has a hash number that can serve as its age
-		    },
-     	       symbol RawFreeModule => rM,
-     	       symbol ring => R,
-     	       symbol numgens => rawRank rM
-     	       })) x
+new Module from (Ring, RawFreeModule) := (Module, R, rM) -> (
+    new Module of Vector from hashTable {
+	symbol cache => new CacheTable from {
+	    cache => new MutableHashTable  -- this hash table is mutable, hence has a hash number that can serve as its age
+	    },
+	symbol RawFreeModule => rM,
+	symbol ring => R,
+	symbol numgens => rawRank rM
+	})
 
 vector(Module, Matrix) := (M, f) -> vector map(M,,entries f)
 vector(Module, List)   := (M, v) -> vector map(M,,apply(splice v, i -> {i}))

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/gb-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/gb-doc.m2
@@ -3,7 +3,7 @@
 --- author(s): 
 --- notes: 
 
-undocumented (NewFromMethod, GroebnerBasis, Sequence)
+undocumented (NewFromMethod, GroebnerBasis, Matrix, GroebnerBasisOptions, OptionTable)
 
 document { 
      Key => {gb,

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_methods.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_methods.m2
@@ -396,7 +396,6 @@ undocumented {
      (NewFromMethod, TO, List),
      (NewFromMethod, TO2, List),
      (NewFromMethod, TOH, List),
-     (NewFromMethod, Module, Sequence),
      (NewFromMethod, TO2, Sequence),
      (NewFromMethod, Matrix, MutableMatrix),
      (NewFromMethod, Matrix, Vector),

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_types.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_types.m2
@@ -223,24 +223,33 @@ document {
 	  Usage => "new AA from C := (A,c) -> ...",
 	  Inputs => {
 	       "AA" => HashTable,
-	       "C" =>Type,
+	       "C" => {Type, Sequence} => {},
 	       { TT "(A,c) -> ...", ", a function of 2 arguments: ", TT "AA", " will be an ancestor of ", TT "A", ",
 		    and ", TT "C", " will be an ancestor of the class of ", TT "c", ".
-		    Alternatively, ", TT "A", " will be a type of ", TT "AA", " and ", TT "c", " will be an instance of ", TT "C", "." }
+		    Alternatively, ", TT "A", " will be a type of ", TT "AA", " and ", TT "c", " will be an instance of ", TT "C", ".
+		    If ", CODE "C", " is a sequence, then it must contain 2 or 3 types and the given function must have the form ",
+		    CODE "(A,c,d) -> ...", " or ", CODE "(A,c,d,e) -> ...", ", where ", CODE "c", " is an instance of ", CODE "C#0", ", ",
+		    CODE "d", " is an instance of ", CODE "C#1", ", and (if applicable) ", CODE "e", " is an instance of ",
+		    CODE "C#2", "."
+		    }
 	       },
 	  Consequences => {
 	       { "the function will be installed as the method for ", TT "new AA from C", ".  It will be stored under the key ", TT "(NewFromMethod,AA,C)", "
-		    in the younger of the hash tables ", TT "AA", " and ", TT "C", "." }
+		    in the younger of the hash tables ", TT "AA", " and ", TT "C", ".
+		    If ", CODE "C", " is a sequence, then it will be stored under the key ", CODE "(NewFromMethod,AA,C#0,C#1)",
+		    " or ", CODE "(NewFromMethod,AA,C#0,C#1,C#2)", ", depending on the length of ", CODE "C", " in the youngest of the hash tables."
+		    }
 	       },
 	  Outputs => {
 	       { "the function is returned as the value of the expression" }
 	       },
 	  PARA {
-	       "Let's use the class ", TT "M", " defined above, and introduce a method for creating lists of class ", TT "M", " from integers.  Then we use it
+	       "Let's use the class ", TT "M", " defined above, and introduce methods for creating lists of class ", TT "M", " from integers.  Then we use them
 	       in the subsection below."
 	       },
 	  EXAMPLE lines ///
 	       new M from ZZ := (M',i) -> 0 .. i
+	       new M from (ZZ,ZZ) := (M',i,j) -> splice(i:0 .. j)
 	  ///
 	  ),
      SYNOPSIS (
@@ -252,8 +261,10 @@ document {
 	       },
 	  Consequences => {
 	       { "the function previously installed as the method for ", TT "new A from C", " will be called with arguments ", TT "(A,c)", "." },
-	       { "if no such method has been installed, then ancestors of ", TT "A", " and ", TT "C", ", will be consulted, searching
-		    lexicographically for a method; see ", TO "inheritance", "." },
+	       { "if ", CODE "C", " is a sequence, then this method will be called with arguments ",
+		   CODE "(A,c#0,c#1)", " or ", CODE "A(c#0,c#1,c#2)", ", depending on its length."},
+	       { "if no such method has been installed, then ancestors of ", TT "A", " and ", TT "C", " (or its elements if it is a sequence),
+		   will be consulted, searching lexicographically for a method; see ", TO "inheritance", "." },
 	       { "if no method is found by searching the ancestors, then the function ", TT "(A,c) -> c", " will be used" },
 	       { "the value returned by the function, (or ", TT "c", ", if no method was found), will have
 		    its class set to ", TT "A", " and its parent retained; see ", TO "newClass" }
@@ -267,6 +278,7 @@ document {
 	  EXAMPLE lines ///
 	       n = new M from 13
 	       - n
+	       new M from (3,2)
 	  ///
 	  ),
      SYNOPSIS (

--- a/M2/Macaulay2/tests/normal/new.m2
+++ b/M2/Macaulay2/tests/normal/new.m2
@@ -1,0 +1,17 @@
+X = new SelfInitializingType of HashTable
+
+-- NewFromMethod
+new X from  ZZ        := (T,x)     -> T {a => x, b => 0, c => 0}
+new X from (ZZ,ZZ)    := (T,x,y)   -> T {a => x, b => y, c => 0}
+new X from (ZZ,ZZ,ZZ) := (T,x,y,z) -> T {a => x, b => y, c => z}
+
+x = X {a => 1, b => 2, c => 3}
+assert(x.a == 1 and x.b == 2 and x.c == 3)
+x = X 1
+assert(x.a == 1 and x.b == 0 and x.c == 0)
+x = X(1, 2)
+assert(x.a == 1 and x.b == 2 and x.c == 0)
+x = X(1, 2, 3)
+assert(x.a == 1 and x.b == 2 and x.c == 3)
+
+-- TODO: add tests for NewMethod, NewOfMethod, and NewOfFromMethod


### PR DESCRIPTION
I'm a big fan of self-initializing types since they make the syntax of constructing new objects of a given type similar to other object-oriented languages.

However, it's kind of a pain if you want to make it work with multiple arguments.  Currently, we have to do the following:

```m2
Foo = new SelfInitializingType of HashTable
new Foo from Sequence := (T, s) -> (
   -- check the length of s and the types of its elements to make sure that they're what you want
```

I figured it would be great if we could let the usual multiple dispatch we use when looking up methods do this work for us.  So we add the ability to for `new ... from` to take 2 or 3 arguments.  (We can't go up to 4 since the type counts as one of the arguments already.)

For example:

```m2
i1 : X = new SelfInitializingType of HashTable;

i2 : new X from (ZZ,ZZ)    := (T,x,y)   -> T {a => x, b => y, c => 0};

i3 : new X from (ZZ,ZZ,ZZ) := (T,x,y,z) -> T {a => x, b => y, c => z};

i4 : X(2,3)

o4 = X{a => 2}
       b => 3
       c => 0

o4 : X

i5 : X(3,4,5)

o5 = X{a => 3}
       b => 4
       c => 5

o5 : X
```

As a proof of concept, we update a couple `new .. from` methods in `Core` (for `Module` and `GroebnerBasis`) to use this proposed feature.

