### PR TITLE
Fix IgnoreExampleErrors option to installPackage

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -626,9 +626,7 @@ checkForWarnings := pkg -> (
 
 checkForErrors := pkg -> (
     if 0 < numDocumentationErrors then error("installPackage: ", toString numDocumentationErrors,
-	" error(s) occurred in processing documentation for package ", toString pkg);
-    if 0 < numExampleErrors then error("installPackage: ", toString numExampleErrors,
-	" error(s) occurred in running examples for package ", toString pkg))
+	" error(s) occurred in processing documentation for package ", toString pkg))
 
 -----------------------------------------------------------------------------
 -- installPackage
@@ -783,8 +781,9 @@ installPackage Package := opts -> pkg -> (
 	if 0 < numExampleErrors then verboseLog stack apply(readDirectory exampleOutputDir,
 	    file -> if match("\\.errors$", file) then stack {
 		file, concatenate(width file : "="), getErrors(exampleOutputDir | file)});
-
-	if not opts.IgnoreExampleErrors then checkForErrors pkg;
+	if not opts.IgnoreExampleErrors and  0 < numExampleErrors
+	then error("installPackage: ", numExampleErrors,
+	    " error(s) occurred in running examples for package ", pkg);
 
 	-- if no examples were generated, then remove the directory
 	if length readDirectory exampleOutputDir == 2 then removeDirectory exampleOutputDir;


### PR DESCRIPTION
We were checking in several places if there were example errors, and only avoided raising an error when `IgnoreExampleErrors` was true in one of these places.  So when an example had an error, we ended up raising an error the next time it was checked.

We fix this by removing the example error check from the `checkForErrors` helper function and move this code to right after we generate the examples, when we were checking `IgnoreExampleErrors`.

### Before

Let's take the silly *Foo* package:

```m2
newPackage("Foo", Headline => "foo")

beginDocumentation()

doc ///
  Key
    Foo
  Description
    Example
      1/0
///
```

```m2
i1 : installPackage("Foo", FileName => "~/tmp/Foo.m2", IgnoreExampleErrors => true)
 -- making example results for "Foo"                                         -- running failed
 -- error log:  /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/___Foo.errors:0:1:(3):[12]: 
 -- input code: /tmp/M2-2113520-0/0___Foo.m2:0:1
*** error: M2 exited with status code 1         -- 1.23912s elapsed
===============================================================================
 -- Summary: 1 example(s) failed in package Foo:
 -- Foo  ../../../tmp/Foo.m2:12:0
stdio:1:14:(3): error: installPackage: 1 error(s) occurred in running examples for package Foo
```
### After

```m2
i1 : installPackage("Foo", FileName => "~/tmp/Foo.m2", IgnoreExampleErrors => true)
 -- making example results for "Foo"                                         -- running failed
 -- error log:  /home/profzoom/.Macaulay2/local/share/doc/Macaulay2/Foo/example-output/___Foo.errors:0:1:(3):[12]: 
 -- input code: /tmp/M2-2113771-0/0___Foo.m2:0:1
*** error: M2 exited with status code 1 -- 1.76826s elapsed
===============================================================================
 -- Summary: 1 example(s) failed in package Foo:
 -- Foo  ../../../tmp/Foo.m2:12:0

o1 = Foo

o1 : Package
```

@mikestillman: This fixes the issue you pointed out to me on Zulip the other day.

@mahrud: You touched this code last.  Was there a reason we were using the same helper function to check both documentation and example errors several times during `installPackage`?  It seems like just checking for example errors in this one spot should work.
