### PR TITLE
Define methodOptions(List)

### DIFF
--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -226,7 +226,7 @@ method = methodDefaults >> opts -> args -> (
 -- get the options used when a method was declared
 -- TODO: doesn't work for MethodFunctionSingle, MethodFunctionBinary
 methodOptions = method(TypicalValue => OptionTable)
-methodOptions Function := methodOptions Symbol := f -> null
+methodOptions Function := methodOptions Symbol := methodOptions List := f -> null
 methodOptions MethodFunctionWithOptions := MultipleArgsWithOptionsGetMethodOptions
 methodOptions MethodFunction := MultipleArgsNoOptionsGetMethodOptions
 methodOptions Command := f -> methodOptions f#0

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_methods.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_methods.m2
@@ -584,6 +584,7 @@ document { Key => MethodFunctionWithOptions,
 undocumented (methodOptions, MethodFunctionWithOptions)
 undocumented (methodOptions, MethodFunction)
 undocumented (methodOptions, Symbol)
+undocumented (methodOptions, List)
 document { Key => {(methodOptions, Function),(methodOptions, Command),(methodOptions, ScriptedFunctor),methodOptions},
      Headline => "recover the options used when a method function was created",
      Usage => "methodOptions f",

--- a/M2/Macaulay2/tests/normal/methods.m2
+++ b/M2/Macaulay2/tests/normal/methods.m2
@@ -133,3 +133,6 @@ assert(2 == length methods parent class code first)
 -- this used to fail because of a bug in (package, Sequence)
 debug Core
 assert(1 == length methods needsPackage "FirstPackage")
+
+-- used to give an error
+code methods {Standard, Print}


### PR DESCRIPTION
This fixes an error when calling `code` on a method installed using a list as a key, e.g., `{Standard, Print}`.

### Before

```m2
i1 : code methods {Standard, Print}
stdio:1:4:(3): error: no method found for applying methodOptions to:
     argument   :  {Standard, Print} (of class List)
```

### After
```m2
i3 : code methods {Standard, Print}

o3 = -- code for method: {Standard, Print}(InexactNumber)
     /usr/share/Macaulay2/Core/reals.m2:447:33-447:91: --source code:
     InexactNumber#{Standard,Print} = x ->  withFullPrecision ( () -> Thing#{Standard,Print} x )
     ------------------------------------------------------------------------------------------
     -- code for method: {Standard, Print}(Thing)
     /usr/share/Macaulay2/Core/robust.m2:133:25-149:6: --source code:
     Thing#{Standard,Print} = x -> (
          oprompt := concatenate(interpreterDepth:"o", toString lineNumber, " = ");
          save := printWidth;
          if printWidth != 0 then printWidth = printWidth - #oprompt;
          z := robustNet x;
          wrapper := lookup(global Wrap,class x);
          if wrapper =!= null then (
               fun := () -> z = wrapper z;
               try timelimit(printingTimeLimit, fun)
               else (
                    alarm 0;
                    global debugError <- fun;
                    stderr << "--error or time limit reached in applying Wrap method to output; type 'debugError()' to see it" << endl << endl);
               );
          << endl << oprompt << z << endl;
          printWidth = save;
          )
     ------------------------------------------------------------------------------------------
     -- code for method: {Standard, Print}(Nothing)
     compiled function identity:  source code not available
```