### PR TITLE
Esnure emacs directory exists before installing files in it

### DIFF
--- a/M2/Macaulay2/editors/Makefile.in
+++ b/M2/Macaulay2/editors/Makefile.in
@@ -5,12 +5,13 @@ ARGS = --script
 MADEFILES = M2-symbols.el M2-emacs-help.txt M2-emacs.m2
 SRCFILES = M2-init.el M2-mode.el M2.el README.md
 
-all: @pre_emacsdir@ $(addprefix @pre_emacsdir@/, $(SRCFILES) $(MADEFILES))
+all: $(addprefix @pre_emacsdir@/, $(SRCFILES) $(MADEFILES))
 verify: $(addprefix @pre_emacsdir@/, $(SRCFILES) $(MADEFILES)) $(addprefix emacs/, $(SRCFILES) $(MADEFILES)); ls -lrt $^
 Makefile: @srcdir@/Makefile.in; cd ../..; ./config.status Macaulay2/editors/Makefile
 
 @pre_emacsdir@ :; @INSTALL@ -d "$@"
-@pre_emacsdir@/% : $(addprefix emacs/, %) ; @INSTALL_DATA@ $^ @pre_emacsdir@
+@pre_emacsdir@/% : emacs/% | @pre_emacsdir@
+	@INSTALL_DATA@ $< $(@D)
 
 emacs/M2-symbols.el prism/macaulay2.js :                         \
 	@srcdir@/make-M2-symbols.m2 @srcdir@/../m2/exports.m2    \

--- a/M2/libraries/factory/Makefile.in
+++ b/M2/libraries/factory/Makefile.in
@@ -76,15 +76,6 @@ Makefile: @srcdir@/Makefile.in ; cd ../.. && ./config.status libraries/factory/M
 #      #include <wchar.h>
 #    }
 
-.installed-$(VERSION) : $(LIBRARIESDIR)/include/factory/cf_assert.h \
-			$(LIBRARIESDIR)/include/factory/templates/ftmpl_list.cc
-$(LIBRARIESDIR)/include/factory/cf_assert.h : $(BUILDDIR)/cf_assert.h .compiled-$(VERSION) 
-	$(MKDIR_P) $(LIBRARIESDIR)/include/factory
-	@INSTALL_DATA@ $< $@
-$(LIBRARIESDIR)/include/factory/templates/ftmpl_list.cc : $(BUILDDIR)/templates/ftmpl_list.cc .compiled-$(VERSION) 
-	$(MKDIR_P) $(LIBRARIESDIR)/include/factory/templates
-	@INSTALL_DATA@ $< $@
-
 uninstall clean ::
 	if [ -d $(LIBRARIESDIR) ] ;\
 	then cd $(LIBRARIESDIR) && rm -rf \


### PR DESCRIPTION
This is a quick followup to #4153.

Now that we can run `make` in parallel with the `-j` option, there was a chance we might try installing the various files from the M2-emacs repository in the emacs directory before actually creating said directory.  This was leading to lots of failed PPA builds, e.g.:

```
/usr/bin/install -c -d "/<<PKGBUILDDIR>>/M2/usr-dist/common/share/emacs/site-lisp/elpa-src/macaulay2-1.25.11"
/usr/bin/install -c -m 644 emacs/M2-init.el /<<PKGBUILDDIR>>/M2/usr-dist/common/share/emacs/site-lisp/elpa-src/macaulay2-1.25.11
...
src/macaulay2-1.25.11': No such file or directory
make[3]: *** [Makefile:13: /<<PKGBUILDDIR>>/M2/usr-dist/common/share/emacs/site-lisp/elpa-src/macaulay2-1.25.11/M2-init.el] Error 1
```

Full log: https://launchpadlibrarian.net/852064116/buildlog_ubuntu-noble-amd64.macaulay2_1.25.11+git202603171603-0ppa202603162001~ubuntu24.04.1_BUILDING.txt.gz

The two lines were run in separate threads, and the command from the first line creating the directory hadn't finished yet before the second line was run.

The fix is to make the directory a prerequisite for the files.