### PR TITLE
Add --enable-download option to check-configure

### DIFF
--- a/M2/check-configure/Makefile.in
+++ b/M2/check-configure/Makefile.in
@@ -29,6 +29,7 @@ check-config:
 	    --with-system-memtailor=$(SYSTEM_MEMTAILOR)				\
 	    --with-system-mathic=$(SYSTEM_MATHIC)				\
 	    --with-system-mathicgb=$(SYSTEM_MATHICGB)				\
+	    --enable-download=@DOWNLOAD@					\
 	    --disable-building
 distclean:: clean; rm -f Makefile
 Makefile: Makefile.in ; cd .. && ./config.status check-configure/Makefile


### PR DESCRIPTION
During configure, we raise an error if the input for --enable-download is "yes" but neither wget nor curl are available on the system.

Now that the default for --enable-download is "yes", we should make sure that we don't raise this error during check-configure if the user initially ran configure with "no", e.g., in Debian/Ubuntu package builds.