### PR TITLE
Msolve parser fix

### DIFF
--- a/M2/Macaulay2/e/BasicPoly.cpp
+++ b/M2/Macaulay2/e/BasicPoly.cpp
@@ -2,6 +2,14 @@
 #include "gb-f4/MonomialView.hpp"
 #include <sstream>
 
+void BasicPoly::clear()
+{
+  for (mpz_t& num : mCoefficients) 
+    mpz_clear(num);  
+  mCoefficients.clear();
+  mComponents.clear();
+  mMonomials.clear();
+}
 std::string BasicPoly::toString(const std::vector<std::string> & varnames,
                                 bool print_one,
                                 bool print_plus,

--- a/M2/Macaulay2/e/BasicPoly.cpp
+++ b/M2/Macaulay2/e/BasicPoly.cpp
@@ -4,8 +4,8 @@
 
 void BasicPoly::clear()
 {
-  for (mpz_t& num : mCoefficients) 
-    mpz_clear(num);  
+  // for (auto& num : mCoefficients) 
+  //   mpz_clear(num);  
   mCoefficients.clear();
   mComponents.clear();
   mMonomials.clear();

--- a/M2/Macaulay2/e/BasicPoly.hpp
+++ b/M2/Macaulay2/e/BasicPoly.hpp
@@ -12,9 +12,12 @@
 class BasicPoly
 {
 public:
-  std::vector<int> mCoefficients;
+  std::vector<mpz_t> mCoefficients;
   std::vector<int> mComponents; // if zero length: all components are 0.
   std::vector<int> mMonomials; // a concatenated list of varpower monomials.  Each first entry is its length.
+
+  void clear(); // resets all data to represent the zero polynomial
+  ~BasicPoly() { clear(); }
   
   size_t termCount() const { return mCoefficients.size(); } 
   void debug_display(std::ostream& o) const;

--- a/M2/Macaulay2/e/BasicPoly.hpp
+++ b/M2/Macaulay2/e/BasicPoly.hpp
@@ -8,11 +8,12 @@
 #include <iosfwd>
 #include <string>
 #include <unordered_map>
-  
+#include <gmpxx.h>
+
 class BasicPoly
 {
 public:
-  std::vector<mpz_t> mCoefficients;
+  std::vector<mpz_class> mCoefficients;
   std::vector<int> mComponents; // if zero length: all components are 0.
   std::vector<int> mMonomials; // a concatenated list of varpower monomials.  Each first entry is its length.
 

--- a/M2/Macaulay2/e/BasicPolyList.cpp
+++ b/M2/Macaulay2/e/BasicPolyList.cpp
@@ -40,7 +40,7 @@ void BasicPolyListStreamCollector::appendExponent(VarIndex index, Exponent expon
   mValue[mCurrentPoly].mMonomials[mSizeEntryInMonomial] += 2;
 }
 
-void BasicPolyListStreamCollector::appendTermDone(Coefficient coefficient)
+void BasicPolyListStreamCollector::appendTermDone(const Coefficient& coefficient)
 {
   mValue[mCurrentPoly].mCoefficients[mCurrentTerm] = coefficient;
 }

--- a/M2/Macaulay2/e/BasicPolyList.hpp
+++ b/M2/Macaulay2/e/BasicPolyList.hpp
@@ -25,16 +25,17 @@ long bytesUsed(const BasicPolyList& F);
 class BasicPolyListStreamCollector
 {
 public:
-  using Coefficient = int32_t;
+  using Coefficient = mpz_class;
   using VarIndex = int32_t; // TODO: these must match BasicPoly above.
   using Exponent = int32_t;
   using Component = int32_t;
+  using ModulusType = int32_t;
 private:
   BasicPolyList mValue;
 
   // We store these, as we need to be able to respond to what they are,
   // but we don't use them here at all.
-  Coefficient mModulus;
+  ModulusType mModulus;
   VarIndex mVarCount;
   Component mComCount;
 
@@ -56,7 +57,7 @@ public:
 
   // Fields required for the general stream interface (see mathicgb::mathicgb.h)
   
-  Coefficient modulus() const { return mModulus; }
+  ModulusType modulus() const { return mModulus; }
   VarIndex varCount() const { return mVarCount; }
   Component comCount() const { return mComCount; }
 
@@ -64,7 +65,7 @@ public:
   void appendPolynomialBegin(size_t termCount);
   void appendTermBegin(Component com);
   void appendExponent(VarIndex index, Exponent exponent);
-  void appendTermDone(Coefficient coefficient);
+  void appendTermDone(const Coefficient& coefficient);
   void appendPolynomialDone();
   void idealDone();
 };

--- a/M2/Macaulay2/e/BasicPolyListParser.cpp
+++ b/M2/Macaulay2/e/BasicPolyListParser.cpp
@@ -59,20 +59,38 @@ long readInteger_long(const std::string_view& str, size_t& begin_loc, size_t end
 }
 
 // allocates memory to (and inits) an __mpz_struct
-void readInteger_mpz_t(mpz_t& result, const std::string_view& str, size_t& begin_loc, size_t end_loc)
+// void readInteger_mpz_t(mpz_t& result, const std::string_view& str, size_t& begin_loc, size_t end_loc)
+// {
+//   // if str[0] is a digit, find the value, and increment str past the number.
+//   // if it is not: return 1, leave str unchanged.
+//   if (not isdigit(str[begin_loc])) return mpz_set_ui(result,1);
+//   mpz_set_ui(result, 0);
+//   size_t loc = begin_loc;
+//   while (loc < end_loc and isdigit(str[loc]))
+//     {
+//       mpz_mul_ui(result, result, 10);
+//       mpz_add_ui(result, result, (str[loc] - '0'));
+//       loc++;
+//     }
+//   begin_loc = loc;
+// }
+
+mpz_class readInteger_mpz_class(const std::string_view& str, size_t& begin_loc, size_t end_loc)
 {
   // if str[0] is a digit, find the value, and increment str past the number.
   // if it is not: return 1, leave str unchanged.
-  if (not isdigit(str[begin_loc])) return 1;
-  mpz_set_ui(result, 0);
+  mpz_class result;
+  if (not isdigit(str[begin_loc])) return result = 1;
+  result = 0;
   size_t loc = begin_loc;
   while (loc < end_loc and isdigit(str[loc]))
     {
-      mpz_mul_ui(result, result, 10);
-      mpz_add_ui(result, result, (str[loc] - '0'));
+      result *= 10;
+      result += str[loc] - '0';
       loc++;
     }
   begin_loc = loc;
+  return result;
 }
 
 int readIdentifier(const std::string_view& str, const IdentifierHash& map, size_t& begin_loc, size_t end_loc)
@@ -149,11 +167,9 @@ void parseBasicPoly(const std::string_view& str, const IdentifierHash& idenHash,
           ++begin_loc;
           sign = -1;
         }
-      mpz_t coeff;
-      mpz_init(coeff);
-      readInteger_mpz_t(coeff, str, begin_loc, end_loc); // defaults to 1 if no integer present.
+      mpz_class coeff{readInteger_mpz_class(str, begin_loc, end_loc)}; // defaults to 1 if no integer present.
 
-      if (sign == -1) mpz_neg(coeff,coeff);
+      if (sign == -1) coeff = -coeff;
       result.mCoefficients.push_back(coeff); // do not clear(coeff) !
 
       // Now we read the monomial part.

--- a/M2/Macaulay2/e/VectorArithmetic.hpp
+++ b/M2/Macaulay2/e/VectorArithmetic.hpp
@@ -384,6 +384,19 @@ public:
     return sparse;
   }
 
+  template<typename Container>
+  ElementArray elementArrayFromContainerOf_mpz_class(const Container& c) const
+  {
+    ElementArray sparse = allocateElementArray(c.size()); // initializes all elements
+    auto& svec = * elementArray(sparse); 
+    for (auto i = 0; i < c.size(); ++i)
+    {
+      __mpz_struct* x = const_cast<__mpz_struct*>(c[i].get_mpz_t());
+      mRing->set_from_mpz(svec[i], x);
+    }
+    return sparse;
+  }
+
   ring_elem ringElemFromElementArray(const ElementArray& sparse,
                                      int index) const
   {
@@ -762,6 +775,11 @@ public:
     return std::visit([&](auto& arg) -> ElementArray { return arg->template elementArrayFromContainerOfLongs<Container>(c); }, mConcreteVector);
   }
   
+  template<class Container>
+  ElementArray elementArrayFromContainerOf_mpz_class(const Container& c) const {
+    return std::visit([&](auto& arg) -> ElementArray { return arg->template elementArrayFromContainerOf_mpz_class<Container>(c); }, mConcreteVector);
+  }
+
   ring_elem ringElemFromElementArray(const ElementArray& coeffs,
                                      int index) const {
     return std::visit([&](auto& arg) -> ring_elem { return arg->ringElemFromElementArray(coeffs,index); }, mConcreteVector);

--- a/M2/Macaulay2/e/coeffrings.hpp
+++ b/M2/Macaulay2/e/coeffrings.hpp
@@ -66,6 +66,15 @@ class CoefficientRingZZp : public M2::SimpleARing<CoefficientRingZZp>
     if (a < 0) a += p;
     result = log_table[a];
   }
+  
+  void set_from_mpz(elem &result, mpz_t a) const
+  {
+    mpz_t tmp;
+    mpz_init_set_si(tmp, p);        // Convert int p to mpz_t
+    mpz_mod(a, a, tmp);             // a = a mod p (always non-negative)
+    mpz_clear(tmp);
+    result = log_table[mpz_get_si(a)];
+  }
 
   long coerceToLongInteger(const elem &f) const
   {
@@ -226,6 +235,7 @@ class CoefficientRingR
   void set_zero(elem &result) const { result = R->zero(); }
   void set(elem &result, elem a) const { result = a; }
   void set_from_long(elem &result, long a) const { result = R->from_long(a); }
+  void set_from_mpz(elem &result, mpz_t a) const { result = R->from_int(a); }
   bool is_zero(elem result) const { return R->is_zero(result); }
   bool is_equal(elem a, elem b) const { return R->is_equal(a, b); }
   bool is_unit(elem f) const { return R->is_unit(f); }

--- a/M2/Macaulay2/e/gb-f4/PolynomialList.cpp
+++ b/M2/Macaulay2/e/gb-f4/PolynomialList.cpp
@@ -44,7 +44,7 @@ void PolynomialListStreamCollector::appendTermDone(Coefficient coefficient)
 
 void PolynomialListStreamCollector::appendPolynomialDone()
 {
-  mValue[mCurrentPoly].mCoefficients = mValue.vectorArithmetic().elementArrayFromContainerOfLongs(mCoefficients);
+  mValue[mCurrentPoly].mCoefficients = mValue.vectorArithmetic().elementArrayFromContainerOf_mpz_class(mCoefficients);
   if (mCurrentTerm != mValue[mCurrentPoly].mComponents.size() - 1)
     throw exc::engine_error("internal error: building PolyList from stream has incorrect number of terms in a polynomial");
 }

--- a/M2/Macaulay2/e/matrix-stream.cpp
+++ b/M2/Macaulay2/e/matrix-stream.cpp
@@ -43,7 +43,7 @@ void MatrixStream::appendTermDone(Coefficient coefficient)
   // Now we need to create an Nterm, and attach it at mCurrentComponent
   Nterm* t = ring().new_term();
   ring().getMonoid()->from_expvector(mCurrentExponents, t->monom);
-  t->coeff = ring().getCoefficients()->from_long(coefficient);
+  t->coeff = ring().getCoefficients()->from_int(coefficient.get_mpz_t());
   t->next = nullptr;
   if (mLastTerms[mCurrentComponent] == nullptr)
     {

--- a/M2/Macaulay2/e/matrix-stream.hpp
+++ b/M2/Macaulay2/e/matrix-stream.hpp
@@ -6,6 +6,7 @@
 #include "poly.hpp"
 #include "matrix.hpp"
 #include "matrix-con.hpp"
+#include <gmpxx.h>
 
 #if 0
 // Example of the calls used to create an ideal (one rowed matrix), over a poly ring
@@ -44,7 +45,7 @@ class MatrixStream
   }  // This will return null before idealDone() is called.
 
   // Fields required for the general stream interface (see mathicgb::mathicgb.h)
-  typedef int Coefficient;
+  using Coefficient = mpz_class;
   // typedef long Coefficient;
   // typedef size_t VarIndex;
   typedef int VarIndex;

--- a/M2/Macaulay2/packages/Msolve/tests.m2
+++ b/M2/Macaulay2/packages/Msolve/tests.m2
@@ -106,9 +106,7 @@ TEST ///
 ///
 
 TEST ///
-  --restart
   debugLevel=1
-  needsPackage "Msolve";
   R = QQ[x..z,t]
   K = ideal(x^6+y^6+x^4*z*t+z^3,36*x^5+60*y^5+24*x^3*z*t,
       -84*x^5+10*x^4*t-56*x^3*z*t+30*z^2,-84*y^5-6*x^4*t-18*z^2,
@@ -116,9 +114,18 @@ TEST ///
   errorDepth=2
   W1 = msolveEliminate(R_0, K, Verbosity => 1)
   W2 = eliminate(R_0, K)
-  sub(W1, R) == W2
+  assert(sub(W1, R) == W2)
 ///
 
+/// 
+kk = QQ
+R1 = kk[a..f, MonomialSize=>8];
+setRandomSeed 42
+J1 = ideal random(R1^1, R1^{-2,-2,-3,-3}, Height=>100);
+elapsedTime gbC = flatten entries gens (G = gb(ideal J1_*));
+gbMsolve = flatten entries msolveGB ideal J1_*;
+assert(gbC == gbMsolve)
+///
 end
 
 restart


### PR DESCRIPTION
Fixed the parser for `msolve` output.
Note:
* we replace `int` with `mpz_t` and `mpz_class` where appropriate
* this change affects the classes used by `mathicgb` (but we have no issues so far)
 