### PR TITLE
fix set Set, add toList Tally

### DIFF
--- a/M2/Macaulay2/d/sets.dd
+++ b/M2/Macaulay2/d/sets.dd
@@ -19,6 +19,7 @@ makeSet(e:Expr):Expr := (
      is v:Sequence do makeSet(v)
      is w:List do if ancestor(w.Class,visibleListClass) then makeSet(w.v)
      else WrongArg("a visible list")
+     is h:HashTable do makeSet(keys(h))
      else WrongArg("a visible list"));
 setupfun("set",makeSet);
 

--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -15,7 +15,7 @@ tally String      :=
 tally VisibleList := Tally => tally
 
 elements = method()
-elements Tally := x -> splice apply(pairs x, (k,v) -> v:k)
+elements Tally := toList Tally := x -> splice apply(pairs x, (k,v) -> v:k)
 
 toString VirtualTally := x -> concatenate( "new ", toString class x, " from {", demark(", ", sort apply(pairs x, (v,i) -> (toString v, " => ", toString i))), "}" )
 
@@ -85,7 +85,6 @@ Set.synonym = "set"
 -- constructors, both compiled functions defined in d/sets.dd
 set VisibleList := Set => set
 new Set from List := Set => (X,x) -> set x
-set Set := identity
 
 -- set operations
 elements Set := List => keys

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
@@ -1,6 +1,5 @@
 undocumented {
     (NewFromMethod, Set, List),
-    (set, Set)
 }
 
 document {


### PR DESCRIPTION
this is another (minor) fix of [#3574](https://github.com/Macaulay2/M2/pull/3574): the definition of `set Set` didn't work since `set` is defined at d level.
Instead we let `set` be equivalent to `keys` on hash tables. We also add a missing `toList Tally`.
