### PR TITLE
SRdeformations 0.53: use Polyhedra instead of OldPolyhedra

### DIFF
--- a/M2/Macaulay2/packages/MultiplicitySequence.m2
+++ b/M2/Macaulay2/packages/MultiplicitySequence.m2
@@ -23,7 +23,7 @@ newPackage(
         "Normaliz",
         "PrimaryDecomposition",
         "MinimalPrimes",
-        "OldPolyhedra",
+        "Polyhedra",
     },
     Certification => {
 	"journal name" => "Journal of Software for Algebra and Geometry",
@@ -213,7 +213,7 @@ monReduction Ideal := MonomialIdeal => I -> (
 --- from a matrix M extract the rows where all the entries are not zero
 isBddFacet := (n, M) -> (
     s := rank source M; --- # of columns
-    mutableM := mutableIdentity (ZZ,s); --- row as a vector
+    mutableM := mutableIdentity (ring M,s); --- row as a vector
     for i from 0 to (s - 1) do (mutableM_(i,i) = M_(n,i));
     det mutableM != 0 --- No if 0, Yes otherwise
 )
@@ -245,7 +245,7 @@ monAnalyticSpread Ideal := ZZ => I -> (
     Mm := M_0;
     Mv := M_1;
     r := rank target Mm;  --- # of rows
-    1 + max apply(r, p -> dim convexHull vertices intersection (Mm, Mv, Mm^{p}, Mv^{p}))
+    1 + max apply(r, p -> dim convexHull vertices polyhedronFromHData (Mm, Mv, Mm^{p}, Mv^{p}))
     -- monAS := 0;
     -- for p from 0 to r-1 do (
         -- face := intersection (Mm, Mv, Mm^{p}, Mv^{p});
@@ -268,7 +268,7 @@ monjMult Ideal := ZZ => I -> (
     monj := 0;
     for p from 0 to r-1 do (
     if isBddFacet(p, Mm) then (
-        face := intersection (Mm, Mv, Mm^{p}, Mv^{p});
+        face := polyhedronFromHData (Mm, Mv, Mm^{p}, Mv^{p});
         monj = monj + (d!)*(volume convexHull pyrF(vertices face));
         );
     );


### PR DESCRIPTION
This PR makes minimal changes to SRdeformations to make it compatible with Polyhedra instead of OldPolyhedra. There aren't any tests, but I checked and the examples in the documentation basically haven't changed (in a couple of places some answers were permuted, but I believe it's the same).

@jankoboehm does this look okay to you?

Note that the package still overwrites a few symbols from Polyhedra and at least a few from other packages, so further improvements can be made, but for the purposes of deprecating `OldPolyhedra` this seems to suffice.

Here are the changes in the documentation which I believe are permutations of the correct answer:

In the documentation of [Complex](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/SRdeformations/html/___Complex.html):
```diff
i8 : complement C

 o8 = 2: x x x  x x x  x x x  x x x  x x x  x x x  x x x  x x x
-         3 4 5  1 4 5  2 1 5  2 3 4  3 0 4  1 0 4  2 3 1  2 1 0
+         4 5 3  1 4 5  1 5 2  4 2 3  0 4 3  1 0 4  1 2 3  1 0 2
```

In the documentation of [hull](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/SRdeformations/html/_hull.html)
```diff
i6 : dC.grading

-o6 = | 0 1 -1 -1 0  |
+o6 = | 0 1 -1 1  0  |
      | 0 1 1  -1 0  |
-     | 0 1 -1 1  0  |
+     | 0 1 -1 -1 0  |
+     | 0 1 -1 -1 2  |
+     | 1 0 0  0  1  |
      | 1 0 0  0  -1 |
      | 1 0 2  0  -1 |
      | 1 0 0  2  -1 |
-     | 1 0 0  0  1  |
-     | 0 1 -1 -1 2  |
```