### PR TITLE
Add IFRAME class for <iframe> html tags

### DIFF
--- a/M2/Macaulay2/m2/content.m2
+++ b/M2/Macaulay2/m2/content.m2
@@ -54,7 +54,7 @@ BlockExtra = set {}
 ---<!ENTITY % Form.class  "| %form.qname;" >
 ---<!ENTITY % Fieldset.class  "| %fieldset.qname;" >
 ---<!ENTITY % BlkSpecial.class "%Table.class; %Form.class; %Fieldset.class;" >
-BlkSpecial = set { "table", "form", "fieldset" }
+BlkSpecial = set { "table", "form", "fieldset", "iframe"}
 
 -- <!ENTITY % Blkpres.class "| %hr.qname;" >
 ---<!ENTITY % BlkPres.class "| %hr.qname;" >
@@ -109,6 +109,7 @@ validContent = new MutableHashTable
 -----------------------------------------------------------------------------
 -- <!ENTITY % dd.content "( #PCDATA | %Flow.mix; )*" >
 validContent#"dd" =
+validContent#"iframe" =
 -- <!ENTITY % li.content "( #PCDATA | %Flow.mix; )*" >
 validContent#"li" = 
 -- <!ENTITY % div.content "( #PCDATA | %Flow.mix; )*" >

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -133,6 +133,7 @@ DIV        = new MarkUpType of HypertextContainer
 BR         = new MarkUpType of HypertextVoid
 HR         = new MarkUpType of HypertextVoid
 SCRIPT     = new MarkUpType of HypertextParagraph
+IFRAME     = new MarkUpType of HypertextContainer
 
 -- Headers
 HEADER1    = new MarkUpType of HypertextParagraph
@@ -372,6 +373,9 @@ addAttribute(TH,     htmlAttr | {"colspan", "headers", "rowspan"})
 addAttribute(IMG,    htmlAttr | {"alt", "src", "srcset", "width", "height",
 	"sizes", "crossorigin", "longdesc", "referrerpolicy", "ismap", "usemap"})
 addAttribute(OL, htmlAttr | {"start"=>"0", "reversed", "type"})
+addAttribute(IFRAME, htmlAttr | {"allow", "allowfullscreen",
+	"allowpaymentrequest", "height", "loading", "name", "referrerpolicy",
+	"sandbox", "src", "srcdoc", "width"})
 buttonAttr = htmlAttr | {"autofocus","disabled",
     "form","formaction","formenctype","formmethod","formnovalidate","formtarget",
     "name", "type", "value"}

--- a/M2/Macaulay2/packages/Text.m2
+++ b/M2/Macaulay2/packages/Text.m2
@@ -9,7 +9,7 @@ newPackage("Text",
 
 exportFrom_Core {
      "ANCHOR", "BLOCKQUOTE", "BODY", "BOLD", "BR", "CDATA", "CODE", "COMMENT", "DD", "DIV", "DL", "DT", "EM", "ExampleItem", "HEAD", "HEADER1",
-     "HEADER2", "HEADER3", "HEADER4", "HEADER5", "HEADER6", "HR", "HREF", "HTML", "Hypertext", "HypertextContainer", "HypertextParagraph", "HypertextVoid", "IMG", "INDENT", "ITALIC", "KBD",
+     "HEADER2", "HEADER3", "HEADER4", "HEADER5", "HEADER6", "HR", "HREF", "HTML", "Hypertext", "HypertextContainer", "HypertextParagraph", "HypertextVoid", "IFRAME", "IMG", "INDENT", "ITALIC", "KBD",
      "LABEL", "LATER", "LI", "LINK", "LITERAL", "M2CODE", "MENU", "META", "PARA", "PRE", "SAMP", "SCRIPT", "SMALL", "SPAN", "STRONG", "STYLE", "SUB", "SUBSECTION", "SUP", "TABLE", "TD", "TH",
      "TEX", "TITLE", "TO", "TO2", "TOH", "TR", "TT", "UL", "VAR", "OL", "INPUT", "BUTTON", "validate",
      "MarkUpType", "IntermediateMarkUpType",
@@ -854,6 +854,19 @@ document {
      },
      "For an example, see ", TO "Macaulay2Doc::hypertext list format", "."
      }
+
+document {
+    Key => {IFRAME},
+    Headline => "HTML inline frame (iframe) element",
+    Usage => "IFRAME x",
+    Inputs => {"x" => List => "specifying the iframe attributes"},
+    PARA {
+	"An ", M2CODE "IFRAME", " object represents an inline frame in HTML, ",
+	"which allows embedding an independent browsing context (another HTML ",
+	"document) within the current one."},
+    EXAMPLE "html IFRAME {\"src\" => \"https://example.com\"}",
+    PARA {"This is rendered in the browser as:"},
+    IFRAME {"src" => "https://example.com"}}
 
 document { Key => (options, MarkUpType),
      "Optional arguments of mark up types allow attributes to be added to html elements.",


### PR DESCRIPTION
<iframe> tags are used for inlining html documents inside html documents.  One use case is for using JavaScript in webapp mode.  For example, running the following will print "Hello, world!" to the Developer Tools console:

```m2
IFRAME("srcdoc" => "<script>console.log('Hello, world!')</script>")
```

I think this could open up lots of exciting possibilities for visualizing things in Macaulay2Web and Jupyter.

Cc: @pzinn 