### PR TITLE
Temporarily stop using factory from homebrew

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -67,7 +67,8 @@ jobs:
           brew install --overwrite python
           brew install automake bison boost libtool tbb ccache ctags texinfo llvm make ninja yasm libffi msolve googletest fplll eigen
           brew install --only-dependencies macaulay2/tap/M2
-          brew link factory --force
+# TODO: restore this once factory package works again
+#          brew link factory --force
 
 # ----------------------
 #   Install missing tools and libraries for Linux


### PR DESCRIPTION
It's broken until we can rebuild it against the new version of NTL

This hopefully will fix the failing macOS builds.