### PR TITLE
Increase upper bound on timing quotient test

### DIFF
--- a/M2/Macaulay2/tests/normal/timing-quotient.m2
+++ b/M2/Macaulay2/tests/normal/timing-quotient.m2
@@ -229,4 +229,4 @@ P=QQ[x,y,z,MonomialOrder=>Lex];
 d=z^4+z^2*x*y^9+z*x^9*y+x^5*y^5;
 phi=map(P,P,matrix{{x^13*y^4,x^3*y,x^20*y^6*z}});
 tim = timing factor(phi(d));
-assert BinaryOperation {symbol <, tim#0, .05 * standardSecond}
+assert BinaryOperation {symbol <, tim#0, .1 * standardSecond}


### PR DESCRIPTION
This test has started to fail frequently on 64-bit ARM builds of the Ubuntu PPA package in more recent releases (24.04 and 26.04), e.g:

```m2
ii14 : assert BinaryOperation {symbol <, tim#0, .05 * standardSecond}
timing-quotient.m2:232:6:(3):[6]: error: assertion failed:
.092404<.0586669 is false
```

Full log: https://launchpadlibrarian.net/858673536/buildlog_ubuntu-noble-arm64.macaulay2_1.25.11+git202604221732-0ppa202604240205~ubuntu24.04.1_BUILDING.txt.gz

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
