### PR TITLE
Update mutable list reallocation

### DIFF
--- a/M2/Macaulay2/d/actors2.dd
+++ b/M2/Macaulay2/d/actors2.dd
@@ -58,11 +58,7 @@ toList(e:Expr):Expr := (
      is a:Sequence do list(a)
      is b:List do (
 	  if b.Class == listClass then e
-	  else Expr(
-	       sethash(
-	       	    List(listClass, if b.Mutable then copy(b.v) else b.v,
-		    	 hash_t(0), false),
-	       	    false)))
+	  else list(if b.Mutable then copy(b.v) else b.v))
      is s:stringCell do list(strtoseq(s))
      is c:PseudocodeClosure do toList(c.code)
      is c:Pseudocode do toList(c.code)
@@ -184,7 +180,9 @@ newClassParent(e:Expr,classs:HashTable,parent:HashTable,returned:bool):Expr := (
 	       else if classs == sequenceClass then Expr(o.v)
 	       else (
 	       	    is_mutable := ancestor(classs,mutableListClass);
-		    Expr(sethash( List(classs, if is_mutable || o.Mutable then copy(o.v) else o.v, hash_t(0),false), is_mutable))))
+		    list(classs,
+			if is_mutable || o.Mutable then copy(o.v) else o.v,
+			is_mutable)))
 	  else if basicType == hashTableClass then expected("a hash table",returned)
 	  else wrongTarget())
      is v:Sequence do (
@@ -193,7 +191,9 @@ newClassParent(e:Expr,classs:HashTable,parent:HashTable,returned:bool):Expr := (
 	       else if classs == sequenceClass then Expr(v)
 	       else (
 	       	    is_mutable := ancestor(classs,mutableListClass);
-		    Expr( sethash( List(classs, if is_mutable then copy(v) else v, hash_t(0),false), is_mutable))))
+		    list(classs,
+			if is_mutable then copy(v) else v,
+			is_mutable)))
 	  else if basicType == hashTableClass then expected("a hash table",returned)
 	  else wrongTarget())
      is s:SpecialExpr do (
@@ -224,12 +224,9 @@ newClass(e:Expr,classs:HashTable,returned:bool):Expr := (
 	       else if classs == sequenceClass then Expr(o.v)
 	       else (
 		    is_mutable := ancestor(classs,mutableListClass);
-		    Expr(
-			 sethash(
-			      List(classs,
-				   if is_mutable || o.Mutable then copy(o.v) else o.v,
-				   hash_t(0),false),
-			      is_mutable))))
+		    list(classs,
+			if is_mutable || o.Mutable then copy(o.v) else o.v,
+			is_mutable)))
 	  else if basicType == hashTableClass 
 	  then expected("a hash table",returned)
 	  else wrongTarget())
@@ -239,7 +236,9 @@ newClass(e:Expr,classs:HashTable,returned:bool):Expr := (
 	       if classs == sequenceClass then Expr(v)
 	       else (
 		    is_mutable := ancestor(classs,mutableListClass);
-		    Expr( sethash( List(classs, if is_mutable then copy(v) else v, hash_t(0),false), is_mutable))))
+		    list(classs,
+			if is_mutable then copy(v) else v,
+			is_mutable)))
 	  else if basicType == hashTableClass 
 	  then expected("a hash table",returned)
 	  else wrongTarget())
@@ -297,7 +296,7 @@ makenew(classs:HashTable,parent:HashTable):Expr := (
 	  then buildErrorPacket("expected Nothing as parent for list")
 	  else if classs == sequenceClass
 	  then Expr(emptySequence)
-	  else Expr(sethash( List(classs,emptySequence,hash_t(0),false), ancestor(classs,mutableListClass))))
+	  else list(classs, emptySequence,ancestor(classs,mutableListClass)))
      else if basicType == dictionaryClass then Expr(DictionaryClosure(globalFrame,newGlobalDictionary()))
      else buildErrorPacket("basic type for 'new' method should have been BasicList, HashTable, or Dictionary"));
 makenew(classs:HashTable):Expr := makenew(classs,nothingClass);
@@ -376,8 +375,9 @@ newfromfun(newClassCode:Code,newInitCode:Code):Expr := (
 			    else newClass(newInitExpr, classs, false))
 			else newClass(newInitExpr,classs,false))
 		    is p:List do (
-			 if p.Class == classs
-			 then Expr(if p.Mutable then copy(p) else p)
+			 if p.Class == classs then (
+			     if p.Mutable then list(classs, copy(p.v), true)
+			     else newInitExpr)
 			 else newClass(newInitExpr,classs,false))
 		    is p:HashTable do (
 			 if p.Class == classs
@@ -406,8 +406,9 @@ newoffromfun(newClassCode:Code,newParentCode:Code,newInitCode:Code):Expr := (
 			 when newInitExpr
 			 is p:Sequence do newClassParent(newInitExpr,classs,parent,false)
 			 is p:List do (
-			      if p.Class == classs && nothingClass == parent
-			      then Expr(if p.Mutable then copy(p) else p)
+			      if p.Class == classs && nothingClass == parent then (
+				  if p.Mutable then list(classs, copy(p.v), true)
+				  else newInitExpr)
 			      else newClassParent(newInitExpr,classs,parent,false))
 			 is p:HashTable do (
 			      if p.Class == classs && p.parent == parent

--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -621,7 +621,7 @@ mergepairs(xx:Expr,yy:Expr,f:Expr):Expr := (
 	       else return WrongArg(1,"a list of pairs"));
 	  if n < length(x)+length(y)
 	  then z = new Sequence len n do foreach a in z do provide a;
-	  Expr(sethash(List(commonAncestor(xl.Class,yl.Class), z,hash_t(0),false),xl.Mutable | yl.Mutable)))
+	  list(commonAncestor(xl.Class,yl.Class), z, xl.Mutable | yl.Mutable))
      else WrongArg(2,"a list")
      else WrongArg(1,"a list"));
 mergepairsfun(e:Expr):Expr := (

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1174,7 +1174,7 @@ join(e:Expr):Expr := (
 	  is Sequence do join(a)
 	  is List do join(a)
 	  else applyEE(getGlobalVariable(joinIteratorsS), e))
-     is c:List do if c.Mutable then Expr(copy(c)) else e
+     is c:List do if c.Mutable then copy(Expr(c)) else e
      else WrongArg("lists or sequences"));
 setupfun("join",join);
 

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -528,6 +528,13 @@ examine(e:Expr):Expr := (
      else WrongArg("(), a function, a symbol, or a basic list"));
 setupfun("examine",examine);
 
+size(e:Expr):Expr := (
+    when e
+    is x:Sequence do toExpr(length(x))
+    is x:List do toExpr(x.capacity)
+    else WrongArg("a list or sequence"));
+setupfun("size0", size);
+
 numparms(e:Expr):Expr := (
      when e
      is fc:FunctionClosure do toExpr(if fc.model.desc.restargs then -1 else fc.model.desc.numparms)

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -617,7 +617,7 @@ remove(x:List,i:int):Expr:= (
 	  if i < 0 then i = n + i;
 	  ret := x.v.i;
 	  for j from i to n - 2 do x.v.j = x.v.(j + 1);
-	  Ccode(void, x.v, "->len = ", n - 1);
+	  changeLength(x, n - 1);
 	  ret));
 
 removefun(e:Expr):Expr := (

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -516,7 +516,8 @@ examine(e:Expr):Expr := (
 	  << "basic list:" << endl
 	  << " length: " << length(s.v) << endl
 	  << " hash: " << s.hash << endl
-	  << " mutable: " << s.Mutable << endl;
+	  << " mutable: " << s.Mutable << endl
+	  << " capacity: " << s.capacity << endl;
 	  nullE)
      is s:SpecialExpr do (
 	  stdIO

--- a/M2/Macaulay2/d/actors5.d
+++ b/M2/Macaulay2/d/actors5.d
@@ -60,15 +60,13 @@ prependfun(e:Expr):Expr := (
 			 foreach t in y do provide t;
 			 )		    
 		    )
-	       is y:List do (
-		    r := List(
+	       is y:List do list(
 			 y.Class,
 			 new Sequence len length(y.v) + 1 do (
 			      provide elem;
 			      foreach t in y.v do provide t;
 			      ),
-			 hash_t(0),y.Mutable);
-		    Expr(sethash(r,y.Mutable)))
+			 y.Mutable)
 	       else WrongArg(1+1,"a list or sequence")
 	       )
 	  )
@@ -90,15 +88,13 @@ appendfun(e:Expr):Expr := (
 			 provide elem;
 			 )		    
 		    )
-	       is y:List do (
-		    r := List(
+	       is y:List do list(
 			 y.Class,
 			 new Sequence len length(y.v) + 1 do (
 			      foreach t in y.v do provide t;
 			      provide elem;
 			      ),
-			 hash_t(0),y.Mutable);
-		    Expr(sethash(r,y.Mutable)))
+			 y.Mutable)
 	       else WrongArg(0+1,"a list or sequence")
 	       )
 	  )
@@ -1644,7 +1640,7 @@ setupfun("isGlobalSymbol",isGlobalSymbol);
 --      else WrongNumArgs(0));
 -- setupfun("history",history);
 
-listFrame(s:Sequence):Expr := Expr(List(mutableListClass, s, nextHash(), true));	  
+listFrame(s:Sequence):Expr := list(mutableListClass, s, true);
 listFrame(f:Frame):Expr := if f.frameID == 0 then listFrame(emptySequence) else listFrame(f.values); -- refuse to defeat the protection of global variables
 frame(e:Expr):Expr := (
      when e

--- a/M2/Macaulay2/d/basic.d
+++ b/M2/Macaulay2/d/basic.d
@@ -78,8 +78,8 @@ export hash(x:List):hash_t := (
      h := x.Class.hash + 23407;
      foreach y in x.v do h = h * 1299833 + hash(y);
      h);
-export sethash(x:List,is_mutable:bool):List := (
-     if is_mutable 
+export sethash(x:List):List := (
+     if x.Mutable
      then (
 	  x.Mutable = true;
 	  x.hash = nextHash();
@@ -91,33 +91,18 @@ export sethash(x:List,is_mutable:bool):List := (
      x);
 export copy(v:Sequence):Sequence := (
      new Sequence len length(v) do foreach i in v do provide i);
-export copy(a:List):List := List(
-     a.Class, 
-     new Sequence len length(a.v) do foreach i in a.v do provide i,
-     a.hash,
-     a.Mutable);
 export reverse(a:Sequence):Sequence := (
      n := length(a);
      new Sequence len n do (n = n-1; provide a.n));
-export reverse(a:List):List := sethash( 
-     List( a.Class, reverse(a.v), hash_t(0), a.Mutable), a.Mutable 
-     );
 export seq():Expr := emptySequenceE;
 export seq(e:Expr):Expr := Expr(Sequence(e));
 export seq(e:Expr,f:Expr):Expr := Expr(Sequence(e,f));
 export seq(e:Expr,f:Expr,g:Expr):Expr := Expr(Sequence(e,f,g));
-export list(a:Sequence):Expr := (
-     r := List(listClass,a,hash_t(0),false);
-     r.hash = hash(r);
-     Expr(r));     
-export list(classs:HashTable,a:Sequence):Expr := (
-     r := List(classs,a,hash_t(0),false);
-     r.hash = hash(r);
-     Expr(r));     
 export list(classs:HashTable,a:Sequence,is_mutable:bool):Expr := (
      r := List(classs,a,hash_t(0),is_mutable);
-     r.hash = hash(r);
-     Expr(r));     
+     Expr(sethash(r)));
+export list(classs:HashTable,a:Sequence):Expr := list(classs, a, false);
+export list(a:Sequence):Expr := list(listClass, a);
 export list(classs:HashTable,e:Expr):Expr := (
      when e
      is a:Sequence do list(classs,a)
@@ -129,10 +114,7 @@ export list(e:Expr,f:Expr):Expr := list(Sequence(e,f));
 export list(e:Expr,f:Expr,g:Expr):Expr := list(Sequence(e,f,g));
 export list(e:Expr,f:Expr,g:Expr,h:Expr):Expr := list(Sequence(e,f,g,h));
 
-export Array(a:Sequence):Expr := (
-     r := List(arrayClass,a,hash_t(0),false);
-     r.hash = hash(r);
-     Expr(r));
+export Array(a:Sequence):Expr := list(arrayClass, a);
 export Array(e:Expr):Expr := (
      when e
      is a:Sequence do Array(a)
@@ -143,10 +125,7 @@ export Array(e:Expr,f:Expr):Expr := Array(Sequence(e,f));
 export Array(e:Expr,f:Expr,g:Expr):Expr := Array(Sequence(e,f,g));
 export Array(e:Expr,f:Expr,g:Expr,h:Expr):Expr := Array(Sequence(e,f,g,h));
 
-export AngleBarList(a:Sequence):Expr := (
-     r := List(angleBarListClass,a,hash_t(0),false);
-     r.hash = hash(r);
-     Expr(r));
+export AngleBarList(a:Sequence):Expr := list(angleBarListClass, a);
 export emptyAngleBarList := AngleBarList(Sequence());
 
 -- Local Variables:

--- a/M2/Macaulay2/d/basic.d
+++ b/M2/Macaulay2/d/basic.d
@@ -99,7 +99,7 @@ export seq(e:Expr):Expr := Expr(Sequence(e));
 export seq(e:Expr,f:Expr):Expr := Expr(Sequence(e,f));
 export seq(e:Expr,f:Expr,g:Expr):Expr := Expr(Sequence(e,f,g));
 export list(classs:HashTable,a:Sequence,is_mutable:bool):Expr := (
-     r := List(classs,a,hash_t(0),is_mutable);
+     r := List(classs,a,hash_t(0),is_mutable, length(a));
      Expr(sethash(r)));
 export list(classs:HashTable,a:Sequence):Expr := list(classs, a, false);
 export list(a:Sequence):Expr := list(listClass, a);

--- a/M2/Macaulay2/d/debugging.dd
+++ b/M2/Macaulay2/d/debugging.dd
@@ -217,13 +217,12 @@ setupconst("FilePosition", Expr(filePositionClass));
 export locate(p:Position):Expr := (
     if p == dummyPosition || p == tempPosition
     then nullE
-    else Expr(sethash(List(filePositionClass,
+    else list(filePositionClass,
 		Sequence(
 		    toExpr(verifyMinimizeFilename(p.filename)),
 		    toExpr(int(p.lineL)), toExpr(int(p.columnL)),
 		    toExpr(int(p.lineR)), toExpr(int(p.columnR)),
-		    toExpr(int(p.lineF)), toExpr(int(p.columnF))),
-		hash_t(0), false), false)));
+		    toExpr(int(p.lineF)), toExpr(int(p.columnF)))));
 
 locate(e:Expr):Expr := (
     when e

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -107,6 +107,17 @@ export storeInDictionary(dc:DictionaryClosure,i:Code,rhs:Code):Expr := (
      is Error do ival
      else printErrorMessageE(i,"expected a string"));
 
+export changeLength(x:List, newlen:int):void := (
+    newcapacity := max(4, x.capacity);
+    while newcapacity < newlen do newcapacity = 2 * newcapacity;
+    while newcapacity > max(4, 4 * newlen) do newcapacity = newcapacity / 2;
+    if newcapacity != x.capacity then (
+	x.v = new Sequence len newcapacity do (
+	    foreach y in x.v do provide y;
+	    while true do provide nullE);
+	x.capacity = newcapacity);
+    Ccode(void, x.v, "->len = ", newlen));
+
 assignvector(m:List,i:Code,rhs:Code):Expr := (
      x := m.v;
      ival := eval(i);
@@ -119,13 +130,8 @@ assignvector(m:List,i:Code,rhs:Code):Expr := (
 	       if k < 0 then return printErrorMessageE(i,"negative subscript out of bounds 0 .. "+tostring(length(x)-1));
 	       val := eval(rhs);
 	       when val is Error do return val else (
-		    if k >= length(x) then (
-			 x = new Sequence len k+1 do (
-			      foreach t in x do provide t;
-			      while true do provide nullE;
-			      );
-			 m.v = x; );
-	       	    x.k = val;
+		    if k >= length(x) then changeLength(m, k + 1);
+	       	    m.v.k = val;
 	       	    val))
 	  else printErrorMessageE(i,"expected small integer"))
      is Error do ival

--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -115,7 +115,8 @@ export changeLength(x:List, newlen:int):void := (
 	x.v = new Sequence len newcapacity do (
 	    foreach y in x.v do provide y;
 	    while true do provide nullE);
-	x.capacity = newcapacity);
+	x.capacity = newcapacity)
+    else for i from newlen to length(x.v) - 1 do x.v.i = nullE;
     Ccode(void, x.v, "->len = ", newlen));
 
 assignvector(m:List,i:Code,rhs:Code):Expr := (

--- a/M2/Macaulay2/d/hashtables.dd
+++ b/M2/Macaulay2/d/hashtables.dd
@@ -936,7 +936,7 @@ export (x:string) => (y:constcharstar) ::= x => tostring(y);
 
 export copy(e:Expr):Expr := (
      when e
-     is a:List do if a.Mutable then Expr(copy(a)) else e
+     is a:List do if a.Mutable then list(a.Class, copy(a.v), a.Mutable) else e
      is o:HashTable do if o.Mutable then Expr(copy(o)) else e
      else e);
 setupfun("copy",copy);

--- a/M2/Macaulay2/d/parse.d
+++ b/M2/Macaulay2/d/parse.d
@@ -321,7 +321,8 @@ export List := {+
      Class:HashTable,
      v:Sequence,
      hash:hash_t,
-     Mutable:bool
+     Mutable:bool,
+     capacity:int -- amount of allocated memory (for mutable lists)
      };
 
 export Error := {+

--- a/M2/Macaulay2/d/struct.d
+++ b/M2/Macaulay2/d/struct.d
@@ -6,7 +6,7 @@ reverse(e:Expr):Expr := (
      when e
      -- # typical value: reverse, BasicList, BasicList
      is a:Sequence do Expr(reverse(a))
-     is a:List do Expr(reverse(a))
+     is a:List do list(a.Class, reverse(a.v), a.Mutable)
      -- # typical value: reverse, String, String
      is s:stringCell do toExpr(reverse(s.v))
      else WrongArg("a list, sequence, or string"));
@@ -109,10 +109,6 @@ export toArrayExpr(v:array(int)):Sequence := (
      new Sequence len length(v) do foreach i in v do provide Expr(ZZcell(toInteger(i)))
      );
 
-export newlist(classs:HashTable,v:Sequence):List := (
-     x := List(classs,v,hash_t(0),false);
-     x.hash = hash(x);
-     x);
 export basictype(o:HashTable):HashTable := (
      while true do (
 	  if o.parent == thingClass then return o;

--- a/M2/Macaulay2/m2/lists.m2
+++ b/M2/Macaulay2/m2/lists.m2
@@ -11,6 +11,8 @@ needs "methods.m2"
  MutableList.synonym = "mutable list"
 AngleBarList.synonym = "angle bar list"
 
+size BasicList := ZZ => size0
+
 List ? List := (s,t) -> if class s === class t then toSequence s ? toSequence t else (class s) ? (class t)
 Option ? Option := (s,t) -> toSequence s ? toSequence t
 

--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -531,7 +531,8 @@ between(Thing,VisibleList) := List => (m,v) -> mingle(v,#v-1:m)
 
 length Dictionary := s -> #s
 length String := s -> #s
-length VisibleList := s -> #s
+length VisibleList :=
+length MutableList := s -> #s
 
 Nothing == Nothing := Boolean => (x,y) -> x === y			    -- actually, x and y must both be "null"!
 

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_rings.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_rings.m2
@@ -294,16 +294,36 @@ document {
     SeeAlso => {IndexedVariable}
     }
 
-document {
-     Key => {size, (size, RingElement)},
-     Headline => "the size of an object",
-     TT "size x", " -- returns the size of ", TT "x", " which usually gives
-     a rough indication of memory space required to store the object ", TT "x", ".",
-     PARA{},
-     "For a polynomial, the size is the number of terms.",
-     PARA{},
-     "This function should be replaced by something more generally useful."
-     }
+doc ///
+  Key
+     size
+    (size, RingElement)
+    (size, BasicList)
+  Usage
+    size x
+  Headline
+    the size of an object
+  Description
+    Text
+      @M2CODE "size x"@ returns the size of @VAR "x"@, which usually gives
+      a rough indication of memory space required to store it.
+
+      For a polynomial, the size is the number of terms.
+    Example
+      R = QQ[x,y,z,w]
+      f = z^2 - y*w
+      size f
+    Text
+      For lists, @M2CODE "size"@ reports the capacity of the underlying
+      sequence, which may exceed the number of elements when the list is
+      mutable.  This reflects the amount of memory currently allocated to allow
+      efficient growth without reallocating on every insertion.
+    Example
+      x = new MutableList
+      x#5 = 2;
+      #x
+      size x
+///
 
 document {
     Key => {

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/length-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/length-doc.m2
@@ -7,7 +7,7 @@ document {
     }
 
 document {
-    Key => (length, VisibleList),
+    Key => {(length, VisibleList), (length, MutableList)},
     Headline => "length of a visible list",
     Usage => "n = length x",
     Inputs => { "x" },

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_lists.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_lists.m2
@@ -822,14 +822,6 @@ doc ///
       t = new MutableList from {};
       t#4 = e
       peek t
-    Text
-      When working with mutable lists, be careful not to turn a linear algorithm into
-      a quadratic one by repeatedly appending to it.  Compare the following:
-    Example
-      s = new MutableList
-      elapsedTime scan(1000, i -> s#i = i^2) -- quadratic, since we grow s at each step
-      t = new MutableList from 1000
-      elapsedTime scan(1000, i -> t#i = i^2) -- linear
   SeeAlso
     BasicList
   Subnodes

--- a/M2/Macaulay2/tests/normal/mutable-lists.m2
+++ b/M2/Macaulay2/tests/normal/mutable-lists.m2
@@ -13,6 +13,7 @@ assert Equation(M''#0, 5)
 
 -- ensure that we clean up when removing elements
 x = new MutableList from {1, 2, 3, 4}
+assert Equation(length x, 4)
 assert Equation(remove(x, 0), 1)
 assert Equation(toList x, {2, 3, 4})
 assert Equation(remove(x, 2), 4)

--- a/M2/Macaulay2/tests/normal/mutable-lists.m2
+++ b/M2/Macaulay2/tests/normal/mutable-lists.m2
@@ -10,3 +10,11 @@ assert Equation(#M'',3)
 for i to 2 do assert Equation(M''#i, 2*(i + 1))
 M''#0 = 5
 assert Equation(M''#0, 5)
+
+-- ensure that we clean up when removing elements
+x = new MutableList from {1, 2, 3, 4}
+assert Equation(remove(x, 0), 1)
+assert Equation(toList x, {2, 3, 4})
+assert Equation(remove(x, 2), 4)
+x#3 = 5
+assert Equation(toList x, {2, 3, null, 5}) -- 4 should be gone

--- a/bugs/dan/0-mutable-lists
+++ b/bugs/dan/0-mutable-lists
@@ -1,8 +1,0 @@
-This should not slow down by a factor of 100!
-
-
-i39 : time (x=new MutableList ; for i to 1000 do x#i = i ;  )
-     -- used 0.002677 seconds
-
-i40 : time (x=new MutableList ; for i to 10000 do x#i = i ;  )
-     -- used 2.56211 seconds


### PR DESCRIPTION
Currently, when we add an element to a mutable list, we reallocate exactly enough memory to fit the new element.  So doing something like `for i to n - 1 do x##x = i` constructs n brand new mutable lists.

Instead, we double the length of the underlying sequence if needed.  (And also halve it if it gets small from repeated calls to `remove`.)

So each list `x` now has two lengths:

* `length(x.v)` -- the "visible" length at top level
* `x.capacity` -- the actual length allocated for the underlying sequence

*Edit:  Originally, I had these swapped, but that broke pretty much everything, since so much code depends on `x.v` having exactly the same elements as `x`.*

For immutable lists, these two numbers should always be the same.

I changed some pretty low-level stuff, so chances are there are bugs... Draft for now

### Before

```m2
i1 : x = new MutableList

o1 = MutableList{}

o1 : MutableList

i2 : elapsedTime for i to 99999 do x##x = i
 -- 10.8305s elapsed
```

### After

```m2
i2 : elapsedTime for i to 99999 do x##x = i
 -- .0493995s elapsed
```

Closes: #659 