### PR TITLE
Bump msolve to 0.9.1

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -485,8 +485,8 @@ endif()
 
 # https://github.com/algebraic-solving/msolve
 ExternalProject_Add(build-msolve
-  URL               https://github.com/algebraic-solving/msolve/archive/refs/tags/v0.9.0.tar.gz
-  URL_HASH          SHA256=742e84cf4d11eeadf62002623ecb7658e5d6d8c838fcf571fac06acf44252983
+  URL               https://github.com/algebraic-solving/msolve/archive/refs/tags/v0.9.1.tar.gz
+  URL_HASH          SHA256=65e5108fa9ef0628c57c3d74737b27582f8deb49a716fbec39d40f4faeb76d4f
   PREFIX            libraries/msolve
   SOURCE_DIR        libraries/msolve/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/libraries/msolve/Makefile.in
+++ b/M2/libraries/msolve/Makefile.in
@@ -1,5 +1,5 @@
 HOMEPAGE = https://msolve.lip6.fr/
-VERSION = 0.9.0
+VERSION = 0.9.1
 URL = https://github.com/algebraic-solving/msolve/archive/refs/tags
 TARFILE = v$(VERSION).tar.gz
 LICENSEFILES = README.md COPYING


### PR DESCRIPTION
[msolve 0.9.1](https://github.com/algebraic-solving/msolve/releases/tag/v0.9.1) was released earlier today.  This is a draft for now to test the GitHub builds.