### PR TITLE
SLP expressions abbreviate printing

### DIFF
--- a/M2/Macaulay2/packages/SLPexpressions.m2
+++ b/M2/Macaulay2/packages/SLPexpressions.m2
@@ -903,12 +903,12 @@ expression DetGate := g -> (expression det) eGM g.Inputs
 printLargeGate = g -> VerticalList { class g, "depth"=>depth g, "#gates"=> countGates g }
 net Gate := g -> (
     n := net expression g;
-    if depth g > 5 and width n <= printWidth and height n <= printWidth then n
+    if depth g < 6 and width n <= printWidth and height n <= printWidth then n
     else net printLargeGate g
     )
 html Gate := g -> (
     e := expression g;
-    html if depth g > 5 and width net e <= printWidth then e else printLargeGate g
+    html if depth g < 6 and width net e <= printWidth then e else printLargeGate g
     )
 
 beginDocumentation()

--- a/M2/Macaulay2/packages/SLPexpressions.m2
+++ b/M2/Macaulay2/packages/SLPexpressions.m2
@@ -282,6 +282,11 @@ countGates GateMatrix := M -> (
     scan(flatten entries M, g->findTally(g,t));
     new HashTable from t
     ) 
+countGates Gate := g -> (
+    t := new MutableHashTable from {cache=>new CacheTable};
+    findTally(g,t);
+    new HashTable from t
+    ) 
 
 findTally = method()
 findTally (InputGate,MutableHashTable) := (g,t) -> if t.cache#?g then t.cache#g = t.cache#g+1 else (
@@ -883,6 +888,28 @@ GY = value(diff(Y,G),h)
 FY = value(diff(Y,F),h)
 assert ( value(compress diff(Y,G/F), h) == (GY*value(F,h) - value(G,h)*FY)/(value(F,h))^2 )
 ///
+
+
+------------------------
+-- expression, net, html
+expression InputGate := g -> expression g.Name
+expression SumGate := g -> Parenthesize sum(g.Inputs,expression)
+expression ProductGate := g -> Parenthesize product(g.Inputs,expression)
+expression DivideGate := g -> expression g.Inputs#0 / expression g.Inputs#1
+html GateMatrix := html @@ expression
+eGM:=
+expression GateMatrix := g -> new MatrixExpression from applyTable(g,expression)
+expression DetGate := g -> (expression det) eGM g.Inputs
+printLargeGate = g -> VerticalList { class g, "depth"=>depth g, "#gates"=> countGates g }
+net Gate := g -> (
+    n := net expression g;
+    if width n <= printWidth and height n <= printWidth then n
+    else net printLargeGate g
+    )
+html Gate := g -> (
+    e := expression g;
+    html if width net e <= printWidth then e else printLargeGate g
+    )
 
 beginDocumentation()
 -* run

--- a/M2/Macaulay2/packages/SLPexpressions.m2
+++ b/M2/Macaulay2/packages/SLPexpressions.m2
@@ -903,12 +903,12 @@ expression DetGate := g -> (expression det) eGM g.Inputs
 printLargeGate = g -> VerticalList { class g, "depth"=>depth g, "#gates"=> countGates g }
 net Gate := g -> (
     n := net expression g;
-    if width n <= printWidth and height n <= printWidth then n
+    if depth g > 5 and width n <= printWidth and height n <= printWidth then n
     else net printLargeGate g
     )
 html Gate := g -> (
     e := expression g;
-    html if width net e <= printWidth then e else printLargeGate g
+    html if depth g > 5 and width net e <= printWidth then e else printLargeGate g
     )
 
 beginDocumentation()

--- a/M2/Macaulay2/packages/SLPexpressions/doc.m2
+++ b/M2/Macaulay2/packages/SLPexpressions/doc.m2
@@ -590,6 +590,7 @@ doc ///
 	(depth,ProductGate)
 	(depth,SumGate)
 	countGates
+	(countGates, Gate)
 	(countGates, GateMatrix)
     Usage
         d = depth g


### PR DESCRIPTION
These are minor changes to the way SLPexpressions are displayed following a discussion with @pzinn 
 sometime ago. Now there is a heuristic guess on how complex a `Gate` is --- only if it is not too complex it is printed fully.

(I've cherry-picked a branch that later accumulated more commits that are not relevant to this.)
 
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
