### PR TITLE
Don't remove version.m2 in "make clean"

### DIFF
--- a/M2/Macaulay2/m2/Makefile.in
+++ b/M2/Macaulay2/m2/Makefile.in
@@ -24,7 +24,6 @@ DUMPEDM2DOCFILES := \
 ############################## version.m2
 all: version.m2
 version.m2: version.m2.in ; ./config.status Macaulay2/m2/version.m2
-clean::; rm -f version.m2
 ############################## tvalues.m2
 STOP = --stop
 ARGS = -q --silent $(STOP) -e errorDepth=0


### PR DESCRIPTION
Otherwise, subsequent calls to `make` will fail.

It's still removed by `make distclean`, which makes sense since it's generated by `configure` and not by `make`.

This is the current behavior after running `make clean`:

```
$ make
make: Entering directory '/home/profzoom/src/macaulay2/M2/M2/BUILD/build'
: "checking for strings that look like undefined configure variables in all *.in files..."
grep: Macaulay2/m2/version.m2: No such file or directory
: creating or removing symbolic link to common staging area, if necessary,
: based on comparison of these directories:
:                      pre_prefix : /home/profzoom/src/macaulay2/M2/M2/BUILD/build/usr-dist/common
: abs_builddir/usr-dist/common : /home/profzoom/src/macaulay2/M2/M2/BUILD/build/usr-dist/common
rm -f srcdir .link-test
echo "../../" >srcdir
chmod: cannot access 'Macaulay2/m2/version.m2': No such file or directory
make: *** [Makefile:110: protect-configs] Error 1
make: Leaving directory '/home/profzoom/src/macaulay2/M2/M2/BUILD/build'
```