### PR TITLE
Really raise syntax errors when local/threadLocal don't get a symbol

### DIFF
--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -404,13 +404,13 @@ export unaryglobal(quotetoken:Token,file:TokenFile,prec:int,obeylines:bool):Pars
 export unarythread(quotetoken:Token,file:TokenFile,prec:int,obeylines:bool):ParseTree := (
      arg := gettoken(file,false);
      if arg == errorToken then return errorTree;
-     if arg.word.typecode != TCid then makeParseError(arg, "syntax error: " + arg.word.name);
+     if arg.word.typecode != TCid then return makeParseError(arg, "syntax error: " + arg.word.name);
      r := ParseTree(ThreadQuote(quotetoken,arg));
      accumulate(r,file,prec,obeylines));
 export unarylocal(quotetoken:Token,file:TokenFile,prec:int,obeylines:bool):ParseTree := (
      arg := gettoken(file,false);
      if arg == errorToken then return errorTree;
-     if arg.word.typecode != TCid then makeParseError(arg, "syntax error: " + arg.word.name);
+     if arg.word.typecode != TCid then return makeParseError(arg, "syntax error: " + arg.word.name);
      r := ParseTree(LocalQuote(quotetoken,arg));
      accumulate(r,file,prec,obeylines));
 export unaryif(ifToken:Token,file:TokenFile,prec:int,obeylines:bool):ParseTree := (


### PR DESCRIPTION
They printed the errors but still returned something.

### Before

```m2
i1 : symbol 5
stdio:1:7:(3): error: syntax error: 5

i1 : global 5
stdio:2:7:(3): error: syntax error: 5

i1 : local 5
stdio:3:6:(3): error: syntax error: 5

o1 = 5

o1 : Symbol

i2 : threadLocal 5
stdio:4:12:(3): error: syntax error: 5

o2 = -*dummy symbol*-

o2 : Keyword
```

### After

```m2
i1 : symbol 5
stdio:1:7:(3): error: syntax error: 5

i1 : global 5
stdio:2:7:(3): error: syntax error: 5

i1 : local 5
stdio:3:6:(3): error: syntax error: 5

i1 : threadLocal 5
stdio:4:12:(3): error: syntax error: 5
```