### PR TITLE
Replace egrep in "communicating with programs" documentation example

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_files.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_files.m2
@@ -394,11 +394,11 @@ document {
      "Bidirectional communication with a program is also possible.  We use
      ", TO "openInOut", " to create a file that serves as a bidirectional
      connection to a program.  That file is called an input output file.  In
-     this example we open a connection to the unix utility ", TT "egrep", "
+     this example we open a connection to the unix utility ", TT "grep", "
      and use it to locate the symbol names in Macaulay2 that begin with
      ", TT "in", ".",
      EXAMPLE {
-	  ///f = openInOut "!egrep '^in'"///,
+	  ///f = openInOut "!grep -E '^in'"///,
 	  ///scan(keys Core.Dictionary, key -> f << key << endl)///,
 	  ///f << closeOut///,
 	  ///get f///
@@ -406,7 +406,7 @@ document {
      "With this form of bidirectional communication there is always a danger
      of blocking, because the buffers associated with the communication
      channels (pipes) typically hold only 4096 bytes.  In this example we
-     succeeded because the entire output from ", TT "egrep", " was smaller
+     succeeded because the entire output from ", TT "grep", " was smaller
      than 4096 bytes.  In general, one should be careful to arrange things
      so that the two programs take turns using the communication channel, so
      that when one is writing data, the other is reading it.",


### PR DESCRIPTION
This is a quick followup to #3859, replacing `egrep` with `grep -E` in the [communicating with programs](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_communicating_spwith_spprograms.html) documentation example.  It still works as expected.


```m2
i1 : f = openInOut "!grep -E '^in'"

o1 = !grep -E '^in'

o1 : File

i2 : scan(keys Core.Dictionary, key -> f << key << endl)

i3 : f << closeOut

o3 = !grep -E '^in'

o3 : File

i4 : get f

o4 = interpreterDepth
     infoHelp
     integrate
     inducedMap
     installMethod
     insert
     info
     interval
     intersect
     inversePermutation
     inverseErf
     index
     indexComponents
     installAssignmentMethod
     infinity
     intersection
     indices
     incomparable
     indeterminate
     in
     inverseRegularizedBeta
     independentSets
     installPackage
     instance
     installedPackages
     input
     inducesWellDefinedMap
     inverseRegularizedGamma
     inverse
     installHilbertFunction
     instances
```