### PR TITLE
Only regenerate tvalues.m2 if it's writable

### DIFF
--- a/M2/Macaulay2/m2/Makefile.in
+++ b/M2/Macaulay2/m2/Makefile.in
@@ -29,10 +29,10 @@ clean::; rm -f version.m2
 STOP = --stop
 ARGS = -q --silent $(STOP) -e errorDepth=0
 TVFILES := $(wildcard @srcdir@/../d/*.d)
-all: tvalues.m2
-tvalues.m2: $(TVFILES) @pre_packagesdir@/Core
-	rm -f tvalues.m2 && @pre_exec_prefix@/bin/M2 $(ARGS) --no-preload -e 'exit 0'
-clean::;rm -f tvalues.m2
+all: @pre_packagesdir@/Core/tvalues.m2
+@pre_packagesdir@/Core/tvalues.m2: $(TVFILES) @pre_packagesdir@/Core
+	rm -f $@ && @pre_exec_prefix@/bin/M2 $(ARGS) --no-preload -e 'exit 0'
+clean::;rm -f @pre_packagesdir@/Core/tvalues.m2
 #################################
 all: tags
 tags: Makefile @srcdir@/TAGS @srcdir@/TAGS.doc

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -125,12 +125,8 @@ generateTypicalValues = (srcdir) -> (
     outfile << "-- DONE: generated based on " | version#"git description" << endl << close)
 
 -- if missing or not successfully generated, tvalues.m2 is regenerated directly
-ddir := currentFileDirectory | "../d/"
-if (
-    not fileExists typicalValuesSource or
-    not match("-- DONE", get typicalValuesSource) or
-    isDirectory ddir and fileTime typicalValuesSource < fileTime ddir)
-then generateTypicalValues ddir
+if not fileExists typicalValuesSource or not match("-- DONE", get typicalValuesSource)
+then generateTypicalValues(currentFileDirectory | "../d/")
 
 -----------------------------------------------------------------------------
 -- numerical functions that will be wrapped


### PR DESCRIPTION
This is a quick follow up to #3923.  In some situations, we might try to regenerate tvalues.m2 when we don't have write permissions to the file, which raises an error on startup.  In particular, I was starting up M2 with the `--srcdir` option pointing to the source repo, but tvalues.m2 was in `/usr/share/Macaulay2/Core`, and I was running into this issue.  So we check to make sure it's writable first.

Unrelated, but we also take the opportunity to fix a typo regarding the location of `locate`.