### PR TITLE
Check for file existence in packageFiles instead of matching strings

### DIFF
--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -37,6 +37,7 @@ addStartFunction(
 		   DebuggingMode  => true);
 	       User.PackageIsLoaded = true;
 	       User#"source directory" = "";
+	       User#"source file" = "stdio";
 	       path = prepend("./",path); -- now we search also the user's current directory, since our files have already been loaded
 	       path = unique apply( path, minimizeFilename);	    -- beautify
 	       allowLocalCreation User#"private dictionary";

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -556,11 +556,7 @@ debug GlobalDictionary := dict -> (
 
 packageFiles = pkg -> (
     srcfile := realpath pkg#"source file";
-    if (
-	srcfile == "stdio"         or
-	srcfile == "currentString" or
-	match("/startup\\.m2(?:\\.in)?$", srcfile))
-    then {}
+    if not fileExists srcfile then {}
     else prepend(srcfile,
 	if not pkg#?"auxiliary files" then {}
 	else select(values loadedFiles, match_(pkg#"auxiliary files"))))


### PR DESCRIPTION
This is much more robust, and also avoids an issue where `realpath` was stripping away the filename so that the "startup.m2" regex didn't match.

In particular, this was the big problem:

```m2
i1 : User#"source file"

o1 = /usr/local/share/Macaulay2/Core/startup.m2

i2 : realpath oo

o2 = /usr/local/share/Macaulay2
```

I'm not sure if this is the expected behavior of `realpath` or not, but that might be a bug too.

