### PR TITLE
Use elements of base ring for coefficients in random(Module, Module)

### DIFF
--- a/M2/Macaulay2/m2/genmat.m2
+++ b/M2/Macaulay2/m2/genmat.m2
@@ -120,8 +120,6 @@ random(Module, Module) := Matrix => opts -> (F,G) -> (
      R := ring F;
      if R =!= ring G then error "modules over different rings";
      if opts.MaximalRank then return (randomMR opts)(F,G);
-     p := char R;
-     if p === 0 then p = opts.Height;
      degreesTable := table(degrees F, degrees G, 
 	  (i,j) -> toList apply(j,i,difference));
      degreesTally := tally flatten degreesTable;
@@ -144,7 +142,7 @@ random(Module, Module) := Matrix => opts -> (F,G) -> (
 	       deg -> (
 		    numused := 0;
 		    if deg === 0 then (
-			 n := apply(degreesTally#deg, x -> random p);
+			 n := apply(degreesTally#deg, x -> random(R.BaseRing, opts));
 			 () -> (
 			      r := n#numused;
 			      numused = numused + 1;
@@ -158,7 +156,7 @@ random(Module, Module) := Matrix => opts -> (F,G) -> (
 			      n = first entries (
 				   m * matrix (R, table(
 					     k, degreesTally#deg, 
-					     (i,j)->random p)));
+					     (i,j)->random(R.BaseRing, opts))));
 			      () -> (
 				   r := n#numused;
 				   numused = numused + 1;


### PR DESCRIPTION
Currently, the code for `random(Module, Module)` in the case where the differences in degrees aren't consistent (which has been untouched since 1999!) assumes we're working over the integers, regardless of the base ring, and thus spits out matrices with integer coefficients:

```m2
i1 : R = QQ[x];

i2 : random(R^2, R^{-1, -2})

o2 = | 6x 7x2 |
     | 6x 7x2 |

             2      2
o2 : Matrix R  <-- R

i3 : S = CC[x];

i4 : random(S^2, S^{-1, -2})
-- warning: experimental computation over inexact field begun
--          results not reliable (one warning given per session)

o4 = | 8x 2x2 |
     | 6x 4x2 |

             2      2
o4 : Matrix S  <-- S
```

We update it to use random elements of the base ring as coefficients:

```m2
i1 : R = QQ[x];

i2 : random(R^2, R^{-1, -2})

o2 = | 1/7x 1/10x2 |
     | 3/8x 3/5x2  |

             2      2
o2 : Matrix R  <-- R

i3 : S = CC[x];

i4 : random(S^2, S^{-1, -2})
-- warning: experimental computation over inexact field begun
--          results not reliable (one warning given per session)

o4 = | (.478476+.798072ii)x (.550045+.323718ii)x2 |
     | (.994119+.640657ii)x (.193998+.214085ii)x2 |

             2      2
o4 : Matrix S  <-- S
```

Note that this currently breaks this method for modules over `RRi` since `random RRi` isn't defined, but that will be fixed by #4040.