### PR TITLE
Use etags to generate m2 directory TAGS file (autotools)

### DIFF
--- a/M2/Macaulay2/m2/Makefile.in
+++ b/M2/Macaulay2/m2/Makefile.in
@@ -36,31 +36,9 @@ clean::;rm -f @pre_packagesdir@/Core/tvalues.m2
 all: tags
 tags: Makefile @srcdir@/TAGS @srcdir@/TAGS.doc
 clean::; rm -f TAGS @srcdir@/TAGS @srcdir@/TAGS.doc
-@srcdir@/TAGS: \
-		$(DUMPEDM2SRCFILES) \
-		$(shell @FIND@ @srcdir@/../packages -name "*.m2" -a -not -name .\#\* | sort) \
-		../editors/emacs/make-M2-emacs-help.m2 \
-		../editors/make-M2-symbols.m2 \
-		@srcdir@/../*/COPYRIGHT \
-		@srcdir@/basictests/*.m2 \
-		@srcdir@/../packages/*.m2 \
-		@srcdir@/../packages/*/*.m2 \
-		@srcdir@/../tests/*/*.m2 \
-		@srcdir@/../packages/SimpleDoc/doc.txt \
-		loadsequence \
-		Makefile.in \
-		../editors/Makefile.in \
-		../tests/Makefile.in \
-		../tests/Makefile.test.in \
-		../tests/slow/Makefile.in \
-		../tests/engine/Makefile.in \
-		../packages/Makefile.in \
-		../../Makefile.in
+@srcdir@/TAGS: $(DUMPEDM2FILES) @pre_packagesdir@/Core/tvalues.m2
 	: making $@
-	@ set -e ; \
-	  cd @srcdir@ && \
-	  for i in $(patsubst @srcdir@/%, "%", $^) ; \
-	  do [ -f $$i ] || (echo "file not found: $$i" >&2; exit 1) ; echo  ; echo $$i,0 ; done >TAGS
+	@ETAGS@ -o $@ $^ || true
 
 @srcdir@/TAGS.doc: Makefile.in $(shell @FIND@ @srcdir@/../packages/Macaulay2Doc -not \( -name .svn -prune \) -type d)
 	: making $@ : $^


### PR DESCRIPTION
~~It's as pretty pointless file, as no functions are defined, and beginning in April 2026, we started having so many package files that the build failed with "Argument list too long" errors~~

I've replaced this with another solution -- generate the `TAGS` file the same way we do in cmake, by running `etags` on the Core .m2 files.  Not only should this fix the failing autotools builds, but it also gives us a useful `M-.` in the M2 directory!

Should fix #4233

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
