### PR TITLE
GraphicalModels: Fix caching of `gaussianRing MixedGraph`

### DIFF
--- a/M2/Macaulay2/packages/GraphicalModels.m2
+++ b/M2/Macaulay2/packages/GraphicalModels.m2
@@ -684,8 +684,8 @@ gaussianRing MixedGraph := Ring => opts -> (g) -> (
      p := toSymbol opts.pVariableName;
      k := toSymbol opts.kVariableName; 
      kk := opts.Coefficients;        
-     if (not gaussianRingList#?(kk,s,k,l,p,vv)) then ( 
-	  --(kk,s,k,l,p,vv) uniquely identifies gaussianRing in case of MixedGraph input.
+     if (not gaussianRingList#?(kk,s,k,l,p,dd,bb,uu)) then (
+	  --(kk,s,k,l,p,dd,bb,uu) uniquely identifies gaussianRing in case of MixedGraph input.
      sL := delete(null, flatten apply(vv, x-> apply(vv, y->if pos(vv,x)>pos(vv,y) then null else s_(x,y))));
      kL := join(apply(U, i->k_(i,i)),delete(null, flatten apply(U, x-> apply(toList uu#x, y->if pos(vv,x)>pos(vv,y) then null else k_(x,y)))));
      lL := delete(null, flatten apply(vv, x-> apply(toList dd#x, y->l_(x,y))));	 
@@ -715,8 +715,8 @@ gaussianRing MixedGraph := Ring => opts -> (g) -> (
      R.graphType=class g;
      R.graph= g;
      -- fill into internal gaussianRingList
-     gaussianRingList#((kk,s,k,l,p,vv)) = R;); 
-     gaussianRingList#((kk,s,k,l,p,vv))
+     gaussianRingList#((kk,s,k,l,p,dd,bb,uu)) = R;);
+     gaussianRingList#((kk,s,k,l,p,dd,bb,uu))
      )
 
 
@@ -3588,6 +3588,13 @@ TEST ///
 G = mixedGraph(digraph {{b,{c,d}},{c,{d}}},bigraph {{a,d}})
 R = gaussianRing G
 assert(sort gens R === sort {l_(b,c), l_(b,d), l_(c,d), p_(a,a), p_(b,b), p_(c,c), p_(d,d), p_(a,d), s_(a,a), s_(a,b), s_(a,c), s_(a,d), s_(b,b), s_(b,c), s_(b,d), s_(c,c), s_(c,d), s_(d,d)})
+///
+
+-- Test caching issue GH#3553
+TEST ///
+R1 = gaussianRing digraph({a,b,c}, {(a,b)})
+R2 = gaussianRing digraph({a,b,c}, {(a,b),(b,c),(a,c)})
+assert(R1 =!= R2)
 ///
 
 -----------------------------------------------


### PR DESCRIPTION
This fixes GitHub issue #3553. The gaussianRing function caches its return value. However, for a MixedGraph input, the key only records the vertex set and none of the graph structure which leads to wrong rings being returned.