### PR TITLE
update package GeometricDecomposability; add package IntegerProgramming

### DIFF
--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -280,3 +280,4 @@ NumericalSemigroups
 IncidenceCorrespondenceCohomology
 ToricHigherDirectImages
 Brackets
+IntegerProgramming

--- a/M2/Macaulay2/packages/GeometricDecomposability.m2
+++ b/M2/Macaulay2/packages/GeometricDecomposability.m2
@@ -814,24 +814,24 @@ doc///
 
                         [CDSRVT] Mike Cummings, Sergio Da Silva, Jenna Rajchgot, and Adam Van Tuyl.
                         Geometric vertex decomposition and liaison for toric ideals of
-                        graphs. Algebr. Comb., 6(4):965--997, 2023.
+                        graphs. Algebr. Comb., 6 (2023), no. 4, 965--997.
 
                         [CVT] Mike Cummings and Adam Van Tuyl.
                         The GeometricDecomposability package for Macaulay2.
-                        Preprint, available at @arXiv "2211.02471"@, 2022.
+                        J. Softw. Algebra Geom., 14 (2024), no. 1, 41--50.
 
                         [DSH] Sergio Da Silva and Megumi Harada. Geometric vertex decomposition, Gröbner bases, and Frobenius 
                         splittings for regular nilpotent Hessenberg Varieties. 
                         Transform. Groups, 2023.
 
                         [KMY] Allen Knutson, Ezra Miller, and Alexander Yong. Gröbner geometry of vertex
-                        decompositions and of flagged tableaux. J. Reine Angew. Math. 630 (2009) 1–31.
+                        decompositions and of flagged tableaux. J. Reine Angew. Math. 630 (2009), 1–-31.
 
                         [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                         [SM] Hero Saremi and Amir Mafi. Unmixedness and arithmetic properties of
-                        matroidal ideals. Arch. Math. 114 (2020) 299–304.
+                        matroidal ideals. Arch. Math. 114 (2020), no. 3 299–-304.
 
                 Subnodes
                         CheckCM
@@ -914,7 +914,7 @@ doc///
 
 		References
 		        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                 SeeAlso
                         CheckUnmixed
@@ -971,7 +971,7 @@ doc///
 
                 References
 		        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                 SeeAlso
                         CheckUnmixed
@@ -1023,7 +1023,7 @@ doc///
                                 getGVDIdeal(I, {{"C", y}, {"N", s}})
                 References
 		        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                 SeeAlso
                         CheckUnmixed
@@ -1070,10 +1070,10 @@ doc///
 
 		References
                         [KMY] Allen Knutson, Ezra Miller, and Alexander Yong. Gröbner geometry of vertex
-                        decompositions and of flagged tableaux. J. Reine Angew. Math. 630 (2009) 1–31.
+                        decompositions and of flagged tableaux. J. Reine Angew. Math. 630 (2009), 1–-31.
 
                         [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 		SeeAlso
                         oneStepGVD
                         UniversalGB
@@ -1202,13 +1202,13 @@ doc///
 		References
                         [CDSRVT] Mike Cummings, Sergio Da Silva, Jenna Rajchgot, and Adam Van Tuyl.
                         Geometric vertex decomposition and liaison for toric ideals of
-                        graphs. To appear in Algebraic Combinatorics, preprint available at @arXiv "2207.06391"@ (2022).
+                        graphs. Algebr. Comb., 6 (2023), no. 4, 965--997.
 
                         [KMY] Allen Knutson, Ezra Miller, and Alexander Yong. Gröbner geometry of vertex
-                        decompositions and of flagged tableaux. J. Reine Angew. Math. 630 (2009) 1–31.
+                        decompositions and of flagged tableaux. J. Reine Angew. Math. 630 (2009), 1–-31.
 
-		        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                 SeeAlso
                         CheckCM
@@ -1264,7 +1264,7 @@ doc///
 				isLexCompatiblyGVD(I, {s,x,w,y,r,z}, Verbose=>true)
                 References
 		        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
 
                 SeeAlso
@@ -1306,8 +1306,8 @@ doc///
                                 I = ideal(x_1*x_3, x_1*x_4, x_1*x_5, x_2*x_3, x_2*x_4, x_2*x_5);
 				isUnmixed I
 		References
-		        [SM] Hero Saremi and Amir Mafi. Unmixedness and Arithmetic Properties of
-                        Matroidal Ideals. Arch. Math. 114 (2020) 299–304.
+		        [SM] Hero Saremi and Amir Mafi. Unmixedness and arithmetic properties of
+                        matroidal ideals. Arch. Math. 114 (2020), no. 3 299–-304.
                 SeeAlso
                         CheckUnmixed
                         isGVD
@@ -1361,7 +1361,7 @@ doc///
 
                 References
         	        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                 SeeAlso
                         CheckUnmixed
@@ -1464,13 +1464,13 @@ doc///
 		References
                         [CDSRVT] Mike Cummings, Sergio Da Silva, Jenna Rajchgot, and Adam Van Tuyl.
                         Geometric vertex decomposition and liaison for toric ideals of
-                        graphs. To appear in Algebraic Combinatorics, preprint available at @arXiv "2207.06391"@ (2022).
+                        graphs. Algebr. Comb., 6 (2023), no. 4, 965--997.
 
                         [KMY] Allen Knutson, Ezra Miller, and Alexander Yong. Gröbner geometry of vertex
-                        decompositions and of flagged tableaux. J. Reine Angew. Math. 630 (2009) 1–31.
+                        decompositions and of flagged tableaux. J. Reine Angew. Math. 630 (2009), 1–-31.
 
                         [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 		SeeAlso
                         CheckDegenerate
                         CheckUnmixed
@@ -1539,7 +1539,7 @@ doc///
 			        L_1 == oneStepGVDCyI(I, b) -- CyI is the second element in the list given by oneStepGVD
     	    	References
 		        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
                 SeeAlso
                         CheckUnmixed
                         getGVDIdeal
@@ -1602,7 +1602,7 @@ doc///
                                 L_2 == oneStepGVDNyI(I, b) -- NyI is the second element in the list given by oneStepGVD
 		References
 		        [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
 		SeeAlso
                         CheckUnmixed
@@ -1657,7 +1657,7 @@ doc///
 
                 References
                         [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                 SeeAlso
                         isGVD
@@ -1698,7 +1698,7 @@ doc///
 
                 References
                         [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                 SeeAlso
                         isWeaklyGVD
@@ -1752,8 +1752,8 @@ doc///
                         vertex decomposable, as not all of conditions in the definition were checked.
 
                 References
-                        [SM] Hero Saremi and Amir Mafi. Unmixedness and Arithmetic Properties of
-                        Matroidal Ideals. Arch. Math. 114 (2020) 299–304.
+                        [SM] Hero Saremi and Amir Mafi. Unmixedness and arithmetic properties of
+                        matroidal ideals. Arch. Math. 114 (2020), no. 3 299–-304.
 
                 SeeAlso
                         findLexCompatiblyGVDOrders
@@ -1792,7 +1792,7 @@ doc///
 
                 References
                         [KR] Patricia Klein and Jenna Rajchgot. Geometric vertex decomposition and
-                        liaison. Forum Math. Sigma, 9 (2021) e70:1-23.
+                        liaison. Forum Math. Sigma, 9 (2021) Paper No. e70, 23pp.
 
                 SeeAlso
                         CheckCM

--- a/M2/Macaulay2/packages/GeometricDecomposability.m2
+++ b/M2/Macaulay2/packages/GeometricDecomposability.m2
@@ -73,10 +73,9 @@ export {
 --------------------------------------------------------------------------------
 
 findLexCompatiblyGVDOrders = method(
-        TypicalValue => List, 
         Options => {CheckUnmixed => true}
         )
-findLexCompatiblyGVDOrders(Ideal) := opts -> I -> (
+findLexCompatiblyGVDOrders(Ideal) := List => opts -> I -> (
         if isGVDBaseCase I then (
                 return permutations gens ring I;
                 );
@@ -97,7 +96,6 @@ findLexCompatiblyGVDOrders(Ideal) := opts -> I -> (
 --------------------------------------------------------------------------------
 
 findOneStepGVD = method(
-        TypicalValue => List, 
         Options => {
                 CheckUnmixed => true, 
                 OnlyDegenerate => false,
@@ -107,7 +105,7 @@ findOneStepGVD = method(
                 Verbose => false
                 }
         )
-findOneStepGVD(Ideal) := opts -> I -> (
+findOneStepGVD(Ideal) := List => opts -> I -> (
         -- returns a list of indeterminates for which there exists a one-step geometric vertex decomposition
 
         if opts.OnlyDegenerate and opts.OnlyNondegenerate then (
@@ -150,13 +148,12 @@ findOneStepGVD(Ideal) := opts -> I -> (
 --------------------------------------------------------------------------------
 
 getGVDIdeal = method(
-        TypicalValue => List, 
         Options => {
                 CheckUnmixed => true,
                 UniversalGB => false
                 }
         )
-getGVDIdeal(Ideal, List) := opts -> (I, L) -> (
+getGVDIdeal(Ideal, List) := List => opts -> (I, L) -> (
         CNs := new HashTable from {
                 "C" => oneStepGVDCyI,
                 "N" => oneStepGVDNyI
@@ -169,10 +166,9 @@ getGVDIdeal(Ideal, List) := opts -> (I, L) -> (
 
 -- [KMY, Section 2.1]
 initialYForms = method(
-        TypicalValue => Ideal,
         Options => {UniversalGB => false}
         )
-initialYForms(Ideal, RingElement) := opts -> (I, y) -> (
+initialYForms(Ideal, RingElement) := Ideal => opts -> (I, y) -> (
         givenRing := ring I;
 
         -- set up the ring
@@ -199,8 +195,8 @@ initialYForms(Ideal, RingElement) := opts -> (I, y) -> (
 
 --------------------------------------------------------------------------------
 
-isGeneratedByIndeterminates = method(TypicalValue => Boolean)
-isGeneratedByIndeterminates(Ideal) := I -> (
+isGeneratedByIndeterminates = method()
+isGeneratedByIndeterminates(Ideal) := Boolean => I -> (
         R := ring I;
         indeterminates := gens R;
         gensI := first entries gens I;
@@ -211,7 +207,6 @@ isGeneratedByIndeterminates(Ideal) := I -> (
 
 -- [KR, Definition 2.7]
 isGVD = method(
-        TypicalValue => Boolean, 
         Options => {
                 CheckCM => "always", 
                 CheckUnmixed => true, 
@@ -221,7 +216,7 @@ isGVD = method(
                 Verbose => false
                 }
         )
-isGVD(Ideal) := opts -> I -> (
+isGVD(Ideal) := Boolean => opts -> I -> (
 
         if not instance(opts.CheckCM, String) then (
                 error "value of CheckCM must be a string";
@@ -294,7 +289,6 @@ isGVD(Ideal) := opts -> I -> (
 
 -- [KR, Definition 2.11]
 isLexCompatiblyGVD = method(
-        TypicalValue => Boolean, 
         Options => {
                 CheckCM => "always", 
                 CheckUnmixed => true, 
@@ -304,7 +298,7 @@ isLexCompatiblyGVD = method(
                 Verbose => false
                 }
         )
-isLexCompatiblyGVD(Ideal, List) := opts -> (I, indetOrder) -> (
+isLexCompatiblyGVD(Ideal, List) := Boolean => opts -> (I, indetOrder) -> (
         if not instance(opts.CheckCM, String) then (
                 error "value of CheckCM must be a string";
                 ) else (
@@ -370,8 +364,8 @@ isLexCompatiblyGVD(Ideal, List) := opts -> (I, indetOrder) -> (
 
 --------------------------------------------------------------------------------
 
-isUnmixed = method(TypicalValue => Boolean)
-isUnmixed(Ideal) := I -> (
+isUnmixed = method()
+isUnmixed(Ideal) := Boolean => I -> (
         R := ring I;
         D := primaryDecomposition I;
         
@@ -388,8 +382,7 @@ isUnmixed(Ideal) := I -> (
 --------------------------------------------------------------------------------
 
 -- [KR, Definition 4.6]
-isWeaklyGVD = method(
-        TypicalValue => Boolean, 
+isWeaklyGVD = method( 
         Options => {
                 CheckUnmixed => true, 
                 IsIdealUnmixed => false,
@@ -397,7 +390,7 @@ isWeaklyGVD = method(
                 Verbose => false
                 }
         )
-isWeaklyGVD(Ideal) := opts -> I -> (
+isWeaklyGVD(Ideal) := Boolean => opts -> I -> (
         R := ring I;
         printIf(opts.Verbose, "I = " | toString I);
 
@@ -454,8 +447,7 @@ isWeaklyGVD(Ideal) := opts -> I -> (
 
 --------------------------------------------------------------------------------
 
-oneStepGVD = method(
-        TypicalValue => Sequence, 
+oneStepGVD = method( 
         Options => {
                 CheckDegenerate => false, 
                 CheckUnmixed => true, 
@@ -463,7 +455,7 @@ oneStepGVD = method(
                 Verbose => false
                 }
         )
-oneStepGVD(Ideal, RingElement) := opts -> (I, y) -> (
+oneStepGVD(Ideal, RingElement) := Sequence => opts -> (I, y) -> (
 
         -- set up the rings
         indeterminates := switch(0, index y, gens ring y);
@@ -517,25 +509,23 @@ oneStepGVD(Ideal, RingElement) := opts -> (I, y) -> (
 
 --------------------------------------------------------------------------------
 
-oneStepGVDCyI = method(
-        TypicalValue => Ideal, 
+oneStepGVDCyI = method( 
         Options => {
                 CheckUnmixed => true,
                 UniversalGB => false
                 }
         )
-oneStepGVDCyI(Ideal, RingElement) := opts -> (I, y) -> (oneStepGVD(I, y, CheckUnmixed=>opts.CheckUnmixed, UniversalGB=>opts.UniversalGB))_1;
+oneStepGVDCyI(Ideal, RingElement) := Ideal => opts -> (I, y) -> (oneStepGVD(I, y, CheckUnmixed=>opts.CheckUnmixed, UniversalGB=>opts.UniversalGB))_1;
 
 --------------------------------------------------------------------------------
 
-oneStepGVDNyI = method(
-        TypicalValue => Ideal, 
+oneStepGVDNyI = method( 
         Options => {
                 CheckUnmixed => true,
                 UniversalGB => false
                 }
         )
-oneStepGVDNyI(Ideal, RingElement) := opts -> (I, y) -> (oneStepGVD(I, y, CheckUnmixed=>opts.CheckUnmixed, UniversalGB=>opts.UniversalGB))_2;
+oneStepGVDNyI(Ideal, RingElement) := Ideal => opts -> (I, y) -> (oneStepGVD(I, y, CheckUnmixed=>opts.CheckUnmixed, UniversalGB=>opts.UniversalGB))_2;
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -543,8 +533,8 @@ oneStepGVDNyI(Ideal, RingElement) := opts -> (I, y) -> (oneStepGVD(I, y, CheckUn
 --** METHODS (Hidden from users, not exported)
 
 
-areGensSquarefreeInY = method(TypicalValue => Boolean)
-areGensSquarefreeInY(List, RingElement) := (L, y) -> (
+areGensSquarefreeInY = method()
+areGensSquarefreeInY(List, RingElement) := Boolean => (L, y) -> (
         -- L a list of polynomials (e.g., generators of some ideal), and y an indeterminate in the ring
         -- returns true if and only if ideal(L) is squarefre in y, that is, if y^2 does not divide any term of any of the polynomials
 
@@ -553,8 +543,8 @@ areGensSquarefreeInY(List, RingElement) := (L, y) -> (
 
 
 -- check if C_{y, I} and N_{y, I} form a degenerate (or not) geometric vertex decomposition
-degeneracyCheck = method(TypicalValue => String)
-degeneracyCheck(Ideal, Ideal) := (C, N) -> (
+degeneracyCheck = method()
+degeneracyCheck(Ideal, Ideal) := String => (C, N) -> (
         -- degenerate if C == 1 or radical C == radical N
         if C == 1 then return "degenerate";
 
@@ -567,8 +557,8 @@ degeneracyCheck(Ideal, Ideal) := (C, N) -> (
         )
 
 
-getQ = method(TypicalValue => RingElement)
-getQ(RingElement, RingElement) := (f, y) -> (
+getQ = method()
+getQ(RingElement, RingElement) := RingElement => (f, y) -> (
         -- f is of the form q*y^d+r, return q  (where y^d does not divide any term of r and y does not divide any term of q)
         L := terms f;  -- this preserves the coefficient (and hence sign) of each term
         yDegrees := L / degree_y;
@@ -577,14 +567,14 @@ getQ(RingElement, RingElement) := (f, y) -> (
         )
 
 
-isGVDBaseCase = method(TypicalValue => Boolean)
-isGVDBaseCase(Ideal) := I -> (
+isGVDBaseCase = method()
+isGVDBaseCase(Ideal) := Boolean => I -> (
         return (I == 1 or I == 0 or isGeneratedByIndeterminates(I));
         )
 
 
-isIdealSquarefreeInY = method(TypicalValue => Boolean)
-isIdealSquarefreeInY(Ideal, RingElement) := (I, y) -> (
+isIdealSquarefreeInY = method()
+isIdealSquarefreeInY(Ideal, RingElement) := Boolean => (I, y) -> (
         -- returns true if and only if I is squarefree in y, that is: if and only if
         -- y^2 does not divide any term of a Grobner basis of I with respect to a y-compatible monomial order 
         -- we use lex with y > all other variables
@@ -601,22 +591,22 @@ isIdealSquarefreeInY(Ideal, RingElement) := (I, y) -> (
         )
 
 
-intersectLists = method(TypicalValue => List)
-intersectLists(List) := L -> (
+intersectLists = method()
+intersectLists(List) := List => L -> (
         -- L is a list of lists
         S := for l in L list (set l);
         return toList fold(intersectSets, S)
         )
 
 
-intersectSets = method(TypicalValue => Set)
-intersectSets(Set, Set) := (S1, S2) -> (
+intersectSets = method()
+intersectSets(Set, Set) := Set => (S1, S2) -> (
         return S1 * S2;
         )
 
 
-inTruncatedList = method(TypicalValue => Boolean)
-inTruncatedList(List, List) := (L, LL) -> (
+inTruncatedList = method()
+inTruncatedList(List, List) := Boolean => (L, LL) -> (
         -- LL is a list of lists
         -- return True if: for some list l of length n in LL, the first n terms of L are exactly l
         for l in LL do (
@@ -640,8 +630,8 @@ isSquarefreeInY(RingElement, RingElement) := (m, y) -> (
 
 -- determine whether the one-step geometric vertex decomposition holds
 -- uses [KR, Lemmas 2.6 and 2.12]
-isValidOneStep = method(TypicalValue => Boolean)
-isValidOneStep(List, RingElement) := (G, y) -> (
+isValidOneStep = method()
+isValidOneStep(List, RingElement) := Boolean => (G, y) -> (
         -- G is a list, whose elements form a reduced Gröbner basis
 
         -- analyze the powers of y appearing in the Gröbner basis
@@ -653,8 +643,8 @@ isValidOneStep(List, RingElement) := (G, y) -> (
         )
 
 
-isValidOneStepFromUGB = method(TypicalValue => Boolean)
-isValidOneStepFromUGB(List, Ideal, Ideal, RingElement) := (G, C, N, y) -> (
+isValidOneStepFromUGB = method()
+isValidOneStepFromUGB(List, Ideal, Ideal, RingElement) := Boolean => (G, C, N, y) -> (
         -- G is a UGB for the ideal I it generates; C = C_{y, I} and N_{y, I}
         -- the previous check may not work for UGBs because it requires the GB to be reduced
         currentRing := ring y;
@@ -666,8 +656,8 @@ isValidOneStepFromUGB(List, Ideal, Ideal, RingElement) := (G, C, N, y) -> (
         )
 
 
-lexOrderHelper = method(TypicalValue => List, Options => {CheckUnmixed => true})
-lexOrderHelper(List, List) := opts -> (idealList, order) -> (
+lexOrderHelper = method(Options => {CheckUnmixed => true})
+lexOrderHelper(List, List) := List => opts -> (idealList, order) -> (
         -- remove ideals that are trivially GVD
         nontrivialIdeals := select(idealList, i -> not isGVDBaseCase i);
         -- if there are none left, return the order
@@ -695,8 +685,8 @@ lexOrderHelper(List, List) := opts -> (idealList, order) -> (
         )
 
 
-sumGenerators = method(TypicalValue => List)
-sumGenerators(Ideal) := I -> (
+sumGenerators = method()
+sumGenerators(Ideal) := List => I -> (
         -- returns a list {I1, I2} where I = I1 + I2 and (support I1) and (support I2) are disjoint,
         -- if no such I1 and I2 exist, then {I} is returned
         -- only uses the given generators of I (does not compute a minimal generating set)
@@ -725,7 +715,6 @@ sumGenerators(Ideal) := I -> (
         )
 
 
-
 printIf = method()
 printIf(Boolean, String) := (bool, str) -> (
         if bool then print str;
@@ -743,8 +732,8 @@ printIf(Boolean, String) := (bool, str) -> (
                 )
 
 
-unmixedCheck = method(TypicalValue => Boolean)
-unmixedCheck(Ideal, Ideal, Boolean) := (C, N, verb) -> (
+unmixedCheck = method()
+unmixedCheck(Ideal, Ideal, Boolean) := Boolean => (C, N, verb) -> (
 
         CisCM := isHomogeneous C and (pdim((ring C)^1/C) == codim C);
         NisCM := isHomogeneous N and (pdim((ring N)^1/N) == codim N);

--- a/M2/Macaulay2/packages/GeometricDecomposability.m2
+++ b/M2/Macaulay2/packages/GeometricDecomposability.m2
@@ -316,6 +316,7 @@ isLexCompatiblyGVD(Ideal, List) := Boolean => opts -> (I, indetOrder) -> (
 
         printIf(opts.Verbose, "initial ideal = " | toString initIdeal);
 
+        -- run recursive definition [KR, Definition 2.11] on the initial ideal [KR, Proposition 2.14]
         recursiveLexGVD(initIdeal, indetOrder, 
                 CheckCM=>opts.CheckCM, CheckUnmixed=>opts.CheckUnmixed, 
                 IsIdealHomogeneous=>true, IsIdealUnmixed=>opts.IsIdealUnmixed,
@@ -323,6 +324,7 @@ isLexCompatiblyGVD(Ideal, List) := Boolean => opts -> (I, indetOrder) -> (
                 )
         )
 
+-- recursive definition of <-compatibly geometrically vertex decomposable [KR, Definition 2.11]
 recursiveLexGVD = method(
         Options => {
                 CheckCM => "always", 

--- a/M2/Macaulay2/packages/GeometricDecomposability.m2
+++ b/M2/Macaulay2/packages/GeometricDecomposability.m2
@@ -2,14 +2,14 @@
 
 newPackage(
         "GeometricDecomposability",
-        Version => "1.4.1",
-        Date => "May 7, 2024",
+        Version => "1.4.2",
+        Date => "May 2, 2025",
         Headline => "checking whether ideals are geometrically vertex decomposable",
         Authors => {
                 {
                 Name => "Mike Cummings",
-                Email => "cummim5@mcmaster.ca",
-                HomePage => "https://math.mcmaster.ca/~cummim5/"
+                Email => "mike.cummings@uwaterloo.ca",
+                HomePage => "https://mikecummings.ca"
                 },
                 {
                 Name => "Adam Van Tuyl",

--- a/M2/Macaulay2/packages/GeometricDecomposability.m2
+++ b/M2/Macaulay2/packages/GeometricDecomposability.m2
@@ -2093,7 +2093,7 @@ assert(not isGVD I)
 
 
 TEST///  -- Toric ideal of the complete bipartite graph K_{3,2}; GVD by [CDSRVT, Theorem 5.8]
-loadPackage "Quasidegrees";
+needsPackage "Quasidegrees";
 R = QQ[e_1..e_6];
 A = matrix{
         {1,0,0,1,0,0},
@@ -2108,7 +2108,7 @@ assert(isGVD I)
 
 
 TEST///  -- Toric ideal of the graph constructed by connecting two triangles by a bridge of length 2
-loadPackage "Quasidegrees";
+needsPackage "Quasidegrees";
 R = QQ[e_1..e_8];
 A = matrix{
         {1, 0, 1, 0, 0, 0, 0, 0},

--- a/M2/Macaulay2/packages/GeometricDecomposability.m2
+++ b/M2/Macaulay2/packages/GeometricDecomposability.m2
@@ -314,6 +314,8 @@ isLexCompatiblyGVD(Ideal, List) := Boolean => opts -> (I, indetOrder) -> (
         lexRing := (cr) monoid([allVariables, MonomialOrder=>Lex]);  
         initIdeal := ideal leadTerm sub(I, lexRing);
 
+        printIf(opts.Verbose, "initial ideal = " | toString initIdeal);
+
         recursiveLexGVD(initIdeal, indetOrder, 
                 CheckCM=>opts.CheckCM, CheckUnmixed=>opts.CheckUnmixed, 
                 IsIdealHomogeneous=>true, IsIdealUnmixed=>opts.IsIdealUnmixed,
@@ -387,11 +389,11 @@ recursiveLexGVD(Ideal, List) := Boolean => opts -> (I, indetOrder) -> (
         printIf(opts.Verbose, "-- N = " | toString N);
 
         -- check N first, same reasoning as in isGVD
-        NisGVD := isLexCompatiblyGVD(N, remainingOrder, CheckCM=>CMTable#(opts.CheckCM), CheckUnmixed=>opts.CheckUnmixed, IsIdealHomogeneous=>x, IsIdealUnmixed=>true, UniversalGB=>opts.UniversalGB, Verbose=>opts.Verbose);
+        NisGVD := recursiveLexGVD(N, remainingOrder, CheckCM=>CMTable#(opts.CheckCM), CheckUnmixed=>opts.CheckUnmixed, IsIdealHomogeneous=>x, IsIdealUnmixed=>true, UniversalGB=>opts.UniversalGB, Verbose=>opts.Verbose);
         if not NisGVD then return false;
 
         -- if are here, then NisGVD is true
-        CisGVD := isLexCompatiblyGVD(C, remainingOrder, CheckCM=>CMTable#(opts.CheckCM), CheckUnmixed=>opts.CheckUnmixed, IsIdealHomogeneous=>x, IsIdealUnmixed=>true, UniversalGB=>opts.UniversalGB, Verbose=>opts.Verbose);
+        CisGVD := recursiveLexGVD(C, remainingOrder, CheckCM=>CMTable#(opts.CheckCM), CheckUnmixed=>opts.CheckUnmixed, IsIdealHomogeneous=>x, IsIdealUnmixed=>true, UniversalGB=>opts.UniversalGB, Verbose=>opts.Verbose);
         return CisGVD;
 )
 

--- a/M2/Macaulay2/packages/IntegerProgramming.m2
+++ b/M2/Macaulay2/packages/IntegerProgramming.m2
@@ -8,8 +8,7 @@ newPackage(
         Email => "mike.cummings@uwaterloo.ca",
         HomePage => "https://mikecummings.ca"
     }},
-    Keywords => {"Applied Algebraic Geometry"},
-    DebuggingMode => true
+    Keywords => {"Applied Algebraic Geometry"}
 )
 
 export {

--- a/M2/Macaulay2/packages/IntegerProgramming.m2
+++ b/M2/Macaulay2/packages/IntegerProgramming.m2
@@ -181,7 +181,7 @@ toStandardForm(Matrix) := Matrix => A -> (
 
 toStandardForm(Matrix, Matrix) := Sequence => (A, c) -> (
     -- input: matrix A corresponding to constraints Ax <= b and matrix c corresponding to objective function cx
-    -- output: matrix A' and matrix c' corresopnding to constraints A'x' = b and objective function c'x'
+    -- output: matrix A' and matrix c' corresponding to constraints A'x' = b and objective function c'x'
     
     if numRows c > 1 and numColumns c > 1 then error("expected a one-dimensional matrix as the second argument");
     
@@ -191,7 +191,7 @@ toStandardForm(Matrix, Matrix) := Sequence => (A, c) -> (
 
 toStandardForm(Matrix, List) := Sequence => (A, c) -> (
     -- input: matrix A corresponding to constraints Ax <= b and list c corresponding to objective function cx
-    -- output: matrix A' and list c' corresopnding to constraints A'x' = b and objective function c'x'
+    -- output: matrix A' and list c' corresponding to constraints A'x' = b and objective function c'x'
     (toStandardForm A, join(c, (numRows A):0))
 )
 

--- a/M2/Macaulay2/packages/IntegerProgramming.m2
+++ b/M2/Macaulay2/packages/IntegerProgramming.m2
@@ -1,0 +1,611 @@
+newPackage(
+    "IntegerProgramming",
+    Version => "0.1",
+    Date => "April 21, 2025",
+    Headline => "solving integer programs with Gröbner bases",
+    Authors => {{
+        Name => "Mike Cummings", 
+        Email => "mike.cummings@uwaterloo.ca",
+        HomePage => "https://mikecummings.ca"
+    }},
+    Keywords => {"Applied Algebraic Geometry"},
+    DebuggingMode => true
+)
+
+export {
+    -- methods
+    "adaptedMonomialOrder",
+    "isFeasiblePoint",
+    "solveILP",
+    "toStandardForm",
+
+    -- options
+    "Field",
+    "IsInStandardForm"
+}
+
+-* code section *-
+
+
+-- [CLO, Chapter 8, Section 1, Exercise 7]
+adaptedMonomialOrder = method(
+    Options => {
+        Field => QQ,
+        Variables => {"w", "z"}
+    }
+)
+
+adaptedMonomialOrder(Matrix, Matrix) := Ring => opts -> (A, c) -> (
+    if numRows c > 1 and numColumns c > 1 then error("expected a one-dimensional matrix as the second argument");
+    adaptedMonomialOrder(A, flatten entries c)
+)
+
+adaptedMonomialOrder(Matrix, List) := Ring => opts -> (A, c) -> (
+    if min flatten entries A < 0 then error("expected nonnegative matrix entries");
+    if any(join(flatten entries A, c), i -> not instance(i, ZZ)) then error("expected integer entries");
+
+    numVars := numColumns A;
+    numConstraints := numRows A;
+    -- if numVars != #c then error("incompatible input sizes");
+
+    w := getSymbol first opts.Variables;
+    z := getSymbol last opts.Variables;
+
+    R := (opts.Field)(monoid[z_1..z_numConstraints]);
+
+    if min c >= 0 then (
+        S := (opts.Field)(monoid[w_1..w_numVars, MonomialOrder=>{Weights=>c}]);
+    ) else (
+        degs := apply(numVars, j -> sum flatten entries A_{j});
+
+        negativeIndices := select(#c, i -> c_i < 0);
+        negativeCs := c_negativeIndices;
+        negativeDs := degs_negativeIndices;  -- these aren't negative, but they correspond to the negative coefficients in the objective function
+
+        mu := 1 - min apply(#negativeCs, i -> floor(negativeCs_i / negativeDs_i));  -- = 1 + max( ceiling(-c_i / d_i) )
+        varWeights := apply(#c, i -> c_i + mu*degs_i);
+
+        S = (opts.Field)(monoid[w_1..w_numVars, Degrees=>degs, MonomialOrder=>{Weights=>varWeights}]);
+    );
+    R ** S
+)
+
+-- [CLO, Chapter 8, Proposition 1.6]
+isFeasiblePoint = method(
+    Options => {
+        Field => QQ
+    }
+)
+
+isFeasiblePoint(Matrix, Matrix, Matrix) := Boolean => opts -> (A, b, X) -> (
+    if numRows b > 1 and numColumns b > 1 then error("expected a one-dimensional matrix as the second argument");
+    if numRows X > 1 and numColumns X > 1 then error("expected a one-dimensional matrix as the third argument");
+    isFeasiblePoint(A, flatten entries b, flatten entries X, Field=>opts.Field)
+)
+
+isFeasiblePoint(Matrix, Matrix, List) := Boolean => opts -> (A, b, X) -> (
+    if numRows b > 1 and numColumns b > 1 then error("expected a one-dimensional matrix as the second argument");
+    isFeasiblePoint(A, flatten entries b, X, Field=>opts.Field)
+)
+
+isFeasiblePoint(Matrix, List, Matrix) := Boolean => opts -> (A, b, X) -> (
+    if numRows X > 1 and numColumns X > 1 then error("expected a one-dimensional matrix as the third argument");
+    isFeasiblePoint(A, b, flatten entries X, Field=>opts.Field)
+)
+
+isFeasiblePoint(Matrix, List, List) := Boolean => opts -> (A, b, X) -> (
+    -- whether AX = b, where A and b have nonnegative entries 
+
+    allEntries := join(flatten entries A, b, X);
+    if any(allEntries, i -> not instance(i, ZZ)) then error("expected integer entries");
+    if min allEntries < 0 then error("expected nonnegative entries");
+
+    numVars := numColumns A;
+    numConstraints := numRows A;
+    -- if numVars != #X or numConstraints != #b then error("incompatible input sizes");
+    if numConstraints != #b then error("incompatible input sizes");
+
+    R := (opts.Field)(monoid[(getSymbol "w")_1..(getSymbol "w")_numVars]);
+    S := (opts.Field)(monoid[(getSymbol "z")_1..(getSymbol "z")_numConstraints]);
+
+    -- mapOutputs := matrix{for j from 1 to numVars list product apply(toList(1..numConstraints), i -> (S_(i-1))^(A_(i-1, j-1)))};
+    mapOutputs := matrix{for j from 1 to numVars list product apply(numConstraints, i -> (S_i)^(A_(i, j-1)))};   -- check this (I changed this and didn't check it) ------------------------------
+    phi := map(S, R, mapOutputs);
+
+    phi(R_X) == S_b
+)
+
+
+-- [CLO, Chapter 8, Theorem 1.11], and the algorithm that follows
+solveILP = method(
+    Options => {
+        Field => QQ,
+        IsInStandardForm => true
+    }
+)
+
+solveILP(Matrix, Matrix, Matrix) := opts -> (A, b, c) -> (
+    if numRows b > 1 and numColumns b > 1 then error("expected a one-dimensional matrix as the second argument");
+    if numRows c > 1 and numColumns c > 1 then error("expected a one-dimensional matrix as the third argument");
+    transpose matrix {solveILP(A, flatten entries b, flatten entries c, Field=>opts.Field, IsInStandardForm=>opts.IsInStandardForm)}
+)
+
+solveILP(Matrix, Matrix, List) := opts -> (A, b, c) -> (
+    if numRows b > 1 and numColumns b > 1 then error("expected a one-dimensional matrix as the second argument");
+    transpose matrix {solveILP(A, flatten entries b, c, Field=>opts.Field, IsInStandardForm=>opts.IsInStandardForm)}
+)
+
+solveILP(Matrix, List, Matrix) := opts -> (A, b, c) -> (
+    if numRows c > 1 and numColumns c > 1 then error("expected a one-dimensional matrix as the third argument");
+    solveILP(A, b, flatten entries c, Field=>opts.Field, IsInStandardForm=>opts.IsInStandardForm)
+)
+
+solveILP(Matrix, List, List) := opts -> (A, b, c) -> (
+    -- gives a solution that minimizes cx such that Ax = b is in standard form with all entries in A, b positive
+
+    if not opts.IsInStandardForm then (
+        (A', c') := toStandardForm(A, c);
+        return (solveILP(A', b, c'))_{0..(#c-1)};
+    );
+
+    numVars := #c;
+    numConstraints := numRows A;
+
+    if any(join(flatten entries A, b, c), i -> not instance(i, ZZ)) then error("expected integer entries");
+    if min join(flatten entries A, b) < 0 then error("expected nonnegative entries");
+    -- if numVars != #c or numConstraints != #b then error("incompatible input sizes");
+    if numConstraints != #b then error("incompatible input sizes");
+
+    R := adaptedMonomialOrder(A, c);
+    f := R_b;
+    fs := apply(numVars, j -> R_(flatten entries A_{j}));
+    I := ideal apply(numVars, j -> fs_j - R_(numConstraints + j));  -- this should be in R
+    g := f % I;  -- this is a monomial by [CLO, Chapter 8, Proposition 1.8]
+
+
+    if isSubset(support g, (gens R)_{numConstraints..(numConstraints+numVars-1)}) then (
+        solution := first exponents g;  -- includes the coordinates corresponding to variables we eliminated
+        return solution_{numConstraints..(numVars + numConstraints - 1)};
+    ) else return false;
+)
+
+
+toStandardForm = method()
+toStandardForm(Matrix) := Matrix => A -> (
+    -- input: matrix A corresponding to constraints Ax <= b
+    -- output: matrix A' corresponding to constraints A'x' = b
+    n := numRows A;
+    R := ring A;
+    A | id_(R^n)
+)
+
+toStandardForm(Matrix, Matrix) := Sequence => (A, c) -> (
+    -- input: matrix A corresponding to constraints Ax <= b and matrix c corresponding to objective function cx
+    -- output: matrix A' and matrix c' corresopnding to constraints A'x' = b and objective function c'x'
+    
+    if numRows c > 1 and numColumns c > 1 then error("expected a one-dimensional matrix as the second argument");
+    
+    output := toStandardForm(A, flatten entries c);
+    if numRows c == 1 then (first output, matrix {last output}) else (first output, transpose matrix {last output})
+)
+
+toStandardForm(Matrix, List) := Sequence => (A, c) -> (
+    -- input: matrix A corresponding to constraints Ax <= b and list c corresponding to objective function cx
+    -- output: matrix A' and list c' corresopnding to constraints A'x' = b and objective function c'x'
+    (toStandardForm A, join(c, (numRows A):0))
+)
+
+
+-* unexported methods *-
+
+
+-* Documentation section *-
+beginDocumentation()
+
+doc ///
+    Key
+        IntegerProgramming
+    
+    Headline
+        solving integer programs with Gröbner bases
+    
+    Description
+        Text
+            Integer linear programming concerns optimization problems of the form 
+            $$
+            \begin{matrix}
+                \text{minimize} & c^T x \\ 
+                \text{such that} & Ax = b \\ 
+                \text{and} & x \in \mathbb Z^n_{\ge 0}
+            \end{matrix}
+            $$
+            for some $m \times n$ matrix $A$ and vectors $b$ and $c$.
+            In general, solving integer linear programs is an NP-hard problem.
+            Work from the early 1990s (see [CT, O, P]) developed algorithms for solving integer linear programs 
+            using Gröbner bases.
+            
+            The key to this approach is constructing a term order that is compatible with the objective function 
+            of the program.
+            We implement this in @TO adaptedMonomialOrder@, which returns a ring equipped with such a term order.
+            This order is used in @TO solveILP@ to solve integer programs.
+
+    Acknowledgement
+        This package was developed as part of the graduate course Computational Commutative Algebra and Algebraic Geometry during 
+        the Fields Institute's Thematic Program in Commutative Algebra and Applications in Winter 2025.
+        We thank Mike Stillman, for his instruction of the course, and the organizers of the thematic program: David Eisenbud, 
+        Elisa Gorla, Megumi Harada, Jenna Rajchgot, Hal Schenck, and Adam Van Tuyl.
+
+        Cummings is partially supported by NSERC CGS-D 588999--2024 and a University of Waterloo President's Graduate Scholarship.
+    
+    References
+        [CT] Pasqualina Conti and Carlo Traverso. Buchberger algorithm and integer programming. 
+                {\em Applied algebra, algebraic algorithms and error-correcting codes (New Orleans, LA, 1991)}, 130--139, 
+                Lecture Notes in Comput. Sci., 539, Springer, Berlin, 1991.
+
+        [CLO] David A. Cox, John Little, and Donal O'Shea. Using Algebraic Geometry. Second edition. Graduate Texts in Mathematics, 185. 
+                {\em Springer, New York}, 2005.
+
+        [O] François Ollivier . Canonical bases: relations with standard bases, finiteness conditions and application to tame automorphisms. 
+            {\em Effective methods in algebraic geometry (Castiglioncello, 1990)}, 379–400, Progr. Math., 94, Birkhäuser Boston, Boston, MA, 1991.
+
+        [P] Loïc Pottier . Minimal solutions of linear Diophantine systems: bounds and algorithms. 
+            {\em Rewriting techniques and applications (Como, 1991)}, 162–173, Lecture Notes in Comput. Sci., 488, Springer , Berlin, 1991.
+
+    Subnodes
+        adaptedMonomialOrder
+        isFeasiblePoint
+        solveILP
+        toStandardForm
+        Field
+        IsInStandardForm
+///
+
+
+
+doc ///
+    Key
+        adaptedMonomialOrder
+        (adaptedMonomialOrder, Matrix, List)
+        (adaptedMonomialOrder, Matrix, Matrix)
+        [adaptedMonomialOrder, Variables]
+    
+    Headline
+        constructs a ring with monomial order adapted to an integer program
+    
+    Usage
+        adaptedMonomialOrder(A, c)
+        adaptedMonomialOrder(A, c, Variables=>L)
+    
+    Inputs
+        A: Matrix
+            with nonnegative entries in @TO ZZ@
+        c: {Matrix, List}
+            with entries in @TO ZZ@
+        L: List
+            optionally, a list of length two containing strings that we use as variable names in the ring
+    
+    Outputs
+        :Ring
+            equipped with a term order adapted to the given integer program
+    
+    Description
+        Text
+            Solving integer linear programs using Gröbner bases relies on constructing a monomial order that is {\em adapted} to the program at hand.
+            This method returns a ring equipped with such an order.
+
+        Text
+            {\bf Definition.}
+            Fix a matrix $A \in \mathbb Z^{m \times n}$ and vectors $b \in \mathbb Z^m$, $c \in \mathbb Z^n$.
+            Consider the integer linear program in @TO2 {toStandardForm, "standard form"}@: 
+            $$\text{minimize } c^Tx \quad \text{subject to } Ax = b \text{ and } x \in \mathbb Z_{\ge 0}^n.$$
+            Let $\varphi$ be as in @TO isFeasiblePoint@.
+            A monomial order $<$ on $k[z_1, \ldots, z_m, w_1, \ldots, w_n]$ is {\em adapted} to the program if both of the following hold:
+
+            1. (Elimination) $z_i > w^\alpha$ for all $\alpha \in \mathbb Z_{\ge 0}^n$, for all $i = 1, \ldots, m$;
+
+            2. (Compatibility with the program) if $c^T \alpha > c^T \beta$ and $\varphi(w^\alpha) = \varphi(w^\beta)$, then $w^\alpha > w^\beta$.
+
+        Text
+            {\bf Construction.}
+            We outline here the construction of such an order, following Exercise 7 in [CLO, Chapter 8, Section 1].
+
+            First, suppose that the vector $c$ defining the objective function contains only nonnegative entries.
+            Define a weight order on the variables $w_1, \ldots, w_m$ by giving weight $c_j$ to $w_j$.
+            We extend this to an adapted monomial order on $k[z_1, \ldots, z_n, w_1, \ldots, w_m]$ by treating each $z_i$ as lexicographically larger than every $w_j$.
+
+            Assume now that $c$ is not nonnegative.
+            For each $j = 1, \ldots, n$, define $d_j = \sum_{i=1}^m A_{i,j}$.
+            (Note that $d_j > 0$ for otherwise the constraints in the linear program do not depend on $x_j$.)
+            Equip $k[z_1, \ldots, z_m, w_1, \ldots, w_m]$ with nonstandard grading: $\deg(z_i) = 1$ for all $i$ and $\deg(w_j) = d_j$ for all $j$.
+            Now for the term order, pick $\mu$ such that the vector $(c_1, \ldots, c_n) + \mu(d_1, \ldots, d_n)$ contains only nonnnegative entries.
+            This gives rise to a weight order on $k[w_1, \ldots, w_n]$ which satisfies condition (2) above.
+            We extend this to an adapted monomial order on $k[z_1, \ldots, z_n, w_1, \ldots, w_m]$ by again treating each $z_i$ as lexicographically larger than every $w_j$.
+    
+    References
+        [CLO] David A. Cox, John Little, and Donal O'Shea. Using Algebraic Geometry. Second edition. Graduate Texts in Mathematics, 185. Springer, New York, 2005.
+    
+    SeeAlso
+        solveILP
+        toStandardForm
+        Field
+
+///
+
+doc ///
+    Key
+        isFeasiblePoint
+        (isFeasiblePoint, Matrix, List, List)
+        (isFeasiblePoint, Matrix, List, Matrix)
+        (isFeasiblePoint, Matrix, Matrix, List)
+        (isFeasiblePoint, Matrix, Matrix, Matrix)
+    
+    Headline
+        whether a point is feasible to an integer linear program
+    
+    Usage
+        isFeasiblePoint(A, b, X)
+    
+    Inputs
+        A: Matrix
+            with nonnegative entries in @TO ZZ@
+        b: {Matrix, List}
+            with nonnegative entries in @TO ZZ@
+        X: {Matrix, List}
+            with nonnegative entries in @TO ZZ@
+    
+    Outputs
+        :Boolean
+    
+    Description
+        Text            
+            Fix a matrix $A \in \mathbb Z^{m \times n}$ and integer linear program in @TO2 {toStandardForm, "standard form"}@ with constraints $Ax = b$.
+            The following is a characterization of when the vector $x \in \mathbb Z_{\ge 0}^n$ satisfies $Ax = b$, in which case we say that it is {\em feasible}.
+            This condition is exactly [CLO, Chapter 8, Proposition 1.6].
+
+        Text
+            {\bf Proposition.} 
+            Let $A \in \mathbb Z^{m \times n}$ and consider the feasible region $Ax = b$.
+            Define a homomorphism of rings $\varphi:k[w_1, \ldots, w_n] \to k[z_1, \ldots, z_m]$, where $k$ is any @TO2 {Field, "field"}@, by 
+            $$\varphi: w_j \mapsto \prod_{i=1}^m z_i^{A_{i, j}} \quad \text{for all } j = 1, \ldots, n.$$
+            Then, a vector $x \in \mathbb Z_{\ge 0}^n$ satisfies $Ax = b$ if and only if $\varphi(w^x) = z^b$.
+
+        Example
+            A = matrix{{1, 2}, {3, 4}}
+            b = matrix{{4}, {10}}
+            isFeasiblePoint(A, b, {1, 1})
+            isFeasiblePoint(A, b, matrix{{2}, {1}})
+    References
+        [CLO] David A. Cox, John Little, and Donal O'Shea. Using Algebraic Geometry. Second edition. Graduate Texts in Mathematics, 185. Springer, New York, 2005.
+
+    Caveat
+        Assumes the program is @TO2 {toStandardForm, "in standard form"}@.
+    
+    SeeAlso
+        solveILP
+        Field
+        IsInStandardForm
+///
+
+doc ///
+    Key
+        solveILP
+        (solveILP, Matrix, List, List)
+        (solveILP, Matrix, List, Matrix)
+        (solveILP, Matrix, Matrix, List)
+        (solveILP, Matrix, Matrix, Matrix)
+    
+    Headline
+        solve an integer linear program in standard form
+    
+    Usage
+        solveILP(A, b, c)
+    
+    Inputs
+        A: Matrix
+            with nonnegative entries in @TO ZZ@
+        b: {Matrix, List}
+            with nonnegative entries in @TO ZZ@
+        c: {Matrix, List}
+            with entrines in @TO ZZ@
+    
+    Outputs
+        :Boolean 
+            {\tt false} if there is no solution, otherwise:
+        :{Matrix, List}
+            a minimizer of the ILP, if a solution exists, of the same type as {\tt b}
+    
+    Description
+        Text
+            Consider the integer linear program
+            $$\text{minimize } c^T x \quad\text{subject to } Ax = b \text{ and } x \in \mathbb Z_{\ge 0}^n,$$
+            where $A$ is an $m \times n$ integer-valued matrix and $b \in \mathbb Z^m$, $c \in \mathbb Z^n$.
+            Suppose that every entry in $A$ and $b$ is nonnegative.
+            A solution to the problem is given by [CLO, Chapter 8, Theorem 1.11], which we now detail.
+
+            We work in the polynomial ring $R = k[z_1, \ldots, z_m, w_1, \ldots, w_n]$, where $k$ is a @TO2 {Field, "field"}@, 
+            equipped with an @TO2 {adaptedMonomialOrder, "monomial order adapted to the program"}@.
+            For each $j = 1, \ldots, n$, let $f_j = \prod_{i=1}^m z_i^{A_{i,j}}$ and let $\mathcal G$ be a Gröbner basis for 
+            $\langle f_1 - w_1 , \ldots, f_n - w_n \rangle$ in $R$.
+            Consider the remainder on division $\overline f^{\mathcal G}$ of $f = z^b$.
+            The result of [CLO, Chapter 8, Proposition 1.8] guarantees that $\overline f^{\mathcal G}$ is a monomial.
+            Moreover, the program is feasible if $\overline f^{\mathcal G}$ involves only the variables $w_1, \ldots, w_n$ and, 
+            in this case, a solution is given by the exponent vector of $\overline f^{\mathcal G}$.
+
+            The following example is from [CLO, Chapter 8, Section 1].
+
+        Example
+            A = matrix{{4, 5, 1, 0}, {2, 3, 0, 1}}
+            b = {37, 20}
+            c = {-11, -15, 0, 0}
+            solveILP(A, b, c)
+        Text
+            Alternately, one can write the program not in standard form, see @TO IsInStandardForm@.
+            
+        Text
+            {\bf Remark.}
+            Maximization and minimization (integer) linear programs are equivalent by multiplying objective functions by $-1$.
+            This package treats every problem as a minimization problem and leaves the multiplication for maximiation problems to the user.
+
+    References
+        [CLO] David A. Cox, John Little, and Donal O'Shea. Using Algebraic Geometry. Second edition. Graduate Texts in Mathematics, 185. Springer, New York, 2005.
+
+    Caveat
+        This method produces only one solution (that is, a feasible point that attains the minimum), even when multiple solutions exist.
+        
+    SeeAlso
+        adaptedMonomialOrder
+        isFeasiblePoint
+        toStandardForm
+        Field
+        IsInStandardForm
+///
+
+doc ///
+    Key
+        toStandardForm
+        (toStandardForm, Matrix)
+        (toStandardForm, Matrix, List)
+        (toStandardForm, Matrix, Matrix)
+    
+    Headline
+        converts an LP to standard form
+    
+    Usage
+        toStandardForm A
+        toStandardForm(A, c)
+    
+    Inputs
+        A: Matrix
+        c: {Matrix, List}
+    
+    Outputs
+        : {Matrix, Sequence}
+            the standard form corresponding to the given program 
+
+    Description
+        Text
+            The {\bf standard form} of an integer linear program is 
+            $$\text{minimize } c^T x \quad\text{subject to } Ax = b \text{ and } x \in \mathbb Z_{\ge 0}^n.$$
+            An integer linear program with constraints $Bx \le b$ is equivalent to one in standard form in the following way:
+            One constraint $B_{j,1}x_1 + \cdots + B_{j,r}x_r \le d_j$ in this system is equivalent to the pair of constraints 
+            $B_{j,1}x_1 + \cdots + B_{j, r}x_r + y_j = d_j$ and $y_j \ge 0$.
+
+            Hence we rewrite the constrains $Bx \le b$ as $Ax = b$ by introducing {\em slack variables} $y_j$ and @TO2{"|", "concatenating"}@ a copy of the identity matrix
+            {\tt A = B|I} of the appropriate size.
+            (Note that we abuse notation here and write $x$ for both the vector of the given program and the vector that includes the slack variables $y_j$.)
+
+            This equivalence does not change the objective function; we pad $c$ with a zero for each slack variable introduced.
+
+        Example
+            A = matrix{{1, 2}, {3, 4}}
+            c = matrix{{5}, {6}}
+            toStandardForm(A, c) 
+    SeeAlso
+        adaptedMonomialOrder
+        solveILP
+///
+
+doc ///
+    Key
+        Field
+        [adaptedMonomialOrder, Field]
+        [isFeasiblePoint, Field]
+        [solveILP, Field]
+    
+    Headline
+        field over which to define polynomial rings
+
+    Description
+        Text 
+            The field used for computations in @TO adaptedMonomialOrder@, @TO isFeasiblePoint@, @TO solveILP@, default value @TO QQ@.
+
+    SeeAlso
+        adaptedMonomialOrder
+        isFeasiblePoint
+        solveILP
+///
+
+doc ///
+    Key
+        IsInStandardForm
+        [solveILP, IsInStandardForm]
+
+    Headline
+        specify whether the integer program is in standard form
+
+    Description
+        Text
+            An optional method for @TO solveILP@ to specify whether a program is in @TO2 {toStandardForm, "standard form"}@.
+            The default value is {\tt true}.
+            If {\tt IsInStandardForm=>false}, we first convert @TO2 {toStandardForm, "to standard form"}@ before solving.
+
+            The following example is in [CLO, Chapter 8, Section 1].
+            Note that in contrast to @TO solveILP@ with {\tt IsInStandardForm=>true}, the output involves only variables that 
+            are in the specified program, meaning that the slack variables, that get introduced to convert to standard form, 
+            are omitted in the following output.
+
+        Example
+            A = matrix{{4, 5}, {2, 3}}
+            b = matrix{{37}, {20}}
+            c = matrix{{-11, -15}}
+            solveILP(A, b, c, IsInStandardForm=>false) 
+    SeeAlso
+        solveILP
+        toStandardForm
+///
+
+
+-* Test section *-
+TEST /// -* isFeasiblePoint [CLO, Chapter 8, Section 1] *-
+A = matrix{
+    {4, 5, 1, 0}, 
+    {2, 3, 0, 1}
+};
+b = {37, 20};
+assert(isFeasiblePoint(A, b, {4, 4, 1, 0}))
+///
+
+TEST /// -* solveILP [CLO, Chapter 8, Section 1] *-
+A = matrix{
+    {4, 5, 1, 0}, 
+    {2, 3, 0, 1}
+};
+b = {37, 20};
+c = {-11, -15, 0, 0};
+assert(solveILP(A, b, c) == {4, 4, 1, 0})
+/// 
+
+TEST /// -* [solveILP, IsInStandardForm=>false] [CLO, Chapter 8, Section 1] *-
+A = matrix{
+    {4, 5},
+    {2, 3}
+};
+b = {37, 20};
+c = {-11, -15};
+assert(solveILP(A, b, c, IsInStandardForm=>false) == {4, 4})
+///
+
+TEST ///  -* toStandardForm [CLO, Chapter 8, Section 1] *-
+A = matrix{
+    {4, 5},
+    {2, 3}
+};
+c = {-11, -15};
+assert(toStandardForm(A, c) == (matrix{{4, 5, 1, 0}, {2, 3, 0, 1}}, {-11, -15, 0, 0}))
+///
+
+
+end--
+
+
+-* Development section *-
+restart
+debug needsPackage "IntegerProgramming"
+check "IntegerProgramming"
+
+uninstallPackage "IntegerProgramming"
+restart
+installPackage "IntegerProgramming"
+viewHelp "IntegerProgramming"
+
+


### PR DESCRIPTION
1. Minor updates to the package GeometricDecomposability, including updating references and output type hints for exported methods. Fixed an issue in the package tests by replacing `loadPackage` with `needsPackage`. Rewrote method `isLexCompatiblyGVD` using an equivalent definition that should be faster.

2. Introduces the package IntegerProgramming, a small package to solve integer linear programs using Gröbner bases (using an algorithm from Cox, Little, O'Shea's Using Algebraic Geometry). This was developed as part of Mike Stillman's course Computational Commutative Algebra and Algebraic Geometry at the Fields Institute earlier this year.