### PR TITLE
Run autotools build in parallel

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Run Tests using Autotools
         if: matrix.build-system == 'autotools' && runner.os == 'Linux' && matrix.compiler == 'default'
         run: |
-          make check -o check-in-libraries
+          make -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu) check -o check-in-libraries
           make -C Macaulay2/html-check-links check
 
       - name: Validate HTML documentation

--- a/M2/Macaulay2/Makefile.in
+++ b/M2/Macaulay2/Makefile.in
@@ -6,6 +6,12 @@ all: @pre_docdir@/COPYING-GPL-2 @pre_docdir@/COPYING-GPL-3 @pre_docdir@/LAYOUT
 SUBDIRS = e c d system bin m2 man packages editors \
 	$(if $(filter html, @DOCUMENTATION@), html-check-links) tests
 
+all-in-d: all-in-c
+all-in-bin: all-in-e all-in-d all-in-system
+all-in-m2: all-in-bin
+all-in-packages all-in-editors all-in-tests: all-in-m2
+all-in-html-check-links: all-in-packages
+
 define do-in-subdirs
 $(foreach d,$(SUBDIRS),
 	$(eval .PHONY: $1-in-subdirs)
@@ -25,4 +31,3 @@ distclean:; rm -f Makefile
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2 "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/bin/Makefile.in
+++ b/M2/Macaulay2/bin/Makefile.in
@@ -40,7 +40,7 @@ M2SCRIPT = @pre_bindir@/M2
 
 all: $(EXEFILE) $(M2SCRIPT) 
 
-$(M2SCRIPT): M2
+$(M2SCRIPT): M2 @pre_bindir@
 	@INSTALL_SCRIPT@ M2 $(M2SCRIPT)
 
 relink:
@@ -199,4 +199,3 @@ M2: M2.in; cd ../..; ./config.status Macaulay2/bin/M2
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/bin relink "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/c/Makefile.in
+++ b/M2/Macaulay2/c/Makefile.in
@@ -81,4 +81,3 @@ Makefile: Makefile.in
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/c "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/e/Makefile.in
+++ b/M2/Macaulay2/e/Makefile.in
@@ -178,4 +178,3 @@ help:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/e DEPENDS=no initialize && make -C $M2BUILDDIR/Macaulay2/e "
 # End:
 
-.NOTPARALLEL:

--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -1,7 +1,6 @@
 # @configure_input@
 include ../../include/config.Makefile
 ARGS = --script
-.NOTPARALLEL:
 
 MADEFILES = M2-symbols.el M2-emacs-help.txt M2-emacs.m2
 SRCFILES = M2-init.el M2-mode.el M2.el README.md

--- a/M2/Macaulay2/html-check-links/Makefile.in
+++ b/M2/Macaulay2/html-check-links/Makefile.in
@@ -75,4 +75,3 @@ distclean : clean
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/html-check-links run-html-check-links"
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/m2/Makefile.in
+++ b/M2/Macaulay2/m2/Makefile.in
@@ -114,4 +114,3 @@ distclean: clean; rm -f Makefile version.m2
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/m2/basictests/Makefile.in
+++ b/M2/Macaulay2/m2/basictests/Makefile.in
@@ -68,4 +68,3 @@ check-return-code :; if echo 'error "foo"' | @pre_exec_prefix@/bin/M2@EXE@ $(ARG
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/basictests "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/m2/typicalvalues.m2
+++ b/M2/Macaulay2/m2/typicalvalues.m2
@@ -126,7 +126,7 @@ generateTypicalValues = (srcdir) -> (
 
 -- if missing or not successfully generated, tvalues.m2 is regenerated directly
 if not fileExists typicalValuesSource or not match("-- DONE", get typicalValuesSource)
-then generateTypicalValues(currentFileDirectory | "../d/")
+then generateTypicalValues(topSrcdir | "Macaulay2/d/")
 
 -----------------------------------------------------------------------------
 -- numerical functions that will be wrapped

--- a/M2/Macaulay2/man/Makefile.in
+++ b/M2/Macaulay2/man/Makefile.in
@@ -13,4 +13,3 @@ distclean: clean; rm -f M2.1
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/man "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/packages/SCSCP/docinput/Makefile.in
+++ b/M2/Macaulay2/packages/SCSCP/docinput/Makefile.in
@@ -23,4 +23,3 @@ checkmagma:
 %.out: %.m2; 
 	$(M2) -q --stop -e 'loadPackage "SCSCP"' < $^ > out.tmp
 	mv out.tmp $@
-.NOTPARALLEL:

--- a/M2/Macaulay2/system/Makefile.in
+++ b/M2/Macaulay2/system/Makefile.in
@@ -45,4 +45,3 @@ tests : tests.o supervisor.o
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/system "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/Makefile.in
@@ -19,4 +19,3 @@ distclean:clean; rm -f Makefile
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/tests/ComputationsBook "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/completeIntersections/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/completeIntersections/Makefile.in
@@ -5,4 +5,3 @@ include ../Makefile.chapter
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/tests/ComputationsBook/completeIntersections "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/constructions/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/constructions/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/d-modules/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/d-modules/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/exterior-algebra/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/exterior-algebra/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/geometry/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/geometry/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/monomialIdeals/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/preface/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/preface/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/programming/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/programming/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/schemes/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/schemes/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/solving/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/solving/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/toricHilbertScheme/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/toricHilbertScheme/Makefile.in
@@ -1,4 +1,3 @@
 # @configure_input@
 chapter_srcdir = @srcdir@
 include ../Makefile.chapter
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/ComputationsBook/varieties/Makefile.in
+++ b/M2/Macaulay2/tests/ComputationsBook/varieties/Makefile.in
@@ -5,7 +5,6 @@ include ../Makefile.chapter
 
 Makefile: Makefile.in; cd ../../../..; ./config.status Macaulay2/tests/ComputationsBook/varieties/Makefile
 
-.NOTPARALLEL:
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/tests/ComputationsBook/varieties "
 # End:

--- a/M2/Macaulay2/tests/Makefile.in
+++ b/M2/Macaulay2/tests/Makefile.in
@@ -43,4 +43,3 @@ mike-tests: $(MIKE_RESULTS) ; grep sys $^
 # Local Variables:
 # compile-command: "make -k -C $M2BUILDDIR/Macaulay2/tests check "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/engine/Makefile.in
+++ b/M2/Macaulay2/tests/engine/Makefile.in
@@ -12,4 +12,3 @@ Makefile: Makefile.in; cd $(DOTS)/..; ./config.status Macaulay2/tests/engine/Mak
 # Local Variables:
 # compile-command: "make -k -C $M2BUILDDIR/Macaulay2/tests/engine check "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/gigantic/Makefile.in
+++ b/M2/Macaulay2/tests/gigantic/Makefile.in
@@ -27,4 +27,3 @@ Makefile: Makefile.in; cd $(DOTS)/..; ./config.status Macaulay2/tests/gigantic/M
 # compile-command: "make -k -C $M2BUILDDIR/Macaulay2/tests/gigantic "
 # End:
 
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/goals/Makefile.in
+++ b/M2/Macaulay2/tests/goals/Makefile.in
@@ -25,4 +25,3 @@ Makefile: Makefile.in; cd $(DOTS)/..; ./config.status Macaulay2/tests/goals/Make
 # Local Variables:
 # compile-command: "make -k -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test/slow "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/normal/Makefile.in
+++ b/M2/Macaulay2/tests/normal/Makefile.in
@@ -21,4 +21,3 @@ all: $(patsubst $(SRCDIR)/%.m2, @pre_packagesdir@/Core/tests/%.m2, $(wildcard $(
 # Local Variables:
 # compile-command: "make -k -C $M2BUILDDIR/Macaulay2/tests/normal check "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/quarantine/Makefile.in
+++ b/M2/Macaulay2/tests/quarantine/Makefile.in
@@ -26,4 +26,3 @@ Makefile: Makefile.in; cd $(DOTS)/..; ./config.status Macaulay2/tests/quarantine
 # Local Variables:
 # compile-command: "make -k -C $M2BUILDDIR/Macaulay2/tests/quarantine check "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/rationality/Makefile.in
+++ b/M2/Macaulay2/tests/rationality/Makefile.in
@@ -22,4 +22,3 @@ all:
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/Macaulay2/tests/rationality/ -k check"
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/slow/Makefile.in
+++ b/M2/Macaulay2/tests/slow/Makefile.in
@@ -23,4 +23,3 @@ Makefile: Makefile.in; cd $(DOTS)/..; ./config.status Macaulay2/tests/slow/Makef
 # Local Variables:
 # compile-command: "make -k -C $M2BUILDDIR/Macaulay2/tests/slow "
 # End:
-.NOTPARALLEL:

--- a/M2/Macaulay2/tests/threads/Makefile.in
+++ b/M2/Macaulay2/tests/threads/Makefile.in
@@ -12,4 +12,3 @@ Makefile: Makefile.in; cd $(DOTS)/..; ./config.status Macaulay2/tests/threads/Ma
 # Local Variables:
 # compile-command: "make -k -C $M2BUILDDIR/Macaulay2/tests/threads check "
 # End:
-.NOTPARALLEL:

--- a/M2/libraries/Makefile.in
+++ b/M2/libraries/Makefile.in
@@ -52,7 +52,11 @@ $(foreach f,Makefile Makefile.library,					\
 show-licenses:; grep -wnH license @srcdir@/*/Makefile.in
 clean:; rm -rf final
 distclean:clean ; rm -f Makefile
+
+# can't check out submodules in parallel -- they fight over .git/config.lock
+# maybe check out submodules during configure instead?
+.NOTPARALLEL:
+
 # Local Variables:
 # compile-command: "make -C $M2BUILDDIR/libraries "
 # End:
-.NOTPARALLEL:

--- a/M2/libraries/Makefile.library.in
+++ b/M2/libraries/Makefile.library.in
@@ -8,7 +8,6 @@ export LD_LIBRARY_PATH:=$(BUILTLIBPATH)/lib:$(LD_LIBRARY_PATH)
 # prefix that was used at compile time, i.e., the only change allowed to the prefix
 # between compile time and install time is to prepend a string
 PREFIX = $(BUILTLIBPATH)
-.NOTPARALLEL:
 ifneq ($(PARALLEL),yes)
 NOTPARALLEL = -j1
 endif


### PR DESCRIPTION
We remove most of the `.NOTPARALLEL:` targets in the Makefiles and add some prereqs so we can run `make -jX` and run the autotools build in parallel.

The d directory can't be built in parallel at the moment since because we need the have already built the .sig files for each file's dependencies to generate its .dep file -- but we need the .dep file to know the dependencies...

