### PR TITLE
Update ToricHigherDirectImages test so that order doesn't matter

### DIFF
--- a/M2/Macaulay2/packages/ToricHigherDirectImages.m2
+++ b/M2/Macaulay2/packages/ToricHigherDirectImages.m2
@@ -1060,7 +1060,7 @@ assert(isWellDefined phi)
 D = {0,-2,0,0,0,-2,1,0}
 HT = computeEigencharacters(phi,1,D);
 chars = keys HT
-assert(chars == {matrix{{0},{1}}, matrix{{0},{-1}}})
+assert(set chars == set {matrix{{0},{1}}, matrix{{0},{-1}}})
 ///
 
 end--


### PR DESCRIPTION
See https://github.com/Macaulay2/M2/pull/3683#issuecomment-2781518437.  This failing test is also affecting #3726 now.

Cc: @sashahbc 