### PR TITLE
Raise error if duplicate symbols are given in function parameters

### DIFF
--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -615,6 +615,13 @@ bindFormalParmList(e:ParseTree,dictionary:Dictionary,desc:functionDescription):v
 	  then (
 	       bindFormalParmList(binary.lhs,dictionary,desc);
 	       bindop(binary.Operator,dictionary);
+	       when binary.rhs
+	       is t:Token do (
+		   when lookup(t.word, dictionary.symboltable)
+		   is Symbol do makeErrorTree(t,
+		       "duplicate symbol in parameter list: " + t.word.name)
+		   else nothing)
+	       else nothing;
 	       bindFormalParm(binary.rhs,dictionary,desc);)
 	  else makeErrorTree(e,"syntax error: expected function parameter list"))
      else bindFormalParm(e,dictionary,desc));

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -460,17 +460,17 @@ submatrix  = method(TypicalValue => Matrix)
 submatrix' = method(TypicalValue => Matrix)
 
 submatrix(Matrix, VisibleList, VisibleList) := (m, rows, cols) -> map(sliceModule(target m, rows), sliceModule(source m, cols), raw submatrixFree(m, rows, cols))
-submatrix(Matrix, VisibleList, Nothing)     := (m, rows, null) -> map(sliceModule(target m, rows), source m,                    raw submatrixFree(m, rows, null))
+submatrix(Matrix, VisibleList, Nothing)     := (m, rows, cols) -> map(sliceModule(target m, rows), source m,                    raw submatrixFree(m, rows, null))
 submatrix(Matrix, VisibleList)              := (m,       cols) -> map(target m,                    sliceModule(source m, cols), raw submatrixFree(m, null, cols))
-submatrix(Matrix, Nothing,     VisibleList) := (m, null, cols) -> submatrix(m, cols)
-submatrix(Matrix, Nothing,     Nothing)     := (m, null, null) -> m
+submatrix(Matrix, Nothing,     VisibleList) := (m, rows, cols) -> submatrix(m, cols)
+submatrix(Matrix, Nothing,     Nothing)     := (m, rows, cols) -> m
 
 compl := (M, rows) -> if #(rows = listZZ rows) > 0 then toList(0 .. numgens M - 1) - set rows
 submatrix'(Matrix, VisibleList, VisibleList) := (m, rows, cols) -> submatrix(m, compl(target m, rows), compl(source m, cols))
-submatrix'(Matrix, VisibleList, Nothing)     := (m, rows, null) -> submatrix(m, compl(target m, rows), null)
+submatrix'(Matrix, VisibleList, Nothing)     := (m, rows, cols) -> submatrix(m, compl(target m, rows), null)
 submatrix'(Matrix, VisibleList)              := (m,       cols) -> submatrix(m, null, compl(source m, cols))
-submatrix'(Matrix, Nothing,     VisibleList) := (m, null, cols) -> submatrix'(m, cols)
-submatrix'(Matrix, Nothing,     Nothing)     := (m, null, null) -> m
+submatrix'(Matrix, Nothing,     VisibleList) := (m, rows, cols) -> submatrix'(m, cols)
+submatrix'(Matrix, Nothing,     Nothing)     := (m, rows, cols) -> m
 
 submatrixByDegrees = method()
 submatrixByDegrees(Matrix, Sequence, Sequence) := (m, tarBox, srcBox) -> (

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -101,11 +101,11 @@ promote(MutableMatrix,Number) := Matrix => (f,S) -> (
 --------------------------------
 MutableMatrix _ List := Matrix => (f,v) -> submatrix(f,listZ splice v)	-- get some columns
 MutableMatrix ^ List := Matrix => (f,v) -> submatrix(f,listZ splice v,) -- get some rows
-submatrix(MutableMatrix,VisibleList,VisibleList) := (m,rows,cols) -> map(ring m,rawSubmatrix(raw m, listZ toList splice rows, listZ toList splice cols))
-submatrix(MutableMatrix,VisibleList            ) := (m,cols     ) -> map(ring m,rawSubmatrix(raw m, listZ toList splice cols))
-submatrix(MutableMatrix,Nothing    ,VisibleList) := (m,null,cols) -> submatrix(m,cols)
-submatrix(MutableMatrix, VisibleList, Nothing)     := (m, rows, null) -> map(ring m, rawSubmatrix(raw m, listZZ rows, 0 .. numColumns m - 1))
-submatrix(MutableMatrix, Nothing,     Nothing)     := (m, null, null) -> m
+submatrix(MutableMatrix, VisibleList, VisibleList) := (m, rows, cols) -> map(ring m,rawSubmatrix(raw m, listZ toList splice rows, listZ toList splice cols))
+submatrix(MutableMatrix, VisibleList             ) := (m,       cols) -> map(ring m,rawSubmatrix(raw m, listZ toList splice cols))
+submatrix(MutableMatrix, Nothing,     VisibleList) := (m, rows, cols) -> submatrix(m,cols)
+submatrix(MutableMatrix, VisibleList, Nothing)     := (m, rows, cols) -> map(ring m, rawSubmatrix(raw m, listZZ rows, 0 .. numColumns m - 1))
+submatrix(MutableMatrix, Nothing,     Nothing)     := (m, rows, cols) -> m
 
 --------------------------------
 numRows(RawMutableMatrix) := (m) -> rawNumberOfRows m


### PR DESCRIPTION
I noticed this after fat-fingering some code:

```m2
i1 : f = (x, x) -> x;

i2 : f(3, 4)

o2 = 4
```

It doesn't seem like we should allow duplicate symbols like this.  For contrast, here's Python:

```python
>>> def f(x, x):
...     return x
... 
  File "<stdin>", line 1
SyntaxError: duplicate argument 'x' in function definition
```

So I propose we raise an error, too:

```m2
i1 : f = (x, x) -> x;
stdio:1:8:(3): error: duplicate symbol in parameter list: x
```

I had to tweak some `submatrix` methods that were passing two different `null`'s as parameters to avoid raising this error after the change.