### PR TITLE
Install exports.m2 manually since it's no longer in loadsequence

### DIFF
--- a/M2/Macaulay2/m2/CMakeLists.txt
+++ b/M2/Macaulay2/m2/CMakeLists.txt
@@ -42,7 +42,7 @@ add_custom_command(OUTPUT ${CORE_DIR}/tvalues.m2
 configure_file(version.m2.in ${M2_DIST_PREFIX}/${M2_INSTALL_DATADIR}/Core/version.m2 @ONLY)
 
 foreach(filename IN LISTS M2LIST ITEMS
-    ${CMAKE_CURRENT_BINARY_DIR}/startup.m2 Core.m2 loadsequence)
+    ${CMAKE_CURRENT_BINARY_DIR}/startup.m2 Core.m2 exports.m2 loadsequence)
   file(COPY ${filename} DESTINATION ${CORE_DIR})
 endforeach()
 

--- a/M2/Macaulay2/m2/Makefile.in
+++ b/M2/Macaulay2/m2/Makefile.in
@@ -13,8 +13,9 @@ Makefile: Makefile.in ; cd ../.. && ./config.status Macaulay2/m2/Makefile
 ##############################
 .SUFFIXES: .m2
 .PHONY: html initialize tags install-tmp
-DUMPEDM2FILES := Core.m2 startup.m2 version.m2 $(shell cat @srcdir@/loadsequence)
-DUMPEDM2SRCFILES := Core.m2 startup.m2.in version.m2.in
+DUMPEDM2FILES := Core.m2 exports.m2 startup.m2 version.m2 \
+	$(shell cat @srcdir@/loadsequence)
+DUMPEDM2SRCFILES := Core.m2 exports.m2 startup.m2.in version.m2.in
 DUMPEDM2DOCFILES := \
 		@srcdir@/../packages/Macaulay2Doc/*.m2 \
 		@srcdir@/../packages/Macaulay2Doc/functions/*.m2 \


### PR DESCRIPTION
The autotools build uses this file to determine which .m2 files to install

