### PR TITLE
Fix non-alphanumeric package export in TropicalToric

### DIFF
--- a/M2/Macaulay2/packages/TropicalToric.m2
+++ b/M2/Macaulay2/packages/TropicalToric.m2
@@ -14,7 +14,7 @@ newPackage(
   PackageExports => {
     "NormalToricVarieties",
     "Tropical",
-    "Package$gfanInterface"
+    "gfanInterface"
   },
   PackageImports => {
     "FourierMotzkin"


### PR DESCRIPTION
needsPackage now (since #3803) checks that package names are alphanumeric, which was causing the build to fail since TropicalToric exported "Package$gfanInterface".

From https://launchpadlibrarian.net/803259145/buildlog_ubuntu-jammy-amd64.macaulay2_1.25.06+git202507042258-0ppa202507021920~ubuntu22.04.1_BUILDING.txt.gz:

```m2
../../m2/debugging.m2:18:13:(1):[72]: error: package title not alphanumeric: "Package$gfanInterface"
../../m2/packages.m2:106:14:(1):[71]: --back trace--
../../m2/packages.m2:202:30:(1):[70]: --back trace--
../../m2/methods.m2:154:98:(1):[69]: --back trace--
../../m2/option.m2:17:14:(1):[68]: --back trace--
../../m2/packages.m2:292:8:(1):[66]: --back trace--
../../m2/methods.m2:130:48:(1):[65]: --back trace--
../../m2/methods.m2:146:20:(1):[64]: --back trace--
../../m2/option.m2:17:14:(1):[63]: --back trace--
../TropicalToric.m2:1:10:(3):[62]: --back trace--
```