### PR TITLE
Some updates to the Valuations package

### DIFF
--- a/M2/Macaulay2/packages/Binomials.m2
+++ b/M2/Macaulay2/packages/Binomials.m2
@@ -30,7 +30,7 @@ newPackage(
 		  HomePage => "http://www.thomas-kahle.de"}},
     	Headline => "specialized routines for binomial ideals",
 	Keywords => {"Commutative Algebra"},
-	PackageImports => {"FourTiTwo", "Cyclotomic", "LLLBases", "MinimalPrimes", "Elimination"},
+	PackageImports => {"FourTiTwo", "Cyclotomic", "LLLBases", "MinimalPrimes", "Elimination", "Classic"},
 	Certification => {
 	     "journal name" => "The Journal of Software for Algebra and Geometry: Macaulay2",
 	     "journal URI" => "https://msp.org/jsag/",

--- a/M2/Macaulay2/packages/LocalRings/localring.m2
+++ b/M2/Macaulay2/packages/LocalRings/localring.m2
@@ -67,6 +67,9 @@ localRing(EngineRing, Ideal) := (R, P) ->
         RP.localRing    = RP;
         RP.maxIdeal     =  P;
         commonEngineRingInitializations RP;
+	setupPromote(
+	    f -> numerator f / denominator f,
+	    RP, frac R);
 	RP.residueMap   = map(frac(R/P), RP, vars R % P);
          expression RP := r -> expression numerator r / expression denominator r;
            toString RP := r -> toString expression r;

--- a/M2/Macaulay2/packages/LocalRings/tests.m2
+++ b/M2/Macaulay2/packages/LocalRings/tests.m2
@@ -624,6 +624,15 @@ end--
   gens gb Iloc
 ///
 
+TEST ///
+-- promoting to fraction field
+R = QQ[x]
+p = ideal x
+S = R_p
+F = frac R
+assert(promote(x_S, F) === x_F)
+///
+
 end--
 
 --  Development stuff

--- a/M2/Macaulay2/packages/Valuations.m2
+++ b/M2/Macaulay2/packages/Valuations.m2
@@ -57,7 +57,7 @@ valuation Function := v -> (
     internalValuation(v, null, null)
 )
 
-ourSources := {Ring,Subring,LocalRing,RingOfInvariants}
+ourSources := {Ring,Subring,LocalRing,RingOfInvariants,RingFamily}
 ourTargets := {Ring,Subring,LocalRing,RingOfInvariants,OrderedQQn}
 
 -- Create different valuation functions for various inputs

--- a/M2/Macaulay2/packages/Valuations.m2
+++ b/M2/Macaulay2/packages/Valuations.m2
@@ -38,6 +38,8 @@ export{"valuation",
        "OrderedQQVector",
        "orderedQQn"}
 
+importFrom(Core, "isPromotable")
+
 OrderedQQn = new Type of Module
 OrderedQQVector = new Type of Vector
 
@@ -89,16 +91,15 @@ ourInputs := {Number, RingElement, Constant}
 -- Other inputs will need to be added to that list, if needed
 for i in ourInputs do (
     Valuation i := (v,t) -> (
-        num := try numerator t then numerator t else t;
-        den := try denominator t then denominator t else 1_(ring t);
-        if (v#source === null) or (ring t) === v#source then
-            v#"function" t
-        else if (isMember(ring t, v#source.baseRings)) then
-            v#"function" promote(t, v#source)
-        else if (ring t) === v#source then
-            v#"function" num - v#"function" den
-        else if (isMember(ring num, v#source.baseRings)) then
-            v#"function" promote(num, v#source) - v#"function" promote(den, v#source)
+	(f, R) := (v#"function", v#source);
+	if R === null then f t
+	else (
+	    if not isPromotable(ring t, R)
+	    then error("expected an element of ", R);
+	    if lookup(numerator, class t) =!= null then (
+		(num, den) := (numerator t, denominator t);
+		f num - f den)
+	    else f t)
     )
 )
 

--- a/M2/Macaulay2/packages/Valuations.m2
+++ b/M2/Macaulay2/packages/Valuations.m2
@@ -223,14 +223,12 @@ countPrimeFactor (ZZ, ZZ) := (p, x) -> (
 )
 
 -- p-adic Valuation valuation construction
--- Allows for inputs to be rationals and computes difference of the
--- valuations for the numerator and denominator
 padicValuation = method()
 padicValuation ZZ := p -> (
     if not isPrime p then error "expected a prime integer";
     func := x -> (
         if x == 0 then infinity
-        else countPrimeFactor(p, numerator x_QQ) - countPrimeFactor(p, denominator x_QQ)
+        else countPrimeFactor(p, x)
     );
     valuation(func,QQ,ZZ)
 )

--- a/M2/Macaulay2/packages/Valuations.m2
+++ b/M2/Macaulay2/packages/Valuations.m2
@@ -231,7 +231,7 @@ padicValuation ZZ := p -> (
         if x == 0 then infinity
         else countPrimeFactor(p, numerator x_QQ) - countPrimeFactor(p, denominator x_QQ)
     );
-    valuation(func,QQ,QQ)
+    valuation(func,QQ,ZZ)
 )
 
 -- Leading Term Valuation,

--- a/M2/Macaulay2/packages/Valuations.m2
+++ b/M2/Macaulay2/packages/Valuations.m2
@@ -279,7 +279,7 @@ localRingValuation LocalRing := R -> (
         if x == 0 then infinity
         else getMExponent(m, sub(x, S))
     );
-    valuation(func, R, ZZ)
+    valuation(func, frac R, ZZ)
 )
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
A few updates to *Valuations*:

* The target of `padicValuation` is now `ZZ` instead of `QQ`
* The source of `localRingValuation` is now the fraction field of the local ring instead of just the local ring itself.
* Allow `RingFamily` as a source for valuations.  This way, we can define valuations on `RR`, `CC`, etc.
* Refactor evaluation of valuations.  In particular, we don't actually do any promotion of the input to the source, but just check to see if it's possible as a type check. 
* Drop the redundant calls to `numerator` and `denominator` in `padicValuation` since that's already taken care of for all valuations.

Also a few related changes that popped up while I worked on this:
* We import *Classic* in *Binomials* since it calls `matrix "0"`, which will fail if *Classic* isn't loaded.
* Add promotion from local rings to fraction fields in *LocalRings*.