### PR TITLE
Document that we need to use installMethod for >>

### DIFF
--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -298,15 +298,16 @@ getOperator := key -> if operator#?key then (
     op := toString key;
     if match("^[[:alpha:]]*$", op) then op = " " | op | " ";
     fixup DIV (
-	if binary#?key and key =!= symbol ?? then {
-	    PARA {"This operator may be used as a binary operator in an expression like ", TT ("x" | op | "y"), ". ",
-		"The user may install ", TO "Macaulay2Doc :: binary methods", " for handling such expressions with code such as"},
-	    PRE if key === symbol SPACE
-	    then "         X Y := (x,y) -> ..."
-	    else "         X "|op|" Y := (x,y) -> ...",
-	    PARA {"where ", TT "X", " is the class of ", TT "x", " and ", TT "Y", " is the class of ", TT "y", "."}},
-	if key === symbol ?? then { -- can't install binary methods
-	    PARA {"This operator may be used as a binary operator in an expression like ", TT ("x" | op | "y"), ". "}},
+	if binary#?key then {
+	    PARA {"This operator may be used as a binary operator in an expression like ", TT ("x" | op | "y"), "."}},
+	    -- ?? binary methods can't be installed
+	    -- >> needs to use installMethod due to precedence
+	    if not isMember(key, {symbol ??, symbol >>}) then {
+		PARA {"The user may install ", TO "Macaulay2Doc :: binary methods", " for handling such expressions with code such as"},
+		PRE if key === symbol SPACE
+		then "         X Y := (x,y) -> ..."
+		else "         X "|op|" Y := (x,y) -> ...",
+		PARA {"where ", TT "X", " is the class of ", TT "x", " and ", TT "Y", " is the class of ", TT "y", "."}},
 	if prefix#?key then {
 	    PARA {"This operator may be used as a prefix unary operator in an expression like ", TT (op | "y"), ". ",
 		"The user may ", TO2{ "Macaulay2Doc :: installing methods", "install a method" }, " for handling such expressions with code such as"},

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators/shift.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators/shift.m2
@@ -19,7 +19,11 @@ document {
      Key => symbol >>,
      Headline => "a binary operator, used for bit shifting or attaching optional inputs to functions",
      SeeAlso => { (symbol >>, OptionTable, Function) },
-     Subnodes => { TO "right shift" }
+     Subnodes => { TO "right shift" },
+     Caveat => {"Because ", CODE ">>", " has the same precedence as ",
+	 TO symbol := , ", it is not possible to use the syntax ",
+	 CODE "X >> Y := f", " to install a method for this operator.  ",
+	 "Instead, ", TO installMethod, " should be used directly"}
      }
 
 document {


### PR DESCRIPTION
`X >> Y := f` parses as `X >> (Y := f)` due to precedence.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
