### PR TITLE
Update FSF address in GPL headers

### DIFF
--- a/M2/Macaulay2/COPYING-GPL-2
+++ b/M2/Macaulay2/COPYING-GPL-2
@@ -2,7 +2,7 @@
                        Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -304,8 +304,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 

--- a/M2/Macaulay2/packages/Binomials.m2
+++ b/M2/Macaulay2/packages/Binomials.m2
@@ -16,8 +16,7 @@
 --  General Public License for more details.
 --
 --  You should have received a copy of the GNU General Public License along
---  with this program; if not, write to the Free Software Foundation, Inc.,
---  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+--  with this program; if not, see <https://www.gnu.org/licenses/>.
 --
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/M2/Macaulay2/packages/Cyclotomic.m2
+++ b/M2/Macaulay2/packages/Cyclotomic.m2
@@ -16,8 +16,7 @@
 --  General Public License for more details.
 --
 --  You should have received a copy of the GNU General Public License along
---  with this program; if not, write to the Free Software Foundation, Inc.,
---  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+--  with this program; if not, see <https://www.gnu.org/licenses/>.
 --
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -12,9 +12,7 @@
 -- GNU General Public License for more details.
 
 -- You should have received a copy of the GNU General Public License
--- along with this program; if not, write to the Free Software
--- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
--- 02110-1301, USA.
+-- along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 newPackage("ForeignFunctions",
     Headline => "foreign function interface",

--- a/M2/Macaulay2/packages/JSONRPC.m2
+++ b/M2/Macaulay2/packages/JSONRPC.m2
@@ -12,8 +12,7 @@
 -- GNU General Public License for more details.
 
 -- You should have received a copy of the GNU General Public License along
--- with this program; if not, write to the Free Software Foundation, Inc.,
--- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-- with this program; if not, see <https://www.gnu.org/licenses/>.
 
 newPackage("JSONRPC",
     Headline => "JSON-RPC server",

--- a/M2/Macaulay2/packages/PackageCitations.m2
+++ b/M2/Macaulay2/packages/PackageCitations.m2
@@ -18,9 +18,8 @@
 --  for more details.
 --
 --  You should have received a copy of the GNU General
---  Public License along with this program; if not, write
---  to the Free Software Foundation, Inc.,  51 Franklin
---  Street, Fifth Floor, Boston, MA 02110-1301 USA.
+--  Public License along with this program; if not, see
+--  <https://www.gnu.org/licenses/>.
 --
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 --

--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -12,9 +12,7 @@
 -- GNU General Public License for more details.
 
 -- You should have received a copy of the GNU General Public License
--- along with this program; if not, write to the Free Software
--- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
--- 02110-1301, USA.
+-- along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 newPackage("Probability",
     Headline => "basic probability functions",

--- a/M2/Macaulay2/packages/TerraciniLoci.m2
+++ b/M2/Macaulay2/packages/TerraciniLoci.m2
@@ -15,9 +15,7 @@
 -- GNU General Public License for more details.
 
 -- You should have received a copy of the GNU General Public License
--- along with this program; if not, write to the Free Software
--- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
--- 02110-1301, USA.
+-- along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 --
 


### PR DESCRIPTION
The physical office in Boston closed in August 2024, and headers should now point to the URL of their webpage.

We edit various instances of GPL-2 headers to match the updated text at https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
