### PR TITLE
Fix garbage collection of foreign gmp/mpfr objects

### DIFF
--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -250,6 +250,10 @@ ffiIntegerType(e:Expr):Expr := (
     else WrongNumArgs(2));
 setupfun("ffiIntegerType", ffiIntegerType);
 
+gmpFinalizer(obj:voidPointer, clientData:voidPointer):void := (
+    Ccode(void, "(void)", obj);
+    Ccode(void, "mpz_clear((mpz_ptr)", clientData, ")"));
+
 -- returns pointer to integer object with given value
 -- inputs (x:ZZ, y:ZZ, signed:Boolean)
 -- x = value
@@ -270,7 +274,7 @@ ffiIntegerAddress(e:Expr):Expr := (
 			ptr := getMem(pointerSize);
 			Ccode(void, "*(mpz_ptr *)", ptr, " = ", z);
 			Ccode(void, "GC_REGISTER_FINALIZER(", ptr, ", ",
-			    "(GC_finalization_proc)mpz_clear, ", z, ", 0, 0)");
+			    gmpFinalizer, ", ", z, ", 0, 0)");
 			toExpr(ptr))
 		    else when a.2
 		    is signed:Boolean do (
@@ -381,6 +385,10 @@ ffiRealType(e:Expr):Expr := (
     else WrongArgZZ());
 setupfun("ffiRealType", ffiRealType);
 
+mpfrFinalizer(obj:voidPointer, clientData:voidPointer):void := (
+    Ccode(void, "(void)", obj);
+    Ccode(void, "mpfr_clear((mpfr_ptr)", clientData, ")"));
+
 -- returns pointer to real number object with given value
 -- inputs: (x:RR, y:ZZ)
 -- x = value
@@ -400,10 +408,8 @@ ffiRealAddress(e:Expr):Expr := (
 			Ccode(void, "mpfr_set(", z, ", ", x.v, ", MPFR_RNDN)");
 			ptr := getMem(pointerSize);
 			Ccode(void, "*(mpfr_ptr *)", ptr, " = ", z);
-			-- TODO: we get segfaults during garbage collection
-			-- if the following is uncommented
-			-- Ccode(void, "GC_REGISTER_FINALIZER(", ptr, ", ",
-			--  "(GC_finalization_proc)mpfr_clear, ", z, ", 0, 0)");
+			 Ccode(void, "GC_REGISTER_FINALIZER(", ptr, ", ",
+			     mpfrFinalizer, ", ", z, ", 0, 0)");
 			toExpr(ptr))
 		    else if bits == 32 || bits == 64 then (
 			ptr := getMemAtomic(bits / 8);

--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -2632,3 +2632,10 @@ mpfi = openSharedLibrary "mpfi"
 assert instance(value describe mpfi, SharedLibrary)
 assert instance(value toExternalString mpfi, SharedLibrary)
 ///
+
+TEST ///
+-- finalizing gmp and mpfr objects
+scan(1000, i -> mpzT 2^100)
+scan(1000, i -> mpfrT numeric(100, pi))
+collectGarbage()
+///


### PR DESCRIPTION
The GC finalizer callback function expects two parameters: a pointer to the GC memory we're finalizing and a pointer to some client data. We were previously passing the *first* object to `mpz_clear` and `mpfr_clear`, which was incorrect.  (This is why the mpfr code was commented out, as otherwise we were segfaulting trying to call `mpfr_clear` on our pointer object rather than on the `mpfr_ptr` it's pointing to!.  I'm surprised the gmp code wasn't segfaulting too!)

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
