### PR TITLE
Add texMath(Type) to avoid recursion error

### DIFF
--- a/M2/Macaulay2/m2/latex.m2
+++ b/M2/Macaulay2/m2/latex.m2
@@ -197,16 +197,14 @@ texMathMutable :=
 texMath MutableList  := L -> concatenate(texMath class L, "\\left\\{", if #L > 0 then "\\ldots "|#L|"\\ldots" else "\\,", "\\right\\}")
 
 texMath HashTable := H -> (
-    if isMutable H then texMathMutable H
-    else texMath class H | texMath apply(sortByName pairs H, (k, v) -> k => v)
+    texMath class H | texMath apply(sortByName pairs H, (k, v) -> k => v)
     )
 
-texMath RingFamily :=
-texMath Ring := R -> (
-    if R.?texMath then R.texMath
-    else if hasAttribute(R, ReverseDictionary) then texMath toString getAttribute(R, ReverseDictionary)
-    else (lookup(texMath,HashTable)) R -- should never happen
-    )
+texMath MutableHashTable := H -> (
+    if H.?texMath then H.texMath -- used by some rings, e.g., ZZ, QQ, RR
+    else if hasAttribute(H, ReverseDictionary)
+    then texMath toString getAttribute(H, ReverseDictionary)
+    else texMathMutable H)
 
 texMath Function := f -> texMath toString f
 

--- a/M2/Macaulay2/tests/normal/texmath.m2
+++ b/M2/Macaulay2/tests/normal/texmath.m2
@@ -1,0 +1,3 @@
+assert Equation(
+    texMath new HashTable,
+    ///\texttt{HashTable}\left\{\,\right\}///)


### PR DESCRIPTION
This fixes a recursion error which I think may have been introduced in #3845 (when `texMath(Ring)` was split off from `texMath(HashTable)`):

```m2
i1 : texMath HashTable
stdio:2:7:(3): error: recursion limit of 300 exceeded
```

The issue is that types are mutable hash tables, and the `texMath` method for mutable hash tables calls `texMath` on the class, which is itself a mutable hash table, causing the infinite recursion.