### PR TITLE
Bump Eigen to versions 3.4.0 through 5.0.0

### DIFF
--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -166,7 +166,6 @@ target_include_directories(M2-interpreter
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Macaulay2/e/mathic>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Macaulay2/e/memtailor>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Macaulay2/e/mathicgb>
-    $<BUILD_INTERFACE:$<TARGET_PROPERTY:Eigen3::Eigen,INTERFACE_INCLUDE_DIRECTORIES>>
     # for libraries that the interpreter needs
     $<BUILD_INTERFACE:${READLINE_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${LIBXML2_INCLUDE_DIR}>
@@ -193,6 +192,10 @@ foreach(LIB IN LISTS LIBRARIES_LIST)
         "$<BUILD_INTERFACE:${${LIB}_INCLUDE_DIR}>")
   endif()
 endforeach()
+
+if(TARGET Eigen3::Eigen)
+  target_include_directories(M2-interpreter PUBLIC $<BUILD_INTERFACE:$<TARGET_PROPERTY:Eigen3::Eigen,INTERFACE_INCLUDE_DIRECTORIES>>)
+endif()
 
 foreach(LIB IN LISTS LIBRARY_LIST)
   if(${LIB}_FOUND)

--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -151,11 +151,6 @@ target_link_libraries(M2-interpreter PRIVATE M2-supervisor
   $<$<BOOL:${WITH_TBB}>:TBB::tbb>
   $<$<BOOL:${WITH_FFI}>:FFI::ffi>)
 
-if(EIGEN3_FOUND)
-  #version.d is using an Eigen header it can't find without this line
-  target_link_libraries(M2-interpreter PRIVATE Eigen3::Eigen)
-endif()
-
 # TODO: c.f. https://github.com/Macaulay2/M2/issues/2682
 if(NOT APPLE)
   target_link_libraries(M2-interpreter PRIVATE quadmath)
@@ -171,10 +166,10 @@ target_include_directories(M2-interpreter
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Macaulay2/e/mathic>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Macaulay2/e/memtailor>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Macaulay2/e/mathicgb>
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:Eigen3::Eigen,INTERFACE_INCLUDE_DIRECTORIES>>
     # for libraries that the interpreter needs
     $<BUILD_INTERFACE:${READLINE_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${LIBXML2_INCLUDE_DIR}>
-    $<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include/Macaulay2>
     $<$<BOOL:${WITH_PYTHON}>:$<BUILD_INTERFACE:${Python3_INCLUDE_DIRS}>>
   PRIVATE

--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -151,6 +151,11 @@ target_link_libraries(M2-interpreter PRIVATE M2-supervisor
   $<$<BOOL:${WITH_TBB}>:TBB::tbb>
   $<$<BOOL:${WITH_FFI}>:FFI::ffi>)
 
+if(EIGEN3_FOUND)
+  #version.d is using an Eigen header it can't find without this line
+  target_link_libraries(M2-interpreter PRIVATE Eigen3::Eigen)
+endif()
+
 # TODO: c.f. https://github.com/Macaulay2/M2/issues/2682
 if(NOT APPLE)
   target_link_libraries(M2-interpreter PRIVATE quadmath)

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -127,6 +127,10 @@ find_package(GMP	6.0.0 REQUIRED)
 #   givaro	prime field and algebraic computations	(needs gmp)
 #  fflas_ffpack	Finite Field Linear Algebra Routines	(needs gmp, givaro + LAPACK)
 
+# Prior to 3.4.1, find_package for Eigen3 doesn't support version ranges
+# but Ubuntu only has 3.4.0 right now, so we should support it
+# For Eigen 5.0 and later, the way the version checking is setup, specifying
+# a version of 3.4.0 or similar won't find version 5.0
 find_package(Eigen3	3.4.0 PATHS ${M2_HOST_PREFIX})
 if(NOT EIGEN3_FOUND)
   find_package(Eigen3	3.4.1...5.0 PATHS ${M2_HOST_PREFIX})

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -127,7 +127,13 @@ find_package(GMP	6.0.0 REQUIRED)
 #   givaro	prime field and algebraic computations	(needs gmp)
 #  fflas_ffpack	Finite Field Linear Algebra Routines	(needs gmp, givaro + LAPACK)
 
-find_package(Eigen3	3.3.0 PATHS ${M2_HOST_PREFIX})
+find_package(Eigen3	3.4...5.0 PATHS ${M2_HOST_PREFIX})
+# FindEigen3 doesn't set EIGEN3_FOUND, and instead we should check
+# if the target Eigen3::Eigen is defined, so we set EIGEN3_FOUND
+# for compatibility with the rest of the build code
+if(TARGET Eigen3::Eigen)
+  set(EIGEN3_FOUND TRUE)
+endif (TARGET Eigen3::Eigen)
 find_package(BDWGC	7.6.4)
 find_package(MPFR	4.0.1)
 find_package(MPFI	1.5.1)

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -127,13 +127,16 @@ find_package(GMP	6.0.0 REQUIRED)
 #   givaro	prime field and algebraic computations	(needs gmp)
 #  fflas_ffpack	Finite Field Linear Algebra Routines	(needs gmp, givaro + LAPACK)
 
-find_package(Eigen3	3.4...5.0 PATHS ${M2_HOST_PREFIX})
-# FindEigen3 doesn't set EIGEN3_FOUND, and instead we should check
-# if the target Eigen3::Eigen is defined, so we set EIGEN3_FOUND
-# for compatibility with the rest of the build code
-if(TARGET Eigen3::Eigen)
-  set(EIGEN3_FOUND TRUE)
-endif (TARGET Eigen3::Eigen)
+find_package(Eigen3	3.4.0 PATHS ${M2_HOST_PREFIX})
+if(NOT EIGEN3_FOUND)
+  find_package(Eigen3	3.4.1...5.0 PATHS ${M2_HOST_PREFIX})
+  # FindEigen3 doesn't set EIGEN3_FOUND, and instead we should check
+  # if the target Eigen3::Eigen is defined, so we set EIGEN3_FOUND
+  # for compatibility with the rest of the build code
+  if(TARGET Eigen3::Eigen)
+    set(EIGEN3_FOUND TRUE)
+  endif()
+endif()
 find_package(BDWGC	7.6.4)
 find_package(MPFR	4.0.1)
 find_package(MPFI	1.5.1)


### PR DESCRIPTION
Eigen changed how their versioning works, so the new version is version 5.0.0. They still use Eigen3 as the name in cmake it seems. See https://libeigen.gitlab.io/news/eigen_5.0.0_released/ for the release, it doesn't seem they made any notable breaking changes, the main change being a bump in the required c++ version which we also satisfy.

A draft pull request for now since I've only looked at the cmake build and I haven't tried testing it with older Eigen versions to make sure that the compile still works. We might also have to update the github actions