### PR TITLE
Document "Citation" option to "document"

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/document-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/document-doc.m2
@@ -33,6 +33,7 @@ Node
     Subnodes=>List
     SourceCode=>List
     ExampleFiles=>List
+    Citation=>List
   Consequences
     Item
       formatted documentation is created and stored in the @TO2 {"currentPackage", "current package"}@
@@ -118,6 +119,7 @@ Node
     [document, Subnodes]
     [document, SourceCode]
     [document, ExampleFiles]
+    [document, Citation]
 
 Node
   Key
@@ -457,6 +459,27 @@ Node
       EXAMPLE { PRE ////ExampleFiles => {"datafile1", "datafile2"}//// }
   SeeAlso
     [newPackage, AuxiliaryFiles]
+///
+
+doc ///
+Node
+  Key
+    Citation
+    [document, Citation]
+  Headline
+    package citation information
+  Description
+    Text
+      This option gives the BibTeX code to be used to cite the package being
+      documented.  Note this is only used in the main documentation node for
+      the package and is ignored otherwise.
+    Code
+      EXAMPLE { PRE ////Citation => {//////@misc{mypkg,
+        author = "John Doe",
+        title = "My Macaulay2 package",
+        year = "2025" }//////}//// }
+  SeeAlso
+    "PackageCitations::cite"
 ///
 
 doc ///

--- a/M2/Macaulay2/packages/PackageCitations.m2
+++ b/M2/Macaulay2/packages/PackageCitations.m2
@@ -310,6 +310,10 @@ doc ///
             user is urged to check for correct spelling and grammar.
       Example
           cite "Bruns"
+      Text
+          To override the automatically generated citation, package authors
+          may provide a @TO "Macaulay2Doc::Citation"@ entry in the main
+          documentation node for a package.
     SeeAlso
         PackageCitations
 ///


### PR DESCRIPTION
We add documentation for the currently undocumented `Citation` option to `document`.  See #3797 and #4031.
