### PR TITLE
Bump linbox to 1.7.1

### DIFF
--- a/M2/libraries/linbox/Makefile.in
+++ b/M2/libraries/linbox/Makefile.in
@@ -1,4 +1,4 @@
-VERSION = 1.7.0
+VERSION = 1.7.1
 # URL = http://www.linalg.org
 URL = https://github.com/linbox-team/linbox/archive/refs/tags
 TARFILE = v$(VERSION).tar.gz


### PR DESCRIPTION
We don't actually use linbox yet (so not bothering with the GitHub builds), and we only provide the option of building it during the autotools build, but they just released a new version.
