### PR TITLE
Simplify startup banner

### DIFF
--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -28,9 +28,6 @@ Number.Wrap = x -> wr("",x)
 if instance(PythonObject,Type) then PythonObject.Wrap = x -> wr("",x) else protect PythonObject
 QQ.Wrap = x -> wr("=",x)
 
-ignoreP := set { "Core", "Classic", "Parsing", "SimpleDoc" }
-mentionQ := p -> not ignoreP#?(toString p)
-
 addStartFunction(
      () -> (
 	  if class value getGlobalSymbol "User" =!= Package then (
@@ -58,11 +55,6 @@ addStartFunction( () -> (
 addStartFunction( () -> (
 	  if not nobanner then (
 	       if topLevelMode === TeXmacs then stderr << TeXmacsBegin << "verbatim:";
-	       relevant := select(loadedPackages,mentionQ);
-	       if #relevant > 0 then (
-	       	    hd := "with packages: ";
-	       	    stderr << hd << wrap(printWidth-#hd, concatenate between_", " sort apply(relevant,toString)) << endl;
-		    );
 	       stderr << "Type `help` to see useful commands" << endl;
 	       if topLevelMode === TeXmacs then stderr << TeXmacsEnd << flush;
 	       );

--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -63,6 +63,7 @@ addStartFunction( () -> (
 	       	    hd := "with packages: ";
 	       	    stderr << hd << wrap(printWidth-#hd, concatenate between_", " sort apply(relevant,toString)) << endl;
 		    );
+	       stderr << "Type `help` to see useful commands" << endl;
 	       if topLevelMode === TeXmacs then stderr << TeXmacsEnd << flush;
 	       );
 	  )

--- a/M2/Macaulay2/packages/BeginningMacaulay2/tutorial
+++ b/M2/Macaulay2/packages/BeginningMacaulay2/tutorial
@@ -12,9 +12,8 @@ Description
 	  on a command line to bring up the program. You should see something like:
      Code
      	  EXAMPLE {
-	  PRE ///Macaulay2, version 1.7
-      with packages: ConwayPolynomials, Elimination, IntegralClosure, LLLBases,
-             PrimaryDecomposition, ReesAlgebra, TangentCone///}
+	      PRE concatenate("Macaulay2, version ", version#"VERSION",
+		  newline, "Type `help` to see useful commands")}
      Text
           We suggest you do that now, so that you can experiment while you read
 	  this tutorial!

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
@@ -368,4 +368,21 @@ Node
     Text
       To read the documentation in info form, in case you happen to be running Macaulay2 in a
       terminal window, replace @TO "help"@ by @TO "infoHelp"@ in any of the commands above.
+
+      To get BibTeX code for citing Macaulay2 or one of its packages, type one
+      of the following commands.
+    Code
+      TABLE {
+	  { M2CODE "cite",                               "-- how to cite Macaulay2" },
+	  { M2CODE "cite \"FirstPackage\"",              "-- how to cite a package" }
+      }
+    Text
+      To get information about the startup of Macaulay2, type one of the
+      following commands.
+    Code
+      TABLE {
+	  { M2CODE "loadedPackages",                            "-- a list of the currently loaded packages" },
+	  { M2CODE "help \"packages provided with Macaulay2\"", "-- a list of all the available packages" },
+	  { M2CODE "help \"initialization file \"",             "-- show documentation about the file init.m2" }
+      }
 ///


### PR DESCRIPTION
There was some discussion at the March M2internals about updating our startup banner to address the following concerns:

* Perhaps the list of pre-loaded packages should be removed or fewer of them should appear.
* Perhaps we should announce several commands to get useful information for new users.

Here are a few options (the exact wording of the list of commands is certainly up for discussion as well). 

## Option A (no pre-loaded packages)
```m2
Macaulay2, version 1.24.11-471-g5b79022404 (development)
Useful commands:  see 'copyright', how to 'cite', and get initial `help`.
```

## Option B (fewer pre-loaded packages)
```m2
Macaulay2, version 1.24.11-471-g5b79022404 (development)
with packages: Elimination, IntegralClosure, InverseSystems, Isomorphism,
               MinimalPrimes, OnlineLookup, Polyhedra, PrimaryDecomposition,
               ReesAlgebra, Varieties
Useful commands:  see 'copyright', how to 'cite', and get initial `help`.
```

## Option C (mention `loadedPackages`)
```m2
Macaulay2, version 1.24.11-471-g5b79022404 (development)
(Type `loadedPackages` for the list of preloaded packages.)
Useful commands:  see 'copyright', how to 'cite', and get initial `help`.
```
