### PR TITLE
Don't create single-letter symbols for "export" error messages

### DIFF
--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -428,7 +428,7 @@ export List   := v -> (
 		if class sym#1 =!= String then error("expected a string: ", nam);
 		sym = getGlobalSymbol(pd, sym#1))
 	    else if instance(sym, String) then (
-		if match("^[[:alpha:]]$", sym) then error ("cannot export single-letter symbol ", getGlobalSymbol(pd, sym));
+		if match("^[[:alpha:]]$", sym) then error ("cannot export single-letter symbol '", sym, "'");
 		nam = sym;
 		sym = if pd#?nam then pd#nam else getGlobalSymbol(pd, nam))
 	    else error ("'export' expected a string or an option but was given ", sym, ", of class ", class sym);


### PR DESCRIPTION
There's no reason to call `getGlobalSymbol` since we're not going to end up exporting a symbol.

Plus the error message was strange:

```m2
i1 : export "x"
stdio:1:6:(3): error: cannot export single-letter symbol 'x'
-* invalid file position *-: here is the first use of 'x'
```
This gets rid of the second part.