### PR TITLE
Tweak A1BrouwerDegrees test to account for floating point rounding

### DIFF
--- a/M2/Macaulay2/packages/A1BrouwerDegrees.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees.m2
@@ -704,7 +704,8 @@ C2 = makeGWuClass matrix(CC, {{1,0,-3+ii,0},{0,-2,0,0},{-3+ii,0,-3,0},{0,0,0,5}}
 C3 = makeGWuClass matrix(CC, {{2*ii,0,0,0,0,0,0},{0,-2,0,0,0,0,0},{0,0,-3,0,0,0,0},{0,0,0,1,0,-3+ii,0},{0,0,0,0,-2,0,0},{0,0,0,-3+ii,0,-3,0},{0,0,0,0,0,0,5}});
 
 assert(addGWu(A1, A2) === A3);
-assert(addGWu(B1, B2) === B3);
+assert(getMatrix addGWu(B1, B2) === getMatrix B3);
+assert(abs(getScalar addGWu(B1, B2) - getScalar B3) < 1e-15);
 assert(addGWu(C1, C2) === C3);
 ///
 


### PR DESCRIPTION
The scalars of the two unstable Grothendieck-Witt classes may differ on systems that use extended precision floating point numbers (e.g., 32-bit i686).

This fixes a test failure on the latest i386 build of the development PPA package ([full log](https://launchpadlibrarian.net/826263604/buildlog_ubuntu-bionic-i386.macaulay2_1.25.06+git202510221653-0ppa202510212333~ubuntu18.04.1_BUILDING.txt.gz)), which is due to the following slight difference in test 32:

```m2
i1 : needsPackage "A1BrouwerDegrees"

o1 = A1BrouwerDegrees

o1 : Package

i2 : B1 = makeGWuClass matrix(RR, {{sqrt(2),0,-3},{0,sqrt(5),0},{-3,0,-1/5}});

i3 : B2 = makeGWuClass matrix(RR, {{1/3}});

i4 : getScalar addGWu(B1, B2)

o4 = -6.919022443177262

o4 : RR (of precision 53)

i5 : getScalar makeGWuClass matrix(RR, {{sqrt(2),0,-3,0},{0,sqrt(5),0,0},{-3,0,-1/5,0},{0,0,0,1/3}}) 

o5 = -6.919022443177261

o5 : RR (of precision 53)
```

Cc: @wgabrielong 