### PR TITLE
Install eigen in macOS GitHub builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -67,7 +67,7 @@ jobs:
           brew update
           brew tap macaulay2/tap
           brew install --overwrite python
-          brew install automake boost tbb ccache ctags texinfo llvm make ninja yasm libffi msolve googletest fplll
+          brew install automake boost tbb ccache ctags texinfo llvm make ninja yasm libffi msolve googletest fplll eigen
           brew install --only-dependencies macaulay2/tap/M2
           brew link factory --force
 


### PR DESCRIPTION
I just noticed that both the autotools and cmake macOS builds are building eigen, which is silly since it's available via brew.

I think this is relatively new -- maybe from https://github.com/Macaulay2/homebrew-tap/commit/b88f4394a162aa178eaf0ef718b7e801247c2faa, when eigen was switched from a dependency to a build dependency of the brew formula, `brew install --only-dependencies macaulay2/tap/M2` might not be pulling it in anymore?