### PR TITLE
Switch ~ from postfix -> prefix/binary

### DIFF
--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -210,8 +210,9 @@ setup(BoxTimesS, boxtimesfun);
 shuffleproductfun(lhs:Code, rhs:Code):Expr := binarymethod(lhs, rhs, ShuffleProductS);
 setup(ShuffleProductS, shuffleproductfun);
 
-Tildefun(rhs:Code):Expr := unarymethod(rhs,TildeS);
-setuppostfix(TildeS,Tildefun);
+Tildefun2(lhs:Code,rhs:Code):Expr := binarymethod(lhs,rhs,TildeS);
+Tildefun1(rhs:Code):Expr := unarymethod(rhs,TildeS);
+setup(TildeS,Tildefun1,Tildefun2);
 
 PowerTildefun(rhs:Code):Expr := unarymethod(rhs,PowerTildeS);
 setuppostfix(PowerTildeS,PowerTildefun);

--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -267,6 +267,7 @@ bumpPrecedence();
      export QuestionS := makeKeyword(unarybinaryright("?"));
      export NotEqualEqualEqualS := makeKeyword(binaryright("=!="));
      export NotEqualS := makeKeyword(binaryright("!="));
+     export TildeS := makeKeyword(unarybinaryright("~"));
 -- operations on terms that yield terms:
 bumpPrecedence();
      export BarBarS := makeKeyword(binaryleft("||"));
@@ -335,7 +336,6 @@ bumpPrecedence();
      export AtAtS := makeKeyword(binaryleft("@@"));
      export AtAtQuestionS := makeKeyword(binaryleft("@@?"));
 bumpPrecedence();
-     export TildeS := makeKeyword(postfix("~"));
      export PowerTildeS := makeKeyword(postfix("^~"));
      export UnderscoreTildeS := makeKeyword(postfix("_~"));
      export UnderscoreStarS := makeKeyword(postfix("_*"));
@@ -500,7 +500,7 @@ export opsWithBinaryMethod := array(SymbolClosure)(
      LongDoubleRightArrowS, LongLongDoubleRightArrowS,
      LongDoubleLeftArrowS, LongLongDoubleLeftArrowS,
      ColonS, BarS, HatHatS, AmpersandS, DotDotS, DotDotLessS, MinusS, PlusS, PlusPlusS, StarStarS, StarS, BackslashBackslashS, DivideS, LeftDivideS, PercentS, SlashSlashS, AtS, 
-     AdjacentS, AtAtS, AtAtQuestionS, orS, andS, xorS,
+     AdjacentS, AtAtS, AtAtQuestionS, orS, andS, xorS, TildeS,
      -- TODO: why are these four not listed here?
      -- GreaterS, GreaterEqualS, LessS, LessEqualS,
      BarUnderscoreS,
@@ -516,13 +516,13 @@ export opsWithBinaryMethod := array(SymbolClosure)(
      );
 export opsWithUnaryMethod := array(SymbolClosure)(
      StarS, MinusS, PlusS, LessLessS, QuestionQuestionS,
-     LongDoubleLeftArrowS, LongLongDoubleLeftArrowS, 
+     LongDoubleLeftArrowS, LongLongDoubleLeftArrowS, TildeS,
      notS, DeductionS, QuestionS,LessS,GreaterS,LessEqualS,GreaterEqualS);
 export opsWithPostfixMethod := array(SymbolClosure)(
     ExclamationS,    PowerExclamationS, UnderscoreExclamationS,
     -- FIXME:        PowerSharpS,       UnderscoreSharpS,
     ParenStarParenS, PowerStarS,        UnderscoreStarS,
-    TildeS,          PowerTildeS,       UnderscoreTildeS
+    PowerTildeS,     UnderscoreTildeS
     );
 
 -- ":=" "=" "<-" "->"  "=>" "===" "=!=" "!=" "#" "#?" "." ".?" ";" "," "<" ">" "<=" ">="

--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -255,7 +255,6 @@ fSeq := new HashTable from splice {
     (2, symbol (*)     ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol ^*      ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol _*      ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
-    (2, symbol ~       ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol ^~      ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol _~      ) => s -> (toString s#1, " ", toString s#0), -- postfix operator
     (2, symbol !       ) => s -> (toString s#1, " ", toString s#0), -- postfix operator

--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -101,7 +101,7 @@ Function or  Function := (f, g) -> s -> f s or  g s
 Function xor Function := (f, g) -> s -> f s xor g s
 not Function := f -> s -> not f s
 
-ZZ~ := bitnotfun
+~ ZZ := bitnotfun
 
 changeBase = method()
 changeBase(ZZ,     ZZ)     := String =>

--- a/M2/Macaulay2/packages/CoincidentRootLoci.m2
+++ b/M2/Macaulay2/packages/CoincidentRootLoci.m2
@@ -958,7 +958,7 @@ JoinOfCoincidentRootLoci * JoinOfCoincidentRootLoci := (X,Y) -> joinOfHooks (toS
 --=== Binary forms and utilities =================================
 --================================================================
 
-RingElement ~ := (F) -> RingElement := (G) -> (
+RingElement ~ RingElement := (F, G) -> (
   if not (isPolynomialRing ring F and isPolynomialRing ring G and numgens ring F == 2 and numgens ring G == 2) then error "expected two binary forms";
   K := coefficientRing ring F;
   if K =!= coefficientRing ring G then error "got different coefficient rings";

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators.m2
@@ -456,20 +456,14 @@ doc ///
   Headline
     logical not
   Usage
-    n~
+    ~n
   Inputs
     n:ZZ
   Outputs
     :ZZ -- the bitwise complement of @TT "n"@
   Description
     Example
-      7~
-    Text
-      Note that @TT "~"@ has @TO2 {"precedence of operators",
-      "higher precedence"}@ than @TT "-"@, so enclose negative integers in
-      parentheses.
-    Example
-      (-12)~
+      ~7
   SeeAlso
     (symbol &, ZZ, ZZ)
     (symbol |, ZZ, ZZ)
@@ -488,8 +482,9 @@ document {
 
 document {
      Key => symbol ~,
-     Headline => "a unary postfix operator",
+     Headline => "a unary or binary operator, often used for bitwise negation",
     Subnodes => { TO (symbol ~, ZZ) },
+    SeeAlso => { "Python::~ PythonObject", "RInterface::~ RObject"}
      }
 
 document {

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators/assignment.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators/assignment.m2
@@ -359,8 +359,8 @@ document {
 		    }},
 	  "The first line of the following example illustrates the syntax above.",
 	  EXAMPLE lines ///
-	       String ~ = peek;
-	       "foo" ~ = "value"
+	       String ^~ = peek;
+	       "foo" ^~ = "value"
 	  ///,
 	  PARA "Warning: the installation of new methods may supplant old ones, changing the behavior of Macaulay2."
 	  },
@@ -381,8 +381,8 @@ document {
 	  References to currently installed assignment methods are given below.",
 	  "The second line of the following example illustrates the syntax above.",
 	  EXAMPLE lines ///
-	       String ~ = peek;
-	       "foo" ~ = "value"
+	       String ^~ = peek;
+	       "foo" ^~ = "value"
 	  ///
 	  },
      SeeAlso => {":=", "<-", "globalAssignmentHooks" }
@@ -610,8 +610,8 @@ document {
 		    }},
 	  "The first line of the following example illustrates the syntax above.",
 	  EXAMPLE lines ///
-	       String ~ := peek;
-	       "foo" ~
+	       String ^~ := peek;
+	       "foo" ^~
 	  ///,
 	  PARA "Warning: the installation of new methods may supplant old ones, changing the behavior of Macaulay2."
 	  },
@@ -630,8 +630,8 @@ document {
 	       },
 	  "The second line of the following example illustrates the syntax above.",
 	  EXAMPLE lines ///
-	       String ~ := peek;
-	       "foo" ~
+	       String ^~ := peek;
+	       "foo" ^~
 	  ///
 	  },
      SYNOPSIS {

--- a/M2/Macaulay2/packages/Python.m2
+++ b/M2/Macaulay2/packages/Python.m2
@@ -766,7 +766,7 @@ assert Equation(0 xor y, 2)
 ----------------------
 assert Equation(-x, -5)
 assert Equation(+x, 5)
-assert Equation(x~, -6)
+assert Equation(~x, -6)
 assert Equation(not x, false)
 ///
 

--- a/M2/Macaulay2/packages/Python/doc/bitwise.m2
+++ b/M2/Macaulay2/packages/Python/doc/bitwise.m2
@@ -503,7 +503,7 @@ doc ///
   Headline
     bitwise negation of a python object
   Usage
-    x~
+    ~x
   Inputs
     x:PythonObject
   Outputs
@@ -511,10 +511,9 @@ doc ///
   Description
     Text
       This operation negates each bit.  For integers, this is equivalent to
-      CODE "-x - 1".  Unlike Python, @CODE "~"@ is a postfix unary operator
-      in Macaulay2.
+      CODE "-x - 1".
     Example
-      (toPython 5)~
+      ~toPython 5
   SeeAlso
     (symbol &, PythonObject, PythonObject)
     (symbol |, PythonObject, PythonObject)

--- a/M2/Macaulay2/packages/RInterface/doc.m2
+++ b/M2/Macaulay2/packages/RInterface/doc.m2
@@ -491,7 +491,7 @@ doc ///
     Example
       x = RObject 12
       y = RObject 10
-      x~
+      ~x
     Text
       @TO symbol &@ is bitwise @EM "and"@, calling R's @SAMP "bitwAnd"@.
     Example

--- a/M2/Macaulay2/packages/RInterface/test.m2
+++ b/M2/Macaulay2/packages/RInterface/test.m2
@@ -157,7 +157,7 @@ assert Equation(sum RObject {1, 3, 5}, RObject 9)
 assert Equation(tan RObject 0, RObject 0)
 assert Equation(tanh RObject 0, RObject 0)
 assert Equation((RObject 1)!, RObject 1)
-assert Equation((RObject 1)~, RObject(-2))
+assert Equation(~RObject 1, RObject(-2))
 assert Equation(conjugate RObject ii, RObject(-ii))
 assert(abs(Digamma RObject 1 + RObject EulerConstant) <
     RObject(1e-15))

--- a/M2/Macaulay2/packages/Varieties.m2
+++ b/M2/Macaulay2/packages/Varieties.m2
@@ -298,10 +298,6 @@ sheaf(Variety, Module)   := CoherentSheaf => (X, M) -> (
 sheaf Ideal := Ideal^~ := CoherentSheaf =>     I  -> sheaf(variety ring I, module I)
 sheaf(Variety, Ideal)  := CoherentSheaf => (X, I) -> sheaf(X,              module I)
 
--- TODO: remove by M2 1.25
-tildeWarn = true
-Thing~ := x -> (if tildeWarn then (tildeWarn = false; printerr "Note: M~ is deprecated; use M^~ or sheaf instead."); x^~)
-
 OO = new ScriptedFunctor from {
      subscript => X -> applyMethod((symbol _,     OO, class X), (OO, X)),
      argument  => X -> applyMethod((symbol SPACE, OO, class X), (OO, X)),

--- a/M2/Macaulay2/tests/normal/boolean.m2
+++ b/M2/Macaulay2/tests/normal/boolean.m2
@@ -40,8 +40,8 @@ assert Equation(1 | 0 ^^ 1, 1)
 -----------------
 -- bitwise not --
 -----------------
-assert Equation(1138~, -1139)
-assert Equation((-1139)~, 1138)
+assert Equation(~1138, -1139)
+assert Equation(~-1139, 1138)
 
 -----------------
 -- expressions --


### PR DESCRIPTION
This has been discussed before (e.g., https://github.com/Macaulay2/M2/pull/3183#issuecomment-2059599972).  The original reason for it being a postfix operator was sheafification, but that has used `^~` since #3567.

As a prefix unary operator, it makes much more sense for the remaining methods (bitwise negation of integers).  We also add it as a binary operator for potential other uses such as equivalence relations (hence the choice to use the same precedence as `==` and friends) or building formulas in the *RInterface* package.

Draft for now for discussion since this is a breaking change.