### PR TITLE
Bump FLINT to v3.5.0

### DIFF
--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -267,6 +267,7 @@ foreach(_library IN LISTS LIBRARY_OPTIONS)
       unset(${_name}_INCLUDEDIR CACHE)
       unset(${_name}_INCLUDE_DIR CACHE)
       unset(${_name}_INCLUDE_DIRS CACHE)
+      unset(${_name}_ROOT)
       # for GTest:
       unset(${_name}_MAIN_LIBRARY CACHE)
       unset(${_name}_MAIN_LIBRARY_DEBUG CACHE)

--- a/M2/libraries/flint/Makefile.in
+++ b/M2/libraries/flint/Makefile.in
@@ -2,7 +2,7 @@ SUBMODULE = true
 # LIBNAME = flint2
 HOMEPAGE = http://flintlib.org
 URL = https://github.com/flintlib/flint
-VERSION = 3.4.0
+VERSION = 3.5.0
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 PARALLEL = yes
 


### PR DESCRIPTION
FLINT 3.5.0 was just released.  Draft for now to test the builds