### PR TITLE
Add threadLock keyword -- locks mutex, evals code, then unlocks

### DIFF
--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -318,6 +318,7 @@ bumpPrecedence();
      export breakpointS    := special("breakpoint",    unaryop, precSpace, wide);
      export profileS       := special("profile",       unaryop, precSpace, wide);
      export shieldS        := special("shield",        unaryop, precSpace, wide);
+     export threadLockS    := special("threadLock",    unaryop, precSpace, wide);
      export throwS         := special("throw",        nunaryop, precSpace, wide);
      export returnS        := special("return",       nunaryop, precSpace, wide);
      export breakS         := special("break",        nunaryop, precSpace, wide);

--- a/M2/Macaulay2/d/pthread0.d
+++ b/M2/Macaulay2/d/pthread0.d
@@ -30,6 +30,7 @@ export SpinLock := atomicType "struct spinlockStructure";
 export init(x:ThreadMutex) ::= Ccode(int, "pthread_mutex_init(&(",lvalue(x),"),NULL)");
 export destroy(x:ThreadMutex) ::= Ccode(int, "pthread_mutex_destroy(&(",lvalue(x),"))");
 export lock(x:ThreadMutex) ::= Ccode(int, "pthread_mutex_lock(&(",lvalue(x),"))");
+export trylock(x:ThreadMutex) ::= Ccode(int, "pthread_mutex_trylock(&(",lvalue(x),"))");
 export unlock(x:ThreadMutex) ::= Ccode(int, "pthread_mutex_unlock(&(",lvalue(x),"))");
 export getthreadself() ::= Ccode(Thread, "pthread_self()");
 

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1203,6 +1203,7 @@ export {
 	"texMath",
 	"then",
 	"threadLocal",
+	"threadLock",
 	"throw",
 	"time",
 	"times",

--- a/M2/Macaulay2/tests/normal/threads.m2
+++ b/M2/Macaulay2/tests/normal/threads.m2
@@ -85,6 +85,13 @@ assert Equation(getIOThreadMode f, 2)
 
 removeFile fn
 
+-- threadLock
+-- mutable lists are *not* thread safe
+-- if they ever become thread safe, then change this test
+x = new MutableList
+taskResult \ apply(1000, i -> schedule(() -> threadLock x##x = null));
+assert Equation(#x, 1000)
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test threads.out"
 -- End:


### PR DESCRIPTION
We add a `threadLock` keyword as suggested in https://github.com/Macaulay2/M2/pull/3739#issuecomment-2816776740 to  help write thread-safe code.  For example:

```m2
i1 : x = new MutableList;

i2 : y = new MutableList;

i3 : scan(1000, i -> schedule(() -> (x##x = null; threadLock y##y = null)))

i4 : #x

o4 = 180

i5 : #y

o5 = 1000
```

### TODO:
- [ ] Add documentation
- [ ] Deal with any potential issues (e.g., what happens if we cancel a task that locked the mutex before it unlocks it?)