### PR TITLE
Use C++ when checking for eigen (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1125,6 +1125,7 @@ found and $msolve_min_version is required; will build])
          [AC_MSG_RESULT([no, will build])
           BUILD_msolve=yes])])
 
+AC_LANG([C++])
 AS_IF([test $BUILD_eigen = no],
   [AC_MSG_CHECKING([whether pkg-config provides flags for eigen])
    AS_IF([$PKG_CONFIG --exists eigen3],

--- a/M2/libraries/cddlib/Makefile.in
+++ b/M2/libraries/cddlib/Makefile.in
@@ -9,7 +9,7 @@ VERSION = 0.94m
 # https://www.inf.ethz.ch/personal/fukudak/cdd_home/
 URL = https://macaulay2.com/Downloads/OtherSourceCode
 ALLOPTIONS     = SUBDIRS="lib-src" gmpdir=/nowhere
-CONFIGOPTIONS  = $(ALLOPTIONS)
+CONFIGOPTIONS  = $(ALLOPTIONS) MAKE="$(MAKE)"
 
 # we build mpir as gmp statically, so we can't make a shared library here
 CONFIGOPTIONS += --disable-shared

--- a/M2/libraries/givaro/Makefile.in
+++ b/M2/libraries/givaro/Makefile.in
@@ -17,7 +17,7 @@ LICENSEFILES = COPYRIGHT Licence_CeCILL-B_V1-en.txt Licence_CeCILL-B_V1-fr.txt
 # linking givaro as a shared library is bad, because then under Mac OS X its static constructors
 # get run before ours do, and it calls our "operator new", which calls GC_malloc, before we've
 # had a chance to initialize it.
-CONFIGOPTIONS += --disable-shared
+CONFIGOPTIONS += --disable-shared MAKE="$(MAKE)"
 
 include ../Makefile.library
 Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/givaro/Makefile


### PR DESCRIPTION
I was playing around with building Macaulay2 in [OpenIndiana](https://www.openindiana.org/) and was puzzled when it failed detecting eigen.

I checked out `config.log` and noticed that the check failed when one of the eigen headers tried to `#include <cmath>`, and it couldn't find the file.  It turns out that it was trying to compile using `gcc` instead of `g++`!

It's a trivial fix, just adding `AC_LANG([C++])`, so I'm skipping the builds.

Cc: @MichaelABurr 