### PR TITLE
Make Jansson optional

### DIFF
--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -114,6 +114,9 @@ endif()
 if(NOT WITH_FFI)
   list(REMOVE_ITEM DLIST ffi.d)
 endif()
+if(NOT WITH_JANSSON)
+  list(REMOVE_ITEM DLIST json.d)
+endif()
 
 ###############################################################################
 ## Generate TAGS file

--- a/M2/Macaulay2/d/Makefile.files.in
+++ b/M2/Macaulay2/d/Makefile.files.in
@@ -103,7 +103,9 @@ M2_DFILES += monoid.dd
 M2_DFILES += monomial_ordering.dd
 M2_DFILES += boostmath.dd
 M2_DFILES += atomic2.d
+ifeq (@JANSSON@,yes)
 M2_DFILES += json.d
+endif
 ifneq (@LIBFFI@,no)
 M2_DFILES += ffi.d
 else

--- a/M2/Macaulay2/d/parser.d
+++ b/M2/Macaulay2/d/parser.d
@@ -51,6 +51,9 @@ export hexvalue   (c:char ):int  := (
      );
 export hexvalue   (c:int ):int  := hexvalue(char(c));
 
+hexvalue(a:char, b:char, c:char, d:char):int := (
+    hexvalue(d) + 16*(hexvalue(c) + 16*(hexvalue(b) + 16*hexvalue(a))));
+
 export parseInt(s:string):ZZ := (
      i := zeroZZ;
      n := length(s);
@@ -90,7 +93,18 @@ export parseString(s:string):string := (
 	       else if c == '\\' then v << '\\'
 	       else if c == 'u' then (
 		    i = i+4;
-		    utf8(v, ((hexvalue(s.(i-3)) * 16 + hexvalue(s.(i-2))) * 16 + hexvalue(s.(i-1))) * 16 + hexvalue(s.i)))
+		    val := hexvalue(s.(i-3), s.(i-2), s.(i-1), s.i);
+		    -- high surrogate (0xd800 - 0xdbff)
+		    if 55296 <= val && val <= 56319 then (
+			if i + 6 < length(s) && s.(i+1) == '\\' && s.(i+2) == 'u'
+			then (
+			    val2 := hexvalue(s.(i+3), s.(i+4), s.(i+5), s.(i+6));
+			    -- low surrogate (0xdc00 - 0xdfff)
+			    if 56320 <= val2 && val2 <= 57343 then (
+				i = i + 6;
+				-- 0x10000 + 0x400*(high-0xd800) + low-0xdc00
+				val = 65536 + 1024*(val-55296) + val2-56320)));
+		    utf8(v, val))
 	       else if c == 'x' then (
 		    i = i + 2;
 		    v << char(hexvalue(s.(i - 1)) * 16 + hexvalue(s.i)))

--- a/M2/Macaulay2/d/version.dd
+++ b/M2/Macaulay2/d/version.dd
@@ -72,7 +72,9 @@ header "
 
    #include <libxml/xmlversion.h>
 
+   #ifdef WITH_JANSSON
    #include <jansson.h>
+   #endif
    ";
 
 header "
@@ -192,7 +194,13 @@ setupconst("version", Expr(toHashTable(Sequence(
    "ntl version" => Ccode(constcharstar,"NTL_VERSION"),
    "frobby version" => Ccode(constcharstar,"frobby_version"),
    "flint version" => Ccode(constcharstar,"FLINT_VERSION"),
-   "jansson version" => Ccode(constcharstar, "JANSSON_VERSION"),
+   "jansson version" => Ccode(constcharstar, "
+       #ifdef WITH_JANSSON
+           JANSSON_VERSION
+       #else
+           \"not present\"
+       #endif
+       "),
    "scscp version" => Ccode(constcharstar,"
 	 #ifdef HAVE_SCSCP
 	   stringize(SCSCP_VERSION_MAJOR) \".\" stringize(SCSCP_VERSION_MINOR) \".\" stringize(SCSCP_VERSION_PATCH)

--- a/M2/Macaulay2/packages/JSON.m2
+++ b/M2/Macaulay2/packages/JSON.m2
@@ -18,13 +18,14 @@ newPackage(
     "JSON",
     Headline => "JSON encoding and decoding",
     Version => "0.6",
-    Date => "February 18, 2026",
+    Date => "February 28, 2026",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance@piedmont.edu",
 	    HomePage => "https://webwork.piedmont.edu/~dtorrance"}},
     Keywords => {"System"},
     PackageExports => {"Text"},
+    PackageImports => {"Parsing"},
     AuxiliaryFiles => true)
 
 ---------------
@@ -33,9 +34,10 @@ newPackage(
 
 -*
 
-0.6 (2026-02-18, M2 1.26.05)
+0.6 (2026-02-28, M2 1.26.05)
 * parsing is now handled by jansson in the interpreter, which speeds things up
-  considerably
+  considerably (if M2 is built w/o jansson support, then we fall back on the
+  old behavior)
 * breaking changes:
   - "null" now returns as null, not nil
   - \0 is no longer allowed in object keys
@@ -78,11 +80,100 @@ export {
     "ValueSeparator",
     }
 
-importFrom(Core, "fromJSON0")
+---------------------------------------------------------------
+-- parser based on https://datatracker.ietf.org/doc/html/rfc8259
+----------------------------------------------------------------
+-- only used if we build M2 w/o jansson support
+
+-- whitespace
+wsP   = *orP(" ", "\t", "\n", "\r")
+strip = p -> first % (p @ wsP)
+
+-- structural characters
+beginArrayP     = strip "["
+beginObjectP    = strip "{"
+endArrayP       = strip "]"
+endObjectP      = strip "}"
+nameSeparatorP  = strip ":"
+valueSeparatorP = strip ","
+
+-- literals
+falseP = (x -> false) % constParser "false"
+nullP  = (x -> nil)   % constParser "null" -- using null would break parsing
+trueP  = (x -> true)  % constParser "true"
+
+-- numbers
+digit19P = orP("1", "2", "3", "4", "5", "6", "7", "8", "9")
+digitP   = "0" | digit19P
+expP     = andP(orP("e", "E"), optP(orP("-", "+")), +digitP)
+fracP    = andP(".", +digitP)
+intP     = orP("0", digit19P @ *digitP)
+numberP  = (x -> value concatenate delete(nil, deepSplice x)
+    ) % andP(optP("-"), intP, optP(fracP), optP(expP))
+
+-- strings
+hexDigitP = digitP | orP("a", "b", "c", "d", "e", "f",
+    "A", "B", "C", "D", "E", "F");
+unescapedP = Parser(c -> if c === null then null else (
+	x := first utf8 c;
+	if x < 0x20 or x == 0x22 or x == 0x5c or x > 0x10ffff
+	then null
+	else terminalParser c))
+escapedP = ((l, r) -> if r === "/" then r else concatenate(l, r))  % ("\\" @
+    orP("\"", "\\", "/", "b", "f", "n", "r", "t",
+	andP("u", hexDigitP, hexDigitP, hexDigitP, hexDigitP)))
+charP = unescapedP | escapedP
+stringP = ((l, x, r) -> value concatenate(l, x, r)) % andP("\"", *charP, "\"")
+
+-- objects
+memberP = ((k, gets, v) -> k => v) % andP(
+    stringP, nameSeparatorP, futureParser valueP)
+objectP = ((l, x, r) ->  hashTable (
+	if x === nil then {}
+	else toList deepSplice x)) % andP(
+    beginObjectP,
+    optP(memberP @ * (last % valueSeparatorP @ memberP)),
+    endObjectP)
+
+-- arrays
+arrayP = ((l, x, r) -> (
+	if x === nil then {}
+	else toList deepSplice x)) % andP(
+    beginArrayP,
+    optP(futureParser valueP @
+	*(last % valueSeparatorP @ futureParser valueP)),
+    endArrayP)
+
+-- values
+valueP = strip orP(falseP, nullP, trueP, objectP, arrayP, numberP, stringP)
+jsonTextP = (last @@ last) % (*wsP @ valueP)
+
+utf8Analyzer = Analyzer(s -> (
+	if not instance(s, String) then error "analyzer expected a string";
+	chars := characters s;
+	i := 0;
+	() -> if chars#?i then (
+	    r := (i, chars#i);
+	    i = i + 1;
+	    r)))
+
+-- hack so we can transform nil -> null
+processJSON = method()
+processJSON Thing := identity
+processJSON Symbol := x -> null -- should only ever be nil
+processJSON List := x -> apply(x, processJSON)
+processJSON HashTable := x -> applyValues(x, processJSON)
 
 fromJSON = method()
-fromJSON String :=
-fromJSON File   := fromJSON0
+
+-- did we build w/ jansson support?
+fromJSON0 = value(?? Core#"private dictionary"#"fromJSON0")
+if fromJSON0 === null then (
+    fromJSON String := processJSON @@ (jsonTextP : utf8Analyzer);
+    fromJSON File   := fromJSON @@ get
+    ) else (
+    fromJSON String :=
+    fromJSON File   := fromJSON0)
 
 --------------
 -- encoding --

--- a/M2/Macaulay2/tests/normal/strings.m2
+++ b/M2/Macaulay2/tests/normal/strings.m2
@@ -85,6 +85,9 @@ assert Equation(format(ascii(0..31) | "\"\\"),
     ///\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017/// |
     ///\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f\"\\"///)
 
+-- surrogate pair
+assert Equation("\ud834\udd1e", "𝄞")
+
 -- subclasses (issue #4069)
 T = new SelfInitializingType of String
 assert Equation(net T "foo", "foo")

--- a/M2/check-configure/Makefile.in
+++ b/M2/check-configure/Makefile.in
@@ -29,6 +29,7 @@ check-config:
 	    --with-system-memtailor=$(SYSTEM_MEMTAILOR)				\
 	    --with-system-mathic=$(SYSTEM_MATHIC)				\
 	    --with-system-mathicgb=$(SYSTEM_MATHICGB)				\
+	    --with-jansson=@JANSSON@						\
 	    --enable-download=@DOWNLOAD@					\
 	    --disable-building
 distclean:: clean; rm -f Makefile

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -1252,7 +1252,7 @@ message("\n## Library information
      GMP Arithmetic    = ${GMP_LIBRARIES}")
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "     Optional libs     =")
-foreach(_opt IN ITEMS OMP TBB FFI MPI XML PYTHON MYSQL)
+foreach(_opt IN ITEMS OMP TBB FFI MPI XML PYTHON MYSQL JANSSON)
   if(WITH_${_opt})
     execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append " ${_opt}")
   endif()

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -66,7 +66,9 @@ check_include_files(boost/math/tools/atomic.hpp
 # TODO: replace gdbm, see https://github.com/Macaulay2/M2/issues/594
 find_package(GDBM	REQUIRED QUIET) # See FindGDBM.cmake
 
-find_package(Jansson REQUIRED)
+if (WITH_JANSSON)
+  find_package(Jansson REQUIRED)
+endif()
 
 if(WITH_OMP)
   find_package(OpenMP REQUIRED)

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -32,6 +32,7 @@ option(WITH_FFI		"Link with the FFI library"		ON)
 option(WITH_XML		"Link with the libxml2 library"		ON)
 option(WITH_PYTHON	"Link with the Python library"		ON)
 option(WITH_MYSQL	"Link with the MySQL library"		OFF)
+option(WITH_JANSSON	"Link with the Jansson library"		ON)
 
 set(BUILD_PROGRAMS  "" CACHE STRING "Build programs, even if found")
 set(BUILD_LIBRARIES "" CACHE STRING "Build libraries, even if found")

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1669,9 +1669,17 @@ AS_IF([test x$with_libffi != xno ],
 AC_SUBST([LIBFFI], [$with_libffi])
 AC_DEFINE_UNQUOTED([FFI_VERSION], ["$FFI_VERSION"], [libffi version])
 
-AC_CHECK_HEADERS([jansson.h],, [AC_MSG_ERROR([jansson.h not found])])
-AC_SEARCH_LIBS([json_loadb], [jansson], [],
-    [AC_MSG_ERROR([libjansson not found])])
+AC_ARG_WITH([jansson],
+    [AS_HELP_STRING([--without-jansson],
+        [don't link with the jansson for json parsing])],,
+    [with_jansson=yes])
+AS_IF([test "x$with_jansson" = xyes],
+    [AC_CHECK_HEADERS([jansson.h],, [AC_MSG_ERROR([jansson.h not found])])
+     AC_SEARCH_LIBS([json_loadb], [jansson], [],
+         [AC_MSG_ERROR([libjansson not found])])
+     AC_DEFINE([WITH_JANSSON], [1],
+         [whether we are linking with the jansson library])])
+AC_SUBST([JANSSON], [$with_jansson])
 
 # after this point we add no more libraries to $LIBS, e.g., with AC_SEARCH_LIBS()
 SAVELIBS=$LIBS


### PR DESCRIPTION
If we build with `--without-janson` (autotools) or `-DWITH_JANSSON=OFF` (cmake), then we fall back on the top-level JSON parsing using the *Parsing* package.

We also fix our handling of [UTF-16 surrogate pairs](https://en.wikipedia.org/wiki/UTF-16#U+D800_to_U+DFFF_(surrogates)) (which I noticed when making sure the Jansson and top-level behaviors agreed for the JSON package tests):

### Before
```m2
1 : "\ud834\udd1e"

o1 = ������
```

### After
```m2
i1 : "\ud834\udd1e"

o1 = 𝄞
```

Draft for now to test the GitHub builds with Jansson disabled.