### PR TITLE
Bump gdbm to 1.26

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -175,7 +175,8 @@ jobs:
           ../../autogen.sh
           export F77=gfortran-14
           export FC=gfortran-14
-          ../../configure --with-system-gc --with-fplll
+          ../../configure --with-system-gc --with-fplll \
+            --enable-build-libraries=gdbm
 
       - name: Build libraries using Make
         if: matrix.build-system == 'autotools'

--- a/M2/libraries/gdbm/Makefile.in
+++ b/M2/libraries/gdbm/Makefile.in
@@ -7,6 +7,8 @@ ifeq (@SHARED@,no)
 CONFIGOPTIONS += --disable-shared --enable-static
 endif
 
+CONFIGOPTIONS += --without-readline
+
 ifeq ($(VERSION) @host@,1.9.1 x86_64-w64-mingw32)
 PATCHFILE += @abs_srcdir@/patch-1.9.1-mingw64
 endif

--- a/M2/libraries/gdbm/Makefile.in
+++ b/M2/libraries/gdbm/Makefile.in
@@ -1,7 +1,7 @@
 LICENSEFILES = COPYING
 
 URL = https://ftp.gnu.org/gnu/gdbm
-VERSION = 1.24
+VERSION = 1.26
 
 ifeq (@SHARED@,no)
 CONFIGOPTIONS += --disable-shared --enable-static


### PR DESCRIPTION
Autotools only, as cmake doesn't have the option of building it.

Draft for now to test the builds.