### PR TITLE
Fix a couple xml deprecation warnings

### DIFF
--- a/M2/Macaulay2/d/M2.d
+++ b/M2/Macaulay2/d/M2.d
@@ -54,7 +54,7 @@ export tocharstar(s:string):charstar := tocharstarn(s, length(s));
 export tocharstarOrNull(s:string):charstarOrNull := (
     if length(s) == 0 then charstarOrNull(null())
     else charstarOrNull(tocharstar(s)));
-export tostringn(s:charstar,n:int):string := Ccode(returns, "
+export tostringn(s:constcharstar,n:int):string := Ccode(returns, "
   M2_string p = (M2_string)getmem_atomic(sizeofarray(p,n));
   p->len = n;
   memcpy(p->array,s,n);

--- a/M2/Macaulay2/d/xml-c.c
+++ b/M2/Macaulay2/d/xml-c.c
@@ -70,10 +70,17 @@ xmlNode *xml_AddText(xmlNode *parent, M2_string content){
 
 M2_string xml_toString(xmlNode *n) {
   M2_string s;
-  xmlBuffer *buf = xmlBufferCreate();
-  int len = xmlNodeDump(buf,NULL,n,2,1);
-  s = M2_tostringn((char*)buf->content,len);
-  xmlBufferFree(buf);
+  xmlOutputBuffer *buf;
+  const xmlChar* content;
+  int len;
+
+  buf = xmlAllocOutputBuffer(NULL);
+  xmlNodeDumpOutput(buf, n->doc, n, 2, 1, NULL);
+  content = xmlOutputBufferGetContent(buf);
+  len = xmlOutputBufferGetSize(buf);
+  s = M2_tostringn((const char *)content, len);
+  xmlOutputBufferClose(buf);
+
   return s;
 }
 

--- a/M2/Macaulay2/d/xml-c.c
+++ b/M2/Macaulay2/d/xml-c.c
@@ -18,7 +18,10 @@ static char *copystring(const char *s) {
 
 static void initxml() __attribute__ ((constructor));
 static void initxml() {
-  xmlGcMemSetup(freemem,(void *(*)(size_t))getmem,(void *(*)(size_t))getmem_atomic,(void *(*)(void *,size_t))getmoremem1,copystring);
+  xmlMemSetup((xmlFreeFunc) freemem,
+	      (xmlMallocFunc) getmem,
+	      (xmlReallocFunc) getmoremem1,
+	      (xmlStrdupFunc) copystring);
 }
 
 

--- a/M2/Macaulay2/e/unit-tests/M2-replacement.c
+++ b/M2/Macaulay2/e/unit-tests/M2-replacement.c
@@ -39,7 +39,7 @@ M2_string M2_tostring(M2_constcharstarOrNull s)
   //GC_CHECK_CLOBBER(p);
   return p;
 }
-M2_string M2_tostringn(char *s, int n)
+M2_string M2_tostringn(const char *s, int n)
 {
     M2_string p = (M2_string)getmem_atomic(sizeofarray(p,n));
     p->len = n;


### PR DESCRIPTION
This fixes the following compiler warnings when building with newer versions of libxml2:

```c
CC xml-c.c
../../../../Macaulay2/d/xml-c.c: In function 'initxml':
../../../../Macaulay2/d/xml-c.c:21:3: warning: 'xmlGcMemSetup' is deprecated: See https://gnome.pages.gitlab.gnome.org/libxml2/html/deprecated.html [-Wdeprecated-declarations]
   21 |   xmlGcMemSetup(freemem,(void *(*)(size_t))getmem,(void *(*)(size_t))getmem_atomic,(void *(*)(void *,size_t))getmoremem1,copystring);
      |   ^~~~~~~~~~~~~
In file included from /usr/include/libxml2/libxml/tree.h:33,
                 from /usr/include/libxml2/libxml/parser.h:20,
                 from ./xml-exports.h:12,
                 from ../../../../Macaulay2/d/xml-c.c:8:
/usr/include/libxml2/libxml/xmlmemory.h:130:9: note: declared here
  130 |         xmlGcMemSetup   (xmlFreeFunc freeFunc,
      |         ^~~~~~~~~~~~~
../../../../Macaulay2/d/xml-c.c: In function 'xml_toString':
../../../../Macaulay2/d/xml-c.c:72:3: warning: 'content' is deprecated [-Wdeprecated-declarations]
   72 |   s = M2_tostringn((char*)buf->content,len);
      |   ^
/usr/include/libxml2/libxml/tree.h:115:14: note: declared here
  115 |     xmlChar *content XML_DEPRECATED_MEMBER;
      |              ^~~~~~~
```