### PR TITLE
Add Keywords to package template

### DIFF
--- a/M2/Macaulay2/packages/SimpleDoc/templates.m2
+++ b/M2/Macaulay2/packages/SimpleDoc/templates.m2
@@ -29,6 +29,7 @@ packagetemplate = "newPackage(
     Date => \"\",
     Headline => \"\",
     Authors => {{ Name => \"\", Email => \"\", HomePage => \"\"}},
+    Keywords => {\"\"},
     AuxiliaryFiles => false,
     DebuggingMode => false
     )


### PR DESCRIPTION
The Core tests will now fail when this field is missing, so adding it to the output of packageTemplate should help encourage package authors to include it.
