### PR TITLE
Use makeZeroMatrix, not copy constructor, for mutable submatrices

### DIFF
--- a/M2/Macaulay2/e/mutablemat-defs.hpp
+++ b/M2/Macaulay2/e/mutablemat-defs.hpp
@@ -518,8 +518,7 @@ class MutableMat : public MutableMatrix
                 n_cols() - 1);
           return 0;
         }
-    MutableMat* result =
-        new MutableMat(*this);  // zero matrix, over the same ring
+    MutableMat* result = makeZeroMatrix(rows->len, cols->len);
     MatOps::setFromSubmatrix(getMat(), rows, cols, result->getMat());
     return result;
   }
@@ -534,8 +533,7 @@ class MutableMat : public MutableMatrix
                 n_cols() - 1);
           return 0;
         }
-    MutableMat* result =
-        new MutableMat(*this);  // zero matrix, over the same ring
+    MutableMat* result = makeZeroMatrix(n_rows(), cols->len);
     MatOps::setFromSubmatrix(getMat(), cols, result->getMat());
     return result;
   }

--- a/M2/Macaulay2/tests/normal/mutmat.m2
+++ b/M2/Macaulay2/tests/normal/mutmat.m2
@@ -78,3 +78,8 @@ assert Equation(source M, ZZ^3)
 -- submatrices
 assert Equation(M_{0, -1}, mutableMatrix {{1, 3}, {4, 6}})
 assert Equation(M^{-1}, mutableMatrix {{4, 5, 6}})
+
+-- issue #997
+A = mutableMatrix {{10}}
+B = submatrix(A, {0}, {0})
+assert(hash A != hash B)


### PR DESCRIPTION
This way, we end up calling the default constructor, which creates a new hash code.  Previously, we used the same hash code as the original matrix.

Also add a test to ensure that the hash changes.

Closes: #997 

### Before
```m2
i1 : A = mutableMatrix {{10}}

o1 = | 10 |

o1 : MutableMatrix

i2 : B = submatrix(A, {0}, {0})

o2 = | 10 |

o2 : MutableMatrix

i3 : (hash A, hash B)

o3 = (1845190296659672920, 1845190296659672920)

o3 : Sequence
```

### After
```m2
i1 : A = mutableMatrix {{10}}

o1 = | 10 |

o1 : MutableMatrix

i2 : B = submatrix(A, {0}, {0})

o2 = | 10 |

o2 : MutableMatrix

i3 : (hash A, hash B)

o3 = (2554347540320848225, 2672540414264377250)
```