### PR TITLE
Add libxml2 to version hash table

### DIFF
--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -69,6 +69,8 @@ header "
    #ifdef HAVE_FPLLL
    #include <fplll.h>
    #endif
+
+   #include <libxml/xmlversion.h>
    ";
 
 header "
@@ -173,6 +175,7 @@ setupconst("version", Expr(toHashTable(Sequence(
 	   \"not present\"
        #endif
        "),
+   "libxml2 version" => Ccode(constcharstar, "LIBXML_DOTTED_VERSION"),
    "mpsolve version" => Ccode(constcharstar, "stringize(MPS_MAJOR_VERSION) \".\" stringize(MPS_MINOR_VERSION) \".\" stringize(MPS_PATCH_VERSION)" ),
    "python version" => Ccode(constcharstar,"
 	#ifdef WITH_PYTHON


### PR DESCRIPTION
I think it's the only library we directly link against that wasn't included


```m2
i1 : version

o1 = HashTable{"architecture" => x86_64             }
               .
               .
               .
               "libxml2 version" => 2.9.14
               .
               .
               .
```