### PR TITLE
Regenerate tvalues.m2 if d directory has been updated

### DIFF
--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -125,8 +125,12 @@ generateTypicalValues = (srcdir) -> (
     outfile << "-- DONE: generated based on " | version#"git description" << endl << close)
 
 -- if missing or not successfully generated, tvalues.m2 is regenerated directly
-if not fileExists typicalValuesSource or not match("-- DONE", get typicalValuesSource)
-then generateTypicalValues(currentFileDirectory | "../d/")
+ddir := currentFileDirectory | "../d/"
+if (
+    not fileExists typicalValuesSource or
+    not match("-- DONE", get typicalValuesSource) or
+    isDirectory ddir and fileTime typicalValuesSource < fileTime ddir)
+then generateTypicalValues ddir
 
 -----------------------------------------------------------------------------
 -- numerical functions that will be wrapped


### PR DESCRIPTION
Now that tvalues.m2 is generated at startup instead of during the build process, it's no longer updated when there have been changes to the d files, which may potentially include new methods.  If someone adds a new method in the d directory using a "typical value" comment, then they need to manually delete tvalues.m2 so that it can be regenerated.

To simplify this, we now check the file time of the d directory and compare it to the generated file.  If the d directory is newer, then we regenerate the file.