### PR TITLE
recognise the new way to spell macos in configure

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -117,6 +117,7 @@ then if test -f /usr/bin/sw_vers
      # translate to something standard (for us), and verify :
      case $ISSUE_FLAVOR in
          "Mac OS X") ISSUE_FLAVOR=MacOS ;;
+         "macOS") ISSUE_FLAVOR=MacOS ;;
 	 "debian"|"Debian"*) ISSUE_FLAVOR=Debian ;;
          "ubuntu"|"Ubuntu") ISSUE_FLAVOR=Ubuntu ;;
 	 "FedoraCore"*) ISSUE_FLAVOR=FedoraCore ;;


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
this is merely cosmetic fix, to make @mikestillman happy 