### PR TITLE
Fix to a bug in Msolve package RUR function

### DIFF
--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -1,9 +1,9 @@
 newPackage(
 	"Msolve",
-	Version => "1.24.05", 
-    	Date => "July 2024",
+	Version => "1.24.06", 
+    	Date => "September 2025",
     	Authors => {{Name => "Martin Helmer", 
-		  Email => "mhelmer@ncsu.edu", 
+		  Email => "martin.helmer@swansea.ac.uk", 
 		  HomePage => "http://martin-helmer.com/"}, {Name => "Mike Stillman", 
 		  Email => "mike@math.cornell.edu", 
 		  HomePage => "https://math.cornell.edu/michael-e-stillman"},{Name => "Anton Leykin", 
@@ -252,11 +252,22 @@ msolveRUR Ideal := opt -> I0 ->(
     RUR#"var"=T;
     RUR#"degree"=(solsp_1)_2;
     para:= ((solsp_1)_5)_1;
+    sVarsMsolve:=(solsp_1)_3;
     W:=sum((para_0)_0+1,i->(T)^i*(((para_0)_1)_i));
     RUR#"findRootsUniPoly"=W;
     RUR#"denominator"=diff(T,W);
     vs:=last para;
-    RUR#"numerator"=append(for f in vs list sum((f_0)_0+1,i->T^i*((f_0)_1)_i),-T*diff(T,W));
+    <<"S= "<<toString gens(S)<<endl;
+    <<"vs= "<<vs<<endl;
+    <<"Msolve vars= "<<sVarsMsolve<<endl;
+    msolveVarOrder:=for sg in gens(S) list position(sVarsMsolve,i->i==toString(sg));
+    tempNumerator:=(append(for f in vs list sum((f_0)_0+1,i->T^i*((f_0)_1)_i),-T*diff(T,W)));
+    if (numgens(S)==#(tempNumerator)) then(
+	RUR#"numerator"=tempNumerator_msolveVarOrder;
+	)
+    else(
+	RUR#"numerator"=tempNumerator_(append(msolveVarOrder, numgens(S)));
+	);
     return new HashTable from RUR;
     );
 

--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -257,9 +257,6 @@ msolveRUR Ideal := opt -> I0 ->(
     RUR#"findRootsUniPoly"=W;
     RUR#"denominator"=diff(T,W);
     vs:=last para;
-    <<"S= "<<toString gens(S)<<endl;
-    <<"vs= "<<vs<<endl;
-    <<"Msolve vars= "<<sVarsMsolve<<endl;
     msolveVarOrder:=for sg in gens(S) list position(sVarsMsolve,i->i==toString(sg));
     tempNumerator:=(append(for f in vs list sum((f_0)_0+1,i->T^i*((f_0)_1)_i),-T*diff(T,W)));
     if (numgens(S)==#(tempNumerator)) then(

--- a/M2/Macaulay2/packages/Msolve/tests.m2
+++ b/M2/Macaulay2/packages/Msolve/tests.m2
@@ -106,6 +106,17 @@ TEST ///
 ///
 
 TEST ///
+R=QQ[x,y,z];
+I = ideal {(x^3-z)*(x^2-y)};
+S = ideal {z-2,y-1};
+rur = msolveRUR(I+S);
+p = matrix{{1}};
+assert(apply(rur#"numerator", n->sub(-n,p)) / sub(rur#"denominator",p)=={1,1,2});
+p = matrix{{-1}};
+assert(apply(rur#"numerator", n->sub(-n,p)) / sub(rur#"denominator",p)=={-1,1,2});
+///
+
+TEST ///
   debugLevel=1
   R = QQ[x..z,t]
   K = ideal(x^6+y^6+x^4*z*t+z^3,36*x^5+60*y^5+24*x^3*z*t,

--- a/M2/Macaulay2/packages/WhitneyStratifications.m2
+++ b/M2/Macaulay2/packages/WhitneyStratifications.m2
@@ -1341,12 +1341,7 @@ Node
 	    I=ideal(y^2+x^3-x^2*z^2)
 	    WS3=whitneyStratifyPol(I,Algorithm=>"M2F4")
 	Text 
-	    On harder examples the whitneyStratifyPol can be much faster than other methods. The following example, while taking some seconds below, takes many minutes or hours with other methods. In the example below the output is in fact the minimal Whitney stratification (though more often the output Whitney stratification returned by whitneyStratifyPol is not minimal). 
-	Example 
-	    R=QQ[x..z,t]
-	    I=ideal(z^3+t*y^3*z+y^4*x+x^9)
-	    elapsedTime W=whitneyStratifyPol(I,Algorithm=>"msolve")
-	    peek W
+	    On harder examples the whitneyStratifyPol can be much faster than other methods and often the option Algorithm=>"msolve" will be the fastest (the msolve option is not currently set as default since the msolve package is a new addition to M2). 
 	    
 	    
 Node 

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -864,7 +864,7 @@ _ADD_COMPONENT_DEPENDENCY(programs gfan "gmp;cddlib" GFAN)
 # http://www-cgrl.cs.mcgill.ca/~avis/C/lrs.html
 # TODO: the shared library target doesn't work on Apple
 ExternalProject_Add(build-lrslib
-  URL               https://cgm.cs.mcgill.ca/~avis/C/lrslib/archive/lrslib-073.tar.gz
+  URL               https://macaulay2.com/Downloads/OtherSourceCode/lrslib-073.tar.gz
   URL_HASH          SHA256=c49a4ebd856183473d1d5a62785fcdfe1057d5d671d4b96f3a1250eb1afe4e83
   PREFIX            libraries/lrslib
   SOURCE_DIR        libraries/lrslib/build

--- a/M2/libraries/lrslib/Makefile.in
+++ b/M2/libraries/lrslib/Makefile.in
@@ -4,7 +4,7 @@
 # run make -C ../..
 # reconfigure in the build directory
 HOMEPAGE = http://www-cgrl.cs.mcgill.ca/~avis/C/lrs.html
-URL = https://cgm.cs.mcgill.ca/~avis/C/lrslib/archive
+URL = https://macaulay2.com/Downloads/OtherSourceCode/
 VERSION = 073
 PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 TARFILE = lrslib-$(VERSION).tar.gz


### PR DESCRIPTION
@antonleykin : This should fix the variable order bug you noticed in Msolve RUR. I now reorder the RUR numerator based on the variable order returned by Msolve. 

This example now works as expected:
needsPackage "Msolve"
QQ[x,y,z]
I = ideal {(x^3-z)*(x^2-y)}
S = ideal {z-2,y-1}
rur = msolveRUR(I+S, Verbosity=>2)
factor rur#"findRootsUniPoly"
-- point corresponding to T=1 or T=-1                                                                                                                                       
p = matrix{{1}}
p = matrix{{-1}}
apply(rur#"numerator", n->sub(-n,p)) / sub(rur#"denominator",p)

