### PR TITLE
Use an atomic hash counter

### DIFF
--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -22,20 +22,13 @@ threadLocal export recursionDepth := 0;
 --Maximum function depth before triggering errors
 threadLocal export recursionLimit := 300;
 
-
-threadCounter := 0;
-threadLocal HashCounter := (
-    threadCounter = threadCounter + 1;
-    hash_t(1000000 + 3 + (threadCounter-1) * 10000 ));
--- give 32-bit machines enough space to store a 64-bit hash code
--- TODO: instead, allow 64-bit entries in the array of thread local variables
-threadLocal HashCounterExtraBits := 0;
+header "_Atomic uint64_t HashCounter = 1000004;";
 
 export nextHash():hash_t := (
-     if HashCounter == Ccode(hash_t, "18446744073709551615ull") -- check for integer overflow
+     currentHash := Ccode(hash_t, "atomic_load(&HashCounter)");
+     if currentHash ==  Ccode(hash_t, "18446744073709551615ull") -- check for integer overflow
      then Ccode(void, " fprintf(stderr, \" *** hash code serial number counter overflow (too many mutable objects created)\\n\"); abort(); ");
-     HashCounter = HashCounter + 1;
-     HashCounter);
+     Ccode(hash_t, "atomic_fetch_add(&HashCounter, 1)"));
 
 ------------------------------------------------------------
 -- hash codes for mutable objects that don't use nextHash --

--- a/M2/Macaulay2/tests/normal/threads.m2
+++ b/M2/Macaulay2/tests/normal/threads.m2
@@ -87,6 +87,10 @@ assert Equation(getIOThreadMode f, 2)
 
 removeFile fn
 
+-- issue #3358
+Foo = taskResult schedule(() -> new Type of HashTable)
+assert BinaryOperation(symbol ===, youngest(Foo, Matrix), Foo)
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test threads.out"
 -- End:


### PR DESCRIPTION
Previously, it was thread-local, which meant that mutable objects created in threads might not be "younger" than older objects created in other threads.

This also has the added advantage of avoiding the hack from #3359 we needed for 32-bit systems.

Closes: #3358

### Before:
```m2
i1 : Foo = taskResult schedule(() -> new Type of HashTable);

i2 : youngest(Foo, Matrix)

o2 = Matrix
```

### After:
```m2
i1 : Foo = taskResult schedule(() -> new Type of HashTable);

i2 : youngest(Foo, Matrix)

o2 = Foo
```
