### PR TITLE
Smith normal form

### DIFF
--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -25,23 +25,21 @@ smithNormalForm = method(
 	  }
      )
 smithNormalForm Matrix := o -> A -> (
-    (D,P,Q) := preSmithNormalForm(A, ChangeMatrix=>{true,true}, KeepZeroes=>true);
-    D = mutableMatrix D;
-    P = mutableMatrix P;
-    Q = mutableMatrix Q;
+    (D',P,Q) := preSmithNormalForm(A,o);
+    D := mutableMatrix D';
     -- get into a diagonal matrix
     n := min(numRows D, numColumns D);
     start'i := 0;
     done := false;
+    P' := mutableMatrix map((ring D')^(numRows D'));
+    Q' := mutableMatrix map((ring D')^(numColumns D'));
     while not done do (
-	i := position(start'i..(n-2),j->D_(j+1,j+1)!=0 and D_(j+1,j+1) % D_(j,j) != 0);	
-	print(start'i,i);
-	if i === null then (
+	pos'i := position(start'i..(n-2),j->D_(j+1,j+1)!=0 and D_(j+1,j+1) % D_(j,j) != 0);	
+	if pos'i === null then (
 	    if start'i > 0 then start'i = 0 else done = true
 	    ) else (
+	    i := pos'i + start'i;
 	    start'i = i + 1;
-	    P' := mutableMatrix map((ring P)^(numRows P));
-	    Q' := mutableMatrix map((ring Q)^(numRows Q));
 	    a := D_(i,i);
 	    b := D_(i+1,i+1);
 	    (g,e,f) := toSequence gcdCoefficients(a,b);
@@ -52,11 +50,13 @@ smithNormalForm Matrix := o -> A -> (
 	    rowAdd(P',i+1,-1,i);
 	    rowAdd(Q',i,f,i+1);
 	    rowAdd(Q',i+1,(a//g-1)*b//g,i);
-	    P = P'* P;
-	    Q = Q * transpose Q';
     )
 	);-- end while 
-    (matrix D, matrix P, matrix Q)
+    P'' := matrix P';
+    Q'' := matrix Q';
+    if P =!= null then P = P'' * P;
+    if Q =!= null then Q = Q * transpose Q'';
+    unsequence nonnull (P'' * D' * transpose Q'', P, Q)
 )
 
 preSmithNormalForm = method(

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -42,7 +42,7 @@ smithNormalForm Matrix := o -> A -> (
 	    start'i = i + 1;
 	    a := D_(i,i);
 	    b := D_(i+1,i+1);
-	    (g,e,f) := toSequence gcdCoefficients(a,b);
+	    (g,e,f) := gcdCoefficients(a,b);
 	    D_(i,i) = g;
 	    D_(i+1,i+1) = lcm(a,b);
 	    rowAdd(P',i+1,e,i);

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -66,7 +66,7 @@ preSmithNormalForm = method(
 	  }
      )
 preSmithNormalForm Matrix := o -> (f) -> (
-     pruneSyz := m -> generators gb(syz m, StopWithMinimalGenerators=>true, Syzygies=>false, ChangeMatrix=>false);
+     pruneSyz := m -> generators gb(syz m, Syzygies=>false, ChangeMatrix=>false);
      if not isFreeModule source f or not isFreeModule target f then error "expected map between free modules";
      (tchg,schg,keepz) := (o.ChangeMatrix#0, o.ChangeMatrix#1,o.KeepZeroes);
      (tmat,smat) := (null,null);	-- null represents the identity, lazily
@@ -119,7 +119,7 @@ preSmithNormalForm Matrix := o -> (f) -> (
 	  g = transpose h;
 	  op = not op;
 	  count = count + 1;
-	  );
+	  ); -- end while
      if op then g = transpose g;
      if tchg then (
 	  if tmat === null
@@ -141,10 +141,17 @@ preSmithNormalForm Matrix := o -> (f) -> (
 	       else schange = smat));
      g = lift(g,R);
      -- D == P f Q ;
-     D := map(R^(numgens target g),,g);			    -- this makes D homogeneous, if possible
-     P := if tchg then map(target D,target f,lift(tchange,R));
-     Q := if schg then map(source f, source D,lift(schange,R));
-     ( D, P, Q ))
+     D := if not keepz then map(R^(numgens target g),,g) else (
+	 m := numgens target f;
+	 n := numgens source f;
+	 m' := numgens target g;
+	 n' := numgens source g;
+	 (map(R^m',R^n',g) | map(R^m',R^(n-n'),0)) || map(R^(m-m'),R^n,0) 
+	 );			    -- this makes D homogeneous, if possible
+     P := if tchg then map(target D, target f, lift(tchange,R));
+     Q := if schg then map(source f, source D, lift(schange,R));
+     ( D, P, Q )
+     )
 
  
 complementOkay = method()     -- modeled after isAffineRing, but allows ZZ, too

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -25,6 +25,28 @@ smithNormalForm = method(
 	  }
      )
 smithNormalForm Matrix := o -> (f) -> (
+    preSmithNormalForm(f, o)
+    -*
+    -- get into a diagonal matrix
+    diagEntries = sort for i from 0 to numrows D -1 list D_(i,i) -- extract diagonal entries
+    diagMods = for i from 0 to #diagEntries-2 list diagEntries_i % diagEntries_(i+1) -- checks divisibility criterion
+    while any(diagMods, i-> i!= 0) do (
+	
+	)
+    --sort diagonal entries
+    --find 2 consecutive indices on diagonal missing divisibility criterion
+    --do transformation on correct side, run preSNF again
+    )
+*-
+)
+
+preSmithNormalForm = method(
+     Options => {
+	  ChangeMatrix => {true, true},		    -- target, source
+     	  KeepZeroes => true
+	  }
+     )
+preSmithNormalForm Matrix := o -> (f) -> (
      if not isFreeModule source f or not isFreeModule target f then error "expected map between free modules";
      (tchg,schg,keepz) := (o.ChangeMatrix#0, o.ChangeMatrix#1,o.KeepZeroes);
      (tmat,smat) := (null,null);	-- null represents the identity, lazily
@@ -53,7 +75,7 @@ smithNormalForm Matrix := o -> (f) -> (
 	  if op then (
 	       if tchg then (
 	       	    chg := getChangeMatrix G;
-	       	    zer := syz G;
+	       	    zer := mingens image syz G;
 		    if keepz then (
 			 if tmat === null
 			 then (tmat,tzer) = (chg,zer)
@@ -65,7 +87,7 @@ smithNormalForm Matrix := o -> (f) -> (
 	  else (
 	       if schg then (
 	       	    chg = getChangeMatrix G;
-	       	    zer = syz G;
+	       	    zer = mingens image syz G;
 		    if keepz then (
 			 if smat === null
 			 then (smat, szer) = (chg, zer)
@@ -77,6 +99,9 @@ smithNormalForm Matrix := o -> (f) -> (
 	  g = transpose h;
 	  op = not op;
 	  count = count + 1;
+	  print g;
+	  print (tmat,tzer);
+	  print (smat,szer);
 	  );
      if op then g = transpose g;
      if tchg then (
@@ -102,8 +127,9 @@ smithNormalForm Matrix := o -> (f) -> (
      D := map(R^(numgens target g),,g);			    -- this makes D homogeneous, if possible
      P := if tchg then map(target D,target f,lift(tchange,R));
      Q := if schg then map(source f, source D,lift(schange,R));
-     unsequence nonnull ( D, P, Q ))
+     ( D, P, Q ))
 
+ 
 complementOkay = method()     -- modeled after isAffineRing, but allows ZZ, too
 complementOkay Ring := R -> isField R or R === ZZ
 complementOkay PolynomialRing := R -> (
@@ -369,7 +395,10 @@ addHook((quotient, Matrix, Matrix), Strategy => "Reflexive", (opts, f, g) -> if 
      -- now M is a quotient module, without explicit generators
      f' := matrix f;
      g' := matrix g;
-     G := ( g.cache#"gb for quotient" ??= (
+     G := (
+	  if g.cache#?"gb for quotient"
+	  then g.cache#"gb for quotient"
+	  else g.cache#"gb for quotient" = (
 	       if M.?relations 
 	       then gb(g' | relations M, ChangeMatrix => true, SyzygyRows => rank source g')
 	       else gb(g',               ChangeMatrix => true)));

--- a/M2/Macaulay2/packages/K3Carpets.m2
+++ b/M2/Macaulay2/packages/K3Carpets.m2
@@ -160,7 +160,7 @@ mat
 ///
 
 
-
+importFrom(Core, "preSmithNormalForm") 
 analyzeStrand = method()
 analyzeStrand(Complex,ZZ) := (F,a) -> (
     mainStrand := constantStrand(F,a+1);
@@ -170,7 +170,8 @@ analyzeStrand(Complex,ZZ) := (F,a) -> (
     M2 := mainStrand.dd_a;
     M2Z := lift(M2,ZZ);
     assert(M1Z*M2Z == 0);
-    M1s := smithNormalForm(M1Z,ChangeMatrix=>{false,false});
+    M1s := first preSmithNormalForm(M1Z,ChangeMatrix=>{false,false},KeepZeroes=>false);
+    -- M1s := smithNormalForm(M1Z,ChangeMatrix=>{false,false},KeepZeroes=>false); -- takes much longer time in examples
     L := apply(rank source M1s,i->M1s_(i,i));
     assert(diagonalMatrix L == M1s);
     assert(product L == 1);
@@ -178,7 +179,8 @@ analyzeStrand(Complex,ZZ) := (F,a) -> (
     cM2 := complex M2Z;
     compare := extend(cM1,cM2,id_cM1_0);
     M:= compare_1;
-    elapsedTime Ms := smithNormalForm(M,ChangeMatrix=>{false,false});
+    elapsedTime Ms := first preSmithNormalForm(M,ChangeMatrix=>{false,false},KeepZeroes=>false);
+    -- elapsedTime Ms := smithNormalForm(M,ChangeMatrix=>{false,false},KeepZeroes=>false); -- takes much longer time in examples  
     L = apply(rank source Ms,i->Ms_(i,i));
     assert(diagonalMatrix L == Ms);
     L1:= select(L,d-> d!=1);

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/smithNormalForm-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/smithNormalForm-doc.m2
@@ -4,7 +4,7 @@ document {
 	  [smithNormalForm,ChangeMatrix],
 	  [smithNormalForm,KeepZeroes]
 	  },
-     Headline => "compute the Smith normal form of a matrix over the integers or a PID",
+     Headline => "smith normal form for a matrix over a PID",
      Usage => "(D,P,Q) = smithNormalForm M\n(D,P) = smithNormalForm(M,ChangeMatrix=>{true,false})\n(D,Q) = smithNormalForm(M,ChangeMatrix=>{false,true})\nD = smithNormalForm(M,ChangeMatrix=>{false,false})\n",
      Inputs => {
 	  "M",
@@ -18,8 +18,7 @@ document {
 	  "Q" => Matrix => "invertible (right) change of basis matrix"
 	  },
      "This function produces a diagonal matrix ", TT "D", ", and invertible matrices ", TT "P", " and ", TT "Q", " such that
-     ", TT "D = PMQ", ".  Warning: even though this function is called the Smith normal form, it doesn't necessarily satisfy the
-     more stringent condition that the diagonal entries ", TT "d1, d2, ..., dn", " of ", TT "D", " satisfy: ", TT "d1|d2|...|dn.", ".",
+     ", TT "D = PMQ", "with diagonal entries ", TT "d1, d2, ..., dn", " of ", TT "D", " satisfying ", TT "d1|d2|...|dn.",
      EXAMPLE lines ///
 	 M = matrix{{1,2,3},{1,34,45},{2213,1123,6543},{0,0,0}}
 	 (D,P,Q) = smithNormalForm M
@@ -45,10 +44,8 @@ document {
 	  D1 - P1*M*Q1 == 0
 	  prune coker M
      ///,
-     "This routine is under development.  The main idea is to compute a Gröbner basis, transpose the generators, and repeat, until
-     we encounter a matrix whose transpose is already a Gröbner basis.  This may depend heavily on the monomial order.",
-     Caveat => "The Smith normal form itself is NOT returned! This function is under development,
-     and its performance might need to be improved.  Also, this function
-       doesn't warn the user if the ring is not a PID.",
+     "The key idea of the current implementation is as follows: compute a Gröbner basis, transpose the generators, and repeat, until
+     we encounter a matrix whose transpose is already a Gröbner basis.",
+     Caveat => "The behavior of this function is not defined when the ring is not a PID.",
      SeeAlso => {(minimalPresentation,Module)}
      }

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/smithNormalForm-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/smithNormalForm-doc.m2
@@ -23,8 +23,8 @@ document {
 	 M = matrix{{1,2,3},{1,34,45},{2213,1123,6543},{0,0,0}}
 	 (D,P,Q) = smithNormalForm M
 	 D == P * M * Q
-	 (D,P) = smithNormalForm(M, ChangeMatrix=>{true,false})
-	 D = smithNormalForm(M, ChangeMatrix=>{false,false}, KeepZeroes=>true)
+	 (D,P) = smithNormalForm(M, ChangeMatrix=>{true,false}, KeepZeroes=>false)
+	 D = smithNormalForm(M, ChangeMatrix=>{false,false})
      ///,
      PARA{
 	  "This function is the underlying routine used by ", TO minimalPresentation,

--- a/M2/Macaulay2/packages/OldPolyhedra.m2
+++ b/M2/Macaulay2/packages/OldPolyhedra.m2
@@ -8909,15 +8909,8 @@ assert isNormal Q
 -- Test 63
 -- Checking sublatticeBasis and toSublattice
 TEST ///
-
--- new answer:
-assert((sublatticeBasis matrix{{2,4,2,4},{1,2,2,3}}) === matrix({{2, 4}, {2, 3}}) );
--- assert(sublatticeBasis matrix{{2,4,2,4},{1,2,2,3}} == matrix {{2,2},{1,2}})
-
--- new answer:
-assert( (sublatticeBasis convexHull matrix {{1,2,2},{0,-1,2}}) === map(ZZ^2,ZZ^2,{{0, 1}, {-1, 2}}) );
--- assert(sublatticeBasis convexHull matrix {{1,2,2},{0,-1,2}} == matrix {{-1,1},{1,0}})
-
+assert(abs det solve(sublatticeBasis matrix{{2,4,2,4},{1,2,2,3}},matrix({{2, 4}, {2, 3}})) == 1);
+assert(abs det solve(sublatticeBasis convexHull matrix {{1,2,2},{0,-1,2}}, matrix {{-1,1},{1,0}}) == 1)
 assert(toSublattice convexHull matrix {{2,0},{0,3}} == convexHull matrix {{0,1}})
 ///
 

--- a/M2/Macaulay2/packages/QuillenSuslin.m2
+++ b/M2/Macaulay2/packages/QuillenSuslin.m2
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------------
 -- PURPOSE : QuillenSuslin package for Macaulay2 provides the ability to 
--- compute a free basis for a projective moadule over a polynomial ring 
+-- compute a free basis for a projective module over a polynomial ring 
 -- with coefficients in Q, Z or Z/p for a prime integer p. 
 --
 -- Copyright (C) 2013 Brett Barwick and Branden Stone

--- a/M2/Macaulay2/packages/QuillenSuslin.m2
+++ b/M2/Macaulay2/packages/QuillenSuslin.m2
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------------
 -- PURPOSE : QuillenSuslin package for Macaulay2 provides the ability to 
--- compute a free basis for a projective module over a polynomial ring 
+-- compute a free basis for a projective moadule over a polynomial ring 
 -- with coefficients in Q, Z or Z/p for a prime integer p. 
 --
 -- Copyright (C) 2013 Brett Barwick and Branden Stone
@@ -328,7 +328,7 @@ laurentCoeffList(RingElement,RingElement) := (f,var) -> (
 -- entries.
 
 laurentNormalize = method()
-laurentNormalize(Matrix,RingElement) := (f,var) -> (
+laurentNormalize(Matrix,RingElement) := (f',var) -> (
      local D; local degSeqList; local denom; local denomDegSeq;
      local dotList; local E; local Etemp; local f2; local f3; local j;
      local invSubList; local invSubs; local invSubs1; local invSubs2;
@@ -339,15 +339,16 @@ laurentNormalize(Matrix,RingElement) := (f,var) -> (
      local phi; local phiD; 
      
      
-     R = ring f;
-     S = frac((coefficientRing ring f)(monoid [gens ring f]));
+     R = ring f';
+     S = frac((coefficientRing ring f')(monoid [gens ring f']));
    
      phi = map(S,R); 
-     f = phi f;
+     f := phi f';
      var = phi var;
    
      varList = gens S;
      usedVars = unique support f_(0,0); -- Need to use 'unique support' since for a rational function, the 'support' command returns the concatenation of the support of the numerator and the support of the denominator.
+     if #usedVars == 0 then return (map source f', vars R, vars R);
      if not member(var,usedVars) then error "Error: Expected the given variable to be in the support of the first polynomial.";
      if numcols f < 2 then error "Error: Expected the given row to have at least 2 columns.";
      -- The following code creates a list of lists where each interior list is the degree vector of a term of

--- a/M2/Macaulay2/tests/normal/smith.m2
+++ b/M2/Macaulay2/tests/normal/smith.m2
@@ -40,8 +40,14 @@ assert isHomogeneous minimalPresentation coker vars R
 assert isHomogeneous first smithNormalForm vars R
 
 chk = M -> (
+     -*
+     (D',P',Q') = preSmithNormalForm M;
+     *-
      (D,P,Q) = smithNormalForm M;
-     assert isHomogeneous D;
+     -*
+     (D',P',Q') / degrees
+     (D,P,Q) / degrees
+     *-
      assert( P*M*Q === D );
      assert( target P === target D );
      assert( target M === source P );
@@ -51,3 +57,4 @@ chk = M -> (
 chk vars R
 chk matrix {{x^5}}
 chk matrix {{x^5,x^7},{0,x^3}}
+chk matrix {{x^5,x^7,x^11},{x^2,x^3,x^3},{x^11,x^7,x^2}}

--- a/M2/Macaulay2/tests/normal/smith.m2
+++ b/M2/Macaulay2/tests/normal/smith.m2
@@ -40,14 +40,7 @@ assert isHomogeneous minimalPresentation coker vars R
 assert isHomogeneous first smithNormalForm vars R
 
 chk = M -> (
-     -*
-     (D',P',Q') = preSmithNormalForm M;
-     *-
      (D,P,Q) = smithNormalForm M;
-     -*
-     (D',P',Q') / degrees
-     (D,P,Q) / degrees
-     *-
      assert( P*M*Q === D );
      assert( target P === target D );
      assert( target M === source P );
@@ -58,3 +51,17 @@ chk vars R
 chk matrix {{x^5}}
 chk matrix {{x^5,x^7},{0,x^3}}
 chk matrix {{x^5,x^7,x^11},{x^2,x^3,x^3},{x^11,x^7,x^2}}
+
+
+--this test would have failed before 2025
+M = matrix{{4,0},{0,6}};
+snfM = matrix{{2,0},{0,12}};
+assert(first smithNormalForm M == snfM)
+
+--this test also would have failed before 2025
+--issue related to calling syz vs trim gens syz
+--this example used to output a 2x2 matrix, which was wrong
+
+R = QQ[x]
+h = matrix{{x^3+1},{x^2+1}}
+chk h

--- a/M2/Macaulay2/tests/normal/smith.m2
+++ b/M2/Macaulay2/tests/normal/smith.m2
@@ -26,7 +26,7 @@ assert ( t*f*s == g )
 assert ( # pivots g == 3 )
 
 R = QQ[x]
-time (g,t,s) = smithNormalForm ( f = random(R^8,R^3,MaximalRank=>true) * matrix "14+x,,;,140-x2,;,,1261+2x" * random(R^3,R^10,MaximalRank=>true) );
+time (g,t,s) = smithNormalForm ( f = random(R^5,R^3,MaximalRank=>true) * matrix "14+x,,;,140-x2,;,,1261+2x" * random(R^3,R^4,MaximalRank=>true) );
 time assert ( t*f*s == g )
 time assert ( # pivots g == 3 )
 
@@ -34,10 +34,6 @@ S = QQ [x, MonomialOrder => {Position => Down}]
 f = first smithNormalForm(vars S,ChangeMatrix => {true, false})
 debug Core
 assert( degrees raw source f == degrees source raw f )
-
-R = QQ[x]
-assert isHomogeneous minimalPresentation coker vars R
-assert isHomogeneous first smithNormalForm vars R
 
 chk = M -> (
      (D,P,Q) = smithNormalForm M;

--- a/M2/Macaulay2/tests/normal/smith.m2
+++ b/M2/Macaulay2/tests/normal/smith.m2
@@ -65,3 +65,12 @@ assert(first smithNormalForm M == snfM)
 R = QQ[x]
 h = matrix{{x^3+1},{x^2+1}}
 chk h
+
+-- this is the beginning of `examples "smithNormalForm"`
+M = matrix{{1,2,3},{1,34,45},{2213,1123,6543},{0,0,0}}
+(D,P,Q) = smithNormalForm M
+assert(D == P * M * Q)
+(D,P) = smithNormalForm(M, ChangeMatrix=>{true,false}, KeepZeroes=>false)
+assert(numrows D == 3)
+D = smithNormalForm(M, ChangeMatrix=>{false,false})
+assert(numrows D == numrows M and numcols D == numcols M)


### PR DESCRIPTION
This PR fixes issues discussed in #3017. This was done with @antonleykin and @MichaelABurr. 

The old `smithNormalForm` is now the helper function `preSmithNormalForm`, and the new `smithNormalForm` outputs an honest-to-goodness canonical Smith normal form (that is, the diagonal entries satisfy $d_1 | d_2 | d_3 | \dots | d_n$) for a matrix over `ZZ` or a polynomial ring in one variable. Therefore, the output of this version of `smithNormalForm` does not depend on the value of `ChangeMatrix`.