### PR TITLE
Build distribution tarballs

### DIFF
--- a/.github/workflows/make-dist.yml
+++ b/.github/workflows/make-dist.yml
@@ -1,0 +1,30 @@
+name: Build distribution tarballs
+on: workflow_dispatch
+
+jobs:
+  make-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install build dependencies
+        run: |
+          sudo add-apt-repository -y ppa:macaulay2/macaulay2
+          sudo apt-get install -y 4ti2 autoconf automake bison ca-certificates cohomcalg coinor-csdp fflas-ffpack flex g++ gdbmtool gfan gfortran git install-info libboost-dev libboost-regex-dev libboost-stacktrace-dev libcdd-dev libeigen3-dev libffi-dev libflint-dev libfplll-dev libfrobby-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp-dev libgtest-dev liblzma-dev libmathic-dev libmathicgb-dev libmemtailor-dev libmpfi-dev libmpfr-dev libmps-dev libnauty-dev libncurses-dev libnormaliz-dev libntl-dev libopenblas-dev libpython3-dev libreadline-dev libsingular-dev libtbb-dev libtool-bin libxml2-dev lrslib make msolve nauty normaliz patch pkgconf python3 r-base singular-data time topcom wget zlib1g-dev
+      - name: Build Macaulay2
+        run: |
+          cd M2/BUILD/build
+          ../../autogen.sh
+          ../../configure --with-system-libs --with-fplll
+          make -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
+      - name: Make distribution tarballs
+        run: |
+          cd M2/BUILD/build
+          make dist
+          make doc-dist
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-tarballs
+          path: |
+            M2/BUILD/build/*.tar.gz

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -90,8 +90,10 @@ unmark-$1: ; rm -rf  @pre_libm2dir@/$1/.installed
 	@echo "make: Leaving directory \`$(shell pwd)/$1-temporary'"
 	ls -l $1-temporary
 	rm -rf $1-temporary
+ifeq ($(filter info, @DOCUMENTATION@), info)
 	if [ -e @pre_infodir@/$1.info ]; then \
 		@INSTALL_INFO@ --info-dir=@pre_infodir@ @pre_infodir@/$1.info; fi
+endif
 	@ [ "${IgnoreExampleErrors}" = true -o -f $$@ ] || (echo error: file $$@ not made by installPackage >&2; false)
 check-info::@pre_infodir@/$1.info.errors
 @pre_infodir@/$1.info.errors: @pre_infodir@/$1.info

--- a/M2/Makefile.doc-dist
+++ b/M2/Makefile.doc-dist
@@ -1,0 +1,30 @@
+prefix ?= /usr/local
+exec_prefix ?= $(prefix)
+datadir ?= $(prefix)/share
+libdir ?= $(exec_prefix)/lib
+
+PACKAGES := $(patsubst dump/%.dump, %, $(wildcard dump/*.dump))
+ENDIAN := $(shell printf '\x61\x62\x63\x64' | od -An -tx4 -N4 | tr -d ' \n' | \
+	awk '{if($$0=="61626364") print "abcd"; else print "dcba"}')
+POINTER_SIZE := $(shell expr $(shell getconf LONG_BIT) / 8)
+DB_FILENAME = rawdocumentation-$(ENDIAN)-$(POINTER_SIZE).db
+DB_FILES := $(patsubst %, lib/Macaulay2/%/cache/$(DB_FILENAME), $(PACKAGES))
+
+all: $(DB_FILES)
+
+lib/Macaulay2/%/cache/$(DB_FILENAME): dump/%.dump
+	mkdir -p $(@D)
+	gdbm_load $< $@
+
+install:
+	mkdir -p $(DESTDIR)$(datadir)
+	cp -r share/* $(DESTDIR)$(datadir)
+	mkdir -p $(DESTDIR)$(libdir)
+	cp -r lib/* $(DESTDIR)$(libdir)
+
+clean:
+	rm -rf lib
+
+# Local Variables:
+# mode: makefile
+# End:

--- a/M2/Makefile.in
+++ b/M2/Makefile.in
@@ -3,7 +3,7 @@
 include include/config.Makefile
 VPATH = @srcdir@
 .PRECIOUS:@srcdir@/configure config.status
-.PHONY:unconfigure-libs reconfigure configure-help report-M2-location help scripts
+.PHONY:unconfigure-libs reconfigure configure-help report-M2-location help scripts dist
 all install:										\
 	check-make config.status configured check-for-undefined-configure-variables	\
 	srcdir protect-configs configured-files check-machine				\
@@ -62,6 +62,7 @@ clean:
 	rm -f M2 srcdir .link-test srcdir confdefs.h configure.lineno conftest.* include/config.h
 	rm -rf usr-dist conf_* usr-host
 	rm -f pre-install.sh post-install.sh normal-install.sh
+	rm -f $(DIST_NAME).tar.gz
 
 install: configured; $(MAKE) -C distributions $@
 @srcdir@/configure : @srcdir@/configure.ac @srcdir@/m4/files; @srcdir@/autogen.sh
@@ -130,6 +131,32 @@ report-M2-location:
 validate-html:
 	$(MAKE) -C Macaulay2/packages $@
 
+DIST_NAME = @PACKAGE_TARNAME@-@PACKAGE_VERSION@
+
+dist: $(DIST_NAME).tar.gz
+
+$(DIST_NAME)/M2:
+	mkdir -p $@/include/M2
+	cp @top_srcdir@/configure $@
+	cp @top_srcdir@/install-sh $@
+	cp @top_srcdir@/config.guess $@
+	cp @top_srcdir@/config.sub $@
+	cp @top_srcdir@/include/M2/config.h.in $@/include/M2
+
+$(DIST_NAME).tar.gz: $(DIST_NAME)/M2
+	git submodule update --init @top_srcdir@/Macaulay2/editors/emacs
+	cd @top_srcdir@/.. && @GIT@ archive \
+		--prefix=$(DIST_NAME)/ \
+		-o @abs_builddir@/M2.tar HEAD
+	cd @top_srcdir@/Macaulay2/editors/emacs && @GIT@ archive \
+		--prefix=$(DIST_NAME)/M2/Macaulay2/editors/emacs/ \
+		-o @abs_builddir@/M2-emacs.tar HEAD
+	@TAR@ -Af M2.tar M2-emacs.tar
+	@TAR@ -rf M2.tar $(DIST_NAME)
+	gzip M2.tar
+	mv M2.tar.gz $@
+	rm -rf M2-emacs.tar $(DIST_NAME)
+
 announce:
 	@ echo "================================================================="
 	@ echo "    Macaulay2 version @PACKAGE_VERSION@"
@@ -158,6 +185,7 @@ help:
 	@ echo "  check             run the tests"
 	@ echo "  clean             remove all generated files except configured files"
 	@ echo "  distclean         remove all generated files"
+	@ echo "  dist              generate a source tarball for distribution"
 	@ echo "  help              show this help"
 	@ echo ""
 	@ echo "targets for all libraries:"

--- a/M2/Makefile.in
+++ b/M2/Makefile.in
@@ -3,7 +3,8 @@
 include include/config.Makefile
 VPATH = @srcdir@
 .PRECIOUS:@srcdir@/configure config.status
-.PHONY:unconfigure-libs reconfigure configure-help report-M2-location help scripts dist
+.PHONY: unconfigure-libs reconfigure configure-help report-M2-location help \
+	scripts dist doc-dist
 all install:										\
 	check-make config.status configured check-for-undefined-configure-variables	\
 	srcdir protect-configs configured-files check-machine				\
@@ -62,7 +63,7 @@ clean:
 	rm -f M2 srcdir .link-test srcdir confdefs.h configure.lineno conftest.* include/config.h
 	rm -rf usr-dist conf_* usr-host
 	rm -f pre-install.sh post-install.sh normal-install.sh
-	rm -f $(DIST_NAME).tar.gz
+	rm -f $(DIST_NAME).tar.gz $(DOC_DIST_NAME).tar.gz
 
 install: configured; $(MAKE) -C distributions $@
 @srcdir@/configure : @srcdir@/configure.ac @srcdir@/m4/files; @srcdir@/autogen.sh
@@ -157,6 +158,30 @@ $(DIST_NAME).tar.gz: $(DIST_NAME)/M2
 	mv M2.tar.gz $@
 	rm -rf M2-emacs.tar $(DIST_NAME)
 
+DOC_DIST_NAME = @PACKAGE_TARNAME@-docs-@PACKAGE_VERSION@
+
+doc-dist: $(DOC_DIST_NAME).tar.gz
+
+$(DOC_DIST_NAME).tar.gz:
+	$(MAKE) -C Macaulay2/packages
+	mkdir -p $(DOC_DIST_NAME)/share/doc
+	cp -r @pre_docdir@ $(DOC_DIST_NAME)/share/doc
+	cp -r @pre_infodir@ $(DOC_DIST_NAME)/share
+	mkdir -p $(DOC_DIST_NAME)/dump
+	for PACKAGE_DIR in @pre_libm2dir@/*;                                 \
+	do                                                                   \
+		PACKAGE=$$(basename $$PACKAGE_DIR);                          \
+		if test -d @pre_libm2dir@/$$PACKAGE/cache;                   \
+		then cd @pre_libm2dir@/$$PACKAGE/cache;                      \
+		gdbm_dump rawdocumentation-*.db                              \
+			@abs_builddir@/$(DOC_DIST_NAME)/dump/$$PACKAGE.dump; \
+		fi;                                                          \
+	done
+	cp @srcdir@/Makefile.doc-dist $(DOC_DIST_NAME)/Makefile
+	@TAR@ -czf $@ $(DOC_DIST_NAME)
+	rm -rf $(DOC_DIST_NAME)
+
+
 announce:
 	@ echo "================================================================="
 	@ echo "    Macaulay2 version @PACKAGE_VERSION@"
@@ -186,6 +211,7 @@ help:
 	@ echo "  clean             remove all generated files except configured files"
 	@ echo "  distclean         remove all generated files"
 	@ echo "  dist              generate a source tarball for distribution"
+	@ echo "  doc-dist          generate a tarball containing the M2 docs"
 	@ echo "  help              show this help"
 	@ echo ""
 	@ echo "targets for all libraries:"

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -219,7 +219,8 @@ fi
 AC_ARG_ENABLE([documentation],
     [AS_HELP_STRING([--enable-documentation=...],
         [space-delimited list of types of documentation to build; available
-         options are "html", "info", and "pdf"; default value is "html info"])],
+         options are "html", "info", and "pdf"; default value is "html info".
+         "download" will download pre-generated documentation])],
     [DOCUMENTATION=$enableval],
     [DOCUMENTATION="html info"])
 
@@ -227,6 +228,9 @@ if test "$DOCUMENTATION" = no
 then DOCUMENTATION=""
 elif test "$DOCUMENTATION" = yes
 then DOCUMENTATION="html info"
+elif test "$DOCUMENTATION" = download
+then DOCUMENTATION=""
+     BUILDLIST="$BUILDLIST Macaulay2-docs"
 else for DOCTYPE in $DOCUMENTATION
     do case $DOCTYPE in
             html|pdf)

--- a/M2/libraries/Macaulay2-docs/Makefile.in
+++ b/M2/libraries/Macaulay2-docs/Makefile.in
@@ -1,0 +1,8 @@
+VERSION = @PACKAGE_VERSION@
+
+CONFIGURECMD = :
+
+INSTALLTARGET = install prefix=@pre_prefix@ exec_prefix=@pre_exec_prefix@
+
+include ../Makefile.library
+Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/Macaulay2-docs/Makefile

--- a/M2/libraries/Makefile.in
+++ b/M2/libraries/Makefile.in
@@ -4,7 +4,7 @@ BUILT_TARGETS = patch fetch all check unconfigure reinstall
 ALL_TARGETS = $(BUILT_TARGETS) clean distclean
 all:fetch
 $(ALL_TARGETS): Makefile.library
-$(foreach d,@LIBLIST@ @PROGLIST@ libtool M2,		\
+$(foreach d,@LIBLIST@ @PROGLIST@ M2 Macaulay2-docs,	\
 	$(foreach t, $(ALL_TARGETS),			\
 		$(eval $t-in-$d:; + $$(MAKE) -C $d $t)	\
 		$(eval .PHONY: $t $t-in-$d)))

--- a/M2/libraries/Makefile.library.in
+++ b/M2/libraries/Makefile.library.in
@@ -13,6 +13,7 @@ ifneq ($(PARALLEL),yes)
 NOTPARALLEL = -j1
 endif
 LIBNAME ?= $(shell basename `pwd`)
+GIT_REF ?= v$(VERSION)
 UNTARDIR = build
 OLDUNTARDIR = build-old
 TARDIR ?= $(LIBNAME)-$(VERSION)
@@ -127,10 +128,27 @@ fetch: .submodule-updated
 	$(MAKE) update-submodule
 	touch $@
 update-submodule:
-	@GIT@ submodule update --init @abs_top_srcdir@/submodules/$(LIBNAME)
+	if git rev-parse 2> /dev/null;                          \
+	then                                                    \
+		@GIT@ submodule update --init                   \
+			@abs_top_srcdir@/submodules/$(LIBNAME); \
+	else                                                    \
+		cd @abs_top_srcdir@/submodules;                 \
+		rm -rf $(LIBNAME);                              \
+		@GIT@ clone $(URL) $(LIBNAME);                  \
+		cd $(LIBNAME);                                  \
+		@GIT@ checkout $(GIT_REF);                      \
+	fi
+
 clean::
 	rm -f .submodule-updated
-	@GIT@ submodule deinit @abs_top_srcdir@/submodules/$(LIBNAME)
+	if git rev-parse 2> /dev/null;                                         \
+	then                                                                   \
+		@GIT@ submodule deinit @abs_top_srcdir@/submodules/$(LIBNAME); \
+	else                                                                   \
+		rm -rf @abs_top_srcdir@/submodules/$(LIBNAME);                 \
+		mkdir @abs_top_srcdir@/submodules/$(LIBNAME);                  \
+	fi
 else
 fetch: $(TARFILE_DIR)/$(TARFILE)
 endif

--- a/M2/libraries/fflas_ffpack/Makefile.in
+++ b/M2/libraries/fflas_ffpack/Makefile.in
@@ -4,6 +4,7 @@
 # This link is broken: http://linalg.org/projects/fflas-ffpack
 # http://linalg.org/
 SUBMODULE = true
+URL = https://github.com/linbox-team/fflas-ffpack
 VERSION = 2.5.0
 PRECONFIGURE = autoreconf -vif
 PATCHFILE = @abs_srcdir@/patch-$(VERSION)

--- a/M2/libraries/flint/Makefile.in
+++ b/M2/libraries/flint/Makefile.in
@@ -1,7 +1,7 @@
 SUBMODULE = true
 # LIBNAME = flint2
 HOMEPAGE = http://flintlib.org
-# git://github.com/wbhart/flint2.git
+URL = https://github.com/flintlib/flint
 VERSION = 3.3.1
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PARALLEL = yes

--- a/M2/libraries/frobby/Makefile.in
+++ b/M2/libraries/frobby/Makefile.in
@@ -2,7 +2,9 @@
 SUBMODULE = true
 LICENSEFILES = COPYING
 # author: Bjarke Roune <bjarke@cs.au.dk>
+URL = https://github.com/Macaulay2/frobby
 VERSION = 0.9.5
+GIT_REF = 08e7cd9203
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 
 VPATH = @srcdir@

--- a/M2/libraries/gc/Makefile.in
+++ b/M2/libraries/gc/Makefile.in
@@ -1,7 +1,7 @@
 HOMEPAGE = http://www.hboehm.info/gc/
 SUBMODULE = true
 LIBNAME = bdwgc
-URL = http://www.hboehm.info/gc/gc_source/
+URL = https://github.com/ivmai/bdwgc.git
 GITURL = https://github.com/ivmai/bdwgc/
 VERSION = 8.2.8
 LICENSEFILES = README.QUICK

--- a/M2/libraries/givaro/Makefile.in
+++ b/M2/libraries/givaro/Makefile.in
@@ -7,7 +7,8 @@ SUBMODULE = true
 VLIMIT = 900000
 MLIMIT = 900000
 
-VERSION = 4.2.0
+URL = https://github.com/linbox-team/givaro
+VERSION = 4.2.1
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 # the patch modifies test/Makefile.am, so we must remake test/Makefile.in
 PRECONFIGURE = autoreconf -vif

--- a/M2/libraries/gtest/Makefile.in
+++ b/M2/libraries/gtest/Makefile.in
@@ -1,5 +1,6 @@
 SUBMODULE = true
 LIBNAME = googletest
+URL = https://github.com/google/googletest
 VERSION = 1.16.0
 CONFIGURECMD = cmake . -DCMAKE_INSTALL_PREFIX=$(PREFIX) -DBUILD_GMOCK=OFF \
 	-DCMAKE_INSTALL_LIBDIR=lib

--- a/M2/libraries/mathic/Makefile.in
+++ b/M2/libraries/mathic/Makefile.in
@@ -1,7 +1,9 @@
 HOMEPAGE = https://github.com/broune/mathic
+URL = https://github.com/Macaulay2/mathic
 SUBMODULE = true
 VPATH = @srcdir@
-VERSION = 20250513-7abf77e4ce
+VERSION = 1.0~git20250513
+GIT_REF = 7abf77e4ce
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PRECONFIGURE = autoreconf -i
 CONFIGOPTIONS = --disable-shared

--- a/M2/libraries/mathicgb/Makefile.in
+++ b/M2/libraries/mathicgb/Makefile.in
@@ -1,7 +1,9 @@
 HOMEPAGE = https://github.com/broune/mathicgb
+URL = https://github.com/Macaulay2/mathicgb
 SUBMODULE = true
 VPATH = @srcdir@
-VERSION = 20250513-de13956492
+VERSION = 1.0~git20250513
+GIT_REF = de13956492
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PRECONFIGURE = autoreconf -i
 CONFIGOPTIONS = --disable-shared PKG_CONFIG_PATH=$(LIBRARIESDIR)/lib/pkgconfig

--- a/M2/libraries/memtailor/Makefile.in
+++ b/M2/libraries/memtailor/Makefile.in
@@ -1,7 +1,9 @@
 SUBMODULE = true
 HOMEPAGE = https://github.com/broune/memtailor
+URL = https://github.com/Macaulay2/memtailor
 VPATH = @srcdir@
-VERSION = 20250513-07c84a6852
+VERSION = 1.0~git20250513
+GIT_REF = 07c84a6852
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PRECONFIGURE = autoreconf -i
 CONFIGOPTIONS = --disable-shared

--- a/M2/m4/files
+++ b/M2/m4/files
@@ -25,6 +25,7 @@ distributions/deb/macaulay2/preinst
 libraries/Makefile
 libraries/4ti2/Makefile
 libraries/M2/Makefile
+libraries/Macaulay2-docs/Makefile
 libraries/Makefile.library
 libraries/cddlib/Makefile
 libraries/cddplus/Makefile


### PR DESCRIPTION
This PR adds two new make targets, `make dist` and `make doc-dist`.

`make dist` builds an old-school source tarball from the M2 and M2-emacs git repos, and also includes a few generated autotools files so users can immediately run `configure` after unpacking without having to autoconf installed, similar to the `make dist` target in automake projects.  This should be useful for creating deb and rpm packages.  (I've been doing something similar on the Debian side for years.)

We also provide a backup for dealing with submodules when building from an unpacked tarball rather than a git repo.  This will simplify building rpm packages, where we currently have to trick the build system into thinking that there are submodules.

Also, the `make doc-dist` target creates a tarball containing all of the built documentation (html, info, and "dumps" of the gdbm databases).  Then, if someone runs `./configure --enable-documentation=download`, the build system will download this tarball from the webpage, unpack it, and use the prebuilt documentation rather than running all the examples from all the packages.  This will cut the M2 build time from hours down to minutes.  This should simplify the package installation process for users using "build from source" package managers (spack, gentoo, nix, etc.).  See #3905.

There is also a GitHub workflow to generate both tarballs.

