### PR TITLE
Add "new MutableList from ZZ"

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -2377,6 +2377,28 @@ scanPairs(e:Expr):Expr := (
     else WrongNumArgs(2));
 setupfun("scanPairs", scanPairs);
 
+newMutableListFromZZ(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is T:HashTable do (
+		if ancestor(T, mutableListClass) then (
+		    when a.1
+		    is n:ZZcell do (
+			if isInt(n) then (
+			    k := toInt(n);
+			    if k >= 0 then list(T,
+				new Sequence len k do provide nullE, true)
+			    else WrongArg(2, "a nonnegative integer"))
+			else WrongArgSmallInteger(2))
+		    else WrongArgZZ(2))
+		else WrongArg(1, "a type of mutable list"))
+	    else WrongArgHashTable(1))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+installMethod(NewFromS, mutableListClass, ZZClass, newMutableListFromZZ);
+
 nextPrime(e:Expr):Expr := (
      when e
      is x:ZZcell do toExpr(nextPrime(x.v - oneZZ))

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_lists.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_lists.m2
@@ -791,23 +791,50 @@ document {
     SeeAlso => sequence
 }
 
-document {
-     Key => MutableList,
-     Headline => "the class of all mutable lists",
-     PARA {"For an overview of lists and sequences, see ", TO "lists and sequences", "."},
-     PARA{},
-     "Normally the entries in a mutable list are not printed, to prevent
-     infinite loops in the printing routines.  To print them out, use 
-     ", TO "peek", ".",
-     EXAMPLE {
-	  "s = new MutableList from {a,b,c};",
-      	  "s#2 = 1234;",
-	  "s",
-      	  "peek s",
-	  },
-     SeeAlso => {"BasicList"},
-     Subnodes => { TO Bag },
-     }
+doc ///
+  Key
+     MutableList
+     (NewFromMethod, MutableList, ZZ)
+  Headline
+    the class of all mutable lists
+  Description
+    Text
+      For an overview of lists and sequences, see @TO "lists and sequences"@.
+
+      Normally the entries in a mutable list are not printed, to prevent
+      infinite loops in the printing routines.  To print them out, use @TO peek@.
+    Example
+      s = new MutableList from {a,b,c};
+      s#2 = 1234
+      s
+      peek s
+    Text
+      To construct a mutable list with a given length and whose entries are all
+      @TO null@, provide an integer.
+    Example
+      s = new MutableList from 6;
+      peek s
+    Text
+      If a value is assigned at a position that is not yet present in a mutable list,
+      then it grows accordingly, and any intermediate positions are filled with
+      @TO null@.
+    Example
+      t = new MutableList from {};
+      t#4 = e
+      peek t
+    Text
+      When working with mutable lists, be careful not to turn a linear algorithm into
+      a quadratic one by repeatedly appending to it.  Compare the following:
+    Example
+      s = new MutableList
+      elapsedTime scan(1000, i -> s#i = i^2) -- quadratic, since we grow s at each step
+      t = new MutableList from 1000
+      elapsedTime scan(1000, i -> t#i = i^2) -- linear
+  SeeAlso
+    BasicList
+  Subnodes
+    Bag
+///
 
 document {
     Key => {

--- a/bugs/dan/1-mutable-list-doc
+++ b/bugs/dan/1-mutable-list-doc
@@ -1,19 +1,3 @@
-MutableList:
-
-document growth of mutable lists
-
-point out the need to be careful not to convert an order n algorithm into an order n^2 algorithm!
-
-mention hashtables as an alternative
-
-    i31 : t = new MutableList from {};
-
-    i32 : t#4 = e;
-
-    i34 : peek t
-
-    o34 = MutableList{null, null, null, null, e}
-
 document the use of mutable hash tables as push-only stacks:
 
     i35 : x = new MutableHashTable ;

--- a/bugs/dan/long-mutable-lists.m2
+++ b/bugs/dan/long-mutable-lists.m2
@@ -1,4 +1,0 @@
--- feature needed
--- priority: low
-
-new MutableList from 1000 -- should make a new one of that length


### PR DESCRIPTION
We add a new constructor for `MutableList` suggested in an old `bugs/dan` file:

```m2
i1 : new MutableList from 6

o1 = MutableList{...6...}

o1 : MutableList

i2 : peek oo

o2 = MutableList{null, null, null, null, null, null}
```

We also improve the `MutableList` docs a bit, mentioning a couple things suggested in another old `bugs/dan` file.