### PR TITLE
Revert to old code for computing deltaE

### DIFF
--- a/M2/Macaulay2/e/NCAlgebras/FreeAlgebra.hpp
+++ b/M2/Macaulay2/e/NCAlgebras/FreeAlgebra.hpp
@@ -9,7 +9,6 @@
 #include "ringelem.hpp"               // for ring_elem
 #include "style.hpp"                  // for GEOHEAP_SIZE
 
-#include <gmp.h>                      // for mpz_srcptr, mpq_srcptr
 #include <iosfwd>                     // for ostream, string
 #include <utility>                    // for pair
 #include <vector>                     // for vector

--- a/M2/Macaulay2/e/NCAlgebras/FreeAlgebraQuotient.hpp
+++ b/M2/Macaulay2/e/NCAlgebras/FreeAlgebraQuotient.hpp
@@ -8,7 +8,6 @@
 #include "newdelete.hpp"              // for our_new_delete
 #include "ringelem.hpp"               // for ring_elem
 
-#include <gmp.h>                      // for mpz_srcptr, mpq_srcptr
 #include <vector>                     // for vector
 
 class Ring;

--- a/M2/Macaulay2/e/aring-gf-flint-big.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint-big.hpp
@@ -8,6 +8,9 @@
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
+// includes gmp.h, which is required for FLINT functions that use GMP
+#include <M2/math-include.h>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <flint/flint.h>       // for flint_free, flint_rand_t, fmpz_t

--- a/M2/Macaulay2/e/aring-gf-flint.hpp
+++ b/M2/Macaulay2/e/aring-gf-flint.hpp
@@ -8,6 +8,9 @@
 // The following needs to be included before any flint files are included.
 #include <M2/gc-include.h>
 
+// includes gmp.h, which is required for FLINT functions that use GMP
+#include <M2/math-include.h>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <flint/flint.h>      // for flint_rand_t, fmpz_t, ulong

--- a/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/schreyer-resolution/res-f4-m2-interface.cpp
@@ -33,7 +33,6 @@
 #include "schreyer-resolution/res-schreyer-frame.hpp"     // for SchreyerFrame
 #include "schreyer-resolution/res-schreyer-order.hpp"     // for ResSchreyer...
 #include "timing.hpp"                                     // for timer, seconds
-#include <gmp.h>                                          // for mpz_clear
 #include <cstdlib>                                        // for exit, size_t
 #include <chrono>                                         // for common_type...
 #include <iostream>                                       // for operator<<

--- a/M2/Macaulay2/m2/programs.m2
+++ b/M2/Macaulay2/m2/programs.m2
@@ -89,18 +89,21 @@ findProgram(String, List) := opts -> (name, cmds) -> (
 	instance(opts.MinimumVersion, Sequence) and
 	class \ opts.MinimumVersion === (String, String)) then
 	error "expected MinimumVersion to be a sequence of two strings";
-    pathsToTry := fixPath \ join(
+    pathsToTry := fixPath \ nonnull flatten {
 	-- try user-configured path first
-	if programPaths#?name then {programPaths#name} else {},
+	if programPaths#?name then programPaths#name,
 	-- now try M2-installed path
-	{prefixDirectory | currentLayout#"programs"},
+	prefixDirectory | currentLayout#"programs",
 	-- any additional paths specified by the caller
-	opts.AdditionalPaths,
+	 opts.AdditionalPaths,
 	-- try PATH
-	if getenv "PATH" == "" then {} else apply(separate(":", getenv "PATH"),
+	if getenv "PATH" =!= "" then apply(
+	    separate(":", getenv "PATH"),
 	    dir -> if dir == "" then "." else dir),
 	-- try directory containing M2-binary
-	{bindir});
+	bindir,
+	-- try usr-host/bin
+	if topBuilddir =!= null then topBuilddir | "usr-host/bin"};
     prefixes := {(".*", "")} | opts.Prefix;
     errorCode := didNotFindProgram;
     versionFound := "0.0";

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -40,7 +40,6 @@ if not firstTime then debug Core -- we need access to the private symbols (we re
 toString := value' getGlobalSymbol if firstTime then "simpleToString" else "toString"
 
 local exe
-local topBuilddir
 
 -- this next bit has to be *parsed* after the "debug" above, to prevent the symbols from being added to the User dictionary
 if firstTime then (

--- a/M2/Macaulay2/packages/ToricVectorBundles.m2
+++ b/M2/Macaulay2/packages/ToricVectorBundles.m2
@@ -675,10 +675,11 @@ deltaE = method()
 
 --   INPUT : 'tvb',  a ToricVectorBundle
 --  OUTPUT : a Polyhedron
-deltaE ToricVectorBundleKaneyama := (cacheValue symbol deltaE)( tvb -> (
+deltaE ToricVectorBundle := (cacheValue symbol deltaE)( tvb -> (
      	  if not isComplete tvb#"ToricVariety" then error("The toric variety needs to be complete.");
      	  n := tvb#"dimension of the variety";
-          -- Extracting necessary data
+          if instance(tvb,ToricVectorBundleKaneyama) then (
+	  -- Extracting necessary data
           raylist := rays tvb;
           rl := #raylist;
           k := tvb#"rank of the vector bundle";
@@ -706,19 +707,8 @@ deltaE ToricVectorBundleKaneyama := (cacheValue symbol deltaE)( tvb -> (
 		    	      if isCompact P and (not isEmpty P) then vertices P else continue)));
      	       -- Make a matrix of all the vertices in L
      	       M = matrix {L};
-     	       convexHull M))
-
-
-
-
-
-
-
-
-
-deltaE ToricVectorBundleKlyachko := (cacheValue symbol deltaE)( tvb -> (
-     	  if not isComplete tvb#"ToricVariety" then error("The toric variety needs to be complete.");
-     	  n := tvb#"dimension of the variety";
+     	       convexHull M)
+	else (
           -- Extracting necessary data
           rayTable := tvb#"rayTable";
           l := #rayTable;
@@ -726,7 +716,7 @@ deltaE ToricVectorBundleKlyachko := (cacheValue symbol deltaE)( tvb -> (
 		      sset1 := select(subsets(rays tvb,n), s -> rank matrix {s} == n);
   		      convexHull matrix {apply(sset1, s -> (
 		 		     M := transpose matrix {apply(s, r -> (-r | r) || (fMT#r))};
-		 		     vertices polyhedronFromHData(M_{0..n-1},M_{n})))}))
+		 		     vertices polyhedronFromHData(M_{0..n-1},M_{n})))})))
 
 
 --   INPUT : '(tvb1,tvb2)',  two ToricVectorBundle over the same Fan

--- a/M2/Macaulay2/packages/ToricVectorBundles.m2
+++ b/M2/Macaulay2/packages/ToricVectorBundles.m2
@@ -2723,7 +2723,7 @@ document {
      }
 
 document {
-     Key => {deltaE, (deltaE,ToricVectorBundleKlyachko)},
+     Key => {deltaE, (deltaE,ToricVectorBundle)},
      Headline => " the polytope of possible degrees that give non zero cohomology",
      Usage => " P = deltaE E",
      Inputs => {

--- a/M2/Macaulay2/packages/ToricVectorBundles.m2
+++ b/M2/Macaulay2/packages/ToricVectorBundles.m2
@@ -3,12 +3,12 @@
 ---------------------------------------------------------------------------
 -- PURPOSE: Computations with vector bundles on toric varieties 
 -- PROGRAMMER : René Birkner 
--- UPDATE HISTORY : November 2008, November 2009, April 2010, May 2024
+-- UPDATE HISTORY : November 2008, November 2009, April 2010, May 2024, April 2025
 ---------------------------------------------------------------------------
 newPackage("ToricVectorBundles",
     Headline => "vector bundles on toric varieties",
-    Version => "1.2",
-    Date => "May 7, 2024",
+    Version => "1.3",
+    Date => "April 15, 2025",
     Authors => {
          {Name => "René Birkner"
 	  },
@@ -675,62 +675,58 @@ deltaE = method()
 
 --   INPUT : 'tvb',  a ToricVectorBundle
 --  OUTPUT : a Polyhedron
-deltaE ToricVectorBundle := (cacheValue symbol deltaE)( T -> (
-	  if not isComplete T#"ToricVariety" then error("The toric variety needs to be complete.");
-     	  n := T#"dimension of the variety";
-	  if instance(T,ToricVectorBundleKaneyama) then (
-	       dT := values T#"degreeTable";
-	       dT = matrix {dT};
-	       convexHull dT)
-	  else (
-	       W := findWeights T;
-	       W = apply(W,first);
-	       W = matrix {W};
-	       convexHull W)))
+deltaE ToricVectorBundleKaneyama := (cacheValue symbol deltaE)( tvb -> (
+     	  if not isComplete tvb#"ToricVariety" then error("The toric variety needs to be complete.");
+     	  n := tvb#"dimension of the variety";
+          -- Extracting necessary data
+          raylist := rays tvb;
+          rl := #raylist;
+          k := tvb#"rank of the vector bundle";
+          tCT := keys tvb#"topConeTable";
+          dT := tvb#"degreeTable";
+          -- Creating an index table, for each ray the first top cone containing it
+          raytCTindex := hashTable apply(#raylist, r -> r => position(tCT, C -> contains(posHull C_0,raylist#r)));
+          raylist = transpose matrix {raylist};
+          -- Get the subsets of 'n' elements in 'rl'
+          sset := subsets(rl,n);
+          jList := {{}};
+          -- Get all different combinations of choices of variety dimension many degree vectors
+          for i from 0 to n-1 do jList = flatten apply(jList, l -> apply(k, j -> l|{j}));
+          M := map(QQ^1,QQ^n,0);
+          v := map(QQ^1,QQ^1,0);
+          -- For every 'n' in 'l' subset and any combination in jList get the intersection of the dual cones
+          -- of the corresponding rays. If this is a non-empty compact polytope then add the vertices to the
+          -- list L
+     	       L := unique flatten apply(sset, s -> (
+	       	    	 unique for j in jList list (
+		    	      N := matrix apply(n, i -> {raylist^{s#i},raylist^{s#i} * ((dT#(tCT#(raytCTindex#(s#i))))_{j#i})});
+		    	      w := N_{n};
+		    	      N = submatrix'(N,{n});
+		    	      P := polyhedronFromHData(M,v,N,w);
+		    	      if isCompact P and (not isEmpty P) then vertices P else continue)));
+     	       -- Make a matrix of all the vertices in L
+     	       M = matrix {L};
+     	       convexHull M))
 
---oldDeltaE = method()
---oldDeltaE ToricVectorBundle := (cacheValue symbol oldDeltaE)( tvb -> (
---     	  if not isComplete tvb#"ToricVariety" then error("The toric variety needs to be complete.");
---     	  n := tvb#"dimension of the variety";
---	  if instance(tvb,ToricVectorBundleKaneyama) then (
---	       -- Extracting necessary data
---     	       raylist := rays tvb;
---     	       rl := #raylist;
---     	       k := tvb#"rank of the vector bundle";
---     	       tCT := sort keys tvb#"topConeTable";
---     	       dT := tvb#"degreeTable";
---     	       -- Creating an index table, for each ray the first top cone containing it
---     	       raytCTindex := hashTable apply(#raylist, r -> r => position(tCT, C -> contains(C,raylist#r)));
---     	       raylist = transpose matrix {raylist};
---     	       -- Get the subsets of 'n' elements in 'rl'
---     	       sset := subsets(rl,n);
---     	       jList := {{}};
---     	       -- Get all different combinations of choices of variety dimension many degree vectors
---     	       for i from 0 to n-1 do jList = flatten apply(jList, l -> apply(k, j -> l|{j}));
---     	       M := map(QQ^1,QQ^n,0);
---     	       v := map(QQ^1,QQ^1,0);
---     	       -- For every 'n' in 'l' subset and any combination in jList get the intersection of the dual cones
---     	       -- of the corresponding rays. If this is a non-empty compact polytope then add the vertices to the
---     	       -- list L
---     	       L := unique flatten apply(sset, s -> (
---	       	    	 unique for j in jList list (
---		    	      N := matrix apply(n, i -> {raylist^{s#i},raylist^{s#i} * ((dT#(tCT#(raytCTindex#(s#i))))_{j#i})});
---		    	      w := N_{n};
---		    	      N = submatrix'(N,{n});
---		    	      P := intersection(M,v,N,w);
---		    	      if isCompact P and (not isEmpty P) then vertices P else continue)));
---     	       -- Make a matrix of all the vertices in L
---     	       M = matrix {L};
---     	       convexHull M)
---	  else (
---	       -- Extracting necessary data
---	       rayTable := tvb#"rayTable";
---	       l := #rayTable;
---	       fMT := hashTable apply(pairs tvb#"filtrationMatricesTable", (i,j) -> (j = flatten entries j; i => matrix{{-(min j),max j}}));
---	  		      sset1 := select(subsets(rays tvb,n), s -> rank matrix {s} == n);
---	  		      convexHull matrix {apply(sset1, s -> (
---			 		     M := transpose matrix {apply(s, r -> (-r | r) || (fMT#r))};
---			 		     vertices intersection(M_{0..n-1},M_{n})))})))
+
+
+
+
+
+
+
+
+deltaE ToricVectorBundleKlyachko := (cacheValue symbol deltaE)( tvb -> (
+     	  if not isComplete tvb#"ToricVariety" then error("The toric variety needs to be complete.");
+     	  n := tvb#"dimension of the variety";
+          -- Extracting necessary data
+          rayTable := tvb#"rayTable";
+          l := #rayTable;
+          fMT := hashTable apply(pairs tvb#"filtrationMatricesTable", (i,j) -> (j = flatten entries j; i => matrix{{-(min j),max j}}));
+		      sset1 := select(subsets(rays tvb,n), s -> rank matrix {s} == n);
+  		      convexHull matrix {apply(sset1, s -> (
+		 		     M := transpose matrix {apply(s, r -> (-r | r) || (fMT#r))};
+		 		     vertices polyhedronFromHData(M_{0..n-1},M_{n})))}))
 
 
 --   INPUT : '(tvb1,tvb2)',  two ToricVectorBundle over the same Fan
@@ -2727,7 +2723,7 @@ document {
      }
 
 document {
-     Key => {deltaE, (deltaE,ToricVectorBundle)},
+     Key => {deltaE, (deltaE,ToricVectorBundleKlyachko)},
      Headline => " the polytope of possible degrees that give non zero cohomology",
      Usage => " P = deltaE E",
      Inputs => {
@@ -2744,7 +2740,7 @@ document {
      complete then an error is returned.",
      
      EXAMPLE {
-	  " E = toricVectorBundle(2,pp1ProductFan 2, \"Type\" => \"Kaneyama\")",
+	  " E = toricVectorBundle(2,pp1ProductFan 2)",
 	  " P = deltaE E",
 	  " vertices P",
 	  " E1 = tangentBundle projectiveSpaceFan 2",
@@ -4068,9 +4064,9 @@ TEST ///
 T = toricVectorBundle(3,projectiveSpaceFan 2,"Type" => "Kaneyama")
 assert(deltaE T == convexHull matrix{{0},{0}})
 T = tangentBundle(projectiveSpaceFan 2,"Type" => "Kaneyama")
-assert(deltaE T == convexHull matrix {{-1,1,0,1,0,-1},{0,0,-1,-1,1,1}})
+assert(deltaE T == convexHull matrix {{-1,2,-1},{-1,-1,2}})
 T = cotangentBundle(pp1ProductFan 3,"Type" => "Kaneyama")
-assert(deltaE T == convexHull matrix {{-1,1,0,0,0,0},{0,0,-1,1,0,0},{0,0,0,0,-1,1}})
+assert(deltaE T == convexHull matrix {{-1,1,-1,1,-1,1,-1,1},{-1,-1,1,1,-1,-1,1,1},{-1,-1,-1,-1,1,1,1,1}})
 ///
 
 -- Test 10
@@ -4079,9 +4075,9 @@ TEST ///
 T = toricVectorBundle(3,projectiveSpaceFan 2)
 assert(deltaE T == convexHull matrix{{0},{0}})
 T = tangentBundle projectiveSpaceFan 2
-assert(deltaE T == convexHull matrix {{-1, 1, 0, 1, 0, -1}, {0, 0, -1, -1, 1, 1}})
+assert(deltaE T == convexHull matrix {{-1,2,-1},{-1,-1,2}})
 T = cotangentBundle pp1ProductFan 3
-assert(deltaE T == convexHull matrix {{-1,1,0,0,0,0},{0,0,-1,1,0,0},{0,0,0,0,-1,1}})
+assert(deltaE T == convexHull matrix {{-1,1,-1,1,-1,1,-1,1},{-1,-1,1,1,-1,-1,1,1},{-1,-1,-1,-1,1,1,1,1}})
 ///
 
 -- Test 11


### PR DESCRIPTION
The previous version of the package computed the polytope "deltaE" of weights on which all cohomology groups are supported by just taking the convex hull of the weights of generators for the bundle as we range over all charts. I don't know of any mathematical justification of this, and this implementation was likely due to a communication error.

The implementation of deltaE has been replaced by older code that computes the correct thing. In e.g. the Klyachko case, the filtrations induce a natural stratification of the cocharacter lattice on which the graded pieces of the cohomology are independent of the weight. This version of deltaE takes the convex hull of all bounded regions.