### PR TITLE
Bump latest copyright year to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+with this program; if not, see https://www.gnu.org/licenses/.
 
 Macaulay2 binaries are licensed under GPL-3.0 due to linking with LGPL-3.0 libraries (FLINT, MPFR).
 See https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ determined by `check`, in the latest version of Macaulay2.
 
 ### Copyright
 
-Copyright (C) 1993-2025 [The Macaulay2 Authors](
+Copyright (C) 1993-2026 [The Macaulay2 Authors](
 https://github.com/Macaulay2/M2/wiki/The-Macaulay2-Authors)
 
 This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Happy New Year!!  🎉🥳🍾🥂

We bump the latest copyright year in the README to 2026.  And we also update the Free Software Foundation address there -- somehow I missed this file in #3974!