### PR TITLE
Don't put "-* no-capture-flag *-" on its own line

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/debug-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/debug-doc.m2
@@ -27,8 +27,7 @@ Node
     Text
       This function allows access to the local symbols of a any loaded file.
     Example
-      -* no-capture-flag *-
-      load "Macaulay2Doc/demos/demo1.m2"
+      load "Macaulay2Doc/demos/demo1.m2" -* no-capture-flag *-
       listUserSymbols
       debug "Macaulay2Doc/demos/demo1.m2"
       listUserSymbols

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/findProgram-doc.m2
@@ -137,11 +137,10 @@ doc ///
       file, then @TT "name"@ should coincide with the name of this
       file.
     Example
-      -* no-capture-flag *-
-      programPaths#"gfan" = "/path/to/gfan/"
+      programPaths#"gfan" = "/path/to/gfan/" -* no-capture-flag *-
       gfan = findProgram("gfan", "gfan _version --help", Verbose => true)
     Text
-      If @TT "cmd"@ is not provided, then @TT "cmd"@ is run with the common
+      If @TT "cmd"@ is not provided, then @TT "name"@ is run with the common
       @TT "--version"@ command line option.
     Example
       findProgram "normaliz"

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators/assignment.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators/assignment.m2
@@ -242,8 +242,7 @@ document {
 		    }},
 	  "The first line of the following example illustrates the syntax above.",
 	  EXAMPLE lines ///
-               -* no-capture-flag *-
-	       String * String = peek;
+	       String * String = peek; -* no-capture-flag *-
 	       "left" * "right" = "value"
 	  ///,
 	  PARA "Warning: the installation of new methods may supplant old ones, changing the behavior of Macaulay2."
@@ -517,8 +516,7 @@ document {
 		    }},
 	  "The first line of the following example illustrates the syntax above.",
 	  EXAMPLE lines ///
-              -* no-capture-flag *-
-	       String * String := peek;
+	       String * String := peek; -* no-capture-flag *-
 	       "left" * "right"
 	  ///,
 	  PARA "Warning: the installation of new methods may supplant old ones, changing the behavior of Macaulay2."


### PR DESCRIPTION
Otherwise, the documentation will be garbled.

When not-capturing an example, we remove any instances of the string `"-* no-capture-flag *-"`.  If this string is by itself on a line, then we end up with an empty line in the example input, which messes everything up.

One example is the [findProgram](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_find__Program.html) docs.   This is out of order:

```m2
     +----------------------------------------------------------------------------+
     |  i3 : findProgram "normaliz"                                               |
     |                                                                            |
     |  o3 = normaliz                                                             |
     |                                                                            |
     |  o3 : Program                                                              |
     +----------------------------------------------------------------------------+

     If cmd is not provided, then cmd is run with the common --version command
     line option.
```

After the change:

```m2
     If cmd is not provided, then name is run with the common --version command
     line option.

     +-------------------------------+
     |  i3 : findProgram "normaliz"  |
     |                               |
     |  o3 = normaliz                |
     |                               |
     |  o3 : Program                 |
     +-------------------------------+
```

It might be more elegant to also remove the newline in the special case where `-* no-capture-flag *-` is by itself on a line.  Allowing `-- no-capture-flag` would be cool too.  But that would require some fancier regexes.  But right now, this only affects Macaulay2Doc.  Maybe something to think about if/when we start capturing the other packages' examples.