### PR TITLE
tensor(RingMap, Module) fix

### DIFF
--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -211,9 +211,7 @@ RingMap Module := Module => (f, M) -> (
 -- misc
 tensor(RingMap, Module) := Module => {} >> opts -> (f, M) -> (
     if source f =!= ring M then error "expected module over source ring";
-    subquotient(f ambient M,
-	if M.?generators then f M.generators,
-	if M.?relations  then f M.relations))
+    cokernel f presentation M);
 RingMap ** Module := Module => (f, M) -> tensor(f, M)
 
 tensor(RingMap, Matrix) := Matrix => {} >> opts -> (f, m) -> (

--- a/M2/Macaulay2/tests/normal/ringmap8.m2
+++ b/M2/Macaulay2/tests/normal/ringmap8.m2
@@ -1,0 +1,5 @@
+S = QQ[x]
+M = image matrix{{x}}
+R = S/x
+assert(tensor(map(R, S), M) != 0)
+assert(isFreeModule tensor(map(R, S), M))


### PR DESCRIPTION
This reverts commit 4433d30, which introduced the error in #3960 for `tensor(RingMap, Module)`, and adds a test to ensure tensor products with submodules give the correct answer. 