### PR TITLE
Add support for "value" for SpecialExpr types

### DIFF
--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -538,6 +538,7 @@ value(e:Expr):Expr := (
 	       || err.message == breakMessage then if err.value == dummyExpr then nullE else err.value 
 	       else r)
 	  else r)
+     is x:SpecialExpr do value(x.e)
      else WrongArg(1,"a string, a symbol, or pseudocode"));
 setupfun("value'",value);
 

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -89,3 +89,4 @@ assert Equation(format(ascii(0..31) | "\"\\"),
 T = new SelfInitializingType of String
 assert Equation(net T "foo", "foo")
 assert Equation(format T "foo", "\"foo\"")
+assert Equation(value T "5", 5)


### PR DESCRIPTION
In particular, this lets us call `value` on instances of subclasses of `String`, `Symbol`, and `Pseudocode`.

### Before

```m2
i1 : X = new SelfInitializingType of String;

i2 : Y = new SelfInitializingType of Symbol;

i3 : Z = new SelfInitializingType of Pseudocode;

i4 : value X "5"
stdio:4:5:(3): error: expected argument 1 to be a string, a symbol, or pseudocode

i5 : x = 5; value Y symbol x
stdio:5:12:(3): error: expected argument 1 to be a string, a symbol, or pseudocode

i7 : value Z pseudocode functionBody(() -> 5)
stdio:6:5:(3): error: expected argument 1 to be a string, a symbol, or pseudocode
```

### After

```m2
i1 : X = new SelfInitializingType of String;

i2 : Y = new SelfInitializingType of Symbol;

i3 : Z = new SelfInitializingType of Pseudocode;

i4 : value X "5"

o4 = 5

i5 : x = 5; value Y symbol x

o6 = 5

i7 : value Z pseudocode functionBody(() -> 5)

o7 = 5
```