### PR TITLE
fix net BR, HR

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -31,7 +31,16 @@ setupRenderer = (parser, joiner, T) -> (
 -- Default joiners: (TODO: move to string.m2?)
 -- concatenate
 -- horizontalJoin
-wrapHorizontalJoin := x -> wrap horizontalJoin x
+net BR := info BR := x -> stack()
+net HR := info HR := x -> concatenate(printWidth:"-")
+
+horizontalJoin' := x -> ( -- horizontalJoin except for BRs and HRs
+    netBR := net BR{}; netHR := net HR{};
+    x' := sublists(toList x, y -> y=!=netBR and y=!=netHR, toList, y -> {y});
+    stack(horizontalJoin\x')
+    )
+
+wrapHorizontalJoin := x -> wrap horizontalJoin' x
 
 -- Main types: (see hypertext.m2)
 -- Hypertext  > HypertextParagraph, HypertextContainer
@@ -52,7 +61,7 @@ scan({net, info, html, markdown, tex}, parser ->
 
 -- Rendering by horizontal join of inputs
 scan({net, info},
-    parser -> setupRenderer(parser, horizontalJoin, Hypertext))
+    parser -> setupRenderer(parser, horizontalJoin', Hypertext))
 scan({net, info},
     parser -> setupRenderer(parser, wrapHorizontalJoin, HypertextParagraph))
 
@@ -172,19 +181,16 @@ info HEADER1 := Hop(info,"*")
 info HEADER2 := Hop(info,"=")
 info HEADER3 := Hop(info,"-")
 
-net  HR :=
-info HR := x -> concatenate(printWidth:"-")
-
 net  PRE  :=
 net   TT  :=
 net CODE  :=
 net SAMP  :=
 info TT   :=
 info SAMP :=
-info CODE :=  x -> horizontalJoin apply(noopts x,net)
+info CODE :=  x -> horizontalJoin' apply(noopts x,net)
 
 net  KBD :=
-info KBD := x -> formatNoEscaping toString horizontalJoin apply(noopts x,net)
+info KBD := x -> formatNoEscaping toString horizontalJoin' apply(noopts x,net)
 
 info PRE  := x ->
     wrap(printWidth, "-", concatenate apply(noopts x,toString @@ info))

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -31,7 +31,7 @@ toExternalString Hypertext := s -> concatenate(toString class s, toExternalStrin
 
 new Hypertext from VisibleList := (M,x) -> x -- needed because otherwise next line takes over
 new Hypertext from Thing  := (M,x) -> {x}
-new Hypertext from Net    := (M,x) -> {toString x}
+new Hypertext from Net    := (M,x) -> between(BR(),unstack x)
 
 Hypertext#AfterPrint = x -> null
 


### PR DESCRIPTION
(this is *not* urgent; feel free to ignore for upcoming release)
This fixes #2754, in particular.
Before:
the first two have incorrect `net`:
<img width="762" height="300" alt="Screenshot from 2026-05-09 01-49-30" src="https://github.com/user-attachments/assets/71ebaeb1-a406-498d-adff-1cd79af25792" />
here it's the `html` of the first two that's wrong:
<img width="516" height="219" alt="Screenshot from 2026-05-09 02-02-48" src="https://github.com/user-attachments/assets/4428a98d-d2b0-4668-8f8f-27642d0550e2" />

After:
<img width="762" height="300" alt="Screenshot from 2026-05-09 01-49-47" src="https://github.com/user-attachments/assets/43f8f051-5f89-4148-9e23-c4771bea3b75" />
<img width="512" height="229" alt="Screenshot from 2026-05-09 02-03-54" src="https://github.com/user-attachments/assets/b7e25bcf-f681-4afb-b320-e857eacd96c2" />
