### PR TITLE
Bump msolve to 0.8.0

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -485,8 +485,8 @@ endif()
 
 # https://github.com/algebraic-solving/msolve
 ExternalProject_Add(build-msolve
-  URL               https://github.com/algebraic-solving/msolve/archive/refs/tags/v0.7.5.tar.gz
-  URL_HASH          SHA256=e88368abfd1e1918329ff9444164ca0e304835794fec68d192a63c845ae63128
+  URL               https://github.com/algebraic-solving/msolve/archive/refs/tags/v0.8.0.tar.gz
+  URL_HASH          SHA256=d84f0bdefe0e09b23721fbd3b7e2f626e3206602bd245456f4ebfab445f05eb3
   PREFIX            libraries/msolve
   SOURCE_DIR        libraries/msolve/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/libraries/msolve/Makefile.in
+++ b/M2/libraries/msolve/Makefile.in
@@ -1,5 +1,5 @@
 HOMEPAGE = https://msolve.lip6.fr/
-VERSION = 0.7.5
+VERSION = 0.8.0
 URL = https://github.com/algebraic-solving/msolve/archive/refs/tags
 TARFILE = v$(VERSION).tar.gz
 LICENSEFILES = README.md COPYING


### PR DESCRIPTION
msolve 0.8.0 was just released, so we update the cmake and autotools builds to use it if it's not already available.

This is a draft for now.  I'll remove the second commit, which forces the building of msolve in the GitHub builds, if the builds are successful.