### PR TITLE
Use unsigned longs for precision

### DIFF
--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -71,19 +71,19 @@ export rawRandomQQ(e:Expr):Expr := (
 setupfun("rawRandomQQ",rawRandomQQ);
 export rawRandomRRUniform(e:Expr):Expr := (
      when e
-     is prec:ZZcell do if !isULong(prec.v) then WrongArgSmallInteger() 
+     is prec:ZZcell do if !isULong(prec.v) then WrongArgSmallUInteger()
      else toExpr(Ccode(RR, "rawRandomRRUniform(", toULong(prec.v), ")"))
      else WrongArgZZ());
 setupfun("rawRandomRRUniform",rawRandomRRUniform);
 export rawRandomRRNormal(e:Expr):Expr := (
      when e
-     is prec:ZZcell do if !isULong(prec.v) then WrongArgSmallInteger()
+     is prec:ZZcell do if !isULong(prec.v) then WrongArgSmallUInteger()
      else toExpr(Ccode(RR, "rawRandomRRNormal(", toULong(prec.v), ")"))
      else WrongArgZZ());
 setupfun("rawRandomRRNormal",rawRandomRRNormal);
 export rawRandomCC(e:Expr):Expr := (
      when e
-     is prec:ZZcell do if !isULong(prec.v) then WrongArgSmallInteger() 
+     is prec:ZZcell do if !isULong(prec.v) then WrongArgSmallUInteger()
      else toExpr(Ccode(CC, "rawRandomCC(", toULong(prec.v), ")"))
      else WrongArgZZ());
 setupfun("rawRandomCC",rawRandomCC);
@@ -480,20 +480,20 @@ export rawConwayPolynomial(e:Expr):Expr := (
 setupfun("rawConwayPolynomial",rawConwayPolynomial);
 
 export rawRRi(e:Expr):Expr := (
-     when e is prec:ZZcell do if !isInt(prec) then WrongArgSmallInteger(1)
-     else toExpr(Ccode(RawRingOrNull, "IM2_Ring_RRi(",toInt(prec),")" ))
+     when e is prec:ZZcell do if !isULong(prec) then WrongArgSmallUInteger(1)
+     else toExpr(Ccode(RawRingOrNull, "IM2_Ring_RRi(",toULong(prec),")" ))
      else WrongArgZZ(1));
 setupfun("rawRRi",rawRRi);
 
 export rawRR(e:Expr):Expr := (
-     when e is prec:ZZcell do if !isInt(prec) then WrongArgSmallInteger(1)
-     else toExpr(Ccode(RawRingOrNull, "IM2_Ring_RRR(",toInt(prec),")" ))
+     when e is prec:ZZcell do if !isULong(prec) then WrongArgSmallUInteger(1)
+     else toExpr(Ccode(RawRingOrNull, "IM2_Ring_RRR(",toULong(prec),")" ))
      else WrongArgZZ(1));
 setupfun("rawRR",rawRR);
 
 export rawCC(e:Expr):Expr := (
-     when e is prec:ZZcell do if !isInt(prec) then WrongArgSmallInteger(1)
-     else toExpr(Ccode(RawRingOrNull, "IM2_Ring_CCC(",toInt(prec),")" ))
+     when e is prec:ZZcell do if !isULong(prec) then WrongArgSmallUInteger(1)
+     else toExpr(Ccode(RawRingOrNull, "IM2_Ring_CCC(",toULong(prec),")" ))
      else WrongArgZZ(1));
 setupfun("rawCC",rawCC);
 


### PR DESCRIPTION
The precision of our floating point types is stored as an unsigned long, but there were a few spots where we passing an int, potentially causing problems:

```m2
i1 : debug Core

i2 : rawRR(-2)
../../src/init2.c:54: MPFR assertion failed: ((p) >= 1 && (p) <= ((mpfr_prec_t) ((((mpfr_uprec_t) -1) >> 1) - 256)))
Aborted (core dumped)
```

