### PR TITLE
Add minimalPrimes strategy for ideals in ZZ and ZZ/n

### DIFF
--- a/M2/Macaulay2/m2/matrix1.m2
+++ b/M2/Macaulay2/m2/matrix1.m2
@@ -6,6 +6,7 @@ needs "quotient.m2"
 
 -----------------------------------------------------------------------------
 
+module RingFamily :=
 module Ring := Module => (cacheValue symbol module)(R -> R^1)
 
 matrix(RingFamily,List) := Matrix => opts -> (R,m) -> matrix(default R, m, opts)

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -232,8 +232,15 @@ Ring / List := Ring / Sequence := QuotientRing => (R,f) -> R / promote(ideal f, 
 
 -----------------------------------------------------------------------------
 
-presentation PolynomialRing := Matrix => R -> map(R^1, R^0, 0)
-presentation QuotientRing   := Matrix => R -> R.presentation ??= (
+ZZ.presentation =
+QQ.presentation = R -> presentation module R
+presentation Ring := Matrix => R -> (
+    if R.?presentation then R.presentation R
+    else notImplemented "presentation for this ring")
+presentation InexactFieldFamily := Matrix => R -> presentation default R
+presentation PolynomialRing :=
+presentation InexactField   := Matrix => R -> presentation module R
+presentation QuotientRing   := Matrix => R -> R.cache.presentation ??= (
 	  S := ambient R;
 	  f := generators ideal R;
 	  while class S === QuotientRing do (		    -- untested code

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -283,7 +283,7 @@ char QuotientRing := (stashValue symbol char) ((S) -> (
      if isPrime p or isMember(QQ,S.baseRings) then return if S == 0 then 1 else p;
      relns := presentation S;
      if relns == 0 then return char ring relns;
-     if coefficientRing S =!= ZZ then notImplemented();
+     if ultimate(coefficientRing, S) =!= ZZ then notImplemented();
      g := generators gb relns;
      if g == 0 then return char ring g;
      m := g_(0,0);

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -363,8 +363,8 @@ Constant _ Ring := (c,R) -> (
 Number   _ RingFamily :=
 Constant _ RingFamily := (x, R) -> x_(default R)
 -- TODO: find examples, or remove
-Number   ^ RingFamily :=
-Constant ^ RingFamily := (x, R) -> lift(x, default R) -- TODO: set Verify => false?
+Number      ^ RingFamily :=
+RingElement ^ RingFamily := (x, R) -> lift(x, default R) -- TODO: set Verify => false?
 
 Constant + Number := (c,x) -> numeric c + x
 Number + Constant := (x,c) -> x + numeric c

--- a/M2/Macaulay2/m2/rings.m2
+++ b/M2/Macaulay2/m2/rings.m2
@@ -102,7 +102,7 @@ isConstant = method(TypicalValue => Boolean)
 isConstant RingElement := r -> liftable(r, coefficientRing ring r)
 
 lift = method(Dispatch => {Thing, Type, Type}, Options => {Verify => true})
-Number ^ Ring := lift
+Number ^ Ring := RingElement ^ Ring := lift
 
 promote = method(Dispatch => {Thing, Type, Type})
 Number _ Ring := promote

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_module.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_module.m2
@@ -156,7 +156,7 @@ document {
     },
      }
 
-document { Key => (module, Ring),
+document { Key => {(module, Ring), (module, RingFamily)},
      Usage => "module R",
      Inputs => {"R"},
      Outputs => {{"the free module of rank 1 over the ring R"}},

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/lift-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/lift-doc.m2
@@ -54,6 +54,8 @@ document {
       (lift, RRi, ZZ),
 	  (symbol ^, Number, Ring),
 	  (symbol ^, Number, RingFamily),
+	  (symbol ^, RingElement, Ring),
+	  (symbol ^, RingElement, RingFamily),
       (lift,Matrix,RRi',QQ),
       (lift,Matrix,RRi',RR'),
       (lift,Matrix,RRi',ZZ)

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/presentation-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/presentation-doc.m2
@@ -4,6 +4,9 @@
 
 undocumented {
      	  (presentation,QuotientRing,QuotientRing),	  
+	  (presentation,Ring),
+	  (presentation,InexactField),
+	  (presentation,InexactFieldFamily),
 	  (presentation,PolynomialRing),
 	  (presentation,PolynomialRing,PolynomialRing),
 	  (presentation,QuotientRing,PolynomialRing)

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators/caret.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators/caret.m2
@@ -10,7 +10,6 @@ undocumented {
      (symbol ^, QQ, InfiniteNumber),
      (symbol ^, RR, InfiniteNumber),
      (symbol ^, Constant, Constant),
-     (symbol ^, Constant, RingFamily),
      (symbol ^, Constant, InexactNumber),
      (symbol ^, Constant, Number),
      (symbol ^, InexactNumber, Constant),

--- a/M2/Macaulay2/packages/MinimalPrimes.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes.m2
@@ -220,8 +220,6 @@ minprimesHelper = (I, key, opts) -> (
     if I == 1 then return {};
     J := first flattenRing I;
     if J == 0 then return {I};
-    -- TODO: make presentation work for ZZ, then move this line
-    if ring I === ZZ then return ideal \ first \ toList factor (trim I)_0;
     S := ring presentation ring J;
 
     strategy := opts.Strategy;
@@ -311,10 +309,22 @@ algorithms#(minimalPrimes, Ideal) = new MutableHashTable from {
 	minI := dual radical monomialIdeal I;
 	-- TODO: make sure (monomialIdeal, MonomialIdeal) isn't forgetful
 	cast \ if minI == 1 then { 0_R } else support \ minI_*),
+
+    ZZ => (
+	isZZ := R -> (
+	    R === ZZ or
+	    -- ZZ[] (or ZZ[][], ZZ[][][], etc.)
+	    instance(R, PolynomialRing) and numgens R == 0 and
+	    isZZ coefficientRing R);
+	(opts, I) -> (
+	    R := ring I;
+	    if isZZ R or instance(R, QuotientRing) and isZZ baseRing R then (
+		n := gcd append(apply(I_*, a -> a^ZZ), char R);
+		apply(first \ toList factor n, p -> ideal p_R)))),
     }
 
 -- Installing hooks for (minimalPrimes, Ideal)
-scan({"Legacy", "NoBirational", "Birational", Hybrid, Monomial}, strategy ->
+scan({"Legacy", "NoBirational", "Birational", Hybrid, Monomial, ZZ}, strategy ->
     addHook(key := (minimalPrimes, Ideal), algorithms#key#strategy, Strategy => strategy))
 
 --------------------------------------------------------------------

--- a/M2/Macaulay2/packages/MinimalPrimes/tests.m2
+++ b/M2/Macaulay2/packages/MinimalPrimes/tests.m2
@@ -1884,6 +1884,31 @@ TOODAMNSLOW ///
 
   minimalPrimes I -- doesn't seem to finish.  But in fact crashed in <= M2 1.24.05, (see previous test).
 ///
+
+TEST ///
+-- issue #3505
+R = ZZ/5
+assert(minimalPrimes ideal 0_R == {ideal 0_R})
+assert(minimalPrimes ideal 1_R == {})
+assert(minimalPrimes ideal 2_R == {})
+assert(minimalPrimes ideal 3_R == {})
+assert(minimalPrimes ideal 4_R == {})
+R = ZZ/6
+assert(minimalPrimes ideal 0_R == {ideal 2_R, ideal 3_R})
+assert(minimalPrimes ideal 1_R == {})
+assert(minimalPrimes ideal 2_R == {ideal 2_R})
+assert(minimalPrimes ideal 3_R == {ideal 3_R})
+assert(minimalPrimes ideal 4_R == {ideal 2_R})
+assert(minimalPrimes ideal 5_R == {})
+R = ZZ[][][][]/6
+assert(minimalPrimes ideal 0_R == {ideal 2_R, ideal 3_R})
+assert(minimalPrimes ideal 1_R == {})
+assert(minimalPrimes ideal 2_R == {ideal 2_R})
+assert(minimalPrimes ideal 3_R == {ideal 3_R})
+assert(minimalPrimes ideal 4_R == {ideal 2_R})
+assert(minimalPrimes ideal 5_R == {})
+///
+
 end--
 
 -- UHOH problem with finite fields

--- a/M2/Macaulay2/tests/normal/presentation.m2
+++ b/M2/Macaulay2/tests/normal/presentation.m2
@@ -1,0 +1,4 @@
+assert zero presentation ZZ
+assert zero presentation QQ
+assert zero presentation RR
+assert zero presentation CC


### PR DESCRIPTION
This closes #3505:

```m2
i1 : isPrime ideal 0_(ZZ/2)

o1 = true

i2 : isPrime ideal 0_(ZZ/4)

o2 = false
```

We also add a few related updates I encountered along the way:

* We add `module(RingFamily)` so `module RR` and `module CC` work.
* We add `presentation(Ring)` (and `presentation(RingFamily)` so `presentation ZZ` works.  It calls `presentation(Module)`, so the result gets cached.
* We add `RingElement^Ring` as syntactic sugar for `lift` (matching `Number^Ring`)
* We can now find the characterisic of tower rings over `ZZ`.
 
