### PR TITLE
Make startup banner webapp-friendly

### DIFF
--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -55,7 +55,7 @@ addStartFunction( () -> (
 addStartFunction( () -> (
 	  if not nobanner then (
 	       if topLevelMode === TeXmacs then stderr << TeXmacsBegin << "verbatim:";
-	       stderr << "Type `help` to see useful commands" << endl;
+	       print SPAN("Type ", KBD M2CODE "help", " to see useful commands");
 	       if topLevelMode === TeXmacs then stderr << TeXmacsEnd << flush;
 	       );
 	  )


### PR DESCRIPTION
We use `print` instead of writing to stderr to take advantage of webapp mode's custom `print` function, which calls `html`.

The word "help" is wrapped inside `KBD M2CODE` so that it is:

* quoted when using the standard top level mode (thanks to `KBD`)
* made clickable and syntax-highlighted in webapp mode (thanks to `M2CODE`)

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
