### PR TITLE
Simplify printing of matrix expressions

### DIFF
--- a/M2/Macaulay2/m2/expressions.m2
+++ b/M2/Macaulay2/m2/expressions.m2
@@ -933,8 +933,8 @@ toCompactString Divide := x -> toCompactParen x#0 | "/" | toCompactParen x#1
 
 net MatrixExpression := x -> (
     (opts,m) := matrixOpts x;
+    if opts.zero =!= null then return "0";
     blk := opts.Blocks =!= null; -- whether to display blocks
-    if all(m,r->all(r,i->class i===ZeroExpression)) then return "0";
     net1 := if compactMatrixForm then toCompactString else net;
     vbox0 := if opts.Degrees === null then 0 else 1;
     (hbox,vbox) := if blk then (drop(accumulate(plus,0,opts.Blocks#0),-1),prepend(vbox0,accumulate(plus,vbox0,opts.Blocks#1))) else (false,{vbox0,vbox0+#m#0});
@@ -1135,7 +1135,7 @@ texMath Table := m -> (
 
 texMath MatrixExpression := x -> (
     (opts,m) := matrixOpts x;
-    if all(m,r->all(r,i->class i===ZeroExpression)) then return "0";
+    if opts.zero =!= null then return "0";
     blk := opts.Blocks =!= null; -- whether to display blocks
     if blk then ( j := 0; h := 0; );
     m = applyTable(m,texMath);


### PR DESCRIPTION
We don't store the entries of zero matrices any more (see #3726), so there's no reason to check if all the entries are zero.  Instead, check for the existence of a `zero` key.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
