### PR TITLE
Support 2-argument "map" to/from RingFamily objects (RR/CC/RRi)

### DIFF
--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -53,6 +53,8 @@ Ring#id = R -> map(R, R, vars R)
 
 map(RingFamily, Thing, Thing) := RingMap => opts -> (R, S, m) -> map(default R, S, m, opts)
 map(Thing, RingFamily, Thing) := RingMap => opts -> (R, S, m) -> map(R, default S, m, opts)
+map(RingFamily, Thing) := RingMap => opts -> (R, S) -> map(default R, S, opts)
+map(Thing, RingFamily) := RingMap => opts -> (R, S) -> map(R, default S, opts)
 
 map(Ring, Ring)          := RingMap => opts -> (R, S   ) -> map(R, S, matrix(R, {{}}), opts)
 map(Ring, Ring, RingMap) := RingMap => opts -> (R, S, f) -> map(R, S, matrix f,        opts)

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/map-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/map-doc.m2
@@ -7,7 +7,8 @@
 (map,GaloisField,GaloisField)
 *-
 
-undocumented {(map, RingFamily, Thing, Thing),(map, Thing, RingFamily, Thing)}
+undocumented {(map, RingFamily, Thing, Thing),(map, Thing, RingFamily, Thing),
+    (map, RingFamily, Thing), (map, Thing, RingFamily)}
 
 document {
      Key => { map, "morphisms" },

--- a/M2/Macaulay2/tests/normal/ringmap.m2
+++ b/M2/Macaulay2/tests/normal/ringmap.m2
@@ -1,4 +1,8 @@
 -- test map
+f = map(CC, RR)
+assert (f 2 === toCC 2)
+g = map(RRi, RR)
+assert (g 2 === toRRi 2)
 
 << "-- this doesn't work yet, but perhaps the presence of" << endl
 << "-- the test will spur us to make it work" << endl


### PR DESCRIPTION
### Before

```m2
i1 : f = map(CC, RR)
stdio:1:7:(3):[1]: error: no method found for applying map to:
     argument 1 :  CC (of class InexactFieldFamily)
     argument 2 :  RR (of class InexactFieldFamily)
```

### After

```m2
i1 : f = map(CC, RR)

o1 = map (CC  , RR  , {})
            53    53

o1 : RingMap CC   <-- RR
               53       53

i2 : f 2

o2 = 2

o2 : CC (of precision 53)
```
