### PR TITLE
Update testbot dockerfile

### DIFF
--- a/M2/BUILD/docker/testbot/Dockerfile
+++ b/M2/BUILD/docker/testbot/Dockerfile
@@ -1,16 +1,16 @@
 # Time usage: <5min
 # Net usage:  <200MB
-# Disk usage: <800MB
+# Disk usage: <850MB
 
-FROM debian:bookworm
+FROM debian:trixie
 
 LABEL org.opencontainers.image.source=https://github.com/Macaulay2/M2
 
 # Setup the system
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates debian-keyring git && apt-get clean
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget git && apt-get clean
 
 # Install Macaulay2
-RUN echo "deb [signed-by=/usr/share/keyrings/debian-keyring.gpg] https://people.debian.org/~dtorrance/debian bookworm/" >> /etc/apt/sources.list && apt-get update && apt-get install -y --no-install-recommends macaulay2 4ti2 cohomcalg coinor-csdp gfan nauty normaliz topcom msolve && apt-get clean
+RUN wget -O /etc/apt/sources.list.d/macaulay2.sources https://macaulay2.com/Repositories/Debian/trixie/macaulay2.sources && apt-get update && apt-get install -y --no-install-recommends macaulay2 4ti2 cohomcalg coinor-csdp gfan nauty normaliz topcom msolve && apt-get clean
 
 # Add non-root user for using Macaulay2
 RUN useradd -G sudo -g root -u 1000 -m macaulay && echo "macaulay ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
Two changes:
* bookworm -> trixie (released 8/25)
* Use new M2 Debian repo

[ci skip]

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
