### PR TITLE
Add 1x1 matrix constructors for specific rings

### DIFF
--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -258,6 +258,10 @@ matrix(Matrix) := Matrix => opts -> (m) -> (
      )
 
 matrix RingElement := matrix Number := opts -> r -> matrix({{r}}, opts)
+matrix(Ring,       RingElement) :=
+matrix(RingFamily, RingElement) :=
+matrix(Ring,       Number)      :=
+matrix(RingFamily, Number)      := opts -> (R, f) -> matrix(R, {{f}}, opts)
 
 matrix List := Matrix => opts -> L -> (
     if #L === 0 then return matrix(ZZ, {});

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/matrix-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/matrix-doc.m2
@@ -192,13 +192,33 @@ document {
      SeeAlso => {mutableMatrix, mutableIdentity, MutableMatrix}
      }
 
-document {
-     Key => {(matrix, RingElement),(matrix, Number)},
-     Headline => "make a matrix from a ring element",
-     Usage => "matrix r",
-     Inputs => { "r" },
-     Outputs => { Matrix => {"the one by one matrix with ", TT "r", " as its single entry"} },
-     EXAMPLE lines ///
-     matrix 48
-     ///
-     }
+doc ///
+  Key
+    (matrix, Ring, RingElement)
+    (matrix, Ring, Number)
+    (matrix, Number)
+    (matrix, RingElement)
+    (matrix, RingFamily, RingElement)
+    (matrix, RingFamily, Number)
+  Headline
+    make a matrix from a ring element
+  Usage
+    matrix(R, f)
+    matrix f
+  Outputs
+    :Matrix -- the one by one matrix with @VAR "f"@ as its single entry
+  Inputs
+    R:{Ring, RingFamily}
+    f:{RingElement, Number}
+  Description
+    Example
+      matrix 48
+      R = QQ[x,y]
+      matrix(x^2 - y^2)
+    Text
+      Specify a ring @VAR "R"@ to get a matrix over @VAR "R"@ instead of the
+      ring of @VAR "f"@.
+    Example
+      matrix(QQ, 48)
+      matrix(R, 48)
+///

--- a/M2/Macaulay2/tests/normal/matrix.m2
+++ b/M2/Macaulay2/tests/normal/matrix.m2
@@ -397,6 +397,13 @@ B = matrix {{f}}
 assert (norm B === 5_QQ)
 assert (norm_2 B === 6.0)
 
+-- 1x1 matrix constructors
+R = QQ[x]
+assert Equation(matrix 1, matrix {{1}})
+assert Equation(matrix(QQ, 1), matrix 1_QQ)
+assert Equation(matrix(RR, 1), matrix 1.0)
+assert Equation(matrix(R, 1), matrix 1_R)
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test matrix.out"
 -- End:


### PR DESCRIPTION
Currently, we can do `matrix 1` to get a 1x1 matrix over `ZZ` and `matrix(QQ, {{1}})` to get the same matrix over `QQ`.  It makes sense for `matrix(QQ, 1)` to also work.

For example:

```m2
i1 : matrix(QQ, 1)

o1 = | 1 |

              1       1
o1 : Matrix QQ  <-- QQ

i2 : matrix(RR, 1)

o2 = | 1 |

                1         1
o2 : Matrix RR    <-- RR
              53        53

i3 : matrix(QQ[x], 1)

o3 = | 1 |

                   1            1
o3 : Matrix (QQ[x])  <-- (QQ[x])

i4 : matrix(ZZ/2[y], 1)

o4 = | 1 |

             ZZ    1      ZZ    1
o4 : Matrix (--[y])  <-- (--[y])
              2            2
```