### PR TITLE
Return the minimal primes of the zero ideal

### DIFF
--- a/M2/Macaulay2/packages/MinimalPrimes.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes.m2
@@ -218,8 +218,7 @@ updateComputation(MinimalPrimesComputation, List) := List => options minimalPrim
 -- Helper for minimalPrimes and decompose
 minprimesHelper = (I, key, opts) -> (
     if I == 1 then return {};
-    J := first flattenRing I;
-    if J == 0 then return {I};
+    if I == 0 or (J := first flattenRing I) == 0 then return {I};
     -- TODO: make presentation work for ZZ, then move this line
     if ring I === ZZ then return ideal \ first \ toList factor (trim I)_0;
     S := ring presentation ring J;

--- a/M2/Macaulay2/packages/MinimalPrimes/tests.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes/tests.m2
@@ -1884,6 +1884,13 @@ TOODAMNSLOW ///
 
   minimalPrimes I -- doesn't seem to finish.  But in fact crashed in <= M2 1.24.05, (see previous test).
 ///
+
+-- issue #3505
+TEST ///
+assert isPrime ideal 0_(ZZ/2)
+assert isPrime ideal 0_(ZZ/4)
+///
+
 end--
 
 -- UHOH problem with finite fields


### PR DESCRIPTION
Previously, we only checked if the output of flattenRing was the zero ideal, but that may not be the case, e.g., for (0) in ZZ/n, this gives us (n).

This fixes #3505.

### Before
```m2
i1 : minimalPrimes ideal 0_(ZZ/2)
stdio:1:13:(3):[1]: error: no method found for applying presentation to:
     argument   :  ZZ (of class Ring)

i2 : minimalPrimes ideal 0_(ZZ/4)
stdio:2:13:(3):[1]: error: no applicable strategy for (minimalPrimes,Ideal)
```

### After
```m2
i1 : minimalPrimes ideal 0_(ZZ/2)

o1 = {ideal 0}

o1 : List

i2 : minimalPrimes ideal 0_(ZZ/4)

o2 = {ideal 0}

o2 : List
```
