### PR TITLE
Drop 4ti2's autoconf version down to 2.69 for older systems

### DIFF
--- a/M2/BUILD/docker/autotools/Makefile
+++ b/M2/BUILD/docker/autotools/Makefile
@@ -9,7 +9,7 @@ mkdir -p M2/$(BUILD_DIR)
 cd M2/$(BUILD_DIR)
 $(M2_HOME)/M2/M2/autogen.sh
 $(M2_HOME)/M2/M2/configure $(CONFIG_OPT)
-make
+make $(MAKE_OPT)
 endef
 export M2_BUILD_SCRIPT_autotools
 

--- a/M2/BUILD/docker/rhel/Dockerfile
+++ b/M2/BUILD/docker/rhel/Dockerfile
@@ -18,9 +18,9 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
 RUN dnf -y install autoconf automake bison boost-devel bzip2 cmake     \
     diffutils eigen3 flex gc-devel gcc-c++ gcc-gfortran gdbm-devel git \
     glpk-devel gmp-devel gtest-devel lapack-devel libffi-devel libtool \
-    libxml2-devel make mpfr-devel ncurses-devel openblas-devel patch   \
-    python3-devel R readline-devel rpm-build tbb-devel which xz-devel  \
-    zlib-devel
+    libxml2-devel make mpfr-devel ncurses-devel ninja-build            \
+    openblas-devel patch python3-devel R readline-devel rpm-build      \
+    tbb-devel which xz-devel zlib-devel
 
 # Add non-root user for building and running Macaulay2
 RUN useradd -G wheel -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -773,8 +773,9 @@ ExternalProject_Add(build-4ti2
   SOURCE_DIR        libraries/4ti2/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
-  PATCH_COMMAND     mkdir swig # needed because the tar doesn't have a swig directory but 4ti2's Makefile.am seems to need it
-  CONFIGURE_COMMAND autoreconf -vif
+  PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/4ti2/patch-1.6.11
+  # tar doesn't have a swig directory but 4ti2's Makefile.am seems to need it
+  CONFIGURE_COMMAND mkdir -p swig && autoreconf -vif
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
                       --with-glpk=${GLPK_ROOT}

--- a/M2/libraries/4ti2/Makefile.in
+++ b/M2/libraries/4ti2/Makefile.in
@@ -2,7 +2,7 @@
 VERSION = 1.6.11
 TARDIR = 4ti2-$(VERSION)
 
-# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PRECONFIGURE = mkdir -p swig && autoreconf -vif
 
 VERSION_ = $(shell echo $(VERSION) | sed 's/\./_/g')

--- a/M2/libraries/4ti2/patch-1.6.11
+++ b/M2/libraries/4ti2/patch-1.6.11
@@ -1,0 +1,13 @@
+Description: Drop autoconf version down to 2.69 for older systems
+
+--- a/configure.ac
++++ 4ti2-1.6.11/configure.ac
+@@ -1,7 +1,7 @@
+ #                                               -*- Autoconf -*-
+ # Process this file with autoconf to produce a configure script.
+ 
+-AC_PREREQ([2.71])
++AC_PREREQ([2.69])
+ AC_INIT([4ti2],[1.6.11])
+ AC_CONFIG_MACRO_DIR([m4])
+ AM_INIT_AUTOMAKE([foreign std-options])


### PR DESCRIPTION
After #3832, all the RHEL builds started to fail because the minimum autoconf version was bumped to 2.71 in 4ti2 1.6.11.  But that doesn't seem to matter because the build still works fine using autoconf 2.69.

