### PR TITLE
Require GMP >= 6.2.1 when building FLINT (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -929,11 +929,28 @@ then BUILTLIBS="-lflint $BUILTLIBS -lm"
      AC_DEFINE([HAVE_FLINT_NMOD_H])
      AC_DEFINE([HAVE_FLINT_ARB_H])
      AS_IF([test $BUILD_gmp = no],
-         [AC_SEARCH_LIBS([__gmpn_gcd_11], [gmp], [],
-             [AC_MSG_WARN([flint requires __gmp_gcd_11, so we will build gmp])
-              BUILD_gmp=yes
-              LIBS_GMP="-lgmpxx -lgmp"
-              BUILTLIBS="$LIBS_GMP $BUILTLIBS"])])
+         [AC_LANG([C])
+          AC_MSG_CHECKING([if gmp >= 6.2.1 (needed to build flint)])
+          AC_RUN_IFELSE(
+              [AC_LANG_PROGRAM([
+                   #include <gmp.h>
+                   ], [
+                   #if (__GNU_MP_VERSION            < 6) || \
+                       (__GNU_MP_VERSION           == 6  && \
+                        __GNU_MP_VERSION_MINOR      < 2) || \
+                       (__GNU_MP_VERSION           == 6  && \
+                        __GNU_MP_VERSION_MINOR     == 2  && \
+                        __GNU_MP_VERSION_PATCHLEVEL < 1)
+                     return 1;
+                   #else
+                     return 0;
+                   #endif
+                   ])],
+              [AC_MSG_RESULT([yes])],
+              [AC_MSG_RESULT([no; will build gmp])
+                  BUILD_gmp=yes
+                  LIBS_GMP="-lgmpxx -lgmp"
+                  BUILTLIBS="$LIBS_GMP $BUILTLIBS"])])
 fi
 
 dnl debian: 4ti2-


### PR DESCRIPTION
Otherwise, FLINT build will fail.  This is an issue on RHEL 9, where GMP is still 6.2.0.

From https://github.com/d-torrance/M2-workflows/actions/runs/14267926911/job/39994147473:
```
checking gmp.h usability... yes
checking gmp.h presence... yes
checking for gmp.h... yes
configure: error: GMP version 6.2.1 or later is required.
checking if version of GMP is greater than 6.2.1... no
make[2]: *** [../Makefile.library:194: .configured-3.2.1] Error 1
make[2]: Leaving directory '/__w/M2-workflows/M2-workflows/M2/M2/BUILD/build/libraries/flint'
make[1]: Leaving directory '/__w/M2-workflows/M2-workflows/M2/M2/BUILD/build/libraries'
make[1]: *** [Makefile:7: all-in-flint] Error 2
make: *** [Makefile:57: all-in-libraries] Error 2
```