### PR TITLE
Bump C++ standard to C++17 (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -262,7 +262,7 @@ AC_SUBST(M2_CFLAGS)
 AC_SUBST(M2_CXXFLAGS)
 
 dnl Fix standards, apply everywhere
-CXXFLAGS="-std=gnu++14 $CXXFLAGS"
+CXXFLAGS="-std=gnu++17 $CXXFLAGS"
 CFLAGS="-std=gnu11 $CFLAGS"
 
 AC_PROG_CC() 			# set CFLAGS before this


### PR DESCRIPTION
This is necessary if we want to use googletest 1.17.0

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
