### PR TITLE
Use default c++ headers with brew clang

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -102,6 +102,10 @@ jobs:
               echo "CC=clang"    >> $GITHUB_ENV
               echo "CXX=clang++" >> $GITHUB_ENV
               echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+              # https://github.com/Macaulay2/M2/issues/3967
+              # maybe remove after some future llvm release?
+              SDKROOT=$(xcrun --show-sdk-path)
+              echo "CXXFLAGS=-nostdinc++ -isystem $SDKROOT/usr/include/c++/v1 -isystem $SDKROOT/usr/include" >> $GITHUB_ENV
               ;;
           esac
 

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -46,7 +46,7 @@ jobs:
           # This build tests Clang rather than AppleClang (keep)
           - build-system: cmake
             os: macos-13 # TODO: switch to macos-14 for arm64 testing
-            compiler: clang-15
+            compiler: brew-clang
             cxx: clang++
             cc: clang
         exclude:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -118,6 +118,8 @@ jobs:
                echo `brew --prefix make  `/libexec/gnubin >> $GITHUB_PATH
                echo `brew --prefix libtool`/libexec/gnubin >> $GITHUB_PATH
                echo `brew --prefix bison`/bin             >> $GITHUB_PATH
+               echo "CPPFLAGS=-I$(brew --prefix)/include -I$(brew --prefix libomp)/include -I$(brew --prefix readline)/include" >> $GITHUB_ENV
+               echo "LDFLAGS= -L$(brew --prefix)/lib     -L$(brew --prefix libomp)/lib     -L$(brew --prefix readline)/lib"     >> $GITHUB_ENV
           fi
 
       - uses: actions/cache@v4
@@ -166,12 +168,6 @@ jobs:
         if: matrix.build-system == 'autotools'
         run: |
           ../../autogen.sh
-          export CPPFLAGS="-I`brew --prefix`/include \
-            -I`brew --prefix libomp`/include         \
-            -I`brew --prefix readline`/include"
-          export  LDFLAGS="-L`brew --prefix`/lib \
-            -L`brew --prefix libomp`/lib         \
-            -L`brew --prefix readline`/lib"
           export F77=gfortran-14
           export FC=gfortran-14
           ../../configure --with-system-gc --with-fplll

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -47,8 +47,6 @@ jobs:
           - build-system: cmake
             os: macos-13 # TODO: switch to macos-14 for arm64 testing
             compiler: brew-clang
-            cxx: clang++
-            cc: clang
         exclude:
           - build-system: cmake
             os: macos-13
@@ -93,24 +91,30 @@ jobs:
 #   Steps common to all build variants
 # ----------------------
 
+      - name: Set up compiler
+        run: |
+          case "${{ matrix.compiler }}" in
+            default)
+              echo "Using default compiler"
+              ;;
+            brew-clang)
+              echo "Using Homebrew Clang"
+              echo "CC=clang"    >> $GITHUB_ENV
+              echo "CXX=clang++" >> $GITHUB_ENV
+              echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+              ;;
+          esac
+
       - name: Prepare build environment
         run: |
-          echo "CC=${{  matrix.cc  }}" >> $GITHUB_ENV
-          echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
           if [[ "${{ runner.os }}" == "Linux" ]]
-          then shopt -s expand_aliases
-               alias llvm-config="/usr/bin/llvm-config-16"
-               echo "/usr/lib/ccache"                     >> $GITHUB_PATH
+          then echo "/usr/lib/ccache"                     >> $GITHUB_PATH
                echo "/home/linuxbrew/.linuxbrew/bin"      >> $GITHUB_PATH
           else echo `brew --prefix ccache`/libexec        >> $GITHUB_PATH
                echo `brew --prefix make  `/libexec/gnubin >> $GITHUB_PATH
-               echo `brew --prefix llvm`/bin              >> $GITHUB_PATH
-               PATH=`brew --prefix llvm`/bin:$PATH
                echo `brew --prefix libtool`/libexec/gnubin >> $GITHUB_PATH
                echo `brew --prefix bison`/bin             >> $GITHUB_PATH
           fi
-          # Necessary for clang to find the right libomp
-          echo "LIBRARY_PATH=`llvm-config --libdir`" >> $GITHUB_ENV
 
       - uses: actions/cache@v4
         if: matrix.build-system == 'cmake'

--- a/M2/cmake/FindNormaliz.cmake
+++ b/M2/cmake/FindNormaliz.cmake
@@ -71,6 +71,17 @@ if(NOT NORMALIZ_FOUND)
   # find the Normaliz executable
   find_program(NORMALIZ_EXECUTABLE NAMES normaliz)
 
+  # ensure that it runs
+  if(NORMALIZ_EXECUTABLE)
+    execute_process(
+      COMMAND ${NORMALIZ_EXECUTABLE} --version
+      RESULT_VARIABLE NORMALIZ_RESULT
+      OUTPUT_QUIET ERROR_QUIET)
+    if(NOT NORMALIZ_RESULT EQUAL "0")
+      unset(NORMALIZ_EXECUTABLE CACHE)
+    endif()
+  endif()
+
   if(NOT NORMALIZ_INCLUDE_DIR)
     find_path(NORMALIZ_INCLUDE_DIR NAMES libnormaliz/version.h
       HINTS ENV NORMALIZDIR


### PR DESCRIPTION
I think this should fix #3967, which looks to be a special case of https://github.com/llvm/llvm-project/issues/155531

I also took the opportunity to refactor things a bit, splitting the compiler selection into its own step, renaming "clang-15" (we're on clang-21 now!) to "brew-clang", and dropping the `llvm-config` stuff, which I don't think is necessary any more.