### PR TITLE
Add patch for building lrslib in GCC 15

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -871,6 +871,7 @@ ExternalProject_Add(build-lrslib
   SOURCE_DIR        libraries/lrslib/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
+  PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/lrslib/patch-073
   CONFIGURE_COMMAND true
   BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS} prefix=${M2_HOST_PREFIX} lrs # all-shared
                       INCLUDEDIR=${GMP_INCLUDE_DIRS}

--- a/M2/libraries/lrslib/Makefile.in
+++ b/M2/libraries/lrslib/Makefile.in
@@ -6,7 +6,7 @@
 HOMEPAGE = http://www-cgrl.cs.mcgill.ca/~avis/C/lrs.html
 URL = https://cgm.cs.mcgill.ca/~avis/C/lrslib/archive
 VERSION = 073
-# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 TARFILE = lrslib-$(VERSION).tar.gz
 #PROGRAMS = lrs redund lra1 redund1 nash setupnash setupnash2 fourier buffer 2nash
 PROGRAMS = lrs #redund lrs1 redund1 setnash setnash2 2nash

--- a/M2/libraries/lrslib/patch-073
+++ b/M2/libraries/lrslib/patch-073
@@ -1,0 +1,45 @@
+Description: Fix incompatible pointer type errors in GCC 15
+Origin: https://src.fedoraproject.org/rpms/lrslib/blob/rawhide/f/lrslib-fixes.patch
+
+--- a/lrslib.c
++++ lrslib-073/lrslib.c
+@@ -84,10 +84,10 @@ char *lrs_basename(char *path);
+ /* signals handling            */
+ /*******************************/
+ #ifndef SIGNALS
+-static void checkpoint ();
+-static void die_gracefully ();
++static void checkpoint (int signum);
++static void die_gracefully (int signum);
+ static void setup_signals (void);
+-static void timecheck ();
++static void timecheck (int signum);
+ #endif
+ 
+ /*******************************/
+@@ -6368,7 +6368,7 @@ setup_signals ()
+ }
+ 
+ static void
+-timecheck ()
++timecheck (int signum)
+ {
+   lrs_dump_state ();
+   errcheck ("signal", signal (SIGALRM, timecheck));
+@@ -6376,14 +6376,14 @@ timecheck ()
+ }
+ 
+ static void
+-checkpoint ()
++checkpoint (int signum)
+ {
+   lrs_dump_state ();
+   errcheck ("signal", signal (SIGUSR1, checkpoint));
+ }
+ 
+ static void
+-die_gracefully ()
++die_gracefully (int signum)
+ {
+   lrs_dump_state ();
+ 


### PR DESCRIPTION
This fixes the following error I ran into building a Fedora 42 package:

```c
In file included from lrslib.c:36:
lrslib.c: In function 'lrs_read_dic_1':
In file included from lrslib.c:36:
lrslib.c: In function 'lrs_read_dic_gmp':
lrslib.h:154:23: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]
  154 | #define timecheck suf(timecheck)
      |                       ^~~~~~~~~
      |                       |
      |                       void (*)(void)
lrslib.h:175:34: note: in definition of macro 'errcheck'
  175 | #define errcheck(s,e) if ((long)(e)==-1L){  perror(s);exit(1);}
      |                                  ^
lrslib.h:154:19: note: in expansion of macro 'suf'
  154 | #define timecheck suf(timecheck)
      |                   ^~~
lrslib.c:1747:52: note: in expansion of macro 'timecheck'
 1747 |               errcheck ("signal", signal (SIGALRM, timecheck));
      |                                                    ^~~~~~~~~
lrslib.h:154:23: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]
  154 | #define timecheck suf(timecheck)
      |                       ^~~~~~~~~
      |                       |
      |                       void (*)(void)
lrslib.h:175:34: note: in definition of macro 'errcheck'
  175 | #define errcheck(s,e) if ((long)(e)==-1L){  perror(s);exit(1);}
      |                                  ^
lrslib.h:154:19: note: in expansion of macro 'suf'
  154 | #define timecheck suf(timecheck)
      |                   ^~~
lrslib.c:1747:52: note: in expansion of macro 'timecheck'
 1747 |               errcheck ("signal", signal (SIGALRM, timecheck));
      |                                                    ^~~~~~~~~
etc. etc.
```