### PR TITLE
Replace egrep & fgrep with grep -E / -F

### DIFF
--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -174,8 +174,8 @@ endif
 ifeq (@OS@ @SHARED@,Linux yes)
 ifneq (@BUILDLIST@,)
 ifneq (@OBJDUMP@,false)
-	@OBJDUMP@ -x "$@".tmp | egrep RPATH || [ $$? -lt 2 ]
-	@OBJDUMP@ -x "$@".tmp | egrep "RPATH +@librariesdir@$$" || [ $$? -lt 2 ]
+	@OBJDUMP@ -x "$@".tmp | grep -E RPATH || [ $$? -lt 2 ]
+	@OBJDUMP@ -x "$@".tmp | grep -E "RPATH +@librariesdir@$$" || [ $$? -lt 2 ]
 else
 	echo "--warning: 'objdump' not installed, can't check rpath in M2 binary"
 endif

--- a/M2/Macaulay2/tests/Makefile.in
+++ b/M2/Macaulay2/tests/Makefile.in
@@ -25,9 +25,9 @@ $(foreach t,$(CLEANTARGETS),$(eval $(call do-in-subdirs,$t,DEPENDS=no)))
 
 check: check-deferred
 check-deferred:
-	-@ if egrep -nHw 'defer|deferred|disable|disabled' @abs_srcdir@/*.m2 >/dev/null 2>&1 ; \
+	-@ if grep -EnHw 'defer|deferred|disable|disabled' @abs_srcdir@/*.m2 >/dev/null 2>&1 ; \
 	  then echo "make: warning: tests in the following files have been deferred:" >&2 ; \
-	       egrep -nHw 'defer|deferred|disable|disabled' @abs_srcdir@/*.m2 >&2 ; \
+	       grep -EnHw 'defer|deferred|disable|disabled' @abs_srcdir@/*.m2 >&2 ; \
 	       false ; \
 	  fi
 

--- a/M2/Macaulay2/tests/Makefile.test.in
+++ b/M2/Macaulay2/tests/Makefile.test.in
@@ -39,7 +39,7 @@ RESULTS := $(notdir $(patsubst %.m2, %.out, $(TESTFILES))) \
 	   $(notdir $(patsubst %.m2-input, %.out, $(wildcard $(SRCDIR)/*.m2-input)))
 
 PAT := 'internal error|:[0-9][0-9]*:[0-9][0-9]*:\([0-9][0-9]*\):|^GC|^0x|^out of mem|non-zero status|^Command terminated|user.*system.*elapsed|^[0-9]+\.[0-9]+user'
-FILTER := $(if $(VERBOSE),tail,egrep -a $(PAT))
+FILTER := $(if $(VERBOSE),tail,grep -Ea $(PAT))
 
 ifeq ($(DEFERRED),no)
 check: $(RESULTS)
@@ -60,7 +60,7 @@ ARGS += --no-randomize
 
 status: status-files
 status-files: $(TESTFILES)
-	@ egrep -n '^--status:' $(TESTFILES) /dev/null || true
+	@ grep -En '^--status:' $(TESTFILES) /dev/null || true
 
 %.out : %.m2
 	@ echo testing: $<
@@ -72,12 +72,12 @@ status-files: $(TESTFILES)
 		else a=$$?; \
 		     <$*.errors $(FILTER) ; \
 		     echo "$*.errors:0: error output left here for the errors above:" >&2 ; \
-		     egrep -n '^--status:' $< /dev/null || true ; \
+		     grep -En '^--status:' $< /dev/null || true ; \
 		     exit $$a ; \
 		fi
 %.out : %.m2-input
 	@ echo testing: $<
-	@ egrep -n '^--status:' $< /dev/null || true
+	@ grep -En '^--status:' $< /dev/null || true
 	@ $(LIMIT) \
 		echo "--*- compilation -*-" >$*.errors; \
 		if GC_MAXIMUM_HEAP_SIZE=400M time @pre_exec_prefix@/bin/M2 $(ARGS) <$< >>$*.errors 2>&1 ; \

--- a/M2/Makefile.in
+++ b/M2/Makefile.in
@@ -103,14 +103,14 @@ srcdir:
 	echo "@srcdir@/" >$@
 subst: config.status ; ./config.status
 show: config.status
-	<$< sed -e 's/\\\n//' |egrep '^[SD]\["' | sed -e 's/^S."\(.*\)"\]="\(.*\)"$$/\1=\2/' -e 's/^D."\(.*\)"\]="\(.*\)"$$/#define \1 \2/' -e 's/\\"/"/g'
+	<$< sed -e 's/\\\n//' |grep -E '^[SD]\["' | sed -e 's/^S."\(.*\)"\]="\(.*\)"$$/\1=\2/' -e 's/^D."\(.*\)"\]="\(.*\)"$$/#define \1 \2/' -e 's/\\"/"/g'
 CONFIG_FILES = @srcdir@/configure @srcdir@/install-sh @srcdir@/config.sub @srcdir@/config.guess @srcdir@/m4/files
 reconfigure-top-only: recheck check-for-undefined-configure-variables protect-configs
 protect-configs:
 	 @ chmod a-w $(shell cat @srcdir@/m4/files)
 check-for-undefined-configure-variables:
 	: "checking for strings that look like undefined configure variables in all *.in files..."
-	@ if egrep -nH '@[A-Za-z_]+@' $(shell cat @srcdir@/m4/files) | sed -e 's=^\([^:]*\):=@srcdir@/\1.in:=' | egrep . ;	\
+	@ if grep -EnH '@[A-Za-z_]+@' $(shell cat @srcdir@/m4/files) | sed -e 's=^\([^:]*\):=@srcdir@/\1.in:=' | grep -E . ;	\
 	  then exit 1;														\
 	  fi
 configure-help: $(CONFIG_FILES) ; @ @srcdir@/configure --help

--- a/M2/distributions/deb/Makefile.in
+++ b/M2/distributions/deb/Makefile.in
@@ -51,11 +51,11 @@ check-strip-enabled:; [ @ENABLE_STRIP@ = yes ]
 macaulay2/control.prelim : @srcdir@/macaulay2/control.prelim.in Makefile
 	rm -f $@
 	<$< >$@ sed -e 's/[@]DEBARCH[@]/$(DEBARCH)/g' -e 's/[@]PACKAGE_VERSION[@]/$(DIST_VERSION)/g'
-	! egrep -nH '@[A-Za-z_]+@' <$@
+	! grep -EnH '@[A-Za-z_]+@' <$@
 macaulay2-common/control.prelim : @srcdir@/macaulay2-common/control.prelim.in Makefile
 	rm -f $@
 	<$< >$@ sed -e 's/[@]DEBARCH[@]/$(DEBARCH)/g' -e 's/[@]PACKAGE_VERSION[@]/$(DIST_VERSION)/g'
-	! egrep -nH '@[A-Za-z_]+@' <$@
+	! grep -EnH '@[A-Za-z_]+@' <$@
 announce:
 	@ echo "============================================================================="
 	@ echo "package files prepared:"
@@ -96,7 +96,7 @@ T=@TAR@ --create --mode=a+rX,og-ws --exclude-from=@srcdir@/../tar-exclusions --f
 prepare: .prepared
 tmp@bindir@/M2@EXE@ .prepared: 
 	: ensure change log is up to date...
-	fgrep 'macaulay2 (@PACKAGE_VERSION@) ' <@srcdir@/changelog
+	grep -F 'macaulay2 (@PACKAGE_VERSION@) ' <@srcdir@/changelog
 	rm -rf tmp@prefix@ tmp-common@prefix@
 	$(MKDIR_P) tmp@prefix@
 	$(MKDIR_P) tmp-common@prefix@
@@ -124,7 +124,7 @@ macaulay2-common/data.tar.gz : prepare;	(cd tmp-common && @TAR@ cfz - $(TAROPTIO
 macaulay2/md5sums            : prepare; (cd tmp        && @FIND@ * -type f | xargs md5sum) >$@
 macaulay2-common/md5sums     : prepare;	(cd tmp-common && @FIND@ * -type f | xargs md5sum) >$@
 ifneq (@LINTIAN@,)
-SUP = fgrep -v 
+SUP = grep -Fv
 check: check1 check2
 check1:; - @LINTIAN@ -I ../../$(PKG_DEB)
 check2:; - @LINTIAN@ -I ../../$(PKG_COM_DEB)
@@ -150,19 +150,19 @@ libraries-used: .prepared tmp@bindir@/M2@EXE@
 	do if [ -f $$i ] ; then ( set -x ; ldd $$i ) ; fi ; \
 	done \
 	| sed -e 's/.* => //' -e 's/^	//' -e 's/ .*//' \
-	| egrep '^/' \
+	| grep -E '^/' \
 	| sort | uniq \
 	> $@ || true
 clean::; rm -f libraries-used
 libraries-really-used: libraries-used libraries-used-directly
-	egrep `echo \`cat libraries-used-directly\` | sed -e 's=^=.*/=' -e 's= =|.*/=g'` <$< >$@
+	grep -E `echo \`cat libraries-used-directly\` | sed -e 's=^=.*/=' -e 's= =|.*/=g'` <$< >$@
 files-used: Makefile
 	for i in @FILE_PREREQS@ ; do echo $$i ; done >$@
 packages-used: libraries-really-used files-used
 	cat $^ |								\
 	while read x ;								\
 	x=`readlink -f "$$x"` ;							\
-	do @FIND@ /var/lib/dpkg/info -name \*.list | xargs egrep -l "^$$x";	\
+	do @FIND@ /var/lib/dpkg/info -name \*.list | xargs grep -El "^$$x";	\
 	done | sort | uniq | sed -r -e 's=.*/==' -e 's=(:.*)?\.list$$==' >$@
 clean::; rm -f packages-used
 macaulay2/control : macaulay2/control.prelim macaulay2/data.tar.gz packages-used

--- a/M2/distributions/freebsd/Makefile.in
+++ b/M2/distributions/freebsd/Makefile.in
@@ -55,7 +55,7 @@ T=@TAR@ --create --mode=a+rX,og-ws --exclude-from=@srcdir@/../tar-exclusions --f
 	touch $@
 
 libraries-used : files/bin/M2@EXE@
-	ldd files/bin/M2@EXE@ | sed -e 's/.* => //' -e 's/^	//' -e 's/ .*//' | egrep '^/' >$@ || true
+	ldd files/bin/M2@EXE@ | sed -e 's/.* => //' -e 's/^	//' -e 's/ .*//' | grep -E '^/' >$@ || true
 files-used: Makefile
 	for i in @FILE_PREREQS@ ; do echo $i ; done >$@
 packages-used : libraries-used files-used

--- a/M2/distributions/rpm/Makefile.in
+++ b/M2/distributions/rpm/Makefile.in
@@ -103,7 +103,7 @@ file-prereqs: .prepared always
 	do if [ -f $$i ] ; then ( set -x ; ldd $$i ) ; fi ;		\
 	done								\
 	    | sed -e 's/.* => //' -e 's/^	//' -e 's/ .*//'	\
-	    | egrep -v '^$(BUILTLIBPATH)'					\
+	    | grep -Ev '^$(BUILTLIBPATH)'					\
 	    | sort | uniq						\
 	    > $@ || true
 	for i in @FILE_PREREQS@ ; do echo $$i ; done >>$@
@@ -115,7 +115,7 @@ packages-used: file-prereqs
 	cat file-prereqs											\
 	| while read x ;											\
 	do rpm --query -f "$$x" | sed 's/\([^.]*\)-\(.*\)\(-.*$$\)/\1 \2/' ;					\
-	done | fgrep -v 'is not owned by any package' | sort | uniq | sed -e 's=.*/==' -e 's=\.list$$==' >$@
+	done | grep -Fv 'is not owned by any package' | sort | uniq | sed -e 's=.*/==' -e 's=\.list$$==' >$@
 
 ifneq (@RPMLINT@,)
 check:; @RPMLINT@ -i ../../$(PKG_COM_RPM) ../../$(PKG_RPM)

--- a/M2/libraries/Makefile.library.in
+++ b/M2/libraries/Makefile.library.in
@@ -116,7 +116,7 @@ uninstall::; rm -f .installed-$(VERSION)
 reinstall: uninstall install
 always:
 diffs: .untarred2-$(VERSION) always
-	D=`pwd`; cd $(UNTARDIR) && diff -ur $(DIFF_OPTIONS) $$D/tmp/$(TARDIR) $(TARDIR) |egrep -v '^Only in ' >$$D/$@ || echo diffs: `pwd`/$@
+	D=`pwd`; cd $(UNTARDIR) && diff -ur $(DIFF_OPTIONS) $$D/tmp/$(TARDIR) $(TARDIR) | grep -Ev '^Only in ' >$$D/$@ || echo diffs: `pwd`/$@
 unmark:; rm -f .configured-$(VERSION) .compiled-$(VERSION)
 package-clean: unmark ; if [ -d $(BUILDDIR) ]; then $(MAKE) $(NOTPARALLEL) -C $(BUILDDIR) clean ; fi
 PACKAGE-DISTCLEAN-TARGET := distclean


### PR DESCRIPTION
The GNU grep manual says:
```
7th Edition Unix had commands egrep and fgrep that were the counterparts of the modern ‘grep -E’ and ‘grep -F’.
Although breaking up grep into three programs was perhaps useful on the small computers of the 1970s, egrep
and fgrep were deemed obsolescent by POSIX in 1992, removed from POSIX in 2001, deprecated by GNU Grep 2.5.3
in 2007, and changed to issue obsolescence warnings by GNU Grep 3.8 in 2022; eventually, they are planned to be
removed entirely.
```

This patch makes the suggested change to `grep -E` and `grep -F`, except for the example in `M2/Macaulay2/packages/Macaulay2Doc/ov_files.m2`, which I was afraid to touch.