### PR TITLE
Remove use of deprecated strstream header

### DIFF
--- a/M2/Macaulay2/e/f4/f4.cpp
+++ b/M2/Macaulay2/e/f4/f4.cpp
@@ -26,7 +26,6 @@
 #include <algorithm>                   // for stable_sort
 #include <vector>                      // for swap, vector
 #include <atomic>                      // for atomic ints in gauss_reduce
-#include <strstream>
 #include <iostream>
 
 class RingElement;


### PR DESCRIPTION
The `<strstream>` header was deprecated in C++98 and is slated for removal in C++26.  In any case, nothing in `<strstream>` is used in `f4.cpp`.
