### PR TITLE
Raise an error when creating mutable matrices w/ negative dimensions

### DIFF
--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -2371,7 +2371,7 @@ export rawMutableIdentity(e:Expr):Expr := (
      when s.0 is R:RawRingCell do
      when s.1 is nrows:ZZcell do if !isInt(nrows) then WrongArgSmallInteger(2) else
      when s.2 is preferDense:Boolean do
-     toExpr(Ccode(RawMutableMatrix, 
+     toExpr(Ccode(RawMutableMatrixOrNull,
 	       "IM2_MutableMatrix_identity(", 
 	       R.p, ",",
 	       toInt(nrows), ",",
@@ -2396,7 +2396,7 @@ export rawMutableMatrix(e:Expr):Expr := (
      when s.1 is nrows:ZZcell do if !isInt(nrows) then WrongArgSmallInteger(2) else
      when s.2 is ncols:ZZcell do if !isInt(ncols) then WrongArgSmallInteger(3) else
      when s.3 is preferDense:Boolean do
-     toExpr(Ccode(RawMutableMatrix, 
+     toExpr(Ccode(RawMutableMatrixOrNull,
 	       "IM2_MutableMatrix_make(", 
 	       R.p, ",",
 	       toInt(nrows), ",",

--- a/M2/Macaulay2/e/interface/mutable-matrix.cpp
+++ b/M2/Macaulay2/e/interface/mutable-matrix.cpp
@@ -28,7 +28,7 @@ MutableMatrix *IM2_MutableMatrix_identity(const Ring *R,
 {
   if (n < 0)
     {
-      ERROR("expected non-negative integer");
+      ERROR("expected nonnegative integer");
       return nullptr;
     }
   size_t nrows = static_cast<size_t>(n);
@@ -40,8 +40,11 @@ MutableMatrix /* or null */ *IM2_MutableMatrix_make(const Ring *R,
                                                     int ncols,
                                                     M2_bool is_dense)
 {
-  assert(nrows >= 0);
-  assert(ncols >= 0);
+  if (nrows < 0 || ncols < 0) {
+    ERROR("expected nonnegative integers");
+    return nullptr;
+  }
+
   size_t nr = static_cast<size_t>(nrows);
   size_t nc = static_cast<size_t>(ncols);
   //  return R->makeMutableMatrix(nr,nc,is_dense);

--- a/M2/Macaulay2/tests/normal/mutmat.m2
+++ b/M2/Macaulay2/tests/normal/mutmat.m2
@@ -59,3 +59,7 @@ Q = mutableMatrix id_(R^2)_P
 assert(L_(0, 1) == 0)
 assert(U_(1, 0) == 0)
 assert(Q * L * U == M)
+
+-- issue #3709 (these used to crash M2)
+try mutableMatrix(ZZ, -1, 1)
+try mutableIdentity(ZZ, -1)

--- a/M2/Macaulay2/tests/normal/mutmat.m2
+++ b/M2/Macaulay2/tests/normal/mutmat.m2
@@ -61,5 +61,7 @@ assert(U_(1, 0) == 0)
 assert(Q * L * U == M)
 
 -- issue #3709 (these used to crash M2)
-try mutableMatrix(ZZ, -1, 1)
-try mutableIdentity(ZZ, -1)
+assert try ( mutableMatrix(ZZ, -1, -1); false ) else true
+assert try ( mutableMatrix(ZZ, -1,  1); false ) else true
+assert try ( mutableMatrix(ZZ,  1, -1); false ) else true
+assert try ( mutableIdentity(ZZ, -1);   false ) else true


### PR DESCRIPTION
We've actually been trying to do this for `mutableIdentity`, but never checked to see if `IM2_MutableMatrix_identity` returned null.

### Before

```m2
i1 : mutableIdentity(ZZ, -1)
-- SIGSEGV
-* stack trace, pid: 1080639
 0# profiler_stacktrace(std::ostream&, int) at /usr/src/macaulay2-1.24.11+git202503252349-0ppa202503250209~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:131
 1# segv_handler at /usr/src/macaulay2-1.24.11+git202503252349-0ppa202503250209~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:243
 2# 0x0000777B07645330 in /lib/x86_64-linux-gnu/libc.so.6
 3# rawMutableMatrixHash at interface/mutable-matrix.cpp:68
 4# basic_hash at /usr/src/macaulay2-1.24.11+git202503252349-0ppa202503250209~ubuntu24.04.1/M2/Macaulay2/d/basic.d:47
 5# basic_list_1 at /usr/src/macaulay2-1.24.11+git202503252349-0ppa202503250209~
```

```m2
i1 : mutableMatrix(ZZ, -1, 1)


 *** out of memory trying to allocate -16 bytes, exiting ***
```

### After
```m2
i1 : mutableIdentity(ZZ, -1)
stdio:1:15:(3): error: expected nonnegative integer

i2 : mutableMatrix(ZZ, -1, 1)
stdio:2:13:(3): error: expected nonnegative integers
```

Cc: @leokayser 

Closes: #3709