### PR TITLE
Changed Complex strict equality internally

### DIFF
--- a/M2/Macaulay2/packages/Complexes/ChainComplex.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplex.m2
@@ -280,8 +280,12 @@ length Complex := (C) -> (
     hi-lo
     )
 
-Complex == Complex := (C,D) -> (
-    if C === D then return true;
+-- this method is not exported, and is only used internally instead of === and =!=,
+-- since Complex is a MutableHashTable and are never identical unless literally the same.
+isIdentical = method()
+isIdentical(Complex, Complex) := (C, D) -> C === D or C.module === D.module and C.dd.map === D.dd.map
+
+Complex == Complex := (C,D) -> isIdentical(C, D) or (
     (loC,hiC) := C.concentration;
     (loD,hiD) := D.concentration;
     if ring C =!= ring D then return false;

--- a/M2/Macaulay2/packages/Complexes/ChainComplexTests.m2
+++ b/M2/Macaulay2/packages/Complexes/ChainComplexTests.m2
@@ -341,6 +341,16 @@ TEST ///
   assert isWellDefined C
   assert(HH C != complex coker f0)
   assert(prune HH C == complex coker f0)
+
+  C = complex R
+  D = complex R
+  assert(C == D)
+  assert(C =!= D)
+  -- these operations didn't work before isIdentical
+  -- was used internally instead of === and =!=
+  id_C | id_D
+  id_C || id_D
+  id_C // id_D
 ///
 
 TEST ///


### PR DESCRIPTION
This changes how two complexes are compared to be identical internally, without incurring any computational cost. The point is that these basic things didn't work before: (I added these as a test)
```m2
R = QQ[x]
C = complex R
D = complex R
id_C |  id_D
id_C || id_D
id_C // id_D
```
But now complexes are compared like so:
```m2
isIdentical(Complex, Complex) := (C, D) -> C === D or C.module === D.module and C.dd.map === D.dd.map

isIdentical(ComplexMap, ComplexMap) := (f, g) -> f === g or (
    f.degree === g.degree and f.map === g.map
    and isIdentical(f.source, g.source)
    and isIdentical(f.target, g.target))
```
Fixes #3865 and #3868