### PR TITLE
Set up partition table for Hilbert algorithm w/ at least 1 variable

### DIFF
--- a/M2/Macaulay2/e/hilb.cpp
+++ b/M2/Macaulay2/e/hilb.cpp
@@ -350,7 +350,7 @@ hilb_comp::hilb_comp(const PolynomialRing *RR, const Matrix *m)
       this_comp(0),
       n_components(m->n_rows()),
       current(nullptr),
-      part_table(S->n_vars(), mi_stash)
+      part_table(std::max(1, S->n_vars()), mi_stash)
 {
   assert(D == R->getMonoid());
   one = R->getCoefficientRing()->from_long(1);

--- a/M2/Macaulay2/tests/normal/hilbert.m2
+++ b/M2/Macaulay2/tests/normal/hilbert.m2
@@ -82,3 +82,7 @@ assert(truncateSeries(5, {1,1}, Divide{1_R,Product{Power{1-x,1}}}) == x^4+x^3+x^
 assert(truncateSeries(5, {1,1}, Divide{1_R,Product{Power{1+x,1}}}) == x^4-x^3+x^2-x+1)
 assert(truncateSeries(5, {1,1}, Divide{1_R,Product{Power{1+x,1},Power{1-x,1}}}) == x^4+x^2+1)
 assert(truncateSeries(3, {1,1}, Divide{1_R,Product{Power{1+x,1},Power{1-y,1}}}) == x^2-x*y+y^2-x+y+1)
+
+-- used to crash M2 (#4100)
+R = QQ[]
+assert(zero poincare ideal 1_R)


### PR DESCRIPTION
Even when our ring doesn't have any variables, we still represent the monomial 1 using a dummy variable raised to the 0th power.

Previously, when calling `poincaire ideal 1_R` when R had no variables, we segfaulted in `partition_table::partition()` when calling `reset(I->topvar() + 1)`, since `I->topvar()` returned 0 (for the dummy variable) and `reset` tries writing in the `dad` and `occurs` arrays, but they were initialized as length 0.

To fix this, we initialize these arrays to have length 1 even when the ring has no variables.

Fixes: #4100 

### Before

```m2
i1 : R = QQ[]; poincare ideal 1_R
-- SIGSEGV
-* stack trace, pid: 1771091
 0# profiler_stacktrace(std::ostream&, int) at /usr/src/macaulay2-1.25.11+git202602122026-0ppa202602102226~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:131
 1# segv_handler at /usr/src/macaulay2-1.25.11+git202602122026-0ppa202602102226~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:247
 2# 0x00007427EDC45330 in /lib/x86_64-linux-gnu/libc.so.6
 3# partition_table::partition(MonomialIdeal*&, std::vector<MonomialIdeal*, gc_allocator<MonomialIdeal*> >&) at /usr/src/macaulay2-1.25.11+git202602122026-0ppa202602102226~ubuntu24.04.1/M2/Macaulay2/e/hilb.cpp:126
 4# hilb_comp::next_monideal() at /usr/src/macaulay2-1.25.11+git202602122026-0ppa202602102226~ubuntu24.04.1/M2/Macaulay2/e/hilb.cpp:322
 5# hilb_comp::hilb_comp(PolynomialRing const*, Matrix const*) at /usr/src/macaulay2-1.25.11+git202602122026-0ppa202602102226~ubuntu24.04.1/M2/Macaulay2/e/hilb.cpp:369
 6# hilb_comp::hilbertNumerator(Matrix const*) at /usr/src/macaulay2-1.25.11+git202602122026-0ppa202602102226~ubuntu24.04.1/M2/Macaulay2/e/hilb.cpp:674
 7# IM2_Matrix_Hilbert at interface/groebner.cpp:72
```

### After

```m2
i1 : R = QQ[]; poincare ideal 1_R

o2 = 0

o2 : ZZ[T]
```