### PR TITLE
Raise an engine error when a non-unit is found in a "field"

### DIFF
--- a/M2/Macaulay2/e/ring.cpp
+++ b/M2/Macaulay2/e/ring.cpp
@@ -4,6 +4,7 @@
 
 #include "ZZ.hpp"          // for RingZZ
 #include "coeffrings.hpp"  // for CoefficientRingR
+#include "exceptions.hpp"  // for exc::engine_error
 #include "freemod.hpp"     // for FreeModule
 #include "monoid.hpp"      // for Monoid
 #include "poly.hpp"        // for PolyRing
@@ -86,10 +87,11 @@ ring_elem Ring::get_non_unit() const
 
 void Ring::set_non_unit(ring_elem non_unit) const
 {
-  if (_isfield == 1)  // i.e. declared to be a field
-    ERROR("a non unit was found in a ring declared to be a field");
+  bool was_field = (_isfield == 1);
   const_cast<Ring *>(this)->_isfield = -1;
   const_cast<Ring *>(this)->_non_unit = non_unit;
+  if (was_field)
+    throw exc::engine_error("a non unit was found in a ring declared to be a field");
 }
 
 ring_elem Ring::var(int v) const


### PR DESCRIPTION
In certain cases, we ended up returning a valid ring element from a computation instead of null, and so the error was never actually raised.  But this could result in segfaults later (like #4236).

### Before

```m2
i1 : R = QQ[l1,l2]/ideal(l1^2-l1-1, l2^2-l2-1);

i2 : A = matrix{{0,1},{1,1}};

              2       2
o2 : Matrix ZZ  <-- ZZ

i3 : P = matrix{{1,1},{l1,l2}};

             2      2
o3 : Matrix R  <-- R

i4 : Pinv =1/(l2-l1)* matrix{{l2,-1},{-l1,1}};

                    2             2
o4 : Matrix (frac R)  <-- (frac R)

i5 : Pinv*A*P
-- SIGSEGV
-* stack trace, pid: 875584
 0# profiler_stacktrace(std::ostream&, int) at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:132
 1# segv_handler at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:248
 2# 0x000079F80CC45330 in /lib/x86_64-linux-gnu/libc.so.6
 3# engine_hash at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/engine.dd:246
 4# basic_hash at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/basic.d:43
 5# basic_list_1 at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/basic.d:116
 6# evaluate_evalraw at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/evaluate.d:1579
 7# evaluate_evalSequence at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/evaluate.d:447
```
### After

```m2
i1 : R = QQ[l1,l2]/ideal(l1^2-l1-1, l2^2-l2-1);

i2 : A = matrix{{0,1},{1,1}};

              2       2
o2 : Matrix ZZ  <-- ZZ

i3 : P = matrix{{1,1},{l1,l2}};

             2      2
o3 : Matrix R  <-- R

i4 : Pinv =1/(l2-l1)* matrix{{l2,-1},{-l1,1}};

                    2             2
o4 : Matrix (frac R)  <-- (frac R)

i5 : Pinv*A*P
stdio:5:6:(3):[1]: error: a non unit was found in a ring declared to be a field
```

Closes: #4236

## AI Disclosure

This was pretty much all Claude Code.  I figured out that the segfault was happening in `PolyRing::list_form` because one of the monomials was null, but Claude took it from there, found the underlying problem with some guidance, and suggested the fix.