### PR TITLE
Bump 4ti2 to 1.6.11

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -767,8 +767,8 @@ set(4ti2_PROGRAMS
   qsolve rays walk zbasis zsolve hilbert graver ppi genmodel gensymm output)
 list(TRANSFORM 4ti2_PROGRAMS PREPEND ${M2_HOST_PREFIX}/bin/ OUTPUT_VARIABLE 4ti2_PROGRAMS)
 ExternalProject_Add(build-4ti2
-  URL               https://github.com/4ti2/4ti2/releases/download/Release_1_6_10/4ti2-1.6.10.tar.gz
-  URL_HASH          SHA256=f7c191beb14246b643e4fd5b18b53d9966693b9e6d3a569441a0e3ca14b1a86b
+  URL               https://github.com/4ti2/4ti2/releases/download/Release_1_6_11/4ti2-1.6.11.tar.gz
+  URL_HASH          SHA256=cdb7dbb2c2b3797dc8291bed32512767557c553114b7bf496a8f39daafa23a27
   PREFIX            libraries/4ti2
   SOURCE_DIR        libraries/4ti2/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/libraries/4ti2/Makefile.in
+++ b/M2/libraries/4ti2/Makefile.in
@@ -1,5 +1,5 @@
 # temporary beta testing version
-VERSION = 1.6.10
+VERSION = 1.6.11
 TARDIR = 4ti2-$(VERSION)
 
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)


### PR DESCRIPTION
4ti2 1.6.11 was released recently.  Draft for now -- I'll remove the second commit if the builds are successful