### PR TITLE
Use quotes when linking to oo, ooo, and ooo doc nodes

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_first_session.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_first_session.m2
@@ -49,12 +49,12 @@ Node
     Example
       4*5;
     Text
-      The output from the previous line can be obtained with @TO oo@, even if a semicolon prevented it
+      The output from the previous line can be obtained with @TO "oo"@, even if a semicolon prevented it
       from being printed.
     Example
       oo
     Text
-      Lines before that can be obtained with @TO ooo@ and @TO oooo@. Alternatively, the symbol labeling an
+      Lines before that can be obtained with @TO "ooo"@ and @TO "oooo"@. Alternatively, the symbol labeling an
       output line can be used to retrieve the value, as in the following example.
     Example
       o5 + 1


### PR DESCRIPTION
Otherwise, we may try to evaluate them and link to a nonexistent node.

Fixes #3764 using @mahrud's diff from https://github.com/Macaulay2/M2/issues/3764#issuecomment-2847820029.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
