### PR TITLE
Add support for "kernel" for maps from ZZ

### DIFF
--- a/M2/Macaulay2/m2/ringmap.m2
+++ b/M2/Macaulay2/m2/ringmap.m2
@@ -317,7 +317,7 @@ algorithms#(kernel, RingMap) = new MutableHashTable from {
 	       assert (not chh or G#?"rawGBSetHilbertFunction log"); -- ensure the Hilbert function hint was actually used in gb.m2
 	       ideal mapback selectInSubring(1,generators G)
 	),
-
+    ZZ => (opts, f) -> if source f === ZZ then ideal char target f,
     Default => (opts, f) -> (
 	(F, R) := (target f, source f);
 	       numsame := 0;
@@ -342,7 +342,7 @@ algorithms#(kernel, RingMap) = new MutableHashTable from {
     }
 
 -- Installing hooks for kernel RingMap
-scan({Default, "AffineRing", FractionField}, strategy ->
+scan({Default, ZZ, "AffineRing", FractionField}, strategy ->
     addHook(key := (kernel, RingMap), algorithms#key#strategy, Strategy => strategy))
 
 -----------------------------------------------------------------------------

--- a/M2/Macaulay2/tests/normal/ringmap.m2
+++ b/M2/Macaulay2/tests/normal/ringmap.m2
@@ -1,15 +1,9 @@
 -- test map
 
-<< "-- this doesn't work yet, but perhaps the presence of" << endl
-<< "-- the test will spur us to make it work" << endl
-exit 0
-
-errorDepth = 1
-
 f = map(ZZ/5,ZZ)
 assert(class f 4 === ZZ/5)
 assert(f 4 == -1)
-kernel f
+assert(kernel f === ideal 5)
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test ringmap.out"


### PR DESCRIPTION
This adds a simple strategy in the case where the source is ℤ -- the kernel is just the ideal generated by the characteristic of the target.

This fixes a 30-year old feature request!