### PR TITLE
Raise an error when generating random integers when Height option is nonpositive 

### DIFF
--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -47,8 +47,8 @@ setupfun("testCatch",testCatch);
 
 export rawRandomZZ(e:Expr):Expr := (
      when e
-     is Nothing do toExpr(Ccode(ZZ, "rawRandomInteger(", "NULL)"))
-     is maxN:ZZcell do toExpr(Ccode(ZZ, "rawRandomInteger(", maxN.v, ")"))
+     is Nothing do toExpr(Ccode(ZZorNull, "rawRandomInteger(", "NULL)"))
+     is maxN:ZZcell do toExpr(Ccode(ZZorNull, "rawRandomInteger(", maxN.v, ")"))
      else WrongArgZZ());
 setupfun("rawRandomZZ",rawRandomZZ);
 export rawFareyApproximation(e:Expr):Expr := (

--- a/M2/Macaulay2/e/ZZ.cpp
+++ b/M2/Macaulay2/e/ZZ.cpp
@@ -67,7 +67,12 @@ std::pair<bool, long> RingZZ::coerceToLongInteger(ring_elem a) const
                                mpz_get_si(a.get_mpz()));
 }
 
-ring_elem RingZZ::random() const { return ring_elem(rawRandomInteger(nullptr)); }
+ring_elem RingZZ::random() const {
+  mpz_ptr result = new_elem();
+  rawSetRandomInteger(result, nullptr);
+  mpz_reallocate_limbs(result);
+  return ring_elem(result);
+}
 
 void RingZZ::elem_text_out(buffer &o,
                            const ring_elem ap,

--- a/M2/Macaulay2/e/aring-zz-gmp.hpp
+++ b/M2/Macaulay2/e/aring-zz-gmp.hpp
@@ -195,8 +195,7 @@ class ARingZZGMP : public SimpleARing<ARingZZGMP>
   void swap(ElementType& a, ElementType& b) const { mpz_swap(&a, &b); }
   void random(ElementType& result) const
   {
-    // TODO: this leaks a gmp_ZZ
-    mpz_set(&result, rawRandomInteger(nullptr));
+    rawSetRandomInteger(&result, nullptr);
   }
   /** @} */
 

--- a/M2/Macaulay2/e/interface/random.cpp
+++ b/M2/Macaulay2/e/interface/random.cpp
@@ -56,14 +56,11 @@ int32_t rawRandomInt(int32_t max)
 void rawSetRandomInteger(mpz_ptr result, gmp_ZZ maxN)
 /* if height is the null pointer, use the default height */
 {
-  if (maxN == nullptr)
-    mpz_urandomm(result, state, maxHeight);
-  else if (1 != mpz_sgn(maxN))
-    {
-      mpz_set_si(result, 0);
-    }
-  else
-    mpz_urandomm(result, state, maxN);
+  if (maxN == nullptr) maxN = maxHeight;
+  if (mpz_cmp_si(maxN, 0) <= 0)
+    throw exc::engine_error("expected a positive height");
+
+  mpz_urandomm(result, state, maxN);
 }
 
 gmp_ZZ rawRandomInteger(gmp_ZZ maxN)
@@ -72,7 +69,12 @@ gmp_ZZ rawRandomInteger(gmp_ZZ maxN)
   mpz_ptr result = getmemstructtype(mpz_ptr);
   mpz_init(result);
 
-  rawSetRandomInteger(result, maxN);
+  try {
+    rawSetRandomInteger(result, maxN);
+  } catch (const exc::engine_error& e) {
+    ERROR(e.what());
+    return nullptr;
+  }
 
   mpz_reallocate_limbs(result);
   return result;

--- a/M2/Macaulay2/e/interface/random.cpp
+++ b/M2/Macaulay2/e/interface/random.cpp
@@ -53,11 +53,9 @@ int32_t rawRandomInt(int32_t max)
   return RandomSeed % max;
 }
 
-gmp_ZZ rawRandomInteger(gmp_ZZ maxN)
+void rawSetRandomInteger(mpz_ptr result, gmp_ZZ maxN)
 /* if height is the null pointer, use the default height */
 {
-  mpz_ptr result = getmemstructtype(mpz_ptr);
-  mpz_init(result);
   if (maxN == nullptr)
     mpz_urandomm(result, state, maxHeight);
   else if (1 != mpz_sgn(maxN))
@@ -66,6 +64,16 @@ gmp_ZZ rawRandomInteger(gmp_ZZ maxN)
     }
   else
     mpz_urandomm(result, state, maxN);
+}
+
+gmp_ZZ rawRandomInteger(gmp_ZZ maxN)
+/* if height is the null pointer, use the default height */
+{
+  mpz_ptr result = getmemstructtype(mpz_ptr);
+  mpz_init(result);
+
+  rawSetRandomInteger(result, maxN);
+
   mpz_reallocate_limbs(result);
   return result;
 }

--- a/M2/Macaulay2/e/interface/random.h
+++ b/M2/Macaulay2/e/interface/random.h
@@ -27,9 +27,11 @@ int32_t rawRandomInt(int32_t max);
 
 void rawSetRandomInteger(mpz_ptr result, gmp_ZZ maxN);
 /* if height is the null pointer, use the default height */
+/* doesn't deal w/ garbage collection */
 
 gmp_ZZ rawRandomInteger(gmp_ZZ maxN);
 /* if height is the null pointer, use the default height */
+/* returns garbage-collected memory */
 
 void rawSetFareyApproximation(mpq_ptr result, gmp_RR x, gmp_ZZ height);
 /* sets result = the nearest rational to x w/ denominator <= height */

--- a/M2/Macaulay2/e/interface/random.h
+++ b/M2/Macaulay2/e/interface/random.h
@@ -25,6 +25,9 @@ unsigned long rawRandomULong(unsigned long max);
 int32_t rawRandomInt(int32_t max);
 /* generate a random number in the range 0..max-1 */
 
+void rawSetRandomInteger(mpz_ptr result, gmp_ZZ maxN);
+/* if height is the null pointer, use the default height */
+
 gmp_ZZ rawRandomInteger(gmp_ZZ maxN);
 /* if height is the null pointer, use the default height */
 

--- a/M2/Macaulay2/tests/normal/randommat.m2
+++ b/M2/Macaulay2/tests/normal/randommat.m2
@@ -34,3 +34,6 @@ assert isSurjective random(R^3,R^6,MaximalRank=>true)
 assert(random(ZZ^2, ZZ^2, MaximalRank => true) - id_(ZZ^2) != 0)
 assert(random(QQ^2, QQ^2, MaximalRank => true) - id_(QQ^2) != 0)
 assert(random(R^2,  R^2,  MaximalRank => true) - id_(R^2)  != 0)
+
+-- used to crash M2 (#2089)
+assert try random(ZZ^2, ZZ^2, Height => 0) then false else true


### PR DESCRIPTION
This fixes #2089.  Also, we now raise an error when the height is negative instead of silently taking the absolute value (which was undocumented).   The proposed behavior also matches the current behavior for random QQ's, not to mention `random(ZZ)`, which yells if the input isn't positive.

### Before

```m2
i1 : random(ZZ^5, ZZ^5, Height => -20)

o1 = | 13 10 11 3  13 |
     | 8  1  12 13 11 |
     | 16 0  1  1  7  |
     | 9  5  8  9  8  |
     | 1  16 12 15 8  |

              5       5
o1 : Matrix ZZ  <-- ZZ

i2 : random(ZZ^5, ZZ^5, Height => 0)
Floating point exception (core dumped)

Process M2 exited abnormally with code 136
```

### After
```m2
i1 : random(ZZ^5, ZZ^5, Height => -20)
stdio:1:6:(3): error: expected a positive height

i2 : random(ZZ^5, ZZ^5, Height => 0)
stdio:2:6:(3): error: expected a positive height
```