### PR TITLE
fix incorrect stderrorS in webapp mode

### DIFF
--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -668,6 +668,7 @@ export process():void := (
      setMaxAllowableThreads();
      -- setLoadDepth(loadDepth);				    -- loaddata() in M2lib.c increments it, so we have to reflect that at top level
      everytimeRun();
+     setStdError(stdError);
      -- we don't know the right directory; calls commandInterpreter and eventually returns:
      ret := readeval(stringTokenFile(startupFile.filename,startupFile.contents),false,false);
      when ret is err:Error do (


### PR DESCRIPTION
In webapp mode, `stdError` is redefined to be equal to `stdIO` (to avoid annoying out-of-sync output).
Sadly, the M2 level stderr (`stderrorS`) is not updated when this redefinition takes place, causing subtle bugs (mostly due to `capture` changing the value of `stderrorS`). -> one line fix.