### PR TITLE
Load package from same directory when running "tests"

### DIFF
--- a/M2/Macaulay2/m2/testing.m2
+++ b/M2/Macaulay2/m2/testing.m2
@@ -83,7 +83,10 @@ loadTestDir := pkg -> (
 
 tests = method()
 tests Package := pkg -> (
-    if pkg#?"documentation not loaded" then pkg = loadPackage(pkg#"pkgname", LoadDocumentation => true, Reload => true);
+    if pkg#?"documentation not loaded"
+    then pkg = loadPackage(pkg,
+	FileName => pkg#"source file",
+	LoadDocumentation => true);
     if not pkg#?"test directory loaded" then loadTestDir pkg;
     previousMethodsFound = new NumberedVerticalList from pkg#"test inputs"
     )


### PR DESCRIPTION
This fixes a little bug that's bothered me for a while.  Let's say we load a package from some directory other than the one it would usually get loaded from, e.g


```m2
i1 : loadPackage("FirstPackage", FileName => "~/tmp/FirstPackage.m2")

o1 = FirstPackage

o1 : Package
```

Now check out what happens when we run `tests` (or `check`, which calls `tests` to figure out which tests it's supposed to run):

```m2
i2 : tests oo
 -- warning: reloading FirstPackage; recreate instances of types from this package

o2 = {0 => TestInput[/usr/share/Macaulay2/FirstPackage.m2:54:5-56:3]}
     {1 => TestInput[/usr/share/Macaulay2/FirstPackage.m2:58:5-60:3]}

o2 : NumberedVerticalList
```

What happened to the `~/tmp` version?  Here's the code for `tests`:

```m2
i3 : code (tests, Package)

o3 = -- code for method: tests(Package)
     /usr/share/Macaulay2/Core/testing.m2:93:17-97:5: --source code:
     tests Package := pkg -> (
         if pkg#?"documentation not loaded" then pkg = loadPackage(pkg#"pkgname", LoadDocumentation => true, Reload => true);
         if not pkg#?"test directory loaded" then loadTestDir pkg;
         previousMethodsFound = new NumberedVerticalList from pkg#"test inputs"
         )
```

Most of the time, when we load a package, we don't load the documentation.  But also most of the time, the package's tests aren't loaded until we load the documentation.  So we need to reload it with the `LoadDocumentation` option.  But we weren't specifying the path to the package, so we just picked our first option from `path` instead of the one we originally loaded!

We fix this by passing `FileName => pkg#"source file"`  to `loadPackage`.  We can also drop the `Reload => true` since `loadPackage(Package)` passes this automatically.