### PR TITLE
Stop referring to the "bugs" directory in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ downloading binary releases.
 The structure of this directory is as follows:
 
 * `M2`: contains everything needed by a user to build Macaulay2.
-* `bugs`: contains older bug reports.
 
 See `CITATION.cff` for information about citing Macaulay2.
 


### PR DESCRIPTION
It's been removed

[ci skip]

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
