### PR TITLE
PieriMaps: 2.0 overhaul

### DIFF
--- a/M2/Macaulay2/packages/PieriMaps.m2
+++ b/M2/Macaulay2/packages/PieriMaps.m2
@@ -313,26 +313,25 @@ schurRank(ZZ, List) := (n, mu) -> (
 standardTableauxCache = new MutableHashTable
 
 standardTableaux = method()
-standardTableaux(ZZ, List) := (dim, mu) -> (
-     key := (dim, mu);
-     if standardTableauxCache#?key then return standardTableauxCache#key;
-     if #mu == 0 then (standardTableauxCache#key = {{}}; return {{}});
-     output := {};
-     otherrows := standardTableaux(dim, drop(mu, 1));
-     firstrow := rsort compositions(dim, mu#0);
-     for i in firstrow do (
-     	  temp := {};
-     	  for j from 0 to #i-1 do
-     	  for k from 1 to i#j when true do
-     	  temp = append(temp,j);
-     	  for j in otherrows do (
-	       temp2 := prepend(temp,j);
-     	       if isStandardPM(temp2) === null then
-     	       output = append(output, temp2);
+standardTableaux(ZZ, List) := (dim, mu) -> standardTableauxCache#(dim, mu) ??= (
+     if #mu == 0 then {{}}
+     else (
+	  output := {};
+	  otherrows := standardTableaux(dim, drop(mu, 1));
+	  firstrow := rsort compositions(dim, mu#0);
+	  for i in firstrow do (
+	       temp := {};
+	       for j from 0 to #i-1 do
+	       for k from 1 to i#j when true do
+	       temp = append(temp,j);
+	       for j in otherrows do (
+		    temp2 := prepend(temp,j);
+		    if isStandardPM(temp2) === null then
+		    output = append(output, temp2);
+		    );
 	       );
-     	  );
-     standardTableauxCache#key = output;
-     output
+	  output
+	  )
      )
 
 -- Input:
@@ -428,8 +427,7 @@ pmToFillingExpansion = T -> (
           if degenerate then return;
           F := new sfFillingType from sortedCols;
           contribution := (totalSign * 1_QQ) / denom;
-          if accum#?F then accum#F = accum#F + contribution
-          else accum#F = contribution;
+          accum#F = (accum#F ?? 0) + contribution;
           ));
      new HashTable from for k in keys accum list if accum#k != 0 then k => accum#k else continue
      )
@@ -447,7 +445,7 @@ pmToFilling = T -> (
 	  decomp := sfStraightenPM F;
 	  for k in keys decomp do (
 	       v := c * decomp#k;
-	       if out#?k then out#k = out#k + v else out#k = v;
+	       out#k = (out#k ?? 0) + v;
 	       );
 	  );
      new HashTable from for k in keys out list if out#k != 0 then k => out#k else continue
@@ -485,8 +483,7 @@ fillingToPMExpansion = F -> (
                for j from 0 to lambda#i - 1 list (orderedCols#j)#i;
           sortedRows := apply(rows, sort);
           contribution := (totalSign * 1_QQ) / denom;
-          if accum#?sortedRows then accum#sortedRows = accum#sortedRows + contribution
-          else accum#sortedRows = contribution;
+          accum#sortedRows = (accum#sortedRows ?? 0) + contribution;
           ));
      new HashTable from for k in keys accum list if accum#k != 0 then k => accum#k else continue
      )
@@ -502,7 +499,7 @@ fillingToPM = F -> (
           decomp := memo#(apply(K, sort));
           for std in keys decomp do (
                cc := c * decomp#std;
-               if out#?std then out#std = out#std + cc else out#std = cc;
+               out#std = (out#std ?? 0) + cc;
                );
           );
      new HashTable from for k in keys out list if out#k != 0 then k => out#k else continue
@@ -528,10 +525,7 @@ fillingToWeyl = F -> (
 fillingToPMMatrixCache = new MutableHashTable
 pmToFillingMatrixCache = new MutableHashTable
 
-fillingToPMMatrix = (mu, n) -> (
-     mm := trimPartPM mu;
-     key := (mm, n);
-     if fillingToPMMatrixCache#?key then return fillingToPMMatrixCache#key;
+fillingToPMMatrix = (mu, n) -> fillingToPMMatrixCache#(mm := trimPartPM mu, n) ??= (
      pmS := standardTableaux(n, mm);
      muTcols := conjPartPM mm;
      ensureSchurFn();
@@ -544,19 +538,15 @@ fillingToPMMatrix = (mu, n) -> (
           for sj from 0 to #sfS - 1 list (
                decomp := decomps#sj;
                U := pmS#ti;
-               if decomp#?U then decomp#U else 0_QQ
+               decomp#U ?? 0_QQ
                )
           );
      -- Source labels = standard Fillings; target labels = standard PM tableaux.
      attachBasisLabels(result, sfS, pmS);
-     fillingToPMMatrixCache#key = result;
      result
      )
 
-pmToFillingMatrix = (mu, n) -> (
-     mm := trimPartPM mu;
-     key := (mm, n);
-     if pmToFillingMatrixCache#?key then return pmToFillingMatrixCache#key;
+pmToFillingMatrix = (mu, n) -> pmToFillingMatrixCache#(mm := trimPartPM mu, n) ??= (
      pmS := standardTableaux(n, mm);
      muTcols := conjPartPM mm;
      ensureSchurFn();
@@ -566,12 +556,11 @@ pmToFillingMatrix = (mu, n) -> (
           for pj from 0 to #pmS - 1 list (
                decomp := decomps#pj;
                F := sfS#fi;
-               if decomp#?F then decomp#F else 0_QQ
+               decomp#F ?? 0_QQ
                )
           );
      -- Source labels = standard PM tableaux; target labels = standard Fillings.
      attachBasisLabels(result, pmS, sfS);
-     pmToFillingMatrixCache#key = result;
      result
      )
 
@@ -634,10 +623,9 @@ pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
 	       remove(H, T);
 	       straighten(U, memo);
 	       for i in keys memo#U do
-	       if H #? i then H#i = H#i + coeff * (memo#U)#i * X_((T_0)_0)
-	       else H#i = coeff * (memo#U)#i * X_((T_0)_0);
+	       H#i = (H#i ?? 0) + coeff * (memo#U)#i * X_((T_0)_0);
 	       );
-     	  for t in Tbasis do if H #? t then row = append(row, H#t) else row = append(row, 0);
+     	  for t in Tbasis do row = append(row, H#t ?? 0);
 	  output = append(output, row);
 	  );
      return map(P^(#Tbasis), P^{#Sbasis:-1}, transpose output);
@@ -750,14 +738,14 @@ pieriColumnHelper = (mu, k, P) -> (
 			      U#(J#i) = prepend(dropped, U#(J#i));
 			      sgn := if b % 2 == 0 then 1 else -1;
 			      key := new List from U;
-			      cur := if temp#?key then temp#key else 0;
+			      cur := temp#key ?? 0;
 			      temp#key = cur + sgn * coeff;
 			      );
 			 );
 		    h = temp;
 		    );
 	       for K in keys h do (
-		    cur := if H#?K then H#K else 0;
+		    cur := H#K ?? 0;
 		    H#K = cur + h#K;
 		    );
 	       );
@@ -771,10 +759,9 @@ pieriColumnHelper = (mu, k, P) -> (
 	       while #U > 0 and #(U#(#U - 1)) == 0 do U = drop(U, -1);
 	       UF := new sfFillingType from U;
 	       UFkey := toList U;
-	       if not memo#?UFkey then memo#UFkey = sfStraightenPM UF;
-	       decomp := memo#UFkey;
+	       decomp := memo#UFkey ??= sfStraightenPM UF;
 	       for std in keys decomp do (
-		    idx := if Tidx#?(toList std) then Tidx#(toList std) else null;
+		    idx := Tidx#(toList std) ?? null;
 		    if idx === null then continue;
 		    rowVec#idx = rowVec#idx + coeff * (decomp#std) * X#poppedEntry;
 		    );
@@ -1038,7 +1025,7 @@ lrMap(Sequence, List, ZZ) := opts -> (shapes, Q, n) -> (
 			 flatten for k from 0 to n - 1 list
 			      toList(expv#(a*n + k) : k);
 		    straighten(tvec, straightenH);
-		    decomp := if straightenH#?tvec then straightenH#tvec else new HashTable from {};
+		    decomp := straightenH#tvec ?? new HashTable from {};
 		    for ssyt in keys decomp do (
 			 if not nuIdx#?ssyt then continue;
 			 dc := decomp#ssyt;
@@ -1108,7 +1095,7 @@ applyLR(Sequence, List, BasicList, ZZ) := opts -> (shapes, Q, T, n) -> (
 	  Tlist := apply(toList T, r -> sort toList r);
 	  h := new MutableHashTable;
 	  straighten(Tlist, h);
-	  decomp := if h#?Tlist then h#Tlist else new HashTable from {};
+	  decomp := h#Tlist ?? new HashTable from {};
 	  idx := new MutableHashTable;
 	  for i from 0 to #Sb - 1 do idx#(Sb#i) = i;
 	  Tcoords = new MutableList from toList(#Sb : 0_QQ);
@@ -1236,7 +1223,7 @@ straightenByConvPM = (T, convention) -> (
 	  Tlist := apply(toList T, r -> sort toList r);
 	  h := new MutableHashTable;
 	  straighten(Tlist, h);
-	  if h#?Tlist then h#Tlist else new HashTable from {}
+	  h#Tlist ?? new HashTable from {}
 	  )
      else if convention === "Filling" then (
 	  ensureSchurFn();
@@ -1265,7 +1252,7 @@ testWellDefinedTwoTuple0 = (applyFn, srcShape, n, conv, zeroVal, verbose) -> (
 	       img := applyFn K;
 	       for pair in img do (
 		    key := if class pair#1 === List then pair#1 else toList pair#1;
-		    cur := if imgM#?key then imgM#key else zeroVal;
+		    cur := imgM#key ?? zeroVal;
 		    imgM#key = cur + c * pair#0;
 		    );
 	       );
@@ -1277,8 +1264,8 @@ testWellDefinedTwoTuple0 = (applyFn, srcShape, n, conv, zeroVal, verbose) -> (
 	  allKeys := unique (keys imgDmap | keys imgM);
 	  caseOk := true;
 	  for k in allKeys do (
-	       a := if imgDmap#?k then imgDmap#k else zeroVal;
-	       b := if imgM#?k then imgM#k else zeroVal;
+	       a := imgDmap#k ?? zeroVal;
+	       b := imgM#k ?? zeroVal;
 	       if a != b then caseOk = false;
 	       );
 	  if not caseOk then (
@@ -1357,7 +1344,7 @@ verifyWellDefined(Sequence, List, ZZ) := opts -> (shapes, Q, n) -> (
 	       img := applyLR(shapes, Q, K, n, Convention => conv);
 	       for trip in img do (
 		    key := (toList trip#1, toList trip#2);
-		    cur := if imgM#?key then imgM#key else 0;
+		    cur := imgM#key ?? 0;
 		    imgM#key = cur + c * trip#0;
 		    );
 	       );
@@ -1366,8 +1353,8 @@ verifyWellDefined(Sequence, List, ZZ) := opts -> (shapes, Q, n) -> (
 	  allKeys := unique (keys imgDmap | keys imgM);
 	  caseOk := true;
 	  for k in allKeys do (
-	       a := if imgDmap#?k then imgDmap#k else 0;
-	       b := if imgM#?k then imgM#k else 0;
+	       a := imgDmap#k ?? 0;
+	       b := imgM#k ?? 0;
 	       if a != b then (
 		    caseOk = false;
 		    if verbose then
@@ -1503,9 +1490,8 @@ pmPermSign = (a, ref) -> (
 -- Build (or look up) the stacked K-matrix and addable-strips list for
 -- the horizontal-strip dual map at parameters (lambda, d, n, conv).
 -- Returns (addable, A, offsets) with offsets#i = first column of block i.
-pmGetDualHBlocks = (lambda, d, n, conv, P, K) -> (
-     key := ("row", toList lambda, d, n, K, conv);
-     if pmDualBlockCache#?key then return pmDualBlockCache#key;
+pmGetDualHBlocks = (lambda, d, n, conv, P, K) ->
+     pmDualBlockCache#("row", toList lambda, d, n, K, conv) ??= (
      monBasis := flatten entries basis(d, P);
      addable := pmAddableHStrips(lambda, d, n);
      blocks := for pair in addable list (
@@ -1516,15 +1502,12 @@ pmGetDualHBlocks = (lambda, d, n, conv, P, K) -> (
 	  );
      A := fold((a, b) -> a | b, blocks);
      offsets := prepend(0, accumulate(plus, 0, apply(blocks, numColumns)));
-     val := (addable, A, offsets);
-     pmDualBlockCache#key = val;
-     val
+     (addable, A, offsets)
      );
 
 -- Vertical-strip analogue.  Requires P SkewCommutative.
-pmGetDualVBlocks = (lambda, d, n, conv, P, K) -> (
-     key := ("col", toList lambda, d, n, K, conv);
-     if pmDualBlockCache#?key then return pmDualBlockCache#key;
+pmGetDualVBlocks = (lambda, d, n, conv, P, K) ->
+     pmDualBlockCache#("col", toList lambda, d, n, K, conv) ??= (
      monBasis := flatten entries basis(d, P);
      addable := pmAddableVStrips(lambda, d, n);
      blocks := for pair in addable list (
@@ -1535,17 +1518,14 @@ pmGetDualVBlocks = (lambda, d, n, conv, P, K) -> (
 	  );
      A := fold((a, b) -> a | b, blocks);
      offsets := prepend(0, accumulate(plus, 0, apply(blocks, numColumns)));
-     val := (addable, A, offsets);
-     pmDualBlockCache#key = val;
-     val
+     (addable, A, offsets)
      );
 
 -- Stacked LR-block matrix for dualLR with parameters (mu, nu, n, conv).
 -- The key intentionally omits lambda (the target), since the same
 -- decomposition supports projection onto every summand at once.
-pmGetDualLRBlocks = (mu, nu, n, conv) -> (
-     key := ("lr", toList mu, toList nu, n, conv);
-     if pmDualBlockCache#?key then return pmDualBlockCache#key;
+pmGetDualLRBlocks = (mu, nu, n, conv) ->
+     pmDualBlockCache#("lr", toList mu, toList nu, n, conv) ??= (
      totalCells := sum mu + sum nu;
      cands := apply(pmPartitionsAtMost(totalCells, n), p -> toList p);
      -- Per-candidate (lambda', Q') pairs along with their lrMap blocks.
@@ -1560,9 +1540,7 @@ pmGetDualLRBlocks = (mu, nu, n, conv) -> (
      if numRows A =!= numColumns A then
 	  error "dualLR: stacked LR matrix not square (decomposition incomplete)";
      offsets := prepend(0, accumulate(plus, 0, apply(blocks, numColumns)));
-     val := (blockInfo, A, offsets);
-     pmDualBlockCache#key = val;
-     val
+     (blockInfo, A, offsets)
      );
 
 -- Extract rows [startRow .. startRow + blockSize - 1] of A^{-1} via a
@@ -1732,14 +1710,14 @@ pmTableauToCoords = (T, shape, n, conv) -> (
 	       else if class T === List then new sfFillingType from T
 	       else error "tableau must be a List (column form) or Filling";
 	  h := sfStraightenPM Tcast;
-	  for s in stdsF list (if h#?s then h#s else 0_QQ)
+	  for s in stdsF list (h#s ?? 0_QQ)
 	  )
      else if conv === "Row" or conv === "Weyl" then (
 	  stds := standardTableaux(n, shape);
 	  hRow := if class T === List then straighten T
 	       else if class T === sfFillingType then fillingToPM T
 	       else error "tableau must be a List (PM row form) or Filling (column form)";
-	  for s in stds list (if hRow#?s then hRow#s else 0_QQ)
+	  for s in stds list (hRow#s ?? 0_QQ)
 	  )
      else error("unknown Convention: ", conv)
      );
@@ -1894,8 +1872,7 @@ pmActE0 = (i, j, T) -> (
 			  else T#r2);
 		    h := straighten Tprime;
 		    for k in keys h do
-			 if totalH#?k then totalH#k = totalH#k + h#k
-			 else totalH#k = h#k;
+			 totalH#k = (totalH#k ?? 0) + h#k;
 		    );
      new HashTable from totalH
      );
@@ -1907,14 +1884,10 @@ pmCLambdaCache = new MutableHashTable
 
 -- Compute c_lambda for the round-trip pmToFilling -> fillingToPM = c * Id.
 -- We extract it as a diagonal entry of the product matrix.
-pmComputeCLambda = (lambda, n) -> (
-     key := (trimPartPM lambda, n);
-     if pmCLambdaCache#?key then return pmCLambdaCache#key;
+pmComputeCLambda = (lambda, n) -> pmCLambdaCache#(trimPartPM lambda, n) ??= (
      A := pmToFillingMatrix(lambda, n);
      B := fillingToPMMatrix(lambda, n);
-     c := (B * A)_(0, 0);
-     pmCLambdaCache#key = c;
-     c
+     (B * A)_(0, 0)
      );
 
 -- E_{i,j} action on a Filling F of shape `lambda` over K^n.  We route through
@@ -1931,14 +1904,14 @@ pmActEFilling0 = (i, j, F, lambda, n) -> (
 	  c := raw#T;
 	  actT := pmActE0(i, j, T);
 	  for k in keys actT do
-	       pmResult#k = (if pmResult#?k then pmResult#k else 0_QQ) + c * actT#k;
+	       pmResult#k = (pmResult#k ?? 0_QQ) + c * actT#k;
 	  );
      fillResult := new MutableHashTable;
      for T in keys pmResult do (
 	  c := pmResult#T;
 	  fillExp := pmToFilling T;
 	  for F2 in keys fillExp do
-	       fillResult#F2 = (if fillResult#?F2 then fillResult#F2 else 0_QQ) + c * fillExp#F2;
+	       fillResult#F2 = (fillResult#F2 ?? 0_QQ) + c * fillExp#F2;
 	  );
      if #fillResult == 0 then return new HashTable from {};
      cLam := pmComputeCLambda(lambda, n);
@@ -2280,23 +2253,21 @@ labelKeyPM = lab -> (
 
 symbolicForm = method()
 symbolicForm Matrix := M -> (
-     if not M.cache#?"sourceBasis" then
-	  M.cache#"sourceBasis" = toList(1..rank source M);
-     if not M.cache#?"targetBasis" then
-	  M.cache#"targetBasis" = toList(1..rank target M);
-     if not M.cache#?"rule" then (
+     M.cache#"sourceBasis" ??= toList(0 .. rank source M - 1);
+     M.cache#"targetBasis" ??= toList(0 .. rank target M - 1);
+     M.cache#"rule" ??= (
 	  -- Build label-to-index map once for O(1) lookup.
 	  srcLabels := M.cache#"sourceBasis";
 	  idxOfSrc := hashTable for k from 0 to #srcLabels - 1 list
 	       labelKeyPM(srcLabels#k) => k;
-	  M.cache#"rule" = i -> (
+	  i -> (
 	       key := labelKeyPM i;
 	       if not idxOfSrc#?key then error "symbolicForm: source label not found";
 	       l := idxOfSrc#key;
 	       col := flatten entries M_{l};
 	       L := positions(col, j -> not(j == 0_(ring M)));
 	       for j in L list ((M.cache#"targetBasis")_j, col_j)
-	       );
+	       )
 	  );
      netList for i in M.cache#"sourceBasis" list (
 	  {prettyLabelPM i, prettyImagePM ((M.cache#"rule")(i))})

--- a/M2/Macaulay2/packages/PieriMaps.m2
+++ b/M2/Macaulay2/packages/PieriMaps.m2
@@ -10,32 +10,95 @@
 
 newPackage(
     	  "PieriMaps",
-   	  Version => "1.0",
-	  Date => "July 3, 2009",
-	  Certification => {
-	       "journal name" => "The Journal of Software for Algebra and Geometry: Macaulay2",
-	       "journal URI" => "https://msp.org/jsag/",
-	       "article title" => "Computing inclusions of Schur modules",
-	       "acceptance date" => "2009-06-27",
-	       "published article URI" => "https://msp.org/jsag/2009/1-1/p02.xhtml",
-	       "published article DOI" => "10.2140/jsag.2009.1.5",
-	       "published code URI" => "https://msp.org/jsag/2009/1-1/jsag-v1-n1-x02-code.zip",
-	       "release at publication" => "38e96fec660168d488ad0449f8632e6608cc9ede",
-	       "version at publication" => "1.0",
-	       "volume number" => "1",
-	       "volume URI" => "https://msp.org/jsag/2009/1-1/"
-	       },
+   	  Version => "2.0",
+	  Date => "May 1, 2026",
 	  Authors => {{
 		    Name => "Steven V Sam",
 		    Email => "ssam@math.mit.edu",
 		    HomePage => "http://math.mit.edu/~ssam/"
+		    },
+		   {
+		    Name => "Keller VandeBogert",
+		    Email => "keller.v@uky.edu",
+		    HomePage => "https://sites.nd.edu/kellerv/"
 		    }},
-	  Headline => "maps between representations of the general linear group based on the Pieri formulas",
+	  Headline => "Pieri inclusions and projections between Schur modules with multiple basis conventions",
 	  Keywords => {"Representation Theory"},
-	  DebuggingMode => false
+	  DebuggingMode => false,
+	  AuxiliaryFiles => true
 	  )
 
-export {"straighten", "standardTableaux", "pieri", "pureFree", "schurRank"}
+-- SchurFunctors is needed for the convention-aware features (Filling /
+-- WeylFilling bases, column-form Pieri, etc.) but is loaded lazily because
+-- PieriMaps and SchurFunctors both export several symbols (`straighten`,
+-- `standardTableaux`, `isStandard`) and we want PieriMaps's versions to take
+-- precedence on the row-form side.  Convention features call ensureSchurFn
+-- to lazily load SchurFunctors and resolve its symbols via its private
+-- dictionary.
+
+schurFnLoaded = false
+sfStraightenPM = null
+sfStandardTabPM = null
+sfFillingType = null
+sfWeylFillingType = null
+sfWeylFn = null
+
+-- PieriMaps' Filling/Weyl convention features depend on SchurFunctors v >= 1.1
+-- (which exports `straighten Filling`, `straighten HashTable`, and the
+-- `WeylFilling` / `weyl` symbols).  The system-installed version in some M2
+-- distributions is older and only registers `straighten (Filling, Module)`.
+-- We load lazily and detect the incomplete state at first use so the user
+-- gets a clear, actionable error rather than a cryptic "no method for
+-- straighten" later in the call stack.
+ensureSchurFn = () -> (
+     if schurFnLoaded then return;
+     needsPackage "SchurFunctors";
+     sfPkg := value getGlobalSymbol "SchurFunctors";
+     d := sfPkg#"private dictionary";
+     sfStraightenPM = value (d#"straighten");
+     if #methods sfStraightenPM < 2 then error(
+	  "PieriMaps' Filling and Weyl conventions require an updated " |
+	  "SchurFunctors that exports `straighten Filling` directly.  The " |
+	  "currently loaded SchurFunctors only has the (Filling, Module) " |
+	  "signature.  Install the newer SchurFunctors and load it BEFORE " |
+	  "PieriMaps via `loadPackage(\"SchurFunctors\", FileName => \"<path>\")`."
+	  );
+     sfStandardTabPM = value (d#"standardTableaux");
+     sfFillingType = value (d#"Filling");
+     -- WeylFilling and `weyl` are present only in the updated SchurFunctors;
+     -- they are optional (Weyl convention requires them).
+     if d#?"WeylFilling" then sfWeylFillingType = value (d#"WeylFilling");
+     if d#?"weyl" then sfWeylFn = value (d#"weyl");
+     schurFnLoaded = true;
+     )
+
+export {
+     -- Original PieriMaps (unchanged signatures unless noted):
+     "straighten", "standardTableaux", "pieri", "pureFree", "schurRank",
+     -- LR maps (added in this overhaul):
+     "lrTableaux", "lrMap", "applyLR", "displayLRImage",
+     -- Convention-aware overhaul (Convention => "Row" | "Filling" | "Weyl"
+     -- option on pieri / lrMap / applyLR / pureFree).  These are also exposed
+     -- as standalone functions for explicit basis access:
+     "Convention",
+     "pmToFilling", "fillingToPM", "pmToWeyl", "weylToPM",
+     "weylToFilling", "fillingToWeyl",
+     "pmToFillingMatrix", "fillingToPMMatrix",
+     -- Native column-form (SkewCommutative-target) Pieri:
+     "pieriColumn",
+     -- Convention compatibility checker:
+     "verifyWellDefined",
+     -- Dual / projection-direction maps (GL-equivariant):
+     "dualPieri", "dualLR", "applyDualPieri", "applyDualLR",
+     -- Inclusion-direction point evaluators:
+     "applyPieri", "applyPieriColumn",
+     -- Column-form (wedge-target) projection direction:
+     "dualPieriColumn", "applyDualPieriColumn",
+     -- General GL-equivariance check for matrices between Schur reps:
+     "verifyEquivariant", "Direction",
+     -- Pretty-print a matrix as a basis-labeled symbolic map:
+     "symbolicForm"
+     }
 
 --------------------------------
 -- subroutines (not exported) --
@@ -68,7 +131,7 @@ isIncreasing = L -> (
 -- If T not standard (weakly increasing rows, increasing columns), return 
 -- first violating entry (starting from bottom to top, left to right);
 -- otherwise return null
-isStandard = T -> (
+isStandardPM = T -> (
      i := #T-2;
      while i >= 0 do (
 	  a := T#i;
@@ -116,7 +179,7 @@ shuffle = (T, col, row1, row2) -> (
 -- table which contains tableaux T_i as keys and their values c_i which 
 -- represent coefficients: T = c_1T_1 + ... + c_nT_n
 towardStandard = T -> (
-     x := isStandard T;
+     x := isStandardPM T;
      if x === null then return new HashTable from {T=>1};
      H := new MutableHashTable from shuffle(T, x#1+1, x#0, x#0+1);
      if H #? T then (
@@ -148,6 +211,58 @@ subtractOne = (mu, k) -> (
      return result
      )
 
+-------------------------------------------------------------------------------
+-- Convention infrastructure (added in this overhaul).
+--
+-- These helpers are used by the convention-aware versions of pieri / lrMap /
+-- applyLR / pureFree (Convention => "Row" | "Filling" | "Weyl") and by the
+-- standalone basis conversions pmToFilling / fillingToPM / pmToWeyl /
+-- weylToPM.  They depend on the SchurFunctors package being loaded
+-- (PackageImports above).
+-------------------------------------------------------------------------------
+
+-- Sign-tracked sort.  Returns (sign, sortedList) with sign in {1, -1}, or null
+-- if the input has a repeat.
+sortWithSignPM = L -> (
+     s := new MutableList from L;
+     n := #s;
+     swaps := 0;
+     for i from 0 to n-2 do
+          for j from 0 to n-i-2 do (
+               if s#j === s#(j+1) then return null;
+               if s#j > s#(j+1) then (
+                    t := s#(j+1); s#(j+1) = s#j; s#j = t;
+                    swaps = swaps + 1;
+                    );
+               );
+     ((if swaps % 2 == 0 then 1 else -1), toList s)
+     )
+
+factorialPM = n -> if n <= 1 then 1 else n * factorialPM(n - 1)
+
+-- Cartesian product enumerator: yields each combination as a List `current`
+-- to the callback `body`.
+cartesianForEachPM = (lists, body) -> (
+     n := #lists;
+     buf := new MutableList from toList(n : null);
+     descend := null;
+     descend = i -> (
+          if i == n then body(toList buf)
+          else for v in lists#i do (buf#i = v; descend(i + 1));
+          );
+     descend(0);
+     )
+
+-- Drop trailing zeros from a partition.
+trimPartPM = mu -> (
+     L := #mu;
+     while L > 0 and mu#(L-1) == 0 do L = L - 1;
+     for i from 0 to L - 1 list mu#i
+     )
+
+-- Conjugate of a partition (drops trailing zeros first).
+conjPartPM = mu -> toList conjugate (new Partition from trimPartPM mu)
+
 -------------------
 -- Main routines --
 -------------------
@@ -178,9 +293,17 @@ schurRank(ZZ, List) := (n, mu) -> (
 -- List mu: a partition
 -- Output: 
 -- All standard tableaux of shape mu and with labels from 0..dim-1
+-- Memoize standardTableaux: it's called many times per pieri / lrMap with
+-- the same (dim, mu) (e.g., for source and target shapes, repeated across
+-- pieri compositions in lrMap, and between successive iterations of
+-- benchmarks/loops).  The cache is purely a function of (dim, mu).
+standardTableauxCache = new MutableHashTable
+
 standardTableaux = method()
 standardTableaux(ZZ, List) := (dim, mu) -> (
-     if #mu == 0 then return {{}};
+     key := (dim, mu);
+     if standardTableauxCache#?key then return standardTableauxCache#key;
+     if #mu == 0 then (standardTableauxCache#key = {{}}; return {{}});
      output := {};
      otherrows := standardTableaux(dim, drop(mu, 1));
      firstrow := rsort compositions(dim, mu#0);
@@ -191,11 +314,12 @@ standardTableaux(ZZ, List) := (dim, mu) -> (
      	  temp = append(temp,j);
      	  for j in otherrows do (
 	       temp2 := prepend(temp,j);
-     	       if isStandard(temp2) === null then
+     	       if isStandardPM(temp2) === null then
      	       output = append(output, temp2);
 	       );
      	  );
-     return output
+     standardTableauxCache#key = output;
+     output
      )
 
 -- Input:
@@ -213,23 +337,231 @@ straighten(List) := t -> (
 straighten(List, MutableHashTable) := (t, h) -> (
      t = apply(t, i -> sort i);
      if h #? t then return null;
-     if isStandard(t) === null then 
-     h#t = new HashTable from {t => 1};
-     
+     -- Short-circuit: if t is already standard, the straightening is just t.
+     -- Avoids an unnecessary towardStandard + recursive straighten call that
+     -- would otherwise recompute the same answer.
+     if isStandardPM(t) === null then (
+	  h#t = new HashTable from {t => 1};
+	  return null;
+	  );
      firstIter := towardStandard(t);
      H := hashTable({}); -- straightening of t
      for i in keys firstIter do (
 	  coeff := firstIter#i;
      	  straighten(i, h);
-	  temp := {};
-	  for j in keys h#i do temp = append(temp, (j, coeff * (h#i)#j));
-	  H = merge(H, hashTable(temp), plus);
-     	  temp = {};
-	  for j in keys H do if H#j != 0 then temp = append(temp,(j,H#j));
-	  H = hashTable(temp);
+	  temp := for j in keys h#i list (j, coeff * (h#i)#j);
+	  H = merge(H, hashTable temp, plus);
 	  );
-     h#t = H;
+     -- Drop zeros once at the end rather than after every iteration.
+     h#t = hashTable for j in keys H list if H#j != 0 then (j, H#j) else continue;
      return null;
+     )
+
+-------------------------------------------------------------------------------
+-- Basis conversion: PM (row-form, in Sym tensor) <--> Filling (column-form,
+-- in exterior tensor) <--> WeylFilling (divided-power row-form).
+--
+-- pmToFilling : PM-tableau -> HashTable {standard Filling => QQ}
+--             via symmetrize-then-antisymmetrize.
+-- fillingToPM : Filling -> HashTable {standard PM-tableau => QQ}
+--             via antisymmetrize-then-symmetrize.
+-- pmToWeyl    : PM-tableau -> WeylFilling     (data identity)
+-- weylToPM    : WeylFilling -> PM-tableau    (data identity)
+--
+-- These are equivariant isos S_lambda V_PM ~= S_lambda V_Filling (resp. WeylF)
+-- and are inverse up to a uniform shape-dependent scalar c_lambda (the Young-
+-- symmetrizer normalization).
+-------------------------------------------------------------------------------
+
+-- PM tableau -> WeylFilling (just wrap; data is identical).  Requires the
+-- updated SchurFunctors that exports `weyl` and `WeylFilling`.
+pmToWeyl = T -> (
+     ensureSchurFn();
+     if sfWeylFn === null then error "pmToWeyl: this requires the updated SchurFunctors with WeylFilling support; the system version does not export `weyl`/`WeylFilling`";
+     sfWeylFn(toList apply(T, r -> sort toList r))
+     )
+
+-- WeylFilling -> PM tableau (just unwrap).
+weylToPM = W -> apply(toList W, r -> sort toList r)
+
+-- PM tableau -> raw HashTable {Filling => QQ} (not yet straightened).
+pmToFillingExpansion = T -> (
+     ensureSchurFn();
+     T = apply(T, r -> sort toList r);
+     lambda := apply(T, r -> #r);
+     r := #lambda;
+     if r == 0 then return new HashTable from {};
+     s := lambda#0;
+     for i from 1 to r - 1 do if lambda#i > lambda#(i-1) then error "pmToFilling: shape not a partition";
+     lambdaT := for j from 0 to s - 1 list (
+          c := 0;
+          for i from 0 to r - 1 do if lambda#i > j then c = c + 1;
+          c
+          );
+     rowPerms := apply(T, r -> permutations r);
+     denom := product apply(lambda, k -> factorialPM k);
+     accum := new MutableHashTable;
+     cartesianForEachPM(rowPerms, sigmas -> (
+          cols := for j from 0 to s - 1 list
+               for i from 0 to lambdaT#j - 1 list (sigmas#i)#j;
+          totalSign := 1;
+          sortedCols := {};
+          degenerate := false;
+          for c in cols do (
+               sgn := sortWithSignPM c;
+               if sgn === null then ( degenerate = true; break );
+               totalSign = totalSign * (sgn#0);
+               sortedCols = append(sortedCols, sgn#1);
+               );
+          if degenerate then return;
+          F := new sfFillingType from sortedCols;
+          contribution := (totalSign * 1_QQ) / denom;
+          if accum#?F then accum#F = accum#F + contribution
+          else accum#F = contribution;
+          ));
+     new HashTable from for k in keys accum list if accum#k != 0 then k => accum#k else continue
+     )
+
+-- PM -> standard Filling decomposition (run SchurFunctors' straighten).
+-- We iterate over the raw expansion's Filling keys manually rather than
+-- passing the whole HashTable to SchurFunctors' straighten -- in some load
+-- orders the (HashTable) signature of straighten is not registered.
+pmToFilling = T -> (
+     ensureSchurFn();
+     raw := pmToFillingExpansion T;
+     out := new MutableHashTable;
+     for F in keys raw do (
+	  c := raw#F;
+	  decomp := sfStraightenPM F;
+	  for k in keys decomp do (
+	       v := c * decomp#k;
+	       if out#?k then out#k = out#k + v else out#k = v;
+	       );
+	  );
+     new HashTable from for k in keys out list if out#k != 0 then k => out#k else continue
+     )
+
+-- Filling -> raw HashTable {PM-tableau => QQ}.
+fillingToPMExpansion = F -> (
+     F = toList F;
+     s := #F;
+     if s == 0 then return new HashTable from {};
+     lambdaT := apply(F, length);
+     r := lambdaT#0;
+     for j from 1 to s - 1 do if lambdaT#j > lambdaT#(j-1) then error "fillingToPM: shape not a partition";
+     lambda := for i from 0 to r - 1 list (
+          c := 0;
+          for j from 0 to s - 1 do if lambdaT#j > i then c = c + 1;
+          c
+          );
+     colChoices := for j from 0 to s - 1 list (
+          perms := permutations(F#j);
+          for p in perms list (
+               sgn := sortWithSignPM p;
+               (sgn#0, p)
+               )
+          );
+     denom := product apply(lambdaT, k -> factorialPM k);
+     accum := new MutableHashTable;
+     cartesianForEachPM(colChoices, choice -> (
+          totalSign := 1;
+          orderedCols := {};
+          for c in choice do (
+               totalSign = totalSign * (c#0);
+               orderedCols = append(orderedCols, c#1);
+               );
+          rows := for i from 0 to r - 1 list
+               for j from 0 to lambda#i - 1 list (orderedCols#j)#i;
+          sortedRows := apply(rows, sort);
+          contribution := (totalSign * 1_QQ) / denom;
+          if accum#?sortedRows then accum#sortedRows = accum#sortedRows + contribution
+          else accum#sortedRows = contribution;
+          ));
+     new HashTable from for k in keys accum list if accum#k != 0 then k => accum#k else continue
+     )
+
+-- Filling -> standard PM decomposition (run PieriMaps' straighten).
+fillingToPM = F -> (
+     raw := fillingToPMExpansion F;
+     out := new MutableHashTable;
+     memo := new MutableHashTable;
+     for K in keys raw do (
+          c := raw#K;
+          (lookup(straighten, List, MutableHashTable))(K, memo);
+          decomp := memo#(apply(K, sort));
+          for std in keys decomp do (
+               cc := c * decomp#std;
+               if out#?std then out#std = out#std + cc else out#std = cc;
+               );
+          );
+     new HashTable from for k in keys out list if out#k != 0 then k => out#k else continue
+     )
+
+weylToFilling = W -> pmToFilling weylToPM W
+
+fillingToWeyl = F -> (
+     ensureSchurFn();
+     raw := fillingToPM F;
+     new HashTable from for k in keys raw list sfWeylFn k => raw#k
+     )
+
+-- QQ change-of-basis matrices on a Schur shape mu over QQ^n.
+--    fillingToPMMatrix(mu, n) : rows = pmStandardTab(n, mu), cols =
+--      sfStandardTab(n, conjugate mu).  Entry (i, j) is the coefficient of
+--      pmTab_i in fillingToPM(filling_j).  This matrix is invertible (up to a
+--      shape-dependent scalar) since pmToFilling/fillingToPM are equivariant
+--      isos between PM and Filling realizations of S_mu V.
+-- Cache for change-of-basis matrices keyed by (mu_trimmed, n).  These
+-- matrices are pure functions of (mu, n) and are reused across many pieri /
+-- lrMap calls under Convention => "Filling".
+fillingToPMMatrixCache = new MutableHashTable
+pmToFillingMatrixCache = new MutableHashTable
+
+fillingToPMMatrix = (mu, n) -> (
+     mm := trimPartPM mu;
+     key := (mm, n);
+     if fillingToPMMatrixCache#?key then return fillingToPMMatrixCache#key;
+     pmS := standardTableaux(n, mm);
+     muTcols := conjPartPM mm;
+     ensureSchurFn();
+     sfS := sfStandardTabPM(n, muTcols);
+     -- Hoisted: fillingToPM(sfS#sj) depends only on sj, not ti -- compute once
+     -- per column of the result.  This converts an O(#pmS * #sfS) call count
+     -- (in the original loop) to O(#sfS).
+     decomps := for sj from 0 to #sfS - 1 list fillingToPM sfS#sj;
+     result := matrix for ti from 0 to #pmS - 1 list (
+          for sj from 0 to #sfS - 1 list (
+               decomp := decomps#sj;
+               U := pmS#ti;
+               if decomp#?U then decomp#U else 0_QQ
+               )
+          );
+     -- Source labels = standard Fillings; target labels = standard PM tableaux.
+     attachBasisLabels(result, sfS, pmS);
+     fillingToPMMatrixCache#key = result;
+     result
+     )
+
+pmToFillingMatrix = (mu, n) -> (
+     mm := trimPartPM mu;
+     key := (mm, n);
+     if pmToFillingMatrixCache#?key then return pmToFillingMatrixCache#key;
+     pmS := standardTableaux(n, mm);
+     muTcols := conjPartPM mm;
+     ensureSchurFn();
+     sfS := sfStandardTabPM(n, muTcols);
+     decomps := for pj from 0 to #pmS - 1 list pmToFilling pmS#pj;
+     result := matrix for fi from 0 to #sfS - 1 list (
+          for pj from 0 to #pmS - 1 list (
+               decomp := decomps#pj;
+               F := sfS#fi;
+               if decomp#?F then decomp#F else 0_QQ
+               )
+          );
+     -- Source labels = standard PM tableaux; target labels = standard Fillings.
+     attachBasisLabels(result, pmS, sfS);
+     pmToFillingMatrixCache#key = result;
+     result
      )
 
 -- Input:
@@ -237,8 +569,8 @@ straighten(List, MutableHashTable) := (t, h) -> (
 -- ZZ k: a number specifying which row to remove a box from mu
 -- PolynomialRing P: the coefficient ring for the Pieri map over a field K
 -- Output:
--- An GL(n,K)-equivariant map P \otimes S_mu K^n -> P \otimes S_lambda K^n 
--- where lambda is mu with a box removed from the kth row, and S_mu denotes 
+-- An GL(n,K)-equivariant map P \otimes S_mu K^n -> P \otimes S_lambda K^n
+-- where lambda is mu with a box removed from the kth row, and S_mu denotes
 -- the Schur functor associated to mu
 pieriHelper = method()
 pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
@@ -250,13 +582,26 @@ pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
      mu = prepend(0,mu);
      A := {};
      for p from 0 to k when true do A = join(A, apply(subsets(1..(k-1), p), s -> prepend(0, append(s, k))));
+     -- Hoisted memo: shared across all source tableaux.  The straightening of
+     -- a given intermediate tableau U does not depend on which source we are
+     -- processing, so caching results once and reusing them across the s-loop
+     -- avoids re-running expensive Garnir straightening on the same U.
+     -- (~1.3x-1.7x speedup on medium/large pieri calls.)
+     memo := new MutableHashTable;
+     -- Hoisted Olver coefficients: cJ depends only on the path J, not on the
+     -- source tableau s.  Compute (-1)^#J / cJ once per path so the s-loop
+     -- doesn't redo the same arithmetic.
+     hCoefs := for J in A list (
+	  cJ := 1;
+	  for q from 1 to #J-2 when true do cJ = cJ * (mu_(J_q) - mu_k + k - J_q);
+	  (-1)^#J / cJ
+	  );
      for s in apply(Sbasis, i->prepend({},i)) do (
 	  row := {};
      	  H := new HashTable from {};
-     	  for J in A do (
-	       cJ := 1;
-	       for q from 1 to #J-2 when true do cJ = cJ * (mu_(J_q) - mu_k + k - J_q);
-     	       h := hashTable({(s, (-1)^#J / cJ)});
+     	  for jIdx from 0 to #A - 1 do (
+	       J := A#jIdx;
+     	       h := hashTable({(s, hCoefs#jIdx)});
 	       for i from 0 to #J-2 when true do (
 	       	    temp := {};
 	       	    for T in keys h do (
@@ -272,13 +617,12 @@ pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
 	       H = merge(H, h, plus);
 	       );
      	  H = new MutableHashTable from H;
-     	  memo := new MutableHashTable from {};
      	  for T in keys H do (
 	       U := apply(drop(T,1), i->sort(i));
 	       coeff := H#T;
 	       remove(H, T);
 	       straighten(U, memo);
-	       for i in keys memo#U do 
+	       for i in keys memo#U do
 	       if H #? i then H#i = H#i + coeff * (memo#U)#i * X_((T_0)_0)
 	       else H#i = coeff * (memo#U)#i * X_((T_0)_0);
 	       );
@@ -297,8 +641,18 @@ pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
 -- A GL(V)-equivariant map P \otimes S_mu V -> P \otimes S_lambda V, where
 -- S_mu denotes the Schur functor associated to mu, and lambda is the 
 -- partition obtained from mu by deleting boxes_0, boxes_1, ..., in order.
-pieri = method()
-pieri(List, List, PolynomialRing) := (mu, boxes, P) -> (
+-- Stash source / target basis labels on a matrix's cache so that
+-- `symbolicForm` can pretty-print the map in those basis labels.  Cache
+-- keys are strings (rather than symbols) so that the labels are visible
+-- across dictionaries (e.g. from user code or TEST blocks).
+attachBasisLabels = (M, srcLabels, tgtLabels) -> (
+     M.cache#"sourceBasis" = srcLabels;
+     M.cache#"targetBasis" = tgtLabels;
+     M
+     );
+
+pieri = method(Options => {Convention => "Row"})
+pieri(List, List, PolynomialRing) := opts -> (mu, boxes, P) -> (
      -- check if row indices are okay
      for i in boxes do if i < 1 or i > #mu then error "The second argument must specify row indices of the partition in the first argument.";
      -- check if removal of boxes gives a partition
@@ -308,11 +662,155 @@ pieri(List, List, PolynomialRing) := (mu, boxes, P) -> (
 	  if not isDecreasing(lambda) then error "The second argument needs to specify a horizontal strip in the first argument.";
 	  );
      -- check if mu/lambda is a horizontal strip
-     for i from 0 to #mu-2 do 
+     for i from 0 to #mu-2 do
      if lambda#i < mu#(i+1) then error "The second argument needs to specify a horizontal strip in the first argument.";
      -- error checking done
-     if char P == 0 then pierizero(mu, boxes, P)
-     else pierip(mu, boxes, P)
+     M := if char P == 0 then pierizero(mu, boxes, P) else pierip(mu, boxes, P);
+     conv := opts.Convention;
+     n := numgens P;
+     -- Trim trailing zeros from lambda for label and basis-change shape.
+     while #lambda > 0 and lambda#(#lambda - 1) == 0 do lambda = drop(lambda, -1);
+     if conv =!= "Row" and conv =!= "Weyl" and conv =!= "Filling" then
+	  error ("pieri: Convention must be \"Row\", \"Filling\", or \"Weyl\"");
+     if conv === "Filling" then (
+	  A := fillingToPMMatrix(mu, n);
+	  B := fillingToPMMatrix(lambda, n);
+	  M = promote(B^-1, P) * M * promote(A, P);
+	  );
+     -- Attach symbolicForm labels: source basis = std tabs of mu, target = std tabs of lambda.
+     attachBasisLabels(M, pmStdTabsByConv(n, mu, conv),
+	  pmStdTabsByConv(n, lambda, conv))
+     )
+
+-------------------------------------------------------------------------------
+-- pieriColumn: native column-form Pieri (vertical strip removal).
+--
+-- pieriColumn(mu, cols, P) where P is a SkewCommutative QQ-algebra with
+-- numgens P = dim V, returns the matrix of the inclusion
+--      S_mu V  -->  ^^k V (x) S_lambda V
+-- where lambda = mu - {bottom box of cols#0, then bottom of cols#1 in the
+-- intermediate shape, ...}.  The columns specified must form a vertical strip
+-- (no two boxes in the same row).  Source basis = standard Fillings of mu;
+-- target basis = standard Fillings of lambda; strip factor in the wedge ring.
+--
+-- The formula is the dual of the Olver row formula with
+--    c'_J = prod_{q intermediate} (mu'_k - mu'_(J_q) + J_q - k)
+-- (the negative of the literal transpose of the row coefficient, accounting
+-- for the wedge anticommutativity).
+-------------------------------------------------------------------------------
+
+pieriColumnHelper = (mu, k, P) -> (
+     ensureSchurFn();
+     n := numgens P;
+     X := gens P;
+     for i from 0 to #mu - 2 do if mu#i < mu#(i+1) then error ("not a partition: " | toString mu);
+     muTrim := trimPartPM mu;
+     muT := conjPartPM muTrim;
+     if k < 1 or k > #muT then error ("column index " | toString k | " out of range");
+     rowToShorten := muT#(k-1);
+     lambda := trimPartPM (for i from 0 to #muTrim - 1 list (if i == rowToShorten - 1 then muTrim#i - 1 else muTrim#i));
+     muTaug := prepend(0, muT);
+     muTcols := muT;
+     lambdaTcols := conjPartPM lambda;
+     Sbasis := sfStandardTabPM(n, muTcols);
+     Tbasis := sfStandardTabPM(n, lambdaTcols);
+     Tidx := new MutableHashTable;
+     for i from 0 to #Tbasis - 1 do Tidx#(toList Tbasis#i) = i;
+     A := {};
+     for p from 0 to k do A = join(A, apply(subsets(toList(1..k-1), p), s -> prepend(0, append(s, k))));
+     colsList := for F in Sbasis list (
+	  s := prepend({}, toList F);
+	  rowVec := new MutableList from toList(#Tbasis : 0_P);
+	  H := new MutableHashTable;
+	  for J in A do (
+	       cJ := 1;
+	       for q from 1 to #J - 2 do cJ = cJ * (muTaug#k - muTaug#(J#q) + J#q - k);
+	       h := new MutableHashTable;
+	       h#s = ((-1)^(#J - 1)) / cJ;
+	       for i from 0 to #J - 2 do (
+		    temp := new MutableHashTable;
+		    for T in keys h do (
+			 coeff := h#T;
+			 srcCol := T#(J#(i+1));
+			 for b from 0 to #srcCol - 1 do (
+			      dropped := srcCol#b;
+			      U := new MutableList from T;
+			      U#(J#(i+1)) = drop(srcCol, {b, b});
+			      U#(J#i) = prepend(dropped, U#(J#i));
+			      sgn := if b % 2 == 0 then 1 else -1;
+			      key := new List from U;
+			      cur := if temp#?key then temp#key else 0;
+			      temp#key = cur + sgn * coeff;
+			      );
+			 );
+		    h = temp;
+		    );
+	       for K in keys h do (
+		    cur := if H#?K then H#K else 0;
+		    H#K = cur + h#K;
+		    );
+	       );
+	  memo := new MutableHashTable;
+	  for T in keys H do (
+	       coeff := H#T;
+	       if coeff == 0 then continue;
+	       if #(T#0) != 1 then error ("internal: prepended col should have 1 entry");
+	       poppedEntry := (T#0)#0;
+	       U := drop(T, 1);
+	       while #U > 0 and #(U#(#U - 1)) == 0 do U = drop(U, -1);
+	       UF := new sfFillingType from U;
+	       UFkey := toList U;
+	       if not memo#?UFkey then memo#UFkey = sfStraightenPM UF;
+	       decomp := memo#UFkey;
+	       for std in keys decomp do (
+		    idx := if Tidx#?(toList std) then Tidx#(toList std) else null;
+		    if idx === null then continue;
+		    rowVec#idx = rowVec#idx + coeff * (decomp#std) * X#poppedEntry;
+		    );
+	       );
+	  toList rowVec
+	  );
+     map(P^(#Tbasis), P^{#Sbasis : -1}, transpose colsList)
+     )
+
+pieriColumn = method(Options => {Convention => "Filling"})
+pieriColumn(List, List, PolynomialRing) := opts -> (mu, cols, P) -> (
+     ensureSchurFn();
+     curMu := trimPartPM mu;
+     for kk in cols do (
+	  if kk < 1 then error "column index must be positive";
+	  muT := conjPartPM curMu;
+	  if kk > #muT then error ("intermediate shape " | toString curMu | " has no column " | toString kk);
+	  rowR := muT#(kk-1);
+	  newMu := trimPartPM (for i from 0 to #curMu - 1 list (if i == rowR - 1 then curMu#i - 1 else curMu#i));
+	  for i from 0 to #newMu - 2 do
+	       if newMu#i < newMu#(i+1) then error "second argument does not specify a vertical strip";
+	  curMu = newMu;
+	  );
+     lambda := curMu;
+     curMu = trimPartPM mu;
+     result := pieriColumnHelper(curMu, cols#0, P);
+     muT := conjPartPM curMu;
+     curMu = trimPartPM (for i from 0 to #curMu - 1 list (if i == muT#(cols#0 - 1) - 1 then curMu#i - 1 else curMu#i));
+     for b from 1 to #cols - 1 do (
+	  stp := pieriColumnHelper(curMu, cols#b, P);
+	  result = stp * result;
+	  muT2 := conjPartPM curMu;
+	  curMu = trimPartPM (for i from 0 to #curMu - 1 list (if i == muT2#(cols#b - 1) - 1 then curMu#i - 1 else curMu#i));
+	  );
+     conv := opts.Convention;
+     n := numgens P;
+     muTrim := trimPartPM mu;
+     if conv =!= "Filling" and conv =!= "Row" and conv =!= "Weyl" then
+	  error ("pieriColumn: invalid Convention " | toString conv);
+     if conv =!= "Filling" then (
+	  -- Convert from native Filling basis to PM basis.
+	  A := pmToFillingMatrix(muTrim, n);
+	  B := fillingToPMMatrix(lambda, n);
+	  result = promote(B, P) * result * promote(A, P);
+	  );
+     attachBasisLabels(result, pmStdTabsByConv(n, muTrim, conv),
+	  pmStdTabsByConv(n, lambda, conv))
      )
 
 pierizero = method()
@@ -363,8 +861,8 @@ pierip(List, List, PolynomialRing) := (mu, boxes, P) -> (
 -- Output:
 -- An inclusion of GL(V)-representations whose graded minimal resolution is pure 
 -- with degree sequence d
-pureFree = method()
-pureFree(List, PolynomialRing) := (d, P) -> (
+pureFree = method(Options => {Convention => "Row"})
+pureFree(List, PolynomialRing) := opts -> (d, P) -> (
      if not isIncreasing(d) then error "The first argument needs to be a strictly increasing list of degrees.";
      e := {};
      for i from 1 to #d-1 do e = append(e, d#i - d#(i-1));
@@ -374,240 +872,1450 @@ pureFree(List, PolynomialRing) := (d, P) -> (
      for i from 1 to #e-1 do
      lambda = append(lambda, lambda#(i-1) - e#i + 1);
      lambda = prepend(counter, drop(lambda, 1));
-     pieri(lambda, toList(e#0 : 1), P) ** P^{-d#0}
+     pieri(lambda, toList(e#0 : 1), P, Convention => opts.Convention) ** P^{-d#0}
      )
 
--------------------
--- Documentation --
--------------------
+-------------------------------------------------------------------------------
+-- Littlewood--Richardson inclusions  Psi_Q : S_lambda V  ->  S_nu V (x) S_mu V
+--
+-- An LR skew tableau Q of shape lambda/mu with content nu encodes, for each
+-- label a in 1..r (r = #nu), a horizontal strip; iterating row-Pieri maps
+-- in the order a = r, r-1, ..., 1 produces a map
+--    S_lambda V  ->  Sym^{nu_r} V (x) ... (x) Sym^{nu_1} V (x) S_mu V.
+-- A final straightening (Schur projection) on the Sym tensor side lands in
+-- S_nu V (x) S_mu V.  Different LR tableaux give linearly independent
+-- inclusions; their span has dimension c^lambda_{mu,nu}.
+-------------------------------------------------------------------------------
+
+-- Pad mu with trailing zeros to length L.
+padPart = (mu, L) -> (
+     if #mu >= L then toList mu else toList mu | toList(L - #mu : 0)
+     )
+
+-- Subtract one from row k (1-indexed).
+subOneRowLR = (mu, k) -> (
+     for i from 0 to #mu - 1 list (if i == k - 1 then mu#i - 1 else mu#i)
+     )
+
+-- Strip rows (1-indexed) for label a (0-indexed) inside an LR filling Q.
+stripRowsForLabel = (Q, a) -> (
+     rows := {};
+     for i from 0 to #Q - 1 do
+     for lab in Q#i do if lab == a then rows = append(rows, i + 1);
+     rows
+     )
+
+-- LR tableau enumerator.  Returns all fillings of lambda/mu with content nu
+-- that satisfy: rows weakly increasing, columns strictly increasing among
+-- skew cells, reverse-reading-word lattice condition.  Each filling is a
+-- list of rows, row i a list of length lambda_i - mu_i with entries in
+-- 0..#nu - 1 (0-indexed labels).
+lrTableaux = method()
+lrTableaux(List, List, List) := (lambda, mu, nu) -> (
+     if sum lambda != sum mu + sum nu then return {};
+     L := #lambda;
+     lam := toList lambda;
+     mm  := padPart(mu, L);
+     for i from 0 to L - 1 do if lam#i < mm#i then return {};
+     r := #nu;
+     rowLens := for i from 0 to L - 1 list lam#i - mm#i;
+     -- Cells in reverse-reading-word order.
+     cells := {};
+     for i from 0 to L - 1 do (
+	  rs := mm#i;
+	  len := rowLens#i;
+	  for t from 0 to len - 1 do cells = append(cells, (i, rs + len - 1 - t));
+	  );
+     cellIndex := new MutableHashTable;
+     for t from 0 to #cells - 1 do cellIndex#(cells#t) = t;
+     isSkewRC := (row, col) -> (
+	  if row < 0 or row >= L then false
+	  else (rs := mm#row; (rs <= col) and (col < rs + rowLens#row))
+	  );
+     assign := new MutableList from toList(#cells : -1);
+     labelCount := new MutableList from toList(r : 0);
+     prefixCount := new MutableList from toList(r : 0);
+     results := new MutableList;
+     backtrack := null;
+     backtrack = idx -> (
+	  if idx == #cells then (
+	       filling := for i from 0 to L - 1 list (
+		    rs := mm#i;
+		    for k from 0 to rowLens#i - 1 list assign#(cellIndex#(i, rs + k))
+		    );
+	       results#(#results) = filling;
+	       return null;
+	       );
+	  (row, col) := cells#idx;
+	  rightLab := if isSkewRC(row, col + 1) then assign#(cellIndex#(row, col + 1)) else r;
+	  aboveLab := -1;
+	  pr := row - 1;
+	  while pr >= 0 do (
+	       if isSkewRC(pr, col) then ( aboveLab = assign#(cellIndex#(pr, col)); pr = -1 )
+	       else pr = pr - 1;
+	       );
+	  for lab from 0 to r - 1 do (
+	       if lab > rightLab then break;
+	       if aboveLab >= 0 and lab <= aboveLab then continue;
+	       if labelCount#lab >= nu#lab then continue;
+	       if lab >= 1 and prefixCount#lab + 1 > prefixCount#(lab - 1) then continue;
+	       assign#(cellIndex#(row, col)) = lab;
+	       labelCount#lab = labelCount#lab + 1;
+	       prefixCount#lab = prefixCount#lab + 1;
+	       backtrack(idx + 1);
+	       assign#(cellIndex#(row, col)) = -1;
+	       labelCount#lab = labelCount#lab - 1;
+	       prefixCount#lab = prefixCount#lab - 1;
+	       );
+	  return null;
+	  );
+     backtrack(0);
+     toList results
+     )
+
+-- The LR inclusion Psi_Q : S_lambda V  ->  S_nu V (x) S_mu V where dim V = n.
+-- Returns a Matrix over QQ whose
+--   columns are indexed by standardTableaux(n, lambda),
+--   rows    are indexed by (SSYT of nu) (x) (SSYT of mu padded to #lambda),
+-- listed in lex order of (T_nu_index, T_mu_index).
+lrMap = method(Options => {Convention => "Row"})
+lrMap(Sequence, List, ZZ) := opts -> (shapes, Q, n) -> (
+     if #shapes != 3 then error "lrMap: first argument must be the sequence (lambda, mu, nu)";
+     lambda := shapes#0;
+     mu := shapes#1;
+     nu := shapes#2;
+     L := #lambda;
+     lam := padPart(lambda, L);
+     r := #nu;
+     -- Auxiliary multi-block ring with r blocks of n variables.  Block a
+     -- (0-indexed) carries the Sym^{nu_a} factor.
+     z := getSymbol "lrz";
+     Pz := QQ[z_(0,0)..z_(r-1, n-1)];
+     -- Build composite Pieri matrix M_1 * M_2 * ... * M_r (r applied first).
+     curShape := lam;
+     composite := null;
+     for tt from 0 to r - 1 do (
+	  aIdx := r - 1 - tt;
+	  rows := stripRowsForLabel(Q, aIdx);
+	  if #rows != nu#aIdx then error "lrMap: strip size mismatch (Q does not match nu)";
+	  zloc := getSymbol "lrzloc";
+	  Ploc := QQ[zloc_0..zloc_(n-1)];
+	  Mloc := pieri(curShape, rows, Ploc);
+	  phi := map(Pz, Ploc, for i from 0 to n - 1 list Pz_(aIdx * n + i));
+	  Mlift := phi Mloc;
+	  if composite === null then composite = Mlift else composite = Mlift * composite;
+	  for rr in rows do curShape = subOneRowLR(curShape, rr);
+	  );
+     Sbasis := standardTableaux(n, lam);
+     Nmu := standardTableaux(n, curShape);
+     Nnu := standardTableaux(n, nu);
+     -- Column index for each source tableau; row index for each (T_nu, T_mu) pair.
+     muIdx := new MutableHashTable;
+     for i from 0 to #Nmu - 1 do muIdx#(Nmu#i) = i;
+     nuIdx := new MutableHashTable;
+     for i from 0 to #Nnu - 1 do nuIdx#(Nnu#i) = i;
+     numRows := #Nnu * #Nmu;
+     numCols := #Sbasis;
+     -- Fill matrix as nested list of QQ rows.
+     entries := new MutableList from for ri from 0 to numRows - 1 list new MutableList from toList(numCols : 0_QQ);
+     straightenH := new MutableHashTable;
+     for j from 0 to #Sbasis - 1 do (
+	  for i from 0 to #Nmu - 1 do (
+	       f := composite_(i, j);
+	       if f == 0 then continue;
+	       for pair in listForm f do (
+		    expv := pair#0;
+		    c := pair#1;
+		    if c == 0 then continue;
+		    tvec := for a from 0 to r - 1 list (
+			 ms := {};
+			 for k from 0 to n - 1 do for kk from 1 to expv#(a*n + k) do ms = append(ms, k);
+			 ms
+			 );
+		    straighten(tvec, straightenH);
+		    decomp := if straightenH#?tvec then straightenH#tvec else new HashTable from {};
+		    for ssyt in keys decomp do (
+			 if not nuIdx#?ssyt then continue;
+			 dc := decomp#ssyt;
+			 ri := nuIdx#ssyt * #Nmu + i;
+			 (entries#ri)#j = (entries#ri)#j + c * dc;
+			 );
+		    );
+	       );
+	  );
+     M := map(QQ^numRows, QQ^numCols, toList apply(entries, r0 -> toList r0));
+     conv := opts.Convention;
+     muPad := if #mu < L then mu | toList(L - #mu : 0) else mu;
+     if conv =!= "Row" and conv =!= "Weyl" and conv =!= "Filling" then
+	  error ("lrMap: Convention must be \"Row\", \"Filling\", or \"Weyl\"");
+     if conv === "Filling" then (
+	  -- Change basis on source (lambda) and on both target factors (nu, mu).
+	  Blam := pmToFillingMatrix(lambda, n);
+	  Bnu  := pmToFillingMatrix(nu, n);
+	  Bmu  := pmToFillingMatrix(muPad, n);
+	  M = (Bnu ** Bmu) * M * (Blam)^-1;
+	  );
+     -- Build target labels: pairs (T_nu, T_mu) in the same lex order the matrix uses.
+     stdsLam := pmStdTabsByConv(n, lambda, conv);
+     stdsNu := pmStdTabsByConv(n, nu, conv);
+     stdsMu := pmStdTabsByConv(n, muPad, conv);
+     tgtLabels := flatten for tNu in stdsNu list for tMu in stdsMu list (tNu, tMu);
+     attachBasisLabels(M, stdsLam, tgtLabels)
+     )
+
+-- Convenience: accept a polynomial ring and use its number of generators.
+lrMap(Sequence, List, PolynomialRing) := opts -> (shapes, Q, P) -> lrMap(shapes, Q, numgens P, Convention => opts.Convention)
+
+-- Pretty-printer for one tableau as a Net (rows stacked, entries 1-indexed
+-- for human readability so they match the displayed mu/nu/lambda shapes).
+netTableau = T -> (
+     if T === {} or all(T, r -> #r == 0) then return net "()";
+     stack apply(T, r -> horizontalJoin apply(r, x -> net (x + 1) | " "))
+     )
+
+-- Apply Psi_Q to one input tableau T of shape lambda; return its image as a
+-- list of triples {coeff, T_nu, T_mu}.  T may be any list of rows of shape
+-- lambda (entries 0..n-1).  Non-standard tableaux are first straightened into
+-- the SSYT basis of S_lambda V; the GL-equivariant inclusion is then applied.
+--
+-- The output triples are filtered to nonzero coefficients and sorted by
+-- (T_nu, T_mu) for deterministic display.
+applyLR = method(Options => {Convention => "Row"})
+applyLR(Sequence, List, BasicList, ZZ) := opts -> (shapes, Q, T, n) -> (
+     if #shapes != 3 then error "applyLR: first argument must be (lambda, mu, nu)";
+     lambda := shapes#0;
+     mu := shapes#1;
+     nu := shapes#2;
+     L := #lambda;
+     conv := opts.Convention;
+     -- Build the LR matrix in the chosen convention.
+     M := lrMap(shapes, Q, n, Convention => conv);
+     muPad := if #mu < L then mu | toList(L - #mu : 0) else mu;
+     -- Build source basis and look up T via convention-specific straightening.
+     local Sb;
+     local Nmu;
+     local Nnu;
+     local Tcoords;
+     if conv === "Row" or conv === "Weyl" then (
+	  Sb = standardTableaux(n, lambda);
+	  Nmu = standardTableaux(n, muPad);
+	  Nnu = standardTableaux(n, nu);
+	  Tlist := apply(toList T, r -> sort toList r);
+	  h := new MutableHashTable;
+	  straighten(Tlist, h);
+	  decomp := if h#?Tlist then h#Tlist else new HashTable from {};
+	  idx := new MutableHashTable;
+	  for i from 0 to #Sb - 1 do idx#(Sb#i) = i;
+	  Tcoords = new MutableList from toList(#Sb : 0_QQ);
+	  for K in keys decomp do
+	       if idx#?K then Tcoords#(idx#K) = decomp#K;
+	  )
+     else if conv === "Filling" then (
+	  ensureSchurFn();
+	  Sb = sfStandardTabPM(n, conjPartPM lambda);
+	  Nmu = sfStandardTabPM(n, conjPartPM muPad);
+	  Nnu = sfStandardTabPM(n, conjPartPM nu);
+	  Tcast := if instance(T, sfFillingType) then T else new sfFillingType from toList T;
+	  decompF := sfStraightenPM Tcast;
+	  idxF := new MutableHashTable;
+	  for i from 0 to #Sb - 1 do idxF#(toList Sb#i) = i;
+	  Tcoords = new MutableList from toList(#Sb : 0_QQ);
+	  for K in keys decompF do (
+	       Klist := toList K;
+	       if idxF#?Klist then Tcoords#(idxF#Klist) = decompF#K;
+	       );
+	  )
+     else error ("applyLR: invalid Convention " | toString conv);
+     Tcol := transpose matrix {toList Tcoords};
+     wcol := M * Tcol;
+     out := new MutableList;
+     for r from 0 to numRows wcol - 1 do (
+	  v := wcol_(r, 0);
+	  if v == 0 then continue;
+	  i := r // (#Nmu);
+	  jj := r % (#Nmu);
+	  out#(#out) = {v, Nnu#i, Nmu#jj};
+	  );
+     toList out
+     )
+
+-- Pretty-print the result of applyLR as a sum  c_i * T_nu^(i) ⊗ T_mu^(i).
+-- Each term is rendered with the coefficient (as a single-line string) on the
+-- top row and the two tableaux side-by-side, separated by "⊗".
+displayLRImage = method()
+displayLRImage List := terms -> (
+     if #terms == 0 then return net "0";
+     parts := for trip in terms list (
+         c := trip#0;
+         Tnu := trip#1;
+         Tmu := trip#2;
+         coeffStr := if c == 1 then "  +  "
+                     else if c == -1 then "  -  "
+                     else (
+                          s := toString c;
+                          if c > 0 then "  +  " | s | " . "
+                          else "  -  " | substring(s, 1) | " . "
+                          );
+         horizontalJoin {coeffStr, "[", netTableau Tnu, "] ⊗ [", netTableau Tmu, "]"}
+         );
+     -- Drop the leading "+ " from the very first term.
+     first0 := parts#0;
+     parts0 := if #(toString first0) > 0 then (
+          firstStr := toString first0;
+          (replace("^  \\+  ", "    ", firstStr));
+          first0  -- keep as-is for now; stacking handles it
+          ) else first0;
+     stack parts
+     )
+
+-------------------------------------------------------------------------------
+-- verifyWellDefined: check that an LR map respects the straightening
+-- relations of the chosen tableau convention.
+--
+-- Strategy.  For each "test" non-standard tableau T of shape lambda:
+--   (a) compute  applyLR(shapes, Q, T, n, Convention => conv)  directly;
+--   (b) independently straighten T via the convention's straightening into a
+--       sum  T = sum_i c_i T_std_i;
+--   (c) compute  sum_i c_i applyLR(shapes, Q, T_std_i, n, Convention => conv);
+--   (d) verify (a) and (c) agree.
+--
+-- Returns true on success.  Prints offending case and returns false on
+-- failure.
+-------------------------------------------------------------------------------
+
+genNonStdTableauxPM = (lambda, n, convention) -> (
+     out := {};
+     if convention === "Filling" then (
+	  ensureSchurFn();
+	  shape := conjPartPM lambda;
+	  stdF := sfStandardTabPM(n, shape);
+	  if #stdF == 0 then return {};
+	  for F in stdF do (
+	       Fl := apply(toList F, toList);
+	       for c from 0 to #Fl - 1 do (
+		    if #(Fl#c) >= 2 then (
+			 swapped := for j from 0 to #(Fl#c) - 1 list (
+			      if j == 0 then (Fl#c)#1
+			      else if j == 1 then (Fl#c)#0
+			      else (Fl#c)#j
+			      );
+			 newF := for cc from 0 to #Fl - 1 list (if cc == c then swapped else Fl#cc);
+			 out = append(out, new sfFillingType from newF);
+			 if #out >= 3 then return out;
+			 );
+		    );
+	       );
+	  ) else (
+	  std := standardTableaux(n, lambda);
+	  if #std == 0 then return {};
+	  for T in std do (
+	       for ri from 0 to #T - 1 do (
+		    if #(T#ri) >= 2 and (T#ri)#0 != (T#ri)#1 then (
+			 swapped := for j from 0 to #(T#ri) - 1 list (
+			      if j == 0 then (T#ri)#1
+			      else if j == 1 then (T#ri)#0
+			      else (T#ri)#j
+			      );
+			 newT := for rr from 0 to #T - 1 list (if rr == ri then swapped else T#rr);
+			 out = append(out, newT);
+			 if #out >= 3 then return out;
+			 );
+		    );
+	       );
+	  );
+     out
+     )
+
+straightenByConvPM = (T, convention) -> (
+     if convention === "Row" or convention === "Weyl" then (
+	  Tlist := apply(toList T, r -> sort toList r);
+	  h := new MutableHashTable;
+	  straighten(Tlist, h);
+	  if h#?Tlist then h#Tlist else new HashTable from {}
+	  )
+     else if convention === "Filling" then (
+	  ensureSchurFn();
+	  Tcast := if instance(T, sfFillingType) then T else new sfFillingType from toList T;
+	  sfStraightenPM Tcast
+	  )
+     else error "straightenByConv: invalid convention"
+     )
+
+-- Generic well-definedness driver for an apply-style function whose output
+-- pairs are {value, basisKey}.  Compares applyFn(T) (T non-standard) against
+-- sum c_i * applyFn(T_std_i) where T = sum c_i T_std_i in the Schur module.
+testWellDefinedTwoTuple0 = (applyFn, srcShape, n, conv, zeroVal, verbose) -> (
+     tests := genNonStdTableauxPM(srcShape, n, conv);
+     if #tests == 0 then (
+	  if verbose then stdio << "  (no non-standard test tableaux for " << toString srcShape << " in convention " << conv << ")" << endl;
+	  return true;
+	  );
+     ok := true;
+     for T in tests do (
+	  imgD := applyFn T;
+	  decomp := straightenByConvPM(T, conv);
+	  imgM := new MutableHashTable;
+	  for K in keys decomp do (
+	       c := decomp#K;
+	       img := applyFn K;
+	       for pair in img do (
+		    key := if class pair#1 === List then pair#1 else toList pair#1;
+		    cur := if imgM#?key then imgM#key else zeroVal;
+		    imgM#key = cur + c * pair#0;
+		    );
+	       );
+	  imgDmap := new MutableHashTable;
+	  for pair in imgD do (
+	       key := if class pair#1 === List then pair#1 else toList pair#1;
+	       imgDmap#key = pair#0;
+	       );
+	  allKeys := unique (keys imgDmap | keys imgM);
+	  caseOk := true;
+	  for k in allKeys do (
+	       a := if imgDmap#?k then imgDmap#k else zeroVal;
+	       b := if imgM#?k then imgM#k else zeroVal;
+	       if a != b then caseOk = false;
+	       );
+	  if not caseOk then (
+	       ok = false;
+	       if verbose then stdio << "  FAIL on T = " << toString T << endl;
+	       );
+	  );
+     ok
+     );
+
+verifyWellDefined = method(Options => {Convention => "Row", Verbose => true, Direction => "Inclusion"})
+
+-- pieri / pieriColumn / dualPieri / dualPieriColumn well-definedness.
+-- The PolynomialRing P determines which family: SkewCommutative => "column" form
+-- (pieriColumn / dualPieriColumn), else symmetric (pieri / dualPieri).  The
+-- Direction option chooses inclusion vs projection (default "Inclusion").
+verifyWellDefined(List, List, PolynomialRing) := opts -> (mu, boxes, P) -> (
+     n := numgens P;
+     conv := opts.Convention;
+     skewP := isSkewCommutative P;
+     dual := opts.Direction === "Dual";
+     verbose := opts.Verbose;
+     if dual then (
+	  -- Dual: source = wedge/Sym^d V (x) S_lambda; vary the S_lambda factor.
+	  lambda := mu;
+	  for b in boxes do lambda = subtractOne(lambda, b);
+	  while #lambda > 0 and lambda#-1 == 0 do lambda = drop(lambda, -1);
+	  d := #boxes;
+	  monBasis := flatten entries basis(d, P);
+	  if #monBasis == 0 then return true;
+	  poly := monBasis#0;
+	  applyFn := if skewP then
+	       (T -> applyDualPieriColumn((mu, boxes), poly, T, n, Convention => conv))
+	  else (T -> applyDualPieri((mu, boxes), poly, T, n, Convention => conv));
+	  testWellDefinedTwoTuple0(applyFn, lambda, n, conv, 0_QQ, verbose)
+	  )
+     else (
+	  -- Inclusion: source = S_mu; vary T_mu.
+	  applyFnInc := if skewP then
+	       (Targ -> applyPieriColumn((mu, boxes), Targ, P, Convention => conv))
+	  else (Targ -> applyPieri((mu, boxes), Targ, P, Convention => conv));
+	  testWellDefinedTwoTuple0(applyFnInc, mu, n, conv, 0_P, verbose)
+	  )
+     );
+
+verifyWellDefined(Sequence, List, ZZ) := opts -> (shapes, Q, n) -> (
+     if opts.Direction === "Dual" then (
+	  -- Dual LR: source = S_nu (x) S_mu; vary T_mu (we just pick one factor).
+	  (lamD, muD, nuD) := shapes;
+	  convD := opts.Convention;
+	  -- Pick a fixed standard T_nu for the test.
+	  stdsNuD := pmStdTabsByConv(n, nuD, convD);
+	  if #stdsNuD == 0 then return true;
+	  TnuD := stdsNuD#0;
+	  muPadD := muD | toList(#lamD - #muD : 0);
+	  applyFnD := (TmuArg -> applyDualLR(shapes, Q, {TnuD, TmuArg}, n, Convention => convD));
+	  return testWellDefinedTwoTuple0(applyFnD, muPadD, n, convD, 0_QQ, opts.Verbose);
+	  );
+     conv := opts.Convention;
+     verbose := opts.Verbose;
+     lambda := shapes#0;
+     tests := genNonStdTableauxPM(lambda, n, conv);
+     if #tests == 0 then (
+	  if verbose then stdio << "verifyWellDefined: no non-standard test tableaux for shape " << toString lambda << " in convention " << conv << "; nothing to verify." << endl;
+	  return true;
+	  );
+     ok := true;
+     numTests := 0;
+     for T in tests do (
+	  numTests = numTests + 1;
+	  imgD := applyLR(shapes, Q, T, n, Convention => conv);
+	  decomp := straightenByConvPM(T, conv);
+	  imgM := new MutableHashTable;
+	  for K in keys decomp do (
+	       c := decomp#K;
+	       img := applyLR(shapes, Q, K, n, Convention => conv);
+	       for trip in img do (
+		    key := (toList trip#1, toList trip#2);
+		    cur := if imgM#?key then imgM#key else 0;
+		    imgM#key = cur + c * trip#0;
+		    );
+	       );
+	  imgDmap := new MutableHashTable;
+	  for trip in imgD do imgDmap#(toList trip#1, toList trip#2) = trip#0;
+	  allKeys := unique (keys imgDmap | keys imgM);
+	  caseOk := true;
+	  for k in allKeys do (
+	       a := if imgDmap#?k then imgDmap#k else 0;
+	       b := if imgM#?k then imgM#k else 0;
+	       if a != b then (
+		    caseOk = false;
+		    if verbose then
+			 stdio << "  MISMATCH at " << toString k
+			       << ": direct=" << a << " manual=" << b << endl;
+		    );
+	       );
+	  if not caseOk then (
+	       ok = false;
+	       if verbose then stdio << "  Test #" << numTests << " (T = " << toString T << "): FAIL" << endl;
+	       )
+	  else if verbose then
+	       stdio << "  Test #" << numTests << " (T = " << toString T << "): OK" << endl;
+	  );
+     if verbose then
+	  stdio << "verifyWellDefined: " << numTests << " test(s) " << (if ok then "all PASSED" else "FAILED") << " for convention " << conv << "." << endl;
+     ok
+     )
+
+-- ====================================================================
+--  Dual maps (projection direction).
+--
+--  By Schur's lemma, a GL_n-equivariant projection
+--      Sym^d V (x) S_lambda V --> S_mu V         (when mu = lambda + horizontal d-strip)
+--      S_nu V (x) S_mu V     --> S_lambda V       (per LR tableau Q)
+--  is unique up to scalar.  We construct each by stacking the relevant
+--  inclusions for ALL summands of the source (Pieri's rule for the first,
+--  the full LR decomposition for the second), inverting the resulting
+--  square matrix, and reading off the rows for our chosen target.
+--
+--  This guarantees `dualPieri ∘ pieri = Id` exactly.
+-- ====================================================================
+
+-- Enumerate (mu', canonicalBoxes) for every mu' = lambda + horizontal
+-- d-strip with at most n rows.  canonicalBoxes is the list of row
+-- indices (1-indexed) sorted ascending.
+pmAddableHStrips = (lambda, d, n) -> (
+     lam := lambda;
+     while #lam > 0 and lam#-1 == 0 do lam = drop(lam, -1);
+     if #lam > n then return {};
+     lamPad := lam | toList(n - #lam : 0);
+     out := {};
+     for comp in compositions(n, d) do (
+	  muNew := for i from 0 to n-1 list lamPad_i + comp_i;
+	  if not all(0..n-2, i -> muNew_i >= muNew_(i+1)) then continue;
+	  -- horizontal strip: each column has at most one new cell, i.e.
+	  -- muNew_(i+1) <= lamPad_i for all i.
+	  if not all(0..n-2, i -> muNew_(i+1) <= lamPad_i) then continue;
+	  muTrim := muNew;
+	  while #muTrim > 0 and muTrim#-1 == 0 do muTrim = drop(muTrim, -1);
+	  boxes := flatten for i from 0 to n-1 list toList((comp_i):(i+1));
+	  out = append(out, (muTrim, boxes));
+	  );
+     out
+     );
+
+-- All partitions of n with at most maxParts parts.
+pmPartitionsAtMost = (n, maxParts) ->
+     select(toList partitions n, p -> #(toList p) <= maxParts);
+
+-- Enumerate (mu', canonicalCols) for every mu' = lambda + vertical d-strip
+-- with at most n rows.  canonicalCols is the list of column indices (1-indexed)
+-- where boxes are added, sorted descending so iterated single-column removal
+-- yields valid intermediate partitions.
+pmAddableVStrips = (lambda, d, n) -> (
+     lam := lambda;
+     while #lam > 0 and lam#-1 == 0 do lam = drop(lam, -1);
+     if #lam > n then return {};
+     lamPad := lam | toList(n - #lam : 0);
+     out := {};
+     for sub in subsets(toList(0..n-1), d) do (
+	  muNew := for i from 0 to n-1 list (lamPad_i + (if member(i, sub) then 1 else 0));
+	  if not all(0..n-2, i -> muNew_i >= muNew_(i+1)) then continue;
+	  muTrim := muNew;
+	  while #muTrim > 0 and muTrim#-1 == 0 do muTrim = drop(muTrim, -1);
+	  -- For each row r in sub, the new box is at column lamPad_r + 1.
+	  -- Sort by column descending (with ties broken by lower row first) so
+	  -- iterated pieriColumn produces valid intermediate partitions.
+	  pairs := sort apply(sub, r -> (lamPad_r + 1, r));
+	  pairs = reverse pairs;
+	  cols := apply(pairs, p -> p#0);
+	  out = append(out, (muTrim, cols));
+	  );
+     out
+     );
+
+-- Encode a P-matrix M (dim_lambda x dim_mu, entries deg d) as a K-matrix
+-- of size (dim_lambda * #monBasis) x dim_mu.  Row index = (T_lambda, alpha)
+-- in lex order with T_lambda outer (block size #monBasis), alpha inner.
+pmEncodePieriKMat = (M, monBasis, K) -> (
+     dimLam := numRows M;
+     dimMu  := numColumns M;
+     matrix(K, flatten for tLam from 0 to dimLam-1 list (
+	       for alpha in monBasis list (
+		    for tMu from 0 to dimMu-1 list (
+			 lift(coefficient(alpha, M_(tLam, tMu)), K)
+			 )
+		    )
+	       ))
+     );
+
+-- ====================================================================
+-- Dual-map block factorization cache.
+--
+-- dualPieri / dualPieriColumn / dualLR all build the same stacked
+-- block matrix A and only differ in which rows of A^{-1} they extract.
+-- Caching A by (kind, lambda, d, n, K, conv) (resp. (mu, nu, n, K, conv)
+-- for LR) lets sibling calls share the heavy block construction, and
+-- using `solve` instead of `A^{-1}` extracts only the rows we want
+-- (cost O(N^2 * blockSize) instead of O(N^3) for a full inverse).
+--
+-- A typical workflow projects onto many sister summands of the same
+-- ambient tensor product; the cache turns those into nearly-free calls.
+-- ====================================================================
+
+pmDualBlockCache = new MutableHashTable;
+
+-- Sign of the permutation that takes `ref` to `a` (assuming both are
+-- permutations of the same multiset).  Returns 0 if the multisets do
+-- not match.  Equal entries are treated as indistinguishable.
+pmPermSign = (a, ref) -> (
+     n := #a;
+     if n =!= #ref then return 0;
+     b := new MutableList from ref;
+     sgn := 1;
+     for i from 0 to n - 1 do (
+	  if b#i === a#i then continue;
+	  j := i + 1;
+	  while j < n and b#j =!= a#i do j = j + 1;
+	  if j >= n then return 0;
+	  tmp := b#i; b#i = b#j; b#j = tmp;
+	  sgn = -sgn;
+	  );
+     sgn
+     );
+
+-- Build (or look up) the stacked K-matrix and addable-strips list for
+-- the horizontal-strip dual map at parameters (lambda, d, n, conv).
+-- Returns (addable, A, offsets) with offsets#i = first column of block i.
+pmGetDualHBlocks = (lambda, d, n, conv, P, K) -> (
+     key := ("row", toList lambda, d, n, K, conv);
+     if pmDualBlockCache#?key then return pmDualBlockCache#key;
+     monBasis := flatten entries basis(d, P);
+     addable := pmAddableHStrips(lambda, d, n);
+     blocks := for pair in addable list (
+	  (muI, canBoxes) := pair;
+	  pmEncodePieriKMat(
+	       pieri(muI, canBoxes, P, Convention => conv),
+	       monBasis, K)
+	  );
+     A := fold((a, b) -> a | b, blocks);
+     offsets := new MutableList from {0};
+     for blk in blocks do offsets#(#offsets) = (last toList offsets) + numColumns blk;
+     val := (addable, A, toList offsets);
+     pmDualBlockCache#key = val;
+     val
+     );
+
+-- Vertical-strip analogue.  Requires P SkewCommutative.
+pmGetDualVBlocks = (lambda, d, n, conv, P, K) -> (
+     key := ("col", toList lambda, d, n, K, conv);
+     if pmDualBlockCache#?key then return pmDualBlockCache#key;
+     monBasis := flatten entries basis(d, P);
+     addable := pmAddableVStrips(lambda, d, n);
+     blocks := for pair in addable list (
+	  (muI, canCols) := pair;
+	  pmEncodePieriKMat(
+	       pieriColumn(muI, canCols, P, Convention => conv),
+	       monBasis, K)
+	  );
+     A := fold((a, b) -> a | b, blocks);
+     offsets := new MutableList from {0};
+     for blk in blocks do offsets#(#offsets) = (last toList offsets) + numColumns blk;
+     val := (addable, A, toList offsets);
+     pmDualBlockCache#key = val;
+     val
+     );
+
+-- Stacked LR-block matrix for dualLR with parameters (mu, nu, n, conv).
+-- The key intentionally omits lambda (the target), since the same
+-- decomposition supports projection onto every summand at once.
+pmGetDualLRBlocks = (mu, nu, n, conv) -> (
+     key := ("lr", toList mu, toList nu, n, conv);
+     if pmDualBlockCache#?key then return pmDualBlockCache#key;
+     totalCells := sum mu + sum nu;
+     cands := apply(pmPartitionsAtMost(totalCells, n), p -> toList p);
+     blocks := {};
+     blockInfo := {};
+     for lamP in cands do (
+	  lrTabs := lrTableaux(lamP, mu, nu);
+	  for Qp in lrTabs do (
+	       blocks = append(blocks,
+		    lrMap((lamP, mu, nu), Qp, n, Convention => conv));
+	       blockInfo = append(blockInfo, (lamP, Qp));
+	       );
+	  );
+     if #blocks == 0 then error "dualLR: no GL_n summands in S_nu V (x) S_mu V";
+     A := fold((a, b) -> a | b, blocks);
+     if numRows A =!= numColumns A then
+	  error "dualLR: stacked LR matrix not square (decomposition incomplete)";
+     offsets := new MutableList from {0};
+     for blk in blocks do offsets#(#offsets) = (last toList offsets) + numColumns blk;
+     val := (blockInfo, A, toList offsets);
+     pmDualBlockCache#key = val;
+     val
+     );
+
+-- Extract rows [startRow .. startRow + blockSize - 1] of A^{-1} via a
+-- single `solve` against a block of standard-basis columns, avoiding
+-- the cost (and memory) of forming the full inverse.
+--
+-- Math: if Y is the desired row block, then Y * A = E where E is the
+-- (blockSize x N) "rectangular identity" picking out those rows, so
+-- transpose(A) * transpose(Y) = transpose(E), giving
+--    Y = transpose solve(transpose A, transpose E).
+pmDualSolveRows = (A, startRow, blockSize) -> (
+     N := numRows A;
+     K := ring A;
+     E := submatrix(id_(K^N), , toList(startRow .. startRow + blockSize - 1));
+     transpose solve(transpose A, E)
+     );
+
+
+dualPieri = method(Options => {Convention => "Row"})
+dualPieri(List, List, PolynomialRing) := opts -> (mu, boxes, P) -> (
+     n := numgens P;
+     d := #boxes;
+     K := coefficientRing P;
+     -- Normalize boxes to canonical (sorted ascending) order so the
+     -- result matches `pieri(mu, sort boxes, P)` exactly on round trip.
+     -- (Different orderings of the same box-multiset produce pieri
+     -- matrices that differ by a scalar, so we standardize.)
+     canBoxes := sort toList boxes;
+     lambda := mu;
+     for b in canBoxes do lambda = subtractOne(lambda, b);
+     while #lambda > 0 and lambda#-1 == 0 do lambda = drop(lambda, -1);
+     (addable, A, offsets) := pmGetDualHBlocks(lambda, d, n, opts.Convention, P, K);
+     muIdx := position(addable, p -> p#0 == mu);
+     if muIdx === null then error("dualPieri: mu = " | toString mu
+	  | " is not a horizontal " | toString d
+	  | "-strip addition to lambda = " | toString lambda
+	  | " in " | toString n | " variables");
+     startRow := offsets#muIdx;
+     dimMu := offsets#(muIdx + 1) - startRow;
+     N := pmDualSolveRows(A, startRow, dimMu);
+     -- Source basis: pairs (T_lambda, alpha) in lex order with T_lambda outer
+     -- (matches pmEncodePieriKMat's row layout).  Target basis: T_mu.
+     monBasis := flatten entries basis(d, P);
+     stdsLam := pmStdTabsByConv(n, lambda, opts.Convention);
+     stdsMu := pmStdTabsByConv(n, mu, opts.Convention);
+     srcLabels := flatten for tLam in stdsLam list for alpha in monBasis list (tLam, alpha);
+     attachBasisLabels(N, srcLabels, stdsMu)
+     );
+
+dualLR = method(Options => {Convention => "Row"})
+dualLR(Sequence, List, ZZ) := opts -> (shapes, Q, n) -> (
+     (lambda, mu, nu) := shapes;
+     (blockInfo, A, offsets) := pmGetDualLRBlocks(mu, nu, n, opts.Convention);
+     idx := position(blockInfo,
+	  pair -> pair#0 == lambda and pair#1 == Q);
+     if idx === null then error("dualLR: (lambda, Q) not found in LR decomposition of S_nu V (x) S_mu V");
+     startRow := offsets#idx;
+     dimLam := offsets#(idx + 1) - startRow;
+     N := pmDualSolveRows(A, startRow, dimLam);
+     -- Source basis: pairs (T_nu, T_mu) in lex order matching the lrMap row layout.
+     muPad := mu | toList(#lambda - #mu : 0);
+     stdsLam := pmStdTabsByConv(n, lambda, opts.Convention);
+     stdsNu := pmStdTabsByConv(n, nu, opts.Convention);
+     stdsMu := pmStdTabsByConv(n, muPad, opts.Convention);
+     srcLabels := flatten for tNu in stdsNu list for tMu in stdsMu list (tNu, tMu);
+     attachBasisLabels(N, srcLabels, stdsLam)
+     );
+
+dualLR(Sequence, List, PolynomialRing) := opts -> (shapes, Q, P) ->
+     dualLR(shapes, Q, numgens P, opts);
+
+-- dualPieriColumn: GL-equivariant projection wedge^d V (x) S_lambda V --> S_mu V
+-- where mu = lambda + vertical d-strip.  Cached stack-and-solve construction
+-- analogous to dualPieri.  The cache uses the canonical column ordering
+-- produced by pmAddableVStrips; if the user passes a permuted cols list,
+-- a single sign flip suffices since pieriColumn is sgn-equivariant under
+-- column permutation (the wedge factor is antisymmetric).
+-- Requires P to be a SkewCommutative ring (the wedge factor is encoded there).
+dualPieriColumn = method(Options => {Convention => "Filling"})
+dualPieriColumn(List, List, PolynomialRing) := opts -> (mu, cols, P) -> (
+     n := numgens P;
+     d := #cols;
+     K := coefficientRing P;
+     -- Compute lambda = mu after the cols vertical strip is removed.
+     curMu := trimPartPM mu;
+     for kk in cols do (
+	  muT := conjPartPM curMu;
+	  rowR := muT#(kk-1);
+	  curMu = trimPartPM (for i from 0 to #curMu - 1 list (if i == rowR - 1 then curMu#i - 1 else curMu#i));
+	  );
+     lambda := curMu;
+     (addable, A, offsets) := pmGetDualVBlocks(lambda, d, n, opts.Convention, P, K);
+     muTrim := trimPartPM mu;
+     muIdx := position(addable, p -> p#0 == muTrim);
+     if muIdx === null then error("dualPieriColumn: mu = " | toString mu
+	  | " is not a vertical " | toString d | "-strip addition to lambda = "
+	  | toString lambda | " in " | toString n | " variables");
+     -- Sign correction: A was built with the canonical cols ordering.
+     canCols := addable#muIdx#1;
+     sgn := pmPermSign(toList cols, canCols);
+     if sgn == 0 then error("dualPieriColumn: cols " | toString cols
+	  | " are not a permutation of canonical cols " | toString canCols);
+     startRow := offsets#muIdx;
+     dimMu := offsets#(muIdx + 1) - startRow;
+     N := pmDualSolveRows(A, startRow, dimMu);
+     if sgn == -1 then N = -N;
+     monBasis := flatten entries basis(d, P);
+     stdsLam := pmStdTabsByConv(n, lambda, opts.Convention);
+     stdsMu := pmStdTabsByConv(n, muTrim, opts.Convention);
+     srcLabels := flatten for tLam in stdsLam list for alpha in monBasis list (tLam, alpha);
+     attachBasisLabels(N, srcLabels, stdsMu)
+     );
+
+-- applyDualPieriColumn: point evaluation of dualPieriColumn on a basis pair
+-- (wedge_polynomial, T_lambda).  Returns a list of {coefficient, T_mu} pairs.
+applyDualPieriColumn = method(Options => {Convention => "Filling"})
+applyDualPieriColumn(Sequence, RingElement, BasicList, ZZ) := opts ->
+     (muCols, poly, Tlam, n) -> (
+     if poly == 0 then return {};
+     P := ring poly;
+     d := #(muCols#1);
+     if not isHomogeneous poly or first degree poly =!= d then
+	  error("applyDualPieriColumn: poly must be homogeneous of degree d = " | toString d);
+     K := coefficientRing P;
+     monBasis := flatten entries basis(d, P);
+     (mu, cols) := muCols;
+     -- compute lambda
+     curMu := trimPartPM mu;
+     for kk in cols do (
+	  muT := conjPartPM curMu;
+	  rowR := muT#(kk-1);
+	  curMu = trimPartPM (for i from 0 to #curMu - 1 list (if i == rowR - 1 then curMu#i - 1 else curMu#i));
+	  );
+     lambda := curMu;
+     coordsLam := pmTableauToCoords(Tlam, lambda, n, opts.Convention);
+     polyCoords := for alpha in monBasis list lift(coefficient(alpha, poly), K);
+     sourceVec := flatten for c in coordsLam list for pc in polyCoords list c * pc;
+     N := dualPieriColumn(mu, cols, P, Convention => opts.Convention);
+     resultCol := N * transpose matrix(K, {sourceVec});
+     stds := pmStdTabsByConv(n, mu, opts.Convention);
+     for i from 0 to numRows resultCol - 1 list (
+	  c := lift(resultCol_(i, 0), K);
+	  if c != 0 then {c, stds#i} else continue
+	  )
+     );
+
+-- Convert a tableau T to a coordinate vector in the standard basis of
+-- S_shape under the active Convention.
+--
+-- A List is interpreted in the natural form of the convention:
+--   * Convention => "Row" or "Weyl": List = PM row form (rows of the tableau).
+--   * Convention => "Filling":       List = column form (columns of the tableau,
+--                                    top-to-bottom), automatically wrapped as
+--                                    a SchurFunctors Filling.
+-- A Filling argument is always treated as column form (its native meaning),
+-- regardless of the convention -- this lets the user supply a column-form
+-- tableau even in Row/Weyl convention.
+--
+-- Non-standard inputs are straightened first using the convention's
+-- straightening relations (PieriMaps' row-Garnir for Row/Weyl, SchurFunctors'
+-- column-Garnir for Filling).
+pmTableauToCoords = (T, shape, n, conv) -> (
+     ensureSchurFn();
+     if conv === "Filling" then (
+	  stdsF := sfStandardTabPM(n, conjPartPM shape);
+	  Tcast := if class T === sfFillingType then T
+	       else if class T === List then new sfFillingType from T
+	       else error "tableau must be a List (column form) or Filling";
+	  h := sfStraightenPM Tcast;
+	  for s in stdsF list (if h#?s then h#s else 0_QQ)
+	  )
+     else if conv === "Row" or conv === "Weyl" then (
+	  stds := standardTableaux(n, shape);
+	  hRow := if class T === List then straighten T
+	       else if class T === sfFillingType then fillingToPM T
+	       else error "tableau must be a List (PM row form) or Filling (column form)";
+	  for s in stds list (if hRow#?s then hRow#s else 0_QQ)
+	  )
+     else error("unknown Convention: " | toString conv)
+     );
+
+pmStdTabsByConv = (n, shape, conv) -> (
+     if conv === "Filling" then (ensureSchurFn(); sfStandardTabPM(n, conjPartPM shape))
+     else if conv === "Row" or conv === "Weyl" then standardTableaux(n, shape)
+     else error("unknown Convention: " | toString conv)
+     );
+
+-- applyPieri: point evaluation of the inclusion-direction Pieri map.
+-- Takes a single source tableau T of shape mu (List PM-row form, or Filling
+-- column form) and returns the image as a list of {polynomial, T_lambda} pairs:
+-- each polynomial is a homogeneous degree-d form in P encoding the V^d factor.
+-- Non-standard inputs are straightened first via the Convention's relations.
+applyPieri = method(Options => {Convention => "Row"})
+applyPieri(Sequence, BasicList, PolynomialRing) := opts ->
+     (muBoxes, T, P) -> (
+     (mu, boxes) := muBoxes;
+     n := numgens P;
+     K := coefficientRing P;
+     lambda := mu;
+     for b in boxes do lambda = subtractOne(lambda, b);
+     while #lambda > 0 and lambda#-1 == 0 do lambda = drop(lambda, -1);
+     M := pieri(mu, boxes, P, Convention => opts.Convention);
+     coordsMu := pmTableauToCoords(T, mu, n, opts.Convention);
+     sourceVecP := transpose matrix(P, {apply(coordsMu, c -> promote(c, P))});
+     resultCol := M * sourceVecP;
+     stdsLam := pmStdTabsByConv(n, lambda, opts.Convention);
+     for i from 0 to numRows resultCol - 1 list (
+	  f := resultCol_(i, 0);
+	  if f == 0 then continue else {f, stdsLam#i}
+	  )
+     );
+
+-- applyPieriColumn: same but for the column-form Pieri (target wedge^d V).
+-- Requires P to be a SkewCommutative ring (the wedge factor is encoded there).
+applyPieriColumn = method(Options => {Convention => "Filling"})
+applyPieriColumn(Sequence, BasicList, PolynomialRing) := opts ->
+     (muCols, T, P) -> (
+     (mu, cols) := muCols;
+     n := numgens P;
+     K := coefficientRing P;
+     -- Compute lambda by removing the vertical strip described by cols.
+     curMu := trimPartPM mu;
+     for kk in cols do (
+	  muT := conjPartPM curMu;
+	  rowR := muT#(kk-1);
+	  curMu = trimPartPM (for i from 0 to #curMu - 1 list (if i == rowR - 1 then curMu#i - 1 else curMu#i));
+	  );
+     lambda := curMu;
+     M := pieriColumn(mu, cols, P, Convention => opts.Convention);
+     coordsMu := pmTableauToCoords(T, mu, n, opts.Convention);
+     sourceVecP := transpose matrix(P, {apply(coordsMu, c -> promote(c, P))});
+     resultCol := M * sourceVecP;
+     stdsLam := pmStdTabsByConv(n, lambda, opts.Convention);
+     for i from 0 to numRows resultCol - 1 list (
+	  f := resultCol_(i, 0);
+	  if f == 0 then continue else {f, stdsLam#i}
+	  )
+     );
+
+applyDualPieri = method(Options => {Convention => "Row"})
+applyDualPieri(Sequence, RingElement, BasicList, ZZ) := opts ->
+     (muBoxes, poly, Tlam, n) -> (
+     (mu, boxes) := muBoxes;
+     if poly == 0 then return {};
+     P := ring poly;
+     d := #boxes;
+     if not isHomogeneous poly or first degree poly =!= d then
+	  error("applyDualPieri: poly must be homogeneous of degree d = " | toString d);
+     K := coefficientRing P;
+     monBasis := flatten entries basis(d, P);
+     lambda := mu;
+     for b in boxes do lambda = subtractOne(lambda, b);
+     while #lambda > 0 and lambda#-1 == 0 do lambda = drop(lambda, -1);
+     coordsLam := pmTableauToCoords(Tlam, lambda, n, opts.Convention);
+     polyCoords := for alpha in monBasis list lift(coefficient(alpha, poly), K);
+     -- Source basis ordering: (T_lambda outer, alpha inner) -- match dualPieri.
+     sourceVec := flatten for c in coordsLam list for pc in polyCoords list c * pc;
+     N := dualPieri(mu, boxes, P, Convention => opts.Convention);
+     resultCol := N * transpose matrix(K, {sourceVec});
+     stds := pmStdTabsByConv(n, mu, opts.Convention);
+     for i from 0 to numRows resultCol - 1 list (
+	  c := lift(resultCol_(i, 0), K);
+	  if c != 0 then {c, stds#i} else continue
+	  )
+     );
+
+applyDualLR = method(Options => {Convention => "Row"})
+-- NOTE: takes the (Tnu, Tmu) pair as a List {Tnu, Tmu}, not a Sequence,
+-- because M2 flattens nested Sequences in function-call arg lists, but
+-- Lists do not flatten.
+applyDualLR(Sequence, List, List, ZZ) := opts ->
+     (shapes, Q, TnuTmuList, n) -> (
+     if #TnuTmuList =!= 2 then
+	  error "applyDualLR: third argument must be a List {Tnu, Tmu}";
+     (Tnu, Tmu) := (TnuTmuList#0, TnuTmuList#1);
+     (lambda, mu, nu) := shapes;
+     coordsNu := pmTableauToCoords(Tnu, nu, n, opts.Convention);
+     muPad := mu | toList(#lambda - #mu : 0);
+     coordsMu := pmTableauToCoords(Tmu, muPad, n, opts.Convention);
+     -- Source basis ordering: (T_nu outer, T_mu inner) -- matches lrMap row indexing.
+     sourceVec := flatten for cn in coordsNu list for cm in coordsMu list cn * cm;
+     N := dualLR(shapes, Q, n, Convention => opts.Convention);
+     resultCol := N * transpose matrix(QQ, {sourceVec});
+     stds := pmStdTabsByConv(n, lambda, opts.Convention);
+     for i from 0 to numRows resultCol - 1 list (
+	  c := lift(resultCol_(i, 0), QQ);
+	  if c != 0 then {c, stds#i} else continue
+	  )
+     );
+
+-- ====================================================================
+--  verifyEquivariant: rigorous GL_n-equivariance check.
+--
+--  Tests whether a matrix M between Schur-functor representations
+--  commutes with the action of every Chevalley generator E_{i,j} of
+--  gl_n (i != j), which suffices for full GL_n-equivariance (since the
+--  E_{i,j} together with the diagonal -- under which our weight-graded
+--  matrices commute automatically -- generate gl_n).
+--
+--  Action conventions:
+--   * E_{i,j} acts on V = K^n by  x_l |-> delta_{l,j} * x_i
+--     (i.e. as the differential operator x_i * d/dx_j on polynomials).
+--   * E_{i,j} acts on S_lambda V (PM row-SSYT basis) by replacing each
+--     entry equal to j with i, summing over positions, and applying
+--     row-Garnir straightening.
+--   * E_{i,j} acts on S_lambda V (Filling column basis) similarly but
+--     with SchurFunctors' column-Garnir straightening.
+--   * Action on a tensor product is via Leibniz rule.
+--
+--  Five overloads cover our existing maps:
+--    verifyEquivariant(M, mu, boxes, P)               -- pieri / pieriColumn
+--    verifyEquivariant(M, shapes, n)                  -- lrMap
+--    verifyEquivariant(M, mu, boxes, P, "Dual")       -- dualPieri
+--    verifyEquivariant(M, shapes, n, "Dual")          -- dualLR
+--  In each, the Convention option matches the matrix's basis.
+-- ====================================================================
+
+-- Lie-algebra E_{i,j} action on a PM row-SSYT tableau (List of rows).
+-- Returns a HashTable {std PM tab => coeff}.  Uses PieriMaps' straighten.
+pmActE0 = (i, j, T) -> (
+     totalH := new MutableHashTable;
+     for r from 0 to #T-1 do
+	  for c from 0 to #(T#r)-1 do
+	       if T#r#c == j then (
+		    Tprime := for r2 from 0 to #T-1 list
+			 (if r2 == r then
+			      for c2 from 0 to #(T#r2)-1 list
+				   (if c2 == c then i else (T#r2)#c2)
+			  else T#r2);
+		    h := straighten Tprime;
+		    for k in keys h do
+			 if totalH#?k then totalH#k = totalH#k + h#k
+			 else totalH#k = h#k;
+		    );
+     new HashTable from totalH
+     );
+
+-- E_{i,j} on a Filling F: replace each j entry by i, sum, then run
+-- SchurFunctors' straighten (column-Garnir).  Returns HashTable {std Filling => coeff}.
+-- Cache c_lambda values: the round-trip scalar of pmToFilling/fillingToPM.
+pmCLambdaCache = new MutableHashTable
+
+-- Compute c_lambda for the round-trip pmToFilling -> fillingToPM = c * Id.
+-- We extract it as a diagonal entry of the product matrix.
+pmComputeCLambda = (lambda, n) -> (
+     key := (trimPartPM lambda, n);
+     if pmCLambdaCache#?key then return pmCLambdaCache#key;
+     A := pmToFillingMatrix(lambda, n);
+     B := fillingToPMMatrix(lambda, n);
+     c := (B * A)_(0, 0);
+     pmCLambdaCache#key = c;
+     c
+     );
+
+-- E_{i,j} action on a Filling F of shape `lambda` over K^n.  We route through
+-- the PM round-trip and divide out the c_lambda factor:
+--    E.F  =  (1/c_lambda) * pmToFilling( pmActE0( fillingToPM(F) ) ).
+-- This avoids depending on SchurFunctors' single-argument `straighten Filling`
+-- signature (which can fail to register when SchurFunctors is loaded via
+-- needsPackage *after* PieriMaps).
+pmActEFilling0 = (i, j, F, lambda, n) -> (
+     ensureSchurFn();
+     raw := fillingToPM F;
+     pmResult := new MutableHashTable;
+     for T in keys raw do (
+	  c := raw#T;
+	  actT := pmActE0(i, j, T);
+	  for k in keys actT do
+	       pmResult#k = (if pmResult#?k then pmResult#k else 0_QQ) + c * actT#k;
+	  );
+     fillResult := new MutableHashTable;
+     for T in keys pmResult do (
+	  c := pmResult#T;
+	  fillExp := pmToFilling T;
+	  for F2 in keys fillExp do
+	       fillResult#F2 = (if fillResult#?F2 then fillResult#F2 else 0_QQ) + c * fillExp#F2;
+	  );
+     if #fillResult == 0 then return new HashTable from {};
+     cLam := pmComputeCLambda(lambda, n);
+     new HashTable from for k in keys fillResult list (
+	  if fillResult#k != 0 then k => fillResult#k / cLam else continue
+	  )
+     );
+
+-- Pick the appropriate gl_n action based on Convention.
+-- shape, n: only used in the Filling case (for c_lambda correction).
+pmActEConv0 = (i, j, T, conv, shape, n) -> (
+     if conv === "Row" or conv === "Weyl" then pmActE0(i, j, T)
+     else if conv === "Filling" then pmActEFilling0(i, j, T, shape, n)
+     else error("unknown Convention: " | toString conv)
+     );
+
+verifyEquivariant = method(Options => {Convention => "Row", Verbose => false, Direction => "Inclusion"})
+
+-- Pieri (or pieriColumn) inclusion.  M : S_mu V -> Sym^d V (x) S_lambda V
+-- (or wedge instead of Sym for SkewCommutative P).  M is dim_lambda x dim_mu
+-- over P, entries homogeneous of degree d.
+verifyEquivariant(Matrix, List, List, PolynomialRing) := opts ->
+     (M, mu, boxes, P) -> (
+     if opts.Direction === "Dual" then
+	  return verifyEquivariantDual0(M, mu, boxes, P, opts);
+     n := numgens P;
+     X := gens P;
+     conv := opts.Convention;
+     lambda := mu;
+     for b in boxes do lambda = subtractOne(lambda, b);
+     while #lambda > 0 and lambda#-1 == 0 do lambda = drop(lambda, -1);
+     stdsMu  := pmStdTabsByConv(n, mu,     conv);
+     stdsLam := pmStdTabsByConv(n, lambda, conv);
+     -- Index lookup tables: O(1) replacement for `position(stds, s -> s == k)`.
+     idxOfMu  := hashTable for i from 0 to #stdsMu  - 1 list stdsMu#i  => i;
+     idxOfLam := hashTable for i from 0 to #stdsLam - 1 list stdsLam#i => i;
+     -- Cache columns once per tIdx (used by both LHS and RHS branches).
+     colsM := for tIdx from 0 to #stdsMu - 1 list flatten entries M_{tIdx};
+     ok := true;
+     for i from 0 to n-1 do for j from 0 to n-1 do (
+	  if i == j then continue;
+	  -- Hoist: pmActEConv0(i, j, stdsLam#idx, conv) and (i, j, stdsMu#tIdx, conv)
+	  -- depend ONLY on (i, j, idx) -- not on the outer tIdx loop variable.
+	  -- Without this hoist they'd be recomputed #stdsMu times each.
+	  lamActs := for idx from 0 to #stdsLam - 1 list pmActEConv0(i, j, stdsLam#idx, conv, lambda, n);
+	  muActs  := for tIdx from 0 to #stdsMu - 1 list pmActEConv0(i, j, stdsMu#tIdx, conv, mu, n);
+	  for tIdx from 0 to #stdsMu-1 do (
+	       colT := colsM#tIdx;
+	       -- RHS = E . M(T)
+	       vAction := for f in colT list X#i * diff(X#j, f);
+	       sAction := new MutableList from for s in stdsLam list 0_P;
+	       for idx from 0 to #stdsLam-1 do (
+		    h := lamActs#idx;
+		    for kk in keys h do
+			 if idxOfLam#?kk then
+			      sAction#(idxOfLam#kk) = sAction#(idxOfLam#kk) + h#kk * colT#idx;
+		    );
+	       RHS := for idx from 0 to #stdsLam-1 list (vAction#idx + sAction#idx);
+	       -- LHS = M(E . T)
+	       LHS := new MutableList from for s in stdsLam list 0_P;
+	       hT := muActs#tIdx;
+	       for kk in keys hT do
+		    if idxOfMu#?kk then (
+			 colK := colsM#(idxOfMu#kk);
+			 ck := hT#kk;
+			 for r from 0 to #stdsLam-1 do LHS#r = LHS#r + ck * colK#r;
+			 );
+	       if toList LHS =!= RHS then (
+		    ok = false;
+		    if opts.Verbose then
+			 stdio << "  [verifyEquivariant] FAIL at E_{" << i << "," << j
+			       << "}, T = " << toString stdsMu#tIdx << endl;
+		    );
+	       );
+	  );
+     ok
+     );
+
+-- LR inclusion.  M : S_lambda V -> S_nu V (x) S_mu V.
+-- M is (dim_nu * dim_mu) x dim_lambda over QQ; rows in lex order with T_nu outer.
+verifyEquivariant(Matrix, Sequence, ZZ) := opts -> (M, shapes, n) -> (
+     if opts.Direction === "Dual" then
+	  return verifyEquivariantDualLR0(M, shapes, n, opts);
+     (lambda, mu, nu) := shapes;
+     muPad := mu | toList(#lambda - #mu : 0);
+     conv := opts.Convention;
+     stdsLam := pmStdTabsByConv(n, lambda, conv);
+     stdsMu  := pmStdTabsByConv(n, muPad,  conv);
+     stdsNu  := pmStdTabsByConv(n, nu,     conv);
+     dimNu := #stdsNu; dimMu := #stdsMu; dimLam := #stdsLam;
+     -- Index tables for O(1) tableau-to-position lookups.
+     idxOfLam := hashTable for i from 0 to dimLam-1 list stdsLam#i => i;
+     idxOfMu  := hashTable for i from 0 to dimMu-1  list stdsMu#i  => i;
+     idxOfNu  := hashTable for i from 0 to dimNu-1  list stdsNu#i  => i;
+     -- Cache columns of M.
+     colsM := for tIdx from 0 to dimLam-1 list flatten entries M_{tIdx};
+     ok := true;
+     for i from 0 to n-1 do for j from 0 to n-1 do (
+	  if i == j then continue;
+	  -- Hoist actions: each pmActEConv0(i, j, std, conv) depends only on (i, j, std).
+	  nuActs  := for iN from 0 to dimNu-1  list pmActEConv0(i, j, stdsNu#iN, conv, nu, n);
+	  muActs  := for iM from 0 to dimMu-1  list pmActEConv0(i, j, stdsMu#iM, conv, muPad, n);
+	  lamActs := for iL from 0 to dimLam-1 list pmActEConv0(i, j, stdsLam#iL, conv, lambda, n);
+	  for tIdx from 0 to dimLam-1 do (
+	       colT := colsM#tIdx;
+	       -- RHS = E . M(T): Leibniz on S_nu (x) S_mu
+	       RHSrows := new MutableList from for r from 0 to dimNu*dimMu-1 list 0_QQ;
+	       for iN from 0 to dimNu-1 do for iM from 0 to dimMu-1 do (
+		    coef := colT#(iN*dimMu + iM);
+		    if coef == 0 then continue;
+		    -- E acts on T_nu^{iN}
+		    hN := nuActs#iN;
+		    for kN in keys hN do
+			 if idxOfNu#?kN then
+			      RHSrows#((idxOfNu#kN)*dimMu + iM) = RHSrows#((idxOfNu#kN)*dimMu + iM) + hN#kN * coef;
+		    -- E acts on T_mu^{iM}
+		    hM := muActs#iM;
+		    for kM in keys hM do
+			 if idxOfMu#?kM then
+			      RHSrows#(iN*dimMu + (idxOfMu#kM)) = RHSrows#(iN*dimMu + (idxOfMu#kM)) + hM#kM * coef;
+		    );
+	       RHS := toList RHSrows;
+	       -- LHS = M(E . T)
+	       LHS := new MutableList from for r from 0 to dimNu*dimMu-1 list 0_QQ;
+	       hT := lamActs#tIdx;
+	       for kk in keys hT do
+		    if idxOfLam#?kk then (
+			 colK := colsM#(idxOfLam#kk);
+			 ck := hT#kk;
+			 for r from 0 to dimNu*dimMu-1 do
+			      LHS#r = LHS#r + ck * colK#r;
+			 );
+	       if toList LHS =!= RHS then (
+		    ok = false;
+		    if opts.Verbose then
+			 stdio << "  [verifyEquivariant LR] FAIL at E_{" << i << "," << j
+			       << "}, T = " << toString stdsLam#tIdx << endl;
+		    );
+	       );
+	  );
+     ok
+     );
+
+-- Dual Pieri projection.  M : Sym^d V (x) S_lambda V -> S_mu V.  M is K-matrix
+-- of size dim_mu x (dim_lambda * #monsDeg_d), columns in (T_lambda, alpha) order.
+-- Activated by Direction => "Dual"; with Direction => "Inclusion" (default), the
+-- 4-arg overload above handles the inclusion direction.
+verifyEquivariantDual0 = (M, mu, boxes, P, opts) -> (
+     n := numgens P;
+     X := gens P;
+     d := #boxes;
+     conv := opts.Convention;
+     K := coefficientRing P;
+     monBasis := flatten entries basis(d, P);
+     nMons := #monBasis;
+     lambda := mu;
+     for b in boxes do lambda = subtractOne(lambda, b);
+     while #lambda > 0 and lambda#-1 == 0 do lambda = drop(lambda, -1);
+     stdsMu  := pmStdTabsByConv(n, mu,     conv);
+     stdsLam := pmStdTabsByConv(n, lambda, conv);
+     dimLam := #stdsLam; dimMu := #stdsMu;
+     srcIdx := (iLam, iAlpha) -> iLam * nMons + iAlpha;
+     -- Index tables for O(1) tableau lookup (replaces linear `position`).
+     idxOfLam := hashTable for i from 0 to dimLam-1 list stdsLam#i => i;
+     idxOfMu  := hashTable for i from 0 to dimMu-1  list stdsMu#i  => i;
+     -- Cache all columns of M once (each column read used by many iterations).
+     totalCols := dimLam * nMons;
+     colsM := for c from 0 to totalCols - 1 list flatten entries M_{c};
+     -- Pre-decompose E_{i,j}.x^alpha in the monomial basis ONCE for all alpha.
+     ok := true;
+     for i from 0 to n-1 do for j from 0 to n-1 do (
+	  if i == j then continue;
+	  -- Pre-compute the monomial-decomposition of E.x^alpha for each alpha.
+	  monActDecomp := for iAlpha from 0 to nMons-1 list (
+	       newPoly := X#i * diff(X#j, monBasis#iAlpha);
+	       if newPoly == 0 then {} else
+	            for iA2 from 0 to nMons-1 list (
+			 c := lift(coefficient(monBasis#iA2, newPoly), K);
+			 if c == 0 then continue else (iA2, c)
+			 )
+	       );
+	  -- Pre-compute pmActEConv0(i, j, std, conv) for each std (lam, mu).
+	  lamActs := for iLam from 0 to dimLam-1 list pmActEConv0(i, j, stdsLam#iLam, conv, lambda, n);
+	  muActs  := for iM from 0 to dimMu-1  list pmActEConv0(i, j, stdsMu#iM,  conv, mu, n);
+	  for iLam from 0 to dimLam-1 do for iAlpha from 0 to nMons-1 do (
+	       sIdx := srcIdx(iLam, iAlpha);
+	       -- LHS: M(E . source)
+	       LHS := new MutableList from for r from 0 to dimMu-1 list 0_K;
+	       -- (a) E acts on x^alpha
+	       for pair in monActDecomp#iAlpha do (
+		    (iA2, c) := pair;
+		    colNew := colsM#(srcIdx(iLam, iA2));
+		    for r from 0 to dimMu-1 do LHS#r = LHS#r + c * colNew#r;
+		    );
+	       -- (b) E acts on T_lambda
+	       hL := lamActs#iLam;
+	       for kk in keys hL do
+		    if idxOfLam#?kk then (
+			 colNew := colsM#(srcIdx(idxOfLam#kk, iAlpha));
+			 ck := hL#kk;
+			 for r from 0 to dimMu-1 do LHS#r = LHS#r + ck * colNew#r;
+			 );
+	       -- RHS: E . M(source)
+	       colSource := colsM#sIdx;
+	       RHS := new MutableList from for r from 0 to dimMu-1 list 0_K;
+	       for iM from 0 to dimMu-1 do (
+		    coef := colSource#iM;
+		    if coef == 0 then continue;
+		    hM := muActs#iM;
+		    for kk in keys hM do
+			 if idxOfMu#?kk then
+			      RHS#(idxOfMu#kk) = RHS#(idxOfMu#kk) + hM#kk * coef;
+		    );
+	       if toList LHS =!= toList RHS then (
+		    ok = false;
+		    if opts.Verbose then stdio << "  [verifyEquivariant dualPieri] FAIL at E_{"
+		         << i << "," << j << "}, (T_lambda, alpha) = (" << toString stdsLam#iLam
+			 << ", " << toString monBasis#iAlpha << ")" << endl;
+		    );
+	       );
+	  );
+     ok
+     );
+
+-- Dual LR projection.  M : S_nu V (x) S_mu V -> S_lambda V.  M is QQ-matrix
+-- of size dim_lambda x (dim_nu * dim_mu).
+verifyEquivariantDualLR0 = (M, shapes, n, opts) -> (
+     (lambda, mu, nu) := shapes;
+     muPad := mu | toList(#lambda - #mu : 0);
+     conv := opts.Convention;
+     stdsLam := pmStdTabsByConv(n, lambda, conv);
+     stdsMu  := pmStdTabsByConv(n, muPad,  conv);
+     stdsNu  := pmStdTabsByConv(n, nu,     conv);
+     dimNu := #stdsNu; dimMu := #stdsMu; dimLam := #stdsLam;
+     srcIdx := (iN, iM) -> iN * dimMu + iM;
+     -- Index tables and column cache for O(1) lookups.
+     idxOfLam := hashTable for i from 0 to dimLam-1 list stdsLam#i => i;
+     idxOfMu  := hashTable for i from 0 to dimMu-1  list stdsMu#i  => i;
+     idxOfNu  := hashTable for i from 0 to dimNu-1  list stdsNu#i  => i;
+     totalCols := dimNu * dimMu;
+     colsM := for c from 0 to totalCols - 1 list flatten entries M_{c};
+     ok := true;
+     for i from 0 to n-1 do for j from 0 to n-1 do (
+	  if i == j then continue;
+	  -- Hoist actions: each pmActEConv0(i, j, std, conv) computed once per std.
+	  nuActs  := for iN from 0 to dimNu-1  list pmActEConv0(i, j, stdsNu#iN, conv, nu, n);
+	  muActs  := for iM from 0 to dimMu-1  list pmActEConv0(i, j, stdsMu#iM, conv, muPad, n);
+	  lamActs := for iL from 0 to dimLam-1 list pmActEConv0(i, j, stdsLam#iL, conv, lambda, n);
+	  for iN from 0 to dimNu-1 do for iM from 0 to dimMu-1 do (
+	       sIdx := srcIdx(iN, iM);
+	       -- LHS = M(E . (T_nu (x) T_mu))
+	       LHS := new MutableList from for r from 0 to dimLam-1 list 0_QQ;
+	       hN := nuActs#iN;
+	       for kN in keys hN do
+		    if idxOfNu#?kN then (
+			 colNew := colsM#(srcIdx(idxOfNu#kN, iM));
+			 ck := hN#kN;
+			 for r from 0 to dimLam-1 do LHS#r = LHS#r + ck * colNew#r;
+			 );
+	       hM := muActs#iM;
+	       for kM in keys hM do
+		    if idxOfMu#?kM then (
+			 colNew := colsM#(srcIdx(iN, idxOfMu#kM));
+			 ck := hM#kM;
+			 for r from 0 to dimLam-1 do LHS#r = LHS#r + ck * colNew#r;
+			 );
+	       -- RHS = E . M(source)
+	       colSource := colsM#sIdx;
+	       RHS := new MutableList from for r from 0 to dimLam-1 list 0_QQ;
+	       for iL from 0 to dimLam-1 do (
+		    coef := colSource#iL;
+		    if coef == 0 then continue;
+		    hL := lamActs#iL;
+		    for kk in keys hL do
+			 if idxOfLam#?kk then
+			      RHS#(idxOfLam#kk) = RHS#(idxOfLam#kk) + hL#kk * coef;
+		    );
+	       if toList LHS =!= toList RHS then (
+		    ok = false;
+		    if opts.Verbose then stdio << "  [verifyEquivariant dualLR] FAIL at E_{"
+		         << i << "," << j << "}, (T_nu, T_mu) = (" << toString stdsNu#iN
+			 << ", " << toString stdsMu#iM << ")" << endl;
+		    );
+	       );
+	  );
+     ok
+     );
+
+-- ====================================================================
+--  symbolicForm: pretty-print a labeled matrix as a readable basis-element
+--  map.  Each row of the netList shows a source basis element and its image
+--  as a list of (target_label, coefficient) terms.
+--
+--  When the matrix M was produced by pieri / pieriColumn / lrMap / dualPieri /
+--  dualPieriColumn / dualLR, the source/target labels are pulled from
+--  M.cache.sourceBasis / M.cache.targetBasis.  For other matrices, integer
+--  indices 1..rank are used.
+-- ====================================================================
+-- Pretty-print a PM tableau (List of rows) as a boxed grid, columns top-down.
+prettyPMTabPM = T -> (
+     if T === {} or all(T, r -> #r == 0) then return net "()";
+     width := max apply(T, r -> #r);
+     cols := for j from 0 to width-1 list (
+	  for i from 0 to #T - 1 list (if j < #(T#i) then T#i#j else continue));
+     netList {apply(cols, col -> stack apply(col, e -> net e))}
+     );
+
+-- Heuristic check: does a List look like a row-form tableau (list of lists of integers)?
+isPMTabPM = T -> instance(T, List) and all(T, r -> instance(r, List)) and
+     all(T, r -> all(r, e -> instance(e, ZZ)));
+
+-- Render a single basis label, recursively handling tuples.
+prettyLabelPM = lab -> (
+     if isPMTabPM lab then prettyPMTabPM lab
+     else if instance(lab, Sequence) then (
+	  parts := apply(toList lab, prettyLabelPM);
+	  if #parts == 0 then net "()"
+	  else fold((a, b) -> horizontalJoin {a, net "  ⊗  ", b}, parts)
+	  )
+     else net lab
+     );
+
+-- Render the image of one source basis element (a list of (target_label, coef) pairs).
+prettyImagePM = img -> (
+     if #img == 0 then net "0"
+     else stack apply(img, term -> (
+	       (lab, coef) := (term#0, term#1);
+	       horizontalJoin {net coef, net "  *  ", prettyLabelPM lab}))
+     );
+
+-- Robust label-comparison key.  Lists compare by value automatically; Filling
+-- instances need to be flattened to a List first since they don't have ==.
+labelKeyPM = lab -> (
+     if instance(lab, List) then lab
+     else if instance(lab, Sequence) then toList apply(toList lab, labelKeyPM)
+     else if instance(lab, BasicList) then toList lab
+     else lab
+     );
+
+symbolicForm = method()
+symbolicForm Matrix := M -> (
+     if not M.cache#?"sourceBasis" then
+	  M.cache#"sourceBasis" = toList(1..rank source M);
+     if not M.cache#?"targetBasis" then
+	  M.cache#"targetBasis" = toList(1..rank target M);
+     if not M.cache#?"rule" then (
+	  -- Build label-to-index map once for O(1) lookup.
+	  srcLabels := M.cache#"sourceBasis";
+	  idxOfSrc := hashTable for k from 0 to #srcLabels - 1 list
+	       labelKeyPM(srcLabels#k) => k;
+	  M.cache#"rule" = i -> (
+	       key := labelKeyPM i;
+	       if not idxOfSrc#?key then error "symbolicForm: source label not found";
+	       l := idxOfSrc#key;
+	       col := flatten entries M_{l};
+	       L := positions(col, j -> not(j == 0_(ring M)));
+	       for j in L list ((M.cache#"targetBasis")_j, col_j)
+	       );
+	  );
+     netList for i in M.cache#"sourceBasis" list (
+	  {prettyLabelPM i, prettyImagePM ((M.cache#"rule")(i))})
+     );
+
+----------------------------------------------------------------------
+-- Tests and Documentation are kept in auxiliary files; see PieriMaps/
+----------------------------------------------------------------------
+
+load "./PieriMaps/tests.m2"
 
 beginDocumentation()
-document {
-     Key => PieriMaps,
-     Headline => "Pieri inclusions",
-     "For mathematical background of this package and some examples of use, see:",
-     BR{},
-     "Steven V Sam, Computing inclusions of Schur modules, arXiv:0810.4666",
-     BR{},
-     "Some other references:",
-     BR{},
-     "Andrzej Daszkiewicz, On the Invariant Ideals of the Symmetric Algebra $S.(V \\oplus \\wedge^2 V)$, J. Algebra 125, 1989, 444-473.",
-     BR{},
-     "David Eisenbud, Gunnar Fl\\o ystad, and Jerzy Weyman, The existence of pure free resolutions, arXiv:0709.1529.",
-     BR{},
-     "William Fulton, Young Tableaux: With Applications to Representation Theory and Geometry, London Math. Society Student Texts 35, 1997.",
-     BR{},
-     "Jerzy Weyman, Cohomology of Vector Bundles and Syzygies, Cambridge University Press, 2002.",
-     BR{},
-     BR{},     
-     "Let V be a vector space over K. If K has characteristic 0, then
-     given the partition mu and the partition mu' obtained from mu by
-     removing a single box, there is a unique (up to nonzero scalar)
-     GL(V)-equivariant inclusion S_mu V -> V otimes S_mu' V, where
-     S_mu refers to the irreducible representation of GL(V) with
-     highest weight mu. This can be extended uniquely to a map of P =
-     Sym(V)-modules P otimes S_mu V -> P otimes S_mu' V. The purpose
-     of this package is to write down matrix representatives for these
-     maps. The main function for doing so is ",
-     TO pieri,
-     ". Here is an example of the use of the package PieriMaps, which is also
-     designed to check whether the maps are being constructed correctly
-     (important, since it is notoriously difficult to get the signs and
-     coefficients right.) ",
-     "We will construct by hand the free resolution in 3 variables corresponding
-     to the degree sequence (0,2,3,6). Let's start with the packaged code:",
-     EXAMPLE lines ///
-     R = QQ[a,b,c];
-     f = pureFree({0,2,3,6}, R)
-     betti res coker f
-     ///,
-     "By the general theory from Eisenbud-Fl\\o ystad-Weyman, each of these free
-     modules should be essentially Schur functors corresponding to the
-     following partitions.",
-     EXAMPLE lines ///
-     needsPackage "SchurRings"
-     schurRing(s,3)
-     dim s_{2,2}
-     dim s_{4,2}
-     dim s_{4,3}
-     dim s_{4,3,3}
-     ///,
-     "This package also provides a routine ",
-     TO schurRank,
-     " for computing this dimension:",
-     EXAMPLE lines ///
-     schurRank(3, {2,2})
-     schurRank(3, {4,2})
-     schurRank(3, {4,3})
-     schurRank(3, {4,3,3})
-     ///,
-     "We now use ",
-     TO pieri, 
-     " to construct each of the maps of the resolution separately.",
-     EXAMPLE lines ///
-     f1 = pieri({4,2,0},{1,1}, R)
-     f2 = pieri({4,3,0},{2}, R)
-     f3 = pieri({4,3,3},{3,3,3}, R)
-     ///,
-     "Fix the degrees (i.e. make sure that the target of f2 is the source of f1,
-     etc). Otherwise the test of exactness below would fail.",
-     EXAMPLE lines ///
-     f1
-     f2 = map(source f1,,f2)
-     f3 = map(source f2,,f3)
-     f1 * f2
-     f2 * f3
-     ///,
-     "Check that the complex is exact.",
-     EXAMPLE lines ///
-     ker f1 == image f2
-     ker f2 == image f3
-     ///,
-     "Looks great! Now let's try it modulo some prime numbers and see if we get exactness.",
-     EXAMPLE lines ///
-     p = 32003
-     R = ZZ/p[a,b,c];
-     f1 = pieri({4,2,0},{1,1},R)
-     betti res coker f1
-     f2 = pieri({4,3,0},{2},R)
-     f3 = pieri({4,3,3},{3,3,3},R)
-     f2 = map(source f1,,f2)
-     f3 = map(source f2,,f3)
-     f1 * f2
-     f2 * f3
-     ker f1 == image f2
-     ker f2 == image f3
-     ///,
-     "These do not piece together well. The reason is that ",
-     TO pieri,
-     " changes the bases of the free modules in a way which is not invertible
-     (over ZZ) when the ground field has positive characteristic.",
-  SeeAlso => {pieri, pureFree, schurRank}
-  }     
+load "./PieriMaps/doc.m2"
 
-document {
-     Key => {standardTableaux, (standardTableaux, ZZ, List)},
-     Headline => "list all standard tableaux of a certain shape with bounded labels",
-     SeeAlso => schurRank,
-     Usage => "standardTableaux(dim, mu)",
-     Inputs => { 
-	  "dim" => {ofClass ZZ, ", number of labels to be used"},
-	  "mu" => {ofClass List, ", a partition which gives the shape"}
-	  },
-     Outputs => {
-	  List => {"list of all standard tableaux of shape mu with labels 0,...,dim-1"}
-	  },
-     EXAMPLE lines ///
-     	  standardTableaux(3, {2,2}) -- lists all standard tableaux on the 2x2 square with entries 0,1,2
-	  ///
-     }
-
-document {
-     Key => {straighten, (straighten, List), (straighten, List, MutableHashTable)},
-     Headline => "computes straightening of a tableau",
-     Usage => concatenate("straighten(t)", "straighten(t, h)"),
-     Inputs => {
-	  "t" => {ofClass List, ", a tableau to straighten; a tableau looks like {{3,4}, {1,2}} for example, where we list the entries from left to right, top to bottom"},
-	  "h" => {ofClass MutableHashTable, ", where the answers should be stored"}
-	  },
-     Consequences => { "If provided, the hashtable h is updated with any calculations which are performed as a result of calling this function. " },
-     "If a hashtable h is provided, then this outputs nothing, it simply just modifies h. When looking up values, remember that the keys are stored with rows weakly increasing. ",
-     "If no hashtable is provided, then the user is simply given the straightening of the tableau in terms of semistandard tableaux. ",
-     "The answer is in the form a hashtable: each key is a semistandard tableaux, and the value of the key is the coefficient of that semistandard tableaux used to write the input t as a linear combination. ",
-     EXAMPLE lines ///
-     	  h = new MutableHashTable from {}
-	  straighten({{3,4}, {1,2}}, h)
-	  h#{{3,4}, {1,2}} -- get the coefficients
-	  straighten({{3,4}, {1,2}}) -- just get the answer instead
-	  ///
-     }
-
-document {
-     Key => {pieri, (pieri, List, List, PolynomialRing)},
-     Headline => "computes a matrix representation for a Pieri inclusion of representations of a general linear group",
-     SeeAlso => {pureFree},
-     Usage => "pieri(mu, boxes, P)",
-     Inputs => {
-	  "mu" => {ofClass List, ", a partition (mu_1, ..., mu_r) where mu_i is the number of boxes in the ith row"},
-	  "boxes" => {ofClass List, ", a list of rows from which to remove boxes (boxes are always removed from the end of the row). This specifies which map of GL(V) representations we want. The row indices start from 1 and not 0, and this must specify a horizontal strip in mu (see description below). "},
-	  "P" => {ofClass PolynomialRing, ", a polynomial ring over a field K in n variables" }
-	  },
-     Outputs => {
-	  Matrix => {"If K has characteristic 0, then given the partition mu and the partition mu' obtained from mu by removing a single box, 
-	       there is a unique (up to nonzero scalar) GL(V)-equivariant inclusion S_mu V -> V otimes S_mu' V, where S_mu refers to the 
-	       irreducible representation of GL(V) with highest weight mu. This can be extended uniquely to a map of P = Sym(V)-modules 
-	       P otimes S_mu V -> P otimes S_mu' V. This method computes the matrix representation for the composition of maps that one obtains by 
-	       iterating this procedure of removing boxes, i.e., the final output is a GL(V)-equivariant map P otimes S_mu V -> P otimes S_lambda V 
-	       where lambda is the partition obtained from mu by deleting a box from row boxes_0, a box from row boxes_1, etc.
-	       If K has positive characteristic, then the corresponding map is calculated over QQ, lifted to a ZZ-form of the representation which has 
-	       the property that the map has a torsion-free cokernel over ZZ, and then the coefficients are reduced to K."
-	       }
-	  },
-     "Convention: the partition (d) represents the dth symmetric power, while the partition (1,...,1) represents the dth exterior power. ",
-     "Using the notation from the output, mu/lambda must be a horizontal strip. Precisely, this means that lambda_i >= mu_(i+1) for all i. 
-     If this condition is not satisfied, the program throws an error because a nonzero equivariant map of the desired form will not exist. ",
-     EXAMPLE lines ///
-     	  pieri({3,1}, {1}, QQ[a,b,c]) -- removes the last box from row 1 of the partition {3,1}
-	  res coker oo -- resolve this map
-	  betti oo -- check that the resolution is pure
-	  ///
-     }
-
-document {
-     Key => {pureFree, (pureFree, List, PolynomialRing)},
-     Headline => "computes a GL(V)-equivariant map whose resolution is pure, or the reduction mod p of such a map",
-     SeeAlso => {pieri},
-     Usage => "pureFree(d, P)",
-     Inputs => {
-	  "d" => {ofClass List, ", a list of degrees (increasing numbers)"},
-	  "P" => {ofClass PolynomialRing, ", a polynomial ring over a field K in n variables" }
-	  },
-     Outputs => {
-	  Matrix => {"A map whose cokernel has Betti diagram with degree sequence d if K has characteristic 0. 
-	       If K has positive characteristic p, then the corresponding map is calculated over QQ and is lifted to a ZZ-form which is then reduced mod p." }
-	  },
-     "The function translates the data of a degree sequence d for a desired pure free resolution into the data of a Pieri map 
-     according to the formula of Eisenbud-Fl\\o ystad-Weyman and then applies the function ",
-     TO pieri,
-     ".",
-     EXAMPLE lines ///
-     	  betti res coker pureFree({0,1,2,4}, QQ[a,b,c]) -- degree sequence {0,1,2,4}
-	  betti res coker pureFree({0,1,2,4}, ZZ/2[a,b,c]) -- same map, but reduced mod 2
-	  betti res coker pureFree({0,1,2,4}, GF(4)[a,b,c]) -- can also use non prime fields
-     	  ///
-     }
-
-document {
-     Key => {schurRank, (schurRank, ZZ, List)},
-     Headline => "computes the dimension of the irreducible GL(QQ^n) representation associated to a partition",
-     SeeAlso => standardTableaux,
-     Usage => "schurRank(n, mu)",
-     Inputs => {
-	  "n" => {ofClass ZZ, ", the size of the matrix group GL(QQ^n)"},
-	  "mu" => {ofClass List, ", a partition (mu_1, ..., m_r) where mu_i is the number of boxes in the ith row"}
-	  },
-     Outputs => {
-	  ZZ => {"The dimension of the irreducible GL(QQ^n) representation associated to mu"}
-	  },
-     "The dimension is computed using the determinantal formula given by the Weyl character formula.",
-     EXAMPLE lines ///
-     	  schurRank(5, {4,3}) -- should be 560
-     	  ///
-     }     	  
-     
-TEST ///
-t = new BettiTally from {(0,{0},0)=>8, (1,{1},1) =>15, (2,{3},3)=>10, (3,{5},5)=>3};
-assert (t == (betti res coker pieri({3,1},{1},QQ[a,b,c])))
-t = new BettiTally from {(0,{0},0)=>15, (1,{1},1) =>24, (2,{4},4)=>15, (3,{6},6)=>6};
-assert (t == (betti res coker pieri({4,1},{1},QQ[a,b,c])))
-t = new BettiTally from {(0,{0},0)=>20, (1,{2},2) =>60, (2,{3},3)=>64, (3,{4},4)=>20};
-assert (t == (betti res coker pieri({3,2},{2,2},QQ[a,b,c,d])))
-assert(schurRank(5, {4,3}) == 560)
-t = new BettiTally from {(0,{0},0) => 3, (1,{1},1)=>8, (2,{2},2) => 6,
-(3,{4},4)=>1};
-assert(t == (betti res coker pureFree({0,1,2,4}, GF(4)[a,b,c])))
-///
-
-end     
+end
 loadPackage "PieriMaps"
 installPackage PieriMaps

--- a/M2/Macaulay2/packages/PieriMaps.m2
+++ b/M2/Macaulay2/packages/PieriMaps.m2
@@ -12,6 +12,19 @@ newPackage(
     	  "PieriMaps",
    	  Version => "2.0",
 	  Date => "May 1, 2026",
+	  Certification => {
+	       "journal name" => "The Journal of Software for Algebra and Geometry: Macaulay2",
+	       "journal URI" => "https://msp.org/jsag/",
+	       "article title" => "Computing inclusions of Schur modules",
+	       "acceptance date" => "2009-06-27",
+	       "published article URI" => "https://msp.org/jsag/2009/1-1/p02.xhtml",
+	       "published article DOI" => "10.2140/jsag.2009.1.5",
+	       "published code URI" => "https://msp.org/jsag/2009/1-1/jsag-v1-n1-x02-code.zip",
+	       "release at publication" => "38e96fec660168d488ad0449f8632e6608cc9ede",
+	       "version at publication" => "1.0",
+	       "volume number" => "1",
+	       "volume URI" => "https://msp.org/jsag/2009/1-1/"
+	       },
 	  Authors => {{
 		    Name => "Steven V Sam",
 		    Email => "ssam@math.mit.edu",
@@ -405,13 +418,12 @@ pmToFillingExpansion = T -> (
           cols := for j from 0 to s - 1 list
                for i from 0 to lambdaT#j - 1 list (sigmas#i)#j;
           totalSign := 1;
-          sortedCols := {};
           degenerate := false;
-          for c in cols do (
+          sortedCols := for c in cols list (
                sgn := sortWithSignPM c;
-               if sgn === null then ( degenerate = true; break );
+               if sgn === null then ( degenerate = true; break {} );
                totalSign = totalSign * (sgn#0);
-               sortedCols = append(sortedCols, sgn#1);
+               sgn#1
                );
           if degenerate then return;
           F := new sfFillingType from sortedCols;
@@ -465,10 +477,9 @@ fillingToPMExpansion = F -> (
      accum := new MutableHashTable;
      cartesianForEachPM(colChoices, choice -> (
           totalSign := 1;
-          orderedCols := {};
-          for c in choice do (
+          orderedCols := for c in choice list (
                totalSign = totalSign * (c#0);
-               orderedCols = append(orderedCols, c#1);
+               c#1
                );
           rows := for i from 0 to r - 1 list
                for j from 0 to lambda#i - 1 list (orderedCols#j)#i;
@@ -703,10 +714,10 @@ pieriColumnHelper = (mu, k, P) -> (
      ensureSchurFn();
      n := numgens P;
      X := gens P;
-     for i from 0 to #mu - 2 do if mu#i < mu#(i+1) then error ("not a partition: " | toString mu);
+     for i from 0 to #mu - 2 do if mu#i < mu#(i+1) then error("not a partition: ", mu);
      muTrim := trimPartPM mu;
      muT := conjPartPM muTrim;
-     if k < 1 or k > #muT then error ("column index " | toString k | " out of range");
+     if k < 1 or k > #muT then error("column index ", k, " out of range");
      rowToShorten := muT#(k-1);
      lambda := trimPartPM (for i from 0 to #muTrim - 1 list (if i == rowToShorten - 1 then muTrim#i - 1 else muTrim#i));
      muTaug := prepend(0, muT);
@@ -780,7 +791,7 @@ pieriColumn(List, List, PolynomialRing) := opts -> (mu, cols, P) -> (
      for kk in cols do (
 	  if kk < 1 then error "column index must be positive";
 	  muT := conjPartPM curMu;
-	  if kk > #muT then error ("intermediate shape " | toString curMu | " has no column " | toString kk);
+	  if kk > #muT then error("intermediate shape ", curMu, " has no column ", kk);
 	  rowR := muT#(kk-1);
 	  newMu := trimPartPM (for i from 0 to #curMu - 1 list (if i == rowR - 1 then curMu#i - 1 else curMu#i));
 	  for i from 0 to #newMu - 2 do
@@ -802,7 +813,7 @@ pieriColumn(List, List, PolynomialRing) := opts -> (mu, cols, P) -> (
      n := numgens P;
      muTrim := trimPartPM mu;
      if conv =!= "Filling" and conv =!= "Row" and conv =!= "Weyl" then
-	  error ("pieriColumn: invalid Convention " | toString conv);
+	  error("pieriColumn: invalid Convention ", conv);
      if conv =!= "Filling" then (
 	  -- Convert from native Filling basis to PM basis.
 	  A := pmToFillingMatrix(muTrim, n);
@@ -898,12 +909,9 @@ subOneRowLR = (mu, k) -> (
      )
 
 -- Strip rows (1-indexed) for label a (0-indexed) inside an LR filling Q.
-stripRowsForLabel = (Q, a) -> (
-     rows := {};
-     for i from 0 to #Q - 1 do
-     for lab in Q#i do if lab == a then rows = append(rows, i + 1);
-     rows
-     )
+stripRowsForLabel = (Q, a) ->
+     flatten for i from 0 to #Q - 1 list
+	  for lab in Q#i list if lab == a then i + 1 else continue
 
 -- LR tableau enumerator.  Returns all fillings of lambda/mu with content nu
 -- that satisfy: rows weakly increasing, columns strictly increasing among
@@ -920,11 +928,10 @@ lrTableaux(List, List, List) := (lambda, mu, nu) -> (
      r := #nu;
      rowLens := for i from 0 to L - 1 list lam#i - mm#i;
      -- Cells in reverse-reading-word order.
-     cells := {};
-     for i from 0 to L - 1 do (
+     cells := flatten for i from 0 to L - 1 list (
 	  rs := mm#i;
 	  len := rowLens#i;
-	  for t from 0 to len - 1 do cells = append(cells, (i, rs + len - 1 - t));
+	  for t from 0 to len - 1 list (i, rs + len - 1 - t)
 	  );
      cellIndex := new MutableHashTable;
      for t from 0 to #cells - 1 do cellIndex#(cells#t) = t;
@@ -1027,11 +1034,9 @@ lrMap(Sequence, List, ZZ) := opts -> (shapes, Q, n) -> (
 		    expv := pair#0;
 		    c := pair#1;
 		    if c == 0 then continue;
-		    tvec := for a from 0 to r - 1 list (
-			 ms := {};
-			 for k from 0 to n - 1 do for kk from 1 to expv#(a*n + k) do ms = append(ms, k);
-			 ms
-			 );
+		    tvec := for a from 0 to r - 1 list
+			 flatten for k from 0 to n - 1 list
+			      toList(expv#(a*n + k) : k);
 		    straighten(tvec, straightenH);
 		    decomp := if straightenH#?tvec then straightenH#tvec else new HashTable from {};
 		    for ssyt in keys decomp do (
@@ -1125,7 +1130,7 @@ applyLR(Sequence, List, BasicList, ZZ) := opts -> (shapes, Q, T, n) -> (
 	       if idxF#?Klist then Tcoords#(idxF#Klist) = decompF#K;
 	       );
 	  )
-     else error ("applyLR: invalid Convention " | toString conv);
+     else error("applyLR: invalid Convention ", conv);
      Tcol := transpose matrix {toList Tcoords};
      wcol := M * Tcol;
      out := new MutableList;
@@ -1184,7 +1189,7 @@ displayLRImage List := terms -> (
 -------------------------------------------------------------------------------
 
 genNonStdTableauxPM = (lambda, n, convention) -> (
-     out := {};
+     out := new MutableList;
      if convention === "Filling" then (
 	  ensureSchurFn();
 	  shape := conjPartPM lambda;
@@ -1200,8 +1205,8 @@ genNonStdTableauxPM = (lambda, n, convention) -> (
 			      else (Fl#c)#j
 			      );
 			 newF := for cc from 0 to #Fl - 1 list (if cc == c then swapped else Fl#cc);
-			 out = append(out, new sfFillingType from newF);
-			 if #out >= 3 then return out;
+			 out#(#out) = new sfFillingType from newF;
+			 if #out >= 3 then return toList out;
 			 );
 		    );
 	       );
@@ -1217,13 +1222,13 @@ genNonStdTableauxPM = (lambda, n, convention) -> (
 			      else (T#ri)#j
 			      );
 			 newT := for rr from 0 to #T - 1 list (if rr == ri then swapped else T#rr);
-			 out = append(out, newT);
-			 if #out >= 3 then return out;
+			 out#(#out) = newT;
+			 if #out >= 3 then return toList out;
 			 );
 		    );
 	       );
 	  );
-     out
+     toList out
      )
 
 straightenByConvPM = (T, convention) -> (
@@ -1404,8 +1409,7 @@ pmAddableHStrips = (lambda, d, n) -> (
      while #lam > 0 and lam#-1 == 0 do lam = drop(lam, -1);
      if #lam > n then return {};
      lamPad := lam | toList(n - #lam : 0);
-     out := {};
-     for comp in compositions(n, d) do (
+     for comp in compositions(n, d) list (
 	  muNew := for i from 0 to n-1 list lamPad_i + comp_i;
 	  if not all(0..n-2, i -> muNew_i >= muNew_(i+1)) then continue;
 	  -- horizontal strip: each column has at most one new cell, i.e.
@@ -1414,9 +1418,8 @@ pmAddableHStrips = (lambda, d, n) -> (
 	  muTrim := muNew;
 	  while #muTrim > 0 and muTrim#-1 == 0 do muTrim = drop(muTrim, -1);
 	  boxes := flatten for i from 0 to n-1 list toList((comp_i):(i+1));
-	  out = append(out, (muTrim, boxes));
-	  );
-     out
+	  (muTrim, boxes)
+	  )
      );
 
 -- All partitions of n with at most maxParts parts.
@@ -1432,8 +1435,7 @@ pmAddableVStrips = (lambda, d, n) -> (
      while #lam > 0 and lam#-1 == 0 do lam = drop(lam, -1);
      if #lam > n then return {};
      lamPad := lam | toList(n - #lam : 0);
-     out := {};
-     for sub in subsets(toList(0..n-1), d) do (
+     for sub in subsets(toList(0..n-1), d) list (
 	  muNew := for i from 0 to n-1 list (lamPad_i + (if member(i, sub) then 1 else 0));
 	  if not all(0..n-2, i -> muNew_i >= muNew_(i+1)) then continue;
 	  muTrim := muNew;
@@ -1444,9 +1446,8 @@ pmAddableVStrips = (lambda, d, n) -> (
 	  pairs := sort apply(sub, r -> (lamPad_r + 1, r));
 	  pairs = reverse pairs;
 	  cols := apply(pairs, p -> p#0);
-	  out = append(out, (muTrim, cols));
-	  );
-     out
+	  (muTrim, cols)
+	  )
      );
 
 -- Encode a P-matrix M (dim_lambda x dim_mu, entries deg d) as a K-matrix
@@ -1514,9 +1515,8 @@ pmGetDualHBlocks = (lambda, d, n, conv, P, K) -> (
 	       monBasis, K)
 	  );
      A := fold((a, b) -> a | b, blocks);
-     offsets := new MutableList from {0};
-     for blk in blocks do offsets#(#offsets) = (last toList offsets) + numColumns blk;
-     val := (addable, A, toList offsets);
+     offsets := prepend(0, accumulate(plus, 0, apply(blocks, numColumns)));
+     val := (addable, A, offsets);
      pmDualBlockCache#key = val;
      val
      );
@@ -1534,9 +1534,8 @@ pmGetDualVBlocks = (lambda, d, n, conv, P, K) -> (
 	       monBasis, K)
 	  );
      A := fold((a, b) -> a | b, blocks);
-     offsets := new MutableList from {0};
-     for blk in blocks do offsets#(#offsets) = (last toList offsets) + numColumns blk;
-     val := (addable, A, toList offsets);
+     offsets := prepend(0, accumulate(plus, 0, apply(blocks, numColumns)));
+     val := (addable, A, offsets);
      pmDualBlockCache#key = val;
      val
      );
@@ -1549,23 +1548,19 @@ pmGetDualLRBlocks = (mu, nu, n, conv) -> (
      if pmDualBlockCache#?key then return pmDualBlockCache#key;
      totalCells := sum mu + sum nu;
      cands := apply(pmPartitionsAtMost(totalCells, n), p -> toList p);
-     blocks := {};
-     blockInfo := {};
-     for lamP in cands do (
-	  lrTabs := lrTableaux(lamP, mu, nu);
-	  for Qp in lrTabs do (
-	       blocks = append(blocks,
-		    lrMap((lamP, mu, nu), Qp, n, Convention => conv));
-	       blockInfo = append(blockInfo, (lamP, Qp));
+     -- Per-candidate (lambda', Q') pairs along with their lrMap blocks.
+     pairs := flatten for lamP in cands list
+	  for Qp in lrTableaux(lamP, mu, nu) list (
+	       (lamP, Qp, lrMap((lamP, mu, nu), Qp, n, Convention => conv))
 	       );
-	  );
+     blockInfo := apply(pairs, p -> (p#0, p#1));
+     blocks := apply(pairs, p -> p#2);
      if #blocks == 0 then error "dualLR: no GL_n summands in S_nu V (x) S_mu V";
      A := fold((a, b) -> a | b, blocks);
      if numRows A =!= numColumns A then
 	  error "dualLR: stacked LR matrix not square (decomposition incomplete)";
-     offsets := new MutableList from {0};
-     for blk in blocks do offsets#(#offsets) = (last toList offsets) + numColumns blk;
-     val := (blockInfo, A, toList offsets);
+     offsets := prepend(0, accumulate(plus, 0, apply(blocks, numColumns)));
+     val := (blockInfo, A, offsets);
      pmDualBlockCache#key = val;
      val
      );
@@ -1601,10 +1596,10 @@ dualPieri(List, List, PolynomialRing) := opts -> (mu, boxes, P) -> (
      while #lambda > 0 and lambda#-1 == 0 do lambda = drop(lambda, -1);
      (addable, A, offsets) := pmGetDualHBlocks(lambda, d, n, opts.Convention, P, K);
      muIdx := position(addable, p -> p#0 == mu);
-     if muIdx === null then error("dualPieri: mu = " | toString mu
-	  | " is not a horizontal " | toString d
-	  | "-strip addition to lambda = " | toString lambda
-	  | " in " | toString n | " variables");
+     if muIdx === null then error("dualPieri: mu = ", mu,
+	  " is not a horizontal ", d,
+	  "-strip addition to lambda = ", lambda,
+	  " in ", n, " variables");
      startRow := offsets#muIdx;
      dimMu := offsets#(muIdx + 1) - startRow;
      N := pmDualSolveRows(A, startRow, dimMu);
@@ -1662,14 +1657,14 @@ dualPieriColumn(List, List, PolynomialRing) := opts -> (mu, cols, P) -> (
      (addable, A, offsets) := pmGetDualVBlocks(lambda, d, n, opts.Convention, P, K);
      muTrim := trimPartPM mu;
      muIdx := position(addable, p -> p#0 == muTrim);
-     if muIdx === null then error("dualPieriColumn: mu = " | toString mu
-	  | " is not a vertical " | toString d | "-strip addition to lambda = "
-	  | toString lambda | " in " | toString n | " variables");
+     if muIdx === null then error("dualPieriColumn: mu = ", mu,
+	  " is not a vertical ", d, "-strip addition to lambda = ",
+	  lambda, " in ", n, " variables");
      -- Sign correction: A was built with the canonical cols ordering.
      canCols := addable#muIdx#1;
      sgn := pmPermSign(toList cols, canCols);
-     if sgn == 0 then error("dualPieriColumn: cols " | toString cols
-	  | " are not a permutation of canonical cols " | toString canCols);
+     if sgn == 0 then error("dualPieriColumn: cols ", cols,
+	  " are not a permutation of canonical cols ", canCols);
      startRow := offsets#muIdx;
      dimMu := offsets#(muIdx + 1) - startRow;
      N := pmDualSolveRows(A, startRow, dimMu);
@@ -1690,7 +1685,7 @@ applyDualPieriColumn(Sequence, RingElement, BasicList, ZZ) := opts ->
      P := ring poly;
      d := #(muCols#1);
      if not isHomogeneous poly or first degree poly =!= d then
-	  error("applyDualPieriColumn: poly must be homogeneous of degree d = " | toString d);
+	  error("applyDualPieriColumn: poly must be homogeneous of degree d = ", d);
      K := coefficientRing P;
      monBasis := flatten entries basis(d, P);
      (mu, cols) := muCols;
@@ -1746,13 +1741,13 @@ pmTableauToCoords = (T, shape, n, conv) -> (
 	       else error "tableau must be a List (PM row form) or Filling (column form)";
 	  for s in stds list (if hRow#?s then hRow#s else 0_QQ)
 	  )
-     else error("unknown Convention: " | toString conv)
+     else error("unknown Convention: ", conv)
      );
 
 pmStdTabsByConv = (n, shape, conv) -> (
      if conv === "Filling" then (ensureSchurFn(); sfStandardTabPM(n, conjPartPM shape))
      else if conv === "Row" or conv === "Weyl" then standardTableaux(n, shape)
-     else error("unknown Convention: " | toString conv)
+     else error("unknown Convention: ", conv)
      );
 
 -- applyPieri: point evaluation of the inclusion-direction Pieri map.
@@ -1815,7 +1810,7 @@ applyDualPieri(Sequence, RingElement, BasicList, ZZ) := opts ->
      P := ring poly;
      d := #boxes;
      if not isHomogeneous poly or first degree poly =!= d then
-	  error("applyDualPieri: poly must be homogeneous of degree d = " | toString d);
+	  error("applyDualPieri: poly must be homogeneous of degree d = ", d);
      K := coefficientRing P;
      monBasis := flatten entries basis(d, P);
      lambda := mu;
@@ -1957,7 +1952,7 @@ pmActEFilling0 = (i, j, F, lambda, n) -> (
 pmActEConv0 = (i, j, T, conv, shape, n) -> (
      if conv === "Row" or conv === "Weyl" then pmActE0(i, j, T)
      else if conv === "Filling" then pmActEFilling0(i, j, T, shape, n)
-     else error("unknown Convention: " | toString conv)
+     else error("unknown Convention: ", conv)
      );
 
 verifyEquivariant = method(Options => {Convention => "Row", Verbose => false, Direction => "Inclusion"})

--- a/M2/Macaulay2/packages/PieriMaps.m2
+++ b/M2/Macaulay2/packages/PieriMaps.m2
@@ -173,14 +173,13 @@ shuffle = (T, col, row1, row2) -> (
      truncatedrow2 := (T#row2)_{col..len2-1}; -- grab row2 entries
      L := join((T#row1)_{col-1..len1-1}, (T#row2)_{0..col-1});
      P := permutations L;
-     output := {};
      P = apply(P, i-> (for j from 0 to #T-1 list (
 		    if j == row1 then sort join(truncatedrow1, i_{0..len1-col})
 	       	    else if j == row2 then sort join(i_{len1-col+1..#i-1}, truncatedrow2)
 	       	    else T#j)));
      coeff := 0;
      for i in P do if i == T then coeff = coeff + 1;
-     for i in P do if i != T then output = append(output, (i, -1 / coeff));
+     output := for i in P list if i != T then (i, -1 / coeff) else continue;
      return hashTable(plus, output);
      )
 
@@ -198,11 +197,9 @@ towardStandard = T -> (
      if H #? T then (
 	  coeff := -(H#T) + 1;
 	  remove(H,T);
-	  prehash := {};
-	  for i in keys H do 
-	  prehash = append(prehash, (i, H#i / coeff));
+	  prehash := for i in keys H list (i, H#i / coeff);
 	  return hashTable(prehash)
-     	  ) 
+     	  )
      else return new HashTable from H
      )
 
@@ -216,13 +213,8 @@ towardStandard = T -> (
 -- ZZ k: an index
 -- Output:
 -- Subtract one from the kth (in human count, not computer count) row of mu
-subtractOne = (mu, k) -> (
-     result := {};
-     for i from 0 to #mu-1 when true do
-     if i == k-1 then result = append(result, mu_i - 1)
-     else result = append(result, mu_i);
-     return result
-     )
+subtractOne = (mu, k) ->
+     for i from 0 to #mu - 1 list (if i == k - 1 then mu_i - 1 else mu_i)
 
 -------------------------------------------------------------------------------
 -- Convention infrastructure (added in this overhaul).
@@ -283,13 +275,11 @@ conjPartPM = mu -> toList conjugate (new Partition from trimPartPM mu)
 -- Returns dual partition
 dualPart = method()
 dualPart(List) := mu -> (
-     result := {};
-     for i from 1 to mu#0 when true do (
+     for i from 1 to mu#0 list (
 	  counter := 0;
-     	  for j from 0 to #mu-1 when true do if mu#j >= i then counter = counter + 1;
-	  result = append(result, counter);
-	  );
-     return result;
+	  for j from 0 to #mu - 1 do if mu#j >= i then counter = counter + 1;
+	  counter
+	  )
      )
 
 -- Computes the dimension of S_mu V where V has dimension n and 
@@ -316,21 +306,15 @@ standardTableaux = method()
 standardTableaux(ZZ, List) := (dim, mu) -> standardTableauxCache#(dim, mu) ??= (
      if #mu == 0 then {{}}
      else (
-	  output := {};
 	  otherrows := standardTableaux(dim, drop(mu, 1));
 	  firstrow := rsort compositions(dim, mu#0);
-	  for i in firstrow do (
-	       temp := {};
-	       for j from 0 to #i-1 do
-	       for k from 1 to i#j when true do
-	       temp = append(temp,j);
-	       for j in otherrows do (
-		    temp2 := prepend(temp,j);
-		    if isStandardPM(temp2) === null then
-		    output = append(output, temp2);
-		    );
-	       );
-	  output
+	  flatten for i in firstrow list (
+	       temp := flatten for j from 0 to #i - 1 list toList(i#j : j);
+	       for j in otherrows list (
+		    temp2 := prepend(temp, j);
+		    if isStandardPM(temp2) === null then temp2 else continue
+		    )
+	       )
 	  )
      )
 
@@ -576,7 +560,6 @@ pieriHelper = method()
 pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
      d := numgens P;
      X := gens P;
-     output := {};
      Sbasis := standardTableaux(d, mu);
      Tbasis := standardTableaux(d, subtractOne(mu, k));
      mu = prepend(0,mu);
@@ -596,22 +579,19 @@ pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
 	  for q from 1 to #J-2 when true do cJ = cJ * (mu_(J_q) - mu_k + k - J_q);
 	  (-1)^#J / cJ
 	  );
-     for s in apply(Sbasis, i->prepend({},i)) do (
-	  row := {};
+     output := for s in apply(Sbasis, i->prepend({},i)) list (
      	  H := new HashTable from {};
      	  for jIdx from 0 to #A - 1 do (
 	       J := A#jIdx;
      	       h := hashTable({(s, hCoefs#jIdx)});
-	       for i from 0 to #J-2 when true do (
-	       	    temp := {};
-	       	    for T in keys h do (
-		    	 for b from 0 to #(T_(J_(i+1)))-1 when true do (
+	       for i from 0 to #J - 2 do (
+	       	    temp := flatten for T in keys h list
+		    	 for b from 0 to #(T_(J_(i+1))) - 1 list (
 		    	      U := new MutableList from T;
      	       	    	      U#(J_(i+1)) = drop(U#(J_(i+1)), {b, b});
 			      U#(J_i) = append(U#(J_i), (T_(J_(i+1)))_b);
-			      temp = append(temp, (new List from U, h#T));
+			      (new List from U, h#T)
 			      );
-		    	 );
 	       	    h = hashTable(plus, temp);
 	       	    );
 	       H = merge(H, h, plus);
@@ -625,8 +605,7 @@ pieriHelper(List, ZZ, PolynomialRing) := (mu, k, P) -> (
 	       for i in keys memo#U do
 	       H#i = (H#i ?? 0) + coeff * (memo#U)#i * X_((T_0)_0);
 	       );
-     	  for t in Tbasis do row = append(row, H#t ?? 0);
-	  output = append(output, row);
+     	  for t in Tbasis list (H#t ?? 0)
 	  );
      return map(P^(#Tbasis), P^{#Sbasis:-1}, transpose output);
      )
@@ -830,23 +809,18 @@ pierip(List, List, PolynomialRing) := (mu, boxes, P) -> (
      R := QQ[X];
      f := pierizero(mu, boxes, R);
      mon := apply(compositions(d, #boxes), i-> (output := 1; for j from 0 to #i-1 do output = output * X_j^(i#j); output));
-     result := {};
      denom := 1;
-     for i from 0 to (rank source f)-1 do (
+     result := for i from 0 to (rank source f) - 1 list (
 	  row := flatten entries f_{i};
-	  newrow := {};
-	  for j from 0 to #row-1 do 
-	  for k in mon do (
-	       coeff := coefficient(k, row#j);
-	       temp := ceiling(1 / gcd(coeff, 1));
-	       denom = denom * temp / gcd(denom, temp);
-	       newrow = append(newrow, coeff);
-	       );
-	  result = append(result, newrow);
+	  flatten for j from 0 to #row - 1 list
+	       for k in mon list (
+		    coeff := coefficient(k, row#j);
+		    temp := ceiling(1 / gcd(coeff, 1));
+		    denom = denom * temp / gcd(denom, temp);
+		    coeff
+		    )
 	  );
-     result2 := {};
-     for i in result do 
-     result2 = append(result2, apply(i, j -> round(j*denom)));
+     result2 := apply(result, i -> apply(i, j -> round(j * denom)));
      intmat := map(ZZ^((rank target f) * #mon), ZZ^(rank source f), transpose(result2));
      (D, S, T) := smithNormalForm(intmat);
      S' := (S^(-1))_{0..(rank source D)-1};
@@ -862,14 +836,13 @@ pierip(List, List, PolynomialRing) := (mu, boxes, P) -> (
 pureFree = method(Options => {Convention => "Row"})
 pureFree(List, PolynomialRing) := opts -> (d, P) -> (
      if not isIncreasing(d) then error "The first argument needs to be a strictly increasing list of degrees.";
-     e := {};
-     for i from 1 to #d-1 do e = append(e, d#i - d#(i-1));
-     counter := -#e + 1;
-     for i in e do counter = counter + i;
-     lambda := {counter - e#0};
-     for i from 1 to #e-1 do
-     lambda = append(lambda, lambda#(i-1) - e#i + 1);
-     lambda = prepend(counter, drop(lambda, 1));
+     e := for i from 1 to #d - 1 list (d#i - d#(i-1));
+     counter := -#e + 1 + sum e;
+     -- lambda#0 = counter - e#0; lambda#i = lambda#(i-1) - e#i + 1 for i >= 1.
+     -- Build the running tail; the head is later replaced with counter.
+     cur := counter - e#0;
+     tail := for i from 1 to #e - 1 list (cur = cur - e#i + 1; cur);
+     lambda := prepend(counter, tail);
      pieri(lambda, toList(e#0 : 1), P, Convention => opts.Convention) ** P^{-d#0}
      )
 

--- a/M2/Macaulay2/packages/PieriMaps/doc.m2
+++ b/M2/Macaulay2/packages/PieriMaps/doc.m2
@@ -1,0 +1,1429 @@
+document {
+     Key => PieriMaps,
+     Headline => "Pieri inclusions",
+     "For mathematical background of this package and some examples of use, see:",
+     BR{},
+     "Steven V Sam, Computing inclusions of Schur modules, arXiv:0810.4666",
+     BR{},
+     "Some other references:",
+     BR{},
+     "Andrzej Daszkiewicz, On the Invariant Ideals of the Symmetric Algebra $S.(V \\oplus \\wedge^2 V)$, J. Algebra 125, 1989, 444-473.",
+     BR{},
+     "David Eisenbud, Gunnar Fl\\o ystad, and Jerzy Weyman, The existence of pure free resolutions, arXiv:0709.1529.",
+     BR{},
+     "William Fulton, Young Tableaux: With Applications to Representation Theory and Geometry, London Math. Society Student Texts 35, 1997.",
+     BR{},
+     "Jerzy Weyman, Cohomology of Vector Bundles and Syzygies, Cambridge University Press, 2002.",
+     BR{},
+     BR{},     
+     "Let ", TEX "$V$", " be a vector space over ", TEX "$K$", ". If ",
+     TEX "$K$", " has characteristic 0, then given the partition ",
+     TEX "$\\mu$", " and the partition ", TEX "$\\mu'$", " obtained from ",
+     TEX "$\\mu$", " by removing a single box, there is a unique (up to
+     nonzero scalar) ", TEX "$GL(V)$", "-equivariant inclusion ",
+     TEX "$S_\\mu V \\to V \\otimes S_{\\mu'} V$", ", where ",
+     TEX "$S_\\mu$", " refers to the irreducible representation of ",
+     TEX "$GL(V)$", " with highest weight ", TEX "$\\mu$",
+     ". This can be extended uniquely to a map of ",
+     TEX "$P = \\mathrm{Sym}(V)$", "-modules ",
+     TEX "$P \\otimes S_\\mu V \\to P \\otimes S_{\\mu'} V$",
+     ". The purpose of this package is to write down matrix
+     representatives for these maps. The main function for doing so is ",
+     TO pieri,
+     ". Here is an example of the use of the package PieriMaps, which is also
+     designed to check whether the maps are being constructed correctly
+     (important, since it is notoriously difficult to get the signs and
+     coefficients right.) ",
+     "We will construct by hand the free resolution in 3 variables corresponding
+     to the degree sequence (0,2,3,6). Let's start with the packaged code:",
+     EXAMPLE lines ///
+     R = QQ[a,b,c];
+     f = pureFree({0,2,3,6}, R)
+     betti res coker f
+     ///,
+     "By the general theory from Eisenbud-Fl\\o ystad-Weyman, each of these free
+     modules should be essentially Schur functors corresponding to the
+     following partitions.",
+     EXAMPLE lines ///
+     needsPackage "SchurRings"
+     schurRing(s,3)
+     dim s_{2,2}
+     dim s_{4,2}
+     dim s_{4,3}
+     dim s_{4,3,3}
+     ///,
+     "This package also provides a routine ",
+     TO schurRank,
+     " for computing this dimension:",
+     EXAMPLE lines ///
+     schurRank(3, {2,2})
+     schurRank(3, {4,2})
+     schurRank(3, {4,3})
+     schurRank(3, {4,3,3})
+     ///,
+     "We now use ",
+     TO pieri, 
+     " to construct each of the maps of the resolution separately.",
+     EXAMPLE lines ///
+     f1 = pieri({4,2,0},{1,1}, R)
+     f2 = pieri({4,3,0},{2}, R)
+     f3 = pieri({4,3,3},{3,3,3}, R)
+     ///,
+     "Fix the degrees (i.e. make sure that the target of f2 is the source of f1,
+     etc). Otherwise the test of exactness below would fail.",
+     EXAMPLE lines ///
+     f1
+     f2 = map(source f1,,f2)
+     f3 = map(source f2,,f3)
+     f1 * f2
+     f2 * f3
+     ///,
+     "Check that the complex is exact.",
+     EXAMPLE lines ///
+     ker f1 == image f2
+     ker f2 == image f3
+     ///,
+     "Looks great! Now let's try it modulo some prime numbers and see if we get exactness.",
+     EXAMPLE lines ///
+     p = 32003
+     R = ZZ/p[a,b,c];
+     f1 = pieri({4,2,0},{1,1},R)
+     betti res coker f1
+     f2 = pieri({4,3,0},{2},R)
+     f3 = pieri({4,3,3},{3,3,3},R)
+     f2 = map(source f1,,f2)
+     f3 = map(source f2,,f3)
+     f1 * f2
+     f2 * f3
+     ker f1 == image f2
+     ker f2 == image f3
+     ///,
+     "These do not piece together well. The reason is that ",
+     TO pieri,
+     " changes the bases of the free modules in a way which is not invertible
+     (over ZZ) when the ground field has positive characteristic.",
+     PARA{},
+     "Version 1.0 of this package was accepted for publication in ",
+     HREF{"https://msp.org/jsag/2009/1-1/", "volume 1"}, " of ",
+     HREF{"https://msp.org/jsag/", "The Journal of Software for Algebra and Geometry: Macaulay2"},
+     " on 2009-06-27, in the article ",
+     HREF{"https://msp.org/jsag/2009/1-1/p02.xhtml", "Computing inclusions of Schur modules"},
+     " (DOI: ", HREF{"https://doi.org/10.2140/jsag.2009.1.5", "10.2140/jsag.2009.1.5"},
+     ").",
+     PARA{},
+     BOLD "Version 2.0 overhaul.", "  This release extends the original
+     PieriMaps package in three respects:",
+     UL {
+	  {BOLD "Multiple basis conventions.", " Every map can be expressed in
+	   the package's original convention (default ",
+	   TT "Convention => \"Row\"", "), the column-form ", TT "Filling",
+	   " basis from ",
+	   TO2 {"SchurFunctors :: SchurFunctors", "SchurFunctors"}, " (",
+	   TT "Convention => \"Filling\"", "), or the divided-power Weyl-module
+	   basis (", TT "Convention => \"Weyl\"", ").  See ", TO Convention, "."},
+	  {BOLD "Both directions of every map.", " In addition to the inclusion
+	   direction (", TO pieri, ", ", TO pieriColumn, ", ", TO lrMap,
+	   "), the projection direction is provided via ",
+	   TO dualPieri, ", ", TO dualPieriColumn, ", and ", TO dualLR,
+	   ".  Each pair satisfies ",
+	   TEX "$\\mathrm{dual} \\circ \\mathrm{incl} = \\mathrm{Id}$",
+	   ", the canonical ", TEX "$GL$",
+	   "-equivariant projection given by Schur's lemma."},
+	  {BOLD "Verifications.", " ", TO verifyEquivariant, " checks ",
+	   TEX "$GL_n$",
+	   "-equivariance of any matrix between Schur modules via the
+	   Chevalley-generator commutativity test; ", TO verifyWellDefined,
+	   " checks compatibility with the Garnir relations of the chosen
+	   convention."}
+	  },
+     BOLD "Examples.",
+     PARA{},
+     "The single-box Pieri inclusion ",
+     TEX "$S_{(2,1)} V \\to V \\otimes S_{(1,1)} V$",
+     " in three variables.  Each row of ",
+     TT "symbolicForm",
+     " displays a source standard tableau on the left and its image as a sum of (target tableau, coefficient) pairs on the right:",
+     EXAMPLE lines ///
+	  R = QQ[a,b,c];
+	  M = pieri({2,1}, {1}, R);
+	  symbolicForm M
+	  ///,
+     "The same map in the column-form (Filling) convention is the literal change of basis.  Both matrices are equivariant injections and have the same rank:",
+     EXAMPLE lines ///
+	  R = QQ[a,b,c];
+	  Mrow = pieri({2,1}, {1}, R, Convention => "Row");
+	  Mfil = pieri({2,1}, {1}, R, Convention => "Filling");
+	  (rank Mrow, rank Mfil)
+	  ///,
+     "The projection ", TO dualPieri, " left-inverts ", TO pieri,
+     ".  Verified by ",
+     TEX "$\\mathrm{dualPieri} \\circ \\mathrm{applyPieri}(T_\\mu) = T_\\mu$",
+     " on the highest-weight vector:",
+     EXAMPLE lines ///
+	  R = QQ[a,b,c];
+	  Tmu = (standardTableaux(3, {2,1}))#0;
+	  img = applyPieri(({2,1}, {1}), Tmu, R);
+	  back = flatten for term in img list applyDualPieri(({2,1}, {1}), term#0, term#1, 3);
+	  back
+	  ///,
+     "When the Littlewood-Richardson coefficient ",
+     TEX "$c^\\lambda_{\\mu,\\nu}$", " exceeds 1, distinct LR tableaux ",
+     TEX "$Q$", " produce ", TEX "$c$",
+     " linearly independent inclusions ",
+     TEX "$\\Psi_Q : S_\\lambda V \\hookrightarrow S_\\nu V \\otimes S_\\mu V$",
+     ":",
+     EXAMPLE lines ///
+	  Qs = lrTableaux({3,2,1}, {2,1}, {2,1});  -- c^{(3,2,1)}_{(2,1),(2,1)} = 2
+	  M1 = lrMap(({3,2,1}, {2,1}, {2,1}), Qs#0, 3);
+	  M2 = lrMap(({3,2,1}, {2,1}, {2,1}), Qs#1, 3);
+	  rank(M1 | M2) == 16    -- 2 * dim S_{(3,2,1)} -- linearly independent
+	  ///,
+     "Each ", TO dualLR, " projects onto exactly its own ",
+     TEX "$Q$", "-summand and annihilates the others:",
+     EXAMPLE lines ///
+	  Qs = lrTableaux({3,2,1}, {2,1}, {2,1});
+	  M0 = lrMap(({3,2,1},{2,1},{2,1}), Qs#0, 3);
+	  M1 = lrMap(({3,2,1},{2,1},{2,1}), Qs#1, 3);
+	  N0 = dualLR(({3,2,1},{2,1},{2,1}), Qs#0, 3);
+	  N0 * M0 == id_(QQ^(numColumns M0))
+	  N0 * M1 == 0
+	  ///,
+     TO verifyEquivariant,
+     " checks Chevalley-generator commutativity for any matrix between Schur reps -- a direct ",
+     TEX "$GL_n$",
+     "-equivariance test:",
+     EXAMPLE lines ///
+	  R = QQ[a,b,c];
+	  M = pieri({3,2,1}, {2}, R);   -- inclusion at the interior row
+	  verifyEquivariant(M, {3,2,1}, {2}, R)
+	  ///,
+     "And ", TO verifyWellDefined,
+     " confirms that an LR map factors through the Garnir relations of the chosen convention:",
+     EXAMPLE lines ///
+	  Qs = lrTableaux({3,2,1}, {2,1}, {2,1});
+	  verifyWellDefined(({3,2,1},{2,1},{2,1}), Qs#0, 3,
+	       Convention => "Filling", Verbose => false)
+	  ///,
+     SeeAlso => {pieri, pieriColumn, dualPieri, dualPieriColumn,
+	  lrMap, dualLR, applyLR, applyPieri, applyDualPieri,
+	  Convention, verifyEquivariant, verifyWellDefined,
+	  symbolicForm, pureFree, schurRank}
+  }
+
+document {
+     Key => {standardTableaux, (standardTableaux, ZZ, List)},
+     Headline => "list all standard tableaux of a certain shape with bounded labels",
+     SeeAlso => schurRank,
+     Usage => "standardTableaux(dim, mu)",
+     Inputs => { 
+	  "dim" => {ofClass ZZ, ", number of labels to be used"},
+	  "mu" => {ofClass List, ", a partition which gives the shape"}
+	  },
+     Outputs => {
+	  List => {"list of all standard tableaux of shape ", TEX "$\\mu$",
+	       " with labels ", TEX "$0, \\ldots, \\mathrm{dim}-1$"}
+	  },
+     EXAMPLE lines ///
+     	  standardTableaux(3, {2,2}) -- lists all standard tableaux on the 2x2 square with entries 0,1,2
+	  ///
+     }
+
+document {
+     Key => {straighten, (straighten, List), (straighten, List, MutableHashTable)},
+     Headline => "computes straightening of a tableau",
+     Usage => concatenate("straighten(t)", "straighten(t, h)"),
+     Inputs => {
+	  "t" => {ofClass List, ", a tableau to straighten; a tableau looks like {{3,4}, {1,2}} for example, where we list the entries from left to right, top to bottom"},
+	  "h" => {ofClass MutableHashTable, ", where the answers should be stored"}
+	  },
+     Consequences => { "If provided, the hashtable h is updated with any calculations which are performed as a result of calling this function. " },
+     "If a hashtable h is provided, then this outputs nothing, it simply just modifies h. When looking up values, remember that the keys are stored with rows weakly increasing. ",
+     "If no hashtable is provided, then the user is simply given the straightening of the tableau in terms of semistandard tableaux. ",
+     "The answer is in the form a hashtable: each key is a semistandard tableaux, and the value of the key is the coefficient of that semistandard tableaux used to write the input t as a linear combination. ",
+     EXAMPLE lines ///
+     	  h = new MutableHashTable from {}
+	  straighten({{3,4}, {1,2}}, h)
+	  h#{{3,4}, {1,2}} -- get the coefficients
+	  straighten({{3,4}, {1,2}}) -- just get the answer instead
+	  ///
+     }
+
+document {
+     Key => {pieri, (pieri, List, List, PolynomialRing), [pieri, Convention]},
+     Headline => "computes a matrix representation for a Pieri inclusion of representations of a general linear group",
+     SeeAlso => {pureFree, pieriColumn, lrMap},
+     Usage => "pieri(mu, boxes, P)\npieri(mu, boxes, P, Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "mu" => {ofClass List, ", a partition ",
+	       TEX "$(\\mu_1, \\ldots, \\mu_r)$", " where ", TEX "$\\mu_i$",
+	       " is the number of boxes in the ", TEX "$i$", "th row"},
+	  "boxes" => {ofClass List, ", a list of rows from which to remove boxes (boxes are always removed from the end of the row). This specifies which map of ",
+	       TEX "$GL(V)$",
+	       " representations we want. The row indices start from 1 and not 0, and this must specify a horizontal strip in ",
+	       TEX "$\\mu$", " (see description below). "},
+	  "P" => {ofClass PolynomialRing, ", a polynomial ring over a field ",
+	       TEX "$K$", " in ", TEX "$n$", " variables" },
+	  Convention => String => {", the tableau basis convention used to label the source ",
+	       TEX "$S_\\mu V$", " and target ", TEX "$S_\\lambda V$",
+	       ".  One of ",
+	       TT "\"Row\"", " (default; PieriMaps row-form SSYT basis), ",
+	       TT "\"Filling\"", " (SchurFunctors column-form ", TT "Filling", " basis on both sides), or ",
+	       TT "\"Weyl\"", " (data-equivalent to Row, but the bases are interpreted as ", TT "WeylFilling", "s on the divided-power side).  ",
+	       "The strip factor ", TEX "$(\\mathrm{Sym}^k V)$", " stays in P regardless."}
+	  },
+     Outputs => {
+	  Matrix => {"If ", TEX "$K$",
+	       " has characteristic 0, then given the partition ", TEX "$\\mu$",
+	       " and the partition ", TEX "$\\mu'$", " obtained from ",
+	       TEX "$\\mu$",
+	       " by removing a single box, there is a unique (up to nonzero scalar) ",
+	       TEX "$GL(V)$", "-equivariant inclusion ",
+	       TEX "$S_\\mu V \\to V \\otimes S_{\\mu'} V$", ", where ",
+	       TEX "$S_\\mu$", " refers to the irreducible representation of ",
+	       TEX "$GL(V)$", " with highest weight ", TEX "$\\mu$",
+	       ". This can be extended uniquely to a map of ",
+	       TEX "$P = \\mathrm{Sym}(V)$", "-modules ",
+	       TEX "$P \\otimes S_\\mu V \\to P \\otimes S_{\\mu'} V$",
+	       ". This method computes the matrix representation for the composition of maps that one obtains by
+	       iterating this procedure of removing boxes, i.e., the final output is a ",
+	       TEX "$GL(V)$", "-equivariant map ",
+	       TEX "$P \\otimes S_\\mu V \\to P \\otimes S_\\lambda V$",
+	       " where ", TEX "$\\lambda$", " is the partition obtained from ",
+	       TEX "$\\mu$", " by deleting a box from row ",
+	       TEX "$\\mathrm{boxes}_0$", ", a box from row ",
+	       TEX "$\\mathrm{boxes}_1$", ", etc.
+	       If ", TEX "$K$",
+	       " has positive characteristic, then the corresponding map is calculated over ",
+	       TEX "$\\mathbb{Q}$", ", lifted to a ", TEX "$\\mathbb{Z}$",
+	       "-form of the representation which has
+	       the property that the map has a torsion-free cokernel over ",
+	       TEX "$\\mathbb{Z}$", ", and then the coefficients are reduced to ",
+	       TEX "$K$", "."
+	       }
+	  },
+     "Convention: the partition ", TEX "$(d)$",
+     " represents the ", TEX "$d$", "th symmetric power, while the partition ",
+     TEX "$(1, \\ldots, 1)$", " represents the ", TEX "$d$",
+     "th exterior power. ",
+     "Using the notation from the output, ", TEX "$\\mu/\\lambda$",
+     " must be a horizontal strip. Precisely, this means that ",
+     TEX "$\\lambda_i \\geq \\mu_{i+1}$", " for all ", TEX "$i$",
+     ". If this condition is not satisfied, the program throws an error because a nonzero equivariant map of the desired form will not exist. ",
+     PARA{},
+     "The ", TT "Convention",
+     " option re-expresses the same equivariant map in different tableau bases on the source ",
+     TEX "$S_\\mu V$", " and target ", TEX "$S_\\lambda V$", ".  In ",
+     TT "\"Row\"",
+     " (default), the bases are PM-style SSYT (rows weakly increasing).  In ",
+     TT "\"Filling\"",
+     ", they are SchurFunctors-style column-form Fillings (the matrix is obtained by post-hoc basis change with the equivariant iso ",
+     TO pmToFilling, ").  In ", TT "\"Weyl\"",
+     ", the matrix data is the same as ", TT "\"Row\"",
+     " but is interpreted on the WeylFilling (divided-power) side.  All three give matrices of the same rank.",
+     EXAMPLE lines ///
+	  pieri({3,1}, {1}, QQ[a,b,c]) -- removes the last box from row 1 of the partition {3,1}
+	  res coker oo -- resolve this map
+	  betti oo -- check that the resolution is pure
+	  ///,
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  Mrow = pieri({2,1}, {1}, P, Convention => "Row")
+	  ///,
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  Mfil = pieri({2,1}, {1}, P, Convention => "Filling")
+	  ///,
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  Mwey = pieri({2,1}, {1}, P, Convention => "Weyl")
+	  ///,
+     "The Row and Weyl matrices share raw data (only the source/target bases are reinterpreted on the divided-power side); the Filling matrix is obtained by post-hoc basis change.  All three have the same rank.",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  Mrow = pieri({2,1}, {1}, P, Convention => "Row");
+	  Mfil = pieri({2,1}, {1}, P, Convention => "Filling");
+	  Mwey = pieri({2,1}, {1}, P, Convention => "Weyl");
+	  rank Mrow, rank Mfil, rank Mwey
+	  ///,
+     "The Betti table of the cokernel is the same in every convention (the
+     resolutions are isomorphic up to an equivariant change of basis):",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  betti res coker pieri({2,1}, {1}, P, Convention => "Row")
+	  ///,
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  betti res coker pieri({2,1}, {1}, P, Convention => "Filling")
+	  ///,
+     PARA{},
+     "Multi-box horizontal strips: ", TT "boxes",
+     " can list more than one row index (with repeats), and the result is the
+     composition of single-box Pieri inclusions.  The same row index can appear
+     repeatedly when row 1 has enough boxes; entries become degree-",
+     TEX "$d$", " polynomials.",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  pieri({3,1}, {1,1}, P)         -- removes 2 boxes from row 1; entries are deg 2
+	  ///,
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  pieri({3,2,1}, {1,3}, P)       -- removes one box from row 1, then row 3
+	  ///,
+     "And ", TO symbolicForm,
+     " makes the basis-by-basis action of a multi-box map readable:",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  symbolicForm pieri({3,1}, {1,1}, P)
+	  ///
+     }
+
+document {
+     Key => {pureFree, (pureFree, List, PolynomialRing), [pureFree, Convention]},
+     Headline => "computes a GL(V)-equivariant map whose resolution is pure, or the reduction mod p of such a map",
+     SeeAlso => {pieri},
+     Usage => "pureFree(d, P)\npureFree(d, P, Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "d" => {ofClass List, ", a list of degrees (increasing numbers)"},
+	  "P" => {ofClass PolynomialRing, ", a polynomial ring over a field ",
+	       TEX "$K$", " in ", TEX "$n$", " variables" },
+	  Convention => String => {", basis convention used internally by ", TO pieri, ".  Defaults to ", TT "\"Row\"", "; the resulting Betti table does not depend on the choice."}
+	  },
+     Outputs => {
+	  Matrix => {"A map whose cokernel has Betti diagram with degree sequence ",
+	       TEX "$d$", " if ", TEX "$K$",
+	       " has characteristic 0.  If ", TEX "$K$",
+	       " has positive characteristic ", TEX "$p$",
+	       ", then the corresponding map is calculated over ",
+	       TEX "$\\mathbb{Q}$", " and is lifted to a ", TEX "$\\mathbb{Z}$",
+	       "-form which is then reduced mod ", TEX "$p$", "." }
+	  },
+     "The function translates the data of a degree sequence ", TEX "$d$",
+     " for a desired pure free resolution into the data of a Pieri map
+     according to the formula of Eisenbud-Fl\\o ystad-Weyman and then applies the function ",
+     TO pieri,
+     ".  The ", TT "Convention", " option is forwarded to that internal Pieri call so that the resulting matrix is presented in the user's preferred basis convention; the Betti table of the resulting resolution is the same in all conventions.",
+     EXAMPLE lines ///
+	  betti res coker pureFree({0,1,2,4}, QQ[a,b,c]) -- degree sequence {0,1,2,4}
+	  betti res coker pureFree({0,1,2,4}, ZZ/2[a,b,c]) -- same map, but reduced mod 2
+	  betti res coker pureFree({0,1,2,4}, GF(4)[a,b,c]) -- can also use non prime fields
+	  ///,
+     EXAMPLE lines ///
+	  -- The Betti table is independent of the chosen convention:
+	  P = QQ[a,b,c];
+	  bettiR = betti res coker pureFree({0,1,2,4}, P, Convention => "Row");
+	  bettiF = betti res coker pureFree({0,1,2,4}, P, Convention => "Filling");
+	  bettiR == bettiF
+	  ///
+     }
+
+document {
+     Key => {schurRank, (schurRank, ZZ, List)},
+     Headline => "computes the dimension of the irreducible GL(QQ^n) representation associated to a partition",
+     SeeAlso => standardTableaux,
+     Usage => "schurRank(n, mu)",
+     Inputs => {
+	  "n" => {ofClass ZZ, ", the size of the matrix group ",
+	       TEX "$GL(\\mathbb{Q}^n)$"},
+	  "mu" => {ofClass List, ", a partition ",
+	       TEX "$(\\mu_1, \\ldots, \\mu_r)$", " where ", TEX "$\\mu_i$",
+	       " is the number of boxes in the ", TEX "$i$", "th row"}
+	  },
+     Outputs => {
+	  ZZ => {"The dimension of the irreducible ",
+	       TEX "$GL(\\mathbb{Q}^n)$", " representation associated to ",
+	       TEX "$\\mu$"}
+	  },
+     "The dimension is computed using the determinantal formula given by the Weyl character formula.",
+     EXAMPLE lines ///
+     	  schurRank(5, {4,3}) -- should be 560
+     	  ///
+     }     	  
+     
+document {
+     Key => {lrTableaux, (lrTableaux, List, List, List)},
+     Headline => "enumerate Littlewood-Richardson tableaux",
+     Usage => "lrTableaux(lambda, mu, nu)",
+     Inputs => {
+	  "lambda" => {ofClass List, ", a partition"},
+	  "mu" => {ofClass List, ", a partition contained in lambda"},
+	  "nu" => {ofClass List, ", a partition with |nu| = |lambda| - |mu|"}
+	  },
+     Outputs => {
+	  List => {"the list of LR fillings of the skew shape lambda/mu with content nu"}
+	  },
+     "An LR tableau is a semistandard skew tableau (rows weakly increasing, columns strictly increasing) ",
+     "whose reverse reading word is a lattice word.  Each filling is returned as a list of rows; row ",
+     TEX "$i$", " has length ", TEX "$\\lambda_i - \\mu_i$", " and ",
+     "entries in ", TEX "$\\{0, \\ldots, \\#\\nu - 1\\}$",
+     " (so label 0 corresponds to row 1 of ", TEX "$\\nu$", ", etc.).  ",
+     "The number of LR tableaux equals the Littlewood-Richardson coefficient ",
+     TEX "$c^\\lambda_{\\mu,\\nu}$", ".",
+     EXAMPLE lines ///
+	  #lrTableaux({3,2,1}, {2,1}, {2,1}) -- = c^{(3,2,1)}_{(2,1),(2,1)} = 2
+	  #lrTableaux({2,1}, {1}, {1,1})     -- = 1
+	  ///,
+     SeeAlso => lrMap
+     }
+
+document {
+     Key => {lrMap, (lrMap, Sequence, List, ZZ), (lrMap, Sequence, List, PolynomialRing), [lrMap, Convention]},
+     Headline => "GL(V)-equivariant Littlewood-Richardson inclusion",
+     Usage => "lrMap((lambda, mu, nu), Q, n)\nlrMap((lambda, mu, nu), Q, P)\nlrMap(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "(lambda, mu, nu)" => {ofClass Sequence, ", three partitions with ",
+	       TEX "$|\\lambda| = |\\mu| + |\\nu|$", " and ", TEX "$\\mu$",
+	       " contained in ", TEX "$\\lambda$"},
+	  "Q" => {ofClass List, ", an LR tableau of shape ",
+	       TEX "$\\lambda/\\mu$", " with content ", TEX "$\\nu$",
+	       ", as returned by ", TO lrTableaux},
+	  "n" => {ofClass ZZ, ", the dimension of ", TEX "$V$",
+	       " (or pass a ", TO PolynomialRing, " whose ", TT "numgens",
+	       " is used)"},
+	  Convention => String => {", basis convention for both the source ",
+	       TEX "$S_\\lambda V$", " and the target ",
+	       TEX "$S_\\nu V \\otimes S_\\mu V$", ".  ",
+	       TT "\"Row\"", " (default), ", TT "\"Filling\"", ", or ", TT "\"Weyl\"", "."}
+	  },
+     Outputs => {
+	  Matrix => {"a matrix over ", TEX "$\\mathbb{Q}$",
+	       " whose columns index a basis of ", TEX "$S_\\lambda V$",
+	       " and rows index a basis of ",
+	       TEX "$S_\\nu V \\otimes S_\\mu V$"}
+	  },
+     "Builds the ", TEX "$GL(V)$", "-equivariant inclusion ",
+     TEX "$\\Psi_Q \\colon S_\\lambda V \\to S_\\nu V \\otimes S_\\mu V$",
+     " associated to the LR tableau ", TT "Q",
+     ".  The map is constructed by iterating row-Pieri inclusions ",
+     TEX "$S_{\\lambda^{(a)}} V \\to \\mathrm{Sym}^{\\nu_a} V \\otimes S_{\\lambda^{(a-1)}} V$",
+     " in the order ", TEX "$a = r, r-1, \\ldots, 1$",
+     ", then projecting the ",
+     TEX "$\\mathrm{Sym}$", " tensor side onto ", TEX "$S_\\nu V$",
+     " via straightening.",
+     PARA{},
+     "The columns of the output are indexed by ", TT "standardTableaux(n, lambda)", " (or the corresponding Filling / WeylFilling basis if a non-default ", TT "Convention", " is chosen).  ",
+     "The rows are indexed by pairs ", TEX "$(T_\\nu, T_\\mu)$",
+     " in lex order: row ", TEX "$i \\cdot \\#S_\\mu + j$",
+     " corresponds to ",
+     TEX "$(T_\\nu = N\\nu\\#i, T_\\mu = N\\mu\\#j)$", " where ",
+     TT "Nnu = standardTableaux(n, nu)", " and ",
+     TT "Nmu = standardTableaux(n, mu padded to length #lambda)",
+     ".  When ", TT "Convention => \"Filling\"",
+     " is used, the equivariant change of basis ",
+     TO pmToFillingMatrix, " is applied on each side, and the rank is preserved.",
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});                  -- a multiplicity-1 example
+	  Q = (lrTableaux shapes)#0;
+	  Mrow = lrMap(shapes, Q, 3, Convention => "Row")
+	  ///,
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});
+	  Q = (lrTableaux shapes)#0;
+	  Mfilling = lrMap(shapes, Q, 3, Convention => "Filling")
+	  ///,
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});
+	  Q = (lrTableaux shapes)#0;
+	  Mweyl = lrMap(shapes, Q, 3, Convention => "Weyl")
+	  ///,
+     "All three are GL-equivariant injections of ", TEX "$S_\\lambda V$",
+     " into ", TEX "$S_\\nu V \\otimes S_\\mu V$",
+     ".  The Row and Weyl matrices have the same raw entries (only the source/target bases are reinterpreted on the divided-power side); the Filling matrix is obtained by post-hoc basis change.  All three have the same rank.",
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});
+	  Q = (lrTableaux shapes)#0;
+	  Mrow = lrMap(shapes, Q, 3, Convention => "Row");
+	  Mfilling = lrMap(shapes, Q, 3, Convention => "Filling");
+	  Mweyl = lrMap(shapes, Q, 3, Convention => "Weyl");
+	  (rank Mrow, rank Mfilling, rank Mweyl)
+	  ///,
+     "When ", TEX "$c^\\lambda_{\\mu,\\nu} > 1$",
+     ", distinct LR tableaux ", TEX "$Q$",
+     " give linearly independent inclusions; the joint matrix has rank ",
+     TEX "$c^\\lambda_{\\mu,\\nu} \\cdot \\dim S_\\lambda V$",
+     ".  The canonical multiplicity-2 example is ",
+     TEX "$c^{(3,2,1)}_{(2,1),(2,1)} = 2$", ":",
+     EXAMPLE lines ///
+	  Qs = lrTableaux({3,2,1}, {2,1}, {2,1});  -- two distinct LR tableaux
+	  M1 = lrMap(({3,2,1}, {2,1}, {2,1}), Qs#0, 3);
+	  M2 = lrMap(({3,2,1}, {2,1}, {2,1}), Qs#1, 3);
+	  rank M1, rank M2          -- each = dim S_(3,2,1) = 8
+	  rank(M1 | M2) == 16       -- 2 * 8: M1 and M2 are linearly independent
+	  ///,
+     "Use ", TO symbolicForm, " to read off the action of ",
+     TEX "$\\Psi_Q$", " on each standard tableau of ",
+     TEX "$S_\\lambda V$",
+     ", as a sum over basis pairs of ", TEX "$S_\\nu V \\otimes S_\\mu V$", ":",
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});
+	  Q = (lrTableaux shapes)#0;
+	  symbolicForm lrMap(shapes, Q, 3)
+	  ///,
+     SeeAlso => {lrTableaux, pieri, straighten, applyLR, verifyWellDefined, symbolicForm}
+     }
+
+document {
+     Key => {applyLR, (applyLR, Sequence, List, BasicList, ZZ), [applyLR, Convention]},
+     Headline => "apply Psi_Q to a single tableau of shape lambda",
+     Usage => "applyLR((lambda, mu, nu), Q, T, n)\napplyLR(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "(lambda, mu, nu)" => {ofClass Sequence, ", three partitions specifying the LR map"},
+	  "Q" => {ofClass List, ", an LR tableau as returned by ", TO lrTableaux},
+	  "T" => {ofClass BasicList, ", a tableau of shape ", TEX "$\\lambda$",
+	       ".  May be supplied as a ", TT "List", " or as a ",
+	       TT "Filling", ".  In ", TT "\"Row\"", "/", TT "\"Weyl\"",
+	       " convention a ", TT "List", " is interpreted as PM row form;
+	       in ", TT "\"Filling\"", " convention a ", TT "List",
+	       " is interpreted as column form (and wrapped automatically).
+	       A ", TT "Filling", " is always treated as column form. ",
+	       TT "T", " need not be standard; it is straightened internally
+	       using the convention's straightening relations."},
+	  "n" => {ofClass ZZ, ", the dimension of ", TEX "$V$"},
+	  Convention => String => {", basis convention used to interpret ",
+	       TT "T", " and label the output ",
+	       TEX "$T_\\nu$", ", ", TEX "$T_\\mu$", "."}
+	  },
+     Outputs => {
+	  List => {"a list of triples ", TT "{c, T_nu, T_mu}",
+	       " representing the image as the sum ",
+	       TEX "$\\sum c_i \\cdot T_\\nu^{(i)} \\otimes T_\\mu^{(i)}$",
+	       " in ", TEX "$S_\\nu V \\otimes S_\\mu V$"}
+	  },
+     "Computes the image of a single basis vector (or, more generally, of any
+     tableau, which is first straightened into the SSYT basis of ",
+     TEX "$S_\\lambda V$",
+     ") under the LR inclusion ", TEX "$\\Psi_Q$",
+     ".  The output is intended for human
+     reading or interactive exploration when the full ", TO lrMap, " matrix is
+     too large to display.  Use ", TO displayLRImage, " for pretty-printing.",
+     PARA{},
+     "When ", TT "Convention => \"Filling\"", " is chosen, the input ",
+     TT "T", " must be a SchurFunctors ", TT "Filling",
+     ", and the output uses Fillings on both target sides.  Straightening uses SchurFunctors' column-Garnir relations.  When ",
+     TT "Convention => \"Row\"", " or ", TT "\"Weyl\"", ", ", TT "T",
+     " is a list of rows and PieriMaps' row-Garnir straightening is applied.",
+     EXAMPLE lines ///
+	  Qs = lrTableaux({3,2,1}, {2,1}, {2,1});
+	  T = {{0,0,0},{1,1},{2}};   -- highest-weight vector of S_(3,2,1) QQ^3
+	  applyLR(({3,2,1}, {2,1}, {2,1}), Qs#0, T, 3)
+	  displayLRImage applyLR(({3,2,1}, {2,1}, {2,1}), Qs#0, T, 3)
+	  ///,
+     EXAMPLE lines ///
+	  -- Non-standard input: row-Garnir straightening before applying.
+	  Tnonstd = {{1,0},{2}};   -- row 0 not weakly-increasing
+	  applyLR(({2,1}, {1}, {1,1}), (lrTableaux({2,1},{1},{1,1}))#0, Tnonstd, 3)
+	  ///,
+     SeeAlso => {lrMap, lrTableaux, displayLRImage, verifyWellDefined}
+     }
+
+document {
+     Key => {displayLRImage, (displayLRImage, List)},
+     Headline => "pretty-print the result of applyLR",
+     Usage => "displayLRImage(image)",
+     Inputs => {
+	  "image" => {ofClass List, ", as returned by ", TO applyLR}
+	  },
+     Outputs => {
+	  Net => {"a stacked display of the symbolic sum ",
+	       TEX "$\\sum c_i \\cdot T_\\nu^{(i)} \\otimes T_\\mu^{(i)}$"}
+	  },
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});
+	  Q = (lrTableaux shapes)#0;
+	  T = (standardTableaux(3, {2,1}))#0;
+	  img = applyLR(shapes, Q, T, 3);
+	  displayLRImage img
+	  ///,
+     SeeAlso => {applyLR, lrMap}
+     }
+
+document {
+     Key => Convention,
+     Headline => "tableau basis convention used by PieriMaps' overhauled functions",
+     "An option accepted by ", TO pieri, ", ", TO lrMap, ", ", TO applyLR, ", ", TO pureFree, ", and ", TO verifyWellDefined,
+     ".  Possible values:",
+     UL {
+	  {TT "\"Row\"", " (default): the original PieriMaps row-form basis.  Source/target Schur modules are indexed by SSYTs as lists of weakly-increasing rows."},
+	  {TT "\"Filling\"", ": the SchurFunctors column-form basis.  Source/target are indexed by ", TT "Filling", "s, with column-Garnir straightening relations.  The matrix is obtained by post-hoc basis change with the equivariant iso ", TO pmToFilling, "."},
+	  {TT "\"Weyl\"", ": the divided-power row-form basis.  Source/target are indexed by ", TT "WeylFilling", "s.  Numerically the same data as the Row matrix; it is just that the bases are interpreted on the Weyl (divided-power) side rather than the Schur side."}
+	  },
+     "Use ", TO verifyWellDefined, " to verify that the chosen-convention map respects the appropriate straightening relations.",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  pieri({2,1}, {1}, P, Convention => "Row")
+	  pieri({2,1}, {1}, P, Convention => "Filling")
+	  ///,
+     SeeAlso => {pmToFilling, fillingToPM, pmToWeyl, weylToPM, verifyWellDefined}
+     }
+
+document {
+     Key => {pmToFilling},
+     Headline => "convert a PieriMaps row-form tableau to SchurFunctors column-form Fillings",
+     Usage => "pmToFilling T",
+     Inputs => {
+	  "T" => {ofClass List, ", a PieriMaps row-form tableau (list of weakly-increasing rows of the same shape)"}
+	  },
+     Outputs => {
+	  HashTable => {"the image of ", TT "T",
+	       " under the symmetrize-then-antisymmetrize equivariant map ",
+	       TEX "$\\mathrm{Sym}^\\lambda V \\to \\wedge^{\\lambda'} V$",
+	       ", expressed as a sum of standard ", TT "Filling",
+	       "s with rational coefficients (after SchurFunctors straightening)."}
+	  },
+     "PieriMaps' row-form representation ",
+     TEX "$S_\\lambda V \\subset \\mathrm{Sym}^{\\lambda_1} V \\otimes \\cdots$",
+     " and SchurFunctors' column-form representation ",
+     TEX "$S_\\lambda V \\subset \\wedge^{\\lambda'_1} V \\otimes \\cdots$",
+     " are equivariant isomorphisms (over ", TEX "$\\mathbb{Q}$",
+     ").  ",
+     "This function realizes that iso explicitly: each PM monomial ",
+     TEX "$T = (m_1, \\ldots, m_r)$", " is symmetrized into ",
+     TEX "$V^{\\otimes |\\lambda|}$",
+     " via the row-symmetrizer (with normalization ",
+     TEX "$1/\\prod \\lambda_i!$",
+     "), reordered by columns, and then projected to wedges (sort ",
+     TEX "$+$",
+     " sign) per column.  The result is then straightened into the standard ",
+     TT "Filling", " basis via SchurFunctors' ", TT "straighten", ".",
+     PARA{},
+     "Round-tripping ", TT "pmToFilling", " then ", TO fillingToPM,
+     " gives a uniform shape-dependent scalar ",
+     TEX "$c_\\lambda \\cdot \\mathrm{id}$",
+     " (the Young symmetrizer normalization).",
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  pmToFilling {{0,1},{2}}
+	  pmToFilling {{0,0,0},{1,1},{2}}  -- highest-weight vector of S_(3,2,1) Q^3
+	  ///,
+     SeeAlso => {fillingToPM, pmToWeyl, pmToFillingMatrix, Convention}
+     }
+
+document {
+     Key => {fillingToPM},
+     Headline => "convert a SchurFunctors column-form Filling to PieriMaps row-form tableaux",
+     Usage => "fillingToPM F",
+     Inputs => {
+	  "F" => {TT "Filling", ", a SchurFunctors column-form Filling"}
+	  },
+     Outputs => {
+	  HashTable => {"the image of ", TT "F",
+	       " under the antisymmetrize-then-symmetrize equivariant map ",
+	       TEX "$\\wedge^{\\lambda'} V \\to \\mathrm{Sym}^\\lambda V$",
+	       ", expressed as a sum of standard PM-form tableaux with rational coefficients (after PieriMaps straightening)."}
+	  },
+     "Inverse (up to a uniform scalar) of ", TO pmToFilling,
+     ".  Each column of ", TT "F", " is wedge-expanded into ",
+     TEX "$V^{\\otimes |\\lambda|}$",
+     " via the column antisymmetrizer (signed sum over permutations, with normalization ",
+     TEX "$1/\\prod \\lambda'_j!$",
+     "), reordered by rows, and projected to symmetric (sort) per row.  The result is straightened into the standard PM basis.",
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  F = new Filling from {{0,2},{1}};
+	  fillingToPM F
+	  ///,
+     SeeAlso => {pmToFilling, weylToFilling, fillingToPMMatrix}
+     }
+
+document {
+     Key => {pmToWeyl},
+     Headline => "convert a PieriMaps row-form tableau to a SchurFunctors WeylFilling",
+     Usage => "pmToWeyl T",
+     Inputs => {"T" => {ofClass List, ", a PieriMaps row-form tableau"}},
+     Outputs => {{TT "WeylFilling",
+	  " with the same row-data (a SchurFunctors basis element of ",
+	  TEX "$K_\\lambda V$", ")"}},
+     "PM tableaux and ", TT "WeylFilling", "s have the same data layout (rows weakly increasing).  This is purely a relabel: ",
+     TT "pmToWeyl", " wraps a list of rows as a WeylFilling (interpreting it as a basis element of the divided-power module ",
+     TEX "$K_\\lambda V$", "), and ", TO weylToPM,
+     " unwraps.  The conversion is reversible.",
+     "Requires the updated SchurFunctors package that exports ", TT "weyl", " and ", TT "WeylFilling", ".",
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  pmToWeyl {{0,1},{2}}
+	  weylToPM pmToWeyl {{0,1},{2}}
+	  ///,
+     SeeAlso => {weylToPM, pmToFilling, weylToFilling}
+     }
+
+document {
+     Key => {weylToPM},
+     Headline => "convert a SchurFunctors WeylFilling to a PieriMaps row-form tableau",
+     Usage => "weylToPM W",
+     Inputs => {"W" => {TT "WeylFilling"}},
+     Outputs => {List => {"a list of rows (PM-form tableau) with the same data"}},
+     "Inverse of ", TO pmToWeyl, ".  Both WeylFilling and PM-form share the row-of-multisets data layout, so this is purely an unwrapping.",
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  W = pmToWeyl {{0,1},{2}}
+	  weylToPM W
+	  ///,
+     SeeAlso => {pmToWeyl, fillingToWeyl}
+     }
+
+document {
+     Key => {weylToFilling},
+     Headline => "convert a WeylFilling to a SchurFunctors Filling (compose pmToFilling with weylToPM)",
+     Usage => "weylToFilling W",
+     Inputs => {"W" => {TT "WeylFilling"}},
+     Outputs => {HashTable => {"image as a sum of standard ", TT "Filling", "s after straightening"}},
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  W = pmToWeyl {{0,1},{2}};
+	  weylToFilling W
+	  ///,
+     SeeAlso => {pmToFilling, weylToPM, fillingToWeyl}
+     }
+
+document {
+     Key => {fillingToWeyl},
+     Headline => "convert a Filling to a sum of WeylFillings (compose pmToWeyl with fillingToPM)",
+     Usage => "fillingToWeyl F",
+     Inputs => {"F" => {TT "Filling"}},
+     Outputs => {HashTable => {"a HashTable {WeylFilling => coeff}"}},
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  F = new Filling from {{0,2},{1}};
+	  fillingToWeyl F
+	  ///,
+     SeeAlso => {pmToWeyl, fillingToPM, weylToFilling}
+     }
+
+document {
+     Key => {pmToFillingMatrix},
+     Headline => "QQ matrix of the PM-to-Filling change of basis on a Schur module",
+     Usage => "pmToFillingMatrix(mu, n)",
+     Inputs => {
+	  "mu" => {ofClass List, ", a partition (the Schur shape)"},
+	  "n"  => {ofClass ZZ, ", the dimension of ", TEX "$V$"}
+	  },
+     Outputs => {
+	  Matrix => {"a ", TEX "$\\mathbb{Q}$",
+	       " matrix; rows indexed by ", TT "Filling",
+	       "s of column heights ",
+	       TEX "$\\mu^t$",
+	       ", columns indexed by PieriMaps' standard tableaux of shape ",
+	       TEX "$\\mu$", ".  Entry ", TEX "$(i, j)$",
+	       " is the coefficient of Filling ", TEX "$i$", " in ",
+	       TT "pmToFilling(PMtab_j)", "."}
+	  },
+     "This matrix realizes the equivariant change of basis between PieriMaps' row-form basis of ",
+     TEX "$S_\\mu V$",
+     " and SchurFunctors' column-form basis.  It is invertible over ",
+     TEX "$\\mathbb{Q}$",
+     " (up to a shape-dependent overall scalar) and is the workhorse behind ",
+     TO [pieri, Convention], "/", TO [lrMap, Convention],
+     " for the Filling convention.",
+     PARA{},
+     "Source/target basis labels are attached so ", TO symbolicForm,
+     " can display the change-of-basis on each PM tableau:",
+     EXAMPLE lines ///
+	  symbolicForm pmToFillingMatrix({2,1}, 3)
+	  ///,
+     SeeAlso => {fillingToPMMatrix, pmToFilling, symbolicForm}
+     }
+
+document {
+     Key => {fillingToPMMatrix},
+     Headline => "QQ matrix of the Filling-to-PM change of basis on a Schur module",
+     Usage => "fillingToPMMatrix(mu, n)",
+     Inputs => {
+	  "mu" => {ofClass List, ", a partition"},
+	  "n"  => {ofClass ZZ}
+	  },
+     Outputs => {
+	  Matrix => {"a ", TEX "$\\mathbb{Q}$",
+	       " matrix; rows = PM tableaux of ", TEX "$\\mu$",
+	       ", cols = Fillings of ", TEX "$\\mu^t$", ".  Entry ",
+	       TEX "$(i, j)$", " = coefficient of PM tableau ", TEX "$i$",
+	       " in ", TT "fillingToPM(filling_j)", "."}
+	  },
+     "Inverse direction of ", TO pmToFillingMatrix, "; same equivariant iso, transposed convention.",
+     EXAMPLE lines ///
+	  symbolicForm fillingToPMMatrix({2,1}, 3)
+	  ///,
+     SeeAlso => {pmToFillingMatrix, fillingToPM, symbolicForm}
+     }
+
+document {
+     Key => {pieriColumn, (pieriColumn, List, List, PolynomialRing), [pieriColumn, Convention]},
+     Headline => "native column-form (vertical-strip) Pieri inclusion",
+     Usage => "pieriColumn(mu, cols, P)",
+     Inputs => {
+	  "mu" => {ofClass List, ", a partition"},
+	  "cols" => {ofClass List, ", a list of 1-indexed column indices.  One box is removed from the bottom of each listed column; the cumulative removal must form a vertical strip (no two boxes in the same row)."},
+	  "P" => {ofClass PolynomialRing, ", a SkewCommutative ",
+	       TEX "$\\mathbb{Q}$", "-algebra in ", TEX "$n$",
+	       " variables.  Its generators carry the wedge factor ",
+	       TEX "$\\wedge^{|\\mathrm{cols}|} V$",
+	       " on the output side."}
+	  },
+     Outputs => {
+	  Matrix => {"a matrix from ", TEX "$S_\\mu V$", " to ",
+	       TEX "$\\wedge^{|\\mathrm{cols}|} V \\otimes S_\\lambda V$",
+	       ", with rows indexed by standard ", TT "Filling", "s of ",
+	       TEX "$\\lambda$",
+	       " and columns indexed by standard Fillings of ", TEX "$\\mu$",
+	       "."}
+	  },
+     "The dual of ", TO pieri, ".  Where ", TT "pieri(mu, rows, P)",
+     " removes a horizontal strip and lands in ",
+     TEX "$\\mathrm{Sym}^k V$", ", ", TT "pieriColumn(mu, cols, P)",
+     " removes a vertical strip and lands in ", TEX "$\\wedge^k V$", ".  ",
+     "Both maps are unique (up to scalar) ", TEX "$GL(V)$",
+     "-equivariant inclusions ",
+     TEX "$S_\\mu V \\to (\\,?\\text{-tensor}\\,) \\otimes S_\\lambda V$",
+     "; ", TT "pieri", " uses Olver's formula with ",
+     TEX "$c_J = \\prod (\\mu_{J_q} - \\mu_k + k - J_q)$",
+     " on the symmetric (", TEX "$\\mathrm{Sym}$",
+     ") side, while ", TT "pieriColumn", " uses the dual formula with ",
+     TEX "$c'_J = \\prod (\\mu'_k - \\mu'_{J_q} + J_q - k)$",
+     " on the wedge side, where ", TEX "$\\mu'$",
+     " is the conjugate partition.  The extra sign in ", TEX "$c'_J$",
+     " relative to a literal transpose accounts for the wedge anticommutativity.",
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  P = QQ[e_0..e_3, SkewCommutative => true];
+	  M = pieriColumn({3,2,1}, {1}, P);
+	  numRows M, numColumns M
+	  ///,
+     EXAMPLE lines ///
+	  -- Multi-strip: remove a vertical strip of length 2.
+	  P = QQ[e_0..e_3, SkewCommutative => true];
+	  M = pieriColumn({3,2,1}, {1,2}, P);
+	  numRows M, numColumns M
+	  ///,
+     SeeAlso => {pieri, fillingToPM, [pieri, Convention]}
+     }
+
+document {
+     Key => {verifyWellDefined, (verifyWellDefined, Sequence, List, ZZ),
+	  (verifyWellDefined, List, List, PolynomialRing),
+	  [verifyWellDefined, Convention], [verifyWellDefined, Verbose],
+	  [verifyWellDefined, Direction]},
+     Headline => "verify an LR map respects the chosen convention's straightening relations",
+     Usage => "verifyWellDefined((lambda, mu, nu), Q, n, Convention => ...)",
+     Inputs => {
+	  "(lambda, mu, nu)" => {ofClass Sequence, ", three partitions for the LR data"},
+	  "Q" => {ofClass List, ", an LR tableau as returned by ", TO lrTableaux},
+	  "n" => {ofClass ZZ, ", the dimension of ", TEX "$V$"},
+	  Convention => String => {", basis convention to check"},
+	  Verbose => Boolean => {", whether to print per-test progress (default true)"}
+	  },
+     Outputs => {Boolean => {"true if all generated tests pass, false otherwise"}},
+     "For skeptical users.  Generates a few non-standard tableaux of shape lambda in the chosen basis convention, then for each:",
+     UL {
+	  "(a) computes ", TT "applyLR(shapes, Q, T, n, Convention => conv)", " directly (which uses the convention's straightening internally),",
+	  "(b) independently straightens T into a sum of standard tableaux,",
+	  "(c) computes the same sum applied to the standards,",
+	  "(d) asserts (a) and (c) agree."
+	  },
+     "If the matrix were silently using the wrong straightening relations (e.g. PieriMaps row-Garnir on a SchurFunctors column-form Filling input), the check fails and prints the offending case.",
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  Qs = lrTableaux({3,2,1}, {2,1}, {2,1});
+	  verifyWellDefined(({3,2,1},{2,1},{2,1}), Qs#0, 3, Convention => "Filling")
+	  verifyWellDefined(({3,2,1},{2,1},{2,1}), Qs#0, 3, Convention => "Row")
+	  ///,
+     SeeAlso => {lrMap, applyLR, pmToFilling, Convention}
+     }
+
+document {
+     Key => {dualPieri, (dualPieri, List, List, PolynomialRing), [dualPieri, Convention]},
+     Headline => "GL-equivariant projection Sym^d V ⊗ S_lambda V --> S_mu V",
+     Usage => "dualPieri(mu, boxes, P)\ndualPieri(mu, boxes, P, Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "mu" => {ofClass List,
+	       ", a partition (the target shape): ",
+	       TEX "$\\mu = \\lambda + (\\text{horizontal $d$-strip})$",
+	       " where ", TEX "$d = \\#\\mathrm{boxes}$", "."},
+	  "boxes" => {ofClass List,
+	       ", a list of 1-indexed row indices recording the horizontal strip ",
+	       TEX "$\\mu/\\lambda$", ".  Same convention as ", TO pieri, "."},
+	  "P" => {ofClass PolynomialRing,
+	       ", a polynomial ring whose generators carry the symmetric factor ",
+	       TEX "$\\mathrm{Sym}^d V$", " on the source side."},
+	  Convention => String => {", basis convention for both source and target Schur factors.  ",
+	       TT "\"Row\"", " (default), ", TT "\"Filling\"", ", or ", TT "\"Weyl\"", "."}
+	  },
+     Outputs => {
+	  Matrix => {"a ", TEX "$K$", "-matrix of size ",
+	       TEX "$\\dim S_\\mu V \\times \\bigl(\\dim S_\\lambda V \\cdot \\binom{n + d - 1}{d}\\bigr)$",
+	       ".  Columns are indexed by pairs ", TEX "$(T_\\lambda, \\alpha)$",
+	       " (a standard tableau of ", TEX "$\\lambda$",
+	       " paired with a degree-", TEX "$d$", " monomial of ",
+	       TT "P", "), in lex order with ", TEX "$T_\\lambda$",
+	       " outer and ", TEX "$\\alpha$", " inner."}
+	  },
+     "Returns the ", TEX "$GL_n$",
+     "-equivariant projection ",
+     TEX "$\\mathrm{Sym}^d V \\otimes S_\\lambda V \\to S_\\mu V$",
+     " (unique up to scalar by Schur's lemma).  By Pieri's rule, ",
+     TEX "$\\mathrm{Sym}^d V \\otimes S_\\lambda V$",
+     " decomposes as a direct sum of ", TEX "$S_{\\mu'}$", " over all ",
+     TEX "$\\mu' = \\lambda + (\\text{horizontal $d$-strip})$",
+     "; this function returns the projection onto the summand selected by ",
+     TEX "$\\mu$", ".",
+     PARA{},
+     "The construction stacks the inclusion matrices ", TO pieri,
+     " for every addable horizontal ", TEX "$d$",
+     "-strip into a square invertible matrix, then reads off the rows of its inverse corresponding to ",
+     TEX "$S_\\mu$", ".  This realizes ",
+     TEX "$\\mathrm{dualPieri} \\circ \\mathrm{pieri} = \\mathrm{Id}$",
+     " on ", TEX "$S_\\mu V$", " exactly.",
+     PARA{},
+     "When ", TT "Convention => \"Filling\"",
+     ", the source ", TEX "$S_\\lambda$", " factor and target ",
+     TEX "$S_\\mu$",
+     " are expressed in the SchurFunctors column-form basis; ",
+     TT "\"Weyl\"",
+     " uses the divided-power Weyl-module basis (matrix data is identical to ",
+     TT "\"Row\"", ").",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  N = dualPieri({3,2,1}, {1}, P);
+	  M = pieri({3,2,1}, {1}, P);
+	  numRows N == numColumns M and numRows M == 3
+	  ///,
+     EXAMPLE lines ///
+	  P = QQ[a,b,c,d];  -- interior-row removal mu={3,2,1}, k=2, lambda={3,1,1}
+	  N = dualPieri({3,2,1}, {2}, P);
+	  numRows N, numColumns N
+	  ///,
+     PARA{},
+     BOLD "Performance.", " ", TO dualPieri, " caches the stacked block
+     matrix used to invert the GL_n decomposition, keyed by ",
+     TEX "$(\\lambda, d, n, K, \\mathrm{Convention})$",
+     ".  The first call at a given key builds every Pieri inclusion ",
+     TEX "$S_{\\mu'}\\to S_\\lambda \\otimes \\mathrm{Sym}^d V$",
+     " for ", TEX "$\\mu'$", " ranging over all addable horizontal ",
+     TEX "$d$", "-strips and stacks them into one square matrix ",
+     TEX "$A$",
+     "; subsequent calls (for sister summands ", TEX "$\\mu$",
+     " of the same ambient tensor product) reuse ", TEX "$A$",
+     " and only run a single back-solve, so they cost less than the
+     corresponding ", TO pieri, " inclusion.  The selected rows of ",
+     TEX "$A^{-1}$", " are computed via ", TT "solve(transpose A, E)",
+     " (", TT "E", " a small standard-basis block) rather than by
+     forming the full inverse.  ", TT "boxes",
+     " is normalized to canonical (sorted ascending) order; pass the
+     same canonical order to ", TO pieri, " for the round-trip ",
+     TEX "$\\mathrm{dualPieri} \\circ \\mathrm{pieri} = \\mathrm{Id}$",
+     ".",
+     SeeAlso => {pieri, applyDualPieri, dualLR, verifyEquivariant, Convention}
+     }
+
+document {
+     Key => {applyDualPieri, (applyDualPieri, Sequence, RingElement, BasicList, ZZ), [applyDualPieri, Convention]},
+     Headline => "apply dualPieri to a single basis pair (poly, T_lambda)",
+     Usage => "applyDualPieri((mu, boxes), poly, T, n)\napplyDualPieri(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "(mu, boxes)" => {ofClass Sequence, ", the same data passed to ", TO dualPieri},
+	  "poly" => {ofClass RingElement,
+	       ", a homogeneous polynomial of degree ",
+	       TEX "$d = \\#\\mathrm{boxes}$",
+	       " in the polynomial ring ", TT "P", " (an element of ",
+	       TEX "$\\mathrm{Sym}^d V$", ")"},
+	  "T" => {ofClass BasicList, ", a tableau of shape ",
+	       TEX "$\\lambda$", ".  Accepted as either a ", TT "List",
+	       " or a ", TT "Filling", ".  In ", TT "\"Row\"", "/",
+	       TT "\"Weyl\"", " convention a ", TT "List",
+	       " is the PM row form; in ", TT "\"Filling\"", " convention a ",
+	       TT "List", " is column form (auto-wrapped).  A ", TT "Filling",
+	       " is always treated as column form.  Non-standard inputs are straightened first using the convention's relations."},
+	  "n" => {ofClass ZZ, ", ", TEX "$\\dim V$"},
+	  Convention => String => {", basis for source ", TEX "$S_\\lambda$",
+	       " and target ", TEX "$S_\\mu$", "."}
+	  },
+     Outputs => {
+	  List => {"a list of pairs ", TT "{coefficient, T_mu}",
+	       " representing the image as a sum ",
+	       TEX "$\\sum c_i \\cdot T_\\mu^{(i)}$", " in ",
+	       TEX "$S_\\mu V$", ".  Zero coefficients are dropped."}
+	  },
+     "Convenience wrapper for ", TO dualPieri,
+     ": evaluates the projection on a single source basis vector ",
+     TEX "$\\mathrm{poly} \\otimes T_\\lambda$",
+     " and returns a sparse representation of its image.  Useful for hand-checks and interactive exploration when the full ",
+     TO dualPieri, " matrix is too large.",
+     PARA{},
+     "Input flexibility: ", TT "T", " may be in either tableau type.  For ",
+     TT "Convention => \"Row\"", ", a Filling input is converted via ",
+     TO fillingToPM, " before straightening; for ",
+     TT "Convention => \"Filling\"", ", a List input is converted via ",
+     TO pmToFilling, ".  Non-standard tableaux straighten first.",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  Tlam = {{0,0},{1}};   -- standard PM tableau of {2,1}
+	  applyDualPieri(({3,1}, {1}), a, Tlam, 3)
+	  ///,
+     EXAMPLE lines ///
+	  -- Non-standard input is straightened first (row-Garnir).
+	  P = QQ[a,b,c,d];
+	  applyDualPieri(({3,2,1}, {3}), a, {{1,0},{2}}, 4)
+	  ///,
+     SeeAlso => {dualPieri, pieri, applyLR, applyDualLR, Convention}
+     }
+
+document {
+     Key => {dualLR, (dualLR, Sequence, List, ZZ), (dualLR, Sequence, List, PolynomialRing), [dualLR, Convention]},
+     Headline => "GL-equivariant projection S_nu V ⊗ S_mu V --> S_lambda V at a chosen LR tableau",
+     Usage => "dualLR((lambda, mu, nu), Q, n)\ndualLR((lambda, mu, nu), Q, P)\ndualLR(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "(lambda, mu, nu)" => {ofClass Sequence, ", three partitions with ",
+	       TEX "$|\\lambda| = |\\mu| + |\\nu|$", " and ",
+	       TEX "$S_\\lambda V$", " appearing in ",
+	       TEX "$S_\\nu V \\otimes S_\\mu V$", " (i.e. ",
+	       TEX "$c^\\lambda_{\\mu,\\nu} > 0$", ")"},
+	  "Q" => {ofClass List, ", an LR tableau of shape ",
+	       TEX "$\\lambda/\\mu$", " with content ", TEX "$\\nu$",
+	       " (as returned by ", TO lrTableaux,
+	       ") singling out one of the ", TEX "$c^\\lambda_{\\mu,\\nu}$",
+	       " copies of ", TEX "$S_\\lambda V$"},
+	  "n" => {ofClass ZZ, ", or pass a polynomial ring whose ",
+	       TT "numgens", " is used"},
+	  Convention => String => {", basis convention for the three Schur factors."}
+	  },
+     Outputs => {
+	  Matrix => {"a ", TEX "$\\mathbb{Q}$", "-matrix of size ",
+	       TEX "$\\dim S_\\lambda V \\times (\\dim S_\\nu V \\cdot \\dim S_\\mu V)$",
+	       ", the ", TEX "$GL_n$",
+	       "-equivariant projection onto ", TT "Q",
+	       "'s specific copy of ", TEX "$S_\\lambda V$", " inside ",
+	       TEX "$S_\\nu V \\otimes S_\\mu V$"}
+	  },
+     "Returns the ", TEX "$GL_n$",
+     "-equivariant projection onto the LR-summand of ",
+     TEX "$S_\\nu V \\otimes S_\\mu V$", " indexed by ", TT "Q",
+     " (unique up to scalar by Schur's lemma).  When the LR coefficient ",
+     TEX "$c^\\lambda_{\\mu,\\nu}$",
+     " exceeds 1, distinct LR tableaux ", TT "Q",
+     " give different projections, each onto its own copy of ",
+     TEX "$S_\\lambda V$", "; ",
+     TEX "$\\mathrm{dualLR}_Q \\circ \\mathrm{lrMap}_{Q'} = 0$",
+     " when ", TEX "$Q \\neq Q'$", ", and ",
+     TEX "$\\mathrm{dualLR}_Q \\circ \\mathrm{lrMap}_Q = \\mathrm{Id}$",
+     ".",
+     PARA{},
+     "Construction: stack the LR inclusions ", TO lrMap,
+     " for every ", TEX "$(\\lambda', Q')$", " with ",
+     TEX "$c^{\\lambda'}_{\\mu,\\nu} > 0$",
+     " into a square invertible matrix on ",
+     TEX "$S_\\nu V \\otimes S_\\mu V$",
+     " (square by the LR/Pieri rule) and read off the rows of its inverse corresponding to ",
+     TEX "$(\\lambda, Q)$", ".",
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});
+	  Q = (lrTableaux shapes)#0;
+	  M = lrMap(shapes, Q, 3);   -- inclusion S_(2,1) V -> S_(1,1) V ⊗ S_(1) V
+	  N = dualLR(shapes, Q, 3);  -- projection back onto Q's copy
+	  N * M == id_(QQ^(numColumns M))
+	  ///,
+     EXAMPLE lines ///
+	  Qs = lrTableaux({3,2,1}, {2,1}, {2,1});  -- multiplicity-2 case
+	  M0 = lrMap(({3,2,1},{2,1},{2,1}), Qs#0, 3);
+	  M1 = lrMap(({3,2,1},{2,1},{2,1}), Qs#1, 3);
+	  N0 = dualLR(({3,2,1},{2,1},{2,1}), Qs#0, 3);
+	  N0 * M0 == id_(QQ^(numColumns M0))   -- recovers Q_0's copy
+	  N0 * M1 == 0                          -- annihilates Q_1's copy
+	  ///,
+     SeeAlso => {lrMap, lrTableaux, applyDualLR, dualPieri, verifyEquivariant, Convention}
+     }
+
+document {
+     Key => {applyDualLR, (applyDualLR, Sequence, List, List, ZZ), [applyDualLR, Convention]},
+     Headline => "apply dualLR to a single basis pair (T_nu, T_mu)",
+     Usage => "applyDualLR((lambda, mu, nu), Q, {T_nu, T_mu}, n)\napplyDualLR(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "(lambda, mu, nu)" => {ofClass Sequence},
+	  "Q" => {ofClass List, ", an LR tableau"},
+	  "{T_nu, T_mu}" => {ofClass List,
+	       ", a 2-element list containing the source basis pair (a tableau of shape ",
+	       TEX "$\\nu$", " and a tableau of shape ", TEX "$\\mu$",
+	       ").  Each may be a ", TT "List", " or a ", TT "Filling",
+	       ", interpreted in the natural form of the convention (see ",
+	       TO applyPieri, "), independently."},
+	  "n" => {ofClass ZZ},
+	  Convention => String
+	  },
+     Outputs => {
+	  List => {"list of pairs ", TT "{coefficient, T_lambda}",
+	       " representing the image in ", TEX "$S_\\lambda V$"}
+	  },
+     "Note: the ", TT "{T_nu, T_mu}", " argument must be a List (not a Sequence), since M2 flattens nested Sequences in function-call arg lists but does not flatten Lists.  Non-standard inputs are straightened first.",
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});
+	  Q = (lrTableaux shapes)#0;
+	  applyDualLR(shapes, Q, {{{0},{1}}, {{0},{}}}, 3)
+	  ///,
+     SeeAlso => {dualLR, lrMap, applyLR, applyDualPieri, Convention}
+     }
+
+document {
+     Key => {verifyEquivariant,
+	  (verifyEquivariant, Matrix, List, List, PolynomialRing),
+	  (verifyEquivariant, Matrix, Sequence, ZZ),
+	  [verifyEquivariant, Convention],
+	  [verifyEquivariant, Verbose],
+	  [verifyEquivariant, Direction],
+	  Direction
+	  },
+     Headline => "rigorously verify GL_n-equivariance of a Schur-rep matrix",
+     Usage => "verifyEquivariant(M, mu, boxes, P)               -- pieri-type inclusion\nverifyEquivariant(M, shapes, n)                  -- lrMap-type inclusion\nverifyEquivariant(M, mu, boxes, P, Direction => \"Dual\")  -- dualPieri-type projection\nverifyEquivariant(M, shapes, n, Direction => \"Dual\")     -- dualLR-type projection",
+     Inputs => {
+	  "M" => {ofClass Matrix, ", the matrix to test for ", TEX "$GL_n$",
+	       "-equivariance"},
+	  Convention => String => {", basis convention used by ", TT "M",
+	       "'s rows and columns.  Default ", TT "\"Row\"", "."},
+	  Verbose => Boolean => {", if ", TT "true",
+	       " print the first failing ", TEX "$(i, j, T)$",
+	       " when the test fails.  Default ", TT "false", "."},
+	  Direction => String => {", ", TT "\"Inclusion\"", " (default) or ",
+	       TT "\"Dual\"", " to indicate the direction of the map."}
+	  },
+     Outputs => {
+	  Boolean => {"true if ", TT "M",
+	       " commutes with every Chevalley generator ", TEX "$E_{i,j}$",
+	       " of ", TEX "$\\mathfrak{gl}_n$", " (",
+	       TEX "$i \\neq j$", "); false otherwise"}
+	  },
+     "Tests whether a matrix ", TT "M",
+     " between Schur-functor representations is genuinely ", TEX "$GL_n$",
+     "-equivariant by checking that ",
+     TEX "$M \\circ \\rho_{\\mathrm{src}}(E_{i,j}) = \\rho_{\\mathrm{tgt}}(E_{i,j}) \\circ M$",
+     " for every Chevalley generator ", TEX "$E_{i,j}$", ".  Since the ",
+     TEX "$E_{i,j}$ ($i \\neq j$)",
+     " generate the strictly upper- and strictly lower-triangular parts of ",
+     TEX "$\\mathfrak{gl}_n$",
+     ", and our matrices commute with the diagonal automatically (entries are weight-homogeneous), commutativity with all ",
+     TEX "$E_{i,j}$", " is equivalent to full ", TEX "$GL_n$",
+     "-equivariance.",
+     PARA{},
+     "Action conventions: ", TEX "$E_{i,j}$", " acts on ",
+     TEX "$V = K^n$", " by ",
+     TEX "$x_l \\mapsto \\delta_{l,j}\\, x_i$",
+     " (i.e. the differential operator ",
+     TEX "$x_i\\, \\partial/\\partial x_j$", " on polynomials), on a Schur module ",
+     TEX "$S_\\lambda V$", " by replacing each entry equal to ",
+     TEX "$j$", " with ", TEX "$i$",
+     " in a tableau (summed over positions, then straightened), and on a tensor product by Leibniz.",
+     PARA{},
+     "Four overloads cover the maps in this package:",
+     UL {
+	  {TT "verifyEquivariant(M, mu, boxes, P)", " -- ",
+	   TEX "$M \\colon S_\\mu V \\to \\mathrm{Sym}^d V \\otimes S_\\lambda V$",
+	   " (or ", TEX "$\\wedge^d V$",
+	   " for skew-commutative ", TT "P",
+	   "), the inclusion produced by ", TO pieri, " or ", TO pieriColumn, "."},
+	  {TT "verifyEquivariant(M, (lambda, mu, nu), n)", " -- ",
+	   TEX "$M \\colon S_\\lambda V \\to S_\\nu V \\otimes S_\\mu V$",
+	   ", the inclusion produced by ", TO lrMap, "."},
+	  {TT "verifyEquivariant(M, mu, boxes, P, Direction => \"Dual\")",
+	   " -- ",
+	   TEX "$M \\colon \\mathrm{Sym}^d V \\otimes S_\\lambda V \\to S_\\mu V$",
+	   ", the projection produced by ", TO dualPieri, "."},
+	  {TT "verifyEquivariant(M, (lambda, mu, nu), n, Direction => \"Dual\")",
+	   " -- ",
+	   TEX "$M \\colon S_\\nu V \\otimes S_\\mu V \\to S_\\lambda V$",
+	   ", the projection produced by ", TO dualLR, "."}
+	  },
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  M = pieri({3,2,1}, {2}, P);
+	  verifyEquivariant(M, {3,2,1}, {2}, P)
+	  ///,
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];   -- verify the dual Pieri projection
+	  N = dualPieri({3,2,1}, {2}, P);
+	  verifyEquivariant(N, {3,2,1}, {2}, P, Direction => "Dual")
+	  ///,
+     EXAMPLE lines ///
+	  Q = (lrTableaux({3,2,1}, {2,1}, {2,1}))#0;  -- multiplicity-2 LR inclusion
+	  M = lrMap(({3,2,1}, {2,1}, {2,1}), Q, 3);
+	  verifyEquivariant(M, ({3,2,1}, {2,1}, {2,1}), 3)
+	  ///,
+     SeeAlso => {pieri, lrMap, dualPieri, dualLR, verifyWellDefined}
+     }
+
+document {
+     Key => {applyPieri, (applyPieri, Sequence, BasicList, PolynomialRing),
+	  [applyPieri, Convention]},
+     Headline => "apply pieri to a single source tableau T_mu",
+     Usage => "applyPieri((mu, boxes), T, P)\napplyPieri(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "(mu, boxes)" => {ofClass Sequence, ", the same data passed to ", TO pieri},
+	  "T" => {ofClass BasicList, ", a tableau of shape ", TEX "$\\mu$",
+	       ".  May be a ", TT "List", " or a ", TT "Filling", ".  In ",
+	       TT "\"Row\"", "/", TT "\"Weyl\"",
+	       " convention a ", TT "List", " is the PM row form; in ",
+	       TT "\"Filling\"", " convention a ", TT "List",
+	       " is column form (auto-wrapped).  A ", TT "Filling",
+	       " is always treated as column form."},
+	  "P" => {ofClass PolynomialRing, ", whose generators carry ",
+	       TEX "$\\mathrm{Sym}^d V$"},
+	  Convention => String
+	  },
+     Outputs => {
+	  List => {"a list of pairs ", TT "{poly, T_lambda}",
+	       " where each poly is a homogeneous degree-", TEX "$d$",
+	       " form and ", TEX "$T_\\lambda$",
+	       " is a standard tableau of ", TEX "$\\lambda$",
+	       "; the image is ",
+	       TEX "$\\sum \\mathrm{poly}_i \\otimes T_{\\lambda,i}$", " in ",
+	       TEX "$\\mathrm{Sym}^d V \\otimes S_\\lambda V$"}
+	  },
+     "Convenience point-evaluator for ", TO pieri,
+     ": applies the inclusion map to a single source basis vector ",
+     TT "T",
+     " and returns its image as a sparse representation.  Non-standard inputs are straightened first.",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  T = (standardTableaux(3, {3,2,1}))#0;
+	  applyPieri(({3,2,1}, {1}), T, P)
+	  ///,
+     SeeAlso => {pieri, applyDualPieri, applyLR, applyPieriColumn, Convention}
+     }
+
+document {
+     Key => {applyPieriColumn,
+	  (applyPieriColumn, Sequence, BasicList, PolynomialRing),
+	  [applyPieriColumn, Convention]},
+     Headline => "apply pieriColumn to a single source tableau T_mu",
+     Usage => "applyPieriColumn((mu, cols), T, P)\napplyPieriColumn(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "(mu, cols)" => {ofClass Sequence, ", the same data passed to ", TO pieriColumn},
+	  "T" => {ofClass BasicList, ", a tableau of shape ", TEX "$\\mu$",
+	       ".  May be a ", TT "List", " or a ", TT "Filling",
+	       " (interpreted in the natural form of the convention; see ",
+	       TO applyPieri, ")."},
+	  "P" => {ofClass PolynomialRing, ", a SkewCommutative ring whose generators carry ",
+	       TEX "$\\wedge^d V$"},
+	  Convention => String
+	  },
+     Outputs => {
+	  List => {"a list of pairs ", TT "{wedge_poly, T_lambda}",
+	       " representing the image in ",
+	       TEX "$\\wedge^d V \\otimes S_\\lambda V$"}
+	  },
+     "Column-form analogue of ", TO applyPieri, ".",
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  P = QQ[e_0..e_2, SkewCommutative => true];
+	  sfStdTab = value (SchurFunctors#"private dictionary"#"standardTableaux");
+	  F = (sfStdTab(3, {2,1}))#0;
+	  applyPieriColumn(({2,1}, {1}), F, P)
+	  ///,
+     SeeAlso => {pieriColumn, applyPieri, dualPieriColumn, Convention}
+     }
+
+document {
+     Key => {dualPieriColumn,
+	  (dualPieriColumn, List, List, PolynomialRing),
+	  [dualPieriColumn, Convention]},
+     Headline => "GL-equivariant projection wedge^d V ⊗ S_lambda V --> S_mu V",
+     Usage => "dualPieriColumn(mu, cols, P)\ndualPieriColumn(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "mu" => {ofClass List, ", the target shape: ",
+	       TEX "$\\mu = \\lambda + (\\text{vertical $d$-strip})$",
+	       " with ", TEX "$d = \\#\\mathrm{cols}$"},
+	  "cols" => {ofClass List, ", a list of column indices recording the strip ",
+	       TEX "$\\mu/\\lambda$"},
+	  "P" => {ofClass PolynomialRing, ", a SkewCommutative ring (",
+	       TEX "$\\wedge^d V$", " is encoded there)"},
+	  Convention => String
+	  },
+     Outputs => {
+	  Matrix => {"a ", TEX "$K$", "-matrix of size ",
+	       TEX "$\\dim S_\\mu V \\times \\bigl(\\dim S_\\lambda V \\cdot \\binom{n}{d}\\bigr)$",
+	       ".  Columns indexed by ",
+	       TEX "$(T_\\lambda, \\alpha)$",
+	       " pairs (", TEX "$\\alpha$", " an exterior monomial)."}
+	  },
+     "Column-form analogue of ", TO dualPieri,
+     ": the ", TEX "$GL_n$",
+     "-equivariant projection from ",
+     TEX "$\\wedge^d V \\otimes S_\\lambda V$", " onto the chosen ",
+     TEX "$S_\\mu V$",
+     " summand (unique up to scalar).  Construction stacks ",
+     TO pieriColumn,
+     " inclusions for every addable vertical ", TEX "$d$",
+     "-strip and inverts.",
+     EXAMPLE lines ///
+	  P = QQ[e_0..e_2, SkewCommutative => true];
+	  M = pieriColumn({2,1}, {1}, P);
+	  N = dualPieriColumn({2,1}, {1}, P);
+	  numRows N, numColumns N
+	  ///,
+     SeeAlso => {pieriColumn, dualPieri, applyDualPieriColumn, Convention}
+     }
+
+document {
+     Key => {applyDualPieriColumn,
+	  (applyDualPieriColumn, Sequence, RingElement, BasicList, ZZ),
+	  [applyDualPieriColumn, Convention]},
+     Headline => "apply dualPieriColumn to a single basis pair (wedge_poly, T_lambda)",
+     Usage => "applyDualPieriColumn((mu, cols), poly, T, n)\napplyDualPieriColumn(..., Convention => \"Row\" | \"Filling\" | \"Weyl\")",
+     Inputs => {
+	  "(mu, cols)" => {ofClass Sequence, ", the data passed to ", TO dualPieriColumn},
+	  "poly" => {ofClass RingElement, ", a homogeneous degree-",
+	       TEX "$d$", " wedge polynomial"},
+	  "T" => {ofClass BasicList, ", a tableau of shape ", TEX "$\\lambda$",
+	       ".  May be a ", TT "List", " or a ", TT "Filling",
+	       " (interpreted in the natural form of the convention; see ",
+	       TO applyPieri, ")."},
+	  "n" => {ofClass ZZ, ", ", TEX "$\\dim V$"},
+	  Convention => String
+	  },
+     Outputs => {
+	  List => {"a list of pairs ", TT "{coefficient, T_mu}",
+	       " representing the image in ", TEX "$S_\\mu V$"}
+	  },
+     EXAMPLE lines ///
+	  needsPackage "SchurFunctors";
+	  P = QQ[e_0..e_2, SkewCommutative => true];
+	  sfStdTab = value (SchurFunctors#"private dictionary"#"standardTableaux");
+	  T = (sfStdTab(3, {1,1}))#0;
+	  applyDualPieriColumn(({2,1}, {1}), e_0, T, 3)
+	  ///,
+     SeeAlso => {dualPieriColumn, pieriColumn, applyDualPieri, Convention}
+     }
+
+document {
+     Key => {symbolicForm, (symbolicForm, Matrix)},
+     Headline => "print a Schur-rep matrix as a basis-labeled symbolic map",
+     Usage => "symbolicForm M",
+     Inputs => {
+	  "M" => {ofClass Matrix, ", typically the output of ", TO pieri, ", ",
+	       TO pieriColumn, ", ", TO lrMap, ", ", TO dualPieri, ", ",
+	       TO dualPieriColumn, ", or ", TO dualLR, " (which attach
+	       source/target basis labels to ", TT "M.cache",
+	       ").  Plain matrices are accepted too: integer indices ",
+	       TT "1..rank", " are used as labels."}
+	  },
+     Outputs => {
+	  Net => {"a netList; each row shows a source basis element ",
+	       TT "i", " and the nonzero terms of ", TT "M(i)",
+	       " as a list of ", TT "(target_label, coefficient)", " pairs"}
+	  },
+     "Pretty-prints the matrix as the GL-equivariant map it represents on the
+     labeled bases.  Each row of the netList corresponds to a source basis
+     element (a tableau, or a (tableau, monomial) pair, etc.) and lists the
+     image as a sum over target basis elements with their coefficients.  Rows
+     where the image is identically zero appear with an empty list.",
+     PARA{},
+     "After ", TT "symbolicForm M", " is called once, the rule is cached on ",
+     TT "M.cache#\"rule\"", " so subsequent calls reuse it.  ",
+     "For interactive exploration, you can also evaluate the rule on a single
+     basis element directly via ", TT "(M.cache#\"rule\")(label)", ".",
+     EXAMPLE lines ///
+	  P = QQ[a,b,c];
+	  M = pieri({2,1}, {1}, P);
+	  symbolicForm M
+	  ///,
+     EXAMPLE lines ///
+	  shapes = ({2,1}, {1}, {1,1});
+	  Q = (lrTableaux shapes)#0;
+	  N = lrMap(shapes, Q, 3);
+	  symbolicForm N
+	  ///,
+     SeeAlso => {pieri, lrMap, dualPieri, dualLR, applyLR, applyPieri}
+     }

--- a/M2/Macaulay2/packages/PieriMaps/doc.m2
+++ b/M2/Macaulay2/packages/PieriMaps/doc.m2
@@ -1,6 +1,16 @@
 document {
      Key => PieriMaps,
      Headline => "Pieri inclusions",
+     Citation => {///@article{Sam2009,
+    AUTHOR = {Sam, Steven V},
+    TITLE = {Computing inclusions of {S}chur modules},
+    JOURNAL = {The Journal of Software for Algebra and Geometry: Macaulay2},
+    VOLUME = {1},
+    YEAR = {2009},
+    PAGES = {5--10},
+    DOI = {10.2140/jsag.2009.1.5},
+    URL = {https://msp.org/jsag/2009/1-1/p02.xhtml}
+}///},
      "For mathematical background of this package and some examples of use, see:",
      BR{},
      "Steven V Sam, Computing inclusions of Schur modules, arXiv:0810.4666",
@@ -102,14 +112,6 @@ document {
      TO pieri,
      " changes the bases of the free modules in a way which is not invertible
      (over ZZ) when the ground field has positive characteristic.",
-     PARA{},
-     "Version 1.0 of this package was accepted for publication in ",
-     HREF{"https://msp.org/jsag/2009/1-1/", "volume 1"}, " of ",
-     HREF{"https://msp.org/jsag/", "The Journal of Software for Algebra and Geometry: Macaulay2"},
-     " on 2009-06-27, in the article ",
-     HREF{"https://msp.org/jsag/2009/1-1/p02.xhtml", "Computing inclusions of Schur modules"},
-     " (DOI: ", HREF{"https://doi.org/10.2140/jsag.2009.1.5", "10.2140/jsag.2009.1.5"},
-     ").",
      PARA{},
      BOLD "Version 2.0 overhaul.", "  This release extends the original
      PieriMaps package in three respects:",

--- a/M2/Macaulay2/packages/PieriMaps/tests.m2
+++ b/M2/Macaulay2/packages/PieriMaps/tests.m2
@@ -1,0 +1,630 @@
+TEST ///
+-- symbolicForm output structure.
+P = QQ[a,b,c];
+M = pieri({2,1}, {1}, P);
+sf = symbolicForm M;     -- runs without error and caches rule
+assert(M.cache#?"rule");
+assert(#(M.cache#"sourceBasis") == numColumns M);
+assert(#(M.cache#"targetBasis") == numRows M);
+-- Direct rule evaluation matches the column.
+T = (M.cache#"sourceBasis")#0;
+img = (M.cache#"rule")(T);
+col = flatten entries M_{0};
+nonzero = positions(col, x -> x != 0);
+assert(#img == #nonzero);
+///
+
+TEST ///
+-- applyLR matches the corresponding column of lrMap.
+n = 3;
+shapes = ({3,2,1}, {2,1}, {2,1});
+Qs = lrTableaux shapes;
+M = lrMap(shapes, Qs#0, n);
+Sb = standardTableaux(n, shapes#0);
+Nmu = standardTableaux(n, shapes#1 | toList(#(shapes#0) - #(shapes#1) : 0));
+Nnu = standardTableaux(n, shapes#2);
+for j from 0 to #Sb - 1 do (
+     img := applyLR(shapes, Qs#0, Sb#j, n);
+     -- Reconstruct as hash for comparison.
+     h := new MutableHashTable;
+     for trip in img do h#(trip#1, trip#2) = trip#0;
+     for r from 0 to numRows M - 1 do (
+	  v := M_(r, j);
+	  i := r // (#Nmu);
+	  jj := r % (#Nmu);
+	  key := (Nnu#i, Nmu#jj);
+	  expected := if h#?key then h#key else 0;
+	  assert(expected == v);
+	  );
+     );
+///
+
+TEST ///
+t = new BettiTally from {(0,{0},0)=>8, (1,{1},1) =>15, (2,{3},3)=>10, (3,{5},5)=>3};
+assert (t == (betti res coker pieri({3,1},{1},QQ[a,b,c])))
+t = new BettiTally from {(0,{0},0)=>15, (1,{1},1) =>24, (2,{4},4)=>15, (3,{6},6)=>6};
+assert (t == (betti res coker pieri({4,1},{1},QQ[a,b,c])))
+t = new BettiTally from {(0,{0},0)=>20, (1,{2},2) =>60, (2,{3},3)=>64, (3,{4},4)=>20};
+assert (t == (betti res coker pieri({3,2},{2,2},QQ[a,b,c,d])))
+assert(schurRank(5, {4,3}) == 560)
+t = new BettiTally from {(0,{0},0) => 3, (1,{1},1)=>8, (2,{2},2) => 6,
+(3,{4},4)=>1};
+assert(t == (betti res coker pureFree({0,1,2,4}, GF(4)[a,b,c])))
+///
+
+-- LR-coefficient counts (number of LR tableaux).
+TEST ///
+assert(#lrTableaux({3,2,1}, {2,1}, {2,1}) == 2)
+assert(#lrTableaux({2,1}, {1}, {1,1}) == 1)
+assert(#lrTableaux({2,2}, {1,1}, {1,1}) == 1)
+assert(#lrTableaux({3,2,1}, {1,1}, {2,2}) == 1)
+assert(#lrTableaux({4,2,1}, {2,1}, {2,1,1}) == 1)
+assert(#lrTableaux({4,3,2,1}, {2,2}, {2,2,1,1}) == 1)
+assert(#lrTableaux({5,3,2,1}, {3,2,1}, {3,2}) == 3)
+assert(#lrTableaux({3,3}, {2,2}, {2}) == 0)          -- skew has both cells in same column
+assert(#lrTableaux({3,2,1}, {2,1}, {2,2}) == 0)      -- |lambda| != |mu| + |nu|
+assert(#lrTableaux({3,2,1}, {3,2,1}, {}) == 1)       -- trivial: only empty filling
+///
+
+-- LR maps: rank checks for several cases.
+-- For an LR tableau Q, Psi_Q is a GL-equivariant injection of the irrep
+-- S_lambda V into S_nu V (x) S_mu V, hence has rank = dim S_lambda.  Distinct
+-- LR tableaux give linearly independent maps; the joint image has rank
+-- c^lambda_{mu,nu} * dim S_lambda.
+TEST ///
+checkLR := (lambda, mu, nu, n) -> (
+     Qs := lrTableaux(lambda, mu, nu);
+     Ms := for Q in Qs list lrMap((lambda, mu, nu), Q, n);
+     dimSL := schurRank(n, lambda);
+     for M in Ms do assert(rank M == dimSL);
+     if #Ms >= 2 then (
+	  Mall := fold((a, b) -> a | b, Ms);
+	  assert(rank Mall == #Ms * dimSL);
+	  );
+     )
+checkLR({3,2,1}, {2,1}, {2,1}, 3)
+checkLR({3,2,1}, {2,1}, {2,1}, 4)
+checkLR({2,1}, {1}, {1,1}, 3)
+checkLR({2,2}, {1,1}, {1,1}, 3)
+checkLR({4,2,1}, {2,1}, {2,1,1}, 4)
+///
+
+-- Targets of lrMap respect the documented row indexing.
+TEST ///
+n = 4;
+lambda = {3,2,1};
+mu = {2,1};
+nu = {2,1};
+Qs = lrTableaux(lambda, mu, nu);
+M = lrMap((lambda, mu, nu), Qs#0, n);
+muPad = mu | toList(#lambda - #mu : 0);
+Nmu = standardTableaux(n, muPad);
+Nnu = standardTableaux(n, nu);
+Sb = standardTableaux(n, lambda);
+assert(numRows M == #Nnu * #Nmu);
+assert(numColumns M == #Sb);
+-- Both signatures should give identical matrices.
+P = QQ[a,b,c,d];
+assert(M == lrMap((lambda, mu, nu), Qs#0, P));
+///
+
+-- Convention rank checks: pieri/lrMap/pureFree return rank-correct matrices in
+-- all three conventions and Row == Weyl numerically.
+TEST ///
+needsPackage "SchurFunctors";
+linearizeSym = (M, P, k, n) -> (
+     X := gens P;
+     symBasis := flatten entries basis(k, P);
+     entriesM := entries M;
+     newRows := flatten for r in entriesM list (
+	  for mon in symBasis list for v in r list lift(coefficient(mon, v), QQ));
+     matrix newRows
+);
+-- pieri across conventions.
+P = QQ[a,b,c,d];
+M_row = pieri({3,2,1}, {1}, P);
+M_fil = pieri({3,2,1}, {1}, P, Convention => "Filling");
+M_wey = pieri({3,2,1}, {1}, P, Convention => "Weyl");
+assert(M_row == M_wey);
+assert(rank linearizeSym(M_row, P, 1, 4) == 64);
+assert(rank linearizeSym(M_fil, P, 1, 4) == 64);
+
+-- lrMap across conventions.
+Qs = lrTableaux({3,2,1}, {2,1}, {2,1});
+for Q in Qs do (
+     for conv in {"Row","Filling","Weyl"} do
+	  assert(rank lrMap(({3,2,1},{2,1},{2,1}), Q, 3, Convention => conv) == 8);
+     );
+
+-- pureFree across conventions: same Betti table.
+Pp = QQ[a,b,c];
+b0 = betti res coker pureFree({0,1,2,4}, Pp, Convention => "Row");
+b1 = betti res coker pureFree({0,1,2,4}, Pp, Convention => "Filling");
+b2 = betti res coker pureFree({0,1,2,4}, Pp, Convention => "Weyl");
+assert(b0 == b1 and b0 == b2);
+///
+
+-- PM <-> Filling round-trip is c_lambda * id; PM <-> Weyl is a literal
+-- bijection on standard tableaux.
+TEST ///
+-- Cache PieriMaps' standardTableaux BEFORE SchurFunctors gets loaded (it would
+-- shadow the symbol in the user dict).
+pmStdTab = value (PieriMaps#"private dictionary"#"standardTableaux");
+needsPackage "SchurFunctors";
+for shape in {{2,1}, {3,2,1}, {3,2}, {2,2,1}} do (
+     for T in pmStdTab(3, shape) do (
+	  fil := pmToFilling T;
+	  back := new MutableHashTable;
+	  for k in keys fil do (
+	       sub := fillingToPM k;
+	       for K in keys sub do (
+		    cc := fil#k * sub#K;
+		    if back#?K then back#K = back#K + cc else back#K = cc;
+		    );
+	       );
+	  cleaned := for k in keys back list if back#k != 0 then (k => back#k) else continue;
+	  -- Round-trip should be a single nonzero coefficient on T itself.
+	  assert(#cleaned == 1);
+	  assert((cleaned#0)#0 == T);
+	  );
+     );
+-- PM <-> Weyl bijection.
+for shape in {{3,2,1}, {2,2,1}, {3,2}} do (
+     pm := pmStdTab(3, shape);
+     assert(apply(apply(pm, pmToWeyl), weylToPM) == pm);
+     );
+///
+
+-- Column-Pieri proportional to row-Pieri after PM<->Filling change of basis.
+TEST ///
+pmStdTab = value (PieriMaps#"private dictionary"#"standardTableaux");
+needsPackage "SchurFunctors";
+sfStdTab = value (SchurFunctors#"private dictionary"#"standardTableaux");
+mu = {2,1}; r = 1; col = 2; n = 3;
+Psym = QQ[x_0..x_(n-1)];
+Pskew = QQ[e_0..e_(n-1), SkewCommutative => true];
+Mrow = pieri(mu, {r}, Psym);
+Mcol = pieriColumn(mu, {col}, Pskew);
+pmS = pmStdTab(n, mu);
+sfS = sfStdTab(n, toList conjugate (new Partition from mu));
+lambda = {1,1};
+pmL = pmStdTab(n, lambda);
+sfL = sfStdTab(n, toList conjugate (new Partition from lambda));
+A = pmToFillingMatrix(mu, n);
+B = fillingToPMMatrix(lambda, n);
+rowFlat = matrix flatten for ti from 0 to #pmL-1 list
+     for kk from 0 to n-1 list
+	  for sj from 0 to #pmS - 1 list lift(coefficient(Psym_kk, Mrow_(ti, sj)), QQ);
+colFlat = matrix flatten for tj from 0 to #sfL-1 list
+     for kk from 0 to n-1 list
+	  for siF from 0 to #sfS - 1 list lift(coefficient(Pskew_kk, Mcol_(tj, siF)), QQ);
+McolPM = (B ** id_(QQ^n)) * colFlat * A;
+assert(rank rowFlat == rank McolPM);
+assert(rank (rowFlat | McolPM) == rank rowFlat);  -- proportional
+///
+
+-- verifyWellDefined: the Convention option respects the appropriate
+-- straightening relations.
+TEST ///
+needsPackage "SchurFunctors";
+Qs = lrTableaux({3,2,1}, {2,1}, {2,1});
+for Q in Qs do
+     for conv in {"Row","Filling","Weyl"} do
+	  assert(verifyWellDefined(({3,2,1},{2,1},{2,1}), Q, 3,
+	       Convention => conv, Verbose => false));
+///
+
+-- Direct GL_n equivariance check for the row-Pieri inclusion S_mu V -->
+-- V (x) S_lambda V.
+--
+-- The Lie algebra gl_n acts via Chevalley generators E_{i,j} (i != j):
+--   * on V = K^n by E_{i,j}(x_l) = delta_{l,j} * x_i  (i.e. x_i d/dx_j),
+--   * on S_mu V (PM row-SSYT basis) by replacing each entry equal to j
+--     with i, summing over positions, then row-Garnir straightening,
+--   * on V (x) S_lambda V by the Leibniz rule.
+--
+-- For the Pieri matrix  M : S_mu V --> V (x) S_lambda V  encoded as a
+-- (#stdLambda) x (#stdMu) matrix over P with degree-1-form entries, the
+-- equivariance test is, for each column index T of M:
+--     LHS = sum c_k * M_{*, T_k},  where E_{i,j}.T = sum c_k * T_k
+--     RHS = (V-action on M_{*,T} entries) + (S_lambda-action on the
+--                                            target row indices).
+-- The matrix is GL_n-equivariant iff LHS = RHS for every T and every
+-- (i, j).  Since our Pieri map is rationally constructed and S_mu V is
+-- an irreducible GL representation, equivariance is the unique
+-- characterization (up to scalar) by Schur's lemma.
+TEST ///
+-- Action of E_{i,j} on a row-SSYT tableau, returning a HashTable of std
+-- tableau coefficients via straightening.
+actE = (i, j, T) -> (
+     totalH := new MutableHashTable;
+     for r from 0 to #T-1 do
+	  for c from 0 to #(T#r)-1 do
+	       if T#r#c == j then (
+		    Tprime := for r2 from 0 to #T-1 list
+			 (if r2 == r then
+			      for c2 from 0 to #(T#r2)-1 list
+				   (if c2 == c then i else (T#r2)#c2)
+			  else T#r2);
+		    h := straighten Tprime;
+		    for k in keys h do
+			 if totalH#?k then totalH#k = totalH#k + h#k
+			 else totalH#k = h#k;
+		    );
+     new HashTable from totalH
+     );
+
+-- Test M is gl_n-equivariant by checking commutativity with each E_{i,j}.
+checkPieriEquivariant = (mu, boxes, n) -> (
+     P := QQ[x_0..x_(n-1)];
+     X := gens P;
+     M := pieri(mu, boxes, P);
+     subOne := (m, k) -> for ii from 0 to #m-1 list (if ii == k-1 then m_ii - 1 else m_ii);
+     lambda := mu;
+     for b in boxes do lambda = subOne(lambda, b);
+     stdsMu  := standardTableaux(n, mu);
+     stdsLam := standardTableaux(n, lambda);
+     for i from 0 to n-1 do for j from 0 to n-1 do (
+	  if i == j then continue;
+	  for tIdx from 0 to #stdsMu-1 do (
+	       T := stdsMu#tIdx;
+	       colT := flatten entries M_{tIdx};
+	       -- RHS = E.M(T): V-action + S_lambda-action
+	       -- V-action on Sym^m V (x) S_lambda part: x_i * d/dx_j applied
+	       -- to each entry (entries are degree-m forms for m-box strips).
+	       vAction := for f in colT list X#i * diff(X#j, f);
+	       sAction := new MutableList from for s in stdsLam list 0_P;
+	       for idx from 0 to #stdsLam-1 do (
+		    h := actE(i, j, stdsLam#idx);
+		    for kk in keys h do (
+			 idxK := position(stdsLam, s -> s == kk);
+			 if idxK =!= null then
+			      sAction#idxK = sAction#idxK + h#kk * colT#idx;
+			 );
+		    );
+	       RHS := for idx from 0 to #stdsLam-1 list (vAction#idx + sAction#idx);
+	       -- LHS = M(E.T)
+	       LHS := for s in stdsLam list 0_P;
+	       hT := actE(i, j, T);
+	       for kk in keys hT do (
+		    idxK := position(stdsMu, s -> s == kk);
+		    if idxK =!= null then (
+			 colK := flatten entries M_{idxK};
+			 LHS = for idx from 0 to #stdsLam-1 list
+			      (LHS#idx + hT#kk * colK#idx);
+			 );
+		    );
+	       assert(LHS == RHS);
+	       );
+	  );
+     );
+
+-- Single-box, every row removable: the cases that catch the "interior k"
+-- bug discussed in the documentation tests for path-based pieri.
+checkPieriEquivariant({2,1},   {1}, 3);
+checkPieriEquivariant({2,1},   {2}, 3);
+checkPieriEquivariant({3,2,1}, {1}, 3);
+checkPieriEquivariant({3,2,1}, {2}, 3);  -- INTERIOR row removal
+checkPieriEquivariant({3,2,1}, {3}, 3);
+
+-- Multi-box horizontal strips, including patterns through interior rows.
+checkPieriEquivariant({3,2,1}, {1,3},   3);
+checkPieriEquivariant({3,2,1}, {1,2,3}, 3);
+checkPieriEquivariant({3,1},   {1,1},   3);
+///
+
+-- dualPieri ∘ pieri == Id (the defining property of the GL-equivariant
+-- projection by Schur's lemma).  Tested across single- and multi-box
+-- strips and across all three Conventions.
+TEST ///
+encodeKMat = (M, monBasis, K) -> (
+     dimLam := numRows M;
+     dimMu  := numColumns M;
+     matrix(K, flatten for tLam from 0 to dimLam-1 list (
+	       for alpha in monBasis list (
+		    for tMu from 0 to dimMu-1 list (
+			 lift(coefficient(alpha, M_(tLam, tMu)), K)))))
+     );
+
+checkDualPieriId = (mu, boxes, P, conv) -> (
+     M := pieri(mu, boxes, P, Convention => conv);
+     N := dualPieri(mu, boxes, P, Convention => conv);
+     monBasis := flatten entries basis(#boxes, P);
+     Mk := encodeKMat(M, monBasis, QQ);
+     assert(N * Mk == id_(QQ^(numColumns Mk)));
+     );
+
+P = QQ[a,b,c];
+for conv in {"Row", "Filling", "Weyl"} do (
+     checkDualPieriId({2,1},   {1}, P, conv);
+     checkDualPieriId({2,1},   {2}, P, conv);
+     checkDualPieriId({3,2,1}, {1}, P, conv);
+     checkDualPieriId({3,2,1}, {2}, P, conv);
+     checkDualPieriId({3,2,1}, {3}, P, conv);
+     checkDualPieriId({3,2,1}, {1,3}, P, conv);
+     checkDualPieriId({3,1},   {1,1}, P, conv);
+     );
+///
+
+-- dualLR ∘ lrMap == Id (per Q), and for multiplicity > 1, the dual at Q
+-- annihilates the inclusions for OTHER LR tableaux Q': dualLR_Q ∘ lrMap_{Q'} = 0.
+TEST ///
+checkDualLRId = (shapes, Q, n, conv) -> (
+     M := lrMap(shapes, Q, n, Convention => conv);
+     N := dualLR(shapes, Q, n, Convention => conv);
+     assert(N * M == id_(QQ^(numColumns M)));
+     );
+
+checkDualLRCrossZero = (shapes, Q, Qother, n, conv) -> (
+     N := dualLR(shapes, Q, n, Convention => conv);
+     M := lrMap(shapes, Qother, n, Convention => conv);
+     assert(N * M == 0);
+     );
+
+for conv in {"Row", "Filling", "Weyl"} do (
+     -- multiplicity-1 cases
+     checkDualLRId(({2,1}, {1}, {1,1}), (lrTableaux({2,1},{1},{1,1}))#0, 3, conv);
+     checkDualLRId(({2,2}, {1,1}, {1,1}), (lrTableaux({2,2},{1,1},{1,1}))#0, 3, conv);
+     -- multiplicity 2: c^{(3,2,1)}_{(2,1),(2,1)} = 2 -- both directions
+     Qs := lrTableaux({3,2,1}, {2,1}, {2,1});
+     for Q in Qs do checkDualLRId(({3,2,1},{2,1},{2,1}), Q, 3, conv);
+     -- cross-Q orthogonality
+     checkDualLRCrossZero(({3,2,1},{2,1},{2,1}), Qs#0, Qs#1, 3, conv);
+     checkDualLRCrossZero(({3,2,1},{2,1},{2,1}), Qs#1, Qs#0, 3, conv);
+     );
+///
+
+-- applyDualPieri / applyDualLR: point evaluation respects the matrix product
+-- and handles non-standard input via convention-aware straightening.  Inputs
+-- can be passed as either a List (PM row form) or a Filling (column form),
+-- regardless of Convention.
+TEST ///
+-- Cache PM's standardTableaux BEFORE loading SchurFunctors (which would
+-- shadow the symbol with its own Filling-returning version).
+pmStdTab = value (PieriMaps#"private dictionary"#"standardTableaux");
+needsPackage "SchurFunctors";
+
+-- (1) applyDualPieri agrees with the matrix product on standard input.
+P = QQ[a,b,c];
+n = 3;
+mu = {3,2,1};
+boxes = {1};
+lambda = {2,2,1};
+N = dualPieri(mu, boxes, P);
+stdsLam = pmStdTab(n, lambda);
+stdsMu  = pmStdTab(n, mu);
+mons = flatten entries basis(1, P);
+for tLam in stdsLam do for alpha in mons do (
+     img := applyDualPieri((mu, boxes), alpha, tLam, n);
+     -- compare with N applied to e_(tLam, alpha)
+     iLam := position(stdsLam, s -> s == tLam);
+     iAlpha := position(mons, m -> m == alpha);
+     col := iLam * #mons + iAlpha;
+     expected := flatten entries N_{col};
+     observed := for s in stdsMu list (
+	  c := select(img, p -> p#1 == s);
+	  if #c == 0 then 0_QQ else c#0#0
+	  );
+     assert(observed == expected);
+     );
+
+-- (2) applyDualPieri straightens non-standard input.
+-- {{1,0},{2}} is non-standard for shape {2,1}: row 1 is decreasing.
+P2 = QQ[a,b,c,d];
+nonStdRes = applyDualPieri(({3,2,1}, {3}), a, {{1,0},{2}}, 4);
+strRes = applyDualPieri(({3,2,1}, {3}), a, {{0,1},{2}}, 4);
+-- Straightening of {{1,0},{2}} swaps row entries: should give same as {{0,1},{2}}
+-- (row Garnir gives the standard form trivially since {0,1}=sort{1,0}).
+assert(set apply(nonStdRes, p -> {p#0, p#1}) === set apply(strRes, p -> {p#0, p#1}));
+
+-- (3) applyDualLR agrees with the matrix on a standard basis pair.
+shapes = ({2,1}, {1}, {1,1});
+Q = (lrTableaux shapes)#0;
+N2 = dualLR(shapes, Q, 3);
+stdsLam = pmStdTab(3, shapes#0);
+stdsMu  = pmStdTab(3, shapes#1 | toList(#(shapes#0) - #(shapes#1) : 0));
+stdsNu  = pmStdTab(3, shapes#2);
+for tNu in stdsNu do for tMu in stdsMu do (
+     img := applyDualLR(shapes, Q, {tNu, tMu}, 3);
+     iNu := position(stdsNu, s -> s == tNu);
+     iMu := position(stdsMu, s -> s == tMu);
+     col := iNu * #stdsMu + iMu;
+     expected := flatten entries N2_{col};
+     observed := for s in stdsLam list (
+	  c := select(img, p -> p#1 == s);
+	  if #c == 0 then 0_QQ else c#0#0
+	  );
+     assert(observed == expected);
+     );
+
+-- (4) Input-type flexibility: applyDualPieri accepts either a List (PM
+-- row form) or a Filling (column form) regardless of Convention, and
+-- runs without error on each.  Filling inputs go through fillingToPM
+-- internally (under Convention "Row" / "Weyl"), so the result is in
+-- PM std-tableau basis on output.
+P3 = QQ[a,b,c];
+listT = (pmStdTab(3, {2,1}))#0;
+imgFromList = applyDualPieri(({3,1}, {1}), a, listT, 3);
+assert(#imgFromList >= 1);
+-- Same call with a Filling input runs (the conversion path is exercised).
+expansion = pmToFilling listT;
+filT = (keys expansion)#0;
+imgFromFilling = applyDualPieri(({3,1}, {1}), a, filT, 3);
+assert(#imgFromFilling >= 1);
+-- Output T_mu values come from the PM std basis in either case.
+assert(all(imgFromList,    p -> class p#1 === List));
+assert(all(imgFromFilling, p -> class p#1 === List));
+///
+
+-- Transition matrices between conventions are mutually invertible (up to
+-- the documented shape-dependent scalar c_lambda for PM <-> Filling).
+TEST ///
+needsPackage "SchurFunctors";
+for shape in {{2,1}, {3,1}, {3,2}, {3,2,1}, {2,2,1}} do
+     for n in {3, 4} do (
+	  if n < #shape then continue;
+	  A := pmToFillingMatrix(shape, n);
+	  B := fillingToPMMatrix(shape, n);
+	  -- A * B and B * A are scalar multiples of identity (the c_lambda scalar)
+	  prodAB := A * B;
+	  prodBA := B * A;
+	  -- Diagonals are all the same value
+	  diagAB := apply(min(numRows prodAB, numColumns prodAB),
+	       i -> prodAB_(i, i));
+	  assert(all(diagAB, d -> d == diagAB#0));
+	  c := diagAB#0;
+	  assert(c != 0);
+	  assert(prodAB == c * id_(QQ^(numRows prodAB)));
+	  assert(prodBA == c * id_(QQ^(numRows prodBA)));
+	  );
+///
+
+-- verifyEquivariant: all the maps we construct (pieri, lrMap, dualPieri,
+-- dualLR) are GL_n-equivariant.  Tested in Row and Weyl conventions
+-- (matrix data is identical between the two; the test machinery uses
+-- PM row-Garnir straightening for the gl_n action).
+TEST ///
+P = QQ[a,b,c];
+
+-- pieri inclusion S_mu V -> Sym^d V (x) S_lambda V
+for conv in {"Row", "Filling", "Weyl"} do (
+     M := pieri({3,2,1}, {1}, P, Convention => conv);
+     assert(verifyEquivariant(M, {3,2,1}, {1}, P, Convention => conv));
+     M2 := pieri({3,2,1}, {2}, P, Convention => conv);
+     assert(verifyEquivariant(M2, {3,2,1}, {2}, P, Convention => conv));
+     -- multi-box
+     M3 := pieri({3,2,1}, {1,3}, P, Convention => conv);
+     assert(verifyEquivariant(M3, {3,2,1}, {1,3}, P, Convention => conv));
+     );
+///
+
+TEST ///
+-- lrMap S_lambda V -> S_nu V (x) S_mu V
+for conv in {"Row", "Filling", "Weyl"} do (
+     for Q in lrTableaux({3,2,1}, {2,1}, {2,1}) do (
+	  M := lrMap(({3,2,1}, {2,1}, {2,1}), Q, 3, Convention => conv);
+	  assert(verifyEquivariant(M, ({3,2,1}, {2,1}, {2,1}), 3, Convention => conv));
+	  );
+     );
+///
+
+TEST ///
+-- dualPieri Sym^d V (x) S_lambda V -> S_mu V
+P = QQ[a,b,c];
+for conv in {"Row", "Filling", "Weyl"} do (
+     M := dualPieri({3,2,1}, {1}, P, Convention => conv);
+     assert(verifyEquivariant(M, {3,2,1}, {1}, P, Convention => conv, Direction => "Dual"));
+     M2 := dualPieri({3,2,1}, {2}, P, Convention => conv);
+     assert(verifyEquivariant(M2, {3,2,1}, {2}, P, Convention => conv, Direction => "Dual"));
+     );
+///
+
+TEST ///
+-- dualLR S_nu V (x) S_mu V -> S_lambda V (per Q)
+for conv in {"Row", "Filling", "Weyl"} do (
+     for Q in lrTableaux({3,2,1}, {2,1}, {2,1}) do (
+	  N := dualLR(({3,2,1}, {2,1}, {2,1}), Q, 3, Convention => conv);
+	  assert(verifyEquivariant(N, ({3,2,1}, {2,1}, {2,1}), 3, Convention => conv, Direction => "Dual"));
+	  );
+     );
+///
+
+-- pieriColumn with Convention support: matches dim and is consistent with Filling.
+TEST ///
+P = QQ[e_0..e_2, SkewCommutative => true];
+M_F = pieriColumn({2,1}, {1}, P, Convention => "Filling");
+M_R = pieriColumn({2,1}, {1}, P, Convention => "Row");
+M_W = pieriColumn({2,1}, {1}, P, Convention => "Weyl");
+assert(numRows M_R == numRows M_F and numColumns M_R == numColumns M_F);
+assert(M_R == M_W);
+///
+
+-- dualPieriColumn ∘ pieriColumn = Id (column-form analogue of dualPieri).
+TEST ///
+P = QQ[e_0..e_2, SkewCommutative => true];
+encodeKMat = (M, monBasis, K) -> (
+     dimLam := numRows M;
+     dimMu  := numColumns M;
+     matrix(K, flatten for tLam from 0 to dimLam-1 list (
+	       for alpha in monBasis list (
+		    for tMu from 0 to dimMu-1 list (
+			 lift(coefficient(alpha, M_(tLam, tMu)), K)))))
+     );
+checkColId = (mu, cols, P, conv) -> (
+     M := pieriColumn(mu, cols, P, Convention => conv);
+     N := dualPieriColumn(mu, cols, P, Convention => conv);
+     monBasis := flatten entries basis(#cols, P);
+     Mk := encodeKMat(M, monBasis, QQ);
+     assert(N * Mk == id_(QQ^(numColumns Mk)));
+     );
+for conv in {"Row", "Filling", "Weyl"} do (
+     checkColId({2,1},   {1}, P, conv);
+     checkColId({2,1},   {2}, P, conv);
+     checkColId({2,1,1}, {1}, P, conv);
+     );
+///
+
+-- applyPieri / applyPieriColumn agree with the corresponding column of the
+-- matrix on a standard input tableau.
+TEST ///
+P = QQ[a,b,c];
+mu = {3,2,1};
+boxes = {1};
+M = pieri(mu, boxes, P);
+stdsMu = standardTableaux(3, mu);
+for tIdx from 0 to #stdsMu - 1 do (
+     T := stdsMu#tIdx;
+     for r from 0 to #boxes - 1 list r;
+     img := applyPieri((mu, boxes), T, P);
+     col := flatten entries M_{tIdx};
+     -- Reconstruct img as a vector indexed by lambda's std tableaux.
+     stdsLam := standardTableaux(3, {2,2,1});
+     reconstructed := for s in stdsLam list (
+	  matched := select(img, p -> p#1 == s);
+	  if #matched == 0 then 0_P else matched#0#0
+	  );
+     assert(reconstructed == col);
+     );
+///
+
+-- verifyWellDefined for pieri / pieriColumn / dualPieri / dualPieriColumn
+-- across all conventions.  Smoke test that the apply functions factor
+-- through Garnir straightening relations.
+TEST ///
+P = QQ[a,b,c];
+Pcol = QQ[e_0..e_2, SkewCommutative => true];
+for conv in {"Row", "Filling", "Weyl"} do (
+     -- pieri inclusion
+     assert(verifyWellDefined({3,2,1}, {1}, P, Convention => conv, Verbose => false));
+     -- dualPieri projection
+     assert(verifyWellDefined({3,2,1}, {1}, P, Convention => conv, Direction => "Dual", Verbose => false));
+     -- pieriColumn inclusion
+     assert(verifyWellDefined({2,1}, {1}, Pcol, Convention => conv, Verbose => false));
+     -- dualPieriColumn projection
+     assert(verifyWellDefined({2,1}, {1}, Pcol, Convention => conv, Direction => "Dual", Verbose => false));
+     );
+-- dualLR projection
+for conv in {"Row", "Filling", "Weyl"} do (
+     for Q in lrTableaux({2,1}, {1}, {1,1}) do
+	  assert(verifyWellDefined(({2,1}, {1}, {1,1}), Q, 3, Convention => conv,
+	       Direction => "Dual", Verbose => false));
+     );
+///
+
+-- Edge cases: empty boxes, single-cell shapes, n = 1.
+TEST ///
+P3 = QQ[a,b,c];
+-- Empty boxes for pieri: identity-like map (mu == lambda).  pieri requires
+-- at least one box currently; skip and check single-box minimal case.
+assert(numRows pieri({1}, {1}, P3) == 1);   -- {1} -> empty: 1x3 matrix
+M = pieri({1}, {1}, P3);
+assert(rank M == 1);
+-- Single-cell input via applyPieri.
+img = applyPieri(({1}, {1}), {{0}}, P3);
+assert(#img == 1);
+assert(img#0#0 == a);
+-- n = 1 case: only mu = {k} valid.  pieri({2}, {1}, P3) is fine; pieri({2}, {1}, QQ[x]) too.
+P1 = QQ[x];
+M1 = pieri({2}, {1}, P1);
+assert(numRows M1 == 1 and numColumns M1 == 1);   -- dim S_(2) K^1 = 1, dim S_(1) K^1 = 1
+///


### PR DESCRIPTION
Adds projection-direction maps (dualPieri, dualPieriColumn, dualLR),
point evaluators (applyPieri, applyPieriColumn, applyLR, applyDualPieri,
applyDualLR, applyDualPieriColumn), three basis conventions
(Row / Filling / Weyl) with conversion utilities, GL_n equivariance
and well-definedness checkers (verifyEquivariant, verifyWellDefined),
and symbolic display of any constructed map (symbolicForm).