### PR TITLE
Clean up diagonalized via congruence matrix in RR and CC (A1BrouwerDegrees package)

### DIFF
--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/MatrixMethods.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/MatrixMethods.m2
@@ -107,6 +107,7 @@ diagonalizeViaCongruence Matrix := Matrix => AnonMut -> (
                 );
             );
         );
+    if instance(k, InexactField) then A = clean(1e-12, A);
     matrix A 
     )
 


### PR DESCRIPTION
When using floating point arithmetic, there's a chance we end up with small nonzero entries off the diagonal thanks to rounding errors.

---

I ran into this error when trying to build a Macaulay2 package for AlmaLinux 10:

```m2
i1 : needsPackage "A1BrouwerDegrees";

i2 : M = matrix(RR, {{2.091,2.728,6.747},{2.728,7.329,6.257},{6.747,6.257,0.294}});

    	       3         3
o2 : Matrix RR    <-- RR
              53        53

i3 : getSumDecomposition makeGWClass M
stdio:3:19:(3): error: Matrix is not symmetric
```

The non-symmetric matrix it's yelling at us about is this one:

```m2
i4 : diagonalizeViaCongruence M

o4 = | 2.091 -1.40156e-16 3.35723e-16  |
     | 0     3.76995      -8.76349e-16 |
     | 0     0            -23.1951     |

                3         3
o4 : Matrix RR    <-- RR
	      53        53
```

The `diagonalizeViaCongruence` algorithm involves lots of `rowAdd` and `columnAdd` operations that are susceptible to rounding errors when working over `RR` and `CC`, so I propose that we add an extra `clean` at the end in these cases.  I arbitrarily picked $10^{-12}$ for the tolerance.

Another possible option might be to use Sylvester's law of inertia, call `eigenvalues`  (letting the faster BLAS/LAPACK engine code do the row operations for us), then return something like `diagonalMatrix apply(n, i -> sign E#i)` (where `E` is the return value of `eigenvalues`) in the real case.  The complex case I think might be even simpler since I think we can just use 1's if it's full rank.  But that might throw away too much information about the original matrix...

Package authors -- thoughts?

Cc: @nikita-borisov , @tbrazel, @frenlye, @TomHagedorn, @zbtomhan, @JordyLopez27, @jlouwsma, @wgabrielong, @andrew-tawfeek 