### PR TITLE
Double length of time allowed for release-checklist test (autotools)

### DIFF
--- a/M2/Macaulay2/tests/Makefile.test.in
+++ b/M2/Macaulay2/tests/Makefile.test.in
@@ -19,7 +19,7 @@ endif
 # make the stack limit always the same as it would be under MacOS
 SLIMIT ?= 8192
 
-LIMIT :=
+LIMIT =
 ifeq (@ULIMIT_T@,yes)
 LIMIT += ulimit -t $(TLIMIT) ;
 endif

--- a/M2/Macaulay2/tests/normal/Makefile.in
+++ b/M2/Macaulay2/tests/normal/Makefile.in
@@ -7,6 +7,9 @@ VPATH = @srcdir@
 SRCDIR = @srcdir@
 include ../Makefile.test
 
+# often takes longer than 90s in GitHub builds
+release-checklist.out: TLIMIT = 180
+
 Makefile: Makefile.in; cd $(DOTS)/..; ./config.status Macaulay2/tests/normal/Makefile
 
 @pre_packagesdir@/Core/tests: @pre_packagesdir@/Core; $(MKDIR_P) $@


### PR DESCRIPTION
It's been timing out a lot recently in the GitHub builds because we cap the `tests/normal` tests at 90s.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
