### PR TITLE
update ToricTopology, add moment-angle complex

### DIFF
--- a/M2/Macaulay2/packages/ToricTopology.m2
+++ b/M2/Macaulay2/packages/ToricTopology.m2
@@ -469,7 +469,7 @@ doc ///
 			products of disks and circles: $$\mathcal{Z_K} = \bigcup_{\sigma \in K}
 			\left( (D^2)^\sigma \times (S^1)^{[m] \setminus \sigma} \right).$$ These
 			spaces admit a natural action of the torus $T^m = (S^1)^m$. Non-singular
-			toric varities (not necessarily complete) are homotopy equivalent to
+			toric varieties (not necessarily complete) are homotopy equivalent to
 			partial quotients of moment-angle complexes by freely acting subtori of
 			$T^m$. Thus, moment-angle complexes are an important class of spaces
 			studied in Toric Topology. Their topological properties can be determined
@@ -587,7 +587,7 @@ doc ///
 	Description
 		Text
 			Compute the equivariant cohomology of a moment-angle complex over the
-			polynomial ring k[x_1, ..., x_m] where k is the coeffcient ring of the
+			polynomial ring k[x_1, ..., x_m] where k is the coefficient ring of the
 			polynomial ring over which the underlying simplicial complex was
 			created.
 		Text

--- a/M2/Macaulay2/packages/ToricTopology.m2
+++ b/M2/Macaulay2/packages/ToricTopology.m2
@@ -21,16 +21,17 @@
 
 newPackage(
 	"ToricTopology",
-    	Version => "1.0",
-    	Date => "September 1, 2015",
-    	Authors => {
-    		{Name => "Alvise Trevisan", Email => "a.trevisan@enpicom.com", HomePage => "http://www.enpicom.com"},
-    		{Name => "Alexander I. Suciu", Email => "a.suciu@neu.edu"}
-		},
-        Keywords => {"Toric Geometry"},
-     	PackageImports => { "OldChainComplexes", "SimplicialComplexes" },
-    	Headline => "toric topology"
-    	)
+	Version => "1.1",
+	Date => "November 7, 2025",
+	Authors => {
+		{Name => "Alvise Trevisan", Email => "a.trevisan@enpicom.com", HomePage => "http://www.enpicom.com"},
+		{Name => "Alexander I. Suciu", Email => "a.suciu@neu.edu"},
+		{Name => "Kumar Sannidhya Shukla", Email => "kshukla5@uwo.ca"}
+	},
+	Keywords => {"Toric Geometry"},
+	PackageImports => { "OldChainComplexes", "SimplicialComplexes" },
+	Headline => "toric topology"
+)
 
 protect QTMSimplicialComplex
 protect QTMCharacteristicMatrix
@@ -106,10 +107,9 @@ cohomologyRing(SmallCover) := QuotientRing => {CoefficientRing=>ZZ/2} >> opts ->
 	sc := N.QTMSimplicialComplex;
 	lambda := N.QTMCharacteristicMatrix;
 	S := (opts.CoefficientRing)[(entries(vars(ring sc)))_0];
-	newgens:={};
-	scan( (entries(gens(ideal sc)))_0, i->newgens=append(newgens,sub(i,S)) );
-	I := ideal( newgens );
-	J := ideal ((vars S)*(transpose lambda));
+	newgens := apply((entries(gens(ideal sc)))_0, i->sub(i,S));
+	I := ideal(newgens);
+	J := ideal((vars S)*(transpose lambda));
 	S/(I+J)
 )
 
@@ -119,12 +119,12 @@ cohomologyRing(QuasiToricManifold) := QuotientRing =>  {CoefficientRing=>ZZ} >> 
 	lambda := M.QTMCharacteristicMatrix;
 	C := opts.CoefficientRing;
 	S := C[(entries(vars(ring sc)))_0];
-	newgens:={};
-	scan( (entries(gens(ideal sc)))_0, i->newgens=append(newgens,sub(i,S)) );
-	I := ideal( newgens );
-	J := ideal ((vars S)*(transpose lambda));
+	newgens := apply((entries(gens(ideal sc)))_0, i->sub(i,S));
+	I := ideal(newgens);
+	J := ideal((vars S)*(transpose lambda));
 	S/(I+J)
 )
+
 
 chern = method(TypicalValue=>List,Options=>{CoefficientRing=>ZZ})
 -- Chern classes of a quasi-toric manifold
@@ -156,19 +156,16 @@ bettiSmallCover(ZZ,SmallCover) := ZZ => (k,N) -> (
 	sc := N.QTMSimplicialComplex;
 	lambda := N.QTMCharacteristicMatrix;
 	n := numgens(target(lambda));
-	ind := drop( subsets(toList(1..n)), 1);
-	cclist := {};
-	scan(ind, I-> cclist=append(cclist,chainComplex(subComplex(sc,supportChi(lambda,I) ) ) ) );
+	ind := subsets(toList(1..n));
+	cclist := apply(ind, I -> complex(subComplex(sc, supportChi(lambda, I))));
 	b := 0;
-	scan(cclist, cc -> b = b + rank( HH_(k-1)( cc) ) );
+	scan(cclist, cc -> b = b + rank(HH_(k-1)(cc)));
 	b
 )
 
 -- all the betti numbers up to n of an n-dimensional small cover
 bettiSmallCover(SmallCover) := List => (N) -> (
-	b := {1};
-	for i in 1..(N.QTMDimension) do b=append(b, bettiSmallCover(i,N));
-	b
+	apply(N.QTMDimension+1, i -> bettiSmallCover(i,N))
 )
 
 bettiQTM = method()
@@ -185,9 +182,7 @@ bettiQTM(ZZ,QuasiToricManifold) := ZZ => (k, M) -> (
 
 -- all the betti numbers up to 2n of an 2n-dimensional quasi-toric manifold
 bettiQTM(QuasiToricManifold) := List => (M) -> (
-	b := {1};
-	for i in 1..(M.QTMDimension) do b = append(b, bettiQTM(i, M));
-	b
+	apply(M.QTMDimension + 1, i -> bettiQTM(i, M))
 )
 
 -- Sample small covers --
@@ -217,9 +212,7 @@ complexProjectiveSpace(ZZ) := QuasiToricManifold => (n) -> (
 -- Helper functions --
 projectiveSpace = (n, base) -> (
 	I := id_(base^n);
-	l := {};
-	scan(n, i -> l=append(l, {1}));
-	ones := matrix(l);
+	ones := matrix(apply(n, i -> {1}));
 	R := base[vars(0..n)];
 	varlist := (entries(vars(R)))_0;
 	maxmissingface := sub(varlist_0 ,R);
@@ -228,33 +221,38 @@ projectiveSpace = (n, base) -> (
 	(K,I|ones)
 )
 
-listMinors = (sc,lambda) -> (
+listMinors = (sc,chi) -> (
 	listminors:={};
 	for mon in facets(sc) do (
-		listminors=append(listminors,determinant(submatrix(lambda,indices(mon))));
+		listminors=append(listminors,determinant(submatrix(chi,indices(mon))));
 	);
 	listminors
 )
 
+-- method to compute the subcomplex of sc, restricted to variables indexed by
+-- the subset V
+-- if V is empty, the empty complex {1} is returned
 subComplex = (sc, V) -> (
-            varlist := (entries(vars(ring sc)))_0;
-            mV := sub(varlist_(V_0-1),ring sc);
-			scan(drop(V,1),i->mV=mV*sub(varlist_(i-1),ring(sc)));
-			candidates := {};
-			for k in (0..(length V)) do (
-				candidates = join(candidates, faces(k,sc));
-			);
-			k:=0;
-			lis := {};
-            while k!= length(candidates) do (
-	        	if (denominator(sub(mV, ring sc)/(candidates_k)))==1 then (
-	            	lis=append(lis,candidates_k);
-                   	candidates=drop(candidates,{k,k});
-                   	k=k-1;
-            	);
-	            k=k+1;
-		    );
-	        simplicialComplex(lis)
+	if isEmpty V then
+		return simplicialComplex {1_(ring sc)};
+	varlist := (entries(vars(ring sc)))_0;
+	mV := sub(varlist_(V_0-1),ring sc);
+	scan(drop(V,1),i->mV=mV*sub(varlist_(i-1),ring(sc)));
+	candidates := {};
+	for k in (0..(length V)) do (
+		candidates = join(candidates, faces(k,sc));
+	);
+	k:=0;
+	lis := {};
+	while k!= length(candidates) do (
+		if (denominator(sub(mV, ring sc)/(candidates_k)))==1 then (
+			lis=append(lis,candidates_k);
+			candidates=drop(candidates,{k,k});
+			k=k-1;
+		);
+		k=k+1;
+	);
+	simplicialComplex(lis)
 );
 
 -- given a char matrix lambda (n rows, m cols) and a subset I={i_1, .., i_n} of [n]
@@ -370,7 +368,7 @@ permutahedronDual = (n) -> (
 -- equivariant cohomology module of the moment-angle complex wrt. T^m-action
 equivariantCohomology = method()
 equivariantCohomology(MomentAngleComplex) := Module => (mac) -> (
-	return coker gens monomialIdeal mac.MACSimplicialComplex;
+	coker gens monomialIdeal mac.MACSimplicialComplex
 )
 
 -- k-th betti number of a momemnt-angle complex (as given by the Baskakov-Buchstaber-Panov theorem)
@@ -389,9 +387,7 @@ bettiMAC(ZZ, MomentAngleComplex) := ZZ => (k, mac) -> (
 
 -- all the betti numbers up to 2m of a MAC over a complex with m vertices
 bettiMAC(MomentAngleComplex) := List => (mac) -> (
-	b := {};
-	for i in 0..(2*#vertices mac.MACSimplicialComplex) do b=append(b, bettiMAC(i,mac));
-	b
+	apply(2*#vertices mac.MACSimplicialComplex + 1, i-> bettiMAC(i, mac))
 )
 
 -- the Euler characteristic of the moment angle complex
@@ -870,5 +866,6 @@ doc ///
    Text
        Hessenberg variety asscoiated to the n-permutahedron, as small cover.
   SeeAlso
-
 ///
+
+end

--- a/M2/Macaulay2/packages/ToricTopology.m2
+++ b/M2/Macaulay2/packages/ToricTopology.m2
@@ -21,12 +21,12 @@
 
 newPackage(
 	"ToricTopology",
-    	Version => "1.0", 
+    	Version => "1.0",
     	Date => "September 1, 2015",
     	Authors => {
     		{Name => "Alvise Trevisan", Email => "a.trevisan@enpicom.com", HomePage => "http://www.enpicom.com"},
     		{Name => "Alexander I. Suciu", Email => "a.suciu@neu.edu"}
-		},  
+		},
         Keywords => {"Toric Geometry"},
      	PackageImports => { "OldChainComplexes", "SimplicialComplexes" },
     	Headline => "toric topology"
@@ -35,16 +35,18 @@ newPackage(
 protect QTMSimplicialComplex
 protect QTMCharacteristicMatrix
 protect QTMDimension
-		
-export{
-	"SmallCover", "QuasiToricManifold",
+protect MACSimplicialComplex
+
+export {
+	"SmallCover", "QuasiToricManifold", "MomentAngleComplex",
 	"isValidChar",
-	"smallCover", "quasiToricManifold",
-	"cohomologyRing",
+	"smallCover", "quasiToricManifold", "momentAngleComplex",
+	"cohomologyRing", "equivariantCohomology",
 	"chern", "stiefelWhitney",
-	"bettiSmallCover", "bettiQTM",
+	"bettiSmallCover", "bettiQTM", "bettiMAC",
 	"realProjectiveSpace", "hessenbergVariety", "complexProjectiveSpace",
-	"QTMSimplicialComplex", "QTMCharacteristicMatrix", "QTMDimension"
+	"QTMSimplicialComplex", "QTMCharacteristicMatrix", "QTMDimension",
+	"eulerMAC"
 }
 
 -- type definitions --
@@ -52,38 +54,47 @@ SmallCover = new Type of HashTable
 SmallCover.synonym = "small cover"
 QuasiToricManifold = new Type of HashTable
 QuasiToricManifold.synonym = "quasi-toric manifold"
+MomentAngleComplex = new Type of HashTable
+MomentAngleComplex.synonym = "moment-angle complex"
 
 -- constructors --
 -- note: if not mod 2, first reduce
 smallCover = method(TypicalValue => SmallCover)
-smallCover(SimplicialComplex,Matrix) := SmallCover => (sc,chi) -> (
-	chimod2 := sub(chi,ZZ/2);
-	if not isValidChar(sc,chi) then error "expected characteristic matrix";
+smallCover(SimplicialComplex,Matrix) := SmallCover => (sc,lambda) -> (
+	lambdamod2 := sub(lambda,ZZ/2);
+	if not isValidChar(sc,lambda) then error "expected characteristic matrix";
 	new SmallCover from {
 		QTMSimplicialComplex => sc,
-		QTMCharacteristicMatrix => chimod2,
-		QTMDimension => rank( target (chi) )
+		QTMCharacteristicMatrix => lambdamod2,
+		QTMDimension => rank( target (lambda) )
 	}
-) 
+)
 
 quasiToricManifold = method(TypicalValue => QuasiToricManifold)
-quasiToricManifold(SimplicialComplex,Matrix) := QuasiToricManifold => (sc,chi) -> (
-	if not isValidChar(sc,chi) then error "expected characteristic matrix";
-	new QuasiToricManifold from { 
-		QTMSimplicialComplex => sc, 
-		QTMCharacteristicMatrix => chi,
-		QTMDimension => 2*rank( target (chi) )
+quasiToricManifold(SimplicialComplex,Matrix) := QuasiToricManifold => (sc,lambda) -> (
+	if not isValidChar(sc,lambda) then error "expected characteristic matrix";
+	new QuasiToricManifold from {
+		QTMSimplicialComplex => sc,
+		QTMCharacteristicMatrix => lambda,
+		QTMDimension => 2*rank( target (lambda) )
 	}
-) 
-	 
+)
+
+momentAngleComplex = method(TypicalValue => MomentAngleComplex)
+momentAngleComplex(SimplicialComplex) := MomentAngleComplex => (sc) -> (
+	R := newRing(sc.ring, Degrees=>{#vertices sc:2});
+	new MomentAngleComplex from {
+		MACSimplicialComplex => substitute(sc, R)
+	}
+)
 
 -- methods --
 
--- check whether a matrix is characteristic for a given simplicial complex 
+-- check whether a matrix is characteristic for a given simplicial complex
 isValidChar = method(TypicalValue=>Boolean);
-isValidChar(SimplicialComplex,Matrix) := Boolean => (sc,chi) -> (
+isValidChar(SimplicialComplex,Matrix) := Boolean => (sc,lambda) -> (
 	flag := true;
-	mins := listMinors(sc,chi);
+	mins := listMinors(sc,lambda);
 	for i in mins do if (i!=1 and i!=-1) then flag=false;
 	flag
 )
@@ -92,26 +103,26 @@ cohomologyRing = method(TypicalValue=>QuotientRing,Options=>true)
 -- cohomology ring over the integers mod 2 of a small cover
 cohomologyRing(SmallCover) := QuotientRing => {CoefficientRing=>ZZ/2} >> opts -> (N) -> (
 	if not opts.CoefficientRing===ZZ/2 then error "Expected ZZ/2 as coefficient ring";
-	sc := N.QTMSimplicialComplex; 
-	chi := N.QTMCharacteristicMatrix;
+	sc := N.QTMSimplicialComplex;
+	lambda := N.QTMCharacteristicMatrix;
 	S := (opts.CoefficientRing)[(entries(vars(ring sc)))_0];
 	newgens:={};
 	scan( (entries(gens(ideal sc)))_0, i->newgens=append(newgens,sub(i,S)) );
 	I := ideal( newgens );
-	J := ideal ((vars S)*(transpose chi));
+	J := ideal ((vars S)*(transpose lambda));
 	S/(I+J)
 )
 
 -- cohomology ring over the integers of a quasi-toric manifold
 cohomologyRing(QuasiToricManifold) := QuotientRing =>  {CoefficientRing=>ZZ} >> opts -> (M) -> (
 	sc := M.QTMSimplicialComplex;
-	chi := M.QTMCharacteristicMatrix;
+	lambda := M.QTMCharacteristicMatrix;
 	C := opts.CoefficientRing;
 	S := C[(entries(vars(ring sc)))_0];
 	newgens:={};
 	scan( (entries(gens(ideal sc)))_0, i->newgens=append(newgens,sub(i,S)) );
 	I := ideal( newgens );
-	J := ideal ((vars S)*(transpose chi));
+	J := ideal ((vars S)*(transpose lambda));
 	S/(I+J)
 )
 
@@ -143,11 +154,11 @@ bettiSmallCover = method()
 -- k-th betti number of a small cover
 bettiSmallCover(ZZ,SmallCover) := ZZ => (k,N) -> (
 	sc := N.QTMSimplicialComplex;
-	chi := N.QTMCharacteristicMatrix;
-	n := numgens(target(chi));
+	lambda := N.QTMCharacteristicMatrix;
+	n := numgens(target(lambda));
 	ind := drop( subsets(toList(1..n)), 1);
 	cclist := {};
-	scan(ind, I-> cclist=append(cclist,chainComplex(subComplex(sc,supportChi(chi,I) ) ) ) );
+	scan(ind, I-> cclist=append(cclist,chainComplex(subComplex(sc,supportChi(lambda,I) ) ) ) );
 	b := 0;
 	scan(cclist, cc -> b = b + rank( HH_(k-1)( cc) ) );
 	b
@@ -165,7 +176,7 @@ bettiQTM = method()
 bettiQTM(ZZ,QuasiToricManifold) := ZZ => (k, M) -> (
 	if ((k < 0) or (k > M.QTMDimension) or (k % 2 == 1)) then (
 		0
-	) 
+	)
 	else (
 		coho := cohomologyRing M;
 		(((coefficients numerator reduceHilbert hilbertSeries coho)_1)_0)_(sub(k/2,ZZ))
@@ -174,7 +185,7 @@ bettiQTM(ZZ,QuasiToricManifold) := ZZ => (k, M) -> (
 
 -- all the betti numbers up to 2n of an 2n-dimensional quasi-toric manifold
 bettiQTM(QuasiToricManifold) := List => (M) -> (
-	b := {};
+	b := {1};
 	for i in 1..(M.QTMDimension) do b = append(b, bettiQTM(i, M));
 	b
 )
@@ -191,7 +202,7 @@ realProjectiveSpace(ZZ) := SmallCover => (n) -> (
 hessenbergVariety = method(TypicalValue=>SmallCover)
 -- Hessenberg variety associated to the (dual of the) n-dimensional permutahedron
 hessenbergVariety(ZZ) := SmallCover => (n) -> (
-    smallCover(permutahedronDual(n),chiHessenberg(n))
+    smallCover(permutahedronDual(n),lambdaHessenberg(n))
 )
 
 
@@ -217,44 +228,44 @@ projectiveSpace = (n, base) -> (
 	(K,I|ones)
 )
 
-listMinors = (sc,chi) -> (
+listMinors = (sc,lambda) -> (
 	listminors:={};
 	for mon in facets(sc) do (
-		listminors=append(listminors,determinant(submatrix(chi,indices(mon))));
+		listminors=append(listminors,determinant(submatrix(lambda,indices(mon))));
 	);
 	listminors
 )
 
 subComplex = (sc, V) -> (
             varlist := (entries(vars(ring sc)))_0;
-            mV := sub(varlist_(V_0-1),ring sc); 
+            mV := sub(varlist_(V_0-1),ring sc);
 			scan(drop(V,1),i->mV=mV*sub(varlist_(i-1),ring(sc)));
 			candidates := {};
 			for k in (0..(length V)) do (
 				candidates = join(candidates, faces(k,sc));
-			);       
-			k:=0;    
-			lis := {};         
+			);
+			k:=0;
+			lis := {};
             while k!= length(candidates) do (
 	        	if (denominator(sub(mV, ring sc)/(candidates_k)))==1 then (
 	            	lis=append(lis,candidates_k);
                    	candidates=drop(candidates,{k,k});
                    	k=k-1;
-            	); 
+            	);
 	            k=k+1;
 		    );
 	        simplicialComplex(lis)
 );
 
--- given a char matrix chi (n rows, m cols) and a subset I={i_1, .., i_n} of [n]
--- returns the support of chi_I = chi_{i_1} + ... + chi_{i_n} 	  
-supportChi = (chi, I) -> (
+-- given a char matrix lambda (n rows, m cols) and a subset I={i_1, .., i_n} of [n]
+-- returns the support of lambda_I = lambda_{i_1} + ... + lambda_{i_n}
+supportChi = (lambda, I) -> (
                 cI := {};
-                m := numgens(source(chi));
-                n := numgens(target(chi));
+                m := numgens(source(lambda));
+                n := numgens(target(lambda));
                 for i in (1..m) do cI=append(cI,0);
-                scan( I, i-> cI = entries((transpose chi)_(i-1)) + cI );
-                fincI := {};                 
+                scan( I, i-> cI = entries((transpose lambda)_(i-1)) + cI );
+                fincI := {};
                 scan(cI, i -> fincI = append(fincI,sub(sub(i,ZZ/2),ZZ))) ;
                 supp:={};
                 j:=1;
@@ -272,47 +283,47 @@ simplicialIntToMon = (sc) -> (
 			  for i in (1..p) do e=append(e,0);
 			  lis := {};
 			  for i in (0..length(sc)-1) do (
-			  		lis = append(lis,new MutableList from e); 
+			  		lis = append(lis,new MutableList from e);
 			  		for j in sc#i do (
-			  				lis#i#(j-1)=1; 
-			  				); 
+			  				lis#i#(j-1)=1;
+			  				);
 			    	);
 			  lismon := {};
 			  for i in lis do lismon=append(lismon,R_(toList(i)));
 			  simplicialComplex( lismon )
 			  );
-              
+
 -- returns the characteristic matrix for the Hessenberg variety sitting on the dual of the n-dimensional permutahedron
-chiHessenberg = (n) -> (
+lambdaHessenberg = (n) -> (
 	-- finds the char matrix
 	col1s := {};
-	chisimplex := id_((ZZ/2)^n)|(transpose (matrix {apply(n,i->1)} ));
+	lambdasimplex := id_((ZZ/2)^n)|(transpose (matrix {apply(n,i->1)} ));
 	columns := new MutableHashTable;
 	i :=0;
 	for maxl in subsets(n+1,n) do (
-		columns#maxl = chisimplex_{i};
+		columns#maxl = lambdasimplex_{i};
 		i=i+1;
 	);
-	
+
     vertices := drop(drop(subsets(n+1),1),-1);
 	for vert in vertices do (
 		if not member(vert, subsets(n+1,n)) then (
 			supersets := {};
-			scan(subsets(n+1,n), i -> (if (not(i==vert) and isSubset(set(vert),set(i))) then 
+			scan(subsets(n+1,n), i -> (if (not(i==vert) and isSubset(set(vert),set(i))) then
 				supersets= append(supersets,i) ) );
 			col := 0;
-			scan(supersets, i -> col = col+ columns#i);	
+			scan(supersets, i -> col = col+ columns#i);
 			columns#vert = col;
 		);
 	);
-	
+
 	--finally computes the char matrix
-	chi := columns#(vertices#0);
+	lambda := columns#(vertices#0);
 	for i in 1..(length(vertices)-1) do (
-		chi = chi | columns#(vertices#i);
+		lambda = lambda | columns#(vertices#i);
 	);
-	
-    chi
+
+    lambda
 );
 
 permsimplices = (lis) -> (
@@ -336,22 +347,61 @@ permutahedronDual = (n) -> (
 	hashgen := {};
 	for i in 1..length(vertices) do (
 		hashgen = append( hashgen, {vertices#(i-1),i});
-	); 
-	vhash := hashTable(hashgen); 
-    
-	psimplices := {}; 
+	);
+	vhash := hashTable(hashgen);
+
+	psimplices := {};
 	for i in 0..n do (
-		psimplices = append(psimplices,{(subsets(n+1,n))#i}); 
+		psimplices = append(psimplices,{(subsets(n+1,n))#i});
 	);
 	simplices := {};
 	for permsimplex in permsimplices(psimplices) do (
 		simplex := {};
-		for sub in permsimplex do ( 
+		for sub in permsimplex do (
 			simplex = append(simplex, vhash#sub);
 		);
 		simplices = append(simplices, simplex);
 	);
 	simplicialIntToMon(simplices)
+)
+
+-- methods involving moment-angle complexes
+
+-- equivariant cohomology module of the moment-angle complex wrt. T^m-action
+equivariantCohomology = method()
+equivariantCohomology(MomentAngleComplex) := Module => (mac) -> (
+	return coker gens monomialIdeal mac.MACSimplicialComplex;
+)
+
+-- k-th betti number of a momemnt-angle complex (as given by the Baskakov-Buchstaber-Panov theorem)
+bettiMAC = method()
+bettiMAC(ZZ, MomentAngleComplex) := ZZ => (k, mac) -> (
+	b := 0;
+	btally := betti res equivariantCohomology mac;
+	for j in 0..(#vertices mac.MACSimplicialComplex) do (
+		key := (2*j-k, {2*j}, 2*j);
+		if btally#?key then (
+			b += btally#key;
+		);
+	);
+	b
+)
+
+-- all the betti numbers up to 2m of a MAC over a complex with m vertices
+bettiMAC(MomentAngleComplex) := List => (mac) -> (
+	b := {};
+	for i in 0..(2*#vertices mac.MACSimplicialComplex) do b=append(b, bettiMAC(i,mac));
+	b
+)
+
+-- the Euler characteristic of the moment angle complex
+eulerMAC = method()
+eulerMAC(MomentAngleComplex) := ZZ => (mac) -> (
+	b := bettiMAC(mac);
+	e := 0;
+	m := #vertices mac.MACSimplicialComplex;
+	for i in 0..(2*m) do e += (-1)^i * b#i;
+	e
 )
 
 -------------------
@@ -361,19 +411,25 @@ permutahedronDual = (n) -> (
 beginDocumentation()
 
 doc ///
-    Key
-        ToricTopology
-    Headline
-        homological computations in toric topology
-    Description
-        Text 
-            ToricTopology is a package for computing with quasi-toric manifolds and small covers.
-            
-	    A quasi-toric manifold (or small cover) is entirely determined by a pair consisting of a simplicial complex K and a matrix chi which is characteristic for K.
-   
-  	    If K has n vertices, we can think of its k-faces as sets of integers between 1 and n.
-            A matrix chi is characteristic for K if all maximal minors of chi indexed by the facets of  K have determinant equal to 1 or -1.
+	Key
+		ToricTopology
+	Headline
+		homological computations in toric topology
+	Description
+		Text
+			ToricTopology is a package for computing with quasi-toric manifolds,
+			small covers and moment-angle complexes.
 
+			A quasi-toric manifold (or small cover) is entirely determined by a pair
+			consisting of a simplicial complex K and a matrix lambda which is
+			characteristic for K.
+
+			If K has n vertices, we can think of its k-faces as sets of integers
+			between 1 and n. A matrix lambda is characteristic for K if all maximal
+			minors of lambda indexed by the facets of  K have determinant equal to 1
+			or -1.
+	SeeAlso
+		--NormalToricVarieties
 ///
 
 
@@ -381,7 +437,7 @@ doc ///
   Key
     SmallCover
   Headline
-    the class of all small covers 
+    the class of all small covers
   Description
    Text
        A small cover is represented by a simplicial complex K and matrix which is characteristic for K.
@@ -402,23 +458,48 @@ doc ///
 ///
 
 doc ///
+	Key
+		MomentAngleComplex
+	Headline
+		the class of all moment-angle complexes
+	Description
+		Text
+			Given a simplicial complex $K$ on $m$ vertices, the moment-angle complex
+			$\mathcal{Z}_K$ is a cellular complex constructed as a union of certain
+			products of disks and circles: $$\mathcal{Z_K} = \bigcup_{\sigma \in K}
+			\left( (D^2)^\sigma \times (S^1)^{[m] \setminus \sigma} \right).$$ These
+			spaces admit a natural action of the torus $T^m = (S^1)^m$. Non-singular
+			toric varities (not necessarily complete) are homotopy equivalent to
+			partial quotients of moment-angle complexes by freely acting subtori of
+			$T^m$. Thus, moment-angle complexes are an important class of spaces
+			studied in Toric Topology. Their topological properties can be determined
+			from the combinatorics of the underlying simplicial complex.  This
+			package implements methods to determine some of these properties.  A
+			moment-angle complex is a special case of polyhedral products.
+	SeeAlso
+		--NormalToricVariety
+		QuasiToricManifold
+		SmallCover
+///
+
+doc ///
   Key
     isValidChar
     (isValidChar,SimplicialComplex,Matrix)
   Headline
     Whether a matrix is characteristic for a simplicial complex
   Usage
-    isValidChar(K,chi)
+    isValidChar(K,lambda)
   Inputs
     K:SimplicialComplex
-    chi:Matrix
+    lambda:Matrix
   Outputs
     :Boolean
   Description
    Text
-        Checks whether chi is characteristic for K.
+        Checks whether lambda is characteristic for K.
   SeeAlso
-     
+
 ///
 
 
@@ -429,19 +510,19 @@ doc ///
   Headline
     Create a small cover
   Usage
-    smallCover(K,chi)
+    smallCover(K,lambda)
   Inputs
     K:SimplicialComplex
-    chi:Matrix
+    lambda:Matrix
   Outputs
     :SmallCover
   Description
    Text
-        Create a small cover over K with characteristic matrix chi.
-        If chi is not characteristic for K, then an error is returned.
-        The entries of chi are automatically converted to ZZ/2 entries, if they not already so.
+        Create a small cover over K with characteristic matrix lambda.
+        If lambda is not characteristic for K, then an error is returned.
+        The entries of lambda are automatically converted to ZZ/2 entries, if they not already so.
   SeeAlso
-     
+
 ///
 
 doc ///
@@ -451,19 +532,85 @@ doc ///
   Headline
     Create a quasi-toric manifold
   Usage
-    quasiToricManifold(K,chi)
+    quasiToricManifold(K,lambda)
   Inputs
     K:SimplicialComplex
-    chi:Matrix
+    lambda:Matrix
   Outputs
     :QuasiToricManifold
   Description
    Text
-        Create a quasi-toric manifold over K with characteristic matrix chi.
-        If chi is not characteristic for K, an error is returned.
+        Create a quasi-toric manifold over K with characteristic matrix lambda.
+        If lambda is not characteristic for K, an error is returned.
   SeeAlso
 ///
 
+doc ///
+	Key
+		momentAngleComplex
+		(momentAngleComplex,SimplicialComplex)
+	Headline
+		Create a moment-angle complex
+	Usage
+		momentAngleComplex(K)
+	Inputs
+		K:SimplicialComplex
+	Outputs
+		:MomentAngleComplex
+	Description
+		Text
+			Create a moment-angle complex with simplicial complex K.
+		Text
+			This example creates a moment-angle complex over the simplicial
+			complex consisting of two disjoint vertices.
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[x,y]
+			K = simplicialComplex {x, y}
+			Z = momentAngleComplex K
+	SeeAlso
+///
+
+doc ///
+	Key
+		equivariantCohomology
+		(equivariantCohomology,MomentAngleComplex)
+	Headline
+		Compute the equivariant cohomology of a moment-angle complex
+	Usage
+		equivariantCohomology(Z)
+	Inputs
+		Z:MomentAngleComplex
+	Outputs
+		:Module
+			the torus equivariant cohomology of Z, as a module over polynomial ring
+	Description
+		Text
+			Compute the equivariant cohomology of a moment-angle complex over the
+			polynomial ring k[x_1, ..., x_m] where k is the coeffcient ring of the
+			polynomial ring over which the underlying simplicial complex was
+			created.
+		Text
+			The equivariant cohomology of a moment-angle complex is free over the polynomial ring
+			when the simplicial complex is a full simplex.
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[x,y,z]
+			K = simplicialComplex {x*y*z}
+			Z = momentAngleComplex K
+			M = equivariantCohomology Z
+			isFreeModule M
+		Text
+			If there is any missing simplex, then the equivariant cohomology
+			is not free.
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[x,y,z]
+			K = simplicialComplex {x*y, y*z, x*z}
+			Z = momentAngleComplex K
+			M = equivariantCohomology Z
+			isFreeModule M
+///
 
 doc ///
   Key
@@ -482,9 +629,9 @@ doc ///
     :QuotientRing
   Description
    Text
-        Compute the cohomology ring of a small cover (over ZZ/2) or quasi-toric manifold (over ZZ). 
+        Compute the cohomology ring of a small cover (over ZZ/2) or quasi-toric manifold (over ZZ).
   SeeAlso
-     
+
 ///
 
 
@@ -551,7 +698,7 @@ doc ///
         If a dimension k is specified, then only the k-th betti number of N is computed.
         If no dimension is specified, all the betti numbers between 0 and the dimension of N are computed.
   SeeAlso
-     
+
 ///
 
 doc ///
@@ -576,7 +723,96 @@ doc ///
         If a dimension k is specified, then only the k-th betti number of M is computed.
         If no dimension is specified, all the betti numbers between 0 and the dimension of M are computed.
   SeeAlso
-     
+
+///
+
+doc ///
+	Key
+		bettiMAC
+		(bettiMAC,ZZ,MomentAngleComplex)
+		(bettiMAC,MomentAngleComplex)
+	Headline
+		Compute the betti numbers of a moment-angle complex
+	Usage
+		bettiMAC(k,Z)
+		bettiMAC(Z)
+	Inputs
+		k:ZZ
+			(optional)
+		Z:MomentAngleComplex
+	Outputs
+		:ZZ
+			the k-th Betti number of the moment angle complex (if k is provided)
+		:List
+			of all Betti numbers
+	Description
+		Text
+			This method computes the betti numbers of a moment-angle complex using
+			the theorem of Baskakov-Buchstaber-Panov.  If a dimension k is specified,
+			then only the k-th Betti number of Z is computed.  If no dimension is
+			specified, all the Betti numbers between 0 and 2m are computed (where m
+			is the number of vertices in the underlying simplicial complex).
+		Text
+			The moment-angle complex corresponding to the simplicial complex
+			consisting of two disjoint vertices is homeomorphic to $S^3$, the
+			3-sphere as indicated by its Betti numbers.
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[x,y]
+			K = simplicialComplex {x, y}
+			Z = momentAngleComplex K
+			bettiMAC Z
+		Text
+			Let $\mathcal{Z}_K$ be the moment-angle corresponding to the simplicial
+			complex consisting on 3 vertices, with an edge and a disjoint vertex. By
+			Hochster's formula, its third cohomology $H^3(\mathcal{Z}_K)$ will have
+			rank $2$.  We can verify this as follows,
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[x..z]
+			K = simplicialComplex {x, y*z}
+			Z = momentAngleComplex K
+			bettiMAC (3, Z)
+		Text
+			The moment-angle corresponding to the boundary $\partial \Delta^2$ of the
+			2-simplex is homeomorphic to $S^5$, as reflected by its betti
+			numbers.
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[x..z]
+			K = simplicialComplex {x*y, y*z, x*z}
+			Z = momentAngleComplex K
+			bettiMAC Z
+///
+
+doc///
+	Key
+		eulerMAC
+		(eulerMAC,MomentAngleComplex)
+	Headline
+		compute the Euler characteristic of a moment-angle complex
+	Usage
+		eulerMAC(Z)
+	Inputs
+		Z:MomentAngleComplex
+	Outputs
+		:ZZ
+			the Euler characteristic of the moment-angle complex
+	Description
+		Text
+			This method computes the Euler characterisitc of moment-angle complexes.
+		Text
+			The Euler characteristic of a moment-angle complex is $0$ if the
+			underlying simplicial complex is not a full simplex.
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[a..d]
+			K0 = simplicialComplex {a*b, b*c, c*d, d*a}
+			Z0 = momentAngleComplex K0
+			eulerMAC Z0
+			K1 = simplicialComplex {a*b*c*d}
+			Z1 = momentAngleComplex K1
+			eulerMAC Z1
 ///
 
 doc ///
@@ -623,7 +859,7 @@ doc ///
     hessenbergVariety
     (hessenbergVariety,ZZ)
   Headline
-    Hessenberg variety asscoiated to the n-permutahedron 
+    Hessenberg variety asscoiated to the n-permutahedron
   Usage
     hessenbergVariety(n)
   Inputs
@@ -634,5 +870,5 @@ doc ///
    Text
        Hessenberg variety asscoiated to the n-permutahedron, as small cover.
   SeeAlso
-    
+
 ///

--- a/M2/Macaulay2/packages/ToricTopology.m2
+++ b/M2/Macaulay2/packages/ToricTopology.m2
@@ -54,7 +54,7 @@ export {
 SmallCover = new Type of HashTable
 SmallCover.synonym = "small cover"
 QuasiToricManifold = new Type of HashTable
-QuasiToricManifold.synonym = "quasi-toric manifold"
+QuasiToricManifold.synonym = "quasitoric manifold"
 MomentAngleComplex = new Type of HashTable
 MomentAngleComplex.synonym = "moment-angle complex"
 
@@ -67,7 +67,7 @@ smallCover(SimplicialComplex,Matrix) := SmallCover => (sc,lambda) -> (
 	new SmallCover from {
 		QTMSimplicialComplex => sc,
 		QTMCharacteristicMatrix => lambdamod2,
-		QTMDimension => rank( target (lambda) )
+		QTMDimension => rank(target(lambda))
 	}
 )
 
@@ -77,7 +77,7 @@ quasiToricManifold(SimplicialComplex,Matrix) := QuasiToricManifold => (sc,lambda
 	new QuasiToricManifold from {
 		QTMSimplicialComplex => sc,
 		QTMCharacteristicMatrix => lambda,
-		QTMDimension => 2*rank( target (lambda) )
+		QTMDimension => 2*rank(target(lambda))
 	}
 )
 
@@ -113,7 +113,7 @@ cohomologyRing(SmallCover) := QuotientRing => {CoefficientRing=>ZZ/2} >> opts ->
 	S/(I+J)
 )
 
--- cohomology ring over the integers of a quasi-toric manifold
+-- cohomology ring over the integers of a quasitoric manifold
 cohomologyRing(QuasiToricManifold) := QuotientRing =>  {CoefficientRing=>ZZ} >> opts -> (M) -> (
 	sc := M.QTMSimplicialComplex;
 	lambda := M.QTMCharacteristicMatrix;
@@ -125,17 +125,14 @@ cohomologyRing(QuasiToricManifold) := QuotientRing =>  {CoefficientRing=>ZZ} >> 
 	S/(I+J)
 )
 
-
-chern = method(TypicalValue=>List,Options=>{CoefficientRing=>ZZ})
--- Chern classes of a quasi-toric manifold
+chern = method(TypicalValue=>List)
+-- Chern classes of a quasitoric manifold
 chern(QuasiToricManifold) := List => opts -> (M) -> (
 	T := cohomologyRing(M,CoefficientRing=>opts.CoefficientRing);
 	c := 1;
 	scan ((entries(vars(ambient T)))_0, i -> c = c*(1+i));
 	n := numgens target(M.QTMCharacteristicMatrix);
-	chernclasses := {};
-	for i in 1..n do chernclasses=append(chernclasses,part(i,sub(c,T)));
-	chernclasses
+	toList apply(1..n, i -> part(i,sub(c,T)))
 )
 
 stiefelWhitney = method(TypicalValue=>List)
@@ -145,9 +142,7 @@ stiefelWhitney(SmallCover) := List => (N) -> (
 	w := 1;
 	scan ((entries(vars(ambient T)))_0, i -> w = w*(1+i));
 	n := numgens target(N.QTMCharacteristicMatrix);
-	swclasses := {};
-	for i in 1..n do swclasses=append(swclasses,part(i,sub(w,T)));
-	swclasses
+	toList apply(1..n, i -> part(i,sub(w,T)))
 )
 
 bettiSmallCover = method()
@@ -157,7 +152,7 @@ bettiSmallCover(ZZ,SmallCover) := ZZ => (k,N) -> (
 	lambda := N.QTMCharacteristicMatrix;
 	n := numgens(target(lambda));
 	ind := subsets(toList(1..n));
-	cclist := apply(ind, I -> complex(subComplex(sc, supportChi(lambda, I))));
+	cclist := apply(ind, I -> complex(subComplex(sc, charSupport(lambda, I))));
 	b := 0;
 	scan(cclist, cc -> b = b + rank(HH_(k-1)(cc)));
 	b
@@ -169,7 +164,7 @@ bettiSmallCover(SmallCover) := List => (N) -> (
 )
 
 bettiQTM = method()
--- k-th betti number of a quasi-toric manifold
+-- k-th betti number of a quasitoric manifold
 bettiQTM(ZZ,QuasiToricManifold) := ZZ => (k, M) -> (
 	if ((k < 0) or (k > M.QTMDimension) or (k % 2 == 1)) then (
 		0
@@ -180,9 +175,46 @@ bettiQTM(ZZ,QuasiToricManifold) := ZZ => (k, M) -> (
 	)
 )
 
--- all the betti numbers up to 2n of an 2n-dimensional quasi-toric manifold
+-- all the betti numbers up to 2n of an 2n-dimensional quasitoric manifold
 bettiQTM(QuasiToricManifold) := List => (M) -> (
 	apply(M.QTMDimension + 1, i -> bettiQTM(i, M))
+)
+
+-- methods involving moment-angle complexes
+
+-- equivariant cohomology module of the moment-angle complex wrt. T^m-action
+equivariantCohomology = method()
+equivariantCohomology(MomentAngleComplex) := Module => (mac) -> (
+	coker gens monomialIdeal mac.MACSimplicialComplex
+)
+
+-- k-th betti number of a momemnt-angle complex (as given by the Baskakov-Buchstaber-Panov theorem)
+bettiMAC = method()
+bettiMAC(ZZ, MomentAngleComplex) := ZZ => (k, mac) -> (
+	b := 0;
+	btally := betti res equivariantCohomology mac;
+	for j in 0..(#vertices mac.MACSimplicialComplex) do (
+		key := (2*j-k, {2*j}, 2*j);
+		if btally#?key then (
+			b += btally#key;
+		);
+	);
+	b
+)
+
+-- all the betti numbers up to 2m of a MAC over a complex with m vertices
+bettiMAC(MomentAngleComplex) := List => (mac) -> (
+	apply(2*#vertices mac.MACSimplicialComplex + 1, i -> bettiMAC(i, mac))
+)
+
+-- the Euler characteristic of the moment angle complex
+eulerMAC = method()
+eulerMAC(MomentAngleComplex) := ZZ => (mac) -> (
+	b := bettiMAC(mac);
+	e := 0;
+	m := #vertices mac.MACSimplicialComplex;
+	for i in 0..(2*m) do e += (-1)^i * b#i;
+	e
 )
 
 -- Sample small covers --
@@ -193,40 +225,31 @@ realProjectiveSpace(ZZ) := SmallCover => (n) -> (
 	smallCover(projectiveSpace(n, ZZ/2))
 )
 
-
 hessenbergVariety = method(TypicalValue=>SmallCover)
 -- Hessenberg variety associated to the (dual of the) n-dimensional permutahedron
 hessenbergVariety(ZZ) := SmallCover => (n) -> (
-    smallCover(permutahedronDual(n),lambdaHessenberg(n))
+	smallCover(permutahedronDual(n), lambdaHessenberg(n))
 )
 
+-- Sample quasitoric manifolds
 
--- Sample quasi-toric manifolds
 complexProjectiveSpace = method(TypicalValue=>QuasiToricManifold)
 -- n-dimensional complex projective space
 complexProjectiveSpace(ZZ) := QuasiToricManifold => (n) -> (
 	quasiToricManifold(projectiveSpace(n, ZZ))
 )
 
-
 -- Helper functions --
 projectiveSpace = (n, base) -> (
 	I := id_(base^n);
-	ones := matrix(apply(n, i -> {1}));
+	ones := matrix(apply(n, i -> {-1}));
 	R := base[vars(0..n)];
-	varlist := (entries(vars(R)))_0;
-	maxmissingface := sub(varlist_0 ,R);
-	scan(1..n, i -> maxmissingface = maxmissingface * sub(varlist_i, R) );
-	K := simplicialComplex(monomialIdeal(maxmissingface));
+	K := simplicialComplex monomialIdeal {product gens R};
 	(K,I|ones)
 )
 
-listMinors = (sc,chi) -> (
-	listminors:={};
-	for mon in facets(sc) do (
-		listminors=append(listminors,determinant(submatrix(chi,indices(mon))));
-	);
-	listminors
+listMinors = (sc, lambda) -> (
+	apply(facets(sc), f -> determinant(submatrix(lambda, indices(f))))
 )
 
 -- method to compute the subcomplex of sc, restricted to variables indexed by
@@ -257,39 +280,31 @@ subComplex = (sc, V) -> (
 
 -- given a char matrix lambda (n rows, m cols) and a subset I={i_1, .., i_n} of [n]
 -- returns the support of lambda_I = lambda_{i_1} + ... + lambda_{i_n}
-supportChi = (lambda, I) -> (
-                cI := {};
-                m := numgens(source(lambda));
-                n := numgens(target(lambda));
-                for i in (1..m) do cI=append(cI,0);
-                scan( I, i-> cI = entries((transpose lambda)_(i-1)) + cI );
-                fincI := {};
-                scan(cI, i -> fincI = append(fincI,sub(sub(i,ZZ/2),ZZ))) ;
-                supp:={};
-                j:=1;
-                for j in (1..m) do (
-                        if (fincI_(j-1) != 0) then supp=append(supp,j);
-                );
-                supp
+charSupport = (lambda, I) -> (
+	cI := {};
+	m := numgens(source(lambda));
+	n := numgens(target(lambda));
+	cI=apply(m, i -> 0);
+	scan(I, i -> cI = entries((transpose lambda)_(i-1)) + cI);
+	fincI := apply(cI, i -> sub(i,ZZ/2));
+	toList select(1..m, i -> fincI_(i-1) != 0)
 );
 
 
 simplicialIntToMon = (sc) -> (
-			  p := max( flatten( sc ) );
-			  R := ZZ[vars(0..p-1)];
-			  e := {};
-			  for i in (1..p) do e=append(e,0);
-			  lis := {};
-			  for i in (0..length(sc)-1) do (
-			  		lis = append(lis,new MutableList from e);
-			  		for j in sc#i do (
-			  				lis#i#(j-1)=1;
-			  				);
-			    	);
-			  lismon := {};
-			  for i in lis do lismon=append(lismon,R_(toList(i)));
-			  simplicialComplex( lismon )
-			  );
+	p := max( flatten( sc ) );
+	R := ZZ[vars(0..p-1)];
+	e := apply(p, i -> 0);
+	lis := {};
+	for i in (0..length(sc)-1) do (
+		lis = append(lis,new MutableList from e);
+		for j in sc#i do (
+			lis#i#(j-1)=1;
+		);
+	);
+	lismon := apply(lis, i -> R_(toList(i)));
+	simplicialComplex(lismon)
+);
 
 -- returns the characteristic matrix for the Hessenberg variety sitting on the dual of the n-dimensional permutahedron
 lambdaHessenberg = (n) -> (
@@ -303,7 +318,7 @@ lambdaHessenberg = (n) -> (
 		i=i+1;
 	);
 
-    vertices := drop(drop(subsets(n+1),1),-1);
+	vertices := drop(drop(subsets(n+1),1),-1);
 	for vert in vertices do (
 		if not member(vert, subsets(n+1,n)) then (
 			supersets := {};
@@ -320,23 +335,22 @@ lambdaHessenberg = (n) -> (
 	for i in 1..(length(vertices)-1) do (
 		lambda = lambda | columns#(vertices#i);
 	);
-
-    lambda
+	lambda
 );
 
 permsimplices = (lis) -> (
-    resl :={};
-    for fac in lis do (
-        if length(last(fac))==1 then return lis
-        else (
-            tmplis := {};
-            for sub in subsets(last(fac),length(last(fac))-1) do (
-                tmplis = append(tmplis, append(fac, sub));
-            );
-            resl = join(resl, tmplis);
-        );
-    );
-    return permsimplices(resl);
+	resl :={};
+	for fac in lis do (
+		if length(last(fac))==1 then return lis
+		else (
+			tmplis := {};
+			for sub in subsets(last(fac),length(last(fac))-1) do (
+				tmplis = append(tmplis, append(fac, sub));
+			);
+			resl = join(resl, tmplis);
+		);
+	);
+	return permsimplices(resl);
 )
 
 -- returns the simplicial complex dual to the n-dimensional permutahedron
@@ -344,7 +358,7 @@ permutahedronDual = (n) -> (
 	vertices := drop(drop(subsets(n+1),1),-1);
 	hashgen := {};
 	for i in 1..length(vertices) do (
-		hashgen = append( hashgen, {vertices#(i-1),i});
+		hashgen = append(hashgen, {vertices#(i-1),i});
 	);
 	vhash := hashTable(hashgen);
 
@@ -363,42 +377,6 @@ permutahedronDual = (n) -> (
 	simplicialIntToMon(simplices)
 )
 
--- methods involving moment-angle complexes
-
--- equivariant cohomology module of the moment-angle complex wrt. T^m-action
-equivariantCohomology = method()
-equivariantCohomology(MomentAngleComplex) := Module => (mac) -> (
-	coker gens monomialIdeal mac.MACSimplicialComplex
-)
-
--- k-th betti number of a momemnt-angle complex (as given by the Baskakov-Buchstaber-Panov theorem)
-bettiMAC = method()
-bettiMAC(ZZ, MomentAngleComplex) := ZZ => (k, mac) -> (
-	b := 0;
-	btally := betti res equivariantCohomology mac;
-	for j in 0..(#vertices mac.MACSimplicialComplex) do (
-		key := (2*j-k, {2*j}, 2*j);
-		if btally#?key then (
-			b += btally#key;
-		);
-	);
-	b
-)
-
--- all the betti numbers up to 2m of a MAC over a complex with m vertices
-bettiMAC(MomentAngleComplex) := List => (mac) -> (
-	apply(2*#vertices mac.MACSimplicialComplex + 1, i-> bettiMAC(i, mac))
-)
-
--- the Euler characteristic of the moment angle complex
-eulerMAC = method()
-eulerMAC(MomentAngleComplex) := ZZ => (mac) -> (
-	b := bettiMAC(mac);
-	e := 0;
-	m := #vertices mac.MACSimplicialComplex;
-	for i in 0..(2*m) do e += (-1)^i * b#i;
-	e
-)
 
 -------------------
 -- Documentation --
@@ -413,44 +391,45 @@ doc ///
 		homological computations in toric topology
 	Description
 		Text
-			ToricTopology is a package for computing with quasi-toric manifolds,
-			small covers and moment-angle complexes.
+			ToricTopology is a package for computing with quasitoric
+			manifolds, small covers and moment-angle complexes.
 
-			A quasi-toric manifold (or small cover) is entirely determined by a pair
-			consisting of a simplicial complex K and a matrix lambda which is
-			characteristic for K.
+			A quasitoric manifold (or small cover) is entirely determined by a
+			pair consisting of a simplicial complex K and a matrix lambda which
+			is characteristic for K.
 
-			If K has n vertices, we can think of its k-faces as sets of integers
-			between 1 and n. A matrix lambda is characteristic for K if all maximal
-			minors of lambda indexed by the facets of  K have determinant equal to 1
-			or -1.
+			If K has n vertices, we can think of its k-faces as sets of
+			integers between 1 and n. A matrix lambda is characteristic for K
+			if all maximal minors of lambda indexed by the facets of  K have
+			determinant equal to 1 or -1.
 	SeeAlso
 		--NormalToricVarieties
 ///
 
-
 doc ///
-  Key
-    SmallCover
-  Headline
-    the class of all small covers
-  Description
-   Text
-       A small cover is represented by a simplicial complex K and matrix which is characteristic for K.
-  SeeAlso
-    QuasiToricManifold
+	Key
+		SmallCover
+	Headline
+		the class of all small covers
+	Description
+		Text
+			A small cover is represented by a simplicial complex K and matrix
+			which is characteristic for K.
+	SeeAlso
+		QuasiToricManifold
 ///
 
 doc ///
-  Key
-    QuasiToricManifold
-  Headline
-    the class of all quasi-toric manifolds
-  Description
-   Text
-       A quasi-toric manifold is represented by a simplicial complex K and matrix which is characteristic for K.
-  SeeAlso
-   SmallCover
+	Key
+		QuasiToricManifold
+	Headline
+		the class of all quasitoric manifolds
+	Description
+		Text
+			A quasitoric manifold is represented by a simplicial complex K and
+			matrix which is characteristic for K.
+	SeeAlso
+		SmallCover
 ///
 
 doc ///
@@ -460,18 +439,19 @@ doc ///
 		the class of all moment-angle complexes
 	Description
 		Text
-			Given a simplicial complex $K$ on $m$ vertices, the moment-angle complex
-			$\mathcal{Z}_K$ is a cellular complex constructed as a union of certain
-			products of disks and circles: $$\mathcal{Z_K} = \bigcup_{\sigma \in K}
-			\left( (D^2)^\sigma \times (S^1)^{[m] \setminus \sigma} \right).$$ These
-			spaces admit a natural action of the torus $T^m = (S^1)^m$. Non-singular
-			toric varieties (not necessarily complete) are homotopy equivalent to
-			partial quotients of moment-angle complexes by freely acting subtori of
-			$T^m$. Thus, moment-angle complexes are an important class of spaces
-			studied in Toric Topology. Their topological properties can be determined
-			from the combinatorics of the underlying simplicial complex.  This
-			package implements methods to determine some of these properties.  A
-			moment-angle complex is a special case of polyhedral products.
+			Given a simplicial complex $K$ on $m$ vertices, the moment-angle
+			complex $\mathcal{Z}_K$ is a cellular complex constructed as a
+			union of certain products of disks and circles: $$\mathcal{Z_K} =
+			\bigcup_{\sigma \in K} \left( (D^2)^\sigma \times (S^1)^{[m]
+			\setminus \sigma} \right).$$ These spaces admit a natural action of
+			the torus $T^m = (S^1)^m$. Non-singular toric varieties (not
+			necessarily complete) are homotopy equivalent to partial quotients
+			of moment-angle complexes by freely acting subtori of $T^m$. Thus,
+			moment-angle complexes are an important class of spaces studied in
+			Toric Topology. Their topological properties can be determined from
+			the combinatorics of the underlying simplicial complex.  This
+			package implements methods to determine some of these properties.
+			A moment-angle complex is a special case of polyhedral products.
 	SeeAlso
 		--NormalToricVariety
 		QuasiToricManifold
@@ -479,66 +459,83 @@ doc ///
 ///
 
 doc ///
-  Key
-    isValidChar
-    (isValidChar,SimplicialComplex,Matrix)
-  Headline
-    Whether a matrix is characteristic for a simplicial complex
-  Usage
-    isValidChar(K,lambda)
-  Inputs
-    K:SimplicialComplex
-    lambda:Matrix
-  Outputs
-    :Boolean
-  Description
-   Text
-        Checks whether lambda is characteristic for K.
-  SeeAlso
-
-///
-
-
-doc ///
-  Key
-    smallCover
-    (smallCover,SimplicialComplex,Matrix)
-  Headline
-    Create a small cover
-  Usage
-    smallCover(K,lambda)
-  Inputs
-    K:SimplicialComplex
-    lambda:Matrix
-  Outputs
-    :SmallCover
-  Description
-   Text
-        Create a small cover over K with characteristic matrix lambda.
-        If lambda is not characteristic for K, then an error is returned.
-        The entries of lambda are automatically converted to ZZ/2 entries, if they not already so.
-  SeeAlso
-
+	Key
+		isValidChar
+		(isValidChar,SimplicialComplex,Matrix)
+	Headline
+		whether a matrix is characteristic for a simplicial complex
+	Usage
+		isValidChar(K,lambda)
+	Inputs
+		K:SimplicialComplex
+		lambda:Matrix
+	Outputs
+		:Boolean
+	Description
+		Text
+			Checks whether lambda is characteristic for K.
+	SeeAlso
 ///
 
 doc ///
-  Key
-    quasiToricManifold
-    (quasiToricManifold,SimplicialComplex,Matrix)
-  Headline
-    Create a quasi-toric manifold
-  Usage
-    quasiToricManifold(K,lambda)
-  Inputs
-    K:SimplicialComplex
-    lambda:Matrix
-  Outputs
-    :QuasiToricManifold
-  Description
-   Text
-        Create a quasi-toric manifold over K with characteristic matrix lambda.
-        If lambda is not characteristic for K, an error is returned.
-  SeeAlso
+	Key
+		smallCover
+		(smallCover,SimplicialComplex,Matrix)
+	Headline
+		create a small cover
+	Usage
+		smallCover(K,lambda)
+	Inputs
+		K:SimplicialComplex
+		lambda:Matrix
+	Outputs
+		:SmallCover
+	Description
+		Text
+			Create a small cover over K with characteristic matrix lambda.  If
+			lambda is not characteristic for K, then an error is returned.  The
+			entries of lambda are automatically converted to ZZ/2 entries, if
+			they not already so.
+		Text
+			The following example illustrates creating the 2-torus as a small
+			cover over the unit square.
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[a..d]
+			K = simplicialComplex {a*b, b*c, c*d, d*a}
+			lambda = matrix{{1, 0, 1, 0}, {0, 1, 0, 1}}
+			X = smallCover(K, lambda)
+	SeeAlso
+///
+
+doc ///
+	Key
+		quasiToricManifold
+		(quasiToricManifold,SimplicialComplex,Matrix)
+	Headline
+		create a quasitoric manifold
+	Usage
+		quasiToricManifold(K,lambda)
+	Inputs
+		K:SimplicialComplex
+		lambda:Matrix
+	Outputs
+		:QuasiToricManifold
+	Description
+		Text
+			Create a quasitoric manifold over K with characteristic matrix
+			lambda.  If lambda is not characteristic for K, an error is
+			returned.
+		Text
+			The following example creates the 2-dimensional complex projective
+			space as a quasitoric manifold.
+		Example
+			needsPackage "SimplicialComplexes"
+			R = QQ[a..c]
+			K = simplicialComplex {a*b, b*c, c*a}
+			lambda = matrix{{1, 0, -1}, {0, 1, -1}}
+			X = quasiToricManifold(K, lambda)
+	SeeAlso
 ///
 
 doc ///
@@ -546,7 +543,7 @@ doc ///
 		momentAngleComplex
 		(momentAngleComplex,SimplicialComplex)
 	Headline
-		Create a moment-angle complex
+		create a moment-angle complex
 	Usage
 		momentAngleComplex(K)
 	Inputs
@@ -572,20 +569,21 @@ doc ///
 		equivariantCohomology
 		(equivariantCohomology,MomentAngleComplex)
 	Headline
-		Compute the equivariant cohomology of a moment-angle complex
+		compute the equivariant cohomology of a moment-angle complex
 	Usage
 		equivariantCohomology(Z)
 	Inputs
 		Z:MomentAngleComplex
 	Outputs
 		:Module
-			the torus equivariant cohomology of Z, as a module over polynomial ring
+			the torus equivariant cohomology of Z, as a module over polynomial
+			ring
 	Description
 		Text
-			Compute the equivariant cohomology of a moment-angle complex over the
-			polynomial ring k[x_1, ..., x_m] where k is the coefficient ring of the
-			polynomial ring over which the underlying simplicial complex was
-			created.
+			Compute the equivariant cohomology of a moment-angle complex over
+			the polynomial ring k[x_1, ..., x_m] where k is the coefficient
+			ring of the polynomial ring over which the underlying simplicial
+			complex was created.
 		Text
 			The equivariant cohomology of a moment-angle complex is free over the polynomial ring
 			when the simplicial complex is a full simplex.
@@ -597,8 +595,8 @@ doc ///
 			M = equivariantCohomology Z
 			isFreeModule M
 		Text
-			If there is any missing simplex, then the equivariant cohomology
-			is not free.
+			If there is any missing simplex, then the equivariant cohomology is
+			not free.
 		Example
 			needsPackage "SimplicialComplexes"
 			R = QQ[x,y,z]
@@ -609,117 +607,117 @@ doc ///
 ///
 
 doc ///
-  Key
-    cohomologyRing
-    (cohomologyRing,SmallCover)
-    (cohomologyRing,QuasiToricManifold)
-  Headline
-    Compute the cohomology ring of a small cover or quasi-toric manifold
-  Usage
-    cohomologyRing(N)
-    cohomologyRing(M)
-  Inputs
-    N:SmallCover
-    M:QuasiToricManifold
-  Outputs
-    :QuotientRing
-  Description
-   Text
-        Compute the cohomology ring of a small cover (over ZZ/2) or quasi-toric manifold (over ZZ).
-  SeeAlso
-
-///
-
-
-doc ///
-  Key
-    stiefelWhitney
-    (stiefelWhitney,SmallCover)
-  Headline
-    Compute the Stiefel-Whitney classes of a small cover
-  Usage
-    stiefelWhitney(N)
-  Inputs
-    N:SmallCover
-  Outputs
-    :List
-  Description
-   Text
-        Compute the Stiefel-Whitney classes of a small cover.
-        The output is a list of elements in the cohomology ring of N.
-  SeeAlso
-    cohomologyRing
-///
-
-doc ///
-  Key
-    chern
-    (chern,QuasiToricManifold)
-  Headline
-    Compute the Chern classes of a quasi-toric manifold
-  Usage
-    chern(M)
-  Inputs
-    M:QuasiToricManifold
-  Outputs
-    :List
-  Description
-   Text
-        Compute the Chern classes of a quasi-toric manifold.
-        The output is a list of elements in the cohomology ring of M.
-  SeeAlso
-    cohomologyRing
-///
-
-
-doc ///
-  Key
-    bettiSmallCover
-    (bettiSmallCover,ZZ,SmallCover)
-    (bettiSmallCover,SmallCover)
-  Headline
-    Compute the betti numbers of a small cover
-  Usage
-    bettiSmallCover(k,N)
-    bettiSmallCover(N)
-  Inputs
-    k:ZZ
-    N:SmallCover
-  Outputs
-    :ZZ
-    :List
-  Description
-   Text
-        Compute the betti numbers of a small cover.
-        If a dimension k is specified, then only the k-th betti number of N is computed.
-        If no dimension is specified, all the betti numbers between 0 and the dimension of N are computed.
-  SeeAlso
+	Key
+		cohomologyRing
+		(cohomologyRing,SmallCover)
+		(cohomologyRing,QuasiToricManifold)
+	Headline
+		compute the cohomology ring of a small cover or quasitoric manifold
+	Usage
+		cohomologyRing(N)
+		cohomologyRing(M)
+	Inputs
+		N:SmallCover
+		M:QuasiToricManifold
+	Outputs
+		:QuotientRing
+	Description
+		Text
+			Compute the cohomology ring of a small cover (over ZZ/2) or
+			quasitoric manifold (over ZZ).
+	SeeAlso
 
 ///
 
 doc ///
-  Key
-    bettiQTM
-    (bettiQTM,ZZ,QuasiToricManifold)
-    (bettiQTM,QuasiToricManifold)
-  Headline
-    Compute the betti numbers of a quasi-toric manifold
-  Usage
-    bettiQTM(k,M)
-    bettiQTM(M)
-  Inputs
-    k:ZZ
-    M:QuasiToricManifold
-  Outputs
-    :ZZ
-    :List
-  Description
-   Text
-        Compute the betti numbers of a quasi-toric manifold.
-        If a dimension k is specified, then only the k-th betti number of M is computed.
-        If no dimension is specified, all the betti numbers between 0 and the dimension of M are computed.
-  SeeAlso
+	Key
+		stiefelWhitney
+		(stiefelWhitney,SmallCover)
+	Headline
+		compute the Stiefel-Whitney classes of a small cover
+	Usage
+		stiefelWhitney(N)
+	Inputs
+		N:SmallCover
+	Outputs
+		:List
+	Description
+		Text
+			Compute the Stiefel-Whitney classes of a small cover.
+			The output is a list of elements in the cohomology ring of N.
+	SeeAlso
+		cohomologyRing
+///
 
+doc ///
+	Key
+		chern
+		(chern,QuasiToricManifold)
+	Headline
+		compute the Chern classes of a quasitoric manifold
+	Usage
+		chern(M)
+	Inputs
+		M:QuasiToricManifold
+	Outputs
+		:List
+	Description
+		Text
+			Compute the Chern classes of a quasitoric manifold.
+			The output is a list of elements in the cohomology ring of M.
+	SeeAlso
+		cohomologyRing
+///
+
+doc ///
+	Key
+		bettiSmallCover
+		(bettiSmallCover,ZZ,SmallCover)
+		(bettiSmallCover,SmallCover)
+	Headline
+		compute the Betti numbers of a small cover
+	Usage
+		bettiSmallCover(k,N)
+		bettiSmallCover(N)
+	Inputs
+		k:ZZ
+		N:SmallCover
+	Outputs
+		:ZZ
+		:List
+	Description
+		Text
+			Compute the rational Betti numbers of a small cover.  If a dimension k is
+			specified, then only the k-th Betti number of N is computed.  If no
+			dimension is specified, all the Betti numbers between 0 and the
+			dimension of N are computed.
+	SeeAlso
+
+///
+
+doc ///
+	Key
+		bettiQTM
+		(bettiQTM,ZZ,QuasiToricManifold)
+		(bettiQTM,QuasiToricManifold)
+	Headline
+		compute the Betti numbers of a quasitoric manifold
+	Usage
+		bettiQTM(k,M)
+		bettiQTM(M)
+	Inputs
+		k:ZZ
+		M:QuasiToricManifold
+	Outputs
+		:ZZ
+		:List
+	Description
+		Text
+			Compute the Betti numbers of a quasitoric manifold.  If a
+			dimension k is specified, then only the k-th Betti number of M is
+			computed.  If no dimension is specified, all the Betti numbers
+			between 0 and the dimension of M are computed.
+	SeeAlso
 ///
 
 doc ///
@@ -728,7 +726,7 @@ doc ///
 		(bettiMAC,ZZ,MomentAngleComplex)
 		(bettiMAC,MomentAngleComplex)
 	Headline
-		Compute the betti numbers of a moment-angle complex
+		compute the Betti numbers of a moment-angle complex
 	Usage
 		bettiMAC(k,Z)
 		bettiMAC(Z)
@@ -743,11 +741,12 @@ doc ///
 			of all Betti numbers
 	Description
 		Text
-			This method computes the betti numbers of a moment-angle complex using
-			the theorem of Baskakov-Buchstaber-Panov.  If a dimension k is specified,
-			then only the k-th Betti number of Z is computed.  If no dimension is
-			specified, all the Betti numbers between 0 and 2m are computed (where m
-			is the number of vertices in the underlying simplicial complex).
+			This method computes the Betti numbers of a moment-angle complex
+			using the theorem of Baskakov-Buchstaber-Panov. If a dimension k is
+			specified, then only the k-th Betti number of Z is computed. If no
+			dimension is specified, all the Betti numbers between 0 and 2m are
+			computed (where m is the number of vertices in the underlying
+			simplicial complex).
 		Text
 			The moment-angle complex corresponding to the simplicial complex
 			consisting of two disjoint vertices is homeomorphic to $S^3$, the
@@ -759,10 +758,11 @@ doc ///
 			Z = momentAngleComplex K
 			bettiMAC Z
 		Text
-			Let $\mathcal{Z}_K$ be the moment-angle corresponding to the simplicial
-			complex consisting on 3 vertices, with an edge and a disjoint vertex. By
-			Hochster's formula, its third cohomology $H^3(\mathcal{Z}_K)$ will have
-			rank $2$.  We can verify this as follows,
+			Let $\mathcal{Z}_K$ be the moment-angle corresponding to the
+			simplicial complex consisting on 3 vertices, with an edge and a
+			disjoint vertex. By Hochster's formula, its third cohomology
+			$H^3(\mathcal{Z}_K)$ will have rank $2$. We can verify this as
+			follows,
 		Example
 			needsPackage "SimplicialComplexes"
 			R = QQ[x..z]
@@ -770,9 +770,9 @@ doc ///
 			Z = momentAngleComplex K
 			bettiMAC (3, Z)
 		Text
-			The moment-angle corresponding to the boundary $\partial \Delta^2$ of the
-			2-simplex is homeomorphic to $S^5$, as reflected by its betti
-			numbers.
+			The moment-angle corresponding to the boundary $\partial \Delta^2$
+			of the 2-simplex is homeomorphic to $S^5$, as reflected by its
+			Betti numbers.
 		Example
 			needsPackage "SimplicialComplexes"
 			R = QQ[x..z]
@@ -796,7 +796,8 @@ doc///
 			the Euler characteristic of the moment-angle complex
 	Description
 		Text
-			This method computes the Euler characterisitc of moment-angle complexes.
+			This method computes the Euler characterisitc of moment-angle
+			complexes.
 		Text
 			The Euler characteristic of a moment-angle complex is $0$ if the
 			underlying simplicial complex is not a full simplex.
@@ -812,60 +813,143 @@ doc///
 ///
 
 doc ///
-  Key
-    realProjectiveSpace
-    (realProjectiveSpace,ZZ)
-  Headline
-    Real projective space of dimension n
-  Usage
-    realProjectiveSpace(n)
-  Inputs
-    n:ZZ
-  Outputs
-    :SmallCover
-  Description
-   Text
-        Real projective space of dimension n, as small cover.
-  SeeAlso
-    complexProjectiveSpace
+	Key
+		realProjectiveSpace
+		(realProjectiveSpace,ZZ)
+	Headline
+		real projective space of dimension n
+	Usage
+		realProjectiveSpace(n)
+	Inputs
+		n:ZZ
+	Outputs
+		:SmallCover
+	Description
+		Text
+			Real projective space of dimension n, as a small cover.
+	SeeAlso
+		complexProjectiveSpace
 ///
 
 doc ///
-  Key
-    complexProjectiveSpace
-    (complexProjectiveSpace,ZZ)
-  Headline
-    Complex projective space of dimension n
-  Usage
-    complexProjectiveSpace(n)
-  Inputs
-    n:ZZ
-  Outputs
-    :QuasiToricManifold
-  Description
-   Text
-        Complex projective space of dimension n, as small cover.
-  SeeAlso
-    realProjectiveSpace
+	Key
+		complexProjectiveSpace
+		(complexProjectiveSpace,ZZ)
+	Headline
+		complex projective space of dimension n
+	Usage
+		complexProjectiveSpace(n)
+	Inputs
+		n:ZZ
+	Outputs
+		:QuasiToricManifold
+	Description
+		Text
+			Complex projective space of dimension n, as a quasitoric manifold.
+	SeeAlso
+		realProjectiveSpace
 ///
 
-
 doc ///
-  Key
-    hessenbergVariety
-    (hessenbergVariety,ZZ)
-  Headline
-    Hessenberg variety asscoiated to the n-permutahedron
-  Usage
-    hessenbergVariety(n)
-  Inputs
-    n:ZZ
-  Outputs
-    :SmallCover
-  Description
-   Text
-       Hessenberg variety asscoiated to the n-permutahedron, as small cover.
-  SeeAlso
+	Key
+		hessenbergVariety
+		(hessenbergVariety,ZZ)
+	Headline
+		Hessenberg variety asscoiated to the n-permutahedron
+	Usage
+		hessenbergVariety(n)
+	Inputs
+		n:ZZ
+	Outputs
+		:SmallCover
+	Description
+		Text
+			Hessenberg variety asscoiated to the n-permutahedron, as small
+			cover.
+	SeeAlso
+///
+
+-- test 0
+TEST ///
+	X = complexProjectiveSpace 1
+	assert(X.QTMCharacteristicMatrix == matrix{{1, -1}})
+	assert(bettiQTM X == {1, 0, 1})
+///
+
+-- test 1
+TEST ///
+	X = complexProjectiveSpace 2
+	assert(X.QTMCharacteristicMatrix == matrix{{1, 0, -1}, {0, 1, -1}})
+	assert(bettiQTM X == {1, 0, 1, 0, 1})
+///
+
+-- test 2
+TEST ///
+	X = complexProjectiveSpace 3
+	assert(X.QTMCharacteristicMatrix == matrix{{1, 0, 0, -1}, {0, 1, 0, -1}, {0, 0, 1, -1}})
+	assert(bettiQTM X == {1, 0, 1, 0, 1, 0, 1})
+///
+
+-- test 3
+TEST ///
+	X = realProjectiveSpace 1
+	assert(X.QTMCharacteristicMatrix == sub(matrix{{1, 1}}, ZZ/2))
+	assert(bettiSmallCover X == {1, 1})
+///
+
+-- test 4
+TEST ///
+	X = realProjectiveSpace 2
+	assert(X.QTMCharacteristicMatrix == sub(matrix{{1, 0, 1}, {0, 1, 1}}, ZZ/2))
+	assert(bettiSmallCover X == {1, 0, 0})
+///
+
+-- test 5
+TEST ///
+	X = realProjectiveSpace 3
+	assert(X.QTMCharacteristicMatrix == sub(matrix{{1, 0, 0, 1}, {0, 1, 0, 1}, {0, 0, 1, 1}}, ZZ/2))
+	assert(bettiSmallCover X == {1, 0, 0, 1})
+///
+
+-- test 6
+TEST ///
+	needsPackage "SimplicialComplexes"
+	R = QQ[a..d]
+	K = simplicialComplex {a*b, b*c, c*d, d*a}
+	lambda = matrix{{1, 0, 1, 0}, {0, 1, 0, 1}}
+	X = smallCover(K, lambda) -- 2-torus
+	assert(bettiSmallCover X == {1, 2, 1})
+///
+
+-- test 7
+TEST ///
+	needsPackage "SimplicialComplexes"
+	R = QQ[a..d]
+	K = simplicialComplex {a*b, b*c, c*d, d*a}
+	lambda = matrix{{1, 1, 0, 1}, {0, 1, 1, 1}}
+	X = smallCover(K, lambda) -- klein-bottle
+	assert(bettiSmallCover X == {1, 1, 0})
+///
+
+-- test 8
+TEST ///
+	needsPackage "SimplicialComplexes"
+	R = QQ[a,b]
+	K = simplicialComplex {a, b}
+	Z = momentAngleComplex K
+	assert(bettiMAC Z == {1, 0, 0, 1, 0})
+	assert(eulerMAC Z == 0)
+///
+
+-- test 9
+TEST ///
+	needsPackage "SimplicialComplexes"
+	R = QQ[a,b]
+	K = simplicialComplex {a*b}
+	Z = momentAngleComplex K
+	assert(bettiMAC Z == {1, 0, 0, 0, 0})
+	assert(isFreeModule equivariantCohomology Z)
+	assert(eulerMAC Z == 1)
 ///
 
 end


### PR DESCRIPTION
This PR adds the following to the ToricTopology package

- a new class MomentAngleComplex,
- associated methods to compute
- - equivariant cohomology
- - Betti numbers
- - Euler characteristic
- documentation and examples illustrating these features.

Minor fixes to the rest of the ToricTopology package:
- replaces the variable name 'chi' with 'lambda' as it conflicts with the 'chi' method function defined in core (moreover, λ is more commonly used to denote the characteristic map in toric topology)
- fix bettiQTM so that it doesn't skip the 0th Betti number
- remove trailing whitespaces