### PR TITLE
Allow lifting from fraction field -> local ring

### DIFF
--- a/M2/Macaulay2/packages/LocalRings/localring.m2
+++ b/M2/Macaulay2/packages/LocalRings/localring.m2
@@ -67,9 +67,6 @@ localRing(EngineRing, Ideal) := (R, P) ->
         RP.localRing    = RP;
         RP.maxIdeal     =  P;
         commonEngineRingInitializations RP;
-	setupPromote(
-	    f -> numerator f / denominator f,
-	    RP, frac R);
 	RP.residueMap   = map(frac(R/P), RP, vars R % P);
          expression RP := r -> expression numerator r / expression denominator r;
            toString RP := r -> toString expression r;
@@ -94,5 +91,14 @@ localRing(EngineRing, Ideal) := (R, P) ->
         if R.?generatorExpressions then RP.generatorExpressions = R.generatorExpressions;
         if R.?indexSymbols then RP.indexSymbols = applyValues(R.indexSymbols, r -> promote(r,RP));
         if R.?indexStrings then RP.indexStrings = applyValues(R.indexStrings, r -> promote(r,RP));
+	setupPromote(
+	    f -> numerator f / denominator f,
+	    RP, frac R);
+	liftFromFractionFieldMap := map(RP, frac R);
+	setupLift(f -> (
+		if isMember(denominator f, RP.maxIdeal)
+		then error "expected a denominator outside the maximal ideal"
+		else liftFromFractionFieldMap f),
+	    frac R, RP);
         RP
         )

--- a/M2/Macaulay2/packages/LocalRings/tests.m2
+++ b/M2/Macaulay2/packages/LocalRings/tests.m2
@@ -625,12 +625,14 @@ end--
 ///
 
 TEST ///
--- promoting to fraction field
-R = QQ[x]
+-- promoting/lifting to/from fraction field
+S = QQ[x]
 p = ideal x
-S = R_p
+R = S_p
 F = frac R
-assert(promote(x_S, F) === x_F)
+assert(promote(x_R, F) === x_F)
+assert(lift(x_F, R) === x_R)
+assert not liftable(1/x, R)
 ///
 
 end--


### PR DESCRIPTION
This is a quick followup to #4204 addressing https://github.com/Macaulay2/M2/pull/4204#issuecomment-4381090881.

For example:

```m2
i2 : R = QQ[x];

i3 : p = ideal x;

o3 : Ideal of R

i4 : S = R_p;

i5 : lift(1/(x - 1), S)

       1
o5 = -----
     x - 1

o5 : S

i6 : lift(1/x, S)
stdio:6:4:(3):[1]: error: expected a denominator outside the maximal ideal
```