### PR TITLE
Update exterior algebra docs

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
@@ -1190,50 +1190,62 @@ document {
      }
 
 document {
-     Key => "exterior algebras",
-     -- making one, making quotients,
-     -- using it.
-     -- modules are right-modules, example of multiplication.
-     "An exterior algebra is a polynomial ring where multiplication is
-     mildly non-commutative, in that, for every x and y in the ring,
-     y*x = (-1)^(deg(x) deg(y)) x*y, and that for every x of odd degree,
-     x*x = 0.",
-     "In Macaulay2, deg(x) is the degree of x, or the first degree of x, in case 
-     a multi-graded ring is being used.  The default degree for each variable is 1, so
-     in this case, y*x = -x*y, if x and y are variables in the ring.",
-     PARA{},
-     "Create an exterior algebra with explicit generators by creating a polynomial
-     ring with the option ", TO "SkewCommutative", ".",
-     EXAMPLE {
-	  "R = QQ[x,y,z, SkewCommutative => true]",
-      	  "y*x",
-      	  "(x+y+z)^2",
-      	  "basis R",
-      	  "basis(2,R)",
-	  },
-     EXAMPLE {
-	  "S = QQ[a,b,r,s,t, SkewCommutative=>true, Degrees=>{2,2,1,1,1}];",
-	  "r*a == a*r",
-	  "a*a",
-	  "f = a*r+b*s; f^2",
-	  "basis(2,S)",
-	  },
-     -- this section should link to "right modules or left modules?"
-     "In macaulay2, matrix arithmetic is all done in the opposite ring. This is
-     visible in multiplication of matrices over exterior algebras:"
-     EXAMPLE {
-      "T = QQ[a..d, SkewCommutative => true]",
-      "matrix{{a, b}}",
-	  "matrix{{c}, {d}}",
-      "matrix{{a, b}} * matrix{{c}, {d}}",
-	  },
-     "You may compute Gröbner bases, syzygies, and form quotient rings of these skew
-     commutative rings.",
-     Subnodes => {
-	 TO isSkewCommutative,
-	 TO antipode,
-         },
-     }
+    Key => "exterior algebras",
+    -- making one, making quotients,
+    -- using it.
+    -- modules are right-modules, example of multiplication.
+    "An exterior algebra is a polynomial ring where multiplication is
+    mildly non-commutative, in that, for every x and y in the ring,
+    y*x = (-1)^(deg(x) deg(y)) x*y, and that for every x of odd degree,
+    x*x = 0.",
+    "In Macaulay2, deg(x) is the degree of x, or the first degree of x, in case
+    a multi-graded ring is being used.  The default degree for each variable is 1, so
+    in this case, y*x = -x*y, if x and y are variables in the ring.",
+    PARA{},
+    "Create an exterior algebra with explicit generators by creating a polynomial
+    ring with the option ", TO "SkewCommutative", ".",
+    EXAMPLE {
+        "R = QQ[x,y,z, SkewCommutative => true]",
+        "y*x",
+        "(x+y+z)^2",
+        "basis R",
+        "basis(2,R)",
+    },
+    PARA{},
+    "The degree of the variables can be specified just as in the commutative case.",
+    EXAMPLE {
+        "S = QQ[a,b,r,s,t, SkewCommutative=>true, Degrees=>{2,2,1,1,1}];",
+        "r*a == a*r",
+        "a*a",
+        "f = a*r+b*s; f^2",
+        "basis(2,S)",
+    },
+    PARA{},
+    "As usual, matrix arithmetic is performed over the opposite ring. This is
+    visible with multiplication of matrices over exterior algebras.",
+    EXAMPLE {
+        "T = QQ[a..d, SkewCommutative => true]",
+        "A = matrix{{a, b}, {1, 1}}",
+        "B = matrix{{c, 1}, {d, 1}}",
+        "A * B"
+    },
+    "See ", TO "right modules or left modules?", " for more details.",
+    PARA{},
+    "You may compute Gröbner bases, syzygies, and form quotient rings of these skew
+    commutative rings. Warning that quotienting by an ideal which is not a
+    2-sided ideal will produce quotient ring where multiplication is not well
+    defined on coset representives.",
+    EXAMPLE {
+        "R = QQ[a..d, SkewCommutative => true]",
+        "I = ideal {a*b + c}",
+        "promote(I_0 * d, R/I)",
+        "promote(I_0, R/I) * promote(d, R/I)"
+    },
+    Subnodes => {
+        TO isSkewCommutative,
+        TO antipode,
+    },
+}
 
 document {
      Key => "symmetric algebras",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
@@ -1218,11 +1218,14 @@ document {
 	  "f = a*r+b*s; f^2",
 	  "basis(2,S)",
 	  },
-     "All modules over exterior algebras are right modules.  This means that matrices 
-     multiply from the opposite side:",
+     -- this section should link to "right modules or left modules?"
+     "In macaulay2, matrix arithmetic is all done in the opposite ring. This is
+     visible in multiplication of matrices over exterior algebras:"
      EXAMPLE {
-	  "x*y",
-	  "matrix{{x}} * matrix{{y}}"
+      "T = QQ[a..d, SkewCommutative => true]",
+      "matrix{{a, b}}",
+	  "matrix{{c}, {d}}",
+      "matrix{{a, b}} * matrix{{c}, {d}}",
 	  },
      "You may compute Gröbner bases, syzygies, and form quotient rings of these skew
      commutative rings.",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
@@ -1188,64 +1188,71 @@ document {
 	  -- needs an example
 	  }
      }
+doc ///
+    Key
+        "exterior algebras"
+    Headline
+        a polynomial ring with skew-commutative variables
+    Description
+        Text
+            An exterior algebra is a polynomial ring $R$ where multiplication of
+            the variables obeys the commutation relation $xy = (-1)^{\textrm{deg}(x)
+            \textrm{deg}(y)}yx$. One notable consequence of this is
+            that if $\textrm{deg}(x)$ is odd, then $x^2 = 0$.
 
-document {
-    Key => "exterior algebras",
-    -- making one, making quotients,
-    -- using it.
-    -- modules are right-modules, example of multiplication.
-    "An exterior algebra is a polynomial ring where multiplication is
-    mildly non-commutative, in that, for every x and y in the ring,
-    y*x = (-1)^(deg(x) deg(y)) x*y, and that for every x of odd degree,
-    x*x = 0.",
-    "In Macaulay2, deg(x) is the degree of x, or the first degree of x, in case
-    a multi-graded ring is being used.  The default degree for each variable is 1, so
-    in this case, y*x = -x*y, if x and y are variables in the ring.",
-    PARA{},
-    "Create an exterior algebra with explicit generators by creating a polynomial
-    ring with the option ", TO "SkewCommutative", ".",
-    EXAMPLE {
-        "R = QQ[x,y,z, SkewCommutative => true]",
-        "y*x",
-        "(x+y+z)^2",
-        "basis R",
-        "basis(2,R)",
-    },
-    PARA{},
-    "The degree of the variables can be specified just as in the commutative case.",
-    EXAMPLE {
-        "S = QQ[a,b,r,s,t, SkewCommutative=>true, Degrees=>{2,2,1,1,1}];",
-        "r*a == a*r",
-        "a*a",
-        "f = a*r+b*s; f^2",
-        "basis(2,S)",
-    },
-    PARA{},
-    "As usual, matrix arithmetic is performed over the opposite ring. This is
-    visible with multiplication of matrices over exterior algebras.",
-    EXAMPLE {
-        "T = QQ[a..d, SkewCommutative => true]",
-        "A = matrix{{a, b}, {1, 1}}",
-        "B = matrix{{c, 1}, {d, 1}}",
-        "A * B"
-    },
-    "See ", TO "right modules or left modules?", " for more details.",
-    PARA{},
-    "You may compute Gröbner bases, syzygies, and form quotient rings of these skew
-    commutative rings. Warning that quotienting by an ideal which is not a
-    2-sided ideal will produce quotient ring where multiplication is not well
-    defined on coset representatives.",
-    EXAMPLE {
-        "R = QQ[a..d, SkewCommutative => true]",
-        "I = ideal {a*b + c}",
-        "promote(I_0 * d, R/I)",
-        "promote(I_0, R/I) * promote(d, R/I)"
-    },
-    Subnodes => {
-        TO isSkewCommutative,
-        TO antipode,
-    },
-}
+            Here, $\textrm{deg}(x)$ is the degree of $x$ - or the first
+            degree of $x$ in case $R$ is multi-graded. By default, the
+            degree of each variable in a polynomial ring is 1, so in this case
+            we have the simple rule $xy = -yx$ for multiplying variables.
+        Text
+            Create an exterior algebra with explicit generators by creating a polynomial
+            ring with the option @TO "SkewCommutative"@.
+        Example
+            R = QQ[x,y,z, SkewCommutative => true]
+            y*x
+            (x+y+z)^2
+            basis R
+            basis(2,R)
+        Text
+            You can declare that only a subset of the variables are skew-commutative.
+        Example
+            R = QQ[a..c, SkewCommutative => {b, c}]
+            a*b == b*a
+            a*c == c*a
+            b*c == -c*b
+        Text
+            The degree of the variables can be specified just as in the commutative case.
+        Example
+            R = QQ[a,b,r,s,t, SkewCommutative=>true, Degrees=>{2,2,1,1,1}]
+            r*a == a*r
+            a*a
+            f = a*r+b*s; f^2
+            basis(2,R)
+        Text
+            As usual in Macaulay2, matrices are actually matrices over
+            $R^\textrm{op}$ and so matrix arithmetic over exterior algebras is
+            slightly different from what you see in the commutative case.
+        Example
+            R = QQ[a..d, SkewCommutative => true]
+            A = matrix {{a, b}, {1, 1}}
+            B = matrix {{c, 1}, {d, 1}}
+            A * B
+        Text
+            See  @TO "right modules or left modules?"@ for more details.
+        Text
+            You may compute Gröbner bases, syzygies, and form quotient rings of these skew
+            commutative rings. Warning that quotienting by an ideal which is not a
+            2-sided ideal will produce quotient ring where multiplication is not well
+            defined on coset representatives.
+        Example
+            R = QQ[a..d, SkewCommutative => true]
+            I = ideal {a*b + c}
+            promote(I_0 * d, R/I)
+            promote(I_0, R/I) * promote(d, R/I)
+    Subnodes
+        "isSkewCommutative"
+        "antipode"
+///
 
 document {
      Key => "symmetric algebras",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
@@ -1234,7 +1234,7 @@ document {
     "You may compute Gröbner bases, syzygies, and form quotient rings of these skew
     commutative rings. Warning that quotienting by an ideal which is not a
     2-sided ideal will produce quotient ring where multiplication is not well
-    defined on coset representives.",
+    defined on coset representatives.",
     EXAMPLE {
         "R = QQ[a..d, SkewCommutative => true]",
         "I = ideal {a*b + c}",


### PR DESCRIPTION
Updates to the docs page on exterior algebras.

Clarifies the note on left / right module structure over exterior algebras and provides a link to the general docs on modules in macaulay. Improve the example there to give a better indication of what is being communicated. Add a warning example that quotients of exterior algebras by non-two-sided ideals are not well-defined.

edit: updated screenshot to reflect current state of changes.
<img width="800" height="2600" alt="_usr_local_share_doc_Macaulay2_Macaulay2Doc_html__exterior_spalgebras html (2)" src="https://github.com/user-attachments/assets/7ec68816-fc16-4bc7-b8ac-f77c5f624f6e" />
