### PR TITLE
Fixing unexpected behaviour in ToricHigherDirectImages

### DIFF
--- a/M2/Macaulay2/packages/ToricHigherDirectImages.m2
+++ b/M2/Macaulay2/packages/ToricHigherDirectImages.m2
@@ -19,9 +19,10 @@ newPackage(
     "ToricHigherDirectImages",
     Version => "1.1", 
     Date => "2025 June",
-    Authors => {
-	{Name     => "Sasha Zotine", 
-	 Email    => "sashahbc@gmail.com"}
+    Authors => {    
+	{Name     => "Sasha Zotine",	
+	 Email    => "zotinea@mcmaster.ca",
+	 HomePage => "https://sites.google.com/view/szotine/home" }
 	},
     Headline => "computations involving pushforwards and higher direct images of toric maps",
     Keywords => {"Toric Geometry"},

--- a/M2/Macaulay2/packages/ToricHigherDirectImages.m2
+++ b/M2/Macaulay2/packages/ToricHigherDirectImages.m2
@@ -19,8 +19,8 @@ newPackage(
     "ToricHigherDirectImages",
     Version => "1.1", 
     Date => "2025 June",
-    Authors => {    
-	{Name     => "Sasha Zotine",	
+    Authors => {
+	{Name     => "Sasha Zotine",
 	 Email    => "zotinea@mcmaster.ca",
 	 HomePage => "https://sites.google.com/view/szotine/home" }
 	},
@@ -219,8 +219,8 @@ affineSemigroupGenerators (NormalToricVariety, List) := Matrix => (X, w) -> (
     )
 
 -- Internal method. computes the "generating lattice points" in a polyhedron via Hilbert bases.
-idealFromPolyhedron = method();
-idealFromPolyhedron Polyhedron := List => P -> (
+generatingLatticePoints = method();
+generatingLatticePoints Polyhedron := List => P -> (
     H := entries map(ZZ, rawHilbertBasis raw transpose rays cone P);
     for h in H list if h#0 === 1 then drop(h,1) else continue
     )
@@ -351,7 +351,7 @@ computeEigencharacters (ToricMap, ZZ, List) := (phi, i, D) -> (
         if Ps == {} then {} else (
 	    -- take the bounded part of the polyhedron, then compute
 	    -- the lattice points of this. this gives Gamma_sigma.
-	    pts := (flatten (Ps/idealFromPolyhedron))/vector/matrix;
+	    pts := (flatten (Ps/generatingLatticePoints))/vector/matrix;
 	    -- here is the set of eigencharacters C(L,i).
     	    CLi := unique for p in pts list MK * (transpose MK) * p;
 	    -- for each character, compute this minimizing divisor D_sigma.
@@ -450,7 +450,7 @@ HDIComplex (ToricMap, ZZ, List) := (phi, i, D) -> (
 			-- record that the w term is non-zero
 			nonzerow#j = append(nonzerow#j, w);
 			-- compute the vertices and output the ideal.
-			idealgens := idealFromPolyhedron P;
+			idealgens := generatingLatticePoints P;
 			module ideal for gen in idealgens list S_gen
 			)
 		    )


### PR DESCRIPTION
There was unexpected behaviour from the output of HDI, which ultimately came from an incorrect lattice point computation in a polyhedron. I added an internal method for the correct computation ``idealFromPolyhedron`` which uses ``rawHilbertBasis`` to compute the appropriate lattice points. I also added the example which demonstrated the incorrect behaviour as a test.

The example in question is
```
X=normalToricVariety({{1,2},{2,3},{1,1},{1,0},{-1,-1},{0,1}}, {{0,1},{1,2},{2,3},{3,4},{4,5},{5,0}});
Y=normalToricVariety({{-1,-1},{1,0},{0,1}},{{0,1},{1,2},{2,0}});
M = matrix {{1,0},{0,1}};
phi = map(Y,X,M);
D={-3,-6,-3,0,0,0};
prune HDI(phi,0,D)
                 2
o6 = (QQ[x ..x ])
          0   2
o6 : QQ[x ..x ]-module, free, degrees {3..4}
         0   2
```
The source is an interated blowup of PP^2, and this is computing the pushforward of a line bundle via the composition of blowdowns, a birational map. The output turns out to be of rank two, which doesn't make sense---the fibres should generically be rank one. The corrected version appropriately outputs a presentation of the ideal m^3, where m is the blown up point.
```
o8 = cokernel {3} | x_1  0    0    |
              {3} | -x_2 x_1  0    |
              {3} | 0    -x_2 x_1  |
              {3} | 0    0    -x_2 |
                                                4
o8 : QQ[x ..x ]-module, quotient of (QQ[x ..x ])
         0   2                           0   2
```