### PR TITLE
better WebApp mode support for Python

### DIFF
--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -17,7 +17,8 @@ newPackage("Python",
     Keywords => {"Interfaces"},
     PackageImports => {"Text"},
     AuxiliaryFiles => true,
-    OptionalComponentsPresent => Core#"private dictionary"#?"pythonTrue"
+    OptionalComponentsPresent => Core#"private dictionary"#?"pythonTrue",
+    UseCachedExampleOutput => true,
     )
 
 ---------------

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -146,13 +146,14 @@ pythonInitialize(ZZ#"Python executable" = executable)
 
 pythonHelp = Command (() -> builtins@@help())
 
-expression PythonObject := expression @@ pythonUnicodeAsUTF8 @@ pythonObjectStr
-toString PythonObject := toString @@ expression
-net PythonObject := net @@ expression
-texMath PythonObject := texMath @@ expression
+toString PythonObject := pythonUnicodeAsUTF8 @@ pythonObjectStr
+net PythonObject := net @@ toString
+texMath PythonObject := texMath @@ toString
+hypertext PythonObject := x -> SAMP { toString x, "class" => "language-python" }
+html PythonObject := html @@ hypertext
 
 describe PythonObject := x -> Describe FunctionApplication(pythonValue,
-    expression x@@"__repr__"())
+    toString x@@"__repr__"())
 toExternalString PythonObject := toExternalFormat @@ describe
 
 typename = x -> (
@@ -608,6 +609,14 @@ installNumPyMethods = () -> (
     np)
 
 load "Python/doc.m2"
+
+-- if in WebAppp mode, let's also import matplotlib and change the backend
+if topLevelMode === WebApp then try (
+    sys@@"path"@@append Python#"auxiliary files";
+    mpl := pythonImportImportModule "matplotlib";
+    mpl@@use "module://m2web_backend";
+)
+
 
 TEST ///
 -----------

--- a/M2/Macaulay2/packages/Python/doc/string.m2
+++ b/M2/Macaulay2/packages/Python/doc/string.m2
@@ -1,7 +1,6 @@
 doc ///
   Key
     (toString, PythonObject)
-    (expression, PythonObject)
     (net, PythonObject)
     (texMath, PythonObject)
   Headline

--- a/M2/Macaulay2/packages/Python/doc/tutorials.m2
+++ b/M2/Macaulay2/packages/Python/doc/tutorials.m2
@@ -130,28 +130,6 @@ doc ///
     installNumPyMethods
 ///
 
--* code for canned example
-
-pycode = get(Python#"auxiliary files" | "doc/matplotlib-example.py")
-pythonRunScript pycode
-
-matplotlib = PythonContext "import matplotlib.pyplot as plt"
-matplotlib "import numpy as np"
-matplotlib "fig = plt.figure()"
-matplotlib "ax = fig.add_subplot(projection='3d')"
-matplotlib "t = np.linspace(-10, 10, 100)"
-matplotlib "ax.plot(t, t**2, t**3)"
-matplotlib "plt.show()"
-
-plt = import "matplotlib.pyplot"
-np = import "numpy"
-fig = plt@@figure()
-ax = fig@@"add_subplot"(projection => "3d")
-t = np@@linspace(-10, 10, 100);
-ax@@plot(t, t^2, t^3)
-plt@@show()
-
-*-
 
 doc ///
   Key
@@ -173,51 +151,22 @@ doc ///
       way is with the @TO pythonRunScript@ method.
 
       For this example, we have our code saved as a .py file.
-    CannedExample
-      i1 : pycode = get(Python#"auxiliary files" | "doc/matplotlib-example.py")
-
-      o1 = import matplotlib.pyplot as plt
-           import numpy as np
-
-           fig = plt.figure()
-           ax = fig.add_subplot(projection='3d')
-           t = np.linspace(-10, 10, 100)
-           ax.plot(t, t**2, t**3)
-           plt.show()
-
-
-      i2 : pythonRunScript pycode
+    Example
+     pycode = get(Python#"auxiliary files" | "doc/matplotlib-example.py")
+     pythonRunScript pycode
     Text
       @HEADER2 "Using a PythonContext"@
 
       @TO PythonContext@ objects allow us to run Python code one line at a
       time, just like working in the Python REPL.
-    CannedExample
-      i3 : matplotlib = PythonContext "import matplotlib.pyplot as plt"
-
-      o3 = matplotlib
-
-      o3 : PythonContext
-
-      i4 : matplotlib "import numpy as np"
-
-      i5 : matplotlib "fig = plt.figure()"
-
-      i6 : matplotlib "ax = fig.add_subplot(projection='3d')"
-
-      i7 : matplotlib "t = np.linspace(-10, 10, 100)"
-
-      i8 : matplotlib "ax.plot(t, t**2, t**3)"
-
-      o8 = [<mpl_toolkits.mplot3d.art3d.Line3D object at 0x7b8243b7e5f0>]
-
-      o8 : PythonObject of class list
-
-      i9 : matplotlib "plt.show()"
-
-      o9 = None
-
-      o9 : PythonObject of class NoneType
+    Example
+     matplotlib = PythonContext "import matplotlib.pyplot as plt"
+     matplotlib "import numpy as np"
+     matplotlib "fig = plt.figure()"
+     matplotlib "ax = fig.add_subplot(projection='3d')"
+     matplotlib "t = np.linspace(-10, 10, 100)"
+     matplotlib "ax.plot(t, t**2, t**3)"
+     matplotlib "plt.show()"
     Text
       @HEADER2 "Using PythonObjects directly"@
 
@@ -227,19 +176,9 @@ doc ///
       First, we import the necessary modules using @TO import@.  Note that
       we can essentially replace the Python @CODE "import foo as bar"@ with
       @CODE "bar = import \"foo\""@.
-    CannedExample
-      i10 : plt = import "matplotlib.pyplot"
-
-      o10 = <module 'matplotlib.pyplot' from
-            '/usr/lib/python3/dist-packages/matplotlib/pyplot.py'>
-
-      o10 : PythonObject of class module
-
-      i11 : np = import "numpy"
-
-      o11 = <module 'numpy' from '/usr/lib/python3/dist-packages/numpy/__init__.py'>
-
-      o11 : PythonObject of class module
+    Example
+     plt = import "matplotlib.pyplot"
+     np = import "numpy"
     Text
       Next, we begin to create the various Python objects needed for our
       plot.
@@ -249,34 +188,20 @@ doc ///
       (see @TO (symbol \@\@, PythonObject, Thing)@).
       We need to be careful for attributes that include underscores.
       They must given as strings, i.e., delimited using quotes.
-    CannedExample
-      i12 : fig = plt@@figure()
-
-      o12 = Figure(640x480)
-
-      o12 : PythonObject of class matplotlib.figure.Figure
-
-      i13 : ax = fig@@"add_subplot"(projection => "3d")
-
-      o13 = Axes3DSubplot(0.125,0.11;0.775x0.77)
-
-      o13 : PythonObject of class matplotlib.axes._subplots.Axes3DSubplot
-
-      i14 : t = np@@linspace(-10, 10, 100);
+    Example
+      fig = plt@@figure()
+      ax = fig@@"add_subplot"(projection => "3d")
+      t = np@@linspace(-10, 10, 100);
     Text
       Now we construct the twisted cubic.  Note that even though Python itself
       uses @CODE "**"@ for exponentiation, we may use @TO symbol ^@ for
       consistency with the rest of Macaulay2.
-    CannedExample
-      i15 : ax@@plot(t, t^2, t^3)
-
-      o15 = [<mpl_toolkits.mplot3d.art3d.Line3D object at 0x73a51970eb00>]
-
-      o15 : PythonObject of class list
+    Example
+      ax@@plot(t, t^2, t^3)
     Text
       Finally, we show our plot.
-    CannedExample
-      i16 : plt@@show()
+    Example
+      plt@@show()
     Text
       All three of the above methods should have resulted in a window
       appearing containing the following image.

--- a/M2/Macaulay2/packages/Python/examples/___Python_sptutorial_co_spplotting_spthe_sptwisted_spcubic_spwith_sp__Matplotlib.out
+++ b/M2/Macaulay2/packages/Python/examples/___Python_sptutorial_co_spplotting_spthe_sptwisted_spcubic_spwith_sp__Matplotlib.out
@@ -1,0 +1,139 @@
+-- -*- M2-comint -*- hash: 9426046357703022608
+
+i1 : pycode = get(Python#"auxiliary files" | "doc/matplotlib-example.py")
+
+o1 = import matplotlib.pyplot as plt
+     import numpy as np
+
+     fig = plt.figure()
+     ax = fig.add_subplot(projection='3d')
+     t = np.linspace(-10, 10, 100)
+     ax.plot(t, t**2, t**3)
+     plt.show()
+
+
+i2 : pythonRunScript pycode
+
+o2 = {'plt': <module 'matplotlib.pyplot'
+             -9.19191919,  -8.98989899, 
+             -8.38383838,  -8.18181818, 
+             -7.57575758,  -7.37373737, 
+             -6.76767677,  -6.56565657, 
+             -5.95959596,  -5.75757576, 
+             -5.15151515,  -4.94949495, 
+             -4.34343434,  -4.14141414, 
+             -3.53535354,  -3.33333333, 
+             -2.72727273,  -2.52525253, 
+             -1.91919192,  -1.71717172, 
+             -1.11111111,  -0.90909091, 
+             -0.3030303 ,  -0.1010101 , 
+              0.50505051,   0.70707071, 
+              1.31313131,   1.51515152, 
+              2.12121212,   2.32323232, 
+              2.92929293,   3.13131313, 
+              3.73737374,   3.93939394, 
+              4.54545455,   4.74747475, 
+              5.35353535,   5.55555556, 
+              6.16161616,   6.36363636, 
+              6.96969697,   7.17171717, 
+              7.77777778,   7.97979798, 
+              8.58585859,   8.78787879, 
+              9.39393939,   9.5959596 , 
+     from '/usr/lib/python3/dist-packages/matplotlib/pyplot.py'>, 'np':
+     -8.78787879,  -8.58585859,
+     -7.97979798,  -7.77777778,
+     -7.17171717,  -6.96969697,
+     -6.36363636,  -6.16161616,
+     -5.55555556,  -5.35353535,
+     -4.74747475,  -4.54545455,
+     -3.93939394,  -3.73737374,
+     -3.13131313,  -2.92929293,
+     -2.32323232,  -2.12121212,
+     -1.51515152,  -1.31313131,
+     -0.70707071,  -0.50505051,
+      0.1010101 ,   0.3030303 ,
+      0.90909091,   1.11111111,
+      1.71717172,   1.91919192,
+      2.52525253,   2.72727273,
+      3.33333333,   3.53535354,
+      4.14141414,   4.34343434,
+      4.94949495,   5.15151515,
+      5.75757576,   5.95959596,
+      6.56565657,   6.76767677,
+      7.37373737,   7.57575758,
+      8.18181818,   8.38383838,
+      8.98989899,   9.19191919,
+      9.7979798 ,  10.        ])}
+     <module 'numpy' from '/usr/lib/python3/dist-packages/numpy/__init__.py'
+     >, 'fig': <Figure size 640x480 with 1 Axes>, 'ax': <Axes3DSubplot: >,
+     't': array([-10.        ,  -9.7979798 ,  -9.5959596 ,  -9.39393939,
+
+o2 : PythonObject of class dict
+
+i3 : matplotlib = PythonContext "import matplotlib.pyplot as plt"
+
+o3 = matplotlib
+
+o3 : PythonContext
+
+i4 : matplotlib "import numpy as np"
+
+i5 : matplotlib "fig = plt.figure()"
+
+i6 : matplotlib "ax = fig.add_subplot(projection='3d')"
+
+i7 : matplotlib "t = np.linspace(-10, 10, 100)"
+
+i8 : matplotlib "ax.plot(t, t**2, t**3)"
+
+o8 = [<mpl_toolkits.mplot3d.art3d.Line3D object at 0x7187d20db740>]
+
+o8 : PythonObject of class list
+
+i9 : matplotlib "plt.show()"
+
+o9 = None
+
+o9 : PythonObject of class NoneType
+
+i10 : plt = import "matplotlib.pyplot"
+
+o10 = <module 'matplotlib.pyplot' from
+      '/usr/lib/python3/dist-packages/matplotlib/pyplot.py'>
+
+o10 : PythonObject of class module
+
+i11 : np = import "numpy"
+
+o11 = <module 'numpy' from '/usr/lib/python3/dist-packages/numpy/__init__.py'
+      >
+
+o11 : PythonObject of class module
+
+i12 : fig = plt@@figure()
+
+o12 = Figure(640x480)
+
+o12 : PythonObject of class matplotlib.figure.Figure
+
+i13 : ax = fig@@"add_subplot"(projection => "3d")
+
+o13 = Axes3DSubplot(0.125,0.11;0.775x0.77)
+
+o13 : PythonObject of class matplotlib.axes._subplots.Axes3DSubplot
+
+i14 : t = np@@linspace(-10, 10, 100);
+
+i15 : ax@@plot(t, t^2, t^3)
+
+o15 = [<mpl_toolkits.mplot3d.art3d.Line3D object at 0x7187d1971b50>]
+
+o15 : PythonObject of class list
+
+i16 : plt@@show()
+
+o16 = None
+
+o16 : PythonObject of class NoneType
+
+i17 : 

--- a/M2/Macaulay2/packages/Python/m2web_backend.py
+++ b/M2/Macaulay2/packages/Python/m2web_backend.py
@@ -1,0 +1,99 @@
+import io
+import sys
+import base64
+
+# Compatibility import for different Matplotlib versions
+try:
+    from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase
+except ImportError:
+    from matplotlib.backends.backend_bases import FigureManagerBase, FigureCanvasBase
+
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.backends.backend_svg import FigureCanvasSVG
+
+ASCII_START = chr(17)   # DC1
+ASCII_END   = chr(18)   # DC2
+
+# GLOBAL CONFIGURABLE OPTION
+# Valid values: "png", "svg"
+output_format = "svg"     # default
+
+
+def _emit_html(html):
+    sys.stdout.buffer.write((ASCII_START + html + ASCII_END).encode("utf-8"))
+    sys.stdout.buffer.flush()
+
+
+class FigureCanvas(FigureCanvasBase):
+    """
+    Thin wrapper that delegates to either Agg or SVG canvas depending
+    on the chosen output_format.
+    """
+
+    def print_m2web(self, figure):
+        global output_format
+
+        buf = io.BytesIO()
+
+        # Always create a fresh underlying renderer
+        if output_format == "svg":
+            real = FigureCanvasSVG(figure)
+            real.draw()
+            real.print_svg(buf)
+            svg = buf.getvalue().decode("utf-8")
+            html = f"<div>{svg}</div>"
+            _emit_html(html)
+
+        else:  # PNG
+            real = FigureCanvasAgg(figure)
+            real.draw()
+            real.print_png(buf)
+            data = base64.b64encode(buf.getvalue()).decode("ascii")
+            html = f'<img src="data:image/png;base64,{data}" />'
+            _emit_html(html)
+
+
+class FigureManager(FigureManagerBase):
+    pass
+
+
+def show():
+    """
+    Replacement for pyplot.show(): render + emit all figures.
+    """
+    import matplotlib._pylab_helpers as helpers
+    for manager in helpers.Gcf.get_all_fig_managers():
+        canvas = manager.canvas
+        canvas.draw()
+        canvas.print_m2web(canvas.figure)
+
+
+# --- Backend registration hook ---
+# Matplotlib expects FigureCanvas to be an actual real renderer subclass.
+# We dynamically build wrapper instances here.
+
+def new_figure_manager(num, *args, **kwargs):
+    from matplotlib.figure import Figure
+
+    # Matplotlib may pass a custom figure class
+    FigureClass = kwargs.pop("FigureClass", Figure)
+
+    # Case 1: pyplot already created the Figure instance
+    if args and isinstance(args[0], Figure):
+        figure = args[0]
+
+    else:
+        # Case 2: backend must construct the figure
+        figure = FigureClass(*args, **kwargs)
+
+    # Choose actual underlying renderer (Agg or SVG)
+    if output_format == "svg":
+        real_canvas = FigureCanvasSVG(figure)
+    else:
+        real_canvas = FigureCanvasAgg(figure)
+
+    # Wrapper canvas
+    canvas = FigureCanvas(figure)
+
+    manager = FigureManager(canvas, num)
+    return manager


### PR DESCRIPTION
this is work in progress to improve the display of the `Python` package in `WebApp` mode:
- slight improvement to existing output routines
- new backend for matplotlib, automatically loaded when package is loaded in `WebApp` mode
- uncanned an example, though it may need to be cached (uses matplotlib)