### PR TITLE
Make static linking against Boost optional

### DIFF
--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -44,7 +44,10 @@ endif()
 find_package(Threads	REQUIRED QUIET)
 find_package(LAPACK	REQUIRED QUIET)
 
-set(Boost_USE_STATIC_LIBS ON)
+if(STATIC_BOOST)
+  message(STATUS "Using static Boost, if Boost is installed but not found, try setting STATIC_BOOST to OFF")
+endif()
+set(Boost_USE_STATIC_LIBS ${STATIC_BOOST})
 if(UNIX)
   cmake_policy(SET CMP0167 OLD) # load CMake's FindBoost module
   find_package(Boost	REQUIRED QUIET COMPONENTS regex OPTIONAL_COMPONENTS stacktrace_addr2line)

--- a/M2/cmake/configure.cmake
+++ b/M2/cmake/configure.cmake
@@ -33,6 +33,7 @@ option(WITH_XML		"Link with the libxml2 library"		ON)
 option(WITH_PYTHON	"Link with the Python library"		ON)
 option(WITH_MYSQL	"Link with the MySQL library"		OFF)
 option(WITH_JANSSON	"Link with the Jansson library"		ON)
+option(STATIC_BOOST     "Use the static version of Boost" ON)
 
 set(BUILD_PROGRAMS  "" CACHE STRING "Build programs, even if found")
 set(BUILD_LIBRARIES "" CACHE STRING "Build libraries, even if found")


### PR DESCRIPTION
Gentoo doesn't have the static libraries for Boost installed, so setting `Boost_USE_STATIC_LIBS ON` breaks the build. This lets us select if we want to force linking against the static version of Boost. I set it to on by default since that's what was already there and it's probably a better to link statically when possible since Boost updates often break dynamic linking.

Related, but not in this change: the `cmake_policy(SET CMP0167 OLD)` line shouldn't be necessary for any Boost version after 1.70. Are there any systems where this matters still?