### PR TITLE
Bump macOS runners to sonoma (ventura bottles no longer built)

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -65,7 +65,7 @@ jobs:
           brew update
           brew tap macaulay2/tap
           brew install --overwrite python
-          brew install automake bison boost tbb ccache ctags texinfo llvm make ninja yasm libffi msolve googletest fplll eigen
+          brew install automake bison boost libtool tbb ccache ctags texinfo llvm make ninja yasm libffi msolve googletest fplll eigen
           brew install --only-dependencies macaulay2/tap/M2
           brew link factory --force
 

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -39,17 +39,17 @@ jobs:
           - cmake
         os:
           - ubuntu-24.04
-          - macos-13
+          - macos-14
         compiler:
           - default
         include:
           # This build tests Clang rather than AppleClang (keep)
           - build-system: cmake
-            os: macos-13 # TODO: switch to macos-14 for arm64 testing
+            os: macos-14
             compiler: brew-clang
         exclude:
           - build-system: cmake
-            os: macos-13
+            os: macos-14
             compiler: default
     steps:
       - uses: actions/checkout@v5

--- a/M2/Macaulay2/packages/RunExternalM2.m2
+++ b/M2/Macaulay2/packages/RunExternalM2.m2
@@ -1048,7 +1048,7 @@ assert(h#"output file"===null);
 ///;
 
 -- Check that ulimits and statistics work
-TEST ///
+TEST /// -- no-check-flag (#3985)
 fn=temporaryFileName()|".m2";
 fn<<////
 spin = (x,t) -> (

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -869,6 +869,9 @@ fi
 if test -d /usr/include/cdd 
 then CPPFLAGS="$CPPFLAGS -I/usr/include/cdd"
 fi
+if test -d /opt/homebrew/include/cddlib
+then CPPFLAGS="$CPPFLAGS -I/opt/homebrew/include/cddlib"
+fi
 AC_LANG(C)
 AC_CHECK_HEADER(cdd.h,,[ AC_MSG_RESULT([[cddlib not found, will build]])
 			     BUILD_cddlib=yes],


### PR DESCRIPTION
I think the reason that the macOS builds have started failing is that they've stopped building bottles for macos-13 (https://github.com/Homebrew/brew/pull/20672).  So we bump the runners to macos-14.
