### PR TITLE
Move gftables installation from datadir -> libdir (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1550,7 +1550,7 @@ AC_ARG_VAR([GFTABLESDIR],
     [path to gftables directory if factory is already installed])
 if test $BUILD_factory = yes
 then
-    GFTABLESDIR="${datadir}/Macaulay2/Core/factory/"
+    GFTABLESDIR="${libdir}/factory/"
 else
     if test x$GFTABLESDIR = x
     then
@@ -2030,7 +2030,7 @@ exec_prefix=$save_exec_prefix
 if test $BUILD_factory = no
 then PRE_GFTABLESDIR="$GFTABLESDIR"
 else
-PRE_GFTABLESDIR="$pre_datadir/Macaulay2/Core/factory/"
+PRE_GFTABLESDIR="$pre_libdir/factory/"
 fi
 AC_SUBST(PRE_GFTABLESDIR)
 

--- a/M2/libraries/factory/Makefile.in
+++ b/M2/libraries/factory/Makefile.in
@@ -37,7 +37,7 @@ CONFIGOPTIONS += --disable-omalloc --enable-streamio
 CONFIGOPTIONS += --includedir='$(LIBRARIESDIR)/include/'
 CONFIGOPTIONS += --disable-shared
 CONFIGOPTIONS += --without-Singular
-CONFIGOPTIONS += --datadir=@pre_packagesdir@/Core # for gftables
+CONFIGOPTIONS += --datadir=@pre_libdir@ # for gftables
 
 ifeq (@DEBUG@,yes)
 CONFIGOPTIONS += --enable-assertions 


### PR DESCRIPTION
Previously, when we installed gftables instead of using an existing copy provided by a system factory package, we installed them in the architecture-independent directories, e.g., something like /usr/share/Macaulay2/Core/factory/gftables.

This causes problems for building rpm packages.  In particular, on some systems, like Fedora, a factory package is available, but on others, like RHEL, one is not.

The contents of the architecture-independent "share" directory are copied into the Macaulay2-common rpm package, which ideally should be usable by any rpm-compatible distribution.  And so in particular, we shouldn't install the gftables there, since we need them there on some systems but not on others.

Instead, we move installation to the architecture-dependendent "lib" directory, so they will be installed in the specific Macaulay2 rpm package for the target system only when needed.

