### PR TITLE
Raise an error when comparing lists of different types

### DIFF
--- a/M2/Macaulay2/d/actors3.d
+++ b/M2/Macaulay2/d/actors3.d
@@ -96,6 +96,17 @@ override(e:Expr):Expr := (
      else WrongNumArgs(2));
 setupfun("override",override);
 -----------------------------------------------------------------------------
+EqualEqualfunpointer := dummyEE;
+listComparison(s:Sequence, t:Sequence):Expr := (
+    n := length(s);
+    if n == length(t) then (
+	for i from 0 to n - 1 do (
+	    ret := EqualEqualfunpointer(s.i, t.i);
+	    when ret is Error do return ret else nothing;
+	    if ret == False then return False);
+	True)
+    else False);
+
 equalmethod(x:Expr,y:Expr):Expr := (
      method := lookupBinaryMethod(Class(x),Class(y),EqualEqualS);
      if method == nullE 
@@ -177,36 +188,28 @@ EqualEqualfun(x:Expr,y:Expr):Expr := (
 	  when y 
 	  is yy:stringCell do toExpr(xx.v === yy.v)	 -- # typical value: symbol ==, String, String, Boolean
 	  else equalmethod(x,y))
-     is s:Sequence do when y is t:Sequence do (				 -- # typical value: symbol ==, Sequence, Sequence, Boolean
-	  if length(s) != length(t) then return False;
-	  for i from 0 to length(s)-1 do (
-	       ret := EqualEqualfun(s.i,t.i);
-	       when ret is Error do return ret else nothing;
-	       if ret == False then return False;
-	       );
-	  True
-	  ) else equalmethod(x,y)
+     is s:Sequence do (
+	 when y
+	 is t:Sequence do listComparison(s, t)           -- # typical value: symbol ==, Sequence, Sequence, Boolean
+	 is List do WrongArg("lists of the same class")
+	 else equalmethod(x, y))
      else equalmethod(x,y));
+EqualEqualfunpointer = EqualEqualfun;
 listComparison(e:Expr):Expr := (
-     when e 
-     is args:Sequence do if length(args) != 2 then WrongNumArgs(2) else (
-	  when args.0 is a:List do
-	  when args.1 is b:List do (
-	       if a.Class != b.Class then return False;
-	       s := a.v;
-	       t := b.v;
-	       if length(s) != length(t) then return False;
-	       for i from 0 to length(s)-1 do (
-		    ret := EqualEqualfun(s.i,t.i);
-		    when ret is Error do return ret else nothing;
-		    if ret == False then return False;
-		    );
-	       True
-	       )
-	  else WrongArg(2,"a visible list")
-	  else WrongArg(1,"a visible list")
-	  )
-     else WrongNumArgs(2));
+    when e
+    is args:Sequence do (
+	if length(args) == 2 then (
+	    when args.0 is a:List do (
+		when args.1
+		is b:List do (
+		    if a.Class != b.Class
+		    then WrongArg("lists of the same class")
+		    else listComparison(a.v, b.v))
+		is Sequence do WrongArg("lists of the same class")
+		else WrongArg(2,"a visible list"))
+	    else WrongArg(1,"a visible list"))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
 installMethod(EqualEqualS,visibleListClass,visibleListClass,listComparison);
 EqualEqualfun(lhs:Code,rhs:Code):Expr := (
      x := eval(lhs);

--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -210,6 +210,9 @@ export dummyTernaryFun(c:Code,d:Code,e:Code):Expr := (
 export dummyMultaryFun(c:CodeSequence):Expr := (
      anywhereError("dummy multary function called");
      nullE);
+export dummyEE(e:Expr,f:Expr):Expr := (
+     anywhereError("dummy binary function called");
+     nullE);
 
 export emptySequence := Sequence();
 export emptySequenceE := Expr(emptySequence);

--- a/M2/Macaulay2/tests/normal/lists.m2
+++ b/M2/Macaulay2/tests/normal/lists.m2
@@ -20,3 +20,8 @@ assert (class i === AngleBarList)
 assert (delete(y, i) == <| x, z |>)
 
 assert isTable table(0, 0, identity)
+
+-- issue #4267
+assert try (1,2,3) == {1,2,3} then false else true
+assert try {1,2,3} == (1,2,3) then false else true
+assert try {1,2,3} == [1,2,3] then false else true


### PR DESCRIPTION
This is a response to a now-removed commit from #4242.  In it, I had proposed that `==` between lists of different types should return false, but after discussion with others, the consensus was that it should raise an error.

Currently, the behavior is mixed and the error messages are cryptic:

```m2
i1 : (1,2,3) == {1,2,3}
stdio:1:8:(3):[1]: error: expected argument 1 to be a visible list

i2 : {1,2,3} == (1,2,3)
stdio:2:8:(3):[1]: error: expected argument 2 to be a visible list

i3 : {1,2,3} == [1,2,3]

o3 = false
```

Here's the proposed behavior:

```m2
i1 : (1,2,3) == {1,2,3}
stdio:1:8:(3):[1]: error: expected lists of the same class

i2 : {1,2,3} == (1,2,3)
stdio:2:8:(3):[1]: error: expected lists of the same class

i3 : {1,2,3} == [1,2,3]
stdio:3:8:(3):[1]: error: expected lists of the same class
```

Closes: #4267