### PR TITLE
Improvements to "round"

### DIFF
--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -241,12 +241,14 @@ conjugate Constant := conjugate @@ numeric
 
 isConstant Number := i -> true
 
-round RR := round CC := round0
-round Constant := round0 @@ numeric
+round Number := round0 @@ numeric
 round(ZZ,RR) := (n,x) -> (
      prec := precision x;
      p := (toRR(prec,10))^n;
      toRR(prec,round(x*p)/p))
+round(ZZ, CC) := (n, x) -> toCC(round(n, realPart x), round(n, imaginaryPart x))
+round(ZZ, RRi) := (n, x) -> toRRi(round(n, left x), round(n, right x))
+round(ZZ, Number) := (n, x) -> round(n, numeric x)
 
 truncate Number := {} >> o -> x -> (
     if x >= 0 then floor x

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_arithmetic.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_arithmetic.m2
@@ -1,5 +1,13 @@
-document { Key => {round,(round,QQ),(round,RR),(round,ZZ,RR),(round,ZZ),
-	(round,CC),(round,Constant)},
+document {
+    Key => {
+	 round,
+	(round, Number),
+	(round, QQ),
+	(round, ZZ),
+	(round, ZZ, CC),
+	(round, ZZ, Number),
+	(round, ZZ, RR),
+	(round, ZZ, RRi)},
      Headline => "round a number",
      SYNOPSIS (
 	  Usage => "round x",

--- a/M2/Macaulay2/tests/normal/numbers.m2
+++ b/M2/Macaulay2/tests/normal/numbers.m2
@@ -177,9 +177,16 @@ assert( ring(1p44+ii) === CC_44 )
 assert( round 3.4 === 3 )
 assert( round 3.5 === 4 )
 assert( round 4.5 === 4 )
+assert( round toRRi(exp 1, numeric pi) === 3 )
+assert( round pi === 3 )
 assert( round_1 .34 === .3 )
 assert( round_1 .35 === .4 )
 assert( round_1 .45 === .4 )
+assert( round_2 (1/3) == 0.33 )
+assert( round_2 pi === 3.14 )
+assert( round_2 toRRi(exp 1, numeric pi) === toRRi(2.72, 3.14) )
+assert( round_2 toCC(exp 1, numeric pi) === toCC(2.72, 3.14) )
+
 setRandomSeed 4
 assert( apply(20,i -> random 100) === {47, 38, 51, 74, 28, 50, 44, 25, 72, 16, 41, 61, 76, 89, 28, 27, 77, 34, 26, 57} ) -- version 1.1
 


### PR DESCRIPTION
Add `round(Number)`, which supersedes `round(RR)`, `round(CC)`, and `round(Constant)`.  Also allows `RRi` input (which was actually implemented in the interpreter but wasn't called).

Also add several two-argument version to round to a certain number of decimal places (previously only `RR` was supported, but now any `Number` type should work).

### Before
```m2
i1 : round toRRi(exp 1, numeric pi)
stdio:1:5:(3): error: no method found for applying round to:
     argument   :  [2.71828,3.14159] (of class RRi)

i2 : round(2, pi)
stdio:2:5:(3): error: no method found for applying round to:
     argument 1 :  2 (of class ZZ)
     argument 2 :  pi (of class Constant)

i3 : round(2, exp 1 + pi*ii)
stdio:3:5:(3): error: no method found for applying round to:
     argument 1 :  2 (of class ZZ)
     argument 2 :  2.71828+3.14159*ii (of class CC)
```

### After
```m2
i1 : round toRRi(exp 1, numeric pi)

o1 = 3

i2 : round(2, pi)

o2 = 3.14

o2 : RR (of precision 53)

i3 : round(2, exp 1 + pi*ii)

o3 = 2.72+3.14*ii

o3 : CC (of precision 53)
```

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
