### PR TITLE
CI: Add portability testing with passagemath's reusable GH Actions workflows

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -47,6 +47,10 @@ on:
       - '*'
   workflow_dispatch:
     # Allow to run manually
+    inputs:
+      macaulay2_targets:
+        description: 'Targets to build before M2-core, e.g., build-normaliz'
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -89,7 +93,7 @@ jobs:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
       extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" macaulay2
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" SAGE_MACAULAY2_TARGETS="${{ github.event.inputs.macaulay2_targets }}" macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath
       sage_ref: main
@@ -103,7 +107,7 @@ jobs:
     uses: passagemath/passagemath/.github/workflows/macos.yml@main
     with:
       extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" macaulay2
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" SAGE_MACAULAY2_TARGETS="${{ github.event.inputs.macaulay2_targets }}" macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath
       sage_ref: main

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,0 +1,147 @@
+name: Run Sage CI
+
+## This GitHub Actions workflow provides:
+##
+##  - portability testing, by building and testing this project on many platforms
+##    (Linux variants and macOS), each with two configurations (installed packages),
+##
+##  - continuous integration, by building and testing other software
+##    that depends on this project.
+##
+## It runs on every pull request and push of a tag to the GitHub repository.
+##
+## The testing can be monitored in the "Actions" tab of the GitHub repository.
+##
+## After all jobs have finished (or are canceled) and a short delay,
+## tar files of all logs are made available as "build artifacts".
+##
+## This GitHub Actions workflow uses the portability testing framework
+## of SageMath (https://www.sagemath.org/).  For more information, see
+## https://doc.sagemath.org/html/en/developer/portability_testing.html
+
+## The workflow consists of two jobs:
+##
+##  - First, it builds a source distribution of the project
+##    and generates a script "update-pkgs.sh".  It uploads them
+##    as a build artifact named upstream.
+##
+##  - Second, it checks out a copy of the SageMath source tree.
+##    It downloads the upstream artifact and replaces the project's
+##    package in the SageMath distribution by the newly packaged one
+##    from the upstream artifact, by running the script "update-pkgs.sh".
+##    Then it builds a small portion of the Sage distribution.
+##
+## Many copies of the second step are run in parallel for each of the tested
+## systems/configurations.
+
+#on: [push, pull_request]
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  workflow_dispatch:
+    # Allow to run manually
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  # Ubuntu packages to install so that the project's "make dist" can succeed
+  DIST_PREREQ: autoconf automake libtool
+  # Name of this project in the Sage distribution
+  SPKG:        macaulay2
+  REMOVE_PATCHES:   "*"
+
+jobs:
+
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ env.SPKG }}
+        uses: actions/checkout@v4
+        with:
+          path: build/pkgs/${{ env.SPKG }}/src
+      - name: Install prerequisites
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install $DIST_PREREQ
+
+      # From test_build.yml
+
+      - name: Install requirements for Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo add-apt-repository -y -n ppa:macaulay2/macaulay2
+          sudo apt-get update
+          sudo apt-get install -y -q --no-install-recommends clang-16 gfortran libtool-bin ninja-build yasm ccache
+          sudo apt-get install -y -q --no-install-recommends liblzma-dev libboost-stacktrace-dev \
+                  libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev libopenblas-dev libxml2-dev \
+                  libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libmpfi-dev libntl-dev gfan \
+                  libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
+                  libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 libnormaliz-dev normaliz coinor-csdp \
+                  libnauty-dev nauty lrslib polymake pipx phcpack w3c-markup-validator libtbb-dev qepcad libomp-16-dev msolve
+
+
+      - name: Run make dist, prepare upstream artifact
+        run: |
+          (cd build/pkgs/${{ env.SPKG }}/src && cd M2 && ./autogen.sh && ./configure && make dist) \
+          && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/M2/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
+          && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=optional" > upstream/update-pkgs.sh \
+          && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
+          && ls -l upstream/
+      - uses: actions/upload-artifact@v4
+        with:
+          path: upstream
+          name: upstream
+
+  linux:
+    uses: passagemath/passagemath/.github/workflows/docker.yml@main
+    with:
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" macaulay2
+      # Standard setting: Test the current HEAD of passagemath:
+      sage_repo: passagemath/passagemath
+      sage_ref: main
+      upstream_artifact: upstream
+      # We prefix the image name with the SPKG name ("macaulay2-") to avoid the error
+      # 'Package "sage-docker-..." is already associated with another repository.'
+      docker_push_repository: ghcr.io/${{ github.repository }}/macaulay2-
+    needs: [dist]
+
+  macos:
+    uses: passagemath/passagemath/.github/workflows/macos.yml@main
+    with:
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" macaulay2
+      # Standard setting: Test the current HEAD of passagemath:
+      sage_repo: passagemath/passagemath
+      sage_ref: main
+      upstream_artifact: upstream
+    needs: [dist]
+
+  passagemath-macaulay2:
+    uses: passagemath/passagemath/.github/workflows/docker.yml@main
+    with:
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="sagemath_macaulay2" sagemath_macaulay2
+      # Standard setting: Test the current HEAD of passagemath:
+      sage_repo: passagemath/passagemath
+      sage_ref: main
+      upstream_artifact: upstream
+      # Build incrementally from published Docker image
+      incremental: true
+      free_disk_space: true
+      from_docker_repository: ghcr.io/passagemath/passagemath/
+      from_docker_target: "with-targets"
+      from_docker_tag: "dev"
+      docker_targets: "with-targets"
+      tox_system_factors: >-
+        ["ubuntu-jammy"]
+      tox_packages_factors: >-
+        ["standard"]
+      # avoid clash with linux job for the same platform
+      logs_artifact: false
+    needs: [dist]

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -53,7 +53,7 @@ concurrency:
 
 env:
   # Ubuntu packages to install so that the project's "make dist" can succeed
-  DIST_PREREQ: autoconf automake libtool
+  DIST_PREREQ: git
   # Name of this project in the Sage distribution
   SPKG:        macaulay2
   REMOVE_PATCHES:   "*"
@@ -72,26 +72,10 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install $DIST_PREREQ
 
-      # From test_build.yml
-
-      - name: Install requirements for Linux
-        if: runner.os == 'Linux'
-        run: |
-          sudo add-apt-repository -y -n ppa:macaulay2/macaulay2
-          sudo apt-get update
-          sudo apt-get install -y -q --no-install-recommends clang-16 gfortran libtool-bin ninja-build yasm ccache
-          sudo apt-get install -y -q --no-install-recommends liblzma-dev libboost-stacktrace-dev \
-                  libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev libopenblas-dev libxml2-dev \
-                  libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libmpfi-dev libntl-dev gfan \
-                  libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
-                  libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 libnormaliz-dev normaliz coinor-csdp \
-                  libnauty-dev nauty lrslib polymake pipx phcpack w3c-markup-validator libtbb-dev qepcad libomp-16-dev msolve
-
-
       - name: Run make dist, prepare upstream artifact
         run: |
-          (cd build/pkgs/${{ env.SPKG }}/src && cd M2 && ./autogen.sh && ./configure && make dist) \
-          && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/M2/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
+          (cd build/pkgs/${{ env.SPKG }}/src && git archive --format=tar.gz --prefix=${{ env.SPKG }}-git/ HEAD > ${{ env.SPKG }}-git.tar.gz) \
+          && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
           && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=optional" > upstream/update-pkgs.sh \
           && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
           && ls -l upstream/

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -1,5 +1,15 @@
 name: Run Sage CI
-
+##
+## This GitHub Actions workflow uses the portability testing framework
+## of passagemath (https://github.com/passagemath).
+##
+##  - Documentation: https://doc.sagemath.org/html/en/developer/portability_testing.html
+##
+##  - Deployment of ci-sage.yml in upstream projects is tracked at
+##    https://github.com/passagemath/passagemath/issues/704
+##
+##  - Contact: @passagemath/ci team on GitHub
+##
 ## This GitHub Actions workflow provides:
 ##
 ##  - portability testing, by building and testing this project on many platforms
@@ -15,10 +25,6 @@ name: Run Sage CI
 ## After all jobs have finished (or are canceled) and a short delay,
 ## tar files of all logs are made available as "build artifacts".
 ##
-## This GitHub Actions workflow uses the portability testing framework
-## of SageMath (https://www.sagemath.org/).  For more information, see
-## https://doc.sagemath.org/html/en/developer/portability_testing.html
-
 ## The workflow consists of two jobs:
 ##
 ##  - First, it builds a source distribution of the project

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -87,7 +87,7 @@ jobs:
   linux:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
-      extra_sage_packages: gdbm git libxml2
+      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath
@@ -101,7 +101,7 @@ jobs:
   macos:
     uses: passagemath/passagemath/.github/workflows/macos.yml@main
     with:
-      extra_sage_packages: gdbm git libxml2
+      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -87,6 +87,7 @@ jobs:
   linux:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
+      extra_sage_packages: gdbm git libxml2
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath
@@ -100,6 +101,7 @@ jobs:
   macos:
     uses: passagemath/passagemath/.github/workflows/macos.yml@main
     with:
+      extra_sage_packages: gdbm git libxml2
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="macaulay2" macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -18,7 +18,8 @@ name: Run Sage CI
 ##  - continuous integration, by building and testing other software
 ##    that depends on this project.
 ##
-## It runs on every pull request and push of a tag to the GitHub repository.
+## It runs on every push of a tag to the GitHub repository
+## and can also be invoked manually ("workflow_dispatch").
 ##
 ## The testing can be monitored in the "Actions" tab of the GitHub repository.
 ##
@@ -40,14 +41,8 @@ name: Run Sage CI
 ## Many copies of the second step are run in parallel for each of the tested
 ## systems/configurations.
 
-#on: [push, pull_request]
-
 on:
-  pull_request:
-    types: [opened, synchronize]
   push:
-    branches:
-      - master
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -109,26 +109,3 @@ jobs:
       sage_ref: main
       upstream_artifact: upstream
     needs: [dist]
-
-  passagemath-macaulay2:
-    uses: passagemath/passagemath/.github/workflows/docker.yml@main
-    with:
-      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="sagemath_macaulay2" sagemath_macaulay2
-      # Standard setting: Test the current HEAD of passagemath:
-      sage_repo: passagemath/passagemath
-      sage_ref: main
-      upstream_artifact: upstream
-      # Build incrementally from published Docker image
-      incremental: true
-      free_disk_space: true
-      from_docker_repository: ghcr.io/passagemath/passagemath/
-      from_docker_target: "with-targets"
-      from_docker_tag: "dev"
-      docker_targets: "with-targets"
-      tox_system_factors: >-
-        ["ubuntu-jammy"]
-      tox_packages_factors: >-
-        ["standard"]
-      # avoid clash with linux job for the same platform
-      logs_artifact: false
-    needs: [dist]


### PR DESCRIPTION
https://github.com/passagemath/ is my pip-installable modularized fork of SageMath.
- I recently added Macaulay2 as a package to the distribution (building it from source using the cmake build system; see https://github.com/passagemath/passagemath/tree/main/build/pkgs/macaulay2)

In this PR, I propose to add a CI to Macaulay2 that reuses the infrastructure that I use in passagemath to ensure platform compatibility for building from source on a wide range on Linux, macOS platforms.

Preview of the workflow run: https://github.com/passagemath/M2/actions/workflows/ci-sage.yml

Right now, many tests are failing because my package build script (https://github.com/passagemath/passagemath/blob/main/build/pkgs/macaulay2/spkg-install.in) is not careful enough to make sure that M2 finds the right versions of dependencies. For example, an old version of FLINT is installed in the system, so the Sage distribution builds its own copy; but M2 insists on using the old version and fails.

See also:
- https://github.com/Macaulay2/M2/pull/3827