### PR TITLE
Improvements for set

### DIFF
--- a/M2/Macaulay2/d/sets.dd
+++ b/M2/Macaulay2/d/sets.dd
@@ -19,6 +19,7 @@ makeSet(e:Expr):Expr := (
      is v:Sequence do makeSet(v)
      is w:List do if ancestor(w.Class,visibleListClass) then makeSet(w.v)
      else WrongArg("a visible list")
+     is h:HashTable do makeSet(keys(h))
      else WrongArg("a visible list"));
 setupfun("set",makeSet);
 

--- a/M2/Macaulay2/d/sets.dd
+++ b/M2/Macaulay2/d/sets.dd
@@ -37,7 +37,7 @@ makeSet(e:Expr):Expr := (
      else WrongArg("a visible list or a hash table")
      is h:HashTable do makeSet(h)
      else WrongArg("a visible list or a hash table"));
-setupfun("set",makeSet);
+setupfun("set",makeSet).Protected = false; -- will be overloaded in m2/set.m2
 
 -- object is beingInitialized:
 modify(object:HashTable,key:Expr,f:function(Expr):Expr,v:Expr):void := (

--- a/M2/Macaulay2/d/sets.dd
+++ b/M2/Macaulay2/d/sets.dd
@@ -14,12 +14,28 @@ makeSet(v:Sequence):Expr := (
      o.beingInitialized = true;
      foreach e in v do storeInHashTable(o,e,oneE);
      Expr(sethash(o,false)));
+makeSet(h:HashTable):Expr := (
+     x := newHashTable(Set,nothingClass);
+     x.beingInitialized = true;
+     x.numEntries = h.numEntries;
+     x.table = new array(KeyValuePair) len length(h.table) do (
+	  foreach bucket in h.table do (
+	       p := bucket;
+	       q := bucketEnd;
+	       while p != p.next do (
+		    q = KeyValuePair(p.key,p.hash,oneE,q);
+		    p = p.next;
+		    );
+	       provide q;
+	       );
+	  );
+     Expr(sethash(x,false)));
 makeSet(e:Expr):Expr := (
      when e
      is v:Sequence do makeSet(v)
      is w:List do if ancestor(w.Class,visibleListClass) then makeSet(w.v)
      else WrongArg("a visible list")
-     is h:HashTable do makeSet(keys(h))
+     is h:HashTable do makeSet(h)
      else WrongArg("a visible list"));
 setupfun("set",makeSet);
 

--- a/M2/Macaulay2/d/sets.dd
+++ b/M2/Macaulay2/d/sets.dd
@@ -34,9 +34,9 @@ makeSet(e:Expr):Expr := (
      when e
      is v:Sequence do makeSet(v)
      is w:List do if ancestor(w.Class,visibleListClass) then makeSet(w.v)
-     else WrongArg("a visible list")
+     else WrongArg("a visible list or a hash table")
      is h:HashTable do makeSet(h)
-     else WrongArg("a visible list"));
+     else WrongArg("a visible list or a hash table"));
 setupfun("set",makeSet);
 
 -- object is beingInitialized:

--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -15,7 +15,7 @@ tally String      :=
 tally VisibleList := Tally => tally
 
 elements = method()
-elements Tally := x -> splice apply(pairs x, (k,v) -> v:k)
+elements Tally := toList Tally := x -> splice apply(pairs x, (k,v) -> v:k)
 
 toString VirtualTally := x -> concatenate( "new ", toString class x, " from {", demark(", ", sort apply(pairs x, (v,i) -> (toString v, " => ", toString i))), "}" )
 
@@ -85,7 +85,6 @@ Set.synonym = "set"
 -- constructors, both compiled functions defined in d/sets.dd
 set VisibleList := Set => set
 new Set from List := Set => (X,x) -> set x
-set Set := identity
 
 -- set operations
 elements Set := List => keys

--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -83,8 +83,8 @@ product VirtualTally := (w) -> product(pairs w, (k,v) -> k^v)
 Set.synonym = "set"
 
 -- constructors, both compiled functions defined in d/sets.dd
-set VisibleList := Set => set
-new Set from List := Set => (X,x) -> set x
+set HashTable := set VisibleList := Set => set
+new Set from List := new Set from HashTable := Set => (X,x) -> set x
 
 -- set operations
 elements Set := List => keys

--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -83,8 +83,14 @@ product VirtualTally := (w) -> product(pairs w, (k,v) -> k^v)
 Set.synonym = "set"
 
 -- constructors, both compiled functions defined in d/sets.dd
-set HashTable := set VisibleList := Set => set
-new Set from List := new Set from HashTable := Set => (X,x) -> set x
+set' = set
+set = method(TypicalValue => Set, Dispatch => Thing)
+set Set         := identity
+set HashTable   :=
+set VisibleList := Set => set'
+new Set from Set         := Set => (Set, S) -> set' S
+new Set from HashTable   :=
+new Set from VisibleList := Set => (Set, X) -> set' X
 
 -- set operations
 elements Set := List => keys

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
@@ -1,6 +1,5 @@
 undocumented {
     (NewFromMethod, Set, List),
-    (set, Set)
 }
 
 document {

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
@@ -8,7 +8,7 @@ document {
      Key => {set, (set,VisibleList), (set,HashTable), (set, Set)},
      Headline => "make a set",
      Usage => "set v\nset(v1,v2,...)",
-     Inputs => {"v", ofClass { VisibleList, HashTable } },
+     Inputs => { "v" => ofClass { VisibleList, HashTable } },
      Outputs => {Set => " the set whose elements are the members of the list v or keys of the hash table v"},
      EXAMPLE {
 	  "v = {1,2,3,2,1}",

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
@@ -3,11 +3,11 @@ undocumented {
 }
 
 document {
-     Key => {set, (set,VisibleList)},
+     Key => {set, (set,VisibleList), (set,HashTable)},
      Headline => "make a set",
      Usage => "set v\nset(v1,v2,...)",
-     Inputs => {"v" => List},
-     Outputs => {Set => " the set whose elements are the members of the list v"},
+     Inputs => {"v", ofClass { VisibleList, HashTable } },
+     Outputs => {Set => " the set whose elements are the members of the list v or keys of the hash table v"},
      EXAMPLE {
 	  "v = {1,2,3,2,1}",
 	  "S = set v",

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/set-doc.m2
@@ -1,9 +1,11 @@
 undocumented {
-    (NewFromMethod, Set, List),
+    (NewFromMethod, Set, Set),
+    (NewFromMethod, Set, HashTable),
+    (NewFromMethod, Set, VisibleList),
 }
 
 document {
-     Key => {set, (set,VisibleList), (set,HashTable)},
+     Key => {set, (set,VisibleList), (set,HashTable), (set, Set)},
      Headline => "make a set",
      Usage => "set v\nset(v1,v2,...)",
      Inputs => {"v", ofClass { VisibleList, HashTable } },

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/toList-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/toList-doc.m2
@@ -6,6 +6,7 @@ doc///
   toList
   (toList, BasicList)
   (toList, Set)
+  (toList, Tally)
   (toList, String)
   (toList, Thing)
  Headline
@@ -13,7 +14,7 @@ doc///
  Usage
   toList A
  Inputs
-  A:{Set,String,BasicList,ZZ}
+  A:{Set,String,BasicList,Tally}
    or an instance of a class with the @TO iterator@ method installed
  Outputs
   L:List


### PR DESCRIPTION
This is just #3770 plus one additional commit that makes `set(Set)` an idempotent. In particular:
```m2
i1 : elapsedTime S = set (1..10^7);
 -- 2.99931s elapsed

i2 : elapsedTime set S;
 -- .00000913s elapsed

i3 : elapsedTime new Set from S;
 -- .786303s elapsed
```

- **fix set Set, add toList Tally**
- **document toList Tally, set HashTable**
- **improve set HashTable**
- **fix set error message**
- **made set(Set) an idempotent**
