### PR TITLE
CI: Add integration testing with the Python interface passagemath-macaulay2

### DIFF
--- a/.github/workflows/ci-passagemath-macaulay2.yml
+++ b/.github/workflows/ci-passagemath-macaulay2.yml
@@ -86,7 +86,7 @@ jobs:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
       # singular is not suitable, omit
-      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl 4ti2 fflas_ffpack boost_cropped cddlib givaro glpk gmp mpc mpfi mpfr ncurses ntl readline lrslib normaliz topcom gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve eigen gc ninja_build curl gsl libatomic_ops
+      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl 4ti2 fflas_ffpack boost_cropped cddlib givaro glpk gmp mpc mpfi mpfr ncurses ntl readline lrslib normaliz topcom gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve eigen gc ninja_build curl gsl libatomic_ops tox
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="sagemath_macaulay2" sagemath_macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath

--- a/.github/workflows/ci-passagemath-macaulay2.yml
+++ b/.github/workflows/ci-passagemath-macaulay2.yml
@@ -1,0 +1,103 @@
+name: Test integration with passagemath-macaulay2
+##
+## This GitHub Actions workflow uses the portability testing framework
+## of passagemath (https://github.com/passagemath).
+##
+##  - Documentation: https://doc.sagemath.org/html/en/developer/portability_testing.html
+##
+##  - Deployment of ci-sage.yml in upstream projects is tracked at
+##    https://github.com/passagemath/passagemath/issues/704
+##
+##  - Contact: @passagemath/ci team on GitHub
+##
+## This GitHub Actions workflow provides:
+##
+##  - continuous integration, by building and testing other software
+##    that depends on this project.
+##
+## It runs on every push of a tag to the GitHub repository
+## and can also be invoked manually ("workflow_dispatch").
+##
+## The testing can be monitored in the "Actions" tab of the GitHub repository.
+##
+## After all jobs have finished (or are canceled) and a short delay,
+## tar files of all logs are made available as "build artifacts".
+##
+## The workflow consists of two jobs:
+##
+##  - First, it builds a source distribution of the project
+##    and generates a script "update-pkgs.sh".  It uploads them
+##    as a build artifact named upstream.
+##
+##  - Second, it checks out a copy of the SageMath source tree.
+##    It downloads the upstream artifact and replaces the project's
+##    package in the SageMath distribution by the newly packaged one
+##    from the upstream artifact, by running the script "update-pkgs.sh".
+##    Then it builds a small portion of the Sage distribution.
+##
+## Many copies of the second step are run in parallel for each of the tested
+## systems/configurations.
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    # Allow to run manually
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  # Ubuntu packages to install so that the project's "make dist" can succeed
+  DIST_PREREQ: git
+  # Name of this project in the Sage distribution
+  SPKG:        macaulay2
+  REMOVE_PATCHES:   "*"
+
+jobs:
+
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ env.SPKG }}
+        uses: actions/checkout@v4
+        with:
+          path: build/pkgs/${{ env.SPKG }}/src
+      - name: Install prerequisites
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install $DIST_PREREQ
+
+      - name: Run make dist, prepare upstream artifact
+        run: |
+          (cd build/pkgs/${{ env.SPKG }}/src && git archive --format=tar.gz --prefix=${{ env.SPKG }}-git/ HEAD > ${{ env.SPKG }}-git.tar.gz) \
+          && mkdir -p upstream && cp build/pkgs/${{ env.SPKG }}/src/*.tar.gz upstream/${{ env.SPKG }}-git.tar.gz \
+          && echo "sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=optional" > upstream/update-pkgs.sh \
+          && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
+          && ls -l upstream/
+      - uses: actions/upload-artifact@v4
+        with:
+          path: upstream
+          name: upstream
+
+  passagemath-macaulay2:
+    uses: passagemath/passagemath/.github/workflows/docker.yml@main
+    with:
+      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl 4ti2 fflas_ffpack boost_cropped cddlib givaro glpk gmp mpc mpfi mpfr ncurses ntl readline singular lrslib normaliz topcom gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve eigen gc ninja_build curl
+      targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="sagemath_macaulay2" sagemath_macaulay2
+      # Standard setting: Test the current HEAD of passagemath:
+      sage_repo: passagemath/passagemath
+      sage_ref: main
+      upstream_artifact: upstream
+      # Build incrementally from published Docker image
+      free_disk_space: true
+      docker_targets: "with-targets"
+      tox_system_factors: >-
+        ["ubuntu-noble-macaulay2_daily"]
+      tox_packages_factors: >-
+        ["minimal"]
+      # avoid clash with linux job for the same platform
+      logs_artifact: false
+    needs: [dist]

--- a/.github/workflows/ci-passagemath-macaulay2.yml
+++ b/.github/workflows/ci-passagemath-macaulay2.yml
@@ -86,7 +86,7 @@ jobs:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
       # singular is not suitable, omit
-      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl 4ti2 fflas_ffpack boost_cropped cddlib givaro glpk gmp mpc mpfi mpfr ncurses ntl readline lrslib normaliz topcom gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve eigen gc ninja_build curl gsl libatomic_ops tox
+      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl 4ti2 fflas_ffpack boost_cropped cddlib givaro glpk gmp mpc mpfi mpfr ncurses ntl readline lrslib normaliz topcom gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve eigen gc ninja_build curl gsl libatomic_ops tox libgd m4ri m4rie iml
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="sagemath_macaulay2" sagemath_macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath

--- a/.github/workflows/ci-passagemath-macaulay2.yml
+++ b/.github/workflows/ci-passagemath-macaulay2.yml
@@ -85,7 +85,8 @@ jobs:
   passagemath-macaulay2:
     uses: passagemath/passagemath/.github/workflows/docker.yml@main
     with:
-      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl 4ti2 fflas_ffpack boost_cropped cddlib givaro glpk gmp mpc mpfi mpfr ncurses ntl readline singular lrslib normaliz topcom gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve eigen gc ninja_build curl
+      # singular is not suitable, omit
+      extra_sage_packages: gdbm git libxml2 gfortran cmake python3 openblas zlib readline sqlite libpng bzip2 liblzma libffi openssl 4ti2 fflas_ffpack boost_cropped cddlib givaro glpk gmp mpc mpfi mpfr ncurses ntl readline lrslib normaliz topcom gfan frobby nauty libnauty flint onetbb googletest mpsolve msolve eigen gc ninja_build curl gsl libatomic_ops
       targets: SAGE_CHECK=no SAGE_CHECK_PACKAGES="sagemath_macaulay2" sagemath_macaulay2
       # Standard setting: Test the current HEAD of passagemath:
       sage_repo: passagemath/passagemath


### PR DESCRIPTION
https://github.com/passagemath/ is my pip-installable modularized fork of SageMath.
- https://pypi.org/project/passagemath-macaulay2/ ships the Python interface to Macaulay2 from the Sage library.
- Since [passagemath-10.5.41](https://github.com/passagemath/passagemath/releases/tag/passagemath-10.5.41), the binary wheels of passagemath-macaulay2 ship a prebuilt copy of Macaulay2, for the convenience of Python users.

Here I propose adding a CI for integration testing with passagemath-macaulay2. 
- preview: https://github.com/passagemath/M2/actions/runs/15061908487/job/42802455060
- The workflow consists of two jobs and currently takes about 45 minutes; I hope to make it faster later by using more of the prebuilt packages from the Macaulay2 ppa. (These changes will take place in the passagemath repository.)
- The workflow is configured to run only when a (release) tag is pushed to the repository. It can also be invoked manually using a workflow request.

See also:
- #3813