### PR TITLE
Use "html" for hypertext in TeXmacs mode

### DIFF
--- a/M2/Macaulay2/m2/texmacs.m2
+++ b/M2/Macaulay2/m2/texmacs.m2
@@ -20,6 +20,7 @@ Thing#{TeXmacs,Print} = send := v -> (
      << tmhtml fixn mathMode mtable {{po(), red "<mo>=</mo>",fmt v}})
 Nothing#{TeXmacs,Print} = identity
 InexactNumber#{TeXmacs,Print} = v -> withFullPrecision ( () -> send v )
+Hypertext#{TeXmacs, Print} = v -> ( << tmhtml fixn html v )
 
 tmAfterPrint = x -> (
     << endl


### PR DESCRIPTION
This fixes `help` output.

### Before

<img width="1280" height="1019" alt="image" src="https://github.com/user-attachments/assets/e2205f44-6df1-40d3-ad7b-7befa16e9630" />



### After

<img width="1280" height="1019" alt="image" src="https://github.com/user-attachments/assets/b9eac74c-9e81-46cb-a4e6-1f8574c06cf4" />




<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
