### PR TITLE
Update algorithm for "poincare Module"

### DIFF
--- a/M2/Macaulay2/m2/hilbert.m2
+++ b/M2/Macaulay2/m2/hilbert.m2
@@ -84,8 +84,11 @@ poincare Module := M -> (
     if (P := computation M) =!= null then return P;
     error("no applicable strategy for computing poincare over ", toString ring M))
 
-addHook((poincare, Module), Strategy => Default, M -> (
-	new degreesRing ring M from rawHilbert raw leadTerm gb presentation M))
+-- Use that the Poincare polynomial of a subquotient module is the difference of the Poincare polynomials of two quotients.
+addHook((poincare, Module), Strategy => Default, M -> (new degreesRing ring M from
+        if M.cache.?minimalPresentation then rawHilbert raw leadTerm gb M.cache.minimalPresentation
+	else if M.cache.?presentation then rawHilbert raw leadTerm gb M.cache.presentation
+	else (rawHilbert raw leadTerm gb relM) - (rawHilbert raw leadTerm gb M)))
 
 -- manually installs the numerator of the reduced Hilbert series for the module
 storefuns#poincare = method()

--- a/M2/Macaulay2/m2/hilbert.m2
+++ b/M2/Macaulay2/m2/hilbert.m2
@@ -84,11 +84,15 @@ poincare Module := M -> (
     if (P := computation M) =!= null then return P;
     error("no applicable strategy for computing poincare over ", toString ring M))
 
--- Use that the Poincare polynomial of a subquotient module is the difference of the Poincare polynomials of two quotients.
+-- Use that the Poincare polynomial of a subquotient module M is the difference of the Poincare polynomials of two quotients.
+-- This avoids having to find a presentation of M (unless that has already been done).
 addHook((poincare, Module), Strategy => Default, M -> (
-        if any(select(keys M.cache, Option), o -> o#0 === symbol minimalPresentation)
-        then return poincare minimalPresentation M;
-        hf := if not M.?generators then
+        hf := if any(select(keys M.cache, Option), o -> o#0 === symbol minimalPresentation) then
+                  rawHilbert raw leadTerm gb relations minimalPresentation M
+              -- We cannot just call "poincare minimalPresentation M", because there are cases (such as M free)
+              -- where both M and minimalPresentation M are cached as having a minimal presentation;
+              -- so that would lead to an infinite loop. 
+              else if not M.?generators then
                   rawHilbert raw leadTerm gb relations M
               else if M.cache.?presentation then
                   rawHilbert raw leadTerm gb M.cache.presentation

--- a/M2/Macaulay2/m2/hilbert.m2
+++ b/M2/Macaulay2/m2/hilbert.m2
@@ -85,10 +85,16 @@ poincare Module := M -> (
     error("no applicable strategy for computing poincare over ", toString ring M))
 
 -- Use that the Poincare polynomial of a subquotient module is the difference of the Poincare polynomials of two quotients.
-addHook((poincare, Module), Strategy => Default, M -> (new degreesRing ring M from
-        if M.cache.?minimalPresentation then rawHilbert raw leadTerm gb M.cache.minimalPresentation
-	else if M.cache.?presentation then rawHilbert raw leadTerm gb M.cache.presentation
-	else (rawHilbert raw leadTerm gb relations M) - (rawHilbert raw leadTerm gb M)))
+addHook((poincare, Module), Strategy => Default, M -> (
+        if any(select(keys M.cache, Option), o -> o#0 === symbol minimalPresentation)
+        then return poincare minimalPresentation M;
+        hf := if not M.?generators then
+                  rawHilbert raw leadTerm gb relations M
+              else if M.cache.?presentation then
+                  rawHilbert raw leadTerm gb M.cache.presentation
+              else (rawHilbert raw leadTerm gb relations M) - (rawHilbert raw leadTerm gb M);
+        new degreesRing ring M from hf
+        ))
 
 -- manually installs the numerator of the reduced Hilbert series for the module
 storefuns#poincare = method()

--- a/M2/Macaulay2/m2/hilbert.m2
+++ b/M2/Macaulay2/m2/hilbert.m2
@@ -88,7 +88,7 @@ poincare Module := M -> (
 addHook((poincare, Module), Strategy => Default, M -> (new degreesRing ring M from
         if M.cache.?minimalPresentation then rawHilbert raw leadTerm gb M.cache.minimalPresentation
 	else if M.cache.?presentation then rawHilbert raw leadTerm gb M.cache.presentation
-	else (rawHilbert raw leadTerm gb relM) - (rawHilbert raw leadTerm gb M)))
+	else (rawHilbert raw leadTerm gb relations M) - (rawHilbert raw leadTerm gb M)))
 
 -- manually installs the numerator of the reduced Hilbert series for the module
 storefuns#poincare = method()

--- a/M2/Macaulay2/tests/normal/poincare3.m2
+++ b/M2/Macaulay2/tests/normal/poincare3.m2
@@ -1,0 +1,17 @@
+R = QQ[x,y,z]
+M1 = module(ideal(x,y,z))
+hf = poincare M1
+T = (ring hf)_0
+assert(hf == poly"3T-3T2+T3")
+assert(hf == poincare res M1)
+
+M2 = minimalPresentation M1
+assert(hf == poincare M1)
+assert(hf == poincare M2)
+
+R2 = ZZ/101[x0,x1,x2,Degrees=>{1,3,5}]
+M3 = module(ideal(x0,x1))
+pres3 = presentation M3
+hf3 = poincare M3
+U = (ring hf3)_0
+assert(hf3 == poly"U+U3-U4")


### PR DESCRIPTION
The current version of "poincare Module" (computing the Poincare polynomial of a graded module M), in hilbert.m2 (in the Macaulay2 core), starts by finding a presentation of M, when M is represented as a subquotient of a free module. Instead, one can interpret the Poincare series of M as the difference of the Poincare series of two quotient modules. This can be faster. Other functions such as hilbertSeries rely on "poincare M", and so the proposed change should also speed them up.