### PR TITLE
Add l^p norms for finite p

### DIFF
--- a/M2/Macaulay2/m2/enginering.m2
+++ b/M2/Macaulay2/m2/enginering.m2
@@ -376,13 +376,23 @@ frac EngineRing := R -> if isField R then R else if R.?frac then R.frac else (
 clean(RR,Number) := (epsilon,f) -> if abs f < epsilon then f-f else f
 clean(RR,RingElement) := (epsilon,f) -> new ring f from clean(epsilon,raw f)
 
-norm(List) := z -> max(abs\z)
-norm(RR,Number) := (p,z) -> p-p+abs z
-norm(RR,RingElement) := (p,f) -> new RR from norm(p,raw f)
-norm(InfiniteNumber,Number) := 
-norm(InfiniteNumber,RingElement) := (p,f) -> norm(numeric(precision f, p), f)
-norm(RingElement) := (f) -> norm(numeric(precision f,infinity), f)
-norm Number := abs
+norm List        :=
+norm Number      :=
+norm RingElement := norm_infinity
+norm(Number, List) := (p, z) -> norm(p, matrix {z})
+norm(Number, Number) := (p, z) -> abs z
+norm(Number, RingElement) := (p, f) -> (
+    R := ring f;
+    -- l^infinity norm for polynomials over RR or CC in engine
+    if p == infinity and any(R.baseRings,
+	S -> instance(S, RealField) or instance(S, ComplexField))
+    then (
+	if precision p > precision R
+	then p = numeric(precision R, infinity);
+	norm(p, raw f))
+    else (
+	(mons, coeffs) := coefficients f;
+	norm(p, lift(coeffs, coefficientRing R))))
 
 degreeLength Ring := R -> R.degreeLength
 

--- a/M2/Macaulay2/m2/matrix.m2
+++ b/M2/Macaulay2/m2/matrix.m2
@@ -563,25 +563,21 @@ leadTerm(Matrix) := Matrix => m -> (
 borel Matrix := Matrix => m -> generators borel monomialIdeal m
 
 clean(RR,Matrix) := (epsilon,M) -> map(target M, source M, clean(epsilon,raw M))
-norm(RR,Matrix) := (p,M) -> new RR from norm(p,raw M)
-norm(InfiniteNumber,Matrix) := (p,M) -> (
-     prec := precision M;
-     if prec === infinity then (
-	  error "expected a matrix over RR or CC";
-	  )
-     else (
-     	  norm(numeric(prec,p), M)
-	  )
-     )
-norm(Matrix) := (M) -> (
-     prec := precision M;
-     if prec === infinity then (
-	  error "expected a matrix over RR or CC";
-	  )
-     else (
-     	  norm(numeric(prec,infinity), M)
-	  )
-     )
+
+norm Matrix := norm_infinity
+norm(Number, Matrix) := (p, M) -> (
+    R := ring M;
+    if p == infinity then (
+	-- l^infty norm for RR and CC is implemented in the engine
+	if instance(R, RealField) or instance(R, ComplexField)
+	then (
+	    if precision p > precision R
+	    then p = numeric(precision R, infinity);
+	    new RR from norm(p, raw M))
+	else max apply(flatten entries M, norm))
+    else if isReal p and p >= 1
+    then (sum(flatten entries M, x -> (norm(p, x))^p))^(1/p)
+    else error "expected p >= 1")
 
 numRows Matrix := M -> numgens cover target M
 numColumns Matrix := M -> numgens cover source M

--- a/M2/Macaulay2/m2/modules.m2
+++ b/M2/Macaulay2/m2/modules.m2
@@ -79,6 +79,7 @@ Vector.synonym = "vector"
 Vector _ ZZ := (v,i) -> (ambient v#0)_(i,0)
 entries Vector := v -> entries ambient v#0 / first
 norm Vector := v -> norm v#0
+norm(Number, Vector) := (p, v) -> norm(p, v#0)
 expression Vector := v -> VectorExpression apply(flatten entries super v#0,expression)
 net Vector := v -> net expression v
 describe Vector := v -> Describe expression FunctionApplication(

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -45,9 +45,9 @@ mutableMatrix(RingFamily,ZZ,ZZ) := o -> (R,nrows,ncols) -> mutableMatrix(default
 matrix MutableMatrix := o -> m -> map(ring m, rawMatrix raw m)
 
 clean(RR,MutableMatrix) := (epsilon,M) -> map(ring M, clean(epsilon,raw M))
-norm(RR,MutableMatrix) := (p,M) -> new RR from norm(p,raw M)
-norm(InexactField,MutableMatrix) := (p,M) -> norm(numeric(precision M, p), M)
-norm(MutableMatrix) := (M) -> new RR from norm(numeric(precision M,infinity),raw M)
+
+norm MutableMatrix := norm_infinity
+norm(Number, MutableMatrix) := lookup(norm, Number, Matrix)
 
 mutableIdentity = method(Options => {Dense => true}, TypicalValue=>MutableMatrix)
 mutableIdentity(Ring,ZZ) := o -> (R,nrows) -> 

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_analytic_functions.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_analytic_functions.m2
@@ -512,34 +512,57 @@ document { Key => {isANumber, (isANumber,Number)},
      SeeAlso => {isFinite, isInfinite}
      }
 
-document {
-     Key => {norm,
-	  (norm, InfiniteNumber, Matrix),(norm, Matrix),(norm, RR, Matrix),(norm, InfiniteNumber, RingElement),(norm, MutableMatrix),
-	  (norm, RingElement),(norm, InexactField, MutableMatrix),(norm, RR, MutableMatrix),(norm, RR, RingElement),
-	  (norm,List),(norm,Vector),(norm,Number),(norm,RR,Number),(norm,InfiniteNumber,Number)
-	  },
-     Usage => "norm M\nnorm(p,M)",
-     Inputs => {
-	  "M"=>{ofClass{MutableMatrix,Matrix,RingElement,Number,Vector,List}},
-	  "p"=>{ofClass{RR,InfiniteNumber}, ", specifying which norm to compute.  Currently, only ", TT "p=infinity", " is accepted."}
-	  },
-     Outputs => {TEX{"the $L^p$-norm of ", TT "M", " computed to the minimum of the precisions of ", TT "M", " and of ", TT "p",
-	       "."}},
-     EXAMPLE lines ///
-	  printingPrecision = 2
-	  R = RR_100
-	  M = 10*random(R^3,R^10)
-	  norm M
-	  norm_(numeric_20 infinity) M
-	  norm {3/2,4,-5}
-	  ///,
-     "The norm of a polynomial is the norm of the vector of its coefficients.",
-     EXAMPLE lines ///
-	  RR[x]
-	  (1+x)^5
-	  norm oo
-	  ///
-     }
+doc ///
+  Key
+    norm
+    (norm,List)
+    (norm,Matrix)
+    (norm,MutableMatrix)
+    (norm,Number)
+    (norm,Number,List)
+    (norm,Number,Matrix)
+    (norm,Number,MutableMatrix)
+    (norm,Number,Number)
+    (norm,Number,RingElement)
+    (norm,Number,Vector)
+    (norm,RingElement)
+    (norm,Vector)
+  Headline
+    l^p norm
+  Usage
+    norm M
+    norm(p, M)
+  Inputs
+    p:Number -- specifying which norm to compute
+    M:{List, Matrix, MutableMatrix, Number, RingElement, Vector}
+  Outputs
+    :Number
+      The $\ell^p$-norm of @VAR "M"@, computed to the minimum of the precisions
+      of @VAR "M"@ and @VAR "p"@.
+  Description
+    Text
+      By default, the $\ell^\infty$ norm giving the maximum absolute entry is returned.
+    Example
+      printingPrecision = 2
+      R = RR_100
+      M = 10*random(R^3,R^10)
+      norm M
+      norm_(numeric_20 infinity) M
+      norm {3/2,4,-5}
+    Text
+      For finite $p$, the $\ell^p$ norm
+      $$\|M\|_p = \left(\sum_{i,j} |M_{ij}|^p\right)^{1/p}$$
+      is returned.  For example, when $p = 2$, this is the Frobenius norm.
+    Example
+      M = matrix {{3, 4}, {12, 84}}
+      norm_2 M
+    Text
+      The norm of a polynomial is the norm of the vector of its coefficients.
+    Example
+      RR[x]
+      (1+x)^5
+      norm oo
+///
 
 document { Key => {commonRing, (commonRing,List)},
      Usage => "commonRing v",

--- a/M2/Macaulay2/tests/normal/matrix.m2
+++ b/M2/Macaulay2/tests/normal/matrix.m2
@@ -375,6 +375,28 @@ scan({matrix {}, matrix(ZZ, {}), map(ZZ^0, ZZ^0, {}), map(ZZ^0,, {})}, A -> (
 -- issue #3456
 assert Equation(matrix {{ii}}, matrix {{numeric ii}})
 
+-- norm
+A = matrix {{-1, 1}, {3, -5}}
+assert (norm A === 5)
+assert (norm_infinity A === 5)
+assert (norm numeric A === 5.0)
+assert (norm_infinity numeric A === 5.0)
+assert (norm(numeric(20, infinity), numeric A) === 5.0p20)
+assert (norm_2 A === 6.0)
+A = mutableMatrix A
+assert (norm A === 5)
+assert (norm_2 A === 6.0)
+R = QQ[x]
+f = -x^3 + x^2 + 3*x - 5
+assert (norm f === 5_QQ)
+assert (norm_2 f === 6.0)
+v = vector flatten entries A
+assert (norm v === 5)
+assert (norm_2 v === 6.0)
+B = matrix {{f}}
+assert (norm B === 5_QQ)
+assert (norm_2 B === 6.0)
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test matrix.out"
 -- End:


### PR DESCRIPTION
For example:

```m2
i1 : norm vector {3, 4}

o1 = 4

i2 : norm_2 vector {3, 4}

o2 = 5

o2 : RR (of precision 53)

i3 : norm_1 vector {3, 4}

o3 = 7
```

Fixes: #4206