### PR TITLE
Use correct file time for filesLoaded hash table keys

### DIFF
--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -55,11 +55,11 @@ if firstTime then (
      srcdirs = {};
 
      markLoaded = (filepath, filetime, notify) -> (
-	 filepath = realpath toAbsolutePath filepath;
 	 filesLoaded#filepath = filetime;
 	 loadedFiles##loadedFiles = filepath;
 	 if notify then printerr("loaded ", filepath));
      tryLoad = (filename, filepath, loadfun, notify) -> if fileExists filepath then (
+	 filepath = realpath toAbsolutePath filepath;
 	 filetime := fileTime filepath;
 	 if notify then printerr("loading ", filename);
 	 ret := loadfun filepath;

--- a/M2/Macaulay2/tests/normal/testing.m2
+++ b/M2/Macaulay2/tests/normal/testing.m2
@@ -1,8 +1,9 @@
-testpkg = minimizeFilename(temporaryFileName() | ".m2")
+testpkg = temporaryFileName() | ".m2"
 testpkg << ///newPackage("TestPackage")
 beginDocumentation()
 TEST "assert Equation(1 + 1, 2)"
 /// << close
+testpkg = minimizeFilename realpath testpkg
 loadPackage("TestPackage", FileName => testpkg)
 check "TestPackage"
 pkgtest = tests(0, "TestPackage")


### PR DESCRIPTION
The keys were filenames *after* we called realpath, but the keys were file times from *before* we called it, so they may have been incorrect for symlinks.

For example, consider the following situation, where `bar.m2` is a symlink to `foo.m2`:

*Current behavior:*

```m2
i1 : needs "~/tmp/foo.m2"

i2 : debug Core

i3 : filesLoaded#"/home/profzoom/tmp/foo.m2"

o3 = 1749055336

i4 : needs "~/tmp/bar.m2"

i5 : filesLoaded#"/home/profzoom/tmp/foo.m2"

o5 = 1749055341
```

`foo.m2` wasn't updated, but the file time was!

*Proposed behavior:*

```m2
i2 : needs "~/tmp/foo.m2"

i3 : filesLoaded#"/home/profzoom/tmp/foo.m2"

o3 = 1749055336

i4 : needs "~/tmp/bar.m2"

i5 : filesLoaded#"/home/profzoom/tmp/foo.m2"

o5 = 1749055336
```