### PR TITLE
Use factory from brew again

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -67,8 +67,7 @@ jobs:
           brew install --overwrite python
           brew install automake bison boost libtool tbb ccache ctags texinfo llvm make ninja yasm libffi msolve googletest fplll eigen
           brew install --only-dependencies macaulay2/tap/M2
-# TODO: restore this once factory package works again
-#          brew link factory --force
+          brew link factory --force
 
 # ----------------------
 #   Install missing tools and libraries for Linux


### PR DESCRIPTION
We now have a new bottle built against NTL 11.6.0 since https://github.com/Macaulay2/homebrew-tap/pull/291.

This reverts #4022, which was a quick band-aid fix since the macOS builds started to fail just in time for the 1.25.11 PR deadline!