### PR TITLE
Bump nauty to 2.9.1

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -931,13 +931,13 @@ set(nauty_BINARIES
   genspecialg gentourng gentreeg hamheuristic labelg linegraphg listg multig newedgeg pickg
   planarg ranlabg shortg showg subdivideg twohamg vcolg watercluster2)
 ExternalProject_Add(build-nauty
-  URL               https://pallini.di.uniroma1.it/nauty2_9_0.tar.gz
-  URL_HASH          SHA256=7b38834c7cefe17d25e05eef1ef3882fa9cd1933f582b9eb9de7477411956053
+  URL               https://pallini.di.uniroma1.it/nauty2_9_1.tar.gz
+  URL_HASH          SHA256=488fa906d10a372c72d2364c5dee48e0f7307004fbe52c2bce50c52de8cd873e
   PREFIX            libraries/nauty
   SOURCE_DIR        libraries/nauty/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
-  CONFIGURE_COMMAND rm -f aclocal.m4 && autoreconf -vif
+  CONFIGURE_COMMAND autoreconf -vif
             COMMAND ${CONFIGURE} --prefix=${M2_HOST_PREFIX}
                       #-C --cache-file=${CONFIGURE_CACHE}
                       CPPFLAGS=${CPPFLAGS}

--- a/M2/libraries/nauty/Makefile.in
+++ b/M2/libraries/nauty/Makefile.in
@@ -1,7 +1,7 @@
 URL = https://pallini.di.uniroma1.it
-VERSION = 2_9_0
+VERSION = 2_9_1
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
-PRECONFIGURE = rm -f aclocal.m4 && autoreconf -vif
+PRECONFIGURE = autoreconf -vif
 TARFILE = nauty$(VERSION).tar.gz
 TARDIR = nauty$(VERSION)
 


### PR DESCRIPTION
Nauty 2.9.1 was just released, and it is apparently "important to upgrade" due to a "nasty bug"  (https://mailman.anu.edu.au/pipermail/nauty/2025-September/001008.html).

Draft for now to test the GitHub builds.