### PR TITLE
Error reporting fixes

### DIFF
--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -171,7 +171,10 @@ sequenceMethods := (T, F, tallyF) -> nonnull apply(pairs T, (key, func) -> if in
 -- Note: even though HypertextContainer is not an exported type,
 -- but (net, HypertextContainer) is callable through `net help()`
 -- However, (editMethod, String) is not callable as a method.
-isCallable = key -> all(key, e -> instance(e, Type) or isPackageLoaded toString package' e)
+isCallable = key -> all(key, e -> instance(e, Type)
+    or isBinaryAssignmentOperator e
+    or  isUnaryAssignmentOperator e
+    or isPackageLoaded toString package' e)
 
 methods = method(Dispatch => Thing, TypicalValue => NumberedVerticalList)
 methods Manipulator := M -> methods class M

--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -233,8 +233,14 @@ generateAssertions List := y -> (
 	       else lin
 	       )))^-1
 
+-----------------------------------------------------------------------------
+-- FilePosition and currentPosition
+-----------------------------------------------------------------------------
+
 -- FilePosition = new Type of BasicList -- defined in d
 FilePosition.synonym = "file position"
+
+-- TODO: add FilePosition(String, ZZ, ZZ) and FilePosition(String)
 toExternalString FilePosition :=
 toString FilePosition :=
 net FilePosition := p -> concatenate(
@@ -243,7 +249,15 @@ net FilePosition := p -> concatenate(
     if #p>3 then ("-",toString p#3,":",toString p#4),
 --    if #p>5 then (" (",toString p#5,":",toString p#6,")")
     )
+
+String | FilePosition := (s, p) -> s | toString p
+FilePosition | String := (p, s) -> toString p | s
+
 currentPosition = () -> new FilePosition from { currentFileName, currentRowNumber(), currentColumnNumber() }
+
+-----------------------------------------------------------------------------
+-- locate
+-----------------------------------------------------------------------------
 
 locate' = locate -- defined in d/actors4.d
 locate = method(Dispatch => Thing, TypicalValue => FilePosition)

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -773,7 +773,7 @@ installPackage Package := opts -> pkg -> (
 
 	if 0 < numExampleErrors then verboseLog stack apply(readDirectory exampleOutputDir,
 	    file -> if match("\\.errors$", file) then stack {
-		file, concatenate(width file : "*"), getErrors(exampleOutputDir | file)});
+		file, concatenate(width file : "="), getErrors(exampleOutputDir | file)});
 
 	if not opts.IgnoreExampleErrors then checkForErrors pkg;
 

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -543,6 +543,8 @@ generateExampleResults := (pkg, rawDocumentationCache, exampleDir, exampleOutput
 	    toString cachehash);
 	samehash);
 
+    errorList := new MutableList;
+
     usermode := if opts.UserMode === null then not noinitfile else opts.UserMode;
     scan(pairs pkg#"example inputs", (fkey, inputs) -> (
 	    inpf  := inpfn  fkey; -- input file
@@ -568,8 +570,15 @@ generateExampleResults := (pkg, rawDocumentationCache, exampleDir, exampleOutput
 		desc, demark_newline inputs, pkg,
 		inpf, outf, errf, data,
 		inputhash, changeFunc fkey,
-		usermode) then (possiblyCache(outf, outf', fkey))();
+		usermode) then (possiblyCache(outf, outf', fkey))()
+	    else errorList##errorList = fkey;
 	    storeExampleOutput(pkg, fkey, outf, verboseLog)));
+
+    if #errorList > 0 then (
+	stderr << concatenate(printWidth:"=") << endl;
+	printerr("Summary: ", toString(#errorList), " example(s) failed in package ", pkg#"pkgname", ":");
+	printerr netList(Boxes => false, HorizontalSpace => 2,
+	    apply(toList errorList, fkey -> { fkey, locate makeDocumentTag fkey })));
 
     -- check for obsolete example output files and remove them
     if chkdoc then (

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -153,7 +153,7 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
      -- print debugging info
      printerr "running failed";
      printerr("error log:  " | logLocation tmpf);
-     printerr("test input: " | testLocation inf);
+     printerr("input code: " | testLocation inf);
      if debugLevel > 0 then
      stderr << commentize "full command:" << endl << cmd << endl;
      stderr << pad("*** error: M2 " | describeReturnCode r, printWidth - 32) << flush;

--- a/M2/Macaulay2/m2/run.m2
+++ b/M2/Macaulay2/m2/run.m2
@@ -149,8 +149,9 @@ runFile = (inf, inputhash, outf, tmpf, pkg, announcechange, usermode, examplefil
 	  moveFile(tmpf,outf);
 	  return true;
 	  );
+     if gotarg "--check" then if r // 255 == 2 then exit 1 else return false;
      -- print debugging info
-     printerr "running failed, too!";
+     printerr "running failed";
      printerr("error log:  " | logLocation tmpf);
      printerr("test input: " | testLocation inf);
      if debugLevel > 0 then

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -113,10 +113,13 @@ check(List, Package) := opts -> (L, pkg) -> (
     outfile := errfile -> temporaryDirectory() | errfile | ".tmp";
     if #errorList > 0 then (
 	if opts.Verbose then apply(errorList, (k, errfile) -> (
+		stderr << concatenate(printWidth:"=") << endl;
 		stderr << locate inputs#k << " error:" << endl;
 		printerr getErrors(outfile errfile)));
+	stderr << concatenate(printWidth:"=") << endl;
 	printerr("Summary: ", toString(#errorList), " test(s) failed in package ", pkg#"pkgname", ":");
-	printerr net TABLE apply(first \ errorList, i -> { "Test #"|i|".", toString locate tests_i pkg });
+	printerr netList(Boxes => false, HorizontalSpace => 2,
+	    apply(first \ errorList, i -> { "Test #"|i|".", toString locate tests_i pkg }));
 	error("repeat failed tests with:", newline,
 	    "  check({", demark(", ", toString \ first \ errorList), "}, ", format pkg#"pkgname", ")")))
 

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -122,7 +122,7 @@ checkAllPackages = () -> (
     argumentMode = defaultMode - SetCaptureErr - SetUlimit -
 	if noinitfile then 0 else ArgQ;
     fails := for pkg in sort separate(" ", version#"packages") list (
-	stderr << HEADER1 pkg << endl;
+	stderr << HEADER2 pkg << endl;
 	if runString("check(" | format pkg | ", Verbose => true)",
 	    Core, false) then continue else pkg) do stderr << endl;
     argumentMode = tmp;

--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -27,7 +27,7 @@ addTest(String, FilePosition) := (str, loc) -> (
     n := #currentPackage#"test inputs";
     currentPackage#"test inputs"#n = TestInput {
 	"location" => loc,
-	"code" => str})
+	"code" => concatenate("-- test source: ", toString loc, newline, str)})
 -- the following is not called by TEST, but called directly when we want to
 -- add a test from a file (used by loadTestDir)
 addTest String := filename -> addTest(get filename,
@@ -115,7 +115,10 @@ check(List, Package) := opts -> (L, pkg) -> (
 	if opts.Verbose then apply(errorList, (k, errfile) -> (
 		stderr << locate inputs#k << " error:" << endl;
 		printerr getErrors(outfile errfile)));
-	error("test(s) #", demark(", ", toString \ first \ errorList), " of package ", toString pkg, " failed.")))
+	printerr("Summary: ", toString(#errorList), " test(s) failed in package ", pkg#"pkgname", ":");
+	printerr net TABLE apply(first \ errorList, i -> { "Test #"|i|".", toString locate tests_i pkg });
+	error("repeat failed tests with:", newline,
+	    "  check({", demark(", ", toString \ first \ errorList), "}, ", format pkg#"pkgname", ")")))
 
 checkAllPackages = () -> (
     tmp := argumentMode;

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
@@ -396,6 +396,6 @@ Node
       TABLE {
 	  { M2CODE "loadedPackages",                            "-- a list of the currently loaded packages" },
 	  { M2CODE "help \"packages provided with Macaulay2\"", "-- a list of all the available packages" },
-	  { M2CODE "help \"initialization file \"",             "-- show documentation about the file init.m2" }
+	  { M2CODE "help \"initialization file\"",              "-- show documentation about the file init.m2" }
       }
 ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_debugging.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_debugging.m2
@@ -358,7 +358,6 @@ document {
      SeeAlso => { "recursionLimit" }
      }
 
-
 document {
      Key => FilePosition,
      Headline => "the class of all file positions",
@@ -369,6 +368,10 @@ document {
      A single pair is a position, two form a range. The last pair is the central point of interest in that range."
      }
 
+undocumented {
+    (symbol |, FilePosition, String),
+    (symbol |, String, FilePosition),
+}
 
 document {
      Key => uncurry,

--- a/M2/Macaulay2/packages/Saturation/saturate-doc.m2
+++ b/M2/Macaulay2/packages/Saturation/saturate-doc.m2
@@ -116,8 +116,8 @@ Node
   Usage
     isSupportedInZeroLocus_B M
   Inputs
-    M:Module
     B:Ideal
+    M:{Ideal,Module,GradedModule}
   Outputs
     :Boolean
       true if $M$ (or $R^1/I$, if an ideal of $R$ is given) is supported only on the zero locus of $B$;
@@ -125,7 +125,7 @@ Node
   Description
     Text
       Given an module $M$ and an ideal $B$, {\tt isSupportedInZeroLocus} checks whether $\mathrm{ann}(M):B^\infty=R$.
-      If it is, {\tt isSupportedInZeroLocus} returns true otherwise it returns false. If the first argument is an ideal,
+      If it is, {\tt isSupportedInZeroLocus} returns true otherwise it returns false. If the second argument is an ideal,
       $M = R^1/I$ is taken as the module.
     Example
       S = ZZ/32003[x_0..x_4, Degrees=>{2:{1,0}, 3:{0,1}}];

--- a/M2/Macaulay2/packages/SimpleDoc.m2
+++ b/M2/Macaulay2/packages/SimpleDoc.m2
@@ -16,6 +16,13 @@ newPackage(
     AuxiliaryFiles => true
     )
 
+-- TODO: a typo under SubNodes produces an error with unhelpful location:
+-- Macaulay2Doc.m2:30:10:(3):[8]: error: global symbols inadvertently defined by package Macaulay2Doc: 'blah'
+-- currentString:1:0-1:10: here is the first use of 'blah'
+
+-- similarly a broken link like @TO blah@ produces the following:
+-- error: documentation key for "resolution(Complex)" encountered at currentString:2:0 but no method installed
+
 export {"doc", "multidoc", "packageTemplate", -- functions
     "arXiv", "stacksProject", "wikipedia", -- helper functions
     "docTemplate", "docExample", "testExample", "simpleDocFrob" -- templates and examples

--- a/M2/Macaulay2/tests/normal/testing.m2
+++ b/M2/Macaulay2/tests/normal/testing.m2
@@ -8,7 +8,9 @@ check "TestPackage"
 pkgtest = tests(0, "TestPackage")
 assert instance(pkgtest, TestInput)
 assert Equation(toSequence locate pkgtest, (testpkg, 3, 5, 3, 32, 3, 5))
-assert Equation(toString pkgtest, "assert Equation(1 + 1, 2)")
+assert Equation(toString pkgtest, concatenate(
+	"-- test source: ", toString locate pkgtest, newline,
+	"assert Equation(1 + 1, 2)"))
 assert Equation(net pkgtest, "TestInput[" | testpkg | ":3:5-3:32]")
 beginDocumentation()
 expectedCode = DIV{


### PR DESCRIPTION
These are a few cosmetic fixes for how errors are reported. One non-cosmetic change is that C^c C^c now interrupts `check` again.

- **replaced * with = in non-error printouts**
- **improved error reporting missing methods in documents**
- **updated check and runFile**