### PR TITLE
Define various HAVE_* macros to 1 in cmake build

### DIFF
--- a/M2/include/M2/config.h.cmake
+++ b/M2/include/M2/config.h.cmake
@@ -57,14 +57,14 @@
 
 // TODO: only used in Macaulay2/d/interrupts.d. Still needed?
 /* Defined if you have the `alarm' function. */
-#cmakedefine HAVE_ALARM
+#cmakedefine HAVE_ALARM 1
 
 // TODO: used a few places, what is it for?
 /* Define to 1 if you have `alloca', as a function or macro. */
 #cmakedefine HAVE_ALLOCA 1
 
 /* Defined if you have <alloca.h> and it should be used (not on Ultrix). */
-#cmakedefine HAVE_ALLOCA_H
+#cmakedefine HAVE_ALLOCA_H 1
 
 // TODO: only used in Macaulay2/d/types.h. Still needed?
 /* Define to 1 if you have the <arpa/inet.h> header file. */
@@ -76,10 +76,10 @@
 
 // TODO: only used in Macaulay2/d/M2lib.c. Still needed?
 /* Defined if you have the `clock_gettime' function. */
-#cmakedefine HAVE_CLOCK_GETTIME
+#cmakedefine HAVE_CLOCK_GETTIME 1
 
 /* Defined if you have the <dlfcn.h> header file. */
-#cmakedefine HAVE_DLFCN_H
+#cmakedefine HAVE_DLFCN_H 1
 
 // TODO: remove?
 /* Define to 1 if you have the <elf.h> header file. */
@@ -210,7 +210,7 @@
 #cmakedefine HAVE_STDLIB_H 1
 
 /* Defined if you have the <strings.h> header file. */
-#cmakedefine HAVE_STRINGS_H
+#cmakedefine HAVE_STRINGS_H 1
 
 /* Define to 1 if you have the <string.h> header file. */
 #cmakedefine HAVE_STRING_H 1
@@ -228,10 +228,10 @@
 #cmakedefine HAVE_SYS_IOCTL_H 1
 
 /* Defined if you have the <sys/mman.h> header file. */
-#cmakedefine HAVE_SYS_MMAN_H
+#cmakedefine HAVE_SYS_MMAN_H 1
 
 /* Defined if you have the <sys/resource.h> header file. */
-#cmakedefine HAVE_SYS_RESOURCE_H
+#cmakedefine HAVE_SYS_RESOURCE_H 1
 
 /* Define to 1 if you have the <sys/socket.h> header file. */
 #cmakedefine HAVE_SYS_SOCKET_H 1
@@ -240,7 +240,7 @@
 #cmakedefine HAVE_SYS_STAT_H 1
 
 /* Defined if you have the <sys/time.h> header file. */
-#cmakedefine HAVE_SYS_TIME_H
+#cmakedefine HAVE_SYS_TIME_H 1
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #cmakedefine HAVE_SYS_TYPES_H 1
@@ -255,10 +255,10 @@
 #cmakedefine HAVE_TIME_H 1
 
 /* Defined if you have the <unistd.h> header file. */
-#cmakedefine HAVE_UNISTD_H
+#cmakedefine HAVE_UNISTD_H 1
 
 /* Defined if you have the <regex.h> header file. */
-#cmakedefine HAVE_REGEX_H
+#cmakedefine HAVE_REGEX_H 1
 
 /* Define to 1 if you have the `wait4' function. */
 #cmakedefine HAVE_WAIT4 1


### PR DESCRIPTION
This should fix macro redefinition warnings for macros that also defined in the Python headers.

Closes: #3679 
