### PR TITLE
Fetch tags before determining git description

### DIFF
--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -55,6 +55,9 @@ set(PACKAGE_VERSION ${Macaulay2_VERSION})
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/../.git")
   execute_process(
+    COMMAND ${GIT_EXECUTABLE} fetch --tags https://github.com/Macaulay2/M2
+    ERROR_QUIET)
+  execute_process(
     COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -503,6 +503,7 @@ case $COMPRESS in
     *) AC_MSG_ERROR(unrecognized option for enable-compress) ;;
 esac
 
+$GIT fetch --tags https://github.com/Macaulay2/M2 2> /dev/null || true
 AC_SUBST([GIT_DESCRIPTION],
          [`$GIT describe --tags --dirty || echo release-$PACKAGE_VERSION`])
 AC_SUBST([GIT_BRANCH],


### PR DESCRIPTION
This will ensure that the tags in users' local repos are up to date and minimize the version mismatch warnings that result when they're not.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
