### PR TITLE
Add support for FLINT 3.2 (master branch)

### DIFF
--- a/M2/Macaulay2/e/NCAlgebras/FreeAlgebra.hpp
+++ b/M2/Macaulay2/e/NCAlgebras/FreeAlgebra.hpp
@@ -9,7 +9,6 @@
 #include "ringelem.hpp"               // for ring_elem
 #include "style.hpp"                  // for GEOHEAP_SIZE
 
-#include <gmp.h>                      // for mpz_srcptr, mpq_srcptr
 #include <iosfwd>                     // for ostream, string
 #include <utility>                    // for pair
 #include <vector>                     // for vector

--- a/M2/Macaulay2/e/NCAlgebras/FreeAlgebraQuotient.hpp
+++ b/M2/Macaulay2/e/NCAlgebras/FreeAlgebraQuotient.hpp
@@ -8,7 +8,6 @@
 #include "newdelete.hpp"              // for our_new_delete
 #include "ringelem.hpp"               // for ring_elem
 
-#include <gmp.h>                      // for mpz_srcptr, mpq_srcptr
 #include <vector>                     // for vector
 
 class Ring;

--- a/M2/Macaulay2/e/aring-gf-flint-big.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint-big.hpp
@@ -8,6 +8,9 @@
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
+// includes gmp.h, which is required for FLINT functions that use GMP
+#include <M2/math-include.h>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <flint/flint.h>       // for flint_free, flint_rand_t, fmpz_t

--- a/M2/Macaulay2/e/aring-gf-flint.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint.hpp
@@ -8,6 +8,9 @@
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
+// includes gmp.h, which is required for FLINT functions that use GMP
+#include <M2/math-include.h>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <flint/flint.h>      // for flint_rand_t, fmpz_t, ulong

--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
@@ -33,7 +33,6 @@
 #include "schreyer-resolution/res-schreyer-frame.hpp"     // for SchreyerFrame
 #include "schreyer-resolution/res-schreyer-order.hpp"     // for ResSchreyer...
 #include "timing.hpp"                                     // for timer, seconds
-#include <gmp.h>                                          // for mpz_clear
 #include <cstdlib>                                        // for exit, size_t
 #include <chrono>                                         // for common_type...
 #include <iostream>                                       // for operator<<

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -89,18 +89,21 @@ findProgram(String, List) := opts -> (name, cmds) -> (
 	instance(opts.MinimumVersion, Sequence) and
 	class \ opts.MinimumVersion === (String, String)) then
 	error "expected MinimumVersion to be a sequence of two strings";
-    pathsToTry := fixPath \ join(
+    pathsToTry := fixPath \ nonnull flatten {
 	-- try user-configured path first
-	if programPaths#?name then {programPaths#name} else {},
+	if programPaths#?name then programPaths#name,
 	-- now try M2-installed path
-	{prefixDirectory | currentLayout#"programs"},
+	prefixDirectory | currentLayout#"programs",
 	-- any additional paths specified by the caller
-	opts.AdditionalPaths,
+	 opts.AdditionalPaths,
 	-- try PATH
-	if getenv "PATH" == "" then {} else apply(separate(":", getenv "PATH"),
+	if getenv "PATH" =!= "" then apply(
+	    separate(":", getenv "PATH"),
 	    dir -> if dir == "" then "." else dir),
 	-- try directory containing M2-binary
-	{bindir});
+	bindir,
+	-- try usr-host/bin
+	if topBuilddir =!= null then topBuilddir | "usr-host/bin"};
     prefixes := {(".*", "")} | opts.Prefix;
     errorCode := didNotFindProgram;
     versionFound := "0.0";

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -40,7 +40,6 @@ if not firstTime then debug Core -- we need access to the private symbols (we re
 toString := value' getGlobalSymbol if firstTime then "simpleToString" else "toString"
 
 local exe
-local topBuilddir
 
 -- this next bit has to be *parsed* after the "debug" above, to prevent the symbols from being added to the User dictionary
 if firstTime then (


### PR DESCRIPTION
This cherry-picks the `gmp.h` commit from #3698 onto the `master` branch, since the macOS builds are now failing since FLINT 3.2 is available in Homebrew.  (See https://github.com/Macaulay2/M2/actions/runs/14016356099).