### PR TITLE
Use Jansson for JSON parsing

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -64,7 +64,7 @@ jobs:
           brew config
           brew update
           brew tap macaulay2/tap
-          brew install automake bison boost libtool tbb ccache ctags llvm make yasm libffi msolve googletest fplll eigen
+          brew install automake bison boost libtool tbb ccache ctags llvm make yasm libffi msolve googletest fplll eigen jansson
           brew install texinfo || true # sometimes post-install step fails
           brew install --only-dependencies macaulay2/tap/M2
           brew link factory --force
@@ -85,7 +85,7 @@ jobs:
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
                   libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 libnormaliz-dev normaliz coinor-csdp \
                   libnauty-dev nauty lrslib polymake pipx phcpack w3c-markup-validator libtbb-dev qepcad libomp-16-dev \
-                  msolve libfplll-dev
+                  msolve libfplll-dev libjansson-dev
 
 # ----------------------
 #   Steps common to all build variants

--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -93,6 +93,7 @@ set(DLIST
   texmacs.d
   boostmath.dd
   atomic2.d
+  json.d
   ffi.d		# removed unless WITH_FFI
   interp.dd	# this one is last, because it contains the top level interpreter
   version.dd

--- a/M2/Macaulay2/d/Makefile.files.in
+++ b/M2/Macaulay2/d/Makefile.files.in
@@ -103,6 +103,7 @@ M2_DFILES += monoid.dd
 M2_DFILES += monomial_ordering.dd
 M2_DFILES += boostmath.dd
 M2_DFILES += atomic2.d
+M2_DFILES += json.d
 ifneq (@LIBFFI@,no)
 M2_DFILES += ffi.d
 else

--- a/M2/Macaulay2/d/json.d
+++ b/M2/Macaulay2/d/json.d
@@ -1,0 +1,71 @@
+use common;
+use util;
+use hashtables;
+
+header "#include <jansson.h>";
+
+json_tstar := Pointer "struct json_t *";
+json_error_t := Type "struct json_error_t";
+
+toExpr(json:json_tstar):Expr := (
+    type := Ccode(int, "json_typeof(", json, ")");
+    if type == Ccode(int, "JSON_OBJECT")
+    then (
+	h := newHashTable(hashTableClass,nothingClass);
+	iter := Ccode(voidPointer, "json_object_iter(", json, ")");
+	while iter != nullPointer() do (
+	    storeInHashTable(h,
+		-- TODO: use json_object_iter_key_len so we can have \0 in keys
+		-- problem: added in jansson 2.14, which isn't available on
+		-- some older systems like Ubuntu 18.04
+		toExpr(Ccode(constcharstar,
+			"json_object_iter_key(", iter, ")")),
+		toExpr(Ccode(json_tstar,
+			"json_object_iter_value(", iter, ")")));
+	    iter = Ccode(voidPointer,
+		"json_object_iter_next(", json, ", ", iter, ")"));
+	Expr(sethash(h, false)))
+    else if type == Ccode(int, "JSON_ARRAY")
+    then list(new Sequence len Ccode(int, "json_array_size(", json, ")")
+	at i do provide toExpr(
+	    Ccode(json_tstar, "json_array_get(", json, ", ", i, ")")))
+    else if type == Ccode(int, "JSON_STRING")
+    then toExpr(tostringn(
+	    Ccode(constcharstar, "json_string_value(", json, ")"),
+	    Ccode(int, "json_string_length(", json, ")")))
+    else if type == Ccode(int, "JSON_INTEGER")
+    then toExpr(Ccode(long, "json_integer_value(", json, ")"))
+    else if type == Ccode(int, "JSON_REAL")
+    then toExpr(Ccode(double, "json_real_value(", json, ")"))
+    else if type == Ccode(int, "JSON_TRUE") then True
+    else if type == Ccode(int, "JSON_FALSE") then False
+    else if type == Ccode(int, "JSON_NULL") then nullE
+    else buildErrorPacket("unknown json type"));
+
+jsonFlags := Ccode(int, "JSON_DECODE_ANY | JSON_ALLOW_NUL");
+
+fromJSON(e:Expr):Expr := (
+    j := Ccode(json_tstar or null, "NULL");
+    jerr := Ccode(json_error_t, "(json_error_t){0}");
+    when e
+    is buf:stringCell do (
+	j = Ccode(json_tstar or null, "json_loadb((const char *)", buf.v,
+	    "->array, ", length(buf.v), ", ", jsonFlags, ", &", jerr, ")"))
+    is f:file do (
+	j = Ccode(json_tstar or null, "json_loadfd(", f.infd,
+	    ", ", jsonFlags, ", &", jerr, ")"))
+    else return WrongArg("a string or file");
+    when j
+    is json:json_tstar do (
+	ret := toExpr(json);
+	Ccode(void, "json_decref(", json, ")");
+	ret)
+    is null do (
+	n := 55 + Ccode(int, "JSON_ERROR_TEXT_LENGTH");
+	buf := newstring(n);
+	Ccode(void, "snprintf((char *)", buf, "->array, ", n,
+	    ", \"json error at line %d, column %d: %s\", ", jerr, ".line, ",
+	    jerr, ".column, ", jerr, ".text)");
+	Ccode(void, buf, "->len = strlen((char *)", buf, "->array)");
+	buildErrorPacket(buf)));
+setupfun("fromJSON0", fromJSON);

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -71,6 +71,8 @@ header "
    #endif
 
    #include <libxml/xmlversion.h>
+
+   #include <jansson.h>
    ";
 
 header "
@@ -190,6 +192,7 @@ setupconst("version", Expr(toHashTable(Sequence(
    "ntl version" => Ccode(constcharstar,"NTL_VERSION"),
    "frobby version" => Ccode(constcharstar,"frobby_version"),
    "flint version" => Ccode(constcharstar,"FLINT_VERSION"),
+   "jansson version" => Ccode(constcharstar, "JANSSON_VERSION"),
    "scscp version" => Ccode(constcharstar,"
 	 #ifdef HAVE_SCSCP
 	   stringize(SCSCP_VERSION_MAJOR) \".\" stringize(SCSCP_VERSION_MINOR) \".\" stringize(SCSCP_VERSION_PATCH)

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -307,6 +307,8 @@ https://github.com/nst/JSONTestSuite"
 outfile = openOut(outdir | "/tests/parse.m2")
 outfile << commentize  copyrightBanner << endl
 for tst in sort select(tsts, f -> match("^y_", f)) do (
+    -- TODO: allow \0 in keys (need jansson 2.14)
+    if tst == "y_object_escaped_null_in_key.json" then continue;
     outfile << endl << commentize tst << endl;
     testjson = get(testdir | "/" | tst);
     outfile << "assert BinaryOperation(symbol ===, fromJSON " <<

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -1,5 +1,5 @@
 -- JSON package for Macaulay2
--- Copyright (C) 2022-2025 Doug Torrance
+-- Copyright (C) 2022-2026 Doug Torrance
 
 -- This program is free software; you can redistribute it and/or
 -- modify it under the terms of the GNU General Public License
@@ -17,8 +17,8 @@
 newPackage(
     "JSON",
     Headline => "JSON encoding and decoding",
-    Version => "0.5",
-    Date => "November 10, 2025",
+    Version => "0.6",
+    Date => "February 18, 2026",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
@@ -32,6 +32,13 @@ newPackage(
 ---------------
 
 -*
+
+0.6 (2026-02-18, M2 1.26.05)
+* parsing is now handled by jansson in the interpreter, which speeds things up
+  considerably
+* breaking changes:
+  - "null" now returns as null, not nil
+  - \0 is no longer allowed in object keys
 
 0.5 (2025-11-10, M2 1.25.11)
 * add GPL copyright header

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -24,7 +24,6 @@ newPackage(
 	    Email => "dtorrance@piedmont.edu",
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
     Keywords => {"System"},
-    PackageImports => {"Parsing"},
     PackageExports => {"Text"},
     AuxiliaryFiles => true)
 
@@ -72,90 +71,11 @@ export {
     "ValueSeparator",
     }
 
-exportFrom_Parsing "nil"
-
-----------------------------------------------------------------
--- parser based on https://datatracker.ietf.org/doc/html/rfc8259
-----------------------------------------------------------------
-
--- whitespace
-wsP   = *orP(" ", "\t", "\n", "\r")
-strip = p -> first % (p @ wsP)
-
--- structural characters
-beginArrayP     = strip "["
-beginObjectP    = strip "{"
-endArrayP       = strip "]"
-endObjectP      = strip "}"
-nameSeparatorP  = strip ":"
-valueSeparatorP = strip ","
-
--- literals
-falseP = (x -> false) % constParser "false"
-nullP  = (x -> nil)   % constParser "null" -- using null would break parsing
-trueP  = (x -> true)  % constParser "true"
-
--- numbers
-digit19P = orP("1", "2", "3", "4", "5", "6", "7", "8", "9")
-digitP   = "0" | digit19P
-expP     = andP(orP("e", "E"), optP(orP("-", "+")), +digitP)
-fracP    = andP(".", +digitP)
-intP     = orP("0", digit19P @ *digitP)
-numberP  = (x -> value concatenate delete(nil, deepSplice x)
-    ) % andP(optP("-"), intP, optP(fracP), optP(expP))
-
--- strings
-hexDigitP = digitP | orP("a", "b", "c", "d", "e", "f",
-    "A", "B", "C", "D", "E", "F");
-unescapedP = Parser(c -> if c === null then null else (
-	x := first utf8 c;
-	if x < 0x20 or x == 0x22 or x == 0x5c or x > 0x10ffff
-	then null
-	else terminalParser c))
-deformat = x -> (
-    if last x === "/" then "/"
-    else value concatenate("\"", x, "\""))
-escapedP = deformat % ("\\" @
-    orP("\"", "\\", "/", "b", "f", "n", "r", "t",
-	andP("u", hexDigitP, hexDigitP, hexDigitP, hexDigitP)))
-charP = unescapedP | escapedP
-stringP = ((l, x, r) -> concatenate x) % andP("\"", *charP, "\"")
-
--- objects
-memberP = ((k, gets, v) -> k => v) % andP(
-    stringP, nameSeparatorP, futureParser valueP)
-objectP = ((l, x, r) ->  hashTable (
-	if x === nil then {}
-	else toList deepSplice x)) % andP(
-    beginObjectP,
-    optP(memberP @ * (last % valueSeparatorP @ memberP)),
-    endObjectP)
-
--- arrays
-arrayP = ((l, x, r) -> (
-	if x === nil then {}
-	else toList deepSplice x)) % andP(
-    beginArrayP,
-    optP(futureParser valueP @
-	*(last % valueSeparatorP @ futureParser valueP)),
-    endArrayP)
-
--- values
-valueP = strip orP(falseP, nullP, trueP, objectP, arrayP, numberP, stringP)
-jsonTextP = (last @@ last) % (*wsP @ valueP)
-
-utf8Analyzer = Analyzer(s -> (
-	if not instance(s, String) then error "analyzer expected a string";
-	chars := characters s;
-	i := 0;
-	() -> if chars#?i then (
-	    r := (i, chars#i);
-	    i = i + 1;
-	    r)))
+importFrom(Core, "fromJSON0")
 
 fromJSON = method()
-fromJSON String := jsonTextP : utf8Analyzer
-fromJSON File   := fromJSON @@ get
+fromJSON String :=
+fromJSON File   := fromJSON0
 
 --------------
 -- encoding --
@@ -170,15 +90,15 @@ toJSON = method(
 	ValueSeparator => null,
 	Sort           => false})
 
-toJSON Thing   := toJSON MutableHashTable := o -> format @@ toString
+toJSON Thing   :=
+toJSON Symbol  :=
+toJSON MutableHashTable := o -> format @@ toString
 toJSON String  := o -> format
 toJSON RR      := o -> format_0
 toJSON Number  := o -> format_0 @@ numeric
 toJSON ZZ      :=
 toJSON Boolean :=
 toJSON Nothing := o -> toString
-toJSON Symbol  := o -> x -> (
-    if x === nil then "null" else format toString x)
 toJSON Hypertext := o -> format @@ html
 
 maybeNewline = o -> if o.Indent === null then "" else newline
@@ -231,7 +151,7 @@ doc ///
       @TO toJSON@ and @TO fromJSON@, for converting Macaulay2 things to
       valid JSON data and vice versa.
     Example
-      toJSON {hashTable{"foo" => "bar"}, 1, 3.14159, true, false, nil}
+      toJSON {hashTable{"foo" => "bar"}, 1, 3.14159, true, false, null}
       fromJSON oo
 ///
 
@@ -278,7 +198,7 @@ doc ///
       given Macaulay2 thing.  If the @TT "Indent"@ option is @TT "null"@
       (the default), then there are no newlines or indentation.
     Example
-      x = hashTable {"foo" => {1, 2, {pi, true, false, nil}}}
+      x = hashTable {"foo" => {1, 2, {pi, true, false, null}}}
       toJSON x
     Text
       If the @TT "Indent"@ option is an integer, then newlines are added between
@@ -328,8 +248,7 @@ doc ///
   Description
     Text
       The JSON data provided in the given string or file is parsed using the
-      @TO "Parsing"@ package with the context-free grammar specified by
-      @HREF{"https://datatracker.ietf.org/doc/html/rfc8259", "RFC 8259"}@.
+      @HREF("https://github.com/akheron/jansson", "Jansson")@ library.
       The type of the return value will vary depending on the data.
 
       Numbers will result in @TT "ZZ"@ or @TT "RR"@ objects, as appropriate.
@@ -347,11 +266,9 @@ doc ///
       fromJSON "true"
       fromJSON "false"
     Text
-      Due to the implementation of the @TT "Parsing"@ package, @TO "null"@
-      cannot be a return value, and so the symbol @TO "nil"@ is returned
-      when JSON's @TT "null"@ is given.
+      JSON's @TT "null"@ will result in Macaulay2's @TO null@.
     Example
-      fromJSON "null"
+      fromJSON "null" === null
     Text
       Objects will result in hash tables.
     Example
@@ -377,7 +294,6 @@ testdir = tmpdir | "/JSONTestSuite/test_parsing"
 tsts = select(readDirectory(testdir), f ->
     match("\\.json$", f))
 
-needsPackage "Parsing" -- for nil
 debug Core -- for commentize
 
 outdir = (needsPackage "JSON")#"source directory" | "JSON"

--- a/M2/Macaulay2/packages/JSON/tests/encode.m2
+++ b/M2/Macaulay2/packages/JSON/tests/encode.m2
@@ -12,7 +12,6 @@ assert Equation(toJSON "¡pʃɹoʍ 'oʃʃǝH", "\"¡pʃɹoʍ 'oʃʃǝH\"")
 assert Equation(toJSON true, "true")
 assert Equation(toJSON false, "false")
 assert Equation(toJSON null, "null")
-assert Equation(toJSON nil, "null")
 
 -- arrays
 assert Equation(toJSON {1, 2, 3}, "[1, 2, 3]")

--- a/M2/Macaulay2/packages/JSON/tests/parse.m2
+++ b/M2/Macaulay2/packages/JSON/tests/parse.m2
@@ -19,10 +19,10 @@ assert BinaryOperation(symbol ===, fromJSON "[\"a\"]", {"a"})
 assert BinaryOperation(symbol ===, fromJSON "[false]", {false})
 
  -- y_array_heterogeneous.json
-assert BinaryOperation(symbol ===, fromJSON "[null, 1, \"1\", {}]", {nil,1,"1",new HashTable from {}})
+assert BinaryOperation(symbol ===, fromJSON "[null, 1, \"1\", {}]", {,1,"1",new HashTable from {}})
 
  -- y_array_null.json
-assert BinaryOperation(symbol ===, fromJSON "[null]", {nil})
+assert BinaryOperation(symbol ===, fromJSON "[null]", {null})
 
  -- y_array_with_1_and_newline.json
 assert BinaryOperation(symbol ===, fromJSON "[1\n]", {1})
@@ -31,7 +31,7 @@ assert BinaryOperation(symbol ===, fromJSON "[1\n]", {1})
 assert BinaryOperation(symbol ===, fromJSON " [1]", {1})
 
  -- y_array_with_several_null.json
-assert BinaryOperation(symbol ===, fromJSON "[1,null,null,null,2]", {1,nil,nil,nil,2})
+assert BinaryOperation(symbol ===, fromJSON "[1,null,null,null,2]", {1,,,,2})
 
  -- y_array_with_trailing_space.json
 assert BinaryOperation(symbol ===, fromJSON "[2] ", {2})
@@ -111,9 +111,6 @@ assert BinaryOperation(symbol ===, fromJSON "{}", new HashTable from {})
  -- y_object_empty_key.json
 assert BinaryOperation(symbol ===, fromJSON "{\"\":0}", new HashTable from {"" => 0})
 
- -- y_object_escaped_null_in_key.json
-assert BinaryOperation(symbol ===, fromJSON "{\"foo\\u0000bar\": 42}", new HashTable from {"foo\0bar" => 42})
-
  -- y_object_extreme_numbers.json
 assert BinaryOperation(symbol ===, fromJSON "{ \"min\": -1.0e+28, \"max\": 1.0e+28 }", new HashTable from {"max" => .99999999999999996p53e28, "min" => -.99999999999999996p53e28})
 
@@ -133,10 +130,10 @@ assert BinaryOperation(symbol ===, fromJSON "{\n\"a\": \"b\"\n}", new HashTable 
 assert BinaryOperation(symbol ===, fromJSON "[\"\\u0060\\u012a\\u12AB\"]", {"`ÄªáŠ«"})
 
  -- y_string_accepted_surrogate_pair.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uD801\\udc37\"]", {"í í°·"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD801\\udc37\"]", {"ğ·"})
 
  -- y_string_accepted_surrogate_pairs.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\ud83d\\ude39\\ud83d\\udc8d\"]", {"í ½í¸¹í ½í²"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\ud83d\\ude39\\ud83d\\udc8d\"]", {"ğŸ˜¹ğŸ’"})
 
  -- y_string_allowed_escapes.json
 assert BinaryOperation(symbol ===, fromJSON "[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\"]", {"\"\\/\b\f\n\r\t"})
@@ -157,7 +154,7 @@ assert BinaryOperation(symbol ===, fromJSON "[\"\\\\a\"]", {"\\a"})
 assert BinaryOperation(symbol ===, fromJSON "[\"\\\\n\"]", {"\\n"})
 
  -- y_string_escaped_control_character.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0012\"]", {""})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0012\"]", {"\u0012"})
 
  -- y_string_escaped_noncharacter.json
 assert BinaryOperation(symbol ===, fromJSON "[\"\\uFFFF\"]", {"ï¿¿"})
@@ -169,7 +166,7 @@ assert BinaryOperation(symbol ===, fromJSON "[\"asd\"]", {"asd"})
 assert BinaryOperation(symbol ===, fromJSON "[ \"asd\"]", {"asd"})
 
  -- y_string_last_surrogates_1_and_2.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFF\"]", {"í¯¿í¿¿"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFF\"]", {"ô¿¿"})
 
  -- y_string_nbsp_uescaped.json
 assert BinaryOperation(symbol ===, fromJSON "[\"new\\u00A0line\"]", {"newÂ line"})
@@ -181,7 +178,7 @@ assert BinaryOperation(symbol ===, fromJSON "[\"ô¿¿\"]", {"ô¿¿"})
 assert BinaryOperation(symbol ===, fromJSON "[\"ï¿¿\"]", {"ï¿¿"})
 
  -- y_string_null_escape.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\u0000\"]", {"\0"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\u0000\"]", {"\u0000"})
 
  -- y_string_one-byte-utf-8.json
 assert BinaryOperation(symbol ===, fromJSON "[\"\\u002c\"]", {","})
@@ -199,7 +196,7 @@ assert BinaryOperation(symbol ===, fromJSON "[\"asd \"]", {"asd "})
 assert BinaryOperation(symbol ===, fromJSON "\" \"", " ")
 
  -- y_string_surrogates_U+1D11E_MUSICAL_SYMBOL_G_CLEF.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uD834\\uDd1e\"]", {"í ´í´"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD834\\uDd1e\"]", {"ğ„"})
 
  -- y_string_three-byte-utf-8.json
 assert BinaryOperation(symbol ===, fromJSON "[\"\\u0821\"]", {"à ¡"})
@@ -232,10 +229,10 @@ assert BinaryOperation(symbol ===, fromJSON "[\"â‚ãˆ´â‚\"]", {"â‚ãˆ´â‚"})
 assert BinaryOperation(symbol ===, fromJSON "[\"\\u0022\"]", {"\""})
 
  -- y_string_unicode_U+1FFFE_nonchar.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uD83F\\uDFFE\"]", {"í ¿í¿¾"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uD83F\\uDFFE\"]", {"ğŸ¿¾"})
 
  -- y_string_unicode_U+10FFFE_nonchar.json
-assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFE\"]", {"í¯¿í¿¾"})
+assert BinaryOperation(symbol ===, fromJSON "[\"\\uDBFF\\uDFFE\"]", {"ô¿¾"})
 
  -- y_string_unicode_U+200B_ZERO_WIDTH_SPACE.json
 assert BinaryOperation(symbol ===, fromJSON "[\"\\u200B\"]", {"â€‹"})
@@ -268,7 +265,7 @@ assert BinaryOperation(symbol ===, fromJSON "42", 42)
 assert BinaryOperation(symbol ===, fromJSON "-0.1", -.10000000000000001p53)
 
  -- y_structure_lonely_null.json
-assert BinaryOperation(symbol ===, fromJSON "null", nil)
+assert BinaryOperation(symbol ===, fromJSON "null", null)
 
  -- y_structure_lonely_string.json
 assert BinaryOperation(symbol ===, fromJSON "\"asd\"", "asd")

--- a/M2/Macaulay2/packages/JSONRPC.m2
+++ b/M2/Macaulay2/packages/JSONRPC.m2
@@ -1,5 +1,5 @@
 -- JSONRPC package for Macaulay2
--- Copyright (C) 2025 Doug Torrance <dtorrance@piedmont.edu>
+-- Copyright (C) 2025-2026 Doug Torrance <dtorrance@piedmont.edu>
 
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
 newPackage("JSONRPC",
     Headline => "JSON-RPC server",
     Version => "0.2",
-    Date => "December 17, 2025",
+    Date => "February 18, 2026",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
@@ -31,8 +31,9 @@ newPackage("JSONRPC",
 
 -*
 
-0.2 (2025-12-17, M2 1.26.05)
+0.2 (2026-02-18, M2 1.26.05)
 * Use trap for error messages
+* Update for JSON v0.6 (nil -> null)
 
 0.1 (2025-05-19, M2 1.25.11)
 * Initial release
@@ -116,7 +117,7 @@ handleRequestHelper(JSONRPCServer, HashTable) := (server, request) -> (
 	request#?"id" and not (
 	    instance(request#"id", String) or
 	    instance(request#"id", ZZ) or
-	    request#"id" === nil))
+	    request#"id" === null))
     then handleRequestHelper(server, null) -- invalid request
     else if not server#?(request#"method")
     then (

--- a/M2/cmake/FindJansson.cmake
+++ b/M2/cmake/FindJansson.cmake
@@ -1,0 +1,57 @@
+# - Try to find Jansson
+# Once done this will define
+#
+#  JANSSON_FOUND - system has Jansson
+#  JANSSON_INCLUDE_DIRS - the Jansson include directory
+#  JANSSON_LIBRARIES - Link these to use Jansson
+#
+#  Copyright (c) 2011 Lee Hambley <lee.hambley@gmail.com>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+if (JANSSON_LIBRARIES AND JANSSON_INCLUDE_DIRS)
+  # in cache already
+  set(JANSSON_FOUND TRUE)
+else (JANSSON_LIBRARIES AND JANSSON_INCLUDE_DIRS)
+  find_path(JANSSON_INCLUDE_DIR
+    NAMES
+      jansson.h
+    PATHS
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+  )
+
+find_library(JANSSON_LIBRARY
+    NAMES
+      jansson
+    PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+set(JANSSON_INCLUDE_DIRS
+  ${JANSSON_INCLUDE_DIR}
+  )
+
+if (JANSSON_LIBRARY)
+  set(JANSSON_LIBRARIES
+    ${JANSSON_LIBRARIES}
+    ${JANSSON_LIBRARY}
+    )
+endif (JANSSON_LIBRARY)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Jansson DEFAULT_MSG
+    JANSSON_LIBRARIES JANSSON_INCLUDE_DIRS)
+
+  # show the JANSSON_INCLUDE_DIRS and JANSSON_LIBRARIES variables only in the advanced view
+  mark_as_advanced(JANSSON_INCLUDE_DIRS JANSSON_LIBRARIES)
+
+endif (JANSSON_LIBRARIES AND JANSSON_INCLUDE_DIRS)

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -11,7 +11,7 @@
 # TODO: turn all these libraries into imported libraries and find incompatibilities another way.
 set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
 set(LIBRARIES_LIST MPSOLVE FROBBY NORMALIZ FACTORY FLINT NTL MPFI MPFR GMP BDWGC LAPACK)
-set(LIBRARY_LIST   READLINE HISTORY GDBM)
+set(LIBRARY_LIST   READLINE HISTORY GDBM JANSSON)
 
 message(CHECK_START " Checking for existing libraries and programs")
 
@@ -35,6 +35,7 @@ endif()
 #   TBB 	libtbb-dev	tbb-devel	tbb (Optional)
 #   OpenMP	libomp-dev	libomp-devel	libomp (Optional)
 #   GDBM	libgdbm-dev	gdbm-devel	gdbm
+#   jansson	libjansson-dev	jansson-devel	jansson
 
 # Set this variable to specify the linear algebra library.
 # See `cmake --help-module FindLAPACK` for the list of options
@@ -57,6 +58,8 @@ check_include_files(boost/math/tools/atomic.hpp
 
 # TODO: replace gdbm, see https://github.com/Macaulay2/M2/issues/594
 find_package(GDBM	REQUIRED QUIET) # See FindGDBM.cmake
+
+find_package(Jansson REQUIRED)
 
 if(WITH_OMP)
   find_package(OpenMP REQUIRED)

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1669,6 +1669,10 @@ AS_IF([test x$with_libffi != xno ],
 AC_SUBST([LIBFFI], [$with_libffi])
 AC_DEFINE_UNQUOTED([FFI_VERSION], ["$FFI_VERSION"], [libffi version])
 
+AC_CHECK_HEADERS([jansson.h],, [AC_MSG_ERROR([jansson.h not found])])
+AC_SEARCH_LIBS([json_loadb], [jansson], [],
+    [AC_MSG_ERROR([libjansson not found])])
+
 # after this point we add no more libraries to $LIBS, e.g., with AC_SEARCH_LIBS()
 SAVELIBS=$LIBS
 


### PR DESCRIPTION
Currently, our JSON parser is implemented at top level using the *Parsing* package.  This is fine for small things, but not so great for larger ones.

As we have several JSON-reliant projects on the horizon (like MRDI serialization and LSP support), it would be good to improve our JSON support.

We swap our JSON parser for [Jansson](https://github.com/akheron/jansson), a C library that was recently used by Emacs for JSON support (they've since rolled their own). It's widely available as a package on most systems, so the additional dependency shouldn't be too much of a burden.

The improvement is staggering -- a 1.2MB MRDI file containing a big polynomial that used to take ~5 min to parse now takes about a second!