### PR TITLE
Improve thread safety of value and readeval

### DIFF
--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -16,10 +16,10 @@ export setupargv():void := (
      setupconst("environment",toExpr(envp));
      );
 
-fileExitHooks := setupvar("fileExitHooks", Expr(emptyList));
-currentFileName := setupvar("currentFileName", nullE);
-currentPosFile  := dummyPosFile;
-currentFileDirectory := setupvar("currentFileDirectory", toExpr("./"));
+fileExitHooks := setupvarThread("fileExitHooks", Expr(emptyList));
+currentFileName := setupvarThread("currentFileName", nullE);
+threadLocal currentPosFile  := dummyPosFile;
+currentFileDirectory := setupvarThread("currentFileDirectory", toExpr("./"));
 update(err:Error,prefix:string,f:Code):Error := (
      if !err.printed
      then printErrorMessage0(f,prefix + ": " + err.message)
@@ -514,7 +514,7 @@ debugger(f:Frame,c:Code):Expr := (
      ret);
 debuggerpointer = debugger;
 
-currentString := setupvar("currentString", nullE);
+currentString := setupvarThread("currentString", nullE);
 value(e:Expr):Expr := (
      when e
      is q:SymbolClosure do (


### PR DESCRIPTION
This makes several variables thread local so that value and readeval in interp.dd is more thread safe. This seems to fix #3927.

There are a couple more variables that are worth investigating:

- `previousLineNumber` in interp.dd I think this is only used by the interactive prompt, and so it is probably fine either as thread local or global
- `intepreterDepth`, `errorDepth`, and `loadDepth`. These are somewhat related, but currently only `loadDepth` is thread local
- `current`, this seems to be only used by the debugger. Similarly to `previousLineNumber` it's probably fine for it to be either thread local or global, but we should think about it.