### PR TITLE
Fix mathML(Type) -- previously caused a recursion error

### DIFF
--- a/M2/Macaulay2/m2/enginering.m2
+++ b/M2/Macaulay2/m2/enginering.m2
@@ -274,6 +274,7 @@ expression EngineRing := R -> if hasAttribute(R,ReverseDictionary) then expressi
 toString EngineRing := toString @@ expression
 net      EngineRing :=      net @@ expression
 texMath  EngineRing :=  texMath @@ expression
+mathML   EngineRing :=   mathML @@ expression
 
 ZZ _ EngineRing := 
 RR _ EngineRing :=

--- a/M2/Macaulay2/m2/mathml.m2
+++ b/M2/Macaulay2/m2/mathml.m2
@@ -86,6 +86,12 @@ mathML Minus := v -> concatenate( "<mrow><mo>-</mo>", mathML v#0, "</mrow>")
 mathML Divide := x -> concatenate("<mfrac>", mathML x#0, mathML x#1, "</mfrac>")
 mathML OneExpression := x -> "<mn>1</mn>"
 mathML ZeroExpression := x -> "<mn>0</mn>"
+mathML BinaryOperation := m -> (
+    x := mathML m#1;
+    y := mathML m#2;
+    if rightPrecedence m#1 < lprec m#0 then x = mathMLparen x;
+    if precedence m#2 <= rprec m#0 then y = mathMLparen y;
+    mrow(x | mo m#0 | y))
 mathML Sum := v -> (
      n := # v;
      if n === 0 then "<mn>0</mn>"

--- a/M2/Macaulay2/m2/mathml.m2
+++ b/M2/Macaulay2/m2/mathml.m2
@@ -163,8 +163,6 @@ rightbrace := mo "}"
 
 mathML MapExpression := x -> mrow {mathML x#0, leftarrow, mathML x#1}
 mathML Option := s -> concatenate("<mrow>",mathML s#0, doublerightarrow, mathML s#1, "</mrow>")
-mathML Type :=
-mathML ImmutableType := R -> if R.?mathML then R.mathML else mathML expression R
 mathML VirtualTally :=
 mathML HashTable := s -> if s.?mathML then s.mathML else concatenate( "<mrow>",mathML class s,leftbrace, mtable sort apply(pairs s, (k,v) -> {mathML k, doublerightarrow, mathML v}), rightbrace,"</mrow>", newline )
 mathML MutableHashTable := x -> if x.?mathML then x.mathML else (

--- a/M2/Macaulay2/tests/normal/mathml.m2
+++ b/M2/Macaulay2/tests/normal/mathml.m2
@@ -2,3 +2,5 @@
 
 -- used to cause a recursion error
 mathML Matrix
+
+assert Equation(mathML(QQ[a..d]), "<mi>ℚ</mi> <mrow><mo>[</mo><mrow><mrow><mi>a</mi><mo>..</mo><mi>d</mi></mrow></mrow><mo>]</mo></mrow>")

--- a/M2/Macaulay2/tests/normal/mathml.m2
+++ b/M2/Macaulay2/tests/normal/mathml.m2
@@ -1,0 +1,4 @@
+-- TODO: add more tests
+
+-- used to cause a recursion error
+mathML Matrix


### PR DESCRIPTION
Currently, we have:

```m2
i1 : mathML Matrix
stdio:1:6:(3): error: recursion limit of 300 exceeded
```

What's going on?

```m2
i2 : code (mathML, Type)

o2 = -- code for method: mathML(Type)
     /usr/share/Macaulay2/Core/mathml.m2:167:24-167:80: --source code:
     mathML ImmutableType := R -> if R.?mathML then R.mathML else mathML expression R

i3 : peek expression Matrix

o3 = Holder{Matrix}

i4 : code (mathML, Holder)

o4 = -- code for method: mathML(Holder)
     /usr/share/Macaulay2/Core/mathml.m2:40:17-40:32: --source code:
     mathML Holder := v -> mathML v#0
```

Since there's no `Matrix.mathML`, we just bounce back and forth between `mathML(Type)` and `mathML(Holder)`.

We fix this by just removing `mathML(Type)` and using inheritance so it calls `mathML(MutableHashTable)` ~~(and also setting this to be `mathML(ImmutableType)`)~~, which does the expected thing:

```m2
i1 : mathML Matrix

o1 = <mi>Matrix</mi>
```
