### PR TITLE
Matroids -- fixing hasMinor

### DIFF
--- a/M2/Macaulay2/packages/Matroids.m2
+++ b/M2/Macaulay2/packages/Matroids.m2
@@ -463,7 +463,7 @@ hasMinor = method(Options => {Strategy => "flats"})
 hasMinor (Matroid, Matroid) := Boolean => opts -> (M, N) -> (
 	(n, m) := (#N.groundSet, #M.groundSet);
 	if n > m or rank N > rank M or #bases N > #bases M then return false;
-	if n == m then return M == N;
+	if n == m then return areIsomorphic(M,N);
 	if opts.Strategy === "flats" and isSimple N then (
 		v := fVector N;
 		truncatedLattice := select(flats(M, rank N, "corank"), f -> rank_M f >= rank M - rank N);

--- a/M2/Macaulay2/packages/Matroids/tests-Matroids.m2
+++ b/M2/Macaulay2/packages/Matroids/tests-Matroids.m2
@@ -93,6 +93,10 @@ M4 = matroid K4
 assert(toString tuttePolynomial M4 === "x^3+y^3+3*x^2+4*x*y+3*y^2+2*x+2*y")
 assert(tutteEvaluate(M4, 2, 1) === 38)
 assert(getRepresentation M4 === K4)
+B={{0,1,2},{0,1,3},{0,1,4},{0,1,5},{0,2,3},{0,2,5},{0,3,4},{0,4,5},{1,2,3},{1,2,4},{1,3,5},{1,4,5},{2,3,4},{2,3,5},{2,4,5},{3,4,5}}
+altM = matroid(toList(0..5),B)
+assert(areIsomorphic(altM, M4))
+assert(hasMinor(altM,M4))
 A = random(ZZ^3,ZZ^5)
 assert(getRepresentation matroid A === A)
 ///


### PR DESCRIPTION
For matroids of the same size, hasMinor now checks whether they are isomorphic instead of literal equality.

This fixes issue #3700 