### PR TITLE
Find path to Python shared library (autotools)

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -155,15 +155,12 @@ jobs:
         if: matrix.build-system == 'autotools'
         run: |
           ../../autogen.sh
-          export PYVERSION=`python3 -c "from sys import version_info; \
-            print(f'{version_info.major}.{version_info.minor}')"`
           export CPPFLAGS="-I`brew --prefix`/include \
             -I`brew --prefix libomp`/include         \
             -I`brew --prefix readline`/include"
           export  LDFLAGS="-L`brew --prefix`/lib \
             -L`brew --prefix libomp`/lib         \
-            -L`brew --prefix readline`/lib       \
-            -L/Library/Frameworks/Python.framework/Versions/${PYVERSION}/lib"
+            -L`brew --prefix readline`/lib"
           export F77=gfortran-14
           ../../configure --enable-download --with-system-gc
 

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1385,9 +1385,17 @@ then AC_DEFINE(WITH_PYTHON,1,[whether we are linking with the python library])
 	print(get_config_var('CONFINCLUDEPY'))"`
     CPPFLAGS="$CPPFLAGS -I$PYTHON_INCLUDE_DIR"
     AC_CHECK_HEADER(Python.h,,AC_MSG_ERROR(Python.h not found))
-    AC_SEARCH_LIBS(Py_Initialize,
-	python${PYTHON_VERSION} python${PYTHON_VERSION}m,,
-	AC_MSG_ERROR(libpython not found))
+    AC_SEARCH_LIBS([Py_Initialize],
+	[python${PYTHON_VERSION} python${PYTHON_VERSION}m],,
+	[PYTHON_LIBDIR=`$PYTHON_BIN -c \
+	    "from sysconfig import get_config_var; \
+	    print(get_config_var('LIBDIR'))"`
+	 AC_MSG_NOTICE([adding -L$PYTHON_LIBDIR to LDFLAGS and trying again...])
+	 AS_UNSET([ac_cv_search_Py_Initialize])
+	 LDFLAGS="$LDFLAGS -L$PYTHON_LIBDIR"
+	 AC_SEARCH_LIBS([Py_Initialize],
+	     [python${PYTHON_VERSION} python${PYTHON_VERSION}m],,
+	     [AC_MSG_ERROR(libpython not found)])])
 fi
 
 dnl boost 1.65 was the first release containing the stacktrace library


### PR DESCRIPTION
If we can't find it using the default search path, then query the LIBDIR config variable from the sysconfig module, add it to LDFLAGS, and try again.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
