### PR TITLE
Fixing a bug with join in SimplicialComplexes

### DIFF
--- a/M2/Macaulay2/packages/SimplicialComplexes/Code.m2
+++ b/M2/Macaulay2/packages/SimplicialComplexes/Code.m2
@@ -392,7 +392,7 @@ star (SimplicialComplex, RingElement) := (S, f) -> (simplicialComplex(monomialId
 SimplicialComplex * SimplicialComplex := (D, D') -> (
      S := ring D ** ring D';
      fromD := map(S, ring D);
-     fromD' := map(S, ring D');
+     fromD' := if ring D === ring D' then map(S, ring D, (gens S)_{#gens ring D..#gens S - 1}) else map(S, ring D');
      simplicialComplex monomialIdeal(fromD ideal D + fromD' ideal D')
      )
 


### PR DESCRIPTION
Nathan Ilten pointed out this bug to me. I'm not sure if this is meant to be intended behavior for self-tensor products, but this simple line of code fixes it in my situation.

Here's a simpler example illustrating the bug.
```
R = ZZ[x_1,x_2]
S = R
RxR = R ** S
phi1 = map(RxR,R)
phi2 = map(RxR,S)
```
Because R === S in memory, phi2 === phi1. But I would have expected phi1 to be the inclusion into the first factor and phi2 the inclusion into the second factor.