### PR TITLE
Rename Divisor package to WeilDivisors

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -884,7 +884,7 @@ removeFiles = p -> scan(reverse findFiles p, fn -> if fileExists fn or readlink 
 uninstallPackage = method(Options => { InstallPrefix => applicationDirectory() | "local/" })
 uninstallPackage Package := opts -> pkg -> uninstallPackage(toString pkg, opts)
 uninstallPackage String  := opts -> pkg -> (
-    checkPackageName pkg;
+    checkPackageName(pkg, false);
     installPrefix := minimizeFilename opts.InstallPrefix;
     apply(findFiles apply({1, 2},
 	    i -> apply(flatten {

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -15,6 +15,14 @@ loadedPackages = {}
 rawKey   = "raw documentation"
 rawKeyDB = "raw documentation database"
 
+-- warnings or errors to issue for deprecated packages
+-- TODO: also add package deprecation warnings for OldPolyhedra, etc?
+deprecatedPackageWarnings = new HashTable from {
+    -- two warnings added before v1.25.05
+    "Divisor"      => () -> ( printerr "warning: the 'Divisor' package has been renamed as 'WeilDivisors'."; "WeilDivisors" ),
+    "CodepthThree" => () -> ( printerr "warning: the 'CodepthThree' package has been renamed as 'TorAlgebra'."; "TorAlgebra" ),
+}
+
 -----------------------------------------------------------------------------
 -- Local variables
 -----------------------------------------------------------------------------
@@ -93,9 +101,11 @@ isOptionList := opts -> instance(opts, List) and all(opts, opt -> instance(opt, 
 
 isPackageLoaded = pkgname -> PackageDictionary#?pkgname and instance(value PackageDictionary#pkgname, Package)
 
--- TODO: make this local
-checkPackageName = title -> (
-    if not match("^[[:alnum:]]+$", title) then error("package title not alphanumeric: ", format title))
+checkPackageName = (title, checkdeprecated) -> (
+    if not match("^[[:alnum:]]+$", title)
+    then error("package title not alphanumeric: ", format title);
+    if checkdeprecated and deprecatedPackageWarnings#?title
+    then (deprecatedPackageWarnings#title)() else title)
 
 closePackage = pkg -> if pkg#?rawKeyDB then (db -> if isOpen db then close db) pkg#rawKeyDB
 
@@ -163,7 +173,7 @@ loadPackage Package := opts -> pkg     -> loadPackage(toString pkg, opts ++ { Re
 loadPackage String  := opts -> pkgname -> (
     if not isOptionList opts.Configuration then error("expected Configuration option to be a list of options");
     -- package name must be alphanumeric
-    checkPackageName pkgname;
+    pkgname = checkPackageName(pkgname, true);
     -- dismiss the loaded package before reloading
     if opts.Reload === true then (
 	dismiss pkgname;
@@ -228,7 +238,7 @@ newPackage = method(
 newPackage Sequence := opts -> x -> newPackage splice(nonnull x, opts) -- to allow null entries
 newPackage String := opts -> pkgname -> (
     -- package name must be alphanumeric
-    checkPackageName pkgname;
+    checkPackageName(pkgname, false);
     -- required package values
     scan({
 	    (Authors,        List),

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -196,6 +196,8 @@ loadPackage String  := opts -> pkgname -> (
 
 needsPackage = method(TypicalValue => Package, Options => options loadPackage)
 needsPackage String  := opts -> pkgname -> (
+    -- package name must be alphanumeric
+    pkgname = checkPackageName(pkgname, true);
     if PackageDictionary#?pkgname
     and instance(pkg := value PackageDictionary#pkgname, Package)
     and (opts.FileName === null or

--- a/M2/Macaulay2/packages/=distributed-packages
+++ b/M2/Macaulay2/packages/=distributed-packages
@@ -111,7 +111,7 @@ InvariantRing
 QuillenSuslin
 EnumerationCurves
 Book3264Examples
-Divisor
+WeilDivisors
 EllipticCurves
 HighestWeights
 MinimalPrimes

--- a/M2/Macaulay2/packages/AnalyzeSheafOnP1.m2
+++ b/M2/Macaulay2/packages/AnalyzeSheafOnP1.m2
@@ -26,7 +26,7 @@ isNZD(RingElement, Module) := (X,M) ->(ker (X*id_M) == 0)
 doubleDualMap = method()
 doubleDualMap Module := M ->(
     --returns the map from M to its double dual. Code is
-    --adapted from the package "Divisor",
+    --adapted from the package "WeilDivisors",
     --where it is called reflexifyModuleWithMap
     S := ring M;
     h := coverMap M;
@@ -325,7 +325,7 @@ installPackage ("CompleteIntersectionResolutions")
 loadPackage ("CompleteIntersectionResolutions", Reload=>true)
 viewHelp CompleteIntersectionResolutions
 
-installPackage "Divisor"
+installPackage "WeilDivisors"
 viewHelp reflexify
 --
 S = ZZ/101[a,b]

--- a/M2/Macaulay2/packages/Cremona/documentation.m2
+++ b/M2/Macaulay2/packages/Cremona/documentation.m2
@@ -1162,6 +1162,5 @@ EXAMPLE {
 "D = new Tally from {H => 2,C => 1};",
 "time phi = rationalMap D",
 "time ? image(phi,\"F4\")"},
-PARA{"See also the package ",HREF{"http://www2.macaulay2.com/Macaulay2/doc/Macaulay2-1.16/share/doc/Macaulay2/Divisor/html/index.html","Divisor"},", which provides general tools for working with divisors."},
+PARA{"See also the package ", TO "WeilDivisors::WeilDivisors", ", which provides general tools for working with divisors."},
 SeeAlso => {rationalMap,(rationalMap,Ideal,ZZ),(image,RationalMap,String)}}
-

--- a/M2/Macaulay2/packages/ExteriorIdeals.m2
+++ b/M2/Macaulay2/packages/ExteriorIdeals.m2
@@ -389,10 +389,9 @@ document {
      Key => {ExteriorIdeals},
      Headline => "a package for working with ideals over exterior algebra",
      TT "ExteriorIdeals is a package for creating and manipulating ideals over exterior algebra",
-     PARA {"Other acknowledgements:"},      
-     "The method ", TT "isLexIdeal", " was taken from Chris Francisco's package: LexIdeals, which is available at ",
-      HREF{"http://www2.macaulay2.com/Macaulay2/doc/Macaulay2-1.10/share/doc/Macaulay2/LexIdeals/html/","LexIdeals"}
-      
+     Acknowledgement => PARA {
+	 "The method ", TO "isLexIdeal", " was taken from ", TO "LexIdeals::isLexIdeal",
+	 " in Chris Francisco's package ", TO "LexIdeals::LexIdeals", "." },
      }
 
 document {
@@ -468,16 +467,15 @@ document {
      Inputs => {"I" => {"a monomial ideal of an exterior algebra"}
       },
      Outputs => {Boolean => {"true whether ideal ", TT "I", " is lex"}},
-      PARA {"Other acknowledgements:"},      
-     "This method was taken from Chris Francisco's package: LexIdeals, which is available at ",
-      HREF{"http://www2.macaulay2.com/Macaulay2/doc/Macaulay2-1.10/share/doc/Macaulay2/LexIdeals/html/","LexIdeals"},
-      
      PARA {"Examples:"},
      EXAMPLE lines ///
            E=QQ[e_1..e_4,SkewCommutative=>true]
            isLexIdeal ideal {e_1*e_2,e_2*e_3}
            isLexIdeal ideal {e_1*e_2,e_1*e_3,e_1*e_4,e_2*e_3}
      ///,
+     Acknowledgement => PARA {
+	 "This method was taken from ", TO "LexIdeals::isLexIdeal",
+	 " in Chris Francisco's package ", TO "LexIdeals::LexIdeals", "." },
      SeeAlso =>{lexIdeal},
      }
 

--- a/M2/Macaulay2/packages/FrobeniusThresholds/DivisorPatch.m2
+++ b/M2/Macaulay2/packages/FrobeniusThresholds/DivisorPatch.m2
@@ -8,7 +8,7 @@ protect KnownDomain;
 protect IsGraded;
 protect ModuleStrategy;
 
---the following code is take from Divisor.m2
+--the following code is take from WeilDivisors.m2
 
 reflexify = method( Options => { Strategy => NoStrategy, KnownDomain => true, ReturnMap => false } )
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -69,6 +69,7 @@ document {
     UL {
 	LI { "functionality changed in a way that could break code:",
 	    UL {
+		LI { "The package ", TT "Divisor", " has been renamed as ", TO "WeilDivisors :: WeilDivisors", "." },
 		LI { "The method ", TO "Isomorphism :: isIsomorphism", " now only returns true or false. ",
 		    "To retrieved the computed isomorphism, use the method ", TO "Isomorphism :: isomorphism", "." },
 		LI { "The method ", TO (symbol\\, Matrix, Matrix), " is now a shortcut for ", TO (quotient', Matrix, Matrix), ". ",
@@ -953,7 +954,7 @@ document {
      	       	    -- LI { star, " ", TO "::", ", a package by ... for ..., has been published." },
 		    LI { star, " ", TO "LieTypes::LieTypes", " and ", TO "ConformalBlocks::ConformalBlocks", ", two packages by Dave Swinarski for computing ranks and first Chern classes of conformal block bundles
 			 on the moduli space of n-pointed curves of genus 0, have been published." },
-		    LI { star, " ", TO "Divisor::Divisor", ", a package by Karl Schwede and Zhaoning Yang for working with Weil divisors, has been published." },
+		    LI { star, " ", TO "WeilDivisors::WeilDivisors", ", a package by Karl Schwede and Zhaoning Yang for working with Weil divisors, has been published." },
 		    LI { star, " ", TO "StronglyStableIdeals::StronglyStableIdeals", ", a package by Davide Alberelli and Paolo Lella for studying strongly stable ideals related to Hilbert polynomials, has been published." },
 		    LI { star, " ", TO "DiffAlg::DiffAlg", ", a package by Manuel Dubinsky, Cesar Massri, Ariel Molinuevo, and Federico Quallbrunn, for computations with differential forms, has been published." },
 		    LI { star, " ", TO "Matroids::Matroids", ", a package by Justin Chen for computations with matroids, has been published." },
@@ -1256,7 +1257,7 @@ document {
 				package recognizes complete intersection, Gorenstein, and Golod rings of any
 				codepth via the functions isCI, isGorenstein, and isGolod." },
 		    LI {
-			 "The package ", TO "Divisor::Divisor", " has numerous changes to core methods to
+			 "The package ", TO "WeilDivisors::WeilDivisors", " has numerous changes to core methods to
 			 make them compatible with Macaulay2 standards and conventions (including renaming many methods).
 			 Documentation is also improved throughout.  Additional
 			 functionality has also been added (for example, checking if a divisor is very ample)."
@@ -1730,7 +1731,7 @@ document {
 			 has been added."
 			 },
 		    LI { TO "EnumerationCurves::EnumerationCurves", ", a package by Hiep Dang for enumeration of rational curves via torus actions, has been added." },
-		    LI { TO "Divisor::Divisor", ", a package by Karl Schwede and Zhaoning Yang for working with Weil divisors, has been added." },
+		    LI { TO "WeilDivisors::WeilDivisors", ", a package by Karl Schwede and Zhaoning Yang for working with Weil divisors, has been added." },
 		    LI { TO "EllipticCurves::EllipticCurves", ", a package by Alessandro Oneto and Stefano Marseglia for addition on elliptic curves and point counting, has been added." },		
 		    LI { TO "HighestWeights::HighestWeights", ", a package by Federico Galetto for decomposing free resolutions and graded modules with a semisimple Lie group action, has been added." },		
 		    LI { "NumericalHilbert (absorbed by ", TO "NoetherianOperators::NoetherianOperators", "), a package by Robert Krone for numerically computing local dual spaces and Hilbert functions, has been added." },

--- a/M2/Macaulay2/packages/Macaulay2Doc/shared.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/shared.m2
@@ -23,12 +23,12 @@ document { Key => eulers,       methodstr }
 document { Key => genera,       methodstr }
 document { Key => genus,        methodstr }
 document { Key => isSmooth,     methodstr, SeeAlso => {
-	"Divisor::isSmooth(Ideal)", "LatticePolytopes::isSmooth(Polyhedron)",
+	"WeilDivisors::isSmooth(Ideal)", "LatticePolytopes::isSmooth(Polyhedron)",
 	"Varieties::isSmooth(Variety)", "SpaceCurves::isSmooth(Curve)",
 	"Polyhedra::isSmooth(Cone)", "NormalToricVarieties::isSmooth(NormalToricVariety)",
 	"SpecialFanoFourfolds::isSmooth(EmbeddedProjectiveVariety)" } }
 document { Key => isVeryAmple,  methodstr, SeeAlso => {
-	"Divisor::isVeryAmple(WeilDivisor)", "Polyhedra::isVeryAmple(Polyhedron)",
+	"WeilDivisors::isVeryAmple(WeilDivisor)", "Polyhedra::isVeryAmple(Polyhedron)",
 	"PositivityToricBundles::isVeryAmple(ToricVectorBundleKlyachko)",
 	"NormalToricVarieties::isVeryAmple(ToricDivisor)" } }
 document { Key => isNormal,     methodstr, SeeAlso => {

--- a/M2/Macaulay2/packages/MixedMultiplicity.m2
+++ b/M2/Macaulay2/packages/MixedMultiplicity.m2
@@ -31,7 +31,7 @@ newPackage(
 	},
     Headline => "Mixed Multiplicities",
     Headline => "Mixed Multiplicities of ideals",
-    PackageImports=>{"Divisor", "ReesAlgebra", "Depth", "Polyhedra"},
+    PackageImports => { "WeilDivisors", "ReesAlgebra", "Depth", "Polyhedra" },
     Keywords => {"Commutative Algebra"},
     Certification => {
 	"journal name" => "Journal of Software for Algebra and Geometry",

--- a/M2/Macaulay2/packages/RationalMaps.m2
+++ b/M2/Macaulay2/packages/RationalMaps.m2
@@ -2618,7 +2618,7 @@ TEST /// --test #28
 ///
 
 TEST /// --test #29, map from genus 3 curve to projective space
-    needsPackage "Divisor";
+    needsPackage "WeilDivisors";
     C = ZZ/103[x,y,z]/(x^4+x^2*y*z+y^4+z^3*x);
     Q = ideal(y,x+z); --a point on our curve
     f2 = mapToProjectiveSpace(7*divisor(Q)); --a divisor of degree 7 (this is degree 7, so should induce an embedding)

--- a/M2/Macaulay2/packages/SectionRing.m2
+++ b/M2/Macaulay2/packages/SectionRing.m2
@@ -7,7 +7,7 @@ newPackage( "SectionRing",
      	       HomePage => "http://www.math.utah.edu/~bydlon/"
      	       }
 	  },
-     PackageImports => {"Divisor", "Varieties"},
+     PackageImports => { "WeilDivisors", "Varieties" },
      Keywords => {"Commutative Algebra"},
      Headline => "the section ring of a Weil Divisor"
      )

--- a/M2/Macaulay2/packages/TestIdeals/DivisorPatch.m2
+++ b/M2/Macaulay2/packages/TestIdeals/DivisorPatch.m2
@@ -8,7 +8,7 @@ protect KnownDomain;
 protect IsGraded;
 protect ModuleStrategy;
 
---the following code is take from Divisor.m2
+--the following code is take from WeilDivisors.m2
 
 reflexify = method(Options => {Strategy => NoStrategy, KnownDomain=>true, ReturnMap => false});
 

--- a/M2/Macaulay2/packages/TestIdeals/parameterTestIdeal.m2
+++ b/M2/Macaulay2/packages/TestIdeals/parameterTestIdeal.m2
@@ -8,7 +8,7 @@
 --This function computes the parameter test module of a ring, it returns it as a submodule of a canonical ideal.
 --this is a slightly modified function originally written by Moty Katzman for "Parameter test ideals of Cohen Macaulay rings"
 --it returns the lift of the canonical module to the ambient ring
---needsPackage "Divisor";
+--needsPackage "WeilDivisors";
 
 canonicalIdeal = method( Options => { Attempts => 10 } )
 

--- a/M2/Macaulay2/packages/TestIdeals/parameterTestIdealDoc.m2
+++ b/M2/Macaulay2/packages/TestIdeals/parameterTestIdealDoc.m2
@@ -23,7 +23,7 @@ doc ///
     Description
         Text
             Given a ring $R$, typically a domain, {\tt canonicalIdeal(R)} produces an ideal isomorphic to the canonical module of $R$.  
-	    It uses the function {\tt embedAsIdeal} from {\tt Divisor.m2}.
+	    It uses the function @TO "WeilDivisors::embedAsIdeal"@ from @TO "WeilDivisors::WeilDivisors"@.
         Example
             S = QQ[x,y,u,v];
             T = QQ[a,b];

--- a/M2/Macaulay2/packages/WeilDivisors.m2
+++ b/M2/Macaulay2/packages/WeilDivisors.m2
@@ -1,6 +1,6 @@
 --this file is in the public domain
 
-newPackage( "Divisor",
+newPackage( "WeilDivisors",
      Version => "0.3", 
      Date => "May 30th, 2018",
      Authors => {
@@ -19,6 +19,7 @@ newPackage( "Divisor",
 	  "published code URI" => "https://msp.org/jsag/2018/8-1/jsag-v8-n1-x09-Divisor.m2",
 	  "release at publication" => "0e40b423ff375d6eb0a98d6fbbe7be8b2db95a98",	    -- git commit number in hex
 	  "version at publication" => "0.3",
+	  "legacy name" => "Divisor", -- renamed due to GitHub issue #3543
 	  "volume number" => "8",
 	  "volume URI" => "https://msp.org/jsag/2018/8-1/"
 	  }
@@ -1936,9 +1937,9 @@ reflexivePower(ZZ, Ideal) := Ideal => o -> (n1, I1) -> (
 beginDocumentation();
 
 document {
-    Key => Divisor,
+    Key => WeilDivisors,
     Headline => "divisors",
-    EM "Divisor", " is a package for working with (Q/R)-Weil divisors on ", EM "normal", " affine and projective varieties (equivalently, on commutative, normal and graded rings).", 
+    EM "WeilDivisors", " is a package for working with ($\\QQ$/$\\RR$)-Weil divisors on ", EM "normal", " affine and projective varieties (equivalently, on commutative, normal and graded rings).",
     BR{},BR{},
     "This package introduces a type ", TO "WeilDivisor", " which lets the user work with Weil divisors similar to the way one might in algebraic geometry.  We highlight a few important functions below.",
     BR{},BR{},


### PR DESCRIPTION
With permission from the authors, I renamed the Divisor package to WeilDivisors to prevent the conflict caused by #3543. I also added a warning so that anyone using the old name sees this warning:
```m2
i1 : needsPackage "Divisor"
 -- warning: the 'Divisor' package has been renamed as 'WeilDivisors'.

o1 = WeilDivisors

o1 : Package
```
Later, we can change this to be an error.

- **renamed 'Divisor' package as 'WeilDivisors'**
- **added deprecation warning for renamed packages**
- **fixed a dead link in ExteriorIdeals**


(Karl: feel free to review only the changes in your packages -- I've asked Doug to review the changes in Core)