### PR TITLE
Add syntactic sugar for installing nullary methods

### DIFF
--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -992,7 +992,8 @@ installFun2(a:Expr,args:CodeSequence):Expr := (
 	       when b
 	       is Error do b
 	       is bcd:Sequence do (
-		    if length(bcd) == 2 then (
+		    if length(bcd) == 0 then installMethod(a, eval(args.3))
+		    else if length(bcd) == 2 then (
 			 when bcd.0
 			 is bb:HashTable do
 			 when bcd.1
@@ -1018,7 +1019,7 @@ installFun2(a:Expr,args:CodeSequence):Expr := (
 			 else buildErrorPacket("expected second parameter to be a hash table")
 			 else buildErrorPacket("expected first parameter to be a hash table")
 			 )
-		    else buildErrorPacket("expected 1, 2, 3, or 4 parameter types"))
+		    else buildErrorPacket("expected between 0 and 4 parameter types"))
 	       is bb:HashTable do installMethod(a,bb,eval(args.3))
 	       else buildErrorPacket("expected right hand parameter to be a hash table or sequence"))
 	  else buildErrorPacket("expected adjacency operator ' ' on left"))

--- a/M2/Macaulay2/m2/debugging.m2
+++ b/M2/Macaulay2/m2/debugging.m2
@@ -166,14 +166,7 @@ localSymbols Pseudocode :=
 localSymbols Symbol :=
 localSymbols Dictionary :=
 localSymbols Function := ls
-
--- make this work eventually:
--- localSymbols() := () -> if current === null then ls() else ls current
--- meanwhile: (see also method123())
--- nullaryMethods # (1 : localSymbols) = () -> if current =!= null then ls current else error "not in debugger (i.e., current not set)"
--- also meanwhile:
-installMethod(localSymbols, () -> if current =!= null then ls current else error "not in debugger (i.e., current not set)")
-
+localSymbols() := () -> if current =!= null then ls current else error "not in debugger (i.e., current not set)"
 localSymbols(Type,Symbol) :=
 localSymbols(Type,Dictionary) :=
 localSymbols(Type,Function) :=

--- a/M2/Macaulay2/m2/files.m2
+++ b/M2/Macaulay2/m2/files.m2
@@ -484,8 +484,8 @@ prelim := () -> (
      promptUser = true;
      if prefixDirectory === null then error "can't determine Macaulay 2 prefix (prefixDirectory not set)";
      )
-installMethod(setupEmacs, () -> ( prelim(); mungeEmacs(); ))
-installMethod(setup, () -> (
+setupEmacs() := () -> ( prelim(); mungeEmacs(); )
+setup() := () -> (
      prelim();
      dotprofileFix = concatenate(shHeader, apply(shellfixes, (var,dir,rest) -> fix(var,dir,rest,bashtempl)));
      dotloginFix = concatenate(shHeader,apply(shellfixes, (var,dir,rest) -> fix(var,dir,rest,cshtempl)));
@@ -505,7 +505,7 @@ installMethod(setup, () -> (
      -- csh and tcsh:
      mungeFile("~/.login",startToken,endToken,M2loginRead) or
      -- emacs:
-     mungeEmacs(); ))
+     mungeEmacs(); )
 
 scanLines = method()
 ifbrk := x -> if x =!= null then break x

--- a/M2/Macaulay2/m2/integers.m2
+++ b/M2/Macaulay2/m2/integers.m2
@@ -44,7 +44,7 @@ ZZ.random = opts -> ZZ -> rawRandomZZ opts.Height
 texMath ZZ := toString
 
 gcd = method(Binary => true)
-installMethod(gcd, () -> 0)
+gcd()      := () -> 0
 gcd(ZZ,ZZ) := ZZ => gcd0
 gcd(ZZ,QQ) := QQ => (x,y) -> gcd(x * denominator y, numerator y) / denominator y
 gcd(QQ,ZZ) := QQ => (y,x) -> gcd(x * denominator y, numerator y) / denominator y
@@ -62,7 +62,7 @@ sign Number := sign0
 sign Constant := sign @@ numeric
 
 lcm = method(Binary => true)
-installMethod(lcm, () -> 1)
+lcm()      := () -> 1
 lcm(ZZ,ZZ) := (f,g) -> (
     d := gcd(f, g);
     if d == 0 then 0

--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -94,7 +94,7 @@ new Set from VisibleList := Set => (Set, X) -> set' X
 
 -- set operations
 elements Set := List => keys
-installMethod(union, () -> set {})
+union()         := () -> set {}
 union(Set, Set) := Set + Set := Set => (x,y) -> merge(x,y,(i,j)->i)
 
 -- Set ++ Set := Set => (x,y) -> applyKeys(x,i->(0,i)) + applyKeys(y,j->(1,j))

--- a/M2/Macaulay2/m2/set.m2
+++ b/M2/Macaulay2/m2/set.m2
@@ -95,6 +95,7 @@ new Set from VisibleList := Set => (Set, X) -> set' X
 -- set operations
 elements Set := List => keys
 union()         := () -> set {}
+union Set       := identity
 union(Set, Set) := Set + Set := Set => (x,y) -> merge(x,y,(i,j)->i)
 
 -- Set ++ Set := Set => (x,y) -> applyKeys(x,i->(0,i)) + applyKeys(y,j->(1,j))
@@ -105,6 +106,7 @@ Set * Set := Set => (x,y) -> (
      then set select(keys x, k -> y#?k)
      else set select(keys y, k -> x#?k)
      )
+intersect Set       := Set => {} >> o -> identity
 intersect(Set, Set) := Set => {} >> o -> (x,y) -> x*y
 
 Set - Set := Set => (x,y) -> applyPairs(x, (i,v) -> if not y#?i then (i,v))

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_methods.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_methods.m2
@@ -350,8 +350,8 @@ document {
      PARA{"Most users will use a different way of installing methods."},
      PARA{
 	  TT "installMethod(M,f)", "     -- installs a function ", TT "f", " as a nullary method
-	  under the name ", TT "M", ".  This is a replacement for the syntax ", "M () := f", ",
-	  which hasn't yet been made to work.  As currently implemented, this is also the same
+	  under the name ", TT "M", ".  This is the same as ", "M() := f", "
+	  if ", TT "M", " is a function.  As currently implemented, this is also the same
 	  as ", TT "nullaryMethods#(1:M) = f", "."
 	  },
      PARA{

--- a/M2/Macaulay2/packages/Polyhedra/engine/alternatives.m2
+++ b/M2/Macaulay2/packages/Polyhedra/engine/alternatives.m2
@@ -17,7 +17,7 @@ loadAlternative String := name -> (
 )
 
 dropAlternatives = method()
-installMethod(dropAlternatives, o -> (alternative = new MutableHashTable))
+dropAlternatives() := o -> (alternative = new MutableHashTable)
 
 insertAlternatives = method()
 insertAlternatives MutableHashTable := newAlternatives -> (

--- a/M2/Macaulay2/packages/Probability.m2
+++ b/M2/Macaulay2/packages/Probability.m2
@@ -1,5 +1,5 @@
 -- Probability package for Macaulay2
--- Copyright (C) 2022-2025 Doug Torrance
+-- Copyright (C) 2022-2026 Doug Torrance
 
 -- This program is free software; you can redistribute it and/or
 -- modify it under the terms of the GNU General Public License
@@ -16,8 +16,8 @@
 
 newPackage("Probability",
     Headline => "basic probability functions",
-    Version => "0.6",
-    Date => "November 10, 2025",
+    Version => "0.7",
+    Date => "January 13, 2026",
     Authors => {{
 	    Name     => "Doug Torrance",
 	    Email    => "dtorrance@piedmont.edu",
@@ -43,6 +43,9 @@ newPackage("Probability",
 ---------------
 
 -*
+
+0.7 (2026-01-13, M2 1.26.05)
+* use new syntactic sugar for installing nullary methods
 
 0.6 (2025-11-10, M2 1.25.11)
 * update GPL 2 text (FSF no longer has a physical address)
@@ -328,7 +331,7 @@ uniformDistribution(Number, Number) := (a, b) -> (
 	QuantileFunction => p -> a + p * (b - a),
 	Support => (a, b),
 	Description => "U" | toString (a, b)))
-installMethod(uniformDistribution, () -> uniformDistribution(0, 1))
+uniformDistribution() := () -> uniformDistribution(0, 1)
 
 exponentialDistribution = method()
 exponentialDistribution Number := lambda -> (
@@ -357,7 +360,7 @@ normalDistribution(Number, Number) := (mu, sigma) -> (
 	Description => "N" | toString (mu, sigma)))
 
 -- standard normal distribution
-installMethod(normalDistribution, () -> normalDistribution(0, 1))
+normalDistribution() := () -> normalDistribution(0, 1)
 
 gammaDistribution = method()
 gammaDistribution(Number, Number) := (alpha, lambda) -> (


### PR DESCRIPTION
As proof of concept, use it for all the nullary methods defined in `Core`.

For example:

```m2
i1 : foo = method()

o1 = foo

o1 : MethodFunction

i2 : foo () := () -> print "Hello, world!"

o2 = FunctionClosure[stdio:2:10-2:37]

o2 : FunctionClosure

i3 : foo()
Hello, world!
```
Inspired by https://github.com/Macaulay2/M2/pull/4090#discussion_r2688055461.  I'm not sure why this wasn't implemented before.  It's mentioned as a possibility in the docs, and it's literally just one line of code!
