### PR TITLE
Changed findProgram call for msolve to "msolve -h"

### DIFF
--- a/M2/Macaulay2/packages/Msolve.m2
+++ b/M2/Macaulay2/packages/Msolve.m2
@@ -37,7 +37,7 @@ importFrom_Elimination { "eliminationRing" }
 ---------------------------------------------------------------------------
 
 msolveMinimumVersion = "0.7.0"
-msolveProgram = findProgram("msolve", "msolve --help",
+msolveProgram = findProgram("msolve", "msolve -h",
     MinimumVersion => (msolveMinimumVersion, "msolve -V"),
     RaiseError => false,
     Verbose => debugLevel > 0)


### PR DESCRIPTION
`msolve` didn't support a `--help` option until [`v0.9.5`](https://github.com/algebraic-solving/msolve/blob/v0.9.5/src/msolve/main.c#L73).  As of `v0.9.2`, there is no error code thrown, but `msolve` does complain  to STDOUT when you call it with `--help`.  Since the minimum `msolve` version required by Macaulay2 is `v0.7.0` and `-h` works in `v0.9.5`, it might make more sense to use `-h` for now.