### PR TITLE
Add caughtError variable

### DIFF
--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -36,6 +36,8 @@ export applyIteratorS := setupvar("applyIterator", nullE);
 export joinIteratorsS := setupvar("joinIterators", nullE);
 export pairsIteratorS := setupvar("pairsIterator", nullE);
 
+caughtErrorS := setupvarThread("caughtError", nullE);
+
 eval(c:Code):Expr;
 applyEE(f:Expr,e:Expr):Expr;
 export evalAllButTail(c:Code):Code := while true do c = (
@@ -1481,7 +1483,14 @@ export evalraw(c:Code):Expr := (
 	      if tryEvalSuccess then
 	      when ret is Error do ret
 	      else if c.thenClause == NullCode then ret   else eval(c.thenClause)
-	      else if c.elseClause == NullCode then nullE else eval(c.elseClause))
+	      else if c.elseClause == NullCode then nullE else (
+		  when ret
+		  is err:Error do setGlobalVariable(caughtErrorS,
+		      seq(locate(err.position), toExpr(err.message)))
+		  else nothing; -- shouldn't happen
+		  p := eval(c.elseClause);
+		  setGlobalVariable(caughtErrorS, nullE);
+		  p))
 	  is c:catchCode do (
 	       p := eval(c.code);
 	       when p is err:Error do if err.message == throwMessage then err.value else p

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -532,6 +532,7 @@ export {
 	"cancelTask",
 	"capture",
 	"catch",
+	"caughtError",
 	"ceiling",
 	"centerString",
 	"changeBase",

--- a/M2/Macaulay2/packages/JSONRPC.m2
+++ b/M2/Macaulay2/packages/JSONRPC.m2
@@ -16,14 +16,28 @@
 
 newPackage("JSONRPC",
     Headline => "JSON-RPC server",
-    Version => "0.1",
-    Date => "May 19, 2025",
+    Version => "0.2",
+    Date => "December 1, 2025",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
     Keywords => {"System"},
     PackageImports => {"JSON"})
+
+---------------
+-- ChangeLog --
+---------------
+
+-*
+
+0.2 (2025-12-01, M2 1.26.05)
+* Use caughtError for error messages
+
+0.1 (2025-05-19, M2 1.25.11)
+* Initial release
+
+*-
 
 export {
     -- classes
@@ -139,12 +153,10 @@ callMethod(JSONRPCMethod, List, Thing) := (m, params, ID) -> (
 	    i -> if i >= #params then null else params#i)
 	else params);
     if #inp == 1 then inp = inp#0;
+    -- TODO: validate params and throw the following if they're bad:
+    -- JSONRPCError(-32602, "Invalid params")
     r := (try m#"function" inp
-	-- TODO: use lastError here once it's available
-	-- afterwards, validate params and only throw this
-	-- error when they're bad
-	-- also update JSONRPCError doc node
-	else JSONRPCError(-32602, "Invalid params"));
+	else JSONRPCError(-32603, "Internal error: " | caughtError#1));
     if instance(r, JSONRPCError)
     then m#"server"#"logger" concatenate(
 	"method \"", m#"name", "\" failed with error: ", toJSON r)
@@ -383,21 +395,13 @@ doc ///
       data. This class ensures that errors are properly formatted according to
       the JSON-RPC 2.0 specification and can be easily included in responses to
       clients.
-
-      Consider the following example.  The default response doesn't include a
-      very useful error message.
     Example
       server = new JSONRPCServer
-      registerMethod(server, "divide", (x, y) -> x/y)
-      handleRequest(server, makeRequest("divide", {1, 0}, 1))
-    Text
-      Let's replace it with a more useful one.
-    Example
       registerMethod(server, "divide", (x, y) -> (
 	      if zero y then JSONRPCError(-32001, "division by zero")
 	      else x/y))
       handleRequest(server, makeRequest("divide", {1, 0}, 1))
-      handleRequest(server, makeRequest("divide", {22, 7}, 1))
+      handleRequest(server, makeRequest("divide", {22, 7}, 2))
     Text
       Note that the error codes -32000 to -32099 are reserved for use by
       JSON-RPC servers, so @CODE "errCode"@ should lie in this interval

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_debugging.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_debugging.m2
@@ -327,6 +327,23 @@ document {
 	  }
      }
 
+doc ///
+  Key
+    "caughtError"
+  Headline
+    the error caught by try
+  Description
+    Text
+      In order to reach the @M2CODE "else"@ clause of a @TO symbol try@
+      statement, an error must have occurred.  Information about this error is
+      stored in the @M2CODE "caughtError"@ variable as a sequence with
+      two elements, the position of the code where the error occurred
+      (as a @TO FilePosition@ object) and the error message.
+    Example
+      try 1/0 else caughtError
+  SeeAlso
+    symbol try
+///
 
 document {
      Key => "recursionLimit",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_language.m2
@@ -704,6 +704,7 @@ document {
 	  TO "error",
 	  TO "try",
 	  TO "throw",
+	  TO "caughtError",
 	  }
      }
 
@@ -732,8 +733,10 @@ document {
      PARA{},
      "The behavior of interrupts (other than alarms) is unaffected.",
      EXAMPLE "apply(-3..3,i->try 1/i else infinity)",
-     Caveat => "We will change the behavior of this function soon so that it will be possible to catch errors of a particular type.  Meanwhile, users are
-     recommended to use this function sparingly, if at all."
+     "Information about a caught error may be obtained in the ", M2CODE "else",
+     " clause using the variable ", TO "caughtError", ".",
+     EXAMPLE "try 1/0 else caughtError",
+     SeeAlso => {"caughtError"}
      }
 
 document {

--- a/M2/Macaulay2/tests/normal/error-messages.m2
+++ b/M2/Macaulay2/tests/normal/error-messages.m2
@@ -1,3 +1,5 @@
+assert try error "foo" else caughtError#1 == "foo"
+
 stderr << "--testing the error messages must be done manually" << endl
 end
 


### PR DESCRIPTION
This is a simple alternative to `lastError` (see #3654).  Rather than setting a variable every single time we raise an error (which ended up slowing down Macaulay2 considerably, hence #3912), we set it only during the `else` clause of a `try` statement.

For example:
```m2
i1 : try 1/0 else caughtError

o1 = (stdio:1:4-1:7, division by zero)

o1 : Sequence
```

As a proof of concept, we use it in the *JSONRPC* package for improved error messages:

```m2
i1 : needsPackage "JSONRPC";

i2 : server = new JSONRPCServer;

i3 : registerMethod(server, "divide", (x,y) -> x/y);

i4 : handleRequest(server, makeRequest("divide", {1, 0}, 1))

o4 = {"error": {"code": -32603, "message": "Internal error: division by zero"},
     "jsonrpc": "2.0", "id": 1}
```