### PR TITLE
Use stdout for startup banner for consistency

### DIFF
--- a/M2/Macaulay2/m2/startup.m2.in
+++ b/M2/Macaulay2/m2/startup.m2.in
@@ -562,9 +562,9 @@ if firstTime then processCommandLineOptions 1
 srcversion = M2version()
 
 if firstTime and not nobanner then (
-     if topLevelMode === TeXmacs then stderr << TeXmacsBegin << "verbatim:";
-     stderr << "Macaulay2, version " << srcversion << newline << flush;
-     if topLevelMode === TeXmacs then stderr << TeXmacsEnd << flush)
+     if topLevelMode === TeXmacs then << TeXmacsBegin << "verbatim:";
+     << "Macaulay2, version " << srcversion << newline << flush;
+     if topLevelMode === TeXmacs then << TeXmacsEnd << flush)
 
 scan(commandLine, arg -> if arg === "-q" then noinitfile = true)
 homeDirectory = getenv "HOME" | "/"


### PR DESCRIPTION
Currently we use a hodgepodge.  The M2 version info is on `stderr` and the help info is on `stdout`.  We switch it so that everything is `stdout`.

### Before
```sh
$ M2 -e "exit 0" > /dev/null
Macaulay2, version 1.25.11-77-g620ed82f51 (development)
$ M2 -e "exit 0" 2> /dev/null
Type "help" to see useful commands
```
### After
```sh
$ M2 -e "exit 0" > /dev/null
$ M2 -e "exit 0" 2> /dev/null
Macaulay2, version 1.25.11-73-gc0c0867784 (mutable-list)
Type "help" to see useful commands
```