### PR TITLE
Don't install .gitignore files in package directories

### DIFF
--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -719,7 +719,7 @@ installPackage Package := opts -> pkg -> (
 	    verboseLog("copying auxiliary source files from ", auxiliaryFilesDirectory);
 	    makeDirectory(installPrefix | srcDirectory);
 	    copyDirectory(auxiliaryFilesDirectory, installPrefix | srcDirectory,
-		Exclude    => {"^CVS$", "^\\.svn$", "Makefile"},
+		Exclude    => {"^CVS$", "^\\.svn$", "Makefile", "^\\.gitignore$"},
 		UpdateOnly => true,
 		Verbose    => opts.Verbose or debugLevel > 0))
 	else if pkgopts.AuxiliaryFiles


### PR DESCRIPTION
The one for the *Visualize* package is currently causing a [Lintian warning](https://udd.debian.org/lintian-tag/package-contains-vcs-control-file) in the Debian package.