### PR TITLE
Fix robust printing of subclasses of String

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1095,6 +1095,7 @@ setupfun("connectionCount", connectionCount);
 format(e:Expr):Expr := (
      when e
      is s:stringCell do toExpr("\"" + present(s.v) + "\"")
+     is s:SpecialExpr do format(s.e)
      is ZZcell do e
      is QQcell do e
      is RRcell do format(Expr(Sequence(e)))

--- a/M2/Macaulay2/d/regex.dd
+++ b/M2/Macaulay2/d/regex.dd
@@ -230,6 +230,8 @@ regexSeparate(e:Expr):Expr := (
 	    toExpr(r))
 	else WrongArgZZ(4)
 	else WrongArgZZ(3)
+	-- for subclasses of string
+	is text:SpecialExpr do regexSeparate(Expr(Sequence(s.0, text.e, s.2, s.3)))
 	else WrongArgString(2)
 	else WrongArgString(1))
     else WrongNumArgs(1,4))

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -84,3 +84,8 @@ assert Equation(format(ascii(0..31) | "\"\\"),
     ///"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r/// |
     ///\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017/// |
     ///\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\"\\"///)
+
+-- subclasses (issue #4069)
+T = new SelfInitializingType of String
+assert Equation(net T "foo", "foo")
+assert Equation(format T "foo", "\"foo\"")


### PR DESCRIPTION
Both `net` (which calls `separate`) and `format` were broken because the associated compiled functions didn't deal with the `SpecialExpr` case, which is what we have when `String` is subclassed.

This should at least partially fix #4069

### Before
```m2
i1 : T = new SelfInitializingType of String;

i2 : T "foo"

--error or time limit reached in conversion of output to net: type 'debugError()' to run it again; will try conversion to string
--error or time limit reached in applying Wrap method to output; type 'debugError()' to see it


o2 = stdio:2:1:(3): error: at print: expected argument 2 to be a sequence or list of strings, nets, or nulls

i3 : x = new HashTable; x#(T "foo")
stdio:3:20:(3): error: key not found in hash table
```

### After
```m2
i1 : T = new SelfInitializingType of String;

i2 : T "foo"

o2 = foo

i3 : x = new HashTable; x#(T "foo")
stdio:4:20:(3): error: key not found in hash table:
        "foo" (of class T)
```