### PR TITLE
Add support for negative indices for ring variables & submatrices

### DIFF
--- a/M2/Macaulay2/m2/engine.m2
+++ b/M2/Macaulay2/m2/engine.m2
@@ -53,7 +53,7 @@ isSmall := i -> class i === ZZ and i < 2^15 and i > -2^15
 isCount := i -> class i === ZZ and i >= 0 and i < 2^15
 isListOfIntegers = x -> instance(x, List) and all(x,i -> class i === ZZ)
 isListOfListsOfIntegers = x -> instance(x, List) and all(x,isListOfIntegers)
-listZ = listZZ = v -> if isListOfIntegers(v = toList splice v) then v else error "expected a list of integers"
+listZZ = v -> if isListOfIntegers(v = toList splice v) then v else error "expected a list of integers"
 checkCount := i -> if not isCount i then error "expected a small positive integer"
 
 fixup1 := method(Dispatch => Thing)			    -- stage 1, everything except Tiny and Small

--- a/M2/Macaulay2/m2/engine.m2
+++ b/M2/Macaulay2/m2/engine.m2
@@ -323,13 +323,23 @@ RawMatrix.synonym = "raw matrix"
 setAttribute(RawMutableMatrix,ReverseDictionary,symbol RawMutableMatrix)
 RawMutableMatrix.synonym = "raw mutable matrix"
 
+-- helper functions for negative indices
+adjustIndex = (i, n) -> if i < 0 then n + i else i
+adjustIndices = (I, n) -> apply(I, i -> adjustIndex(i, n))
+
 rawExtract = method()
 
 rawExtract(RawMatrix,ZZ,ZZ) := 
-rawExtract(RawMutableMatrix,ZZ,ZZ) := (m,r,c) -> rawMatrixEntry(m,r,c)
+rawExtract(RawMutableMatrix,ZZ,ZZ) := (m,r,c) -> (
+    r = adjustIndex(r, rawNumberOfRows m);
+    c = adjustIndex(c, rawNumberOfColumns m);
+    rawMatrixEntry(m, r, c))
 
 rawExtract(RawMatrix,Sequence,Sequence) := 
-rawExtract(RawMutableMatrix,Sequence,Sequence) := (m,r,c) -> rawSubmatrix(m,spliceInside r,spliceInside c)
+rawExtract(RawMutableMatrix,Sequence,Sequence) := (m,r,c) -> (
+    r = adjustIndices(spliceInside r, rawNumberOfRows m);
+    c = adjustIndices(spliceInside c, rawNumberOfColumns m);
+    rawSubmatrix(m,spliceInside r,spliceInside c))
 
 RawMatrix _ Sequence := 
 RawMutableMatrix _ Sequence := (m,rc) -> ((r,c) -> rawExtract(m,r,c)) rc
@@ -364,7 +374,13 @@ new RawMatrix from RawRingElement := (RawMatrix,f) -> rawMatrix1(rawFreeModule(r
 new RawMatrix from RawMutableMatrix := rawMatrix
 new RawMutableMatrix from RawMatrix := rawMutableMatrix
 
-RawMutableMatrix _ Sequence = (M,ij,val) -> ((i,j) -> (rawSetMatrixEntry(M,i,j,val); val)) ij
+RawMutableMatrix _ Sequence = (M,ij,val) -> ((i,j) -> (
+	rawSetMatrixEntry(
+	    M,
+	    adjustIndex(i, rawNumberOfRows M),
+	    adjustIndex(j, rawNumberOfColumns M),
+	    val);
+	val)) ij
 
 degree RawMatrix := rawMultiDegree
 degrees RawMatrix :=f -> {rawMultiDegree rawTarget f,rawMultiDegree rawSource f}

--- a/M2/Macaulay2/m2/enginering.m2
+++ b/M2/Macaulay2/m2/enginering.m2
@@ -448,6 +448,7 @@ Ring _ ZZ := RingElement => (R,i) -> (generators R)#i
 protect numallvars
 
 EngineRing _ ZZ := (R,i) -> (
+     if R.?numallvars and i < 0 then i += R.numallvars;
      if i < 0 or R.?numallvars and i >= R.numallvars then error("index ", toString i, " out of bounds 0 .. ", toString (R.numallvars-1));
      new R from R.RawRing_i
      )

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -97,10 +97,10 @@ toSameRing = (m,n) -> (
      else (m,n))
 
 Matrix _ Sequence := RingElement => (m,ind) -> (
-     if # ind === 2
-     then promote(rawMatrixEntry(m.RawMatrix, ind#0, ind#1), ring m)
-     else error "expected a sequence of length two"
-     )
+    n := (raw m)_ind;
+    if instance(n, RawRingElement) then promote(n, ring m)
+    else if instance(n, RawMatrix) then map(ring m, n)
+    else error "internal error")
 
 Number      == Matrix :=
 RingElement == Matrix :=
@@ -442,10 +442,9 @@ Matrix _ ZZ := Vector => (m,i) -> (
      new target h from {h})
 
 -- given a map of free modules, find a submatrix of it
-adjustindex := (I, n) -> apply(I, i -> if i < 0 then n + i else i)
 submatrixFree = (m, rows, cols) -> (
-    if rows =!= null then rows = adjustindex(listZZ rows, numRows m);
-    if cols =!= null then cols = adjustindex(listZZ cols, numColumns m);
+    if rows =!= null then rows = adjustIndices(listZZ rows, numRows m);
+    if cols =!= null then cols = adjustIndices(listZZ cols, numColumns m);
     map(ring m, if rows === null
     then rawSubmatrix(raw cover m, cols)
     else rawSubmatrix(raw cover m, rows,

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -431,8 +431,8 @@ Matrix || Number := (f,g) -> concatRows(f,g*id_(source f))
 -----------------------------------------------------------------------------
 -- submatrix, submatrixByDegrees
 -----------------------------------------------------------------------------
-Matrix _ List := Matrix => (f,v) -> submatrix(f,listZ splice v)	-- get some columns
-Matrix ^ List := Matrix => (f,v) -> submatrix(f,listZ splice v,) -- get some rows
+Matrix _ List := Matrix => (f,v) -> submatrix(f, v)  -- get some columns
+Matrix ^ List := Matrix => (f,v) -> submatrix(f, v,) -- get some rows
 
 Matrix _ ZZ := Vector => (m,i) -> (
      R := ring m;

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -442,10 +442,14 @@ Matrix _ ZZ := Vector => (m,i) -> (
      new target h from {h})
 
 -- given a map of free modules, find a submatrix of it
-submatrixFree = (m, rows, cols) -> map(ring m, if rows === null
-    then rawSubmatrix(raw cover m, listZZ cols)
-    else rawSubmatrix(raw cover m, listZZ rows,
-	if cols =!= null then listZZ cols else 0 .. numgens source m - 1))
+adjustindex := (I, n) -> apply(I, i -> if i < 0 then n + i else i)
+submatrixFree = (m, rows, cols) -> (
+    if rows =!= null then rows = adjustindex(listZZ rows, numRows m);
+    if cols =!= null then cols = adjustindex(listZZ cols, numColumns m);
+    map(ring m, if rows === null
+    then rawSubmatrix(raw cover m, cols)
+    else rawSubmatrix(raw cover m, rows,
+	if cols =!= null then cols else 0 .. numgens source m - 1)))
 -- given a module, find a part of the ambient module
 -- along with corresponding generators and relations
 sliceModule = (M, rows) -> (

--- a/M2/Macaulay2/m2/matrix2.m2
+++ b/M2/Macaulay2/m2/matrix2.m2
@@ -525,13 +525,9 @@ support Ideal       := I -> support generators I
 --------------------
 homogenize = method()
 
-listZ := v -> (
-     if not all(v,i -> class i === ZZ) then error "expected list of integers";
-     )
-
 homogCheck := (R, f, v, wts) -> (
      if R =!= ring v then error "homogenization requires variable in the same ring";
-     listZ wts;
+     wts = listZZ wts;
      if degreeLength R =!= 1 then error "homogenization requires degrees of length 1";
      -- if # wts != numgens ring f then error "homogenization weight vector has incorrect length";
      i := index v;

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -99,12 +99,12 @@ promote(MutableMatrix,Number) := Matrix => (f,S) -> (
 --------------------------------
 -- submatrices -----------------
 --------------------------------
-MutableMatrix _ List := Matrix => (f,v) -> submatrix(f,listZ splice v)	-- get some columns
-MutableMatrix ^ List := Matrix => (f,v) -> submatrix(f,listZ splice v,) -- get some rows
-submatrix(MutableMatrix, VisibleList, VisibleList) := (m, rows, cols) -> map(ring m,rawSubmatrix(raw m, listZ toList splice rows, listZ toList splice cols))
-submatrix(MutableMatrix, VisibleList             ) := (m,       cols) -> map(ring m,rawSubmatrix(raw m, listZ toList splice cols))
-submatrix(MutableMatrix, Nothing,     VisibleList) := (m, rows, cols) -> submatrix(m,cols)
-submatrix(MutableMatrix, VisibleList, Nothing)     := (m, rows, cols) -> map(ring m, rawSubmatrix(raw m, listZZ rows, 0 .. numColumns m - 1))
+MutableMatrix _ List := Matrix => (f,v) -> submatrix(f, v)  -- get some columns
+MutableMatrix ^ List := Matrix => (f,v) -> submatrix(f, v,) -- get some rows
+submatrix(MutableMatrix, VisibleList, VisibleList) := (m, rows, cols) -> submatrixFree(m, rows, cols)
+submatrix(MutableMatrix, VisibleList)              := (m,       cols) -> submatrixFree(m, null, cols)
+submatrix(MutableMatrix, Nothing,     VisibleList) := (m, rows, cols) -> submatrix(m, cols)
+submatrix(MutableMatrix, VisibleList, Nothing)     := (m, rows, cols) -> submatrixFree(m, rows, null)
 submatrix(MutableMatrix, Nothing,     Nothing)     := (m, rows, cols) -> m
 
 --------------------------------
@@ -305,6 +305,8 @@ QRDecomposition Matrix := A -> (
      A = mutableMatrix(A,Dense=>true);
      (Q,R) := QRDecomposition A;
      (matrix Q,matrix R))
+
+cover MutableMatrix := MutableMatrix => identity
 
 rank MutableMatrix := (M) -> (
     if isField ring M then

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/cover-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/cover-doc.m2
@@ -8,7 +8,7 @@ document {
      SeeAlso => {"ambient", "super"}}
 
 document {
-     Key => {(cover,Matrix)},
+     Key => {(cover,Matrix), (cover,MutableMatrix)},
      Headline => "get the map between the covering free modules",
      Usage => "cover f",
      Inputs => {"f"},

--- a/M2/Macaulay2/tests/normal/mutmat.m2
+++ b/M2/Macaulay2/tests/normal/mutmat.m2
@@ -72,3 +72,7 @@ assert(ring mutableMatrix(ZZ/101, {{1,2,3}}) === ZZ/101)
 M = mutableMatrix {{1, 2, 3}, {4, 5, 6}}
 assert Equation(target M, ZZ^2)
 assert Equation(source M, ZZ^3)
+
+-- submatrices
+assert Equation(M_{0, -1}, mutableMatrix {{1, 3}, {4, 6}})
+assert Equation(M^{-1}, mutableMatrix {{4, 5, 6}})

--- a/M2/Macaulay2/tests/normal/mutmat.m2
+++ b/M2/Macaulay2/tests/normal/mutmat.m2
@@ -2,7 +2,8 @@ R = QQ
 M = mutableMatrix(QQ,3,5)
 M_(0,0) = 1_QQ
 M_(2,4) = 3/4
-M
+M_(-1,-2) = 7
+assert(M == mutableMatrix {{1,0,0,0,0}, {0,0,0,0,0}, {0,0,0,7,3/4}})
 debug Core
 rawSubmatrix(raw M,(0,1),(0,1))
 
@@ -18,6 +19,7 @@ m
 assert(m_(0,2) == z)
 m_(1,2) = x+y
 assert(m_(1,2) == x+y)
+assert(m_(-1,-1) == z)
 assert(not (m == mutableMatrix f))
 m
 rowSwap(m,0,1)

--- a/M2/Macaulay2/tests/normal/rings.m2
+++ b/M2/Macaulay2/tests/normal/rings.m2
@@ -7,6 +7,7 @@ assert( f == g )
 assert( class f === R )
 assert( class g === R )
 assert( class h === S )
+assert( S_-1 === c )
 
 --Date: Fri, 16 Apr 2004 11:43:07 +0000 (UTC)
 --From: Ben Richert <brichert@polymail.cpunix.calpoly.edu>

--- a/M2/Macaulay2/tests/normal/submatrix.m2
+++ b/M2/Macaulay2/tests/normal/submatrix.m2
@@ -19,8 +19,10 @@ N = coker matrix{{x}}
 m = map(N++R^1, N++R^1, sub(M, R))
 assert(m^{0} == map(N, N++R^1, {{a, b}}))
 assert(m^{1} == map(R^1, N++R^1, {{c, d}}))
+assert(m^{-1} == map(R^1, N++R^1, {{c, d}}))
 assert(m_{0} == map(N++R^1, N, {{a}, {c}}))
 assert(m_{1} == map(N++R^1, R^1, {{b}, {d}}))
+assert(m_{-1} == map(N++R^1, R^1, {{b}, {d}}))
 
 R = QQ[a..d];
 M = image vars R ++ coker vars R

--- a/M2/Macaulay2/tests/normal/submatrix.m2
+++ b/M2/Macaulay2/tests/normal/submatrix.m2
@@ -23,6 +23,7 @@ assert(m^{-1} == map(R^1, N++R^1, {{c, d}}))
 assert(m_{0} == map(N++R^1, N, {{a}, {c}}))
 assert(m_{1} == map(N++R^1, R^1, {{b}, {d}}))
 assert(m_{-1} == map(N++R^1, R^1, {{b}, {d}}))
+assert(m_(-1,-2) == c)
 
 R = QQ[a..d];
 M = image vars R ++ coker vars R


### PR DESCRIPTION
We count from the right when the index is negative, just like lists.

For example:

```m2
i1 : R = ZZ/32003[a..z];

i2 : R_-3

o2 = x

o2 : R

i3 : A = genericMatrix(R, 4, 4)

o3 = | a e i m |
     | b f j n |
     | c g k o |
     | d h l p |

             4      4
o3 : Matrix R  <-- R

i4 : A_{-3, -1}^{-2}

o4 = | g o |

             1      2
o4 : Matrix R  <-- R
```