### PR TITLE
needs and needsPackage updates

### DIFF
--- a/M2/Macaulay2/d/stdiop.d
+++ b/M2/Macaulay2/d/stdiop.d
@@ -81,6 +81,7 @@ export relativizeFilename(filename:string):string := (
      r := getcwd();
      if length(r) == 0 then filename else relativizeFilename(r,filename));
 export minimizeFilename(filename:string):string := (
+     filename = expandFileName(filename);
      a := relativizeFilename(filename);
      b := absoluteFilename(filename);
      c := if length(a) <= length(b) then a else b;

--- a/M2/Macaulay2/m2/Core.m2
+++ b/M2/Macaulay2/m2/Core.m2
@@ -112,9 +112,15 @@ loadPath := (path, filename, loadfun, notify) -> (
 
 load  = filename -> (loadPath(path, filename, simpleLoad, notify);)
 input = filename -> (loadPath(path, filename, simpleInput, false);)
-needs = filename -> if not filesLoaded#?filename then load filename else (
-     (filepath, filetime) := filesLoaded#filename;
-     if filetime < fileTime filepath then load filepath)
+
+simpleNeeds = filename -> (
+    filename = realpath toAbsolutePath filename;
+    if not filesLoaded#?filename
+    then simpleLoad filename
+    else (
+	if filesLoaded#filename < fileTime filename
+	then simpleLoad filename))
+needs = filename -> (loadPath(path, filename, simpleNeeds, notify);)
 
 -----------------------------------------------------------------------------
 -- Setup persistent history

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -54,16 +54,16 @@ if firstTime then (
      restarted = false;
      srcdirs = {};
 
-     markLoaded = (filename, filepath, filetime, notify) -> (
-	 filepath = minimizeFilename filepath;
-	 filesLoaded#filename = (filepath, filetime);
-	 loadedFiles##loadedFiles = realpath toAbsolutePath filepath;
+     markLoaded = (filepath, filetime, notify) -> (
+	 filepath = realpath toAbsolutePath filepath;
+	 filesLoaded#filepath = filetime;
+	 loadedFiles##loadedFiles = filepath;
 	 if notify then printerr("loaded ", filepath));
      tryLoad = (filename, filepath, loadfun, notify) -> if fileExists filepath then (
 	 filetime := fileTime filepath;
 	 if notify then printerr("loading ", filename);
 	 ret := loadfun filepath;
-	 markLoaded(filename, filepath, filetime, notify);
+	 markLoaded(filepath, filetime, notify);
 	 (true, ret)) else (false, null);
      trySimpleLoad := (filename, filepath) -> first tryLoad(filename, filepath, simpleLoad, notify);
 


### PR DESCRIPTION
Several related changes:

* `minimizeFilename` now expands `~` before minimizing
* We update `needs` so that it checks for files in the same way as `load` and `input`, i.e., it searches through the various directories in `path` and loads the first hit, but only if it's been modified since the last load or has never been loaded.  So for example, if we call `needs "foo.m2"` and then later create another `foo.m2` somewhere earlier in `path`, the newer `foo.m2` is loaded.  Previously, we would have just checked to see if the original `foo.m2` needed reloading.  I believe this fixes [#2413](https://github.com/Macaulay2/M2/issues/2413).
* `needsPackage` now checks whether any of the files in a previously-loaded package have been updated, and if so, reloads the package, as requested in [#3225](https://github.com/Macaulay2/M2/issues/3225).

