### PR TITLE
Use macos-15 for GitHub builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -39,17 +39,17 @@ jobs:
           - cmake
         os:
           - ubuntu-24.04
-          - macos-14
+          - macos-15
         compiler:
           - default
         include:
           # This build tests Clang rather than AppleClang (keep)
           - build-system: cmake
-            os: macos-14
+            os: macos-15
             compiler: brew-clang
         exclude:
           - build-system: cmake
-            os: macos-14
+            os: macos-15
             compiler: default
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
The macos-latest runners migrated to sequoia a few months ago (https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/).  Now that tahoe has been released, we're currently testing two versions ago.