### PR TITLE
Fix (about, Keyword)

### DIFF
--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -635,6 +635,7 @@ about Type     :=
 about Symbol   :=
 about ScriptedFunctor :=
 about Function := o -> f -> about("\\b" | toString f | "\\b", o)
+about Keyword := o -> f -> about("(?:^| )" | regexQuote toString f | "(?:$| )")
 about String   := o -> re -> lastabout = (
     packagesSeen := new MutableHashTable;
     NumberedVerticalList sort join(

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/help-doc.m2
@@ -226,6 +226,7 @@ Node
     (about, String)
     (about, Symbol)
     (about, Type)
+    (about, Keyword)
   Headline
     search the documentation
   Usage


### PR DESCRIPTION
Since some keywords are special characters in regexes, we call `regexQuote`.  We also ensure that the keyword is by itself or separated from other characters in the documentation key by a space.

## Before

```m2
i1 : about symbol +
-- Invalid preceding regular expression prior to repetition operator.  The error occurred while parsing the regular expression: '\b+>>>HERE>>>\b'.
stdio:1:5:(3): error: unable to compile regular expression

i2 : about symbol -

o2 = {0 => AbstractSimplicialComplexes :: How to make reduced and non-reduced simplicial chain complexes             }
     {1 => Book3264Examples :: Intersection Theory Section 5.4.1-2                                                   }
 ```

We probably don't want all the documentation keys with hyphens when we're trying to learn about subtraction!

## After

```m2
i1 : about symbol +

o1 = {0 => CoincidentRootLoci :: CoincidentRootLocus + CoincidentRootLocus               }
     {1 => Complexes :: ComplexMap + ComplexMap                                          }
     {2 => Complexes :: ComplexMap + Number                                              }
     {3 => Complexes :: ComplexMap + RingElement                                         }
     {4 => Complexes :: Number + ComplexMap                                              }
     {5 => Complexes :: RingElement + ComplexMap                                         }
     .
     .
     .
     {189 => WeilDivisors :: BasicDivisor + BasicDivisor                                 }
     {190 => WeylGroups :: Weight + Weight                                               }

o1 : NumberedVerticalList

i2 : about symbol -

o2 = {0 => Complexes :: - ComplexMap                                                     }
     {1 => Complexes :: ComplexMap - ComplexMap                                          }
     {2 => Complexes :: ComplexMap - Number                                              }
     {3 => Complexes :: ComplexMap - RingElement                                         }
     {4 => Complexes :: Number - ComplexMap                                              }
     {5 => Complexes :: RingElement - ComplexMap                                         }
      .
      .
      .
     {193 => WeilDivisors :: BasicDivisor - BasicDivisor                                 }
     {194 => WeylGroups :: - Weight                                                      }
     {195 => WeylGroups :: Weight - Weight                                               }

o2 : NumberedVerticalList