### PR TITLE
Quieter autotools build of d directory

### DIFF
--- a/M2/include/config.Makefile.in
+++ b/M2/include/config.Makefile.in
@@ -157,27 +157,27 @@ ifeq "$(NORULES)" ""
 
 .SUFFIXES : .sig.tmp .sig .dep .d .dd -exports.h.tmp -exports.h -tmp.c -tmp.cc
 
-%.sig: ;	test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
-%-exports.h: ;	test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
+%.sig: ;	$(HIDE)test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
+%-exports.h: ;	$(HIDE)test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
 
 %.sig.tmp %.dep: %.d
 	$(SHOW)SCC1 -dep $*.d
 	$(HIDE)$(SCC1) -dep $(SCCFLAGS) $<
-	mv $*.dep.tmp $*.dep
-	test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
+	$(HIDE)mv $*.dep.tmp $*.dep
+	$(HIDE)test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
 %.sig.tmp %.dep: %.dd
 	$(SHOW)SCC1 -dep $*.dd
 	$(HIDE)$(SCC1) -dep $(SCCFLAGS) $<
-	mv $*.dep.tmp $*.dep
-	test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
+	$(HIDE)mv $*.dep.tmp $*.dep
+	$(HIDE)test -e $*.sig && @CMP@ -s $*.sig.tmp $*.sig || cp $*.sig.tmp $*.sig
 %-tmp.c	 %-exports.h.tmp: %.d
 	$(SHOW)SCC1 $*.d
 	$(HIDE)$(SCC1) $(SCCFLAGS) $<
-	test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
+	$(HIDE)test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
 %-tmp.cc %-exports.h.tmp: %.dd
 	$(SHOW)SCC1 $*.dd
 	$(HIDE)$(SCC1) $(SCCFLAGS) $<
-	test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
+	$(HIDE)test -e $*-exports.h && @CMP@ -s $*-exports.h.tmp $*-exports.h || cp $*-exports.h.tmp $*-exports.h
 %.o: %-tmp.c  %-exports.h
 	$(SHOW)CC $*-tmp.c
 	$(HIDE)$(COMPILE.c) $(DCFLAGS) $< $(OUTPUT_OPTION)
@@ -223,8 +223,8 @@ HIDE := $(if $(VERBOSE),,@)
 	$(SHOW)CC $*.c
 	$(HIDE)$(COMPILE.c) $< $(OUTPUT_OPTION)
 
-%.o: %.cc
-	$(SHOW)CXX $*.cc
+%.o: %.cc %.cpp
+	$(SHOW)CXX $<
 	$(HIDE)$(COMPILE.cc) $< $(OUTPUT_OPTION)
 
 # Local Variables:


### PR DESCRIPTION
We add a few more `$(HIDE)`'s so that the default non-verbose build of the `d` directory looks more like the build of the `e` directory.

### Before
```
SCC1 arithmetic.d
test -e arithmetic-exports.h && cmp -s arithmetic-exports.h.tmp arithmetic-exports.h || cp arithmetic-exports.h.tmp arithmetic-exports.h
test -e arithmetic-exports.h && cmp -s arithmetic-exports.h.tmp arithmetic-exports.h || cp arithmetic-exports.h.tmp arithmetic-exports.h
CC arithmetic-tmp.c
SCC1 atomic.d
test -e atomic-exports.h && cmp -s atomic-exports.h.tmp atomic-exports.h || cp atomic-exports.h.tmp atomic-exports.h
test -e atomic-exports.h && cmp -s atomic-exports.h.tmp atomic-exports.h || cp atomic-exports.h.tmp atomic-exports.h
CC atomic-tmp.c
SCC1 M2.d
test -e M2-exports.h && cmp -s M2-exports.h.tmp M2-exports.h || cp M2-exports.h.tmp M2-exports.h
test -e M2-exports.h && cmp -s M2-exports.h.tmp M2-exports.h || cp M2-exports.h.tmp M2-exports.h
CC M2-tmp.c
SCC1 system.d
test -e system-exports.h && cmp -s system-exports.h.tmp system-exports.h || cp system-exports.h.tmp system-exports.h
test -e system-exports.h && cmp -s system-exports.h.tmp system-exports.h || cp system-exports.h.tmp system-exports.h
CC system-tmp.c
...
```

### After

```
SCC1 arithmetic.d
CC arithmetic-tmp.c
SCC1 atomic.d
CC atomic-tmp.c
SCC1 M2.d
CC M2-tmp.c
SCC1 system.d
CC system-tmp.c
...
```
