### PR TITLE
Set googletest to version 1.16.0

### DIFF
--- a/M2/libraries/gtest/Makefile.in
+++ b/M2/libraries/gtest/Makefile.in
@@ -1,11 +1,9 @@
-# from https://github.com/google/googletest/archive/release-1.8.0.tar.gz, renamed to gtest-1.8.0.tar.gz
 SUBMODULE = true
 LIBNAME = googletest
-VERSION = 1.11.0
+VERSION = 1.16.0
 CONFIGURECMD = cmake . -DCMAKE_INSTALL_PREFIX=$(PREFIX) -DBUILD_GMOCK=OFF
 
 LICENSEFILES = LICENSE
-URL = https://macaulay2.com/Downloads/OtherSourceCode
 MLIMIT = 1400000
 VLIMIT = 1400000
 TLIMIT = 400


### PR DESCRIPTION
We're currently using a commit a little between 1.16 and the just-released 1.17.  googletest 1.17 (and the commit we're currently using) requires compiling with C++17 support.  This is currently an issue on systems like RHEL where we need to build googletest.

Eventually, we should add support for 1.17 by compiling with C++17 support in memtailor/mathic/mathicgb, but it would probably be best to deal with this after the 1.25.05 release.

This commit is cherry-picked from #3683, but I'd like to make sure it gets into the release for the sake of the RHEL builds (see https://github.com/d-torrance/M2-workflows/actions/runs/14789884670).

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
