### PR TITLE
Bump FLINT to version 3.3.1

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -64,6 +64,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew config
+          brew update
           brew tap macaulay2/tap
           brew install --overwrite python
           brew install automake boost tbb ccache ctags texinfo llvm make ninja yasm libffi msolve googletest fplll

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -344,7 +344,6 @@ ExternalProject_Add(build-flint
   PREFIX            libraries/flint
   SOURCE_DIR        ${CMAKE_SOURCE_DIR}/submodules/flint
   BUILD_IN_SOURCE   ON
-  PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/flint/patch-3.3.0
   CONFIGURE_COMMAND ./bootstrap.sh &&
                     ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                     ${shared_setting}

--- a/M2/libraries/flint/Makefile.in
+++ b/M2/libraries/flint/Makefile.in
@@ -2,8 +2,8 @@ SUBMODULE = true
 # LIBNAME = flint2
 HOMEPAGE = http://flintlib.org
 # git://github.com/wbhart/flint2.git
-VERSION = 3.3.0
-PATCHFILE = @abs_srcdir@/patch-$(VERSION)
+VERSION = 3.3.1
+# PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PARALLEL = yes
 
 # Many other tests keep failing, so disable them all:


### PR DESCRIPTION
This was just released.  It includes the fix for the LU decomposition issue w/ zero-column matrices, so we can stop applying the patch.

Draft for now to test the builds.