### PR TITLE
Fix / and \ methods for Command objects

### DIFF
--- a/M2/Macaulay2/m2/classes.m2
+++ b/M2/Macaulay2/m2/classes.m2
@@ -86,17 +86,17 @@ Command Thing := (x,y) -> x#0 y
 -- Now some extra stuff:
 
 apply(Thing, Command)   := VisibleList => (v,f) -> apply(v, i -> f i)
-Command   \ VisibleList :=
+Command   \ VisibleList := VisibleList => (f,v) -> apply(v,f#0)
 Function  \ VisibleList := VisibleList => (f,v) -> apply(v,f)
-Command   \ String      :=
+Command   \ String      := Sequence    => (f,s) -> apply(s,f#0)
 Function  \ String      := Sequence    => (f,s) -> apply(s,f)
-Command  \\ Thing       := 
+Command  \\ Thing       :=
 Function \\ Thing       := VisibleList => (f,v) -> f v
-       List /  Command  :=
+       List /  Command  :=        List => (v,f) -> apply(v,f#0)
        List /  Function :=        List => (v,f) -> apply(v,f) -- just because of conflict with List / Thing!
-VisibleList /  Command  :=
+VisibleList /  Command  := VisibleList => (v,f) -> apply(v,f#0)
 VisibleList /  Function := VisibleList => (v,f) -> apply(v,f)
-     String /  Command  :=
+     String /  Command  := Sequence    => (s,f) -> apply(s,f#0)
      String /  Function := Sequence    => (s,f) -> apply(s,f)
 VisibleList // Command  := -- here to make documentation easier
 VisibleList // Function := -- here to make documentation easier

--- a/M2/Macaulay2/m2/classes.m2
+++ b/M2/Macaulay2/m2/classes.m2
@@ -85,7 +85,6 @@ Command Thing := (x,y) -> x#0 y
 
 -- Now some extra stuff:
 
-apply(Thing, Command)   := VisibleList => (v,f) -> apply(v, i -> f i)
 Command   \ VisibleList := VisibleList => (f,v) -> apply(v,f#0)
 Function  \ VisibleList := VisibleList => (f,v) -> apply(v,f)
 Command   \ String      := Sequence    => (f,s) -> apply(s,f#0)

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/apply-doc.m2
@@ -4,10 +4,6 @@
 --- The apply(HashTable,Function) in the "ways to use" section doesn't seem
 --- to have disappeared in my documentation, even though it is obsolete.
 
-undocumented {
-    (apply, Thing, Command),
-}
-
 document { 
      Key => apply,
      Headline => "apply a function to each element",

--- a/M2/Macaulay2/tests/normal/command.m2
+++ b/M2/Macaulay2/tests/normal/command.m2
@@ -7,3 +7,8 @@ assert ( value \ flatten \\ values \ localDictionaries(()->()) === flatten {{"va
 x = "value of x"
 assert (y === "value of y")
 
+f = Command(x -> 5)
+assert Equation(f \ {1, 2, 3}, {5, 5, 5})
+assert Equation({1, 2, 3} / f, {5, 5, 5})
+assert Equation(f \ "foo", (5, 5, 5))
+assert Equation("foo" / f, (5, 5, 5))


### PR DESCRIPTION
We were trying to run `apply` directly, but `Command` objects are really lists containing functions, not functions themselves, so that won't work out of the box.

This fixes an issue mentioned in Zulip by @pzinn.