### PR TITLE
Bump eigen to v5.0.1

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -147,8 +147,8 @@ else()
   set(EIGEN_BUILD_TYPE Release)
 endif()
 ExternalProject_Add(build-eigen
-  URL               https://gitlab.com/libeigen/eigen/-/archive/5.0.0/eigen-5.0.0.tar.bz2
-  URL_HASH          SHA256=bdca0ec740fb83be21fe038699923f4c589ead9ab904f4058a9c97752e60d50b
+  URL               https://gitlab.com/libeigen/eigen/-/archive/5.0.0/eigen-5.0.1.tar.bz2
+  URL_HASH          SHA256=f1148db76cba8df51c9624195e5f36bedc2d1eca6c6e4f77b576635c79f9668c
   PREFIX            libraries/eigen
   BINARY_DIR        libraries/eigen/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles

--- a/M2/libraries/eigen/Makefile.in
+++ b/M2/libraries/eigen/Makefile.in
@@ -1,5 +1,5 @@
 HOMEPAGE = https://eigen.tuxfamily.org/
-VERSION = 5.0.0
+VERSION = 5.0.1
 URL = https://gitlab.com/libeigen/eigen/-/archive/$(VERSION)
 TARFILE = eigen-$(VERSION).tar.gz
 LICENSEFILES = COPYING.* README.md


### PR DESCRIPTION
Eigen 5.0.1 was just released.

~~We also drop the required version when checking for eigen in cmake.  The problem is that Eigen 5's cmake config files see a single version number and expect it to match exactly.  Using a range would fix this for Eigen 5, but Eigen 3's cmake config files expect the major version number to match when a range is used, so we can't use something like "3.3...5".~~

Draft for now to test the builds.