### PR TITLE
Bump normaliz to 3.10.5

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -164,7 +164,7 @@ jobs:
             -L`brew --prefix readline`/lib"
           export F77=gfortran-14
           export FC=gfortran-14
-          ../../configure --enable-download --with-system-gc --with-fplll
+          ../../configure --with-system-gc --with-fplll
 
       - name: Build Macaulay2 using Make
         if: matrix.build-system == 'autotools'

--- a/M2/Macaulay2/packages/Normaliz.m2
+++ b/M2/Macaulay2/packages/Normaliz.m2
@@ -284,11 +284,13 @@ getNumInvs = () -> (
     if debugLevel > 0 then << "--reading " << nmzFile << ".inv" << endl;
     s := lines get(nmzFile | ".inv");
 
-    for i from 0 to #s - 1 do (  -- for each line in the file
+    hashTable for i from 0 to #s - 1 list (  -- for each line in the file
 	key = "";
 	if match("^integer", s#i) then (
 	    local j;
 	    (key, j) = getKeyword(s#i, 8);
+	    -- "multiplicity" was renamed to "multiplicity num" in 3.10.5
+	    if key == "multiplicity num" then key = "multiplicity";
 	    inv = value(getNumber substring(j + 3, s#i))#0;
 	    )
 	else(
@@ -299,6 +301,8 @@ getNumInvs = () -> (
 		if match("^vector", s#i) then (
 		    (len, str) := getNumber substring(7, s#i);
 		    (key, j) = getKeyword(str, 1);
+		    -- new keys added in 3.10.5
+		    if match("^hilbert series cyclo", key) then continue;
 		    inv = {};
 		    --   en:="";
 		    --str=substring(j+10+#len,s#i);
@@ -308,8 +312,7 @@ getNumInvs = () -> (
 		    );
 		);
 	    );
-	numInvs = append(numInvs,{key,inv}));
-    hashTable numInvs)
+	{key, inv}))
 
 ----------------------------------------------------------------------
 -- running normaliz (with options)

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -968,8 +968,8 @@ _ADD_COMPONENT_DEPENDENCY(libraries nauty "" NAUTY_FOUND)
 # https://www.normaliz.uni-osnabrueck.de/
 # normaliz needs libgmp, libgmpxx, boost, and openmp, and is used by the package Normaliz
 ExternalProject_Add(build-normaliz
-  URL               https://github.com/Normaliz/Normaliz/releases/download/v3.10.4/normaliz-3.10.4.tar.gz
-  URL_HASH          SHA256=9b424f966d553ae32e710b8ab674c7887ddcbf0e5ea08af7f8bc1b587bcbb2aa
+  URL               https://github.com/Normaliz/Normaliz/releases/download/v3.10.5/normaliz-3.10.5.tar.gz
+  URL_HASH          SHA256=58492cfbfebb2ee5702969a03c3c73a2cebcbca2262823416ca36e7b77356a44
   PREFIX            libraries/normaliz
   SOURCE_DIR        libraries/normaliz/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1226,8 +1226,11 @@ AC_ARG_WITH(unbuilt-programs,
 	esac
      done])
 
-AC_SUBST(DOWNLOAD,no)
-AC_ARG_ENABLE(download, AS_HELP_STRING(--enable-download,enable automatic downloading of needed third-party libraries), DOWNLOAD=$enableval)
+AC_SUBST([DOWNLOAD], [yes])
+AC_ARG_ENABLE([download],
+    [AS_HELP_STRING([--disable-download],
+        [disable automatic downloading of needed third-party libraries])],
+    [DOWNLOAD=$enableval])
 AC_CHECK_PROGS(WGET,wget,false)
 AC_CHECK_PROGS(CURL,curl,false)
 if test $DOWNLOAD = yes

--- a/M2/libraries/normaliz/Makefile.in
+++ b/M2/libraries/normaliz/Makefile.in
@@ -1,6 +1,6 @@
 HOMEPAGE = https://www.normaliz.uni-osnabrueck.de/
 # get releases from https://github.com/Normaliz/Normaliz/releases
-VERSION = 3.10.4
+VERSION = 3.10.5
 #PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 
 URL = https://github.com/Normaliz/Normaliz/releases/download/v$(VERSION)


### PR DESCRIPTION
This was just released.  We also make `--enable-download` the default behavior in the autotools build.

Draft for now to test the GitHub builds.