### PR TITLE
Fix compilation when TBB support is disabled

### DIFF
--- a/M2/Macaulay2/e/f4/f4.cpp
+++ b/M2/Macaulay2/e/f4/f4.cpp
@@ -69,8 +69,8 @@ F4GB::F4GB(const VectorArithmetic* VA,
       mNewSPairTime(0),
       mInsertGBTime(0),
       clock_make_matrix(0),
-      mNumThreads(mtbb::numThreads(numThreads)),
 #if defined(WITH_TBB)
+      mNumThreads(mtbb::numThreads(numThreads)),
       mScheduler(mNumThreads),
       mSPairSet(mMonomialInfo, mGroebnerBasis, mScheduler)
 #else
@@ -619,6 +619,7 @@ void F4GB::gauss_reduce(bool diagonalize)
 
   mtbb::tick_count t0;
   mtbb::tick_count t1;
+  std::vector<int> spair_rows;
 
   if (hilbert)
     {
@@ -633,7 +634,6 @@ void F4GB::gauss_reduce(bool diagonalize)
 #if defined(WITH_TBB)
 //#if 0
 
-  std::vector<int> spair_rows;
   for (int i = 0; i < nrows; ++i)
     {
       if (not is_pivot_row(i))


### PR DESCRIPTION
A couple lines of code were on the wrong side of `WITH_TBB` conditionals, causing the following compilation errors when building without TBB support:

```
CXX f4/f4.cpp
../../../../Macaulay2/e/f4/f4.cpp: In constructor ‘F4GB::F4GB(const VectorArithmetic*, const MonomialInfo*, const FreeModule*, M2_bool, int, M2_arrayint, int, M2_bool, int, int)’:
../../../../Macaulay2/e/f4/f4.cpp:72:7: error: class ‘F4GB’ does not have any field named ‘mNumThreads’
   72 |       mNumThreads(mtbb::numThreads(numThreads)),
      |       ^~~~~~~~~~~
../../../../Macaulay2/e/f4/f4.cpp: In member function ‘void F4GB::gauss_reduce(bool)’:
../../../../Macaulay2/e/f4/f4.cpp:688:24: error: ‘spair_rows’ was not declared in this scope
  688 |   for (auto i = 0; i < spair_rows.size(); i++)
      |                        ^~~~~~~~~~
```

This is a draft for now with a commit to run the GitHub builds w/o TBB support, which I'll remove if/when the builds succeed.