### PR TITLE
Uncomment "changes made for the next release" documentation node

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -5,7 +5,7 @@ star := IMG { "src" => replace("PKG","Style",currentLayout#"package") | "GoldSta
 document {
      Key => "changes to Macaulay2, by version",
      Subnodes => {
---	  TO "changes made for the next release",
+	  TO "changes made for the next release",
 	  TO "changes, 1.25.05",
 	  TO "changes, 1.24.11",
 	  TO "changes, 1.24.05",
@@ -65,11 +65,41 @@ changesHelper List := opt -> pkgnames -> (
 	    << ".\" },"
 	    << endl)))
 
--*
 document {
-    Key => "changes made for the next release"
+    Key => "changes made for the next release",
+        UL {
+	LI { BOLD "upcoming breaking changes:",
+	    UL {
+		LI {}
+	    }
+	},
+	LI { "packages that have been published and certified:",
+	    UL {
+		LI {}
+		}
+	    },
+	LI { "new packages:",
+	    UL {
+		LI {}
+		}
+	    },
+	LI { "improved packages:",
+	    UL {
+		LI {}
+		}
+	    },
+	LI { "functionality added or improved:",
+	    UL {
+		LI {}
+		}
+	    },
+	LI { "functionality changed in a way that could break code:",
+	    UL {
+		LI {}
+		}
+	    }
+	}
     }
-*-
 
 document {
     Key => "changes, 1.25.05",


### PR DESCRIPTION
It was commented because it doesn't really make sense to have in a stable release, but we should uncomment it to start documenting changes for 1.25.11.

