### PR TITLE
Stop trying to install python & ninja in GitHub macOS builds

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -64,8 +64,7 @@ jobs:
           brew config
           brew update
           brew tap macaulay2/tap
-          brew install --overwrite python
-          brew install automake bison boost libtool tbb ccache ctags llvm make ninja yasm libffi msolve googletest fplll eigen
+          brew install automake bison boost libtool tbb ccache ctags llvm make yasm libffi msolve googletest fplll eigen
           brew install texinfo || true # sometimes post-install step fails
           brew install --only-dependencies macaulay2/tap/M2
           brew link factory --force


### PR DESCRIPTION
They're already installed and we just get warnings.

For example, from https://github.com/Macaulay2/M2/actions/runs/21576025985:

<img width="876" height="316" alt="image" src="https://github.com/user-attachments/assets/6fba8b9f-3322-407b-b0df-bf0ca6d0aabe" />

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
