### PR TITLE
Update hash for ZZ/RR to be platform-independent and use 64 bits

### DIFF
--- a/M2/Macaulay2/d/gmp.d
+++ b/M2/Macaulay2/d/gmp.d
@@ -1406,17 +1406,9 @@ export intersectRRi (x:RRi, y:RRi, prec:ulong):RRi := (
      Ccode( void, "mpfi_intersect(", z, ",",  x, ",",  y, ")" );
      moveToRRiandclear(z));
 
-export hash(x:RR):hash_t := hash_t(precision0(x)) + Ccode(hash_t,
-     "mpfr_hash(",					    -- see gmp_aux.c for this function
-          x, 
-     ")"
-    );
+export hash(x:RR):hash_t := Ccode(hash_t, "mpfr_hash(", x, ")"); -- see gmp_aux.c
 
-export hash(x:RRi):hash_t := hash_t(precision0(x)) + Ccode(hash_t,
-    "mpfi_hash(",     -- Added for MPFI
-    x,
-    ")"
-    ); -- End added for MPFI
+export hash(x:RRi):hash_t := Ccode(hash_t, "mpfi_hash(", x, ")"); -- see gmp_aux.c
 
 export hash(x:CC):hash_t := 123 + hash(x.re) + 111 * hash(x.im);
      

--- a/M2/Macaulay2/d/gmp_aux.c
+++ b/M2/Macaulay2/d/gmp_aux.c
@@ -1,38 +1,51 @@
 /* some routines to augment the gmp library */
 #include <M2/config.h>
 #include "M2/math-include.h"
+#include <stdlib.h>
 #include <string.h>
 
-int mpz_hash(mpz_srcptr x) {
-  int h = 0;
-  int n = x->_mp_size;
-  int i;
-  if (n < 0) n = -n;
-  for (i = 0; i<n; i++, h*=3737) h += x->_mp_d[i];
-  if (x->_mp_size < 0) h = -h;
+uint64_t mpz_hash(mpz_srcptr x) {
+  size_t n_bytes, count, i;
+  uint64_t h;
+  unsigned char *buf;
+
+  n_bytes = (mpz_sizeinbase(x, 2) + 7) / 8;
+  buf = malloc(n_bytes + 1);
+  mpz_export(buf, &count, 1, 1, 1, 0, x);
+  h = 0;
+
+  for (i = 0; i < count; i++)
+    h = h * 3737 + buf[i];
+
+  free(buf);
+
+  return h + 6701 * mpz_sgn(x);
+}
+
+uint64_t mpfr_hash(mpfr_srcptr x) {
+  mpfr_exp_t exp;
+  mpz_t sig;
+  uint64_t h;
+
+  h = 3737 * mpfr_get_prec(x);
+
+  if (mpfr_zero_p(x))
+    return h + 6599 * mpfr_signbit(x) + 569;
+  if (mpfr_nan_p(x))
+    return h + 3581;
+  if (mpfr_inf_p(x))
+    return h +  5039 * mpfr_sgn(x) + 9733;
+
+  mpz_init(sig);
+  exp = mpfr_get_z_2exp(sig, x);
+
+  h += 3449 * mpz_hash(sig) + 2143 * exp;
+  mpz_clear(sig);
   return h;
 }
 
-int mpfr_hash(mpfr_srcptr x) {
-  int h = 0;
-  int n = (x->_mpfr_prec+mp_bits_per_limb-1)/mp_bits_per_limb;
-  int i;
-  if (0 != mpfr_sgn(x))
-    for (i = 0; i<n; i++, h*=3737) h += x->_mpfr_d[i];
-  return 777 + h * 3737 + x->_mpfr_exp + 11 * x->_mpfr_sign;
-}
-
-
-int mpfi_hash(mpfi_srcptr x) { // Really not sure if this is doing the right thing.
-    int h = 0;
-    int n_left = (x->left._mpfr_prec+mp_bits_per_limb-1)/mp_bits_per_limb;
-    int n_right = (x->right._mpfr_prec+mp_bits_per_limb-1)/mp_bits_per_limb;
-    int i;
-    if (0 != mpfr_sgn(&x->left))
-    for (i = 0; i<n_left; i++, h*=3737) h += x->left._mpfr_d[i];
-    if (0 != mpfr_sgn(&x->right))
-    for (i = 0; i<n_right; i++, h*=3737) h += x->right._mpfr_d[i];
-    return 777 + h * 3737 + x->left._mpfr_exp + x->right._mpfr_exp + 11 * x->left._mpfr_sign + 11 * x->right._mpfr_sign;
+uint64_t mpfi_hash(mpfi_srcptr x) {
+  return mpfr_hash(&x->left) + 3737 * mpfr_hash(&x->right);
 }
 
 void mp_free_str(char *str){

--- a/M2/Macaulay2/d/gmp_aux.h
+++ b/M2/Macaulay2/d/gmp_aux.h
@@ -1,6 +1,8 @@
 /* some routines to augment the gmp library */
 
-extern int mpz_hash(mpz_srcptr x);
-extern int mpfr_hash(mpfr_srcptr x);
-extern int mpfi_hash(mpfi_srcptr x);
+#include <stdint.h>
+
+extern uint64_t mpz_hash(mpz_srcptr x);
+extern uint64_t mpfr_hash(mpfr_srcptr x);
+extern uint64_t mpfi_hash(mpfi_srcptr x);
 extern void mp_free_str(char* str);

--- a/M2/Macaulay2/m2/basictests/hashcodes.m2
+++ b/M2/Macaulay2/m2/basictests/hashcodes.m2
@@ -5,6 +5,7 @@ assert ( hash {("a","bcd"),("bcd","a")} == 10180479327404092074 )
 
 -- it would also be nice to keep the following hash codes the same
 assert( (hash 123) === 123 )
+assert( hash 2^100 === 3405506911546692669 )
 assert( (hash "asdf") === 3003444 )
 assert( (hash {1,2,3}) === 5292466133541383614 )
 assert( (hash (1,2,3)) === 568179786079386623 )
@@ -18,9 +19,7 @@ assert( (hash Nothing) === 1000069 )
 assert( (hash (1 => 2)) === 1729140528276943882 )
 assert( hash Nothing == 1000069 )
 assert( (hash Boolean) === 1000035 )
-
--- these might change if our floating point implementation changes, but let's check anyway:
-assert( hash 1.23p200 === 18446744072207201388 -* 64-bit *- or hash 1.23p200 == 18446744073069319069 -* 32-bit *- )
+assert( hash 1.23p200 === 10359908877735906505 )
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/basictests hashcodes.okay"


### PR DESCRIPTION
Previously, we used (mostly) 32-bit integer arithmetic for computing hashes for `RR` objects and large `ZZ` objects that don't fit in a C `int`, and our hashing function was platform-dependent.  For example:

```m2
i1 : version#"pointer size"

o1 = 4

i2 : hash 1.23p200

o2 = 18446744073069319069

i3 : hash 2^100

o3 = 59792
```

vs.

```m2
i1 : version#"pointer size"

o1 = 8

i2 : hash 1.23p200

o2 = 18446744072207201388

i3 : hash 2^100

o3 = 0
```

Also, check this out!  We're in collison town!

```m2
i1 : tally apply(100, hash @@ numeric)

o1 = Tally{842 => 2 }
           843 => 2
           844 => 4
           845 => 8
           846 => 16
           847 => 32
           848 => 36

o1 : Tally
```

We switch to a new algorithm uses 64-bit arithmetic throughout and uses `mpz_export` to guarantee we get the same result regardless of pointer size and endianness.  After the update:

```m2
i1 : version#"pointer size"

o1 = 4

i2 : hash 1.23p200

o2 = 10359908877735906505

i3 : hash 2^100

o3 = 3405506911546692669
```
and

```m2
i1 : version#"pointer size"

o1 = 8

i2 : hash 1.23p200

o2 = 10359908877735906505

i3 : hash 2^100

o3 = 3405506911546692669
```

And no more collisions :)

```m2
i5 : #tally apply(100, hash @@ numeric)

o5 = 100
```

## AI Disclosure

Claude Code wrote the first draft of this code, and in particular was responsible for the suggestion to use `mpz_export` to achieve platform independence.  I heavily modified the code that was generated.
