### PR TITLE
InvariantRing v2.4

### DIFF
--- a/M2/Macaulay2/packages/InvariantRing.m2
+++ b/M2/Macaulay2/packages/InvariantRing.m2
@@ -1,5 +1,5 @@
 -*
-   Copyright 2020, Luigi Ferraro, Federico Galetto,
+   Copyright 2020-2026, Luigi Ferraro, Federico Galetto,
    Francesca Gandini, Hang Huang, Matthew Mastroeni, Xianglong Ni.
 
    You may redistribute this file under the terms of the GNU General Public
@@ -9,12 +9,12 @@
 
 newPackage(
         "InvariantRing",
-        Version => "2.0", 
-        Date => "November 11, 2020",
+        Version => "2.4", 
+        Date => "May 1, 2026",
         Authors => {
 	    {Name => "Luigi Ferraro", 
-		 Email => "lferraro@ttu.edu", 
-		 HomePage => "http://www.math.ttu.edu/~lferraro/"
+		 Email => "luigi.ferraro@utrgv.edu", 
+		 HomePage => "https://faculty.utrgv.edu/luigi.ferraro/"
 		 },
              {Name => "Federico Galetto", 
 		 Email => "f.galetto@csuohio.edu", 
@@ -30,7 +30,7 @@ newPackage(
 		 },
 	     {Name => "Thomas Hawes", Email => "thomas.hawes@maths.ox.ac.uk"},
 	     {Name => "Matthew Mastroeni", 
-		 Email => "mmastro@okstate.edu", 
+		 Email => "mmastro@iastate.edu", 
 		 HomePage => "https://mnmastro.github.io/"
 		 },
              {Name => "Xianglong Ni", 
@@ -47,49 +47,62 @@ newPackage(
 	     "published article URI" => "https://msp.org/jsag/2024/14-1/p02.xhtml",
 	     "published article DOI" => "10.2140/jsag.2024.14.5",
 	     "published code URI" => "https://msp.org/jsag/2024/14-1/jsag-v14-n1-x02-InvariantRing.m2",
+	     "repository code URI" => "https://github.com/Macaulay2/M2/blob/master/M2/Macaulay2/packages/InvariantRing.m2",
 	     "release at publication" => "d708862d93052a37b7f9ff1e584a9b57d1cb7870",
 	     "version at publication" => "2.0",
 	     "volume number" => "14",
 	     "volume URI" => "https://msp.org/jsag/2024/14-1/"
 	     },
 	AuxiliaryFiles => true,
-        DebuggingMode => false
+        DebuggingMode => false,
+	PackageExports => {
+	    "Graphs"
+	    }
         )
 
 
 
 export {
-    "GroupAction",    	      	  
-    "finiteAction",    	       	  
-    "FiniteGroupAction",    	  
+    -- New Types
+    "GroupAction",
+    "FiniteGroupAction",
+    "DiagonalAction",
+    "LinearlyReductiveAction",
+    
+    --FiniteGroups.m2    	      	  
+    "finiteAction",    	       	      	  
     "group",	    	    	  
     "isAbelian",    	    	  
     "permutationMatrix",          
     "schreierGraph",	    	  
-    "words",    	       	  
-    "cyclicFactors",	    	  
-    "DiagonalAction",	     	  
+    "words",
+    
+    --AbelianGroups.m2    	       	  
+    "cyclicFactors",	    	  	     	  
     "diagonalAction",	     	  
     "equivariantHilbert",    	  
     "equivariantHilbertSeries",   
-    "weights",	      	      	  
+    "weights",
+    
+    --LinearlyReductiveGroups.m2	      	      	  
     "actionMatrix",    	       	  
     "groupIdeal",    	     	  
     "hilbertIdeal",    	       	  
-    "linearlyReductiveAction",	  
-    "LinearlyReductiveAction",	  
+    "linearlyReductiveAction",	  	
+    
+    --Invariants.m2  
     "action",	     	     	  
     "definingIdeal",              
     "DegreeBound",    	      	  
     "invariants",    	     	  
     "invariantRing",	    	  
     "isInvariant",    	      	  
-    "reynoldsOperator",	       	  
-    "UseLinearAlgebra",     	  
+    "reynoldsOperator",	       	     	  
     "RingOfInvariants",	       	  
-    "UseCoefficientRing",    	  
-    "UseNormaliz",    	      	  
-    "UsePolyhedra",    	      	  
+    "UseCoefficientRing",
+    "UsePolyhedra",
+    
+    --Hawes.m2    	      	      	  
     "hironakaDecomposition",   	  
     "molienSeries",    	       	  
     "primaryInvariants",    	  
@@ -98,7 +111,6 @@ export {
     "DegreeVector",    	       	  
     "PrintDegreePolynomial"    	  
     }
-
 
 needsPackage("Elimination")
 needsPackage("Normaliz")

--- a/M2/Macaulay2/packages/InvariantRing/AbelianGroups.m2
+++ b/M2/Macaulay2/packages/InvariantRing/AbelianGroups.m2
@@ -19,7 +19,7 @@ diagonalAction = method()                   -- Constructor for DiagonalAction ob
 
 -------------------------------
 ---- diagonalAction constructor
--->-    W1 & W2 - Weight matricies
+-->-    W1 & W2 - Weight matrices
 -->-    g       - Order of the group
 -->-    R       - Ring
 diagonalAction (Matrix, Matrix, List, PolynomialRing) := DiagonalAction => (W1, W2, d, R) -> (
@@ -65,7 +65,7 @@ diagonalAction (Matrix, Matrix, List, PolynomialRing) := DiagonalAction => (W1, 
 
 -------------------------------
 ---- diagonalAction constructor
--->-    W       - Weight matricies
+-->-    W       - Weight matrices
 -->-    g       - Order of the group
 -->-    R       - Ring
 diagonalAction (Matrix, List, PolynomialRing) := DiagonalAction => (W, d, R) -> (

--- a/M2/Macaulay2/packages/InvariantRing/AbelianGroups.m2
+++ b/M2/Macaulay2/packages/InvariantRing/AbelianGroups.m2
@@ -7,70 +7,91 @@
    the License, or any later version.
 *-
 
-
-DiagonalAction = new Type of GroupAction
-
--------------------------------------------
---- DiagonalAction methods -------------------
 -------------------------------------------
 
-diagonalAction = method()
+DiagonalAction = new Type of GroupAction    -- the DiagonalAction object
 
+diagonalAction = method()                   -- Constructor for DiagonalAction object
+
+-------------------------------------------
+--- DiagonalAction Constructors -----------
+-------------------------------------------
+
+-------------------------------
+---- diagonalAction constructor
+-->-    W1 & W2 - Weight matricies
+-->-    g       - Order of the group
+-->-    R       - Ring
 diagonalAction (Matrix, Matrix, List, PolynomialRing) := DiagonalAction => (W1, W2, d, R) -> (
+    --!-- Ensures inputs are valid --!--
     if not isField coefficientRing R then (
-	error "diagonalAction: Expected the last argument to be a polynomial ring over a field."
+	    error "diagonalAction: Expected the last argument to be a polynomial ring over a field."
 	);
     if ring W1 =!= ZZ or ring W2 =!= ZZ then (
-	error "diagonalAction: Expected the first and second arguments to be matrices of integer weights."
+	    error "diagonalAction: Expected the first and second arguments to be matrices of integer weights."
 	);
     if numColumns W1 =!= dim R or numColumns W2 =!= dim R then (
-	error "diagonalAction: Expected the number of columns of each matrix to equal the dimension of the polynomial ring."
+	    error "diagonalAction: Expected the number of columns of each matrix to equal the dimension of the polynomial ring."
 	);
     if numRows W2 =!= #d then (
-	error "diagonalAction: Expected the number of rows of the second argument to equal the size of the list."
+	    error "diagonalAction: Expected the number of rows of the second argument to equal the size of the list."
 	);
     if any(d, j -> not instance(j, ZZ) or j <= 0) then (
-	error "diagonalAction: Expected the second argument to be a list of positive integers."
+	    error "diagonalAction: Expected the second argument to be a list of positive integers."
 	);
     p := char R;
     if p > 0 and any(d, j -> j%p == 0) then (
-	error "diagonalAction: Diagonal action is not defined when the characteristic divides the order of one of the cyclic factors."
-	);    
+	    error "diagonalAction: Diagonal action is not defined when the characteristic divides the order of one of the cyclic factors."
+	); 
+    --!-- ---------------------- --!--
+    ----- - Creates the object - --!--
     r := numRows W1;
     g := numRows W2;
-    z := getSymbol "z";
-    C := ZZ[Variables=> r + g,VariableBaseName=>z,
-	MonomialOrder=> {GroupLex => r,GroupLex => g},
-	Inverses=>true];
+    diagVariable := getSymbol "ζ";
+    C := ZZ[Variables           => r + g,
+            VariableBaseName    => diagVariable,
+	        MonomialOrder       => {GroupLex => r,GroupLex => g},
+	        Inverses            => true];
     new DiagonalAction from {
-	cache => new CacheTable,
-	(symbol cyclicFactors) => d,
-	(symbol degreesRing) => C monoid degreesRing R,
-	(symbol numgens) => g, 
-	(symbol ring) => R, 
-	(symbol rank) => r,
-	(symbol weights) => (W1, W2)
+        cache => new MutableHashTable,
+        (symbol cyclicFactors) => d,
+        (symbol degreesRing) => C monoid degreesRing R,
+        (symbol numgens) => g, 
+        (symbol ring) => R, 
+        (symbol rank) => r,
+        (symbol weights) => (W1, W2)
 	}
-    )
+)
 
+-------------------------------
+---- diagonalAction constructor
+-->-    W       - Weight matricies
+-->-    g       - Order of the group
+-->-    R       - Ring
 diagonalAction (Matrix, List, PolynomialRing) := DiagonalAction => (W, d, R) -> (
     if ring W =!= ZZ then (
-	error "diagonalAction: Expected the first argument to be a matrix of integer weights."
+	    error "diagonalAction: Expected the first argument to be a matrix of integer weights."
 	);
     r := numRows W - #d;
     if r < 0 then (
-	error "diagonalAction: The number of rows of the matrix cannot be smaller than the size of the list."
+	    error "diagonalAction: The number of rows of the matrix cannot be smaller than the size of the list."
 	); 
     W1 := W^(apply(r, i -> i));
     W2 := W^(apply(#d, i -> r + i));
     diagonalAction(W1, W2, d, R)
-    )
+)
 
-diagonalAction (Matrix, PolynomialRing) := DiagonalAction => (W, R) -> diagonalAction(W, {}, R)
-
+---- Additional constructors when parameters have special properties
+diagonalAction (Matrix, PolynomialRing)     := DiagonalAction => (W, R)     -> diagonalAction(W, {}, R)
+diagonalAction (Matrix, ZZ, PolynomialRing) := DiagonalAction => (W, z, R)  -> diagonalAction(W, apply(numRows W, i -> z), R)
 
 -------------------------------------------
+--- DiagonalAction Methods ----------------
+-------------------------------------------
 
+-------------------------------
+---- net DiagonalAction
+-->-    Used to print out a diagonalAction object
 net DiagonalAction := D -> (
     torus := "";
     cyclicGroups := "";
@@ -78,55 +99,68 @@ net DiagonalAction := D -> (
     g := D.numgens;
     local weightMatrix;
     if r > 0 then (
-	torus = (expression coefficientRing D.ring)^(expression "*");
-	if r > 1 then torus = (expression ("("|net torus|")"))^(expression r)
-	);
+        torus = (expression coefficientRing D.ring)^(expression "*");
+	    if r > 1 then (
+            torus = (expression ("("|net torus|")"))^(expression r)
+        );
+    );
     if g > 0 then (
-	cyclicGroups = cyclicGroups|horizontalJoin apply(g, i -> (
-		if i == g - 1 then (net ZZ|"/"|net D.cyclicFactors#i)
-		else (net ZZ|"/"|net D.cyclicFactors#i|" x ")
-		)
+	    cyclicGroups = cyclicGroups|horizontalJoin apply(g, i -> 
+            (   if i == g - 1 then (net ZZ|"/"|net D.cyclicFactors#i)
+                else (net ZZ|"/"|net D.cyclicFactors#i|" x ")
+		    )
 	    );
-	if r > 0 then (
-	    torus = net torus|" x ";
-	    weightMatrix = D.weights
-	    )
-	else weightMatrix = last D.weights
+        if r > 0 then (
+            torus = net torus|" x ";
+            weightMatrix = D.weights
+        )
+        else weightMatrix = last D.weights;
 	)
     else weightMatrix = first D.weights;
     stack {(net D.ring)|" <- "|net torus|net cyclicGroups|" via ","", net weightMatrix}
-    )
+)
 
+
+---- cyclicFactors
+-->- Method to access the cyclicFactors of a DiagonalAction
 cyclicFactors = method()
-
 cyclicFactors DiagonalAction := List => D -> D.cyclicFactors
 
+
+-->- Override of "degreesRing" function for DiagonalAction
 degreesRing DiagonalAction := Ring => D -> D.degreesRing
 
+-->- Override for "numgens" function for DiagonalAction
 numgens DiagonalAction := ZZ => D -> D.numgens
 
+-->- Override for "rank" function for DiagonalAction
 rank DiagonalAction := ZZ => D -> D.rank
 
+---- weights
+-->- Method to access the cyclicFactors of a DiagonalAction
 weights = method()
-
 weights DiagonalAction := Matrix => D -> D.weights
 
 
+-------------------------------------------
+--- Equivariant Hilbert Series Methods ----
+-------------------------------------------
 
 equivariantHilbertSeries = method(Options => {Order => infinity}, TypicalValue => Divide)
 
 equivariantHilbertSeries DiagonalAction := op -> T -> (
-    if unique degrees ring T =!= {{1}} then
-    error "Only implemented for standard graded polynomial rings";
+    if unique degrees ring T =!= {{1}} then error "Only implemented for standard graded polynomial rings";
     ord := op.Order;
     if ord === infinity then (
-	equivariantHilbertRational(T)
+	    equivariantHilbertRational(T)
 	)
     else (
-	equivariantHilbertPartial(T,ord-1)
+	    equivariantHilbertPartial(T,ord-1)
 	)
-    )
+)
 
+-- computes equivariant hilbert series as rational function
+-- INPUT: T, DiagonalAction
 equivariantHilbertRational = T -> (
     n := dim T;
     W1 := first weights T;
@@ -134,7 +168,7 @@ equivariantHilbertRational = T -> (
     d := cyclicFactors T;
     if not zero W2 then (
     	W2 = matrix apply(entries W2,d,(row,m)->apply(row,i->i%m));
-    	);
+    );
     W := W1 || W2;
     R := degreesRing T;
     C := coefficientRing R;
@@ -143,42 +177,44 @@ equivariantHilbertRational = T -> (
     Divide{1,den}
 )
 
+-- computes equivariant hilbert series up to a given degree
+-- INPUT: T, DiagonalAction
 equivariantHilbertPartial = (T, d) -> (
     if not T.cache.?equivariantHilbert then (
-	T.cache.equivariantHilbert = 1_(degreesRing T);
+	    T.cache.equivariantHilbert = 1_(degreesRing T);
 	);
     currentDeg := first degree T.cache.equivariantHilbert;
     (M,C) := coefficients T.cache.equivariantHilbert;
     if (d > currentDeg) then (
-	R := degreesRing T;
-	r := rank T;
-	g := numgens T;
-	cf := cyclicFactors T;
-    	den := value denominator equivariantHilbertSeries T;
-    	denDeg := first degree den;
-	B := last coefficients den;
-	if cf =!= {} then (
-	    CR := coefficientRing R;
-	    phi := map(CR,R);
-	    CRab := ZZ[Variables=>g];
-	    CRab = CRab / ideal apply(g,i -> CRab_i^(cf_i)-1);
-	    psi := map(CRab,CR,toList(r:1)|(gens CRab));
-	    psi' := map(CR,CRab,apply(g, i-> CR_(r+i)));
-      	    (m,c) := coefficients(phi B,Variables=>apply(g, i-> CR_(r+i)));
-	    m = psi' psi m;
-	    B = m*c;
-	    );
-	for i from currentDeg+1 to d do (
-	    p := -sum(1..min(i,denDeg),k -> C_(i-k,0)*B_(k,0) );
-	    if cf =!= {} then (
-	    	(m,c) = coefficients(phi p,Variables=>apply(g, i-> CR_(r+i)));
-	    	m = psi' psi m;
-	    	p = (m*c)_(0,0);
-	    	);
-	    M = M | matrix{{R_0^i}};
-	    C = C || matrix{{p}};
-	    );
+        R := degreesRing T;
+        r := rank T;
+        g := numgens T;
+        cf := cyclicFactors T;
+            den := value denominator equivariantHilbertSeries T;
+            denDeg := first degree den;
+        B := last coefficients den;
+        if cf =!= {} then (
+            CR := coefficientRing R;
+            phi := map(CR,R);
+            CRab := ZZ[Variables=>g];
+            CRab = CRab / ideal apply(g,i -> CRab_i^(cf_i)-1);
+            psi := map(CRab,CR,toList(r:1)|(gens CRab));
+            psi' := map(CR,CRab,apply(g, i-> CR_(r+i)));
+            (m,c) := coefficients(phi B,Variables=>apply(g, i-> CR_(r+i)));
+            m = psi' psi m;
+            B = m*c;
+        );
+        for i from currentDeg+1 to d do (
+            p := -sum(1..min(i,denDeg),k -> C_(i-k,0)*B_(k,0) );
+            if cf =!= {} then (
+                (m,c) = coefficients(phi p,Variables=>apply(g, i-> CR_(r+i)));
+                m = psi' psi m;
+                p = (m*c)_(0,0);
+            );
+            M = M | matrix{{R_0^i}};
+            C = C || matrix{{p}};
+        );
 	);
     q := first flatten entries (M_{0..d}*C^{0..d});
     T.cache.equivariantHilbert = q
-    )
+)

--- a/M2/Macaulay2/packages/InvariantRing/AbelianGroupsDoc.m2
+++ b/M2/Macaulay2/packages/InvariantRing/AbelianGroupsDoc.m2
@@ -11,15 +11,17 @@
 document {
 	Key => {diagonalAction, 
 	    (diagonalAction, Matrix, PolynomialRing),
+		(diagonalAction, Matrix, ZZ, PolynomialRing),
 	    (diagonalAction, Matrix, List, PolynomialRing),
 	    (diagonalAction, Matrix, Matrix, List, PolynomialRing)
 	    },
 	Headline => "diagonal group action via weights",
-	Usage => "diagonalAction(W, R), diagonalAction(W, d, R), diagonalAction(W1, W2, d, R)",
+	Usage => "diagonalAction(W, R), diagonalAction(W, z, R), diagonalAction(W, d, R), diagonalAction(W1, W2, d, R)",
 	Inputs => {
 	    	"W" => Matrix => {"of weights of the diagonal group action"},
 		"W1" => Matrix => {"of weights for the torus action"},
 		"W2" => Matrix => {"of weights for the finite abelian action"},
+		"z" => ZZ => {"of the order of an elementary abelian group"},
 	    	"d" => List => {"of orders of cyclic abelian factors in the 
 		    decomposition of the diagonal group"},
 		"R" => PolynomialRing => {"on which the group acts"}
@@ -67,24 +69,54 @@ document {
 	    },
         	
 	EXAMPLE {
-	    "R = QQ[x_1..x_4]",
-	    "W = matrix{{0,1,-1,1},{1,0,-1,-1}}",
+	    "R = QQ[x_1..x_4];",
+	    "W = matrix{{0,1,-1,1},{1,0,-1,-1}};",
 	    "T = diagonalAction(W, R)"
 		},
 	    
     	PARA {
-	    "Here is an example of a product of two cyclic groups of order 3 
-	    acting on a three-dimensional vector space:"
+	    "Here are examples with products of cyclic groups
+	    acting on a three-dimensional vector space.
+	    The orders of the cyclic factors can be passed as
+	    a list of integers or as a single integer when they are
+	    all the same."
 	    },
 	
 	EXAMPLE {
-	    "R = QQ[x_1..x_3]",
-	    "d = {3,3}",
-	    "W = matrix{{1,0,1},{0,1,1}}",
-	    "A = diagonalAction(W, d, R)",
+	    "R = QQ[x_1..x_3];",
+	    "d = {2,5}; z = 3;",
+	    "W = matrix{{1,0,1},{0,1,1}};",
+		"A = diagonalAction(W, d, R)",
+		"B = diagonalAction(W, z, R)"
 		},
     
-	    }
+    	PARA {
+	    "Here is an example of a diagonal action by the product of
+	     a two-dimensional torus with a cyclic group of order 3 
+	    acting on a two-dimensional vector space:"
+	},
+    
+	EXAMPLE {
+	    "R = QQ[x_1, x_2]",
+	    "d = {3}",
+	    "W1 = matrix{{1,-1}, {-1,1}}",
+	    "W2 = matrix {{1,0}}",
+	    "D = diagonalAction(W1, W2, d, R)"
+		},
+    
+    	PARA {
+	    "Finally, a diagonal action may be constructed with a single
+	    weights matrix obtained by vertically stacking the weights
+	    matrix for the torus action on top of the weight matrix for
+	    the finite abelian action. The following redefines the same
+	    action as in the previous example."
+	},
+    
+	EXAMPLE {
+	    "W = W1 || W2",
+	    "diagonalAction(W, d, R)"
+		}
+}
 
 document {
 	Key => {DiagonalAction},
@@ -103,7 +135,8 @@ document {
 
 document {
 	Key => { equivariantHilbertSeries,
-	    (equivariantHilbertSeries, DiagonalAction)
+	    (equivariantHilbertSeries, DiagonalAction),
+	    [equivariantHilbertSeries, Order]
 	    },
 	Headline => "equivariant Hilbert series for a diagonal action",
 	Usage => "equivariantHilbertSeries D",
@@ -122,19 +155,18 @@ document {
 	    "this function returns the equivariant Hilbert series of the coordinate ring",
 	    TEX /// $K[V]$ ///,
 	    "as a rational function of",
-	    TEX /// $z_0, \ldots, z_{r-1}, t$ ///,
+	    TEX /// $\zeta_0, \ldots, \zeta_{r-1}, T$ ///,
 	    "where",
 	    TEX /// $r$ ///,
 	    "is the rank of the torus. The series in",
-	    TEX /// $t$ ///,
+	    TEX /// $T$ ///,
 	    "which is the coefficient of",
-	    TEX /// $z_0^0\cdots z_{r-1}^0$ ///,
-	    "gives the ordinary Hilbert series of",
-	    TEX /// $K[V]^T$ ///,
-	    ". The option ",
+	    TEX /// $\zeta_0^0\cdots \zeta_{r-1}^0$ ///,
+	    "gives the ordinary Hilbert series of the torus-invariant subring. ",
+	    "The option ",
 	    TT "Order => N",
 	    " can be used to compute the series up to the ",
-	    TEX /// $t$ ///,
+	    TEX /// $T$ ///,
 	    "-degree ",
 	    TT "N-1",
 	    "."
@@ -153,7 +185,7 @@ document {
 	    "T = diagonalAction(W, R)",
 	    "equivariantHilbertSeries T",
 	    "S = equivariantHilbertSeries(T, Order => 7)",
-	    "sub(S, {z_0 => 0, z_1 => 0})"
+	    "sub(S, {ζ_0 => 0, ζ_1 => 0})"
 		},
 	 
 	    }

--- a/M2/Macaulay2/packages/InvariantRing/FiniteGroupsDoc.m2
+++ b/M2/Macaulay2/packages/InvariantRing/FiniteGroupsDoc.m2
@@ -47,7 +47,7 @@ document {
 	    },
 	
 	EXAMPLE {
-		"P = permutationMatrix toString 231",
+		"P = permutationMatrix [2, 3, 1]",
 		"C3 = finiteAction(P, R)",
 		},    
 	    }
@@ -72,7 +72,8 @@ document {
 	}
 
 document {
-	Key => {(generators, FiniteGroupAction)},
+	Key => {(generators, FiniteGroupAction),
+	    [generators, CoefficientRing]},
 	Headline => "generators of a finite group",
 	Usage => "generators G",
 	Inputs => {
@@ -297,21 +298,22 @@ document {
 	
 	
 document {
-	Key => {permutationMatrix, 
-	    (permutationMatrix, String),
+	Key => {permutationMatrix,
+	    (permutationMatrix, Array), 
 	    (permutationMatrix, ZZ, Array),
 	    (permutationMatrix, ZZ, List),
-	    (permutationMatrix, Array),
-	    (permutationMatrix, List)
+	    (permutationMatrix, List),
+	    [permutationMatrix, EntryMode]	    
 	    },
 	
 	Headline => "convert a one-line notation or cyclic notation of a permutation to a matrix representation",
 	
-	Usage => "permutationMatrix s, permutationMatrix(n , c)",
+	Usage => "permutationMatrix c, \n permutationMatrix(n , c), \n permutationMatrix(n, p), \n permutationMatrix p",
 	Inputs => {
-	    	"s" => String =>  {"an array or a list of arrays giving a one-line notation or cyclic notation of a permutation"},
-		"n" => ZZ => {"giving the number of integers getting permuted"},
-		"c" => List => {"of arrays giving a cyclic notation of a permutation"}
+		"c" => Array => {"of positive integers representing a permutation in one-line notation or 
+		    representing a cyclic permutation"},
+	    	"p" => List =>  {"of arrays representing a permutation as a product of cycles"},
+		"n" => ZZ => {"giving the number of integers being permuted"},
 		},
 	Outputs => {
 		Matrix => {"the matrix representation of the permutation"}
@@ -324,25 +326,34 @@ document {
 	    },
 	
 	EXAMPLE {
-		"M = permutationMatrix toString 213",
+		"M = permutationMatrix [2, 1, 3]",
 		},
 	
 	PARA {
-	    "The following example converts the cyclic notation of the same transposition into a matrix representation. Without ",TT "n"," the function assumes ",TT "n"," is the largest integer that appears in your array or list of arrays."
+	    "The following example converts the cyclic notation of the same transposition into a matrix representation."
 	    },
 	
 	EXAMPLE {
 		"M = permutationMatrix(3,[1,2])",
-		"M = permutationMatrix [1,2]",
 		},
+	    
+	PARA {
+	    "If ",TT "n"," is the largest integer that appears in your array, the value of ", TT "n", " can be omitted by 
+	    using the option ", TT "EntryMode => \"cycle\"", "."
+	    },
+		
+	EXAMPLE {
+		"M = permutationMatrix([1,2], EntryMode => \"cycle\")",
+		},
+	    
 	PARA {
 	    "The following example converts the cyclic notation of a permutation of 4 into a matrix representation."
 	    },    
 	EXAMPLE {
 	    	"M = permutationMatrix(4,{[1,2],[3,4]})",
-		"M = permutationMatrix {[1,2],[3,4]}",
 	    },
 	    }
+	
 document {
 	Key => {(relations, FiniteGroupAction)},
 	Headline => "relations of a finite group",
@@ -357,7 +368,7 @@ document {
 	"This function is provided by the package ", TO InvariantRing,". ",
 
     	PARA {
-	    "Use this function to get the relations among elements of a group. Each element is represented by a word of minimal length in the Coxeter generators. And each relation is represented by a list of two words that equates the group element represented by those two words."
+	    "Use this function to get the relations among elements of a group. Each element is represented by a word of minimal length in the Coxter generators. And each relation is represented by a list of two words that equates the group element represented by those two words."
 	},
     
     	PARA { "The following example defines the permutation action

--- a/M2/Macaulay2/packages/InvariantRing/Hawes.m2
+++ b/M2/Macaulay2/packages/InvariantRing/Hawes.m2
@@ -26,7 +26,7 @@ o 'IsGroup' optional argument is not ported because our methods
 -- Considers two cases: when the field the matrices are defined over is QQ 
 -- and when it is a general number field.
 -- This is to get around the fact that frac for number fields is not yet
--- implimented in Macaulay2
+-- implemented in Macaulay2
 -- The author thanks an anonymous referee for suggested improvements to this 
 -- method to ensure a consistent class of polynomial is returned 
 -- Reference:

--- a/M2/Macaulay2/packages/InvariantRing/Hawes.m2
+++ b/M2/Macaulay2/packages/InvariantRing/Hawes.m2
@@ -26,7 +26,7 @@ o 'IsGroup' optional argument is not ported because our methods
 -- Considers two cases: when the field the matrices are defined over is QQ 
 -- and when it is a general number field.
 -- This is to get around the fact that frac for number fields is not yet
--- implemented in Macaulay2
+-- implimented in Macaulay2
 -- The author thanks an anonymous referee for suggested improvements to this 
 -- method to ensure a consistent class of polynomial is returned 
 -- Reference:

--- a/M2/Macaulay2/packages/InvariantRing/HawesDoc.m2
+++ b/M2/Macaulay2/packages/InvariantRing/HawesDoc.m2
@@ -308,7 +308,7 @@ document {
      PARA{
 	  "This page contains a discussion on the two algorithms that are used 
 	  in the function ", TO primaryInvariants, ", which computes a 
-	  homogenous system of parameters (hsop) for the invariant ring ", 
+	  homogeneous system of parameters (hsop) for the invariant ring ", 
 	  TT "R:=K[x", SUB TT "1", TT ",...,x", SUB TT "n", TT "]", SUP TT "G", 
 	  " of a finite group ", TT "G", ". Which algorithm is used depends on 
 	  the ", TO Boolean, " value the optional argument ", TO Dade, " takes. 

--- a/M2/Macaulay2/packages/InvariantRing/HawesDoc.m2
+++ b/M2/Macaulay2/packages/InvariantRing/HawesDoc.m2
@@ -37,8 +37,8 @@ document {
 	  TT "({f", SUB TT "1", TT ",...," , TT "f", SUB TT "n",
 	  TT "}, {g", SUB TT "1", TT ",...," , TT "g", SUB TT "r", TT"})",
 	  " of primary and secondary invariants such that ",
-	  TT "R", SUP TT "G", TT "=A", TT "g", SUB TT "1", TEX "\\oplus", 
-	  TT "...", TEX "\\oplus", TT "A", TT "g", SUB TT "r", ", where ", TT "A=K[", 
+	  TT "R", SUP TT "G", TT "=A", TT "g", SUB TT "1", "$\\oplus$", 
+	  TT "...", "$\\oplus$", TT "A", TT "g", SUB TT "r", ", where ", TT "A=K[", 
 	  TT "f", SUB TT "1", TT ",...," , TT "f", SUB TT "n", TT "]",
 	  " and ", TT "K", " is the field of coefficients of ",
 	  TT "R", "."
@@ -63,7 +63,7 @@ document {
           },  
      PARA{
 	  "From the output one sees that ", TT "QQ[x,y]", SUP(TT "C4"), 
-	  TT "=QQ[f", SUB(TT "1"), TT "f", SUB(TT "2"), TT "]", TEX "\\oplus", TT "QQ[f", 
+	  TT "=QQ[f", SUB(TT "1"), TT "f", SUB(TT "2"), TT "]", "$\\oplus$", TT "QQ[f", 
 	  SUB(TT "1"), TT "f", SUB(TT "2"), TT "](x", SUP(TT "4"), TT "+y", 
 	  SUP(TT "4"), TT ")", ", where ", TT "f", SUB(TT "1"), TT "=x", SUP(TT "2"), 
 	  TT "+y", SUP(TT "2"), " and ",TT "f", SUB(TT "2"), TT "=xy", 
@@ -308,7 +308,7 @@ document {
      PARA{
 	  "This page contains a discussion on the two algorithms that are used 
 	  in the function ", TO primaryInvariants, ", which computes a 
-	  homogeneous system of parameters (hsop) for the invariant ring ", 
+	  homogenous system of parameters (hsop) for the invariant ring ", 
 	  TT "R:=K[x", SUB TT "1", TT ",...,x", SUB TT "n", TT "]", SUP TT "G", 
 	  " of a finite group ", TT "G", ". Which algorithm is used depends on 
 	  the ", TO Boolean, " value the optional argument ", TO Dade, " takes. 

--- a/M2/Macaulay2/packages/InvariantRing/InvariantRingDoc.m2
+++ b/M2/Macaulay2/packages/InvariantRing/InvariantRingDoc.m2
@@ -32,6 +32,10 @@ document {
 		HREF{"https://deepblue.lib.umich.edu/handle/2027.42/151589","Ideals of Subspace Arrangements"}, 
 	   	". Thesis (Ph.D.)-University of Michigan. 2019. ISBN: 978-1392-76291-2. pp 29-34."
 		},
+	    {"A new algorithm for invariants of elementary abelian groups by Arasha, Cassell, Dolorfino, Gandini, Novak, Qin, and Strom. See ",
+		HREF{"https://github.com/gordonovak/algorithms"}, 
+	   	" for more information."
+		},
 	    {"King's algorithm and the linear algebra method for invariants of finite groups: ",
 		"Derksen, H. & Kemper, G. (2015). ",
 		HREF{"https://link.springer.com/book/10.1007%2F978-3-662-48422-7","Computational Invariant Theory"}, 
@@ -66,8 +70,30 @@ document {
 		auxiliary file Hawes.m2 (with documentation
 		    in the file HawesDoc.m2) and has been updated
 		to work with the new types."
-		}
-	    }
+		},
+	    {BOLD "2.1: ", "speeds up checking whether a polynomial
+		is invariant under a finite group action, and
+		fixes a warning that appeared when computing invariants
+		of finite groups (the authors thank N. Iammarino, T. Yu,
+		    and Q. Zhao for the fix)."
+		},
+	    {BOLD "2.2: ", "changed input of ", TO permutationMatrix,
+		", minor documentation and internal code changes."
+		},
+	    {BOLD "2.3: ", "minor documentation updates."},
+	    {BOLD "2.4: ", "a new algorithm for invariants of elementary
+		abelian $p$-groups."}
+	    },
+	Contributors=>{
+	    "The following people worked on the algorithm for invariants of elementary
+	    abelian $p$-groups introduced in version 2.4:
+	    Sasha Arasha,
+	    Marcus Cassell,
+	    Mal Dolorfino,
+	    Gordie Novak,
+	    Daniel Qin,
+	    and Sumner Strom."
+	    },
 	}
     
 document {

--- a/M2/Macaulay2/packages/InvariantRing/Invariants.m2
+++ b/M2/Macaulay2/packages/InvariantRing/Invariants.m2
@@ -14,9 +14,9 @@
 RingOfInvariants = new Type of HashTable   
 
 invariantRing = method(Options => {
-	Strategy => UseNormaliz,
-	UseLinearAlgebra => false,
+	Strategy => "Default",
 	UseCoefficientRing => false,
+	UsePolyhedra => false,
 	DegreeBound => infinity
 	})
 
@@ -112,120 +112,329 @@ reynoldsOperator (RingElement, DiagonalAction) := RingElement => (f, D) -> sum s
 
 -------------------------------------------
 
+-------------------------------------------
+--- NEW April 20th, 2026 ------------------
+--- Elementary Invariants Methods ---------
+-------------------------------------------
+
+
+-->-- Function: seedMinimal --<--
+-- Checks if a given candidate is minimal given the list of seeds, starting at the index, "startIndex"
+--> INPUT:   
+--           Seeds      : List[List[ZZ]] › A list of current seeds that are invariant
+--           Candidate  : List[ZZ]       › A seed that may be added to the Seeds list
+--           startIndex : ZZ             › The index in the Seeds list that you want to start minimizing from
+--> OUTPUT: 
+--           Returns ({-1} | candidate) if our candidate is minimal.
+--           Returns {-2} if our candidate is not minimal.
+--           Returns ({-3, index}) if a seed is not minimal, with the index of the seed. 
+--           Returns ({-4, index} | newSeed) if our candidate helps reduce a seed. 
+seedMinimal := (Seeds, candidate, startIndex) -> (
+	i := startIndex;
+	numSeeds := #Seeds;
+	while i < numSeeds do (	-- Iterate through all seeds
+		candMinimal := true;	-- We start by assuming our candidate & seed are divisible by each other
+		seedIsMinimal := true;
+
+		for k from 0 to #candidate - 1 do (
+			if (candidate#k > Seeds#i#k) then (
+				candMinimal = false; -- If our candidate ever has a greater power than the seed, its not minimal
+			)
+			else if (Seeds#i#k > candidate#k) then (
+				seedIsMinimal = false; -- If our seed ever has a greater power than the candidate, our candidate is safe (for now)
+			);
+		);
+		if seedIsMinimal then (		-- If our seed is exclusively less than our candidate, we:
+			newCandidate := candidate - Seeds#i; -- Reduce our candidate by our seed, as that will still be invariant
+			if (newCandidate === candidate) then (
+				i = i + 1;				-- No change: move forward to avoid infinite loop
+			)
+			else (
+				candidate = newCandidate;
+				if (all (candidate, i -> i == 0)) then return {-2, 0}; -- If the candidate fully reduces, we return -2.
+				i = startIndex;		-- Reduce our index by restarting so we can test candidate again. 
+			);
+		)
+		else if candMinimal then (	-- If our candidate is minimal, we may need to discard our seed instead.
+			removalSeed := Seeds#i;
+			while (all(removalSeed - candidate, i -> i >= 0) and removalSeed =!= removalSeed - candidate) do (
+				removalSeed = removalSeed - candidate;
+			);
+			if (all (removalSeed, i -> i == 0)) then return {-3, i}; -- If the seed fully reduces, we return -3
+			return {-4, i} | removalSeed;						  -- Otherwise, we return -3, the index of the seed, and the updated seed.
+		)
+		else (
+			i = i + 1;	-- Normal case: move forward
+		);
+	);
+	return {-1, 0} | candidate ;
+)
+
+-->--elementaryInvariants function--<--
+--> INPUT:  D (a diagonalAction)
+--> OUTPUT: L (a list of invariants)
+elementaryInvariants := D -> (
+	---------------------
+	-- Seed Generation --
+	---------------------
+
+	-->- Grab our variables W, R, Z from D -<--
+	W := D.weights_1;
+	
+	R := ring D;
+	Z := (D.cyclicFactors)#0;
+
+	-->- Find our m and n from the weight matrix -<--
+	n := numColumns W; m := numRows W;
+
+	-->- STEP 1 -<--
+	-->- Now, we find a n x n submatrix of W with nonzero determinant --<-
+	nonZeroSM := matrix{{0}};           -- Start with an empty submatrix (SM stands for submatrix)
+	colList := {};                       -- This empty list will track the columns we don't use for the submatrix
+	for i from 0 to (n - m) do (                 -- Iterate from 0 to n - m (we don't want our matrix out of bounds)
+		candidateSM := submatrix(W, toList(i .. i+m-1));
+		if (determinant candidateSM != 0) then (
+			nonZeroSM = candidateSM;    -- If candidateSM has nonzero determinant, it is now our nonZero det submatrix
+			colList = toList(0 .. i-1) | toList(i+m .. n-1); -- Grabs the columns we didn't use. 
+			break;                      -- ends the loop
+		)
+	);
+
+	-->- Return error if this submatrix doesn't exist --<--
+	-- Fred G: April 26, 2027; currently the Elementary strategy can only be called
+	-- if the weight matrix has maximal rank, which guarantees the existence of an
+	-- n x n submatrix with nonzero determinant, so this error is never triggered
+	-- I chose to add the maximal rank condition because the default strategy
+	-- Derksen-Gandini returns a result even when the matrix does not have maximal
+	-- rank, so this error created inconsistent outputs
+	-- Francesca suggests row-reducing the matrix then removing zero rows to ensure
+	-- we always have a matrix with maximal rank; this is okay mathematically because
+	-- the invariant rings are isomorphic, but technically it changes the action.
+	-- There is also the issue that row-reducing requires moving to QQ instead of ZZ
+	-- which may introduce denominators, so we would have to deal with that.
+	-- All of this could be considered for a later update.
+	if (nonZeroSM == matrix{{0}}) then (
+		error ("Non-zero submatrix of this weight matrix could not be found.\n");
+		return {};
+	);
+
+	-->- STEP 2 -<--
+	seedList := {};		                     	-- Creates a list for the seed invariants in exponent vec form
+
+	for v in colList do (                   	-- Iterates through all columns we didn't use for nonZeroSM
+		seedInvariant       := {};              -- Current seed invariant we are calculating
+		seedMatrix      := nonZeroSM | matrix(W_v);		-- Matrix we extract the seed invariant from (where W_v is our additional vector)
+		signFlip        := 1;
+		for i from 0 to m do (                 -- This loops lets us remove one of the columns from the matrix to calculate the plücker
+			pluckerMatrix   := submatrix(seedMatrix, toList(0 .. i -1) | toList (i + 1 .. m));  -- Find plucker matrix
+			e               := for j from 0 to n-1 list (if j == i then 1 else 0);              -- Standard basis vector
+			seedInvariant   = seedInvariant | {signFlip * determinant(pluckerMatrix) * e};      -- Calculate vector
+			signFlip        = signFlip * -1;     -- Flip the sign after each iteration.
+		);
+		seedList = seedList | {sum seedInvariant} -- Adds the summed seed invariant vec to our list
+	);
+
+	-- Now, seedList contains our list of seed Invariants, so we move onto expansion.
+
+	--------------------
+	-- Seed Expansion --
+	--------------------
+	ringVars    := gens R;            -- So we don't need to call "gens" each time we need the variables of the ring
+	seedList    = for l in seedList list apply(l, x -> ((x % Z) + Z) % Z); -- Mods our seeds out by Z
+	trashList   := {0} | seedList;    -- List to keep track of duplicate invariants
+	purePowers := apply(#ringVars, i -> 0);	-- List to keep track of pure powers.
+	powerIndex := null; -- added by FG to fix unexported symbol error
+	
+
+	--> Starting with seed expansion <--
+	-- Note that the "drop" function is used in combination with the seedminimal function in this loop.
+	-- This is because seed minimal appends a "result" and "index" value to the begining of a seed.
+	-- Thus by saying drop(candidate, 2), we get rid of those information values. 
+	for s when s < #seedList do (		-- We use a "when" loop here because size of newList will change
+		startingSeed := seedList#s;
+		for k to #seedList - 1 do (		-- We can use a static loop here because we won't add any elements in here. 
+			for p from 1 to (Z - 1) do (
+				candidateSeed := (seedList#k) * p;					-- Put our seed to the power of p.
+				candidateSeed = (startingSeed + candidateSeed) % Z;	-- Multiply two seeds & mod out by Z.
+				if (not all(candidateSeed, i -> i == 0) and not any(trashList, t -> (candidateSeed == {t}))) then (
+					minimality := seedMinimal(seedList, candidateSeed, 0);
+					result := minimality#0;
+					-- If result = -3 or -4, that means one of our seeds was not minimal given our candidate
+					while (result == -3 or result == -4) do (		-- So we must loop to sort out the seeds and get our candidate & seeds minimized
+						editIndex := minimality#1;					-- minimality#2 holds the index of the seed we need to adjust.
+						if (result == -3) then (					-- {-3} -> Our seed is not minimal, so we must remove it.
+							seedList = take(seedList, editIndex) | drop(seedList, editIndex+1);
+						)
+						else if (result == -4) then (				-- {-4} -> We found a reduction for our seed, so we must replace the old one. 
+							newSeed := drop(minimality, 2);
+							seedList = replace(editIndex, newSeed, seedList); -- Replace our old seed with the new one.
+							if (number(newSeed, e -> e != 0) == 1) then ( -- Check if our seed is a pure power of some kind. 
+								powerIndex = position(newSeed, e -> e != 0);
+								purePowers = replace(powerIndex, newSeed#powerIndex, purePowers);
+							);
+							
+						);
+						--> Then we call our seedMinimal function again, this time starting from the editIndex to save time.
+						minimality = seedMinimal(seedList, candidateSeed, editIndex+1);
+						result = minimality#0;
+					);
+					
+					if (result == -1) then (	-- If our candidate is minimal, we add it to the seed list. 
+						newCandSeed := drop(minimality, 2);
+						candidateSeed = newCandSeed;
+						if (number(newCandSeed, e -> e != 0) == 1) then ( -- check if seed is pure power of some kind
+							powerIndex = position(newCandSeed, e -> e != 0);
+							if (powerIndex =!= null and powerIndex < #purePowers) then (
+								purePowers = replace(powerIndex, newCandSeed#powerIndex, purePowers);
+							);
+						);
+						seedList = append(seedList, newCandSeed);	-- Add our seed to the list. 
+					);
+					-- If our result is -2, we do nothing because our candidate is bunk.
+				);
+				trashList = append(trashList, candidateSeed)  -- Always add our candidate to the trashList for efficiency.
+			);
+		);
+	);
+
+	--> Then we add the pure powers to the list, checking if they are minimal via. our purePowers list.
+	for i from 0 to (#ringVars - 1) do (
+		if (Z % (purePowers#i) != 0 ) then (
+			seedList = seedList | {for k to (#ringVars - 1) list (if i == k then Z else 0)};
+		);
+	);
+
+	-->-- Now, we turn each of the exponent vectors into their polynomials in the ring. --<--
+	polyList := {};
+	for i in seedList do (
+		n := 1;
+		for j to #i - 1 do (n = n * (((ringVars)#j)^(i#j)));
+		polyList = polyList | {n};
+	);
+	
+	return polyList; -- Return our list
+)
+
+-------------------------------------------
+--- invariants for DiagonalAction ---------
+-------------------------------------------
+
 invariants = method(Options => {
-	Strategy => UseNormaliz,
-	UseLinearAlgebra => false,
+	Strategy => "Default",
 	UseCoefficientRing => false,
+	UsePolyhedra => false,
 	DegreeBound => infinity,
 	DegreeLimit => {},
 	SubringLimit => infinity
-	})
+	}
+)
 
 invariants DiagonalAction := List => o -> D -> (
+    d := cyclicFactors D;
     (W1, W2) := weights D;
+    -- As of April 2026, the elementary generation method is when
+    -- called by the user with Strategy=>"Elementary", as long as:
+    -- i) there is no torus action: zero(W1)
+    -- ii) there are cyclic factors: d =!= {}
+    -- iii) all cyclic factors have the same order: all(d, i -> d#0 == i)
+    -- iv) the weight matrix has maximal rank: rank W2 == min(numRows W2,numColumns W2)
+    if (o.Strategy === "Elementary") and
+    zero(W1) and d =!= {} and all(d, i -> d#0 == i)
+    and rank W2 == min(numRows W2,numColumns W2)
+    then (
+	return elementaryInvariants D;
+	);
+    --*-* Otherwise, continue with Derksen-Gandini algorithm *-*--
     R := ring D;
     kk := coefficientRing R;
     p := char kk;
-    d := cyclicFactors D;
     r := rank D;
     if p > 0 and o.UseCoefficientRing then (
-	q := kk#order;
-	if any(d, j -> q%j =!= 1) then (
-	    print "-- Diagonal action is not defined over the given coefficient ring. \n-- Returning invariants over an infinite extension field over which the action is defined."
-	    )
-	else (
-	    D' := diagonalAction(W1||W2, apply(r, i -> q - 1)|d, R);
-	    return invariants D'
-	    )
-    	);
+        q := kk#order;
+        if any(d, j -> q%j =!= 1) then (
+            print "-- Diagonal action is not defined over the given coefficient ring. \n-- Returning invariants over an infinite extension field over which the action is defined.";
+        )
+        else (
+            D' := diagonalAction(W1||W2, apply(r, i -> q - 1)|d, R);
+            return invariants D';
+        )
+    );
     R = kk[R_*, MonomialOrder => GLex];
     g := numgens D;
     n := dim D;
     mons := R_*;
     local C, local S, local U;
     local v, local m, local v', local u;
-    
     if g > 0 then (
-	t := product d;
-	
-	reduceWeight := w -> vector apply(g, i -> w_i%d#i);
-	
-	C = apply(n, i -> reduceWeight W2_i);
-	
-	S = new MutableHashTable from apply(C, w -> w => {});
-	scan(#mons, i -> S#(reduceWeight W2_i) = S#(reduceWeight W2_i)|{mons#i});
-	U = R_*;
-	
-	while  #U > 0 do(
-	    m = min U; 
-	    v = first exponents m;
-	    k := max positions(v, i -> i > 0);
-	    v = reduceWeight(W2*(vector v));
-	    
-	    while k < n do(
-	    	u = m*R_k;
-	    	v' = reduceWeight(v + W2_k);
-	    	if (not S#?v') then S#v' = {};
-	    	if all(S#v', m' -> u%m' =!= 0_R) then (
-		    S#v' = S#v'|{u};
-		    if first degree u < t then U = U | {u}
-		    );
-	    	k = k + 1;
-	    	);
-	    U = delete(m, U);
-	    );
-    	if S#?(0_(ZZ^g)) then mons = S#(0_(ZZ^g)) else mons = {}
-    	);
+        t := product d;
+        reduceWeight := w -> vector apply(g, i -> w_i%d#i);
+        C = apply(n, i -> reduceWeight W2_i);
+        S = new MutableHashTable from apply(C, w -> w => {});
+        scan(#mons, i -> S#(reduceWeight W2_i) = S#(reduceWeight W2_i)|{mons#i});
+        U = R_*;
+        while  #U > 0 do(
+            m = min U; 
+            v = first exponents m;
+            k := max positions(v, i -> i > 0);
+            v = reduceWeight(W2*(vector v));
+            while k < n do(
+                u = m*R_k;
+                v' = reduceWeight(v + W2_k);
+                if (not S#?v') then S#v' = {};
+                if all(S#v', m' -> u%m' =!= 0_R) then (
+                    S#v' = S#v'|{u};
+                    if first degree u < t then U = U | {u}
+                );
+                k = k + 1;
+            );
+            U = delete(m, U);
+        );
+        if S#?(0_(ZZ^g)) then mons = S#(0_(ZZ^g)) else mons = {}
+    );
     if r == 0 then return apply(mons, m -> sub(m, ring D) );
-    
     W1 = W1*(transpose matrix (mons/exponents/first));
-    if o.Strategy == UsePolyhedra then (
-	if r == 1 then C = convexHull W1 else C = convexHull( 2*r*W1|(-2*r*W1) );
-	C = (latticePoints C)/vector;
-	)
-    else if o.Strategy == UseNormaliz then (
-	if r == 1 then C = (normaliz(transpose W1, "polytope"))#"gen" 
-	else C = (normaliz(transpose (2*r*W1|(-2*r*W1)), "polytope"))#"gen";
-	C = transpose C_(apply(r, i -> i));
-	C = apply(numColumns C, j -> C_j)
-	);
-    
+    if o.UsePolyhedra then (
+        if r == 1 then C = convexHull W1 else C = convexHull( 2*r*W1|(-2*r*W1) );
+        C = (latticePoints C)/vector;
+    )
+    else (
+        if r == 1 then C = (normaliz(transpose W1, "polytope"))#"gen" 
+        else C = (normaliz(transpose (2*r*W1|(-2*r*W1)), "polytope"))#"gen";
+        C = transpose C_(apply(r, i -> i));
+        C = apply(numColumns C, j -> C_j)
+    );
     S = new MutableHashTable from apply(C, w -> w => {});
     scan(#mons, i -> S#(W1_i) = S#(W1_i)|{mons#i});
     U = new MutableHashTable from S;
-    
     nonemptyU := select(keys U, w -> #(U#w) > 0);
-    while  #nonemptyU > 0 do(
-	v = first nonemptyU;
-	m = first (U#v);
-	
-	scan(#mons, i -> (
-		u := m*mons#i;
-        	v' := v + W1_i;
-        	if ((U#?v') and all(S#v', m' -> (
-			    if u%m' =!= 0_R then true
-			    else if g > 0 then (
-				m'' := u//m';
-			    	v'' := reduceWeight(W2*(vector first exponents m''));
-			    	v'' =!= 0_(ZZ^g)
-				)
-			    else false
-			    )
-			)
-		    ) 
-		then( 
-                    S#v' = S#v'|{u};
-                    U#v' = U#v'|{u};
-		    )
-	    	)
-	    );
-	U#v = delete(m, U#v);
-	nonemptyU = select(keys U, w -> #(U#w) > 0)
-	);
+        while  #nonemptyU > 0 do(
+        v = first nonemptyU;
+        m = first (U#v);
+        
+        scan(#mons, i -> (
+            u := m*mons#i;
+            v' := v + W1_i;
+            if ((U#?v') and all(S#v', m' -> (
+                if u%m' =!= 0_R then true
+                else if g > 0 then (
+                    m'' := u//m';
+                    v'' := reduceWeight(W2*(vector first exponents m''));
+                    v'' =!= 0_(ZZ^g)
+                )
+                else false
+            ))) then ( 
+                S#v' = S#v'|{u};
+                U#v' = U#v'|{u};
+            )
+        ));
+        U#v = delete(m, U#v);
+        nonemptyU = select(keys U, w -> #(U#w) > 0)
+    );
     
     if S#?(0_(ZZ^r)) then mons = S#(0_(ZZ^r)) else mons = {};
     return apply(mons, m -> sub(m, ring D) )
-    )
+
+)
 
 
 -------------------------------------------
@@ -246,7 +455,7 @@ manualTrim (List) := List => L -> (
 -------------------------------------------
 -- Computes an *additive* basis for the degree d part of the
 -- invariant ring following Algorithm 4.5.1 of Derksen-Kemper.
-invariants (LinearlyReductiveAction, List) := List => o -> (V,d) -> (
+invariants (LinearlyReductiveAction, List) := List => o -> (V, d) -> (
     M := actionMatrix V;
     Q := ring V;
     A := groupIdeal V;
@@ -323,12 +532,13 @@ invariants FiniteGroupAction := List => o -> G -> (
     error "Only implemented for standard graded polynomial rings";
     if o.DegreeBound < b then b = o.DegreeBound;
     local M;
-    for d from 1 to b do (
+    for d from 1 to b+1 do (
     	Gb := gb(promote(ideal S,R),DegreeLimit=>d);
 	I := monomialIdeal leadTerm Gb;
 	M = reverse select(flatten entries (basis(d,R)%I),m->not zero m);
+	if d == b+1 then break;
 	if M === {} then break else (
-	    if o.UseLinearAlgebra then (
+	    if o.Strategy == "LinearAlgebra" then (
 		for f in invariants(G,d) do (
 	    	    g := f % Gb;
 	    	    if not zero g then (
@@ -336,7 +546,8 @@ invariants FiniteGroupAction := List => o -> G -> (
 		    	Gb = forceGB ( (gens Gb) | matrix{{g}} );
 	    	    	);
 		    );
-	    	) else (
+	    	) 
+	    else (
 	    	for m in M do (
 	    	    f := reynoldsOperator(m,G);
 	    	    g := f % Gb;
@@ -348,7 +559,7 @@ invariants FiniteGroupAction := List => o -> G -> (
 	    	);
     	    );
 	);
-    if M =!= {} then print"
+    if (M =!= {} and b < #(group G)) then print"
 Warning: stopping condition not met!
 Output may not generate the entire ring of invariants.
 Increase value of DegreeBound.
@@ -382,7 +593,11 @@ invariants(FiniteGroupAction, ZZ) := List => o -> (G,d) -> (
 
 isInvariant = method()
 
-isInvariant (RingElement, FiniteGroupAction) := Boolean => (f, G) -> reynoldsOperator(f, G) == f
+--checking invariants with reynolds operator can be slow for large groups
+--isInvariant (RingElement, FiniteGroupAction) := Boolean => (f, G) -> reynoldsOperator(f, G) == f
+--instead it is enough to check invariance under group generators
+isInvariant (RingElement, FiniteGroupAction) := Boolean => (f, G) ->
+    all(gens G, g -> sub(f, (vars ring G)*(transpose g) ) == f ) 
 
 isInvariant (RingElement, DiagonalAction) := Boolean => (f, D) -> (
     if not instance(f, ring D) then (

--- a/M2/Macaulay2/packages/InvariantRing/Invariants.m2
+++ b/M2/Macaulay2/packages/InvariantRing/Invariants.m2
@@ -248,7 +248,7 @@ elementaryInvariants := D -> (
 
 	--> Starting with seed expansion <--
 	-- Note that the "drop" function is used in combination with the seedminimal function in this loop.
-	-- This is because seed minimal appends a "result" and "index" value to the begining of a seed.
+	-- This is because seed minimal appends a "result" and "index" value to the beginning of a seed.
 	-- Thus by saying drop(candidate, 2), we get rid of those information values. 
 	for s when s < #seedList do (		-- We use a "when" loop here because size of newList will change
 		startingSeed := seedList#s;

--- a/M2/Macaulay2/packages/InvariantRing/InvariantsDoc.m2
+++ b/M2/Macaulay2/packages/InvariantRing/InvariantsDoc.m2
@@ -81,7 +81,6 @@ document {
 	Inputs => {
 	    	"G" => GroupAction,
 	    	"R" => PolynomialRing => {"on which the group acts"},
-		Strategy => {"the strategy used to compute the invariant ring"}
 		},
 	Outputs => {
 		RingOfInvariants => {"the ring of invariants of the given group action"}
@@ -137,7 +136,6 @@ document {
 	
 	Inputs => {  
 	    	"G" => GroupAction => {"a specific type of group action on a polynomial ring"},
-		Strategy => {"the strategy used to compute diagonal invariants, options are UsePolyhedra or UseNormaliz."}
 		},
 	Outputs => {
 		"L" => List => {"a minimal set of generating invariants for the group action"}
@@ -171,7 +169,7 @@ document {
 
 document {
 	Key => { 
-	    (invariants, DiagonalAction)
+	    (invariants, DiagonalAction) 
 	    },
 	
 	Headline => "computes the generating invariants of a group action",
@@ -180,7 +178,6 @@ document {
 	
 	Inputs => {  
 	    	"D" => DiagonalAction => {"a diagonal action on a polynomial ring"},
-		Strategy => {"the strategy used to compute diagonal invariants, options are UsePolyhedra or UseNormaliz."}
 		},
 	Outputs => {
 		"L" => List => {"a minimal set of generating invariants for the group action"}
@@ -243,6 +240,15 @@ document {
 	   ". Thesis (Ph.D.)-University of Michigan. 2019. ISBN: 978-1392-76291-2. pp 29-34."}
         },   
     
+       PARA {
+	    "Version 2.4 includes a new algorithm to compute invariants
+	    of elementary abelian $p$-groups. For more information, see:"
+	     },
+	 
+        UL { 
+	    {HREF{"https://github.com/gordonovak/algorithms"}}
+        },   
+    
     	PARA {
 	    "Here is an example of a one-dimensional torus acting on a 
 	    two-dimensional vector space:"
@@ -267,6 +273,15 @@ document {
 	    "A = diagonalAction(W, d, R)",
 	    "invariants A"
 		},
+    
+    	PARA {
+	    "To call the new algorithm for elementary abelian $p$-groups
+	    use the option ", TT "Strategy=>\"Elementary\"" , "."
+	},
+	
+	EXAMPLE {
+	    "invariants(A,Strategy=>\"Elementary\")"
+		},
 
     	PARA {
 	    "Here is an example of a diagonal action by the product of
@@ -289,6 +304,55 @@ document {
 	    isInvariant
 	    }	
 	}
+    
+document {
+    	Key => {
+	    [invariants, Strategy], [invariantRing, Strategy]
+	    },
+	Headline => "choose the strategy for computing invariants",
+	
+	PARA {
+	    "The default strategy for computing invariants of a finite
+	    group action uses the Reynolds operator, however
+	    this may be slow for large groups. Using the option ", 
+	    TT "Strategy => \"LinearAlgebra\"", " uses the linear algebra 
+	    method for computing invariants of a given degree by calling ",
+	    TO (invariants, FiniteGroupAction, ZZ), ". This may
+	    provide a speedup at lower degrees, especially if the
+	    user-provided generating set for the group is small."
+	    },
+	
+	PARA {
+	    "The following example computes the invariants of the
+	    symmetric group on 4 elements. Note that using
+	    different strategies may lead to different sets of 
+	    generating invariants."
+	    },
+	
+	EXAMPLE {
+	    "R = QQ[x_1..x_4]",
+	    "L = apply({[2, 1, 3, 4], [2, 3, 4, 1]}, permutationMatrix);",
+	    "S4 = finiteAction(L, R)",
+	    "elapsedTime invariants S4",
+	    "elapsedTime invariants(S4, Strategy => \"LinearAlgebra\")"
+	},
+
+	PARA {
+	    "Version 2.4 introduces a new algorithm to compute invariants
+	    of elementary abelian $p$-groups.
+	    To call this algorithm, use the option ",
+	    TT "Strategy=>\"Elementary\"", "; see ",
+	    TO (invariants, DiagonalAction), " for an example."
+	    },
+	
+	SeeAlso => {
+	    diagonalAction,
+	    invariants,
+	    invariantRing,
+	    reynoldsOperator
+	    }	
+	
+    }
 
 document {
 	Key => {
@@ -298,7 +362,6 @@ document {
 	Usage => "invariants G",
 	Inputs => {
 	    "G" => FiniteGroupAction,
-	    Strategy => {"the strategy used to compute diagonal invariants, options are UsePolyhedra or UseNormaliz."}
 	    },
 	Outputs => {
 		"L" => List => {"a minimal set of generating invariants for the group action"}
@@ -321,11 +384,11 @@ document {
 	    "The following example computes the invariants of the
 	    alternating group on 4 elements."
 	    },
-    EXAMPLE {
-	"R = QQ[x_1..x_4]",
-	"L = apply({\"2314\",\"2143\"},permutationMatrix);",
-	"A4 = finiteAction(L,R)",
-	"netList invariants A4"
+    	EXAMPLE {
+	    "R = QQ[x_1..x_4]",
+	    "L = apply({[2, 3, 1, 4], [2, 1, 4, 3]}, permutationMatrix);",
+	    "A4 = finiteAction(L, R)",
+	    "netList invariants A4"
 	},
     
     	SeeAlso => {
@@ -364,10 +427,10 @@ document {
 	    },
     EXAMPLE {
 	"R = QQ[x_1..x_4]",
-	"L = apply({\"2134\",\"2341\"},permutationMatrix);",
-	"S4 = finiteAction(L,R)",
+	"L = apply({[2, 1, 3, 4], [2, 3, 4, 1]}, permutationMatrix);",
+	"S4 = finiteAction(L, R)",
 	"elapsedTime invariants S4",
-	"elapsedTime invariants(S4,DegreeBound=>4)"
+	"elapsedTime invariants(S4, DegreeBound => 4)"
 	},
     	Caveat => {
 	    "If the value provided for this option is too small,
@@ -387,7 +450,7 @@ document {
 	    [invariants, UseCoefficientRing], [invariantRing, UseCoefficientRing], UseCoefficientRing
 	    },
 	Headline => "option to compute invariants over the given coefficient ring",
-	Usage => "invariants G",
+	Usage => "invariants D",
 	Inputs => {"D" => DiagonalAction},
 	Outputs => {
 		"L" => List => {"a minimal set of generating invariants for the group action"}
@@ -438,11 +501,11 @@ document {
 
 document {
 	Key => {
-	    [invariants, UseLinearAlgebra], [invariantRing, UseLinearAlgebra], UseLinearAlgebra
+	    [invariants, UsePolyhedra], [invariantRing, UsePolyhedra], UsePolyhedra
 	    },
-	Headline => "strategy for computing invariants of finite groups",
-	Usage => "invariants G",
-	Inputs => {"G" => FiniteGroupAction},
+	Headline => "use Polyhedra package for invariants of tori",
+	Usage => "invariants D",
+	Inputs => {"D" => DiagonalAction},
 	Outputs => {
 		"L" => List => {"a minimal set of generating invariants for the group action"}
 		},
@@ -452,36 +515,18 @@ document {
 	    },
 	
 	PARA {
-	    "This optional argument determines the strategy used to
-	    compute generating invariants of a finite group action.
-	    The default strategy uses the Reynolds operator, however
-	    this may be slow for large groups. Setting this argument
-	    to ", TO true, " uses the linear algebra method for
-	    computing invariants of a given degree by calling ",
-	    TO (invariants, FiniteGroupAction, ZZ), ". This may
-	    provide a speedup at lower degrees, especially if the
-	    user-provided generating set for the group is small."
+	    "For a diagonal action, the computation of invariants relies on
+	    finding integral points in a convex hull constructed
+	    from a weight matrix. By default, the package ",  TO Normaliz,
+	    " is used for finding integral points. It is also possible
+	    to use the package ", TO Polyhedra, " for finding integral points
+	    by passing the option ", TT "UsePolyhedra => true", "."
 	    },
-	
-	PARA {
-	    "The following example computes the invariants of the
-	    symmetric group on 4 elements. Note that using
-	    different strategies may lead to different sets of 
-	    generating invariants."
-	    },
-	
-	EXAMPLE {
-	    "R = QQ[x_1..x_4]",
-	    "L = apply({\"2134\",\"2341\"},permutationMatrix);",
-	    "S4 = finiteAction(L,R)",
-	    "elapsedTime invariants S4",
-	    "elapsedTime invariants(S4,UseLinearAlgebra=>true)"
-	},
     
     	SeeAlso => {
-	    finiteAction,
-	    invariantRing, 
-	    isInvariant
+	    diagonalAction,
+	    invariants,
+	    invariantRing
 	    }	
 	}
 
@@ -497,8 +542,7 @@ document {
 	
 	Inputs => {  
 	    	"G" => FiniteGroupAction,
-		"d" => ZZ => {"a degree or multidegree"},
-	    	Strategy => {"the strategy used to compute diagonal invariants, options are UsePolyhedra or UseNormaliz."}
+		"d" => ZZ => {"a degree or multidegree"}
 		},
 	Outputs => {
 		"L" => List => {"an additive basis for a graded component of the ring of invariants"}
@@ -559,8 +603,7 @@ document {
 	
 	Inputs => {  
 	    	"V" => LinearlyReductiveAction,
-		"d" => ZZ => {"a degree or multidegree"},
-	    	Strategy => {"the strategy used to compute diagonal invariants, options are UsePolyhedra or UseNormaliz."}
+		"d" => ZZ => {"a degree or multidegree"}
 		},
 	Outputs => {
 		"L" => List => {"an additive basis for a graded component of the ring of invariants"}
@@ -616,8 +659,7 @@ document {
 	Usage => "invariants V",
 	
 	Inputs => {  
-	    	"V" => LinearlyReductiveAction,
-	    	Strategy => {"the strategy used to compute diagonal invariants, options are UsePolyhedra or UseNormaliz."}
+	    	"V" => LinearlyReductiveAction
 		},
 	Outputs => {
 		"L" => List => {"of invariants generating the Hilbert ideal"}
@@ -842,7 +884,7 @@ document {
     	
 	EXAMPLE {
 	    "R = ZZ/3[x_0..x_6]",
-	    "P = permutationMatrix toString 2345671",
+	    "P = permutationMatrix [2, 3, 4, 5, 6, 7, 1]",
 	    "C7 = finiteAction(P, R)",
 	    "reynoldsOperator(x_0*x_1*x_2^2, C7)",
 		},
@@ -863,7 +905,9 @@ document {
 
 document {
 	Key => {definingIdeal,
-	     (definingIdeal, RingOfInvariants)},
+	     (definingIdeal, RingOfInvariants),
+	     [definingIdeal, Variable]
+	     },
 	
 	Headline => "presentation of a ring of invariants as polynomial ring modulo the defining ideal",
 	
@@ -871,7 +915,7 @@ document {
 	
 	Inputs => {
 	    	"S" => RingOfInvariants,
-		Variable => "name of the variables in the polynomial ring."
+		Variable => "name of the varibles in the polynomial ring."
 		},
 	    
 	Outputs => {
@@ -936,7 +980,9 @@ document {
 	    }
 	
 document {
-	Key => {(hilbertSeries, RingOfInvariants)},
+	Key => {(hilbertSeries, RingOfInvariants),
+	    [hilbertSeries, Order],
+	    [hilbertSeries, Reduce]},
 	
 	Headline => "Hilbert series of the invariant ring",
 	
@@ -953,7 +999,7 @@ document {
 	"This function is provided by the package ", TO InvariantRing,". ",
 	
 	PARA {
-	    "This method computes the Hilbert series of the ring of invariants."
+	    "This method computes the hilbert series of the ring of invariants."
 	    },
     	
 	EXAMPLE {
@@ -965,16 +1011,3 @@ document {
 		},
 	    }
 
-document {
-	Key => {UseNormaliz, UsePolyhedra},
-	Headline => "option for diagonal invariants",
-	"This option is provided by the package ", TO InvariantRing,". ",
-	PARA {
-	    "The computation of diagonal invariants relies on
-	    finding integral points in a convex hull constructed
-	    from a weight matrix. This option selects the package
-	    used for finding integral points. See ",
-	    TO (invariants,DiagonalAction),
-	    " for usage."
-	    },
-	}

--- a/M2/Macaulay2/packages/InvariantRing/InvariantsDoc.m2
+++ b/M2/Macaulay2/packages/InvariantRing/InvariantsDoc.m2
@@ -915,7 +915,7 @@ document {
 	
 	Inputs => {
 	    	"S" => RingOfInvariants,
-		Variable => "name of the varibles in the polynomial ring."
+		Variable => "name of the variables in the polynomial ring."
 		},
 	    
 	Outputs => {

--- a/M2/Macaulay2/packages/InvariantRing/LinearlyReductiveGroupsDoc.m2
+++ b/M2/Macaulay2/packages/InvariantRing/LinearlyReductiveGroupsDoc.m2
@@ -114,6 +114,10 @@ document {
 	   ". Heidelberg: Springer. pp 159-164"}
         },
 	
+	PARA { 
+	    "and works in arbitrary characteristic.",
+	    },
+
 	PARA {
 	    "The next example constructs a cyclic group of order 2
 	    as a set of two affine points. Then it introduces an
@@ -155,7 +159,11 @@ document {
 	    generators for the Hilbert ideal."
 	    },
     	 Caveat => "The generators of the Hilbert ideal computed
-	 by this function need not be invariant."	    
+	 by this function need not be invariant.
+	 
+	 Although this method could in principle be used for any group
+	 that can be represented as an affine variety, it tends to be
+	 slow; other specialized methods are likely to be faster."
 	    }
 
 

--- a/M2/Macaulay2/packages/InvariantRing/Tests.m2
+++ b/M2/Macaulay2/packages/InvariantRing/Tests.m2
@@ -354,7 +354,7 @@ assert(value denominator H === sub((1-T)^3, ring value denominator H))
 -- *NB it is possible that primaryInvariants(S3,Dade=>true) can run correctly 
 -- and output an invariant polynomial of degree strictly less than the 
 -- cardinality of the group. If a check on the package invariant ring reports 
--- failure of the folloing test, then one should see if the test is passed upon 
+-- failure of the following test, then one should see if the test is passed upon 
 -- a second attempt. Only if the test fails a second time is it worth inspecting 
 -- the code for errors.  
 

--- a/M2/Macaulay2/packages/InvariantRing/Tests.m2
+++ b/M2/Macaulay2/packages/InvariantRing/Tests.m2
@@ -104,15 +104,12 @@ assert(set invariants T1 === invariants1)
 ///
 
 -- Test 9
-
--- this test often fails, because the result depends on what hashcode values are, so we comment it out for now.
-
--- TEST ///
--- R2 = QQ[x_1..x_4]
--- T2 = diagonalAction(matrix{{0,1,-1,1},{1,0,-1,-1}}, R2)
--- invariants2 = set {x_1*x_2*x_3,x_1^2*x_3*x_4}
--- assert(set invariants T2 === invariants2)
--- ///
+TEST ///
+R2 = QQ[x_1..x_4]
+T2 = diagonalAction(matrix{{0,1,-1,1},{1,0,-1,-1}}, R2)
+invariants2 = set {x_1*x_2*x_3,x_1^2*x_3*x_4}
+assert(set invariants T2 === invariants2)
+///
      
      
 -------------------------------------------
@@ -170,7 +167,10 @@ W1 = matrix{{1,0,-1},{0,1,-1}}
 W2 = matrix{{0,1,1},{1,0,1}}
 d = {3,3}
 D = diagonalAction(W1,W2,d,R)
-degRing = degreesRing D
+-- get degree variable
+T = (degreesRing D)_0
+-- get torus character variables
+z = gens coefficientRing degreesRing D
 e = equivariantHilbertSeries D
 assert(value denominator e === 
     1+(-z_0*z_3-z_1*z_2-z_0^(-1)*z_1^(-1)*z_2*z_3)*T+(z_0*z_1*z_
@@ -203,7 +203,10 @@ TEST ///
 R = QQ[x_1..x_4]
 W = matrix{{0,1,-1,1},{1,0,-1,-1}}
 D = diagonalAction(W, R)
-degRing = degreesRing D
+-- get degree variable
+T = (degreesRing D)_0
+-- get torus character variables
+z = gens coefficientRing degreesRing D
 e = equivariantHilbertSeries D
 assert(value denominator e ===
     1+(-z_0-z_0*z_1^(-1)-z_1-z_0^(-1)*z_1^(-1))*T+(z_0^2*z_1^(-1
@@ -245,7 +248,10 @@ R = QQ[x_1..x_3]
 d = {3,3}
 W = matrix{{1,0,1},{0,1,1}}
 D = diagonalAction(W, d, R)
-degRing = degreesRing D
+-- get degree variable
+T = (degreesRing D)_0
+-- get torus character variables
+z = gens coefficientRing degreesRing D
 e = equivariantHilbertSeries D
 assert(value denominator e ===
     1+(-z_0*z_1-z_0-z_1)*T+(z_0^2*z_1+z_0*z_1^2+z_0*z_1)*T^2-z_0
@@ -281,8 +287,8 @@ R=QQ[x_1..x_4]
 S5=finiteAction({A,B},R)
 assert(#(group S5) === 120)
 assert(not isAbelian S5)
-C=permutationMatrix toString 3124
-D=permutationMatrix toString 2143
+C=permutationMatrix [3, 1, 2, 4]
+D=permutationMatrix [2, 1, 4, 3]
 A4=finiteAction({C,D},R)
 assert(#(group A4) === 12)
 assert(not isAbelian A4)
@@ -327,8 +333,8 @@ assert(invariants D4 === {x*y,x^4+y^4})
 
 TEST ///
 R = QQ[x,y,z]
-r=permutationMatrix toString 312
-s=permutationMatrix toString 213
+r=permutationMatrix [3, 1, 2]
+s=permutationMatrix [2, 1, 3]
 S3 = finiteAction({r,s},R)
 assert(isInvariant(x*y*z,S3))
 assert(isInvariant(x+y+z,S3))
@@ -348,15 +354,15 @@ assert(value denominator H === sub((1-T)^3, ring value denominator H))
 -- *NB it is possible that primaryInvariants(S3,Dade=>true) can run correctly 
 -- and output an invariant polynomial of degree strictly less than the 
 -- cardinality of the group. If a check on the package invariant ring reports 
--- failure of the following test, then one should see if the test is passed upon 
+-- failure of the folloing test, then one should see if the test is passed upon 
 -- a second attempt. Only if the test fails a second time is it worth inspecting 
 -- the code for errors.  
 
 TEST ///
 K=GF(101)
 R=K[x,y,z]
-r=permutationMatrix toString 312
-s=permutationMatrix toString 213
+r=permutationMatrix [3, 1, 2]
+s=permutationMatrix [2, 1, 3]
 S3 = finiteAction({r,s},R)
 setRandomSeed 0
 P=primaryInvariants(S3, Dade=>true)
@@ -405,7 +411,7 @@ assert(
  -- Test 23
  -- Checks the dadeHSOP routine by checking that the list of polynomials output
 -- has the expected output. Namely:
--- they are invariant polynomials,
+-- they are invariant polynimials,
 -- they form a homogeneous system of parameters for the polynomial ring
 -- they have degrees equal to the cardinality of the group (which should occur
 -- with probability 1)*
@@ -430,4 +436,22 @@ assert(
 assert(
      apply(P,degree)==toList(#P:{#(group D4)})
      )
+///
+
+------------------------------------------------------------------------
+--- Tests for elementary invarianst strategy (April 2026) --------------
+------------------------------------------------------------------------
+
+-- Test 24
+-- checks that the new strategy for elementary invariants returns
+-- the same results as the previous strategy by Derksen and Gandini
+TEST ///
+p=11
+R = QQ[x_1..x_3]
+W = matrix{{1,0,1},{0,1,1}}
+L = {p,p}
+T = diagonalAction(W,L,R)
+inv = invariants T
+einv = invariants(T, Strategy => "Elementary")
+assert(set inv == set einv)
 ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/changes.m2
@@ -6,6 +6,7 @@ document {
      Key => "changes to Macaulay2, by version",
      Subnodes => {
 	  -- TO "changes made for the next release",
+	  TO "changes, 1.26.05",
 	  TO "changes, 1.25.11",
 	  TO "changes, 1.25.05",
 	  TO "changes, 1.24.11",
@@ -65,6 +66,17 @@ changesHelper List := opt -> pkgnames -> (
 	    << (if opt.Certification then "published" else "added")
 	    << ".\" },"
 	    << endl)))
+
+document {
+    Key => "changes, 1.26.05",
+        UL {
+	LI { "improved packages:",
+	    UL {
+		LI { TO "InvariantRing::InvariantRing", " has been updated to version 2.4, which includes a new algorithm for invariants of elementary abelian $p$-groups, as well as bugfixes and documentation improvements. The ", TT "permutationMatrix", " method now takes arrays as inputs." },
+		}
+	    },
+	}
+    }
 
 document {
     Key => "changes, 1.25.11",


### PR DESCRIPTION
`InvariantRing` has been updated to version 2.4, which includes a new algorithm for invariants of elementary abelian $p$-groups, as well as bugfixes and documentation improvements. The `permutationMatrix` method now takes arrays as inputs.