### PR TITLE
Add support for converting raw monomial ideals to strings

### DIFF
--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -1011,10 +1011,7 @@ tostringfun(e:Expr):Expr := (
      is x:RawMonoidCell do toExpr(Ccode(string, "rawMonoidToString(",x.p,")" ))
      is x:RawRingCell do toExpr(Ccode(string, "IM2_Ring_to_string(",x.p,")" ))
      is x:RawRingElementCell do toExpr( Ccode(string, "IM2_RingElement_to_string(",x.p,")" ) )
-     is x:RawMonomialIdealCell do toExpr(
-	  "<<raw monomial ideal>>"
-	  -- Ccode(string, "IM2_MonomialIdeal_to_string(",x.p,")" )
-	  )
+     is x:RawMonomialIdealCell do toExpr( Ccode(string, "IM2_MonomialIdeal_to_string(",x.p,")" ) )
      is c:RawComputationCell do toExpr(Ccode(string, "IM2_GB_to_string(",c.p,")" ))
      is pythonObjectCell do toExpr("<<a python object>>")
      is x:xmlNodeCell do toExpr(toString(x.v))

--- a/M2/Macaulay2/e/interface/monomial-ideal.cpp
+++ b/M2/Macaulay2/e/interface/monomial-ideal.cpp
@@ -49,7 +49,7 @@ const Matrix /* or null */ *IM2_MonomialIdeal_to_matrix(const MonomialIdeal *I)
   }
 }
 
-M2_string MonomialIdeal_to_string(const MonomialIdeal *I)
+M2_string IM2_MonomialIdeal_to_string(const MonomialIdeal *I)
 {
   buffer o;
   try

--- a/M2/Macaulay2/e/interface/monomial-ideal.h
+++ b/M2/Macaulay2/e/interface/monomial-ideal.h
@@ -43,7 +43,7 @@ const Matrix /* or null */ *IM2_MonomialIdeal_to_matrix(const MonomialIdeal *I);
 /* Return a one row matrix over the base ring of I consisting
    of the monomials in I */
 
-M2_string IM2_MonomialIdeal_to_string(const MonomialIdeal *I); /* TODO */
+M2_string IM2_MonomialIdeal_to_string(const MonomialIdeal *I);
 
 unsigned int rawMonomialIdealHash(const MonomialIdeal *I);
 /* connected to 'hash', sequential, as it is mutable */


### PR DESCRIPTION
The code was written but never set up

### Before

```m2
i1 : R = QQ[x,y,z,w]; I = monomialIdeal vars R

o2 = monomialIdeal (x, y, z, w)

o2 : MonomialIdeal of R

i3 : debug Core; raw I

o4 = <<raw monomial ideal>>

o4 : RawMonomialIdeal
```

### After

```m2
i1 : R = QQ[x,y,z,w]; I = monomialIdeal vars R

o2 = monomialIdeal (x, y, z, w)

o2 : MonomialIdeal of R

i3 : debug Core; raw I

o4 = w z y x 

o4 : RawMonomialIdeal
```