### PR TITLE
needsPackage updates

### DIFF
--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -1333,6 +1333,7 @@ setupfun("readlink",readlinkfun);
 
 realpathfun(e:Expr):Expr := (
      when e is f:stringCell do (
+	  if f.v === "stdio" || f.v === "currentString" then return e;
      	  when realpath(expandFileName(f.v))
      	  is null do buildErrorPacket(syscallErrorMessage("realpath"))
      	  is p:string do toExpr(p)

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -553,10 +553,15 @@ debug GlobalDictionary := dict -> (
     checkShadow())
 
 packageFiles = pkg -> (
-    pkgaux := (
+    srcfile := realpath pkg#"source file";
+    if (
+	srcfile == "stdio"         or
+	srcfile == "currentString" or
+	match("/startup\\.m2(?:\\.in)?$", srcfile))
+    then {}
+    else prepend(srcfile,
 	if not pkg#?"auxiliary files" then {}
-	else select(values loadedFiles, match_(pkg#"auxiliary files")));
-    prepend(realpath pkg#"source file", pkgaux))
+	else select(values loadedFiles, match_(pkg#"auxiliary files"))))
 
 locate Package := pkg -> NumberedVerticalList (
     -- TODO: somehow keep track of the number of lines of each file

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -168,6 +168,8 @@ loadPackage String  := opts -> pkgname -> (
     if opts.Reload === true then (
 	dismiss pkgname;
 	if isPackageLoaded pkgname then (
+	    printerr("warning: reloading ", pkgname,
+		"; recreate instances of types from this package");
 	    closePackage value PackageDictionary#pkgname;
 	    -- clear out the value of the symbol
 	    PackageDictionary#pkgname <- PackageDictionary#pkgname));

--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -154,7 +154,12 @@ if firstTime then (
      concatPath = (dir, name) -> if isAbsolutePath name then name else concatenate(
 	 dir, if not match("/$", dir) then "/", name);
 
-     toAbsolutePath = pth -> if pth =!= "stdio" and not isAbsolutePath pth then "/" | relativizeFilename("/", pth) else pth;
+     toAbsolutePath = pth -> (
+	 if (
+	     pth =!= "stdio"         and
+	     pth =!= "currentString" and
+	     not isAbsolutePath pth)
+	 then "/" | relativizeFilename("/", pth) else pth);
 
      use = x -> x;				  -- temporary, until methods.m2
 

--- a/M2/Macaulay2/tests/normal/testing.m2
+++ b/M2/Macaulay2/tests/normal/testing.m2
@@ -21,6 +21,9 @@ expectedCode = DIV{
 assert BinaryOperation(symbol ===, code pkgtest, expectedCode)
 assert BinaryOperation(symbol ===, code 0, expectedCode)
 
+TEST "assert Equation(1 + 1, 2)"
+check User
+
 assert( (for i from 1 to 2 list { for j from 1 to 2 do { if j == 2 then break 444; } }) === {{444}, {444}} ) -- see issue #2522
 
 


### PR DESCRIPTION
Two small updates:

* Have `packageFiles User` return the empty list, which fixes the current problem of `needsPackage User` raising a key error (startup.m2 isn't in the loaded files hash table since it's a string not a file)
* Add a warning message about recreating instances of types when reloading a package

Closes: #3851