### PR TITLE
Stop generating Macaulay2Web autocompletion symbols

### DIFF
--- a/M2/Macaulay2/editors/.gitignore
+++ b/M2/Macaulay2/editors/.gitignore
@@ -1,7 +1,6 @@
 emacs/M2-emacs-hlp.txt
 emacs/M2-emacs.m2
 emacs/M2-symbols.el
-Macaulay2Web/M2-symbols.ts
 prism/macaulay2.js
 prism/node_modules/
 prism/package-lock.json

--- a/M2/Macaulay2/editors/Macaulay2Web/M2-symbols.ts.in
+++ b/M2/Macaulay2/editors/Macaulay2Web/M2-symbols.ts.in
@@ -1,3 +1,0 @@
-// @M2BANNER@
-
-export default [@M2SYMBOLS@];

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -35,7 +35,7 @@ prism/%: @srcdir@/prism/% prism
 	cp $< $@
 
 clean:
-	rm -rf @pre_emacsdir@/* emacs prism pygments vim Macaulay2Web
+	rm -rf @pre_emacsdir@/* emacs prism pygments vim
 
 else
 clean:

--- a/M2/Macaulay2/editors/README.md
+++ b/M2/Macaulay2/editors/README.md
@@ -8,7 +8,6 @@ completion of Macaulay2 code.
 Each subdirectory contains one or more template files for a particular
 application.
 
-* [`Macaulay2Web`](Macaulay2Web): Symbols for the Macaulay2 web app.
 * [`emacs`](https://github.com/Macaulay2/M2-emacs): Symbols for GNU Emacs.
 * [`prism`](prism): Symbols for the Prism Javascript library.  These are used
   for syntax highlighting the online Macaulay2 documentation.
@@ -22,3 +21,4 @@ been moved to their own repositories:
 * highlight.js: https://github.com/d-torrance/highlightjs-macaulay2
 * Linguist: https://github.com/Macaulay2/language-macaulay2
 * TextMate: https://github.com/Macaulay2/vscode-macaulay2
+* Macaulay2Web (symbols for autocompletion): https://github.com/pzinn/Macaulay2Web/

--- a/M2/Macaulay2/editors/make-M2-symbols.m2
+++ b/M2/Macaulay2/editors/make-M2-symbols.m2
@@ -21,9 +21,6 @@ generateGrammar("vim/m2.vim.dict", x -> demark(" ", x)) -- TODO: is this necessa
 generateGrammar("pygments/macaulay2.py",
     x -> demark("," | newline | "    ", format \ x))
 
--- Macaulay2Web: Write M2-symbols.ts
-generateGrammar("Macaulay2Web/M2-symbols.ts", x -> demark(",", format \ x))
-
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/emacs M2-symbols "
 -- End:


### PR DESCRIPTION
This is now handled in the Macaulay2Web repository (see https://github.com/pzinn/Macaulay2Web/pull/41).

Closes: #3930 

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
