### PR TITLE
Move -latomic check earlier in configure (autools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -604,6 +604,21 @@ done
 AC_SUBST(OPENMP_CXXFLAGS,"$OPENMP_CXXFLAGS")
 AC_SUBST(OPENMP_LIBS,"$OPENMP_LIBS")
 
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358
+AC_MSG_CHECKING([whether we need to link with -latomic])
+AC_LANG([C++])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([
+	#include <atomic>
+	], [std::atomic<int64_t> x; x++])],
+	[AC_MSG_RESULT([no])],
+	[LIBS="$LIBS -latomic"
+	 AC_LINK_IFELSE([AC_LANG_PROGRAM([
+		#include <atomic>
+		], [std::atomic<int64_t> x; x++])],
+		[AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([error])
+		 AC_MSG_ERROR([unable to handle 64-bit atomics])])])
+
 #############################################################################
 AC_SUBST(BUILTLIBS)
 # The list BUILTLIBS is the list of link options for the libraries we have decided to build,
@@ -1849,21 +1864,6 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([int main() {}])],
     HAVE_WL_MAP=no ;  AC_MSG_RESULT(no))
 rm -f conftest.mapfile
 LDFLAGS=$SAVE
-
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358
-AC_MSG_CHECKING([whether we need to link with -latomic])
-AC_LANG([C++])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([
-	#include <atomic>
-	], [std::atomic<int64_t> x; x++])],
-	[AC_MSG_RESULT([no])],
-	[LIBS="$LIBS -latomic"
-	 AC_LINK_IFELSE([AC_LANG_PROGRAM([
-		#include <atomic>
-		], [std::atomic<int64_t> x; x++])],
-		[AC_MSG_RESULT([yes])],
-		[AC_MSG_RESULT([error])
-		 AC_MSG_ERROR([unable to handle 64-bit atomics])])])
 
 AC_SUBST(DUMPDATAFILE,Macaulay2-$ARCH-data)
 


### PR DESCRIPTION
We may need it to properly detect some libraries (e.g., tbb on various architectures).

This should fix builds on a couple Debian architectures:
* [m68k](https://buildd.debian.org/status/fetch.php?pkg=macaulay2&arch=m68k&ver=1.25.06%2Bds-8&stamp=1756124717&raw=0)
* [powerpc](https://buildd.debian.org/status/fetch.php?pkg=macaulay2&arch=powerpc&ver=1.25.06%2Bds-8&stamp=1756125289&raw=0)

They're currently failing with the following because we haven't added `-latomic` to `LIBS` yet:

```
configure:16081: checking for tbb version
configure:16118: g++ -o conftest -std=gnu++17 -g -ffile-prefix-map=/<<PKGBUILDDIR>>=. -specs=/usr/share/dpkg/pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -g3 -O2   -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64 -Wdate-time -D_FORTIFY_SOURCE=2 -DNDEBUG -I/usr/include/cddlib -I/usr/include/cdd -I/usr/include/eigen3  -specs=/usr/share/dpkg/pie-link.specs -Wl,-z,relro -Wl,-z,now -g3 conftest.cpp -ltbb -lreadline -lcurses -lfrobby -lntl -lflint -lcdd -lglpk -lmps -lmpfi -lmpfr -lgmpxx -lgmp -lgc -lgdbm  -lgivaro -lnormaliz -lgmp -lgmpxx -leantic -leanticxx -lnauty >&5
/usr/bin/ld: /tmp/cctVVJkQ.o: undefined reference to symbol '__atomic_fetch_add_8@@LIBATOMIC_1.0'
/usr/bin/ld: /lib/m68k-linux-gnu/libatomic.so.1: error adding symbols: DSO missing from command line
```
