### PR TITLE
Add in some engine polyhedral/cone functions: low level only

### DIFF
--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -4552,6 +4552,122 @@ export rawZZfactor(e:Expr):Expr := (
   );
 setupfun("rawZZfactor",rawZZfactor);
 
+export rawGVInvariants(e:Expr):Expr := (
+  when e is s:Sequence do (
+  if length(s) == 7 then (
+  if isSequenceOfSmallIntegers(s.0) then (curves := getSequenceOfSmallIntegers(s.0);
+  if isSequenceOfSmallIntegers(s.1) then (lightcone := getSequenceOfSmallIntegers(s.1);
+  if isSequenceOfSmallIntegers(s.2) then (grading := getSequenceOfSmallIntegers(s.2);
+  if isSequenceOfSmallIntegers(s.3) then (Q := getSequenceOfSmallIntegers(s.3);
+  if isSequenceOfSmallIntegers(s.4) then (nefPartition := getSequenceOfSmallIntegers(s.4);
+  if isSequenceOfSmallIntegers(s.5) then (intnums := getSequenceOfSmallIntegers(s.5);
+  if isSequenceOfSmallIntegers(s.6) then (settings := getSequenceOfSmallIntegers(s.6);
+    toExpr(Ccode(RawMutableMatrixOrNull,
+      "rawGVInvariants(",
+        curves, ",", lightcone, ",", grading, ",", Q, ",", nefPartition, ",", intnums, ",", settings, 
+      ")"
+    ))
+  ) else WrongArg(6, "a sequence of small integers")
+  ) else WrongArg(5, "a sequence of small integers")
+  ) else WrongArg(4, "a sequence of small integers")
+  ) else WrongArg(3, "a sequence of small integers")
+  ) else WrongArg(2, "a sequence of small integers")
+  ) else WrongArg(1, "a sequence of small integers")
+  ) else WrongArg(0, "a sequence of small integers")
+  ) else WrongNumArgs(7)
+  ) else WrongNumArgs(7)
+  );
+setupfun("rawGVInvariants",rawGVInvariants);
+
+-- Compute lattice points in a polyhedron, up to given bound.
+-- rawLatticePoints(A, b, B, N1, N2)
+--  A: RawMatrix over ZZ, m rows x d columns
+--  b: RawMatrix over ZZ, m rows x 1 column.
+--    the i-th constraint is (row i of A).(x1...xd) <= b_(i,0)
+--  B: bound: only find lattice points whose coordinates xi satisfy -B <= xi <= B.
+--  N1: maximum number of points to be found
+--  N2: maximum number of nodes to visit in the underlying search tree.
+-- returns: a MutableMatrix with d = #cols(A) rows, one column per lattice
+--   point satisfying the constraints above.
+-- TODO:
+--  - A and result should have the same type (both MutableMatrix)?
+export rawLatticePoints(e:Expr):Expr := (
+  when e is s:Sequence do (
+  if length(s) == 5 then (
+  when s.0 is wa:RawMatrixCell do (a := wa.p;
+  when s.1 is wb:RawMatrixCell do (b := wb.p;
+  when s.2 is wc:ZZcell do (
+  if isInt(wc) then (c := toInt(wc);
+  when s.3 is wd:ZZcell do (
+  if isLong(wd) then (d := toLong(wd);
+  when s.4 is wf:ZZcell do (
+  if isLong(wf) then (f := toLong(wf);
+    toExpr(Ccode(RawMutableMatrixOrNull,
+      "rawLatticePoints(",
+        a, ",", b, ",", c, ",", d, ",", f,
+      ")"
+    ))
+  ) else WrongArgSmallInteger(4)
+  ) else WrongArgZZ(4)
+  ) else WrongArgSmallInteger(3)
+  ) else WrongArgZZ(3)
+  ) else WrongArgSmallInteger(2)
+  ) else WrongArgZZ(2)
+  ) else WrongArg(1, "a raw matrix")
+  ) else WrongArg(0, "a raw matrix")
+  ) else WrongNumArgs(5)
+  ) else WrongNumArgs(5)
+  );
+setupfun("rawLatticePoints",rawLatticePoints);
+
+-- Compute ALL lattice points in a (bounded) polyhedron, via libnormaliz.
+-- rawLatticePointsNormaliz(A, b)
+--  A: RawMatrix over ZZ, m rows x d columns
+--  b: RawMatrix over ZZ, m rows x 1 column.
+--    the i-th constraint is (row i of A).(x1...xd) <= b_(i,0)
+-- returns: a MutableMatrix with d = #cols(A) rows, one column per lattice
+--   point satisfying the constraints above. The polyhedron must be bounded;
+--   otherwise an engine error is reported. Big-integer entries in A and b
+--   are supported.
+export rawLatticePointsNormaliz(e:Expr):Expr := (
+  when e is s:Sequence do (
+  if length(s) == 2 then (
+  when s.0 is wa:RawMatrixCell do (a := wa.p;
+  when s.1 is wb:RawMatrixCell do (b := wb.p;
+    toExpr(Ccode(RawMutableMatrixOrNull,
+      "rawLatticePointsNormaliz(",
+        a, ",", b,
+      ")"
+    ))
+  ) else WrongArg(1, "a raw matrix")
+  ) else WrongArg(0, "a raw matrix")
+  ) else WrongNumArgs(2)
+  ) else WrongNumArgs(2)
+  );
+setupfun("rawLatticePointsNormaliz",rawLatticePointsNormaliz);
+
+-- rawConeInteriorPoint(A): test whether the cone {x : A*x <= 0} is
+-- full-dimensional, returning either a witness interior point or a
+-- dual certificate of degeneracy.
+--   A: RawMatrix over ZZ with m rows (inequalities) and n columns
+--      (ambient dimension); entries must fit in a C int.
+-- Returns: a 1-row MutableMatrix over RR_53.
+--   if full-dimensional:  2 + n columns, [1.0, tStar, x_1, ..., x_n]
+--                         where tStar > 0 and A*x <= 0 strictly (componentwise).
+--   else               :  2 + m columns, [0.0, tStar, y_1, ..., y_m]
+--                         where tStar == 0 and y >= 0, y^T A = 0
+--                         (a Farkas certificate of non-full-dimensionality).
+export rawConeInteriorPoint(e:Expr):Expr := (
+  when e is wC:RawMatrixCell do (C := wC.p;
+    toExpr(Ccode(RawMutableMatrixOrNull,
+      "rawConeInteriorPoint(",
+        C, 
+      ")"
+    ))
+  ) else WrongArg("a raw matrix")
+  );
+setupfun("rawConeInteriorPoint",rawConeInteriorPoint);
+
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d interface.o "
 -- End:

--- a/M2/Macaulay2/e/CMakeLists.txt
+++ b/M2/Macaulay2/e/CMakeLists.txt
@@ -39,6 +39,7 @@ set(CFILES
   error.c
   exptable.c
   table.c
+  cytools/box_enum.c
   )
 # h files
 set(HFILES
@@ -159,6 +160,10 @@ set(CPPONLYFILES
 # these files all have .hpp and .cpp files
 # MES TODO: put these NCAlgebra files (and friends) into alpha order in list
 set(SRCLIST
+  cytools/computeGV
+  cytools/lattice_points
+  cytools/lattice-points-normaliz
+  cytools/cone-interior-point
   BasicPoly
   BasicPolyList
   BasicPolyListParser
@@ -482,6 +487,7 @@ if(BUILD_TESTING)
 
     unit-tests/MatrixIOTest.cpp
     unit-tests/fromStream.cpp
+    unit-tests/LatticePointsTest.cpp
     unit-tests/testMain.cpp # not needed, except for GC_INIT
     )
 

--- a/M2/Macaulay2/e/Makefile.common.in
+++ b/M2/Macaulay2/e/Makefile.common.in
@@ -71,6 +71,7 @@ COMPILE.cpp = $(COMPILE.cc)
 %.dep: %.c
 #	$(WHY)
 	$(SHOW)"MKDEP $*.c"
+	$(HIDE)$(MKDIR_P) `dirname "$@"`
 	$(HIDE)@CC@  -MT $@ -MT $*.o -MM -MP $(CFLAGS)   $(CPPFLAGS) $(TARGET_ARCH) $(MORE_OPTIONS) $< >$*.dep
 
 @pre_librariesdir@/libengine.so: $(LOFILES)

--- a/M2/Macaulay2/e/Makefile.files.in
+++ b/M2/Macaulay2/e/Makefile.files.in
@@ -10,6 +10,10 @@ INTERFACE2 = interrupted
 
 INTERFACE = \
 	myalloc \
+	cytools/computeGV \
+	cytools/lattice_points \
+	cytools/lattice-points-normaliz \
+	cytools/cone-interior-point \
 	BasicPoly \
 	BasicPolyList \
 	BasicPolyListParser \
@@ -224,7 +228,7 @@ NAMES_H = \
 	f4/varpower-monomial \
 	res-a0-pair
 
-C_FILES = error table exptable complex # interface/m2-types interface/m2-mem
+C_FILES = error table exptable complex cytools/box_enum # interface/m2-types interface/m2-mem
 
 D_FILES = 
 DD_FILES = #test

--- a/M2/Macaulay2/e/cytools/README.md
+++ b/M2/Macaulay2/e/cytools/README.md
@@ -1,0 +1,17 @@
+Code in this directory is from cytools
+
+- computeGV, computing GV and GW invariants
+- box_enum, finding lattice points in a polyhedron
+- might include others in the future
+
+Note: the computeGV code is older code, the current version is in
+rust.  It works well though.  I do not know if this version is still
+in source control.  Need to check on that.  The license is GPL >= 3.
+
+The box_enum code is from the repo:
+git@github.com:natemacfadden/latticepts.git, author is Nate MacFadden
+the license is GPL >= 3.
+
+cone-interior-point.cpp: uses glpk to get whether cone id feasible and
+if so, an interior point, and if not, a dual certificate. This is just test
+code, suggested by claude.

--- a/M2/Macaulay2/e/cytools/box_enum.c
+++ b/M2/Macaulay2/e/cytools/box_enum.c
@@ -1,0 +1,4 @@
+// Compiles _box_enum_c from box_enum.h as a standalone C translation unit.
+// Kept minimal so box_enum.h stays bit-identical to the upstream source.
+#define BOX_ENUM_IMPLEMENTATION
+#include "box_enum.h"

--- a/M2/Macaulay2/e/cytools/box_enum.h
+++ b/M2/Macaulay2/e/cytools/box_enum.h
@@ -1,0 +1,360 @@
+#ifndef BOX_ENUM_H
+#define BOX_ENUM_H
+
+// HEADER
+// ======
+#include <stdint.h>
+
+/*
+Enumerate lattice points ``vec`` obeying ``H @ vec >= rhs`` and ``|vec_i| <= B``
+using Kannan's algorithm.
+
+Prefer to sort the columns of ``H`` so that stricter constraints come first.
+(This is automatically done in the .pyx file). See `set_bounds` for the logic.
+
+Parameters
+----------
+out : int32_t*
+    Output buffer. Must be pre-allocated to hold at least max_N_out * dim
+    elements. Lattice points are written in row-major order.
+N_out : long*
+    Written with the number of lattice points found.
+N_nodes : long*
+    Written with the number of nodes visited in the search tree (including
+    the root). For N_hyps=0 (no hyperplane constraints) this equals
+    ((2B+1)^(n+1)-1)/(2B).
+dim : int
+    Dimension of the problem.
+B : int
+    Box half-width: each component satisfies |vec_i| <= B.
+H : int*
+    Constraint matrix of shape (N_hyps, dim), in row-major order. Each row
+    defines one inequality ``H[i] @ vec >= rhs[i]``.
+rhs : int*
+    Right-hand side of each hyperplane constraint, of length N_hyps.
+    May be NULL when N_hyps == 0.
+N_hyps : int
+    Number of hyperplane constraints (rows of H).
+max_N_out : long
+    Maximum number of output lattice points. Enumeration stops early if
+    reached.
+max_N_nodes : long
+    Maximum number of search tree nodes to visit. Enumeration stops early
+    if reached.
+
+Returns
+-------
+int
+    Status code:
+        0  : success
+       -1  : dim > 256 (unsupported)
+       -2  : exceeded max_N_out outputs
+       -3  : exceeded max_N_nodes
+*/
+int _box_enum_c(
+    int32_t * restrict out,
+    long * restrict N_out,
+    long * restrict N_nodes,
+    int dim,
+    int B,
+    int * restrict H,
+    int * restrict rhs,
+    int N_hyps,
+    long max_N_out,
+    long max_N_nodes
+);
+
+
+// IMPLEMENTATION
+// ==============
+#ifdef BOX_ENUM_IMPLEMENTATION
+
+#define MAX_SUPPORTED_DIM 256
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// #define DEBUG  // uncomment to enable debug logging
+#ifdef DEBUG
+    #define DEBUG_LOG(...) fprintf(stderr, __VA_ARGS__)
+#else
+    #define DEBUG_LOG(...) ((void)0)
+#endif
+
+static inline int max_int(int a, int b) {
+    return a > b ? a : b;
+}
+static inline int min_int(int a, int b) {
+    return a < b ? a : b;
+}
+
+// Kannan vec[i] bound setting helper
+static inline int set_bounds(
+    int sp,
+    int i,
+    int dim,
+    int N_hyps,
+    int B,
+    int * restrict H,
+    int * restrict rhs,
+    int64_t * restrict stack_partial_sum,
+    int * restrict abssum,
+    int32_t * restrict stack_val_min,
+    int32_t * restrict stack_val_len)
+{
+    /*
+    Compute the iteration bounds for component i at stack depth sp, writing
+    results into stack_val_min[sp] and stack_val_len[sp].
+
+    Parameters
+    ----------
+    sp : int
+        Current stack depth.
+    i : int
+        Component index being bounded.
+    dim, N_hyps, B, H, rhs : (see _box_enum_c; rhs[j] is the bound for constraint j)
+    stack_partial_sum : int32_t*
+        Partial dot products ``H @ vec`` for components already fixed.
+    abssum : int*
+        Precomputed prefix sums of |H[:,k]| for each constraint.
+    stack_val_min : int32_t*
+        Written with the minimum value to try for vec[i].
+    stack_val_len : int32_t*
+        Written with the number of candidates to try for vec[i].
+
+    Returns
+    -------
+    int
+        Number of candidates (stack_val_len[sp]).
+    */
+    int lo = -B;
+    int hi =  B;
+
+    // cut by each hyperplane
+    for (int j=0; j<N_hyps; ++j) {
+        /*
+        Imposes constraint dot(H[j,:], vec) >= rhs[j].
+
+        Split:
+            rhs[j] <= dot(H[j,:i],vec[:i])
+                    + H[j,i]*vec[i]
+                    + dot(H[j,i+1:],vec[i+1:])
+        the third term is stack_partial_sum[j], so
+            rhs[j] <= dot(H[j,:i],vec[:i])
+                    + H[j,i]*vec[i]
+                    + stack_partial_sum[j].
+        The maximum value possible of dot(H[j,:i],vec[:i]) is
+            dot(H[j,:i],vec[:i]) <= B*sum(abs(H[j,:i])).
+        Thus
+            rhs[j] - stack_partial_sum[j] - B*sum(abs(H[j,:i])) <=  H[j,i]*vec[i].
+
+        The term B * sum(abs(H[j,:i])) is the 'slack'. It is where any looseness
+        in our bounds can arise from. Ideally, then, you'd want
+        sum(abs(H[j,:i])) to be minimized to have as tight bounds as possible.
+
+        We obviously can't sort each row/constraint individually since that'd
+        muddle the components of vec. What we can do is minimize the net slack,
+        sum(abs(H[:,:i])). This is done by ordering *columns* in increasing
+        L1-norm, which is the rationale behind the column sorting.
+        */
+        int h = H[j*dim + i];
+        if (h == 0){
+            continue;
+        }
+
+        // Use int64 to avoid overflow: partial_sum ~ H*B, abssum*B can both exceed 2^31
+        int64_t numer = (int64_t)rhs[j]
+                      - stack_partial_sum[sp*N_hyps + j]
+                      - (int64_t)B * (int64_t)abssum[j*(dim+1) + i];
+
+        if (h>0){
+            double v = ceil((double)numer/h);
+            lo = max_int(lo, v > (double)hi ? hi + 1 : (int)v);
+        } else {
+            double v = floor((double)numer/h);
+            hi = min_int(hi, v < (double)lo ? lo - 1 : (int)v);
+        }
+    }
+
+    // store the data to recreate the interval
+    int num = 0;
+    if (hi >= lo) {
+        num = hi - lo + 1;
+    }
+    stack_val_min[sp] = lo;
+    stack_val_len[sp] = num;
+
+    // debug print statement
+    DEBUG_LOG("Set bounds for %d to %d->%d+%d\n", sp, lo, lo, num);
+
+    return num;
+}
+
+// custom Kannan code for lattice vector generation
+int _box_enum_c(
+    int32_t * restrict out,
+    long * restrict N_out,
+    long * restrict N_nodes,
+    int dim,
+    int B,
+    int * restrict H,
+    int * restrict rhs,
+    int N_hyps,
+    long max_N_out,
+    long max_N_nodes)
+{
+    /* (see header doc) */
+    // check dimensions are reasonable
+    // -------------------------------
+    if (dim > MAX_SUPPORTED_DIM) {
+        *N_out = 0;
+        return -1;
+    }
+
+    // define variables
+    // ----------------
+    int status = 0;
+
+    // define arrays
+    int32_t vec[dim];
+
+    int32_t stack_i[dim+1];
+    int32_t stack_pos[dim+1];
+
+    int32_t stack_val_len[dim+1];
+    int32_t stack_val_min[dim+1];
+
+    int64_t stack_partial_sum[N_hyps*(dim+1)];
+    memset(stack_partial_sum, 0, sizeof(stack_partial_sum));
+
+    // output/stack pointer
+    long op = 0;
+    int sp = 0;
+
+    // misc helpers
+    int abssum[N_hyps*(dim+1)];
+    for (int j=0; j<N_hyps; ++j) {
+        abssum[j*(dim+1) + 0] = 0;
+
+        for (int k=0; k<dim; ++k) {
+            abssum[j*(dim+1) + k+1] = abssum[j*(dim+1) + k] + abs(H[j*dim + k]);
+        }
+    }
+
+    // initialize stack
+    // ----------------
+    stack_i[sp]   = dim-1;
+    stack_pos[sp] = 0;
+
+    int k = set_bounds(
+            sp,
+            dim-1,
+            dim,
+            N_hyps,
+            B,
+            H,
+            rhs,
+            stack_partial_sum,
+            abssum,
+            stack_val_min,
+            stack_val_len);
+    if (k == 0) {
+        goto end;
+    }
+
+    // iterate over the stack
+    // ----------------------
+    int i;
+    int pos;
+
+    *N_nodes = 1;  // count the root
+    while (sp >= 0) {
+
+        // read from the stack
+        i    = stack_i[sp];
+        pos  = stack_pos[sp];
+
+        // debug print statement
+        DEBUG_LOG("Setting component-%d for op=%ld, sp=%d, pos=%d\n",
+                  i, op, sp, pos);
+
+        // save if node is complete
+        // if i==-1, then we have fully written vec
+        if (i == -1) {
+            if (op >= max_N_out) {
+                status = -2;
+                goto end;
+            }
+
+            memcpy(&out[op * dim], vec, dim * sizeof(int32_t));
+
+            op++;
+
+            // kill node
+            sp--;
+            continue;
+        }
+
+        // check if we exhausted values for this component
+        if (pos == stack_val_len[sp]) {
+            sp--;
+            continue;
+        }
+
+        // set vec[i]
+        int veci = stack_val_min[sp] + pos;
+        vec[i] = veci;
+
+        DEBUG_LOG("Set     component-%d for op=%ld, sp=%d, pos=%d to %d\n",
+                  i, op, sp, pos, veci);
+
+        // advance pos for next iteration
+        stack_pos[sp] += 1;
+
+        // passes cuts -> push next depth :)
+        sp += 1;
+        (*N_nodes)++;
+        if (*N_nodes > max_N_nodes) {
+            DEBUG_LOG("QUITTING DUE TO TOO MANY NODES/ITERATIONS\n");
+            status = -3;
+            goto end;
+        }
+        stack_i[sp]       = i-1;
+        stack_pos[sp]     = 0;
+
+        // update the partial sums
+        for (int j = 0; j<N_hyps; ++j) {
+            int64_t prev = stack_partial_sum[(sp-1)*N_hyps + j];
+            stack_partial_sum[sp*N_hyps+j] = prev + (int64_t)H[j*dim + i] * (int64_t)veci;
+        }
+
+        if (i > 0) {
+            set_bounds(
+                sp,
+                i-1,
+                dim,
+                N_hyps,
+                B,
+                H,
+                rhs,
+                stack_partial_sum,
+                abssum,
+                stack_val_min,
+                stack_val_len);
+        }
+    }
+
+    DEBUG_LOG("DONE\n");
+
+    end:
+        *N_out = op;
+        return status;
+}
+
+#undef MAX_SUPPORTED_DIM
+
+#endif // BOX_ENUM_IMPLEMENTATION
+
+#endif // BOX_ENUM_H

--- a/M2/Macaulay2/e/cytools/computeGV.cpp
+++ b/M2/Macaulay2/e/cytools/computeGV.cpp
@@ -1,0 +1,992 @@
+/******************************************************************************
+This file is part of CYTools.
+
+CYTools is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+CYTools is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with CYTools.  If not, see <https://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "computeGV.hpp"
+
+#include <math.h>
+
+#include <map>
+#include <random>
+#include <thread>
+#include <numeric>
+#include <iostream>
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+
+// Sample input for the following function (for h11=3 example).
+// {{-1, -1, 0}, {1, 0, 1}, {1, 2, 0}}
+// {}
+// {-3, 2, 4}
+// {{1, 0, 0, -1, -1, -1, -2}, {0, 1, 0, -1, 0, 1, 1}, {0, 0, 1, 1, 1, 1, 0}}
+// {}
+// {{0, 0, 0, 1}, {0, 0, 1, -1}, {0, 1, 1, -1}, {1, 1, 1, -2}, {1, 1, 2, 1}, {1, 2, 2, 3}, {2, 2, 2, 3}}
+// {20, 150, 0, 300000}
+
+bool computeGVverboseMode = false;
+
+void addCurveAndGV(CurveAndGVCollection &collection,
+                   const std::vector<int> &curve,
+                   mpfr_srcptr gv)
+{
+  mpz_class val;
+  mpfr_get_z(val.get_mpz_t(), gv, MPFR_RNDN);
+  collection.push_back({curve, std::move(val)});
+}
+
+void readArguments(
+    int argc,
+    char** argv,
+    std::vector<std::vector<int>>& input_curves,
+    std::vector<std::vector<int>>& lightcone_curves,
+    std::vector<int>& grading_vec,
+    std::vector<std::vector<int>>& Q,  // GLSM charge matrix
+    VectorList& nef_partition,
+    std::vector<std::vector<int>>& intnums_list,  // intersection numbers
+    std::vector<int>& input_settings)             // computation settings
+{
+  std::cerr << "Reading input curves..." << std::endl;
+  input_curves = ReadVectors(std::cin);
+  if (!input_curves.size()) {
+    throw std::invalid_argument("Empty curve list.");
+  }
+
+  std::cerr << "Reading curves whose past light cone will be computed...";
+  std::cerr << std::endl;
+  lightcone_curves = ReadVectors(std::cin);
+
+  std::cerr << "Reading grading vector..." << std::endl;
+  grading_vec = ReadVector(std::cin);
+
+  std::cerr << "Reading GLSM charge matrix..." << std::endl;
+  Q = ReadVectors(std::cin);
+  if (!Q.size()) {
+    throw std::invalid_argument("Empty GLSM charge matrix.");
+  }
+
+  std::cerr << "Reading nef-partition..." << std::endl;
+  nef_partition = ReadVectors(std::cin, true);
+
+  // Then we read the intersection numbers
+  // Note that when dim(CY) > 3 the first index corresponds to a H_{2,2} class
+  std::cerr << "Reading intersection numbers..." << std::endl;
+  intnums_list = ReadVectors(std::cin);
+  if (!intnums_list.size()) {
+    throw std::invalid_argument("Empty intersection numbers array.");
+  }
+
+  std::cerr << "Reading computation settings..." << std::endl;
+  input_settings = ReadVector(std::cin);
+  if (input_settings.size() != 4) {
+    throw std::invalid_argument("The input vector must have exactly three "
+                                "entries: maximum degree, number of decimal"
+                                "digits, mode, and minimum memory.");
+  }
+}
+
+
+int gvcompute(
+    std::vector<std::vector<int>> input_curves,
+    std::vector<std::vector<int>> lightcone_curves,
+    std::vector<int> grading_vec,
+    std::vector<std::vector<int>> Q,  // GLSM charge matrix
+    VectorList nef_partition,
+    std::vector<std::vector<int>> intnums_list,  // intersection numbers
+              std::vector<int> input_settings,
+    CurveAndGVCollection& result)             // computation settings
+{
+  if (!input_curves.size()) {
+    throw std::invalid_argument("Empty curve list.");
+  }
+  int h11 = input_curves[0].size();
+
+  if (lightcone_curves.size() && lightcone_curves[0].size() != h11) {
+    throw std::invalid_argument("Dimension mismatch.");
+  }
+
+  if (h11 != grading_vec.size()) {
+    throw std::invalid_argument("Rank of lattice must match size of grading "
+                                "vector.");
+  }
+
+  if (!Q.size()) {
+    throw std::invalid_argument("Empty GLSM charge matrix.");
+  }
+
+  // Find the dimension and codimension of the CY
+  int ambient_dim = Q[0].size() - Q.size();
+  int cy_codim = (nef_partition.size() ? nef_partition.size() : 1);
+  int cy_dim = ambient_dim - cy_codim;
+  if (cy_dim < 3) {
+    throw std::invalid_argument("CY must have dimension at least 3.");
+  }
+
+  if (!intnums_list.size()) {
+    throw std::invalid_argument("Empty intersection numbers array.");
+  }
+  if (intnums_list[0].size() != 4) {
+    throw std::invalid_argument("Intersection numbers array must have exactly "
+                                "4 columns.");
+  }
+  VecToIntDict intnums;
+  VectorSet beta_pairs;
+  std::vector<int> tmp_vec_3(3);
+  int min_h11_ind=0, max_h11_ind=0, min_h22_ind=0, max_h22_ind=0;
+  for (auto &v : intnums_list) {
+    tmp_vec_3 = {v[0], v[1], v[2]};
+    int intnum = v[3];
+    std::sort(tmp_vec_3.begin()+(cy_dim > 3 ? 1 : 0), tmp_vec_3.end());
+    if (cy_dim == 3) {
+      beta_pairs.insert({tmp_vec_3[0],tmp_vec_3[1]});
+      beta_pairs.insert({tmp_vec_3[0],tmp_vec_3[2]});
+      beta_pairs.insert({tmp_vec_3[1],tmp_vec_3[2]});
+    }
+    else {
+      beta_pairs.insert({tmp_vec_3[1],tmp_vec_3[2]});
+    }
+    intnums[tmp_vec_3] = intnum;
+    if (v[2] > max_h11_ind) {
+      max_h11_ind = v[2];
+    }
+    if (v[1] < min_h11_ind) {
+      min_h11_ind = v[1];
+    }
+    if (v[0] > max_h22_ind) {
+      max_h22_ind = v[0];
+    }
+    if (v[0] < min_h22_ind) {
+      min_h11_ind = v[0];
+    }
+  }
+  intnums_list.clear();
+  // Check some basic things
+  if (min_h11_ind < 0 || min_h22_ind < 0) {
+    throw std::invalid_argument("Indices must be non-negative.");
+  }
+  if (max_h11_ind >= h11) {
+    throw std::invalid_argument("Indices cannot exceed h11-1.");
+  }
+  int h22 = (cy_dim > 3 ? max_h22_ind+1 : h11);
+
+  // Finally, we read the maximum degree desired, the number of decimal digits,
+  // the mode used for calculations, and the minimum available memory below
+  // which the computation will be terminated.
+  // Modes:
+  //   - 0 Normal:   The full set of curves up to the specified degree is
+  //                 constructed, and the backward light cone is computed.
+  //   - 1 Hilbert:  Only GV invariants of Hilber basis elements are computed.
+  //   - 2 Verbatim: The set of input curves are used exactly as given.
+  // If the mode has the third bit set then it means that GW invariants will
+  // be computed instead of GV invariants.
+  if (input_settings.size() != 4) {
+    throw std::invalid_argument("The input vector must have exactly three "
+                                "entries: maximum degree, number of decimal"
+                                "digits, mode, and minimum memory.");
+  }
+  int max_deg = input_settings[0];
+  int digits = input_settings[1];
+  int mode = input_settings[2];
+  int min_mem = input_settings[3];
+  input_settings.clear();
+
+  bool computeGW = mode & 0b100;
+  mode &= 0b11;
+
+  int min_points = (max_deg >= 0 ? 0 : -max_deg);
+  max_deg *= (max_deg > 0 ? 1 : 0);
+  if (mode == 2) {
+    min_points = 0;
+  }
+
+  if (mode < 0 || mode > 2) {
+    throw std::invalid_argument("Mode must be between 0 and 2.");
+  }
+
+  MPFloat zero_cutoff = 10;
+  zero_cutoff = pow(zero_cutoff,-digits/2);
+
+  // Set the number of decimal digits
+  if (digits < 17 || digits > 2000){
+    throw std::invalid_argument("Number of digits (" + std::to_string(digits)
+                                + ") was likely wrong. ");
+  }
+  int prec = mpfr::digits2bits(digits);
+  mpfr::mpreal::set_default_prec(prec);
+
+  // Set up variables for multithreading.
+  int n_threads = std::thread::hardware_concurrency();
+  if (!n_threads) {
+    n_threads = 1;
+  }
+  std::cerr << "#threads: " << n_threads << std::endl;
+
+  std::vector<std::thread> thread_vec;
+  std::mutex task_mut, mut0, mut1, mut2;
+  int curr_task;
+
+  // Now we check for nonpositive degrees
+  if (computeGVverboseMode) std::cerr << "Checking consistency of input of curves..." << std::endl;
+  std::unordered_set<std::vector<int>,VectorHash> curves_set(
+                                                      input_curves.begin(),
+                                                      input_curves.end());
+  // Add the curves whose light cones will be used (in case they are not
+  // already included)
+  for (auto &v : lightcone_curves) {
+    curves_set.insert(v);
+  }
+  std::vector<std::vector<int> > tmp_all_curves, tmp_new_curves, tmp_check_curves;
+  std::vector<int> origin(h11, 0);
+  int tmp_deg, tmp_n_curves;
+  bool has_nonpos_degs = false;
+  bool find_max_deg = max_deg == 0;
+  // We first remove the origin to save some time
+  auto origin_it = curves_set.find(origin);
+  if (origin_it != curves_set.end()) {
+    curves_set.erase(origin_it);
+  }
+  // First find the maximum degree in the list, and check for non-positive
+  // degrees.
+  std::vector<std::vector<int> > curves_to_remove;
+  for (auto &v : curves_set) {
+    tmp_deg = 0;
+    for (int i = 0; i < h11; i++) {
+      tmp_deg += v[i] * grading_vec[i];
+    }
+    if (tmp_deg <= 0) {
+      has_nonpos_degs = true;
+      break;
+    }
+    else if (tmp_deg > max_deg) {
+      if (find_max_deg) {
+        max_deg = tmp_deg;
+      }
+      else {
+        curves_to_remove.push_back(v);
+      }
+    }
+  }
+  if (has_nonpos_degs) {
+    throw std::invalid_argument("Non-zero curves with non-positive degrees "
+                                "were found.");
+  }
+  for (auto &v : curves_to_remove) {
+    curves_set.erase(v);
+  }
+  curves_to_remove.clear();
+  // Remove curves from lightcone_curves if necessary.
+  for (auto v = lightcone_curves.begin(); v != lightcone_curves.end(); ) {
+    auto search = curves_set.find(*v);
+    if (search == curves_set.end()) {
+      v = lightcone_curves.erase(v);
+    }
+    else{
+      v++;
+    }
+  }
+  // If the maximum degree was not specified, and there are curves whose past
+  // light cone will be computed, then we first set the maximum degree to half
+  // of the maximum degree of these curves
+  int max_lightcone_deg = 0;
+  if (find_max_deg) {
+    for (auto &v : lightcone_curves) {
+      tmp_deg = 0;
+      for (int i = 0; i < h11; i++) {
+        tmp_deg += v[i] * grading_vec[i];
+      }
+      if (tmp_deg > max_lightcone_deg) {
+        max_lightcone_deg = tmp_deg;
+      }
+    }
+    if (max_lightcone_deg) {
+      max_deg = std::ceil(float(max_lightcone_deg)/2.);
+    }
+  }
+  // Now we find the Hilbert basis of the Mori cone
+  VectorSet hilbert_set;
+  if (mode != 2) {
+    if (computeGVverboseMode) std::cerr << "Finding Hilbert basis..." << std::endl;
+    tmp_all_curves = std::vector<std::vector<int> >(curves_set.begin(),
+                                                    curves_set.end());
+    tmp_n_curves = tmp_all_curves.size();
+    hilbert_set = curves_set;
+    curr_task = 0;
+    IntMatrix vecs_to_remove;
+    for (int i = 0; i < n_threads; i++) {
+      thread_vec.push_back(std::thread(RemoveNonGensThr,
+                           std::ref(hilbert_set), std::ref(tmp_all_curves),
+                           std::ref(vecs_to_remove), std::ref(grading_vec),
+                           max_deg, std::ref(curr_task), tmp_n_curves,
+                           std::ref(mut0), std::ref(task_mut)));
+    }
+    for (auto &t : thread_vec) {
+      t.join();
+    }
+    thread_vec.clear();
+    tmp_all_curves.clear();
+    for (IntVector &v : vecs_to_remove) {
+      hilbert_set.erase(v);
+    }
+  }
+
+  IntMatrix hilbert_basis = std::vector<std::vector<int> >(hilbert_set.begin(),
+                                                           hilbert_set.end());
+  // Now iterate over possible sums to find missing vectors if in normal mode
+  if (min_points > 0) {
+    curves_set.clear();
+    curves_set.insert(origin);
+    max_deg = 1;
+  }
+  tmp_check_curves = std::vector<std::vector<int> >(curves_set.begin(),
+                                                    curves_set.end());
+  tmp_n_curves = tmp_check_curves.size();
+  while (mode==0) {
+    curr_task = 0;
+    for (int i = 0; i < (n_threads <= 4 ? n_threads : 4); i++) {
+      thread_vec.push_back(std::thread(CheckCompletenessThr,
+                           std::ref(curves_set), std::ref(tmp_check_curves),
+                           std::ref(tmp_new_curves), std::ref(hilbert_basis),
+                           std::ref(grading_vec), max_deg, std::ref(curr_task),
+                           tmp_n_curves, std::ref(mut0), std::ref(task_mut),
+                           min_mem));
+    }
+    for (auto &t : thread_vec) {
+      t.join();
+    }
+    thread_vec.clear();
+    if (tmp_new_curves.size() == 0) {
+      if (curves_set.size() > min_points) {
+        tmp_check_curves.clear();
+        break;
+      }
+      max_deg++;
+      continue;
+    }
+    if (computeGVverboseMode) std::cerr << "Found " << tmp_new_curves.size() << " new vectors" << std::endl;
+    if (min_points > 0) {
+      tmp_check_curves.insert(tmp_check_curves.end(), tmp_new_curves.begin(),
+                              tmp_new_curves.end());
+    }
+    else {
+      tmp_check_curves.clear();
+      tmp_check_curves = std::move(tmp_new_curves);
+    }
+    tmp_new_curves.clear();
+    tmp_n_curves = tmp_check_curves.size();
+  }
+  tmp_check_curves.clear();
+  tmp_new_curves.clear();
+  // If in Hilbert mode we only keep the Hilbert basis
+  if (mode==1) {
+    curves_set.clear();
+    curves_set = hilbert_set;
+  }
+  // Finally, we add back the origin
+  curves_set.insert(origin);
+  // Now we construct the past light cones for the necessary curves
+  std::unordered_set<std::vector<int>,VectorHash> lightcone_curves_set;
+  for (unsigned int i = 0; i < lightcone_curves.size(); i++) {
+    thread_vec.push_back(std::thread(HalfPastLightConeThr,
+                         std::ref(curves_set), std::ref(lightcone_curves_set),
+                         std::ref(lightcone_curves[i]), std::ref(mut0)));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  // Now we fill out the portion of the past light cone that should be filled.
+  tmp_check_curves = std::vector<std::vector<int> >(curves_set.begin(),
+                                                    curves_set.end());
+  tmp_n_curves = tmp_check_curves.size();
+  while (mode==0) {
+    curr_task = 0;
+    for (int i = 0; i < (n_threads <= 4 ? n_threads : 4); i++) {
+      thread_vec.push_back(std::thread(FillPastLightConeThr,
+                           std::ref(curves_set), std::ref(tmp_check_curves),
+                           std::ref(lightcone_curves_set),
+                           std::ref(tmp_new_curves), std::ref(hilbert_basis),
+                           std::ref(grading_vec), max_deg, std::ref(curr_task),
+                           tmp_n_curves, std::ref(mut0), std::ref(task_mut),
+                           min_mem));
+    }
+    for (auto &t : thread_vec) {
+      t.join();
+    }
+    thread_vec.clear();
+    if (tmp_new_curves.size() == 0) {
+      tmp_check_curves.clear();
+      break;
+    }
+    if (computeGVverboseMode) std::cerr << "Found new vectors" << std::endl;
+    tmp_check_curves.clear();
+    tmp_check_curves = std::move(tmp_new_curves);
+    tmp_new_curves.clear();
+    tmp_n_curves = tmp_check_curves.size();
+    if (computeGVverboseMode) std::cerr << "Found " << tmp_check_curves.size() << " new vectors" << std::endl;
+  }
+  tmp_check_curves.clear();
+  tmp_new_curves.clear();
+  // Now we remove curves that are not in the past light cones of the selected
+  // curves.
+  VectorSet final_curves_set;
+  for (unsigned int i = 0; i < lightcone_curves.size(); i++) {
+    thread_vec.push_back(std::thread(TrimPastLightConeThr,
+                         std::ref(curves_set), std::ref(final_curves_set),
+                         std::ref(lightcone_curves[i]), std::ref(mut0)));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  if (!final_curves_set.size()) {
+    final_curves_set = std::move(curves_set);
+  }
+  curves_set.clear();
+  input_curves.clear();
+  input_curves.reserve(final_curves_set.size());
+  for (auto it = final_curves_set.begin(); it != final_curves_set.end(); ) {
+    input_curves.push_back(std::move(final_curves_set.extract(it++).value()));
+  }
+  curves_set.clear();
+  int n_curves = input_curves.size();
+  if (computeGVverboseMode) std::cerr << "Using " << n_curves << " curves." << std::endl;
+  if (find_max_deg && max_lightcone_deg) {
+    max_deg = max_lightcone_deg;
+  }
+
+  // Compute the degrees of all monomials
+  IntVector degs(n_curves);
+  for (int i = 0; i < n_curves; i++) {
+    tmp_deg = 0;
+    for (int j = 0; j < h11; j++) {
+      tmp_deg += input_curves[i][j] * grading_vec[j];
+    }
+    degs[i] = tmp_deg;
+  }
+  std::vector<int> sorted_ind(n_curves);
+  std::iota(sorted_ind.begin(), sorted_ind.end(), 0);
+  std::sort(sorted_ind.begin(), sorted_ind.end(),
+            [&degs](int a, int b) {
+              return degs[a] < degs[b];
+            });
+  IntMatrix curves;
+  curves.reserve(n_curves);
+  IntVector old_degs = degs;
+  for (int i = 0; i < n_curves; i++) {
+    curves.push_back(input_curves[sorted_ind[i]]);
+    degs[i] = old_degs[sorted_ind[i]];
+  }
+  input_curves.clear();
+  old_degs.clear();
+
+  // Construct a monomial/curve dictionary
+  if (computeGVverboseMode) std::cerr << "Constructing monomial dictionary..." << std::endl;
+  VecToIntDict curve_dict;
+  for (int i = 0; i < n_curves; i++) {
+    curve_dict[curves[i]] = i;
+  }
+
+  // We store some constants that will be used for polygamma computations
+  MPFloat neg_em = -mpfr::const_euler();
+  MPFloat pi2d6 = mpfr::const_pi()*mpfr::const_pi()/6;
+
+  // Now we compute c and its derivatives
+  if (computeGVverboseMode) std::cerr << "Computing c..." << std::endl;
+  Polynomial c0;
+  std::vector<Polynomial> c1(h11);
+  VecToPolyDict c2;
+  for (auto &pp : beta_pairs) {
+    c2[pp] = Polynomial();
+  }
+  int h11pd = h11 + ambient_dim;
+  std::vector<IntVector> Q0s(cy_codim, IntVector(h11));
+  for (int i = 0; i < h11; i++) {
+    for (int j = 0; j < cy_codim; j++) {
+      if (!nef_partition.size()) {
+        Q0s[0][i] = 0;
+        for (int k = 0; k < h11pd; k++) {
+          Q0s[0][i] += Q[i][k];
+        }
+      }
+      else {
+        Q0s[j][i] = 0;
+        for (int k = 0; k < nef_partition[j].size(); k++) {
+          Q0s[j][i] += Q[i][nef_partition[j][k]];
+        }
+      }
+    }
+  }
+  IntVector tmp_vec_h11pd(h11pd);
+  IntMatrix curves_dot_Q;
+  for (int i = 0; i < n_curves; i++) {
+    for (int j = 0; j < h11pd; j++) {
+      tmp_vec_h11pd[j] = 0;
+      for (int k = 0; k < h11; k++) {
+        tmp_vec_h11pd[j] += curves[i][k] * Q[k][j];
+      }
+    }
+    curves_dot_Q.push_back(tmp_vec_h11pd);
+  }
+  IntVector tmp_vec_ncurves(n_curves);
+  IntMatrix curves_dot_Q0s;
+  for (int i = 0; i < cy_codim; i++) {
+    for (int j = 0; j < n_curves; j++) {
+      tmp_vec_ncurves[j] = 0;
+      for (int k = 0; k < h11; k++) {
+        tmp_vec_ncurves[j] += curves[j][k] * Q0s[i][k];
+      }
+    }
+    curves_dot_Q0s.push_back(tmp_vec_ncurves);
+  }
+  std::vector<int> neg0;
+  std::vector<std::tuple<int,int> > neg1;
+  std::vector<std::tuple<int,int,int> > neg2;
+  int k0, k1, k2;
+  for (int i = 0; i < n_curves; i++) {
+    k0 = k1 = k2 = -1;
+    for (int j = 0; j < h11pd; j++) {
+      if (curves_dot_Q[i][j] >= 0) {
+        continue;
+      }
+      else if (k0 == -1) {
+        k0 = j;
+        continue;
+      }
+      else if (k1 == -1) {
+        k1 = j;
+        continue;
+      }
+      k2 = j;
+      break;
+    }
+    if (k2 != -1) {
+      continue;
+    }
+    else if (k1 != -1) {
+      neg2.push_back({i,k0,k1});
+    }
+    else if (k0 != -1) {
+      neg1.push_back({i,k0});
+    }
+    else{
+      neg0.push_back(i);
+    }
+  }
+
+  // 0 negative
+  curr_task = 0;
+  for (int i = 0; i < n_threads; i++) {
+    thread_vec.push_back(std::thread(computeC_0neg, std::ref(c0), std::ref(c1),
+                        std::ref(c2), std::ref(neg0), std::ref(Q),
+                        std::ref(Q0s), std::ref(curves_dot_Q),
+                        std::ref(curves_dot_Q0s), prec, std::ref(mut0),
+                        std::ref(mut1), std::ref(mut2),
+                        h11, h11pd, min_mem, std::ref(curr_task),
+                        std::ref(task_mut), std::ref(beta_pairs),
+                        std::ref(neg_em), std::ref(pi2d6)));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  neg0.clear();
+  // Start computing c0inv while we compute derivatives
+  PolyCleanUp(c0, zero_cutoff, true);
+  Polynomial c0inv;
+  std::thread c0inv_thr = std::thread(ComputeInvC0Thr, std::ref(c0inv),
+                                      std::ref(c0), std::ref(curves),
+                                      std::ref(degs), std::ref(curve_dict),
+                                      prec);
+  // 1 negative
+  curr_task = 0;
+  for (int i = 0; i < n_threads; i++) {
+    thread_vec.push_back(std::thread(computeC_1neg, std::ref(c1), std::ref(c2),
+                        std::ref(neg1), std::ref(Q), std::ref(Q0s),
+                        std::ref(curves_dot_Q), std::ref(curves_dot_Q0s), prec,
+                        std::ref(mut1), std::ref(mut2),
+                        h11, h11pd, min_mem, std::ref(curr_task),
+                        std::ref(task_mut), std::ref(beta_pairs),
+                        std::ref(neg_em)));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  neg1.clear();
+  for (auto &p : c1) {
+    PolyCleanUp(p, zero_cutoff, true);
+  }
+  // 2 negative
+  curr_task = 0;
+  for (int i = 0; i < n_threads; i++) {
+    thread_vec.push_back(std::thread(computeC_2neg, std::ref(c2),
+                        std::ref(neg2), std::ref(Q), std::ref(Q0s),
+                        std::ref(curves_dot_Q), std::ref(curves_dot_Q0s), prec,
+                        std::ref(mut2), h11, h11pd, min_mem,
+                        std::ref(curr_task), std::ref(task_mut),
+                        std::ref(beta_pairs)));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  neg2.clear();
+  for (auto &pp : beta_pairs) {
+    PolyCleanUp(c2[pp], zero_cutoff, true);
+  }
+  // Wait for c0inv to be done
+  c0inv_thr.join();
+  c0 = Polynomial();
+
+  if (computeGVverboseMode) std::cerr << "Computing alpha polynomials..." << std::endl;
+  std::vector<Polynomial> alpha(h11);
+  curr_task = 0;
+  for (int i = 0; i < n_threads; i++) {
+    thread_vec.push_back(std::thread(ComputeAlphaThr, std::ref(alpha),
+                         std::ref(c0inv), std::ref(c1), std::ref(curves),
+                         std::ref(degs), std::ref(curve_dict), prec,
+                         std::ref(curr_task), std::ref(task_mut),
+                         std::ref(mut0), min_mem));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  c1.clear();
+  if (computeGVverboseMode) std::cerr << "Computing beta polynomials..." << std::endl;
+  VecToPolyDict beta;
+  VectorList beta_pairs_vec = VectorList(beta_pairs.begin(),beta_pairs.end());
+  curr_task = 0;
+  for (int i = 0; i < n_threads; i++) {
+    thread_vec.push_back(std::thread(ComputeBetaThr, std::ref(beta),
+                         std::ref(c0inv), std::ref(c2), std::ref(curves),
+                         std::ref(degs), std::ref(curve_dict), prec,
+                         std::ref(curr_task), std::ref(beta_pairs_vec),
+                         std::ref(task_mut), std::ref(mut0), min_mem));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  c2.clear();
+
+  // Compute F polynomials (F_ab = beta_ab - alpha_a * alpha_b)
+  if (computeGVverboseMode) std::cerr << "Computing F polynomials..." << std::endl;
+  VecToPolyDict F;
+  curr_task = 0;
+  for (int i = 0; i < n_threads; i++) {
+    thread_vec.push_back(std::thread(ComputeFThr, std::ref(F),
+                         std::ref(alpha), std::ref(beta), std::ref(curves),
+                         std::ref(degs), std::ref(curve_dict), prec,
+                         std::ref(curr_task), std::ref(beta_pairs_vec),
+                         std::ref(task_mut), std::ref(mut0), min_mem));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  beta.clear();
+  for (auto &p : F) {
+    PolyCleanUp(p.second, zero_cutoff);
+  }
+
+  // Compute instanton corrections
+  if (computeGVverboseMode) std::cerr << "Computing instanton corrections..." << std::endl;
+  if (cy_dim == 3) {
+    h22 = h11;
+  }
+  std::vector<Polynomial> inst(h22);
+  curr_task = 0;
+  for (int i = 0; i < n_threads; i++) {
+    thread_vec.push_back(std::thread(ComputeInstThr, std::ref(inst),
+                        std::ref(F), std::ref(intnums), std::ref(curves),
+                        std::ref(degs), std::ref(curve_dict),
+                        prec, std::ref(curr_task), std::ref(task_mut),
+                        std::ref(mut0), h22, cy_dim, min_mem));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  F.clear();
+  // Clean up inst
+  for (auto &p : inst) {
+    PolyCleanUp(p, zero_cutoff);
+  }
+
+  // Compute expalpha
+  if (computeGVverboseMode) std::cerr << "Computing exp(alpha)..." << std::endl;
+  std::vector<Polynomial> expalpha_pos(h11), expalpha_neg(h11);
+  curr_task = 0;
+  for (int i = 0; i < n_threads; i++) {
+    thread_vec.push_back(std::thread(ComputeExpAlphaThr,
+                         std::ref(expalpha_pos), std::ref(expalpha_neg),
+                         std::ref(alpha), std::ref(curves), std::ref(degs),
+                         std::ref(curve_dict), prec, std::ref(curr_task),
+                         std::ref(task_mut), std::ref(mut0), min_mem));
+  }
+  for (auto &t : thread_vec) {
+    t.join();
+  }
+  thread_vec.clear();
+  alpha.clear();
+
+  // Compute GV invariants iteratively
+  if (computeGVverboseMode) std::cerr << "Computing GV..." << std::endl;
+  if (computeGVverboseMode) std::cout.precision(digits);
+  Polynomial tmp_poly;
+  std::vector<int> vec_deg;
+  MPFloat tmp_GV, tmp_GV_rounded;
+  int n_previous_levels = (h11 < 4 ? 2 : (h11 < 10 ? 5 : 10));
+  std::vector<IntToPolyDict> previous_qN(n_previous_levels);
+  std::vector<IntVector> previous_qN_ind(n_previous_levels);
+  std::vector<int> qN_to_compute;
+  std::vector<MPFloat> GV_qN_to_compute;
+  IntToH22GVDict h22GV_qN_to_compute;
+  IntToPolyDict computed_qN, computed_Li2qN;
+  for (int i = 1; i < degs[n_curves-1]+1 ; i++) {
+    // First check if there are any points with the degree of interest
+    vec_deg.clear();
+    qN_to_compute.clear();
+    GV_qN_to_compute.clear();
+    h22GV_qN_to_compute.clear();
+    for (int j = 0; j < n_curves; j++) {
+      if (degs[j] == i) {
+        vec_deg.push_back(j);
+      }
+      else if (degs[j] > i) {
+        break;
+      }
+    }
+    if (!vec_deg.size()) {
+      continue;
+    }
+    if (cy_dim == 3) {
+      for (auto j : vec_deg) {
+        int kk = 0;
+        for (int k = 0; k < h11; k++) {
+          if (curves[j][k]) {
+            kk = k;
+            break;
+          }
+        }
+        auto search = inst[kk].coeffs.find(j);
+        if (search == inst[kk].coeffs.end()) {
+          continue;
+        }
+        tmp_GV = search->second/curves[j][kk];
+        if (computeGW) {
+          if (mpfr::abs(tmp_GV) < zero_cutoff) {
+            continue;
+          }
+
+          addCurveAndGV(result, curves[j], tmp_GV.mpfr_srcptr());
+
+          if (computeGVverboseMode) {
+            std::cout << "(";
+            for (int k = 0; k < h11; k++) {
+              std::cout << curves[j][k] << (k==h11-1 ? "" : ",");
+            }
+            std::cout << "), " << tmp_GV << std::endl;
+          }
+
+          qN_to_compute.push_back(j);
+          GV_qN_to_compute.push_back(tmp_GV);
+        }
+        else {
+          tmp_GV_rounded = mpfr::round(tmp_GV);
+          if (abs(tmp_GV-tmp_GV_rounded) > 1e-3) {
+            std::cerr << "Error: Non-integer GV invariant was found.\n(";
+            for (int h = 0; h < h11; h++) {
+              std::cerr << curves[j][h] << (h==h11-1 ? "" : ",");
+            }
+            std::cerr << "), " << tmp_GV << std::endl;
+            throw std::logic_error("Non-integer GV invariant was found. Input "
+                                   "may be inconsistent, or the precision "
+                                   "needs to be increased.");
+          }
+          if (mpfr::abs(tmp_GV_rounded) < 0.5) {
+            continue;
+          }
+
+          addCurveAndGV(result, curves[j], tmp_GV.mpfr_srcptr());
+
+          if (computeGVverboseMode) {
+            std::cout << "(";
+            for (int k = 0; k < h11; k++) {
+              std::cout << curves[j][k] << (k==h11-1 ? "" : ",");
+            }
+            std::cout << "), " << tmp_GV_rounded << std::endl;
+          }
+          qN_to_compute.push_back(j);
+          GV_qN_to_compute.push_back(tmp_GV_rounded);
+        }
+      }
+    }
+    else {
+      for (auto j : vec_deg) {
+        for (int k = 0; k < h22; k++) {
+          auto search = inst[k].coeffs.find(j);
+          if (search == inst[k].coeffs.end()) {
+            continue;
+          }
+          tmp_GV = search->second;
+          if (computeGW) {
+            if (mpfr::abs(tmp_GV) < zero_cutoff) { continue; }
+
+            addCurveAndGV(result, curves[j], tmp_GV.mpfr_srcptr());
+
+            if (computeGVverboseMode) {
+              std::cout << "(";
+              for (int h = 0; h < h11; h++) {
+                std::cout << curves[j][h] << (h==h11-1 ? "" : ",");
+              }
+              std::cout << "), " << k << ", " << tmp_GV << std::endl;
+            }
+            auto search_h22 = h22GV_qN_to_compute.find(j);
+            if (search_h22 == h22GV_qN_to_compute.end()) {
+              qN_to_compute.push_back(j);
+              h22GV_qN_to_compute[j] = {{k,tmp_GV}};
+            }
+            else {
+              search_h22->second.push_back({k,tmp_GV});
+            }
+          }
+          else {
+            tmp_GV_rounded = mpfr::round(tmp_GV);
+            if (abs(tmp_GV-tmp_GV_rounded) > 1e-3) {
+              std::cerr << "Error: Non-integer GV invariant was found.\n(";
+              for (int h = 0; h < h11; h++) {
+                std::cerr << curves[j][h] << (h==h11-1 ? "" : ",");
+              }
+              std::cerr << "), " << k << ", " << tmp_GV << std::endl;
+              throw std::logic_error("Non-integer GV invariant was found. Input "
+                                     "may be inconsistent, or the precision "
+                                     "needs to be increased.");
+            }
+            if (mpfr::abs(tmp_GV_rounded) < 0.5) {
+              continue;
+            }
+
+            addCurveAndGV(result, curves[j], tmp_GV.mpfr_srcptr());
+
+            if (computeGVverboseMode) {
+              std::cout << "(";
+              for (int h = 0; h < h11; h++) {
+                std::cout << curves[j][h] << (h==h11-1 ? "" : ",");
+              }
+              std::cout << "), " << k << ", " << tmp_GV_rounded << std::endl;
+            }
+            auto search_h22 = h22GV_qN_to_compute.find(j);
+            if (search_h22 == h22GV_qN_to_compute.end()) {
+              qN_to_compute.push_back(j);
+              h22GV_qN_to_compute[j] = {{k,tmp_GV_rounded}};
+            }
+            else {
+              search_h22->second.push_back({k,tmp_GV_rounded});
+            }
+          }
+        }
+      }
+    }
+    if (!qN_to_compute.size()) {
+      continue;
+    }
+    computed_qN.clear();
+    computed_Li2qN.clear();
+    // compute qN and Li2(qN) in parallel
+    curr_task = 0;
+    for (int i = 0; i < n_threads; i++) {
+      thread_vec.push_back(std::thread(ComputeLi2qNThr,
+                           std::ref(qN_to_compute), std::ref(computed_qN),
+                           std::ref(computed_Li2qN), std::ref(previous_qN),
+                           std::ref(previous_qN_ind), std::ref(expalpha_pos),
+                           std::ref(expalpha_neg), std::ref(curves),
+                           std::ref(degs), std::ref(curve_dict), prec,
+                           std::ref(curr_task), std::ref(task_mut),
+                           std::ref(mut0), computeGW, min_mem));
+    }
+    for (auto &t : thread_vec) {
+      t.join();
+    }
+    thread_vec.clear();
+    // Now we do the subtraction from the instanton corrections
+    if (cy_dim == 3) {
+      for (int j = 0; j < qN_to_compute.size(); j++) {
+        for (int k = 0; k < h11; k++) {
+          int jj = qN_to_compute[j];
+          if (!curves[jj][k]) {
+            continue;
+          }
+          tmp_poly = computed_Li2qN[jj];
+          PolyProdScalarIP(tmp_poly, curves[jj][k]*GV_qN_to_compute[j]);
+          PolySubIP(inst[k], tmp_poly);
+        }
+      }
+    }
+    else {
+      for (int j = 0; j < qN_to_compute.size(); j++) {
+        int jj = qN_to_compute[j];
+        for (int k = 0; k < h22GV_qN_to_compute[jj].size(); k++) {
+          int jj = qN_to_compute[j];
+          int kk = h22GV_qN_to_compute[jj][k].first;
+          tmp_GV = h22GV_qN_to_compute[jj][k].second;
+          tmp_poly = computed_Li2qN[jj];
+          PolyProdScalarIP(tmp_poly, tmp_GV);
+          PolySubIP(inst[kk], tmp_poly);
+        }
+      }
+    }
+    for (int j = 0; j < n_previous_levels-1; j++) {
+      previous_qN[j] = std::move(previous_qN[j+1]);
+      previous_qN_ind[j] = std::move(previous_qN_ind[j+1]);
+    }
+    if (n_previous_levels > 1) {
+      previous_qN[n_previous_levels-1] = std::move(computed_qN);
+      previous_qN_ind[n_previous_levels-1] = std::move(qN_to_compute);
+    }
+  }
+  return 0;
+}
+
+// int gvcompute_main(int argc, char** argv) {
+//   std::vector<std::vector<int>> input_curves;
+//   std::vector<std::vector<int>> lightcone_curves;
+//   std::vector<int> grading_vec;
+//   std::vector<std::vector<int>> Q;  // GLSM charge matrix
+//   VectorList nef_partition;
+//   std::vector<std::vector<int>> intnums_list;  // intersection numbers
+//   std::vector<int> input_settings;             // computation settings
+
+//   readArguments(argc,
+//                 argv,
+//                 input_curves,
+//                 lightcone_curves,
+//                 grading_vec,
+//                 Q,
+//                 nef_partition,
+//                 intnums_list,
+//                 input_settings);
+
+//     return gvcompute(input_curves,
+//                    lightcone_curves,
+//                    grading_vec,
+//                    Q,
+//                    nef_partition,
+//                    intnums_list,
+//                    input_settings
+//                    );            
+// }

--- a/M2/Macaulay2/e/cytools/computeGV.hpp
+++ b/M2/Macaulay2/e/cytools/computeGV.hpp
@@ -1,0 +1,1316 @@
+/******************************************************************************
+This file is part of CYTools.
+
+CYTools is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+CYTools is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with CYTools.  If not, see <https://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "mpreal.h"
+#include <gmpxx.h>
+
+#include <math.h>
+#include <ctype.h>
+#include <unistd.h>
+
+#include <mutex>
+#include <vector>
+#include <string>
+#include <thread>
+#include <cstdlib>
+#include <iostream>
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+
+//// MES: added this to the file /////////////
+using CurveAndGVCollection =
+    std::vector<std::pair<std::vector<int>, mpz_class>>;
+
+void addCurveAndGV(CurveAndGVCollection &collection,
+                   const std::vector<int> &curve,
+                   mpfr_srcptr gv);
+
+// Set to true to print progress messages to std::cerr from gvcompute().
+extern bool computeGVverboseMode;
+//// Above this: added to file ///////////////
+
+// This struct is needed to create sets of vectors
+struct VectorHash {
+  size_t operator()(const std::vector<int>& v) const {
+    size_t seed = v.size();
+    size_t x;
+    for(auto c : v) {
+      x = c;
+      x = ((x >> 16) ^ x) + 0xdf3b45d9f3b;
+      x = ((x << 16) ^ x) + 0xdf3b45d9f3b;
+      seed ^= x + 0x779b99e3779b9 + (seed << 12) + (seed >> 4);
+    }
+    return seed;
+  }
+};
+
+// Define new types for convenience.
+typedef mpfr::mpreal MPFloat;
+typedef std::vector<int> IntVector;
+typedef std::vector<std::vector<int> > IntMatrix;
+typedef std::vector<std::vector<int> > VectorList;
+typedef std::unordered_set<std::vector<int>,VectorHash> VectorSet;
+typedef std::unordered_map<int,std::vector<std::pair<int,MPFloat> > > IntToH22GVDict;
+typedef std::unordered_map<std::vector<int>,int,VectorHash> VecToIntDict;
+
+// Define a polynomial struct
+struct Polynomial {
+  std::unordered_map<int,MPFloat> coeffs;
+  std::vector<int> nonzero;
+};
+
+typedef std::unordered_map<int,Polynomial> IntToPolyDict;
+typedef std::unordered_map<std::vector<int>,Polynomial,VectorHash> VecToPolyDict;
+
+// Returns available RAM
+unsigned long long GetAvailableSystemMemory()
+{
+#ifdef __linux__
+  long pages = sysconf(_SC_AVPHYS_PAGES);
+  long page_size = sysconf(_SC_PAGE_SIZE);
+  return pages * page_size;
+#elif __APPLE__
+  // While I think of a better solution
+  return 1000000;
+#else
+  return 1000000;
+#endif
+}
+
+// Compute factorials with multiple precision
+MPFloat mpfactorial(int z) {
+  MPFloat res = z;
+  if (z < 0) {
+    throw std::invalid_argument("Input must be non-negative.");
+  }
+  else if (z == 0) {
+    res = 1;
+  }
+  for (int i = z-1; i > 1; i--){
+    res *= i;
+  }
+  return res;
+}
+
+// Compute digamma for integers with multiple precision
+MPFloat mpdigamma(int z, const MPFloat &neg_em) {
+  if (z <= 0) {
+    throw std::invalid_argument("Digamma is infinite or complex.");
+  }
+  MPFloat res = neg_em;
+  MPFloat tmpVar;
+  for (int i = 1; i < z; i++){
+    tmpVar = i;
+    res += 1/tmpVar;
+  }
+  return res;
+}
+
+// Compute trigamma for integers with multiple precision
+MPFloat mptrigamma(int z, const MPFloat &pi2d6) {
+  if (z <= 0) {
+    throw std::invalid_argument("Trigamma is infinite or complex.");
+  }
+  MPFloat res = pi2d6;
+  MPFloat tmpVar;
+  for (int i = 1; i < z; i++){
+    tmpVar = i;
+    res -= 1/(tmpVar*tmpVar);
+  }
+  return res;
+}
+
+// Parse a vector from std::cin
+std::vector<int> ReadVector(std::istream &ist) {
+  char c;
+  int i;
+  std::vector<int> vec;
+  ist >> std::ws >> c;
+  if (c == '(' || c == '[' || c == '{') {
+    while (ist >> std::ws >> c) {
+      if (c == ')' || c == ']' || c == '}') {
+        break;
+      }
+      else if (isspace(c)) {
+        continue;
+      }
+      else if (c == ',') {
+        continue;
+      }
+      else if(isdigit(c) || c == '-') {
+        ist.putback(c);
+        ist >> i;
+        vec.push_back(i);
+      }
+      else {
+        throw std::invalid_argument("Failed to parse input as integer.");
+      }
+    }
+  }
+  else {
+    throw std::invalid_argument("Missing vector opening bracket.");
+  }
+  ist.clear(std::ios::goodbit);
+  return vec;
+}
+
+// Parse a vector of vectors from std::cin
+std::vector<std::vector<int> > ReadVectors(std::istream &ist,
+                                           bool allow_diff_lengths=false) {
+  char c;
+  unsigned int vec_size = 0;
+  std::vector<std::vector<int> > vecs;
+  std::vector<int> tmp_vec;
+  ist >> std::ws >> c;
+  if (c == '(' || c == '[' || c == '{') {
+    while (ist >> std::ws >> c) {
+      if (c == ')' || c == ']' || c == '}') {
+        break;
+      }
+      else if (isspace(c)) {
+        continue;
+      }
+      else if (c == ',') {
+        continue;
+      }
+      else if (c == '(' || c == '[' || c == '{') {
+        ist.putback(c);
+        tmp_vec = ReadVector(ist);
+        if (!tmp_vec.size()){
+          throw std::invalid_argument("Read vector with zero size.");
+        }
+        if (!vec_size) {
+          vec_size = tmp_vec.size();
+        }
+        else if (!allow_diff_lengths && vec_size != tmp_vec.size()){
+          throw std::invalid_argument("All vectors must be the same size.");
+        }
+        vecs.push_back(tmp_vec);
+      }
+      else {
+        throw std::invalid_argument("Missing vector opening bracket.");
+      }
+    }
+  }
+  else{
+    throw std::invalid_argument("Missing matrix opening bracket.");
+  }
+  ist.clear(std::ios::goodbit);
+  return vecs;
+}
+
+// Completes a given list of curves by making sure that all possible sums are
+// in the list up to the specified maximum degree.
+void CheckCompletenessThr(VectorSet &vset, const IntMatrix &check_vecs,
+                          IntMatrix &new_vecs,
+                          const IntMatrix &hilbert_basis,
+                          IntVector &grading_vec, int max_deg,
+                          int &curr_task, int n_curves, std::mutex &m,
+                          std::mutex &task_mut, int min_mem) {
+  int h11 = check_vecs[0].size();
+  int tmp_deg;
+  std::vector<int> tmp_vec(h11);
+  while (true) {
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    task_mut.lock();
+    int i = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i >= n_curves) {
+      break;
+    }
+    for (unsigned int j = 0; j < hilbert_basis.size(); j++) {
+      tmp_deg = 0;
+      for (int k = 0; k < h11; k++) {
+        tmp_vec[k] = check_vecs[i][k] + hilbert_basis[j][k];
+        tmp_deg += tmp_vec[k] * grading_vec[k];
+      }
+      // Discard if the vector exceeds the maximum degree
+      if (tmp_deg > max_deg) {
+        continue;
+      }
+      // Search in the set and add if missing
+      m.lock();
+      auto search = vset.find(tmp_vec);
+      if (search != vset.end()){
+        m.unlock();
+        continue;
+      }
+      vset.insert(tmp_vec);
+      new_vecs.push_back(tmp_vec);
+      m.unlock();
+    }
+  }
+}
+
+// Removes curves that are not in the Hilbert basis. This is done by checking
+// that curves are not sums of up to 5 other curves.
+void RemoveNonGensThr(const VectorSet &vset, const IntMatrix &vecs,
+                      IntMatrix &vecs_to_remove, const IntVector &grading_vec,
+                      int max_deg, int &curr_task, int n_curves, std::mutex &m,
+                      std::mutex &task_mut) {
+  int h11 = vecs[0].size();
+  int tmp_deg;
+  std::vector<int> tmp_vec(h11);
+  while (true) {
+    task_mut.lock();
+    int i = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i >= n_curves) {
+      break;
+    }
+    for (int j = i; j < n_curves; j++) {
+      tmp_deg = 0;
+      for (int k = 0; k < h11; k++) {
+        tmp_vec[k] = vecs[i][k] + vecs[j][k];
+        tmp_deg += tmp_vec[k] * grading_vec[k];
+      }
+      // Discard if the vector exceeds the maximum degree
+      if (tmp_deg > max_deg) {
+        continue;
+      }
+      // Search in the set and erase if found
+      auto search2 = vset.find(tmp_vec);
+      if (search2 != vset.end()) {
+        m.lock();
+        vecs_to_remove.push_back(tmp_vec);
+        m.unlock();
+      }
+      for (unsigned int k = j; k < vecs.size(); k++) {
+        tmp_deg = 0;
+        for (int kk = 0; kk < h11; kk++) {
+          tmp_vec[kk] = vecs[i][kk] + vecs[j][kk] + vecs[k][kk];
+          tmp_deg += tmp_vec[kk] * grading_vec[kk];
+        }
+        // Discard if the vector exceeds the maximum degree
+        if (tmp_deg > max_deg) {
+          continue;
+        }
+        // Search in the set and erase if found
+        auto search3 = vset.find(tmp_vec);
+        if (search3 != vset.end()) {
+          m.lock();
+          vecs_to_remove.push_back(tmp_vec);
+          m.unlock();
+        }
+        for (unsigned int l = k; l < vecs.size(); l++) {
+          tmp_deg = 0;
+          for (int kk = 0; kk < h11; kk++) {
+            tmp_vec[kk] = (vecs[i][kk] + vecs[j][kk] + vecs[k][kk]
+                           + vecs[l][kk]);
+            tmp_deg += tmp_vec[kk] * grading_vec[kk];
+          }
+          // Discard if the vector exceeds the maximum degree
+          if (tmp_deg > max_deg) {
+            continue;
+          }
+          // Search in the set and erase if found
+          auto search4 = vset.find(tmp_vec);
+          if (search4 != vset.end()) {
+            m.lock();
+            vecs_to_remove.push_back(tmp_vec);
+            m.unlock();
+          }
+          for (unsigned int ll = l; ll < vecs.size(); ll++) {
+            tmp_deg = 0;
+            for (int kk = 0; kk < h11; kk++) {
+              tmp_vec[kk] = (vecs[i][kk] + vecs[j][kk] + vecs[k][kk]
+                              + vecs[l][kk] + vecs[ll][kk]);
+              tmp_deg += tmp_vec[kk] * grading_vec[kk];
+            }
+            // Discard if the vector exceeds the maximum degree
+            if (tmp_deg > max_deg) {
+              continue;
+            }
+            // Search in the set and erase if found
+            auto search5 = vset.find(tmp_vec);
+            if (search5 != vset.end()) {
+              m.lock();
+              vecs_to_remove.push_back(tmp_vec);
+              m.unlock();
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Fills out the relevant part of the past light cone
+void FillPastLightConeThr(VectorSet &vset, const IntMatrix &check_vecs,
+                          const VectorSet &pset, IntMatrix &new_vecs,
+                          const IntMatrix &hilbert_basis,
+                          IntVector &grading_vec, int max_deg, int &curr_task,
+                          int n_curves, std::mutex &m, std::mutex &task_mut,
+                          int min_mem) {
+  int h11 = check_vecs[0].size();
+  int tmp_deg;
+  std::vector<int> tmp_vec(h11);
+  while (true) {
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    task_mut.lock();
+    int i = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i >= n_curves) {
+      break;
+    }
+    for (unsigned int j = 0; j < hilbert_basis.size(); j++) {
+      tmp_deg = 0;
+      for (int k = 0; k < h11; k++) {
+        tmp_vec[k] = check_vecs[i][k] + hilbert_basis[j][k];
+        tmp_deg += tmp_vec[k] * grading_vec[k];
+      }
+      // Discard if the vector exceeds the maximum degree
+      if (tmp_deg > 2*max_deg) {
+        continue;
+      }
+      // Discard if the vector is not in the past light cone
+      auto search = pset.find(tmp_vec);
+      if (search == pset.end()) {
+        continue;
+      }
+      // Search in the set and add if missing
+      m.lock();
+      search = vset.find(tmp_vec);
+      if (search != vset.end()){
+        m.unlock();
+        continue;
+      }
+      vset.insert(tmp_vec);
+      new_vecs.push_back(tmp_vec);
+      m.unlock();
+    }
+  }
+}
+
+// Computes half of the past light cone. I.e. it takes the cone that was
+// computed and flips it and sets the apex to be the relevant curve.
+void HalfPastLightConeThr(VectorSet &vset, VectorSet &f_vset,
+                          std::vector<int> &vec, std::mutex &m) {
+  int h11 = vec.size();
+  std::vector<int> tmp_vec(h11);
+  for (auto &vec2 : vset) {
+    for (int i = 0; i < h11; i++) {
+      tmp_vec[i] = vec[i] - vec2[i];
+    }
+    auto search = f_vset.find(tmp_vec);
+    if (search != vset.end()){
+      continue;
+    }
+    m.lock();
+    f_vset.insert(tmp_vec);
+    m.unlock();
+  }
+}
+
+// Trims the remaining curves that are not in the past light cone
+void TrimPastLightConeThr(VectorSet &vset, VectorSet &f_vset,
+                          std::vector<int> &vec, std::mutex &m) {
+  int h11 = vec.size();
+  std::vector<int> tmp_vec(h11);
+  for (auto &vec2 : vset) {
+    for (int i = 0; i < h11; i++) {
+      tmp_vec[i] = vec[i] - vec2[i];
+    }
+    // Search in the original and final set and add if missing
+    auto search = vset.find(tmp_vec);
+    if (search == vset.end()){
+      continue;
+    }
+    search = f_vset.find(tmp_vec);
+    if (search != vset.end()){
+      continue;
+    }
+    m.lock();
+    f_vset.insert(tmp_vec);
+    m.unlock();
+  }
+}
+
+// Prints polynomials
+void PolyPrint(const Polynomial &p, char coord_name = 'z') {
+  for (unsigned int i = 0; i < p.nonzero.size(); i++) {
+    std::cerr << (i ? " + " : "");
+    std::cerr << p.coeffs.at(p.nonzero[i]) << "*" << coord_name << "^{n_" << p.nonzero[i] << "}";
+  }
+  std::cerr << std::endl;
+}
+void PolyPrint(const Polynomial &p, const IntMatrix &curves,
+               char coord_name = 'z') {
+  int h11 = curves[0].size();
+  for (unsigned int i = 0; i < p.nonzero.size(); i++) {
+    std::cerr << (i ? " + " : "");
+    std::cerr << p.coeffs.at(i);
+    for (int j = 0; j < h11; j++) {
+      if (!curves[i][j]) {
+        continue;
+      }
+      std::cerr << "*" << coord_name << "_" << i;
+      if (curves[i][j] != 1) {
+        std::cerr << "^" << curves[i][j];
+      }
+    }
+  }
+  std::cerr << std::endl;
+}
+
+// Computes the product of two polynomials
+Polynomial PolyProd(const Polynomial &p1, const Polynomial &p2,
+                    const IntMatrix &curves, const IntVector &degs,
+                    const VecToIntDict &curve_dict) {
+  Polynomial res;
+  int d1, d2, ind;
+  int h11 = curves[0].size();
+  int max_deg = degs[degs.size()-1];
+  IntVector tmp_vec_h11(h11);
+  VecToIntDict::const_iterator search;
+  std::unordered_map<int,MPFloat>::const_iterator search2;
+  const Polynomial *pshort;
+  const Polynomial *plong;
+  if (p1.nonzero.size() < p2.nonzero.size()) {
+    pshort = &p1;
+    plong = &p2;
+  }
+  else {
+    pshort = &p2;
+    plong = &p1;
+  }
+  for (auto &i : pshort->nonzero) {
+    d1 = degs[i];
+    for (auto &j : plong->nonzero) {
+      d2 = degs[j];
+      if (d1+d2 > max_deg) {
+        break;
+      }
+      for (int k = 0; k < h11; k++) {
+        tmp_vec_h11[k] = curves[i][k] + curves[j][k];
+      }
+      search = curve_dict.find(tmp_vec_h11);
+      if (search == curve_dict.end()) {
+        continue;
+      }
+      ind = search->second;
+      search2 = res.coeffs.find(ind);
+      if (search2 == res.coeffs.end()) {
+        res.coeffs[ind] = pshort->coeffs.at(i) * plong->coeffs.at(j);
+        res.nonzero.push_back(ind);
+      }
+      else {
+        res.coeffs[ind] += pshort->coeffs.at(i) * plong->coeffs.at(j);
+      }
+    }
+  }
+  std::sort(res.nonzero.begin(), res.nonzero.end());
+  return res;
+}
+
+// Finds the degree of the monomial with the smallest degree (with non-zero
+// coefficient)
+int PolyMinDeg(const Polynomial &p, const IntVector &degs) {
+  for (auto &i : p.nonzero) {
+    return degs[i];
+  }
+  return degs[degs.size()-1] + 1;
+}
+
+// Truncates a polytop to a certain degree
+Polynomial PolyTrunc(const Polynomial &p, int n, const IntVector &degs) {
+  Polynomial res;
+  for (auto &i : p.nonzero) {
+    if (degs[i] > n) {
+      break;
+    }
+    res.nonzero.push_back(i);
+    res.coeffs[i] = p.coeffs.at(i);
+  }
+  return res;
+}
+
+// Computes the product of a polynomial with a scalar in place
+void PolyProdScalarIP(Polynomial &p, int f) {
+  for (auto &c : p.coeffs) {
+    c.second *= f;
+  }
+}
+void PolyProdScalarIP(Polynomial &p, const MPFloat &f) {
+  for (auto &c : p.coeffs) {
+    c.second *= f;
+  }
+}
+
+// Computes the division of a polynomial by a scalar in place
+void PolyDivIP(Polynomial &p, int d) {
+  for (auto &c : p.coeffs) {
+      c.second /= d;
+  }
+}
+void PolyDivIP(Polynomial &p, const MPFloat &d) {
+  for (auto &c : p.coeffs) {
+      c.second /= d;
+  }
+}
+
+// Computes the sum of polynomials in place
+void PolySumIP(Polynomial &p1, const Polynomial &p2) {
+  bool resort = false;
+  std::unordered_map<int,MPFloat>::const_iterator search;
+  for (auto &c : p2.coeffs) {
+    search = p1.coeffs.find(c.first);
+    if (search == p1.coeffs.end()) {
+      p1.coeffs[c.first] = c.second;
+      p1.nonzero.push_back(c.first);
+      resort = true;
+    }
+    else {
+      p1.coeffs[c.first] += c.second;
+    }
+  }
+  if (resort) {
+    std::sort(p1.nonzero.begin(), p1.nonzero.end());
+  }
+}
+
+// Computes the difference of polynomials in place
+void PolySubIP(Polynomial &p1, const Polynomial &p2) {
+  bool resort = false;
+  std::unordered_map<int,MPFloat>::const_iterator search;
+  for (auto &c : p2.coeffs) {
+    search = p1.coeffs.find(c.first);
+    if (search == p1.coeffs.end()) {
+      p1.coeffs[c.first] = -c.second;
+      p1.nonzero.push_back(c.first);
+      resort = true;
+    }
+    else {
+      p1.coeffs[c.first] -= c.second;
+    }
+  }
+  if (resort) {
+    std::sort(p1.nonzero.begin(), p1.nonzero.end());
+  }
+}
+
+// Computes the sum of polynomials in place, with an additional factor
+void PolySumFactIP(Polynomial &p1, const Polynomial &p2, int f) {
+  bool resort = false;
+  std::unordered_map<int,MPFloat>::const_iterator search;
+  for (auto &c : p2.coeffs) {
+    search = p1.coeffs.find(c.first);
+    if (search == p1.coeffs.end()) {
+      p1.coeffs[c.first] = c.second * f;
+      p1.nonzero.push_back(c.first);
+      resort = true;
+    }
+    else {
+      p1.coeffs[c.first] += c.second * f;
+    }
+  }
+  if (resort) {
+    std::sort(p1.nonzero.begin(), p1.nonzero.end());
+  }
+}
+
+// Computes the sum of polynomials in place, with an additional division
+void PolySumDivIP(Polynomial &p1, const Polynomial &p2, int d) {
+  bool resort = false;
+  std::unordered_map<int,MPFloat>::const_iterator search;
+  for (auto &c : p2.coeffs) {
+    search = p1.coeffs.find(c.first);
+    if (search == p1.coeffs.end()) {
+      p1.coeffs[c.first] = c.second / d;
+      p1.nonzero.push_back(c.first);
+      resort = true;
+    }
+    else {
+      p1.coeffs[c.first] += c.second / d;
+    }
+  }
+  if (resort) {
+    std::sort(p1.nonzero.begin(), p1.nonzero.end());
+  }
+}
+void PolySumDivIP(Polynomial &p1, const Polynomial &p2, const MPFloat &d) {
+  bool resort = false;
+  std::unordered_map<int,MPFloat>::const_iterator search;
+  for (auto &c : p2.coeffs) {
+    search = p1.coeffs.find(c.first);
+    if (search == p1.coeffs.end()) {
+      p1.coeffs[c.first] = c.second / d;
+      p1.nonzero.push_back(c.first);
+      resort = true;
+    }
+    else {
+      p1.coeffs[c.first] += c.second / d;
+    }
+  }
+  if (resort) {
+    std::sort(p1.nonzero.begin(), p1.nonzero.end());
+  }
+}
+
+// Computes the inverse of a polynomial
+Polynomial PolyInv(const Polynomial &p, const IntMatrix &curves,
+                   const IntVector &degs, const VecToIntDict &curve_dict) {
+  Polynomial res;
+  res.nonzero.push_back(0);
+  res.coeffs[0] = 1;
+  if (p.nonzero[0] != 0 || !p.coeffs.at(0)) {
+    throw std::invalid_argument("Polynomial is not invertible.");
+  }
+  int max_deg = degs[degs.size()-1];
+  Polynomial p0 = p;
+  p0.nonzero.erase(p0.nonzero.begin());
+  p0.coeffs.erase(0);
+  PolyDivIP(p0, p.coeffs.at(0));
+  Polynomial tmp_poly = res;
+  int min_deg = PolyMinDeg(p0, degs);
+  for (int i = 1; i < 1+max_deg/min_deg; i++) {
+    tmp_poly = PolyProd(tmp_poly, p0, curves, degs, curve_dict);
+    if (i&1) {
+      PolySumFactIP(res, tmp_poly, -1);
+    }
+    else {
+      PolySumIP(res, tmp_poly);
+    }
+  }
+  PolyDivIP(res, p.coeffs.at(0));
+  return res;
+}
+
+// Computes the nonnegative power of a polynomial
+Polynomial PolyPow(const Polynomial &p, unsigned int n,
+                   const IntMatrix &curves, const IntVector &degs,
+                   const VecToIntDict &curve_dict) {
+  Polynomial res;
+  res.nonzero.push_back(0);
+  res.coeffs[0] = 1;
+  if (n == 0) {
+    return res;
+  }
+  else if (n == 1) {
+    res = p;
+    return res;
+  }
+  int max_deg = degs[degs.size()-1];
+  Polynomial tmp_poly = PolyTrunc(p, max_deg-(n-1)*PolyMinDeg(p, degs), degs);
+  while (true) {
+    if (n & 1) {
+      res = PolyProd(res, tmp_poly, curves, degs, curve_dict);
+    }
+    n >>= 1;
+    if (!n) {
+      break;
+    }
+    tmp_poly = PolyProd(tmp_poly, tmp_poly, curves, degs, curve_dict);
+  }
+  return res;
+}
+
+// Computes the exponential of a polynomial (and its negative)
+void PolyExp(Polynomial &res_pos, Polynomial &res_neg, const Polynomial &p,
+             const IntMatrix &curves, const IntVector &degs,
+             const VecToIntDict &curve_dict) {
+  bool has_const = (p.nonzero.size() > 0 && p.nonzero[0] == 0);
+  res_pos = Polynomial();
+  res_pos.nonzero.push_back(0);
+  res_pos.coeffs[0] = 1;
+  res_neg = res_pos;
+  Polynomial p0 = p;
+  if (has_const) {
+    p0.nonzero.erase(p0.nonzero.begin());
+    p0.coeffs.erase(0);
+  }
+  Polynomial tmp_poly = res_pos;
+  int min_deg = PolyMinDeg(p0, degs);
+  int max_deg = degs[degs.size()-1];
+  MPFloat tmp_var;
+  for (int i = 1; i < 1+max_deg/min_deg; i++) {
+    tmp_poly = PolyProd(tmp_poly, p0, curves, degs, curve_dict);
+    tmp_var = mpfactorial(i);
+    PolySumDivIP(res_pos, tmp_poly, tmp_var);
+    if (i&1) {
+      tmp_var *= -1;
+    }
+    PolySumDivIP(res_neg, tmp_poly, tmp_var);
+  }
+  if (has_const) {
+    tmp_var = exp(p.coeffs.at(0));
+    PolyProdScalarIP(res_pos, tmp_var);
+    PolyProdScalarIP(res_neg, tmp_var);
+  }
+}
+
+// Computes the dilogarithm of a polynomial
+Polynomial PolyLi2(const Polynomial &p, const IntMatrix &curves,
+                   const IntVector &degs, const VecToIntDict &curve_dict) {
+  if ((p.nonzero.size() > 0 && p.nonzero[0] == 0)
+        || p.coeffs.find(0) != p.coeffs.end()) {
+      PolyPrint(p);
+      throw std::invalid_argument("This type of polynomials are not "
+                                  "supported.");
+  }
+  Polynomial res = p;
+  Polynomial tmp_poly = p;
+  int min_deg = PolyMinDeg(p, degs);
+  int max_deg = degs[degs.size()-1];
+  for (int i = 2; i < 1+max_deg/min_deg; i++) {
+    tmp_poly = PolyProd(tmp_poly, p, curves, degs, curve_dict);
+    PolySumDivIP(res, tmp_poly, i*i);
+  }
+  return res;
+}
+
+// Removes coefficients with a very small magnitude
+void PolyCleanUp(Polynomial &p, MPFloat &cutoff, bool force_resort=false) {
+  std::vector<int> new_nonzero;
+  for (auto &i : p.nonzero) {
+    if (abs(p.coeffs[i]) < cutoff) {
+      p.coeffs.erase(i);
+    }
+    else {
+      new_nonzero.push_back(i);
+    }
+  }
+  if (force_resort) {
+    std::sort(new_nonzero.begin(), new_nonzero.end());
+  }
+  p.nonzero = new_nonzero;
+}
+
+// Computes c for curves with zero negative entries in the dot product with Q
+void computeC_0neg(Polynomial &c0, std::vector<Polynomial> &c1,
+                   VecToPolyDict &c2, const std::vector<int> &neg0,
+                   const IntMatrix &Q, const IntMatrix &Q0s,
+                   const IntMatrix &curves_dot_Q,
+                   const IntMatrix &curves_dot_Q0s, int prec,
+                   std::mutex &c0mutex, std::mutex &c1mutex,
+                   std::mutex &c2mutex, int h11, int h11pd, int min_mem,
+                   int &curr_task, std::mutex &task_mut, VectorSet &beta_pairs,
+                   const MPFloat &neg_em, const MPFloat &pi2d6) {
+  mpfr::mpreal::set_default_prec(prec);
+  std::vector<MPFloat> A(h11);
+  MPFloat tmp_num, c0fact, tmp_final;
+  int i, i_ind, a, b;
+  while (true) {
+    task_mut.lock();
+    i_ind = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i_ind >= neg0.size()) {
+      break;
+    }
+    i = neg0[i_ind];
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    c0fact = mpfactorial(curves_dot_Q0s[0][i]);
+    for (int j = 1; j < Q0s.size(); j++){
+      c0fact *= mpfactorial(curves_dot_Q0s[j][i]);
+    }
+    for (int j = 0; j < h11pd; j++) {
+      c0fact /= mpfactorial(curves_dot_Q[i][j]);
+    }
+    c0mutex.lock();
+    c0.coeffs[i] = c0fact;
+    c0.nonzero.push_back(i);
+    c0mutex.unlock();
+    for (int a = 0; a < h11; a++) {
+      A[a] = Q0s[0][a]*mpdigamma(curves_dot_Q0s[0][i]+1, neg_em);
+      for (int j = 1; j < Q0s.size(); j++){
+        A[a] += Q0s[j][a]*mpdigamma(curves_dot_Q0s[j][i]+1, neg_em);
+      }
+      for (int j = 0; j < h11pd; j++) {
+        A[a] -= Q[a][j]*mpdigamma(curves_dot_Q[i][j]+1, neg_em);
+      }
+      tmp_final = c0fact*A[a];
+      c1mutex.lock();
+      c1[a].coeffs[i] = tmp_final;
+      c1[a].nonzero.push_back(i);
+      c1mutex.unlock();
+    }
+    for (auto &pp : beta_pairs) {
+      a = pp[0];
+      b = pp[1];
+      tmp_num = Q0s[0][a]*Q0s[0][b]*mptrigamma(curves_dot_Q0s[0][i]+1, pi2d6);
+      for (int j = 1; j < Q0s.size(); j++){
+        tmp_num += (Q0s[j][a]*Q0s[j][b]
+                    *mptrigamma(curves_dot_Q0s[j][i]+1, pi2d6));
+      }
+      for (int j = 0; j < h11pd; j++) {
+        tmp_num -= Q[a][j]*Q[b][j]*mptrigamma(curves_dot_Q[i][j]+1, pi2d6);
+      }
+      tmp_num += A[a]*A[b];
+      tmp_final = c0fact*tmp_num;
+      c2mutex.lock();
+      c2[{a,b}].coeffs[i] = tmp_final;
+      c2[{a,b}].nonzero.push_back(i);
+      c2mutex.unlock();
+    }
+  }
+  mpfr_free_cache();
+}
+
+// Computes c for curves with one negative entry in the dot product with Q
+void computeC_1neg(std::vector<Polynomial> &c1, VecToPolyDict &c2,
+                   const std::vector<std::tuple<int,int> > &neg1,
+                   const IntMatrix &Q, const IntMatrix &Q0s,
+                   const IntMatrix &curves_dot_Q,
+                   const IntMatrix &curves_dot_Q0s, int prec,
+                   std::mutex &c1mutex, std::mutex &c2mutex, int h11,
+                   int h11pd, int min_mem, int &curr_task,
+                   std::mutex &task_mut, VectorSet &beta_pairs,
+                   const MPFloat &neg_em) {
+  mpfr::mpreal::set_default_prec(prec);
+  std::vector<MPFloat> A(h11);
+  MPFloat tmp_fact, tmp_final;
+  int i, k, m, sn;
+  int i_ind, a, b;
+  while (true) {
+    task_mut.lock();
+    i_ind = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i_ind >= neg1.size()) {
+      break;
+    }
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    i = std::get<0>(neg1[i_ind]);
+    k = std::get<1>(neg1[i_ind]);
+    m = curves_dot_Q[i][k];
+    sn = (m&1 ? 1 : -1);
+    tmp_fact = mpfactorial(curves_dot_Q0s[0][i]);
+    for (int j = 1; j < Q0s.size(); j++){
+      tmp_fact *= mpfactorial(curves_dot_Q0s[j][i]);
+    }
+    tmp_fact *= mpfactorial(-m-1);
+    for (int j = 0; j < h11pd; j++) {
+      if (j == k) {
+        continue;
+      }
+      tmp_fact /= mpfactorial(curves_dot_Q[i][j]);
+    }
+    for (int a = 0; a < h11; a++) {
+      A[a] = Q0s[0][a]*mpdigamma(curves_dot_Q0s[0][i]+1, neg_em);
+      for (int j = 1; j < Q0s.size(); j++){
+        A[a] += Q0s[j][a]*mpdigamma(curves_dot_Q0s[j][i]+1, neg_em);
+      }
+      for (int j = 0; j < h11pd; j++) {
+        A[a] -= Q[a][j]*mpdigamma((j==k ? -m : curves_dot_Q[i][j]+1), neg_em);
+      }
+      tmp_final = (sn*Q[a][k])*tmp_fact;
+      c1mutex.lock();
+      c1[a].coeffs[i] = tmp_final;
+      c1[a].nonzero.push_back(i);
+      c1mutex.unlock();
+    }
+    for (auto &pp : beta_pairs) {
+      a = pp[0];
+      b = pp[1];
+      tmp_final = (sn*(Q[a][k]*A[b]+Q[b][k]*A[a]))*tmp_fact;
+      c2mutex.lock();
+      c2[{a,b}].coeffs[i] = tmp_final;
+      c2[{a,b}].nonzero.push_back(i);
+      c2mutex.unlock();
+      }
+  }
+  mpfr_free_cache();
+}
+
+// Computes c for curves with two negative entries in the dot product with Q
+void computeC_2neg(VecToPolyDict &c2,
+                   const std::vector<std::tuple<int,int,int> > &neg2,
+                   const IntMatrix &Q, const IntMatrix &Q0s,
+                   const IntMatrix &curves_dot_Q,
+                   const IntMatrix &curves_dot_Q0s, int prec,
+                   std::mutex &c2mutex, int h11, int h11pd, int min_mem,
+                   int &curr_task, std::mutex &task_mut,
+                   VectorSet &beta_pairs) {
+  mpfr::mpreal::set_default_prec(prec);
+  std::vector<MPFloat> A(h11);
+  MPFloat c0fact, tmp_num;
+  int i, k0, k1, m0, m1;
+  int i_ind, a, b;
+  while (true) {
+    task_mut.lock();
+    i_ind = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i_ind >= neg2.size()) {
+      break;
+    }
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    i = std::get<0>(neg2[i_ind]);
+    k0 = std::get<1>(neg2[i_ind]);
+    k1 = std::get<2>(neg2[i_ind]);
+    m0 = curves_dot_Q[i][k0];
+    m1 = curves_dot_Q[i][k1];
+    c0fact = ((m0+m1)&1 ? -1 : 1);
+    c0fact *= mpfactorial(curves_dot_Q0s[0][i]);
+    for (int j = 1; j < Q0s.size(); j++){
+      c0fact *= mpfactorial(curves_dot_Q0s[j][i]);
+    }
+    c0fact *= mpfactorial(-m0-1);
+    c0fact *= mpfactorial(-m1-1);
+    for (int j = 0; j < h11pd; j++) {
+      if (j == k0 || j== k1) {
+        continue;
+      }
+      c0fact /= mpfactorial(curves_dot_Q[i][j]);
+    }
+    for (auto &pp : beta_pairs) {
+      a = pp[0];
+      b = pp[1];
+      tmp_num = c0fact*(Q[a][k0]*Q[b][k1]+Q[a][k1]*Q[b][k0]);
+      c2mutex.lock();
+      c2[{a,b}].coeffs[i] = tmp_num;
+      c2[{a,b}].nonzero.push_back(i);
+      c2mutex.unlock();
+    }
+  }
+  mpfr_free_cache();
+}
+
+// Computes the inverse of c0
+void ComputeInvC0Thr(Polynomial &c0inv, const Polynomial &c0,
+                     const IntMatrix &curves, const IntVector &degs,
+                     const VecToIntDict &curve_dict, int prec) {
+  mpfr::mpreal::set_default_prec(prec);
+  c0inv = PolyInv(c0, curves, degs, curve_dict);
+  mpfr_free_cache();
+}
+
+// Computes the beta polynomials
+void ComputeAlphaThr(std::vector<Polynomial> &alpha,
+                     const Polynomial &c0inv,
+                     const std::vector<Polynomial> &c1,
+                     const IntMatrix &curves, const IntVector &degs,
+                     const VecToIntDict &curve_dict, int prec, int &curr_task,
+                     std::mutex &task_mut, std::mutex &m, int min_mem) {
+  mpfr::mpreal::set_default_prec(prec);
+  Polynomial tmp_poly;
+  int i;
+  while (true) {
+    task_mut.lock();
+    i = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i >= c1.size()) {
+      break;
+    }
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    tmp_poly = PolyProd(c0inv, c1.at(i), curves, degs, curve_dict);
+    m.lock();
+    alpha[i] = std::move(tmp_poly);
+    m.unlock();
+  }
+  mpfr_free_cache();
+}
+
+// Computes the alpha or beta polynomials
+void ComputeBetaThr(VecToPolyDict &beta,
+                     const Polynomial &c0inv,
+                     const VecToPolyDict &c2,
+                     const IntMatrix &curves, const IntVector &degs,
+                     const VecToIntDict &curve_dict, int prec, int &curr_task,
+                     const VectorList &beta_pairs_vec,
+                     std::mutex &task_mut, std::mutex &m, int min_mem) {
+  mpfr::mpreal::set_default_prec(prec);
+  Polynomial tmp_poly;
+  int p_ind;
+  std::vector<int> pp;
+  while (true) {
+    task_mut.lock();
+    p_ind = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (p_ind >= beta_pairs_vec.size()) {
+      break;
+    }
+    pp = beta_pairs_vec[p_ind];
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    tmp_poly = PolyProd(c0inv, c2.at(pp), curves, degs, curve_dict);
+    if (tmp_poly.nonzero.size() > 0 && tmp_poly.nonzero[0] == 0) {
+      tmp_poly.nonzero.erase(tmp_poly.nonzero.begin());
+      tmp_poly.coeffs.erase(0);
+    }
+    m.lock();
+    beta[pp] = std::move(tmp_poly);
+    m.unlock();
+  }
+  mpfr_free_cache();
+}
+
+// Computes F polynomials
+void ComputeFThr(VecToPolyDict &F,
+                 const std::vector<Polynomial> &alpha,
+                 const VecToPolyDict &beta,
+                 const IntMatrix &curves, const IntVector &degs,
+                 const VecToIntDict &curve_dict, int prec, int &curr_task,
+                 const VectorList &beta_pairs_vec,
+                 std::mutex &task_mut, std::mutex &m, int min_mem) {
+  mpfr::mpreal::set_default_prec(prec);
+  int h11 = alpha.size();
+  Polynomial tmp_poly;
+  MPFloat tmp_num;
+  int a, b, p_ind;
+  while (true) {
+    task_mut.lock();
+    p_ind = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (p_ind >= beta_pairs_vec.size()) {
+      break;
+    }
+    a = beta_pairs_vec[p_ind][0];
+    b = beta_pairs_vec[p_ind][1];
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    tmp_poly = PolyProd(alpha.at(a), alpha.at(b), curves, degs, curve_dict);
+    PolySubIP(tmp_poly, beta.at({a,b}));
+    PolyProdScalarIP(tmp_poly, -1);
+
+    m.lock();
+    F[{a,b}] = tmp_poly;
+    m.unlock();
+  }
+  mpfr_free_cache();
+}
+
+// Computes instanton corrections
+void ComputeInstThr(std::vector<Polynomial> &inst,
+                    const VecToPolyDict &F,
+                    const VecToIntDict &intnums,
+                    const IntMatrix &curves, const IntVector &degs,
+                    const VecToIntDict &curve_dict, int prec, int &curr_task,
+                    std::mutex &task_mut, std::mutex &m, int h22, int cy_dim,
+                    int min_mem) {
+  mpfr::mpreal::set_default_prec(prec);
+  std::vector<int> tmp_vec(3);
+  int intnum, i;
+  Polynomial tmp_poly;
+  MPFloat tmp_num;
+  VecToIntDict::const_iterator search;
+  int h11 = curves[0].size();
+  while (true) {
+    task_mut.lock();
+    i = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i >= h22) {
+      break;
+    }
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    for (int a = 0; a < h11; a++){
+      for (int b = a; b < h11; b++){
+        tmp_vec = {i,a,b};
+        if (cy_dim > 3) {
+          if (a>b) {
+            tmp_vec = {i,b,a};
+          }
+        }
+        else {
+          std::sort(tmp_vec.begin(), tmp_vec.end());
+        }
+        search = intnums.find(tmp_vec);
+        if (search == intnums.end()) {
+          continue;
+        }
+        intnum = search->second;
+        tmp_poly = F.at({a,b});
+        if (a!=b) {
+          PolyProdScalarIP(tmp_poly, intnum);
+        }
+        else {
+          tmp_num = intnum;
+          tmp_num /= 2;
+          PolyProdScalarIP(tmp_poly, tmp_num);
+        }
+        m.lock();
+        PolySumIP(inst[i], tmp_poly);
+        m.unlock();
+      }
+    }
+  }
+  mpfr_free_cache();
+}
+
+// Computes the exponentials of alpha polynomials
+void ComputeExpAlphaThr(std::vector<Polynomial> &expalpha_pos,
+                        std::vector<Polynomial> &expalpha_neg,
+                        const std::vector<Polynomial> &alpha,
+                        const IntMatrix &curves, const IntVector &degs,
+                        const VecToIntDict &curve_dict, int prec,
+                        int &curr_task, std::mutex &task_mut, std::mutex &m,
+                        int min_mem) {
+  mpfr::mpreal::set_default_prec(prec);
+  Polynomial tmp_poly_pos, tmp_poly_neg;
+  MPFloat tmp_num;
+  int h11 = alpha.size();
+  int i;
+  while (true) {
+    task_mut.lock();
+    i = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i >= h11) {
+      break;
+    }
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    tmp_poly_pos.nonzero.clear();
+    tmp_poly_pos.coeffs.clear();
+    tmp_poly_neg.nonzero.clear();
+    tmp_poly_neg.coeffs.clear();
+    PolyExp(tmp_poly_pos, tmp_poly_neg, alpha.at(i), curves, degs, curve_dict);
+    m.lock();
+    expalpha_pos[i] = std::move(tmp_poly_pos);
+    expalpha_neg[i] = std::move(tmp_poly_neg);
+    m.unlock();
+  }
+  mpfr_free_cache();
+}
+
+// Computes qN for generator curves
+Polynomial ComputeqN(const Polynomial &closest_curve,
+                     const IntVector &closest_curve_diff,
+                     const std::vector<Polynomial> &expalpha_pos,
+                     const std::vector<Polynomial> &expalpha_neg,
+                     const IntMatrix &curves, const IntVector &degs,
+                     const VecToIntDict &curve_dict) {
+  int h11 = curves[0].size();
+  Polynomial res = closest_curve;
+  Polynomial tmp_poly;
+  for (int i = 0; i < h11; i++) {
+    if (!closest_curve_diff[i]) {
+      continue;
+    }
+    else if (closest_curve_diff[i] > 0) {
+      tmp_poly = PolyPow(expalpha_pos.at(i), closest_curve_diff[i], curves, degs, curve_dict);
+    }
+    else {
+      tmp_poly = PolyPow(expalpha_neg.at(i), -closest_curve_diff[i], curves, degs, curve_dict);
+    }
+    res = PolyProd(res, tmp_poly, curves, degs, curve_dict);
+  }
+  return res;
+}
+
+// Computes qN and Li2(qN)
+void ComputeLi2qNThr(const std::vector<int> &qN_to_compute,
+                     IntToPolyDict &computed_qN, IntToPolyDict &computed_Li2qN,
+                     const std::vector<IntToPolyDict> &previous_qN,
+                     const std::vector<IntVector> &previous_qN_ind,
+                     const std::vector<Polynomial> &expalpha_pos,
+                     const std::vector<Polynomial> &expalpha_neg,
+                     const IntMatrix &curves, const IntVector &degs,
+                     const VecToIntDict &curve_dict, int prec, int &curr_task,
+                     std::mutex &task_mut, std::mutex &m, bool computeGW,
+                     int min_mem) {
+  mpfr::mpreal::set_default_prec(prec);
+  int h11 = curves[0].size();
+  Polynomial closest_curve, tmp_qN, tmp_Li2qN, tmp_poly;
+  IntVector closest_curve_diff(h11), tmp_curve_diff(h11);
+  double closest_dist, tmp_dist;
+  VecToIntDict::const_iterator search;
+  int i, i_ind;
+  while (true) {
+    task_mut.lock();
+    i_ind = curr_task;
+    curr_task++;
+    task_mut.unlock();
+    if (i_ind >= qN_to_compute.size()) {
+      break;
+    }
+    if (GetAvailableSystemMemory() < min_mem) {
+      throw std::runtime_error("Memory is running low. "
+                               "Exitting to prevent crash...");
+    }
+    i = qN_to_compute[i_ind];
+    closest_curve = Polynomial();
+    closest_curve.nonzero.push_back(i);
+    closest_curve.coeffs[i] = 1;
+    closest_curve_diff = curves[i];
+    closest_dist = 0;
+    for (int j = 0; j < h11; j++) {
+      if (closest_curve_diff[j]) {
+        closest_dist += std::log2(std::abs(closest_curve_diff[j]))+1;
+      }
+    }
+    // Now we check to see if there is a better starting curve
+    for (int j = 0; j < previous_qN_ind.size(); j++) {
+      for (auto k : previous_qN_ind[j]) {
+        tmp_dist = 0;
+        for (int h = 0; h < h11; h++) {
+          tmp_curve_diff[h] =  curves[i][h] - curves[k][h];
+          if (tmp_curve_diff[h]) {
+            tmp_dist += std::log2(std::abs(tmp_curve_diff[h]))+1;
+          }
+        }
+        if (tmp_dist < closest_dist) {
+          search = curve_dict.find(tmp_curve_diff);
+          if (search == curve_dict.end()) {
+            continue;
+          }
+          tmp_poly = Polynomial();
+          tmp_poly.nonzero.push_back(search->second);
+          tmp_poly.coeffs[search->second] = 1;
+          closest_curve = PolyProd(previous_qN[j].at(k), tmp_poly, curves, degs, curve_dict);
+          closest_dist = tmp_dist;
+          closest_curve_diff = tmp_curve_diff;
+        }
+      }
+    }
+    // Now we compute qN and Li2(qN)
+    tmp_qN = ComputeqN(closest_curve, closest_curve_diff, expalpha_pos,
+                       expalpha_neg, curves, degs, curve_dict);
+    tmp_Li2qN = (computeGW ? tmp_qN : PolyLi2(tmp_qN, curves, degs, curve_dict));
+    m.lock();
+    computed_qN[i] = std::move(tmp_qN);
+    computed_Li2qN[i] = std::move(tmp_Li2qN);
+    m.unlock();
+  }
+  mpfr_free_cache();
+}

--- a/M2/Macaulay2/e/cytools/cone-interior-point.cpp
+++ b/M2/Macaulay2/e/cytools/cone-interior-point.cpp
@@ -1,0 +1,99 @@
+
+#include "cone-interior-point.hpp"
+#include <glpk.h>
+#include <iostream>
+#include <cmath>
+
+// A is m x n, row-major.  Tests whether {x : Ax >= 0} is full-dimensional.
+ConeResult coneInteriorPoint(int m, int n, const std::vector<int>& A) {
+    glp_prob* lp = glp_create_prob();
+    glp_set_obj_dir(lp, GLP_MAX);
+
+    // Rows: A_i x - t >= 0
+    glp_add_rows(lp, m);
+    for (int i = 1; i <= m; ++i)
+        glp_set_row_bnds(lp, i, GLP_LO, 0.0, 0.0);
+
+    // Cols: x_1..x_n bounded in [-1, 1], then t >= 0
+    glp_add_cols(lp, n + 1);
+    for (int j = 1; j <= n; ++j) {
+        glp_set_col_bnds(lp, j, GLP_DB, -1.0, 1.0);
+        glp_set_obj_coef(lp, j, 0.0);
+    }
+    glp_set_col_bnds(lp, n + 1, GLP_LO, 0.0, 0.0);
+    glp_set_obj_coef(lp, n + 1, 1.0);  // maximize t
+
+    // Build sparse matrix in GLPK's 1-indexed triplet form
+    std::vector<int> ia(1, 0), ja(1, 0);
+    std::vector<double> ar(1, 0.0);
+    for (int i = 0; i < m; ++i) {
+        for (int j = 0; j < n; ++j) {
+            int aij = A[i * n + j];
+            if (aij != 0) {
+                ia.push_back(i + 1);
+                ja.push_back(j + 1);
+                ar.push_back(static_cast<double>(aij));
+            }
+        }
+        // -1 coefficient on t
+        ia.push_back(i + 1);
+        ja.push_back(n + 1);
+        ar.push_back(-1.0);
+    }
+    glp_load_matrix(lp, static_cast<int>(ia.size()) - 1,
+                    ia.data(), ja.data(), ar.data());
+
+    glp_smcp params;
+    glp_init_smcp(&params);
+    params.msg_lev = GLP_MSG_OFF;
+    glp_simplex(lp, &params);
+
+    ConeResult res;
+    res.tStar = glp_get_col_prim(lp, n + 1);
+
+    const double tol = 1e-8;
+    if (res.tStar > tol) {
+        res.fullDimensional = true;
+        res.interiorPoint.resize(n);
+        for (int j = 0; j < n; ++j)
+            res.interiorPoint[j] = glp_get_col_prim(lp, j + 1);
+    } else {
+        res.fullDimensional = false;
+        res.dualCert.resize(m);
+        for (int i = 0; i < m; ++i)
+            // GLPK row duals for >= constraints in a max problem may come
+            // out negative depending on convention; take |.| so y >= 0.
+            res.dualCert[i] = std::abs(glp_get_row_dual(lp, i + 1));
+    }
+    glp_delete_prob(lp);
+    return res;
+}
+
+// int main() {
+//     // Example 1: full-dimensional in R^2
+//     // A = [[1,0],[0,1],[1,1]]
+//     {
+//         std::vector<int> A = {1,0,  0,1,  1,1};
+//         auto r = coneInteriorPoint(3, 2, A);
+//         std::cout << "Example 1: t* = " << r.tStar << "\n";
+//         if (r.fullDimensional) {
+//             std::cout << "  interior: ";
+//             for (double v : r.interiorPoint) std::cout << v << " ";
+//             std::cout << "\n";
+//         }
+//     }
+//     // Example 2: NOT full-dimensional (forces x1 = 0)
+//     // A = [[1,0],[-1,0],[0,1]]
+//     {
+//         std::vector<int> A = {1,0,  -1,0,  0,1};
+//         auto r = coneInteriorPoint(3, 2, A);
+//         std::cout << "Example 2: t* = " << r.tStar << "\n";
+//         if (!r.fullDimensional) {
+//             std::cout << "  dual cert y: ";
+//             for (double v : r.dualCert) std::cout << v << " ";
+//             std::cout << "\n  (expect y_1 = y_2 > 0, y_3 = 0; check y^T A = 0)\n";
+//         }
+//     }
+// }
+// g++ -O2 -o cone cone-interior-point.cpp -lglpk -I`brew --prefix glpk`/include
+// -L`brew --prefix glpk`/lib suggested by claude.

--- a/M2/Macaulay2/e/cytools/cone-interior-point.hpp
+++ b/M2/Macaulay2/e/cytools/cone-interior-point.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <vector>
+
+struct ConeResult {
+    bool fullDimensional;
+    double tStar;
+    std::vector<double> interiorPoint;  // valid if fullDimensional
+    std::vector<double> dualCert;       // valid if !fullDimensional: y >= 0, y^T A = 0
+};
+
+ConeResult coneInteriorPoint(int m, int n, const std::vector<int>& A);

--- a/M2/Macaulay2/e/cytools/lattice-points-normaliz.cpp
+++ b/M2/Macaulay2/e/cytools/lattice-points-normaliz.cpp
@@ -1,0 +1,83 @@
+#include "cytools/lattice-points-normaliz.hpp"
+
+#include <libnormaliz/cone.h>
+#include <libnormaliz/cone_property.h>
+#include <libnormaliz/matrix.h>
+#include <libnormaliz/normaliz_exception.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace M2::cytools {
+
+LatticePointsNormalizResult latticePointsNormaliz(
+    int dim,
+    const std::vector<std::vector<mpz_class>>& A,
+    const std::vector<mpz_class>& b)
+{
+  const size_t m = A.size();
+  if (m != b.size())
+    throw std::runtime_error(
+        "latticePointsNormaliz: A.size() must equal b.size()");
+  for (const auto& row : A)
+    if (static_cast<int>(row.size()) != dim)
+      throw std::runtime_error(
+          "latticePointsNormaliz: every row of A must have length dim");
+
+  // Normaliz Type::inhom_inequalities row [a | c] represents a.x + c >= 0.
+  // For Ax <= b that is -A.x + b >= 0, so each row is [-A_i | b_i].
+  libnormaliz::Matrix<mpz_class> ineqs(m, dim + 1);
+  for (size_t i = 0; i < m; ++i)
+    {
+      for (int j = 0; j < dim; ++j) ineqs[i][j] = -A[i][j];
+      ineqs[i][dim] = b[i];
+    }
+
+  try
+    {
+      libnormaliz::Cone<mpz_class> cone(
+          libnormaliz::Type::inhom_inequalities, ineqs);
+      cone.setVerbose(false);
+      cone.compute(libnormaliz::ConeProperty::LatticePoints);
+
+      // Reject unbounded polyhedra explicitly: libnormaliz doesn't throw
+      // for inhom_inequalities with a nontrivial recession cone --- it
+      // silently returns just the polytope's vertex lattice points,
+      // which is misleading.
+      if (cone.getRecessionRank() > 0)
+        throw std::runtime_error(
+            "latticePointsNormaliz: polyhedron is unbounded "
+            "(recession rank > 0)");
+
+      const auto& lps = cone.getLatticePoints();
+      LatticePointsNormalizResult result;
+      result.points.reserve(lps.size());
+      for (const auto& row : lps)
+        {
+          // For inhom_inequalities, libnormaliz returns the n affine
+          // coordinates of each polytope lattice point. Be defensive in
+          // case a homogenizing 1 is appended: take the first `dim`.
+          if (static_cast<int>(row.size()) < dim)
+            throw std::runtime_error(
+                "latticePointsNormaliz: unexpected row width from libnormaliz");
+          result.points.emplace_back(row.begin(), row.begin() + dim);
+        }
+      return result;
+  } catch (const libnormaliz::NotComputableException& e)
+    {
+      throw std::runtime_error(
+          std::string("latticePointsNormaliz: not computable, likely an "
+                      "unbounded polyhedron (")
+          + e.what() + ")");
+  } catch (const libnormaliz::BadInputException& e)
+    {
+      throw std::runtime_error(
+          std::string("latticePointsNormaliz: bad input: ") + e.what());
+  } catch (const libnormaliz::NormalizException& e)
+    {
+      throw std::runtime_error(
+          std::string("latticePointsNormaliz: libnormaliz error: ") + e.what());
+  }
+}
+
+} // namespace M2::cytools

--- a/M2/Macaulay2/e/cytools/lattice-points-normaliz.hpp
+++ b/M2/Macaulay2/e/cytools/lattice-points-normaliz.hpp
@@ -1,0 +1,43 @@
+#ifndef _cytools_lattice_points_normaliz_hpp_
+#define _cytools_lattice_points_normaliz_hpp_
+
+#include <gmpxx.h>
+#include <vector>
+
+namespace M2::cytools {
+
+struct LatticePointsNormalizResult {
+  // Each inner vector is one lattice point of length `dim`.
+  std::vector<std::vector<mpz_class>> points;
+};
+
+// Enumerate integer vectors x of length `dim` satisfying A*x <= b
+// (componentwise), where A is m x dim and b has length m. The polytope
+// must be bounded; an unbounded input is reported via std::runtime_error.
+//
+// Backed by libnormaliz::Cone<mpz_class> with Type::inhom_inequalities,
+// so big integers are handled natively (no fits-in-int restriction).
+//
+// Convention is A*x <= b natively, matching the engine wrapper. (The
+// box_enum-based sibling latticePoints() uses the inverted H*v >= rhs
+// convention; see TODO in cytools/lattice_points.hpp about unifying.)
+//
+// Throws std::runtime_error on:
+//   - shape mismatch (A.size() != b.size(), or row of A has length != dim)
+//   - unbounded polyhedron (Normaliz reports the polytope as not computable)
+//   - other libnormaliz failures (BadInputException, etc.)
+//
+// TODO: no user-facing options for now. Two libnormaliz knobs are worth
+// surfacing later if needed: setVerbose(bool) (currently hard-coded false)
+// for progress output on long runs, and GlobalTimeBound (double seconds)
+// to abort runaway compute. Other libnormaliz options (Approximate,
+// BottomDecomposition, BigInt, etc.) are advanced algorithm-selection flags
+// whose defaults work; expose only on demand.
+LatticePointsNormalizResult latticePointsNormaliz(
+    int dim,
+    const std::vector<std::vector<mpz_class>>& A,
+    const std::vector<mpz_class>& b);
+
+} // namespace M2::cytools
+
+#endif

--- a/M2/Macaulay2/e/cytools/lattice_points.cpp
+++ b/M2/Macaulay2/e/cytools/lattice_points.cpp
@@ -1,0 +1,96 @@
+#include "cytools/lattice_points.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+// Forward-declare the C entry point from box_enum.h with C linkage.
+// We do NOT #include "box_enum.h" here because that header is C99 (uses
+// `restrict` and VLAs in its declaration/body); it is compiled separately
+// as C via cytools/box_enum.c.
+extern "C" {
+int _box_enum_c(
+    int32_t* out,
+    long* N_out,
+    long* N_nodes,
+    int dim,
+    int B,
+    int* H,
+    int* rhs,
+    int N_hyps,
+    long max_N_out,
+    long max_N_nodes);
+}
+
+namespace M2::cytools {
+
+LatticePointsResult latticePoints(
+    int dim,
+    int B,
+    const std::vector<std::vector<int>>& H,
+    const std::vector<int>& rhs,
+    long max_N_out,
+    long max_N_nodes)
+{
+  const int n_hyps = static_cast<int>(H.size());
+  if (static_cast<size_t>(n_hyps) != rhs.size())
+    throw std::runtime_error(
+        "latticePoints: H.size() must equal rhs.size()");
+  for (const auto& row : H)
+    if (static_cast<int>(row.size()) != dim)
+      throw std::runtime_error(
+          "latticePoints: every row of H must have length dim");
+
+  // Flatten H row-major.
+  std::vector<int> H_flat;
+  H_flat.reserve(static_cast<size_t>(n_hyps) * static_cast<size_t>(dim));
+  for (const auto& row : H)
+    H_flat.insert(H_flat.end(), row.begin(), row.end());
+
+  std::vector<int> rhs_copy = rhs; // mutable buffer for non-const C pointer
+  std::vector<std::int32_t> out(static_cast<size_t>(max_N_out)
+                                * static_cast<size_t>(dim));
+
+  long n_out = 0;
+  long n_nodes = 0;
+
+  int status = _box_enum_c(
+      out.data(),
+      &n_out,
+      &n_nodes,
+      dim,
+      B,
+      H_flat.empty() ? nullptr : H_flat.data(),
+      rhs_copy.empty() ? nullptr : rhs_copy.data(),
+      n_hyps,
+      max_N_out,
+      max_N_nodes);
+
+  if (status == -1)
+    throw std::runtime_error(
+        "rawLatticePoints: dim > 256 not supported by box_enum");
+  // status == -2 (max_N_out reached) is intentionally NOT an error: return
+  // the points collected so far and let the caller detect truncation by
+  // comparing result.points.size() against max_N_out.
+  if (status == -3)
+    throw std::runtime_error(
+        "rawLatticePoints: exceeded max_N_nodes = "
+        + std::to_string(max_N_nodes) + " search nodes");
+  if (status != 0 && status != -2)
+    throw std::runtime_error(
+        "rawLatticePoints: unknown box_enum status "
+        + std::to_string(status));
+
+  LatticePointsResult result;
+  result.n_nodes = n_nodes;
+  result.points.resize(static_cast<size_t>(n_out),
+                       std::vector<int>(static_cast<size_t>(dim)));
+  for (long i = 0; i < n_out; ++i)
+    for (int j = 0; j < dim; ++j)
+      result.points[static_cast<size_t>(i)][static_cast<size_t>(j)] =
+          static_cast<int>(out[static_cast<size_t>(i) * dim + j]);
+
+  return result;
+}
+
+} // namespace M2::cytools

--- a/M2/Macaulay2/e/cytools/lattice_points.hpp
+++ b/M2/Macaulay2/e/cytools/lattice_points.hpp
@@ -1,0 +1,46 @@
+#ifndef _cytools_lattice_points_hpp_
+#define _cytools_lattice_points_hpp_
+
+#include <vector>
+
+namespace M2::cytools {
+
+struct LatticePointsResult {
+  // Each inner vector is one lattice point of length `dim`.
+  std::vector<std::vector<int>> points;
+  // Number of nodes visited in the search tree (diagnostic).
+  long n_nodes = 0;
+};
+
+// Enumerate integer vectors `v` of length `dim` satisfying
+//   H * v >= rhs  (componentwise)  and  |v_i| <= B  for all i.
+//
+// `H` has N_hyps rows of length `dim` (may be empty for pure box enumeration).
+// `rhs` has length N_hyps (must match H.size(); may be empty if H is empty).
+//
+// max_N_out is a soft cap: when reached, the search stops and the points
+// found so far are returned. Detect truncation by comparing
+// result.points.size() against max_N_out.
+// Throws std::runtime_error if:
+//   - dim > 256 (unsupported by underlying box_enum)
+//   - the search visited more than max_N_nodes nodes (hard cap, since the
+//     caller cannot easily distinguish "ran out of budget" from "done")
+//
+// TODO: consider flipping this helper's convention to A*x <= b to match the
+// engine wrapper `rawLatticePoints` (and any future Normaliz-backed sibling).
+// Today the wrapper negates A and b before calling this function; if both
+// agreed on Ax <= b, only the C entry point `_box_enum_c` (whose native form
+// is H*v >= rhs and which we don't modify, since it is upstream-sourced)
+// would need a one-line negation at the call site. Cost: flipping the
+// LatticePoints (pure-C++) gtest cases too.
+LatticePointsResult latticePoints(
+    int dim,
+    int B,
+    const std::vector<std::vector<int>>& H,
+    const std::vector<int>& rhs,
+    long max_N_out,
+    long max_N_nodes);
+
+} // namespace M2::cytools
+
+#endif

--- a/M2/Macaulay2/e/interface/cone.cpp
+++ b/M2/Macaulay2/e/interface/cone.cpp
@@ -9,11 +9,18 @@
 #include "interface/matrix.h"
 #include "matrix-con.hpp"
 #include "matrix.hpp"
-#include "relem.hpp"
+#include "interface/mutable-matrix.h"
+#include "mat.hpp"
+//#include "relem.hpp"
+#include "util.hpp"
 
+#include "cytools/lattice_points.hpp"
+#include "cytools/lattice-points-normaliz.hpp"
+#include "cytools/cone-interior-point.hpp"
+#include "interface/ring.h"
 #include <libnormaliz/cone.h>
+#include <stdexcept>
 #include <vector>
-
 typedef mpz_class Integer;
 
 /**
@@ -97,3 +104,315 @@ const Matrix /* or null */ *rawHilbertBasis(const Matrix *C)
       return nullptr;
   }
 }
+
+// Keep this in sync with the typedef in Macaulay2/e/computeGV.hpp.
+using CurveAndGVCollection =
+    std::vector<std::pair<std::vector<int>, mpz_class>>;
+
+// The following is in the file e/computeGV.{hpp,cpp}
+extern int gvcompute(
+    std::vector<std::vector<int>> input_curves,
+    std::vector<std::vector<int>> lightcone_curves,
+    std::vector<int> grading_vec,
+    std::vector<std::vector<int>> Q,  // GLSM charge matrix
+    std::vector<std::vector<int>> nef_partition,
+    std::vector<std::vector<int>> intnums_list,  // intersection numbers
+                     std::vector<int> input_settings,
+    CurveAndGVCollection& result); // computation settings
+
+auto decodeArrayArrayInt(M2_arrayint a) -> std::vector<std::vector<int>>
+{
+  // throw an error if the 
+  auto nelems = a->array[0];
+  std::vector<std::vector<int>> result;
+  int next = 1;
+  for (int i = 0; i < nelems; ++i)
+    {
+      result.emplace_back();
+      int len = a->array[next];
+      for (int j = 1; j <= len; ++j) result[i].push_back(a->array[next + j]);
+      next += len + 1;
+    }
+  return result;
+}
+
+MutableMatrix *rawGVInvariants(M2_arrayint curves,
+                               M2_arrayint lightcone,
+                               M2_arrayint grading,
+                               M2_arrayint Q,
+                               M2_arrayint nefPartition,
+                               M2_arrayint intnums,
+                               M2_arrayint settings)
+{
+  std::vector<std::vector<int>> input_curves {decodeArrayArrayInt(curves)};
+  std::vector<std::vector<int>> lightcone_curves {decodeArrayArrayInt(lightcone)};
+  std::vector<int> grading_vec { M2_arrayint_to_stdvector<int>(grading) };
+  std::vector<std::vector<int>> charge_matrix {decodeArrayArrayInt(Q)};  // GLSM charge matrix
+  std::vector<std::vector<int>> nef_partition {decodeArrayArrayInt(nefPartition)};
+  std::vector<std::vector<int>> intnums_list {decodeArrayArrayInt(intnums)};  // intersection numbers
+  std::vector<int> input_settings {M2_arrayint_to_stdvector<int>(settings)};
+
+  int h11 = input_curves[0].size();
+  //  MatrixConstructor resultCurvesAndGVs(globalZZ->make_FreeModule(h11+1));
+
+  CurveAndGVCollection curveandgvcollection;
+
+
+  gvcompute(input_curves,
+            lightcone_curves,
+            grading_vec,
+            charge_matrix,
+            nef_partition,
+            intnums_list,
+            input_settings,
+            curveandgvcollection);
+
+  MutableMatrix *M =
+    MutableMatrix::zero_matrix(globalZZ, h11 + 1, curveandgvcollection.size(), true);
+
+  int col = -1;
+  for (auto &k : curveandgvcollection)
+    {
+      col++;
+      for (int r = 0; r < h11; ++r)
+        {
+          M->set_entry(r, col, globalZZ->from_long(k.first[r]));
+        }
+      M->set_entry(h11, col, globalZZ->from_int(k.second.get_mpz_t()));
+    }
+  return M;
+  
+  
+  // std::cout << "# curves: " << curveandgvcollection.size() << std::endl;
+  // for (auto &k : curveandgvcollection)
+  //   {
+  //     for (auto &a : k.first) { std::cout << a << " "; }
+  //     gmp_printf("%Zd\n", &k.second);
+  //   }
+  // return nullptr;
+//  return resultCurvesAndGVs.to_matrix();
+}
+// todo here:
+// 1. add in translate functions (make the function...)
+// 2. create the top level function, call the d level function.
+// 3. deal with the output from gvcompute.
+
+// User-facing convention is A * x <= b. The underlying box_enum function
+// works with H * x >= rhs, so we negate A and b on the way in.
+MutableMatrix *rawLatticePoints(const Matrix *A,
+                                const Matrix *b,
+                                int B,
+                                long max_N_out,
+                                long max_N_nodes)
+{
+  try
+    {
+      const size_t n_hyps = A->n_rows();
+      const size_t dim = A->n_cols();
+
+      if (b->get_ring() != globalZZ)
+        {
+          ERROR("rawLatticePoints: b must be a matrix over ZZ");
+          return nullptr;
+        }
+      if (static_cast<size_t>(b->n_rows()) != n_hyps || b->n_cols() != 1)
+        {
+          ERROR("rawLatticePoints: b must be a column matrix with n_rows(A) rows");
+          return nullptr;
+        }
+
+      // Marshal A entries to vector<vector<int>>, negating to convert
+      // A*x <= b into (-A)*x >= -b for the box_enum convention.
+      std::vector<std::vector<int>> Hvec(n_hyps, std::vector<int>(dim));
+      for (size_t i = 0; i < n_hyps; i++)
+        for (size_t j = 0; j < dim; j++)
+          {
+            mpz_srcptr z = A->elem(i, j).get_mpz();
+            if (mpz_fits_sint_p(z) == 0)
+              {
+                ERROR("rawLatticePoints: entry of A does not fit in a C int");
+                return nullptr;
+              }
+            Hvec[i][j] = -static_cast<int>(mpz_get_si(z));
+          }
+
+      std::vector<int> rhsvec(n_hyps);
+      for (size_t i = 0; i < n_hyps; i++)
+        {
+          mpz_srcptr z = b->elem(i, 0).get_mpz();
+          if (mpz_fits_sint_p(z) == 0)
+            {
+              ERROR("rawLatticePoints: entry of b does not fit in a C int");
+              return nullptr;
+            }
+          rhsvec[i] = -static_cast<int>(mpz_get_si(z));
+        }
+
+      auto result = M2::cytools::latticePoints(
+          static_cast<int>(dim), B, Hvec, rhsvec, max_N_out, max_N_nodes);
+
+      // Output: rows = ambient coords (dim), cols = lattice points.
+      const size_t n_points = result.points.size();
+      MutableMatrix *M =
+          MutableMatrix::zero_matrix(globalZZ, dim, n_points, /*dense*/ true);
+      for (size_t i = 0; i < n_points; i++)
+        for (size_t j = 0; j < dim; j++)
+          M->set_entry(j, i, globalZZ->from_long(result.points[i][j]));
+      return M;
+  } catch (const std::runtime_error &e)
+    {
+      // catches both std::runtime_error from latticePoints() and
+      // exc::engine_error (which derives from std::runtime_error)
+      ERROR(e.what());
+      return nullptr;
+  }
+}
+
+// Same user-facing convention as rawLatticePoints (A*x <= b), but backed by
+// libnormaliz: enumerates ALL lattice points of the polyhedron (no box,
+// no caps, big-int entries supported). The polyhedron must be bounded.
+MutableMatrix *rawLatticePointsNormaliz(const Matrix *A, const Matrix *b)
+{
+  try
+    {
+      const size_t n_hyps = A->n_rows();
+      const size_t dim = A->n_cols();
+
+      if (A->get_ring() != globalZZ)
+        {
+          ERROR("rawLatticePointsNormaliz: A must be a matrix over ZZ");
+          return nullptr;
+        }
+      if (b->get_ring() != globalZZ)
+        {
+          ERROR("rawLatticePointsNormaliz: b must be a matrix over ZZ");
+          return nullptr;
+        }
+      if (static_cast<size_t>(b->n_rows()) != n_hyps || b->n_cols() != 1)
+        {
+          ERROR("rawLatticePointsNormaliz: b must be a column matrix with "
+                "n_rows(A) rows");
+          return nullptr;
+        }
+
+      std::vector<std::vector<mpz_class>> Avec(n_hyps,
+                                               std::vector<mpz_class>(dim));
+      for (size_t i = 0; i < n_hyps; i++)
+        for (size_t j = 0; j < dim; j++)
+          Avec[i][j] = static_cast<mpz_class>(A->elem(i, j).get_mpz());
+
+      std::vector<mpz_class> bvec(n_hyps);
+      for (size_t i = 0; i < n_hyps; i++)
+        bvec[i] = static_cast<mpz_class>(b->elem(i, 0).get_mpz());
+
+      auto result = M2::cytools::latticePointsNormaliz(
+          static_cast<int>(dim), Avec, bvec);
+
+      const size_t n_points = result.points.size();
+      MutableMatrix *M =
+          MutableMatrix::zero_matrix(globalZZ, dim, n_points, /*dense*/ true);
+      for (size_t i = 0; i < n_points; i++)
+        for (size_t j = 0; j < dim; j++)
+          M->set_entry(j, i,
+                       globalZZ->from_int(result.points[i][j].get_mpz_t()));
+      return M;
+  } catch (const std::runtime_error &e)
+    {
+      ERROR(e.what());
+      return nullptr;
+  }
+}
+
+// Macaulay2 convention: rows of A are inequalities A*x <= 0.
+// The helper coneInteriorPoint() works with {x : A x >= 0}, so we negate.
+//
+// Return value is a 1-row MutableMatrix over RR(53):
+//   if full-dimensional: 2 + n columns, [1, tStar, interior point]
+//   else                : 2 + m columns, [0, tStar, dual certificate]
+MutableMatrix /* or null */ *rawConeInteriorPoint(const Matrix *A)
+{
+  try
+    {
+      const size_t m = A->n_rows();  // number of inequalities
+      const size_t n = A->n_cols();  // ambient dimension
+
+      std::vector<int> Avec(m * n);
+      for (size_t i = 0; i < m; i++)
+        for (size_t j = 0; j < n; j++)
+          {
+            mpz_srcptr z = A->elem(i, j).get_mpz();
+            if (mpz_fits_sint_p(z) == 0)
+              {
+                ERROR("rawConeInteriorPoint: entry of A does not fit in a C int");
+                return nullptr;
+              }
+            Avec[i * n + j] = -static_cast<int>(mpz_get_si(z));
+          }
+
+      ConeResult cr = coneInteriorPoint(static_cast<int>(m),
+                                        static_cast<int>(n),
+                                        Avec);
+
+      const Ring *RR = IM2_Ring_RRR(53);
+      const std::vector<double> &tail =
+          cr.fullDimensional ? cr.interiorPoint : cr.dualCert;
+      MutableMatrix *M = MutableMatrix::zero_matrix(
+          RR, 1, 2 + tail.size(), /*dense*/ true);
+
+      ring_elem r;
+      RR->from_double(cr.fullDimensional ? 1.0 : 0.0, r);
+      M->set_entry(0, 0, r);
+      RR->from_double(cr.tStar, r);
+      M->set_entry(0, 1, r);
+      for (size_t k = 0; k < tail.size(); k++)
+        {
+          RR->from_double(tail[k], r);
+          M->set_entry(0, 2 + k, r);
+        }
+
+      return M;
+  } catch (const exc::engine_error &e)
+    {
+      ERROR(e.what());
+      return nullptr;
+  }
+}
+
+// struct ConeResult {
+//     bool fullDimensional;
+//     int rank;                        // dimension of the cone
+//     std::vector<mpz_class> interior; // valid if fullDimensional: lattice point with Ax > 0
+// };
+
+// // A is m x n, row-major: cone is { x : A x >= 0 }.
+// ConeResult coneInteriorPointNormaliz(int m, int n, const std::vector<mpz_class>& A) {
+//     // Build the m x n matrix of inequality rows.
+//     std::vector<std::vector<mpz_class>> ineqs(m, std::vector<mpz_class>(n));
+//     for (int i = 0; i < m; ++i)
+//         for (int j = 0; j < n; ++j)
+//             ineqs[i][j] = A[i * n + j];
+
+//     // Construct the cone from inequalities (H-representation).
+//     libnormaliz::Cone<mpz_class> C(libnormaliz::Type::inequalities, ineqs);
+
+//     // Ask for rank and (if full-dim) a witness of the interior.
+//     C.compute(libnormaliz::ConeProperty::Rank,
+//               libnormaliz::ConeProperty::IsPointed,
+//               libnormaliz::ConeProperty::Generators);  // extreme rays, used below
+
+//     ConeResult res;
+//     res.rank = C.getRank();
+//     res.fullDimensional = (res.rank == n);
+
+//     if (res.fullDimensional) {
+//         // Sum of extreme rays lies in the relative interior; since the cone
+//         // is full-dimensional, that's the interior, and it's a lattice point.
+//         const auto& rays = C.getExtremeRays();   // vector<vector<mpz_class>>
+//         std::vector<mpz_class> x(n, 0);
+//         for (const auto& r : rays)
+//             for (int j = 0; j < n; ++j)
+//                 x[j] += r[j];
+//         res.interior = std::move(x);
+//     }
+//     return res;
+// }

--- a/M2/Macaulay2/e/interface/cone.h
+++ b/M2/Macaulay2/e/interface/cone.h
@@ -2,16 +2,23 @@
 #  define _cone_h_
 
 #  include "engine-includes.hpp"
-
+#include "m2-types.h"
 // TODO: fix this
 #  if defined(__cplusplus)
-class Matrix;
+  class Matrix;
 #  else
-typedef struct Matrix Matrix;
+  typedef struct Matrix Matrix;
 #  endif
 
 /**
-   Cone interface routines
+ * \defgroup cones Cones
+ * \brief Cone interface routines (most backed by libnormaliz).
+ *
+ * Macaulay2's sign convention for inequality matrices is uniformly
+ * `A * x <= 0` (or `A * x <= b` in the inhomogeneous case).
+ * Implementations negate as needed to adapt to the conventions used by
+ * libnormaliz (`A * x >= 0`) and the internal `box_enum` helper
+ * (`H * x >= rhs`).
  */
 
 #  if defined(__cplusplus)
@@ -22,10 +29,359 @@ extern "C" {
 /**** Cone routines (via Normaliz) ****************/
 /**************************************************/
 
+/** \brief Extreme rays of a polyhedral cone given by inequalities, via libnormaliz.
+ *
+ * Computes the extreme rays of the cone `{ x in QQ^c : C * x <= 0 }`
+ * defined by linear inequalities. The implementation negates `C` on the
+ * way in because libnormaliz uses the opposite convention `A * x >= 0`.
+ *
+ * \warning The cone is assumed to be pointed (that is, `ker(C) = 0`).
+ *          Only extreme rays are returned, so if `C` has a non-trivial
+ *          kernel the cone has a non-trivial lineality space and the
+ *          positive hull of the returned rays is a *proper* subset of
+ *          `{x : C x <= 0}`. Basis vectors for `ker(C)` (and their
+ *          negatives) are not emitted.
+ *
+ * \warning The row/column convention here is the **transpose** of the
+ *          pure-M2 `FourierMotzkin` package: that package takes hyperplanes
+ *          as **columns** and returns extremal rays as **columns**. This
+ *          engine routine takes hyperplanes as **rows** and returns
+ *          extremal rays as **rows**. The convention used here may change
+ *          in the future to align with the package.
+ *
+ * \param C An r-by-c matrix over ZZ. Each row is one inequality
+ *          `C(i,*) * x <= 0`; columns index the c-dimensional ambient
+ *          lattice.
+ * \return An n-by-c matrix over ZZ whose **rows** are the extremal rays
+ *         of the cone, or `nullptr` on engine error.
+ *
+ * \par Example (M2 top level)
+ * \code{.unparsed}
+ *   A = matrix {{1,1,1}, {-1,1,0}, {-1,0,1}, {1,2,3}}
+ *   map(ZZ, rawFourierMotzkin raw A)
+ *     -- matrix {{-1, -1, -1}, {1, -2, 1}, {1, 1, -2}}
+ * \endcode
+ * The three rows of the result are the extremal rays of the cone
+ * `{x in QQ^3 : A x <= 0}`.
+ *
+ * \ingroup cones
+ */
 const Matrix /* or null */ *rawFourierMotzkin(const Matrix *C);
 
+/** \brief Hilbert basis of a polyhedral cone given by its rays, via libnormaliz.
+ *
+ * Computes the Hilbert basis of the cone `pos(rows of C)` in `QQ^c`,
+ * i.e. the unique minimal generating set of the additive monoid
+ * `pos(rows of C) intersect ZZ^c`. The cone is presented in
+ * V-representation (rays as input rows), the dual to the H-representation
+ * accepted by `rawFourierMotzkin`.
+ *
+ * \warning The cone is assumed to be pointed. For non-pointed cones the
+ *          Hilbert basis is not well-defined in the usual minimal-set
+ *          sense; libnormaliz will still return generators, but their
+ *          interpretation differs.
+ *
+ * \warning The intended M2 engine convention is **hyperplanes as rows**
+ *          and **rays/points as columns**. This routine pre-dates that
+ *          convention and uses **rows for both** input rays and output
+ *          basis elements. The signature may be transposed in the future
+ *          to match the convention; for now the row-based layout is used.
+ *
+ * \param C An r-by-c matrix over ZZ. Each row is one cone generator
+ *          (ray); columns index the c-dimensional ambient lattice.
+ * \return An n-by-c matrix over ZZ whose **rows** are the Hilbert basis
+ *         elements, or `nullptr` on engine error.
+ *
+ * \todo Validate that `C` is over ZZ (currently assumed).
+ * \todo Lift cones over QQ to ZZ before passing to libnormaliz.
+ * \todo Expose libnormaliz's support for cones over algebraic number
+ *       fields embedded in RR.
+ *
+ * \par Example (M2 top level)
+ * \code{.unparsed}
+ *   debug Core
+ *   C = matrix {{1,0}, {1,2}}
+ *   map(ZZ, rawHilbertBasis raw C)
+ *     -- | 1 0 |
+ *     -- | 1 1 |
+ *     -- | 1 2 |
+ * \endcode
+ * The cone in `ZZ^2` spanned by the rays `(1,0)` and `(1,2)` has
+ * Hilbert basis `{(1,0), (1,1), (1,2)}`; the middle element `(1,1)`
+ * is the non-trivial lattice point in the half-open parallelepiped
+ * spanned by the two primitive rays.
+ *
+ * \sa rawFourierMotzkin (H-representation counterpart)
+ * \ingroup cones
+ */
 const Matrix /* or null */ *rawHilbertBasis(const Matrix *C);
 
+/** \brief Gopakumar-Vafa invariants of a Calabi-Yau threefold.
+ *
+ * Computes Gopakumar-Vafa (GV) invariants for a Calabi-Yau threefold
+ * via the `gvcompute` routine ported from CYTools (see Reference
+ * below for the algorithm and the precise meaning of the inputs).
+ *
+ * Each `M2_arrayint` argument is a flattened encoding produced on
+ * the d-language side: nested-list inputs use a length-prefix-per-row
+ * format, flat-list inputs are passed through.
+ *
+ * \param curves        Input curves: the curve classes whose GV
+ *                      invariants are to be computed. Each inner
+ *                      list has length `h11`.
+ * \param lightcone     Lightcone curves. Currently non-empty values
+ *                      are not yet functional or tested; pass the
+ *                      empty list.
+ * \param grading       Grading vector.
+ * \param Q             GLSM charge matrix.
+ * \param nefPartition  Nef partition data. Currently non-empty values
+ *                      are not yet functional or tested; pass the
+ *                      empty list.
+ * \param intnums       Triple intersection numbers.
+ * \param settings      Computation settings: exactly four `int`s, in
+ *                      order:
+ *                      - `[0] max_deg`: maximum curve degree to
+ *                        enumerate. A negative value `-k` is
+ *                        reinterpreted as a minimum-points request
+ *                        (`min_points = k`, `max_deg` clamped to 0).
+ *                      - `[1] digits`: decimal digits of internal
+ *                        MPFR precision (valid range 17..2000).
+ *                      - `[2] mode`: enumeration strategy and a
+ *                        GV/GW switch; see the bit layout and the
+ *                        Normal / Hilbert / Verbatim modes documented
+ *                        in `Macaulay2/e/computeGV.cpp`.
+ *                      - `[3] min_mem`: **currently ignored** — the
+ *                        memory threshold is hardcoded internally
+ *                        (notably on macOS); the slot is kept in the
+ *                        signature for forward compatibility.
+ *
+ * \return A MutableMatrix over ZZ with `h11 + 1` rows and one column
+ *         per (curve class, GV invariant) pair found by the search:
+ *         rows `0..h11-1` hold the curve coordinates and row `h11`
+ *         holds the GV invariant (an `mpz_class`, which may be very
+ *         large). Returns `nullptr` if `gvcompute` fails.
+ *
+ * \par Reference
+ * M. Demirtas, M. Kim, L. McAllister, J. Moritz, A. Rios-Tascon,
+ * *Computational Mirror Symmetry*, arXiv:2303.00757 (2024).
+ * https://arxiv.org/abs/2303.00757
+ *
+ * \par Example (M2 top level)
+ * \code{.unparsed}
+ *   debug Core
+ *
+ *   -- Helper: pack a list-of-list-of-int into the flat
+ *   -- length-prefix-per-row encoding rawGVInvariants expects.
+ *   encodeArrayArrayInt = method()
+ *   encodeArrayArrayInt List := List => L -> (
+ *       parts := flatten for i from 0 to #L - 1 list prepend(#L#i, L#i);
+ *       prepend(#L, parts))
+ *
+ *   mori       = encodeArrayArrayInt {{-1,3,-1},{0,-2,1},{1,2,-1}}
+ *   lightcone  = encodeArrayArrayInt {}
+ *   gradingvec = {2, 4, 9}
+ *   Q          = encodeArrayArrayInt {{1,0,0,0,1,0,1},{0,1,0,1,0,1,1},
+ *                                     {0,0,1,3,1,2,2}}
+ *   nefpart    = encodeArrayArrayInt {}
+ *   intnums    = encodeArrayArrayInt {{0,0,0,-1},{0,1,1,-2},{0,1,2,1},
+ *                                     {1,1,1,8},{1,1,2,-4},{1,2,2,2},
+ *                                     {2,2,2,-1}}
+ *   settings   = {6, 150, 0, 300000}
+ *
+ *   transpose map(ZZ, rawGVInvariants(mori, lightcone, gradingvec, Q,
+ *                                     nefpart, intnums, settings))
+ *     -- | 1  2  -1 1     |
+ *     -- | 0  -2 1  -2    |
+ *     -- | 1  0  0  126   |
+ *     -- | -1 1  0  1     |
+ *     -- ...
+ *     -- | 1  1  0  20615 |
+ *     -- ...                              (19 rows total)
+ * \endcode
+ * Each row of the (transposed) output is one tuple
+ * `[c_1, c_2, c_3, GV(c)]`: the first `h11 = 3` entries are the curve
+ * coordinates, the last entry is the GV invariant for that class.
+ * Only curve classes with non-zero GV invariants are returned (e.g.
+ * the class `(1,1,0)` has `GV = 20615`).
+ *
+ * \ingroup cones
+ */
+MutableMatrix /* or null */ *rawGVInvariants(M2_arrayint curves,
+                                             M2_arrayint lightcone,
+                                             M2_arrayint grading,
+                                             M2_arrayint Q,
+                                             M2_arrayint nefPartition,
+                                             M2_arrayint intnums,
+                                             M2_arrayint settings);
+
+/** \brief Enumerate lattice points in a bounded box of a polyhedron (int-precision).
+ *
+ * Enumerates every integer vector `x` in `ZZ^d` (where `d = n_cols(A)`)
+ * satisfying both
+ *   - `A * x <= b`  componentwise, and
+ *   - `|x_i| <= B`  for every coordinate `i`.
+ *
+ * Backed by the cytools `box_enum.h`, written by Nate MacFadden,, which works in C `int`
+ * arithmetic. The implementation negates `A` and `b` to convert M2's
+ * `A x <= b` into `box_enum`'s `H x >= rhs` convention.
+ *
+ * \note This routine follows the intended M2 engine convention:
+ *       **hyperplanes as rows** of `A`, **lattice points as columns**
+ *       of the result.
+ *
+ * \param A           An m-by-d matrix over ZZ; each row is one
+ *                    inequality. All entries must fit in a C `int`.
+ * \param b           A column matrix over ZZ with `m` rows and 1 column.
+ *                    All entries must fit in a C `int`.
+ * \param B           Per-coordinate absolute-value bound on `x`.
+ * \param max_N_out   **Soft** cap on the number of returned points: if
+ *                    reached, the enumeration stops cleanly and returns
+ *                    the partial list. Callers should compare the
+ *                    returned column count against this bound to detect
+ *                    truncation.
+ * \param max_N_nodes **Hard** cap on the number of search-tree nodes
+ *                    explored: if exceeded, an error is reported (the
+ *                    routine returns `nullptr`) rather than returning
+ *                    a partial result, since otherwise the caller cannot
+ *                    distinguish a complete enumeration from one cut
+ *                    short.
+ * \return A dense MutableMatrix over ZZ with `d` rows and one column
+ *         per enumerated lattice point, or `nullptr` on error (bad
+ *         input shape, ring mismatch, entries that overflow C `int`,
+ *         or `max_N_nodes` exceeded).
+ *
+ * \par Example (M2 top level)
+ * \code{.unparsed}
+ *   debug Core
+ *   A = matrix {{1,1,1}}
+ *   b = matrix {{-2}}
+ *   map(ZZ, rawLatticePoints(raw A, raw b, 1, 100, 1000))
+ *     -- | -1 0  -1 -1 |
+ *     -- | -1 -1 0  -1 |
+ *     -- | -1 -1 -1 0  |
+ * \endcode
+ * Enumerates the integer points `x` in `ZZ^3` with `x_1+x_2+x_3 <= -2`
+ * and `|x_i| <= 1`. There are exactly four such points:
+ * `(-1,-1,-1), (0,-1,-1), (-1,0,-1), (-1,-1,0)`. The output has 3 rows
+ * (the ambient dimension) and 4 columns (one per point).
+ *
+ * \sa rawLatticePointsNormaliz — libnormaliz-backed counterpart with
+ *     big-integer support and no box bound, but requires a bounded
+ *     polyhedron.
+ * \ingroup cones
+ */
+MutableMatrix /* or null */ *rawLatticePoints(const Matrix *A,
+                                              const Matrix *b,
+                                              int B,
+                                              long max_N_out,
+                                              long max_N_nodes);
+
+/** \brief Enumerate all lattice points of a bounded polyhedron, via libnormaliz.
+ *
+ * Same user-facing convention as `rawLatticePoints` (enumerate every
+ * integer `x` in `ZZ^d` with `A * x <= b`), but with no box bound and
+ * no caps: every lattice point of the polyhedron is returned. The
+ * polyhedron must be bounded; an unbounded input is reported as an
+ * error. Big-integer entries in `A` and `b` are fully supported (no
+ * fits-in-int restriction).
+ *
+ * \note This routine follows the intended M2 engine convention:
+ *       **hyperplanes as rows** of `A`, **lattice points as columns**
+ *       of the result.
+ *
+ * \param A An m-by-d matrix over ZZ; each row is one inequality.
+ * \param b A column matrix over ZZ with `m` rows and 1 column.
+ * \return A dense MutableMatrix over ZZ with `d` rows and one column
+ *         per lattice point, or `nullptr` on error (ring mismatch,
+ *         bad shape, or unbounded polyhedron).
+ *
+ * \par Example (M2 top level)
+ * \code{.unparsed}
+ *   debug Core
+ *   A = matrix {{1,0},{0,1},{-1,0},{0,-1}}    -- unit square: 0 <= x,y <= 1
+ *   b = matrix {{1},{1},{0},{0}}
+ *   map(ZZ, rawLatticePointsNormaliz(raw A, raw b))
+ *     -- | 0 0 1 1 |
+ *     -- | 0 1 0 1 |
+ * \endcode
+ * The polyhedron is bounded by its inequalities alone (no `B` is
+ * needed, unlike `rawLatticePoints`). The four columns are the four
+ * lattice points `(0,0), (0,1), (1,0), (1,1)` of the unit square.
+ *
+ * \sa rawLatticePoints — cytools `box_enum`-backed counterpart that requires
+ *     a per-coordinate box bound `B` and uses `int` arithmetic, but
+ *     can enumerate inside an unbounded polyhedron clipped by the box.
+ * \ingroup cones
+ */
+MutableMatrix /* or null */ *rawLatticePointsNormaliz(const Matrix *A,
+                                                      const Matrix *b);
+
+
+/** \brief Test full-dimensionality of a cone and produce a witness, via GLPK.
+ *
+ * For the cone `{ x in QQ^n : A * x <= 0 }`, runs a single linear
+ * program (GLPK, double precision) that simultaneously decides
+ * full-dimensionality and produces either an interior witness or a
+ * Farkas-style dual certificate of non-full-dimensionality. The
+ * implementation negates `A` because the helper `coneInteriorPoint()`
+ * works with `{x : A x >= 0}`.
+ *
+ * \par The LP
+ * In the user-facing convention `A x <= 0`, the LP is:
+ * \code{.unparsed}
+ *   maximize     t
+ *   subject to   A_i * x  <=  -t        for each row i = 1, ..., m
+ *                -1 <= x_j <= 1         for j = 1, ..., n  (normalization)
+ *                t >= 0
+ * \endcode
+ * `t` is the strict-feasibility margin. If the optimum `tStar > 0`
+ * (with numerical tolerance `1e-8`), the cone is full-dimensional
+ * and the primal `x` is an interior witness (each `A_i x < 0`
+ * strictly). If `tStar <= 0` the cone is not full-dimensional, and
+ * the row duals supply a non-negative `y >= 0` with `y^T A = 0`.
+ * The `[-1, 1]` box on `x` keeps the LP bounded; without it `t`
+ * could scale to infinity along any interior ray.
+ *
+ * \note Hyperplanes-as-rows convention. Callers whose data is in the
+ *       `M x >= 0` form should pass `-M` (in M2: `raw(-M)`).
+ *
+ * \param A An m-by-n matrix over ZZ; each row is one inequality.
+ *          Entries must fit in a C `int`.
+ * \return A 1-row dense MutableMatrix over RR(53):
+ *         - **Full-dimensional** (`tStar > 0`): `2 + n` columns,
+ *           `[1, tStar, x_1, ..., x_n]`.
+ *         - **Not full-dimensional** (`tStar <= 0`): `2 + m` columns,
+ *           `[0, tStar, y_1, ..., y_m]` where `y >= 0` and
+ *           `y^T A = 0`.
+ *
+ *         Returns `nullptr` on error (entry of `A` overflows C `int`,
+ *         or engine error).
+ *
+ * \par Example (M2 top level)
+ * \code{.unparsed}
+ *   debug Core
+ *
+ *   -- Full-dimensional: first octant in QQ^3
+ *   A = matrix {{-1,0,0},{0,-1,0},{0,0,-1}}
+ *   map(RR_53, rawConeInteriorPoint raw A)
+ *     -- | 1 1 1 1 1 |        -- flag=1, tStar=1, interior=(1,1,1)
+ *
+ *   -- Not full-dimensional: the positive y-axis in QQ^2
+ *   A = matrix {{1,0},{-1,0},{0,-1}}
+ *   map(RR_53, rawConeInteriorPoint raw A)
+ *     -- | 0 0 .5 .5 0 |      -- flag=0, tStar=0, dualCert=(.5,.5,0)
+ * \endcode
+ * In the second example the certificate `(0.5, 0.5, 0)` gives
+ * `0.5*(1,0) + 0.5*(-1,0) + 0*(0,-1) = (0,0)`, witnessing that the
+ * inequalities `x <= 0` and `-x <= 0` collapse the cone to the line
+ * `x = 0`.
+ *
+ * \sa rawFourierMotzkin — consumes the same `A x <= 0` H-representation
+ *     and returns the cone's extreme rays.
+ * \ingroup cones
+ */
+MutableMatrix /* or null */ *rawConeInteriorPoint(const Matrix *A);
+  
 #  if defined(__cplusplus)
 }
 #  endif

--- a/M2/Macaulay2/e/unit-tests/LatticePointsTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/LatticePointsTest.cpp
@@ -1,0 +1,676 @@
+// Tests for the pure-C++ lattice-point enumerator
+// `M2::cytools::latticePoints` (Kannan/box_enum, in cytools/lattice_points.hpp)
+// AND for the engine wrapper `rawLatticePoints` (interface/cone.h), which is
+// the A*x <= b entry point used by Macaulay2 callers.
+//
+// Convention reminder: the cytools helper enumerates v with H*v >= rhs
+// (componentwise) and |v_i| <= B; the engine wrapper flips signs to expose
+// the user-facing A*x <= b convention. The two are exercised in separate
+// gtest groups (LatticePoints / LatticePointsRaw).
+
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "cytools/lattice-points-normaliz.hpp"
+#include "cytools/lattice_points.hpp"
+
+#include "ZZp.hpp"
+#include "error.h"
+#include "interface/cone.h"
+#include "mat.hpp"
+#include "matrix-con.hpp"
+#include "matrix.hpp"
+#include "ring.hpp"
+
+using M2::cytools::latticePoints;
+using M2::cytools::LatticePointsResult;
+using M2::cytools::latticePointsNormaliz;
+using M2::cytools::LatticePointsNormalizResult;
+
+namespace {
+
+// Brute-force enumeration of lattice points in [-B,B]^dim satisfying
+// H * v >= rhs (componentwise). Returns a set for easy comparison against
+// the box_enum-produced points.
+std::set<std::vector<int>> bruteForce(
+    int dim, int B,
+    const std::vector<std::vector<int>>& H,
+    const std::vector<int>& rhs)
+{
+  std::set<std::vector<int>> out;
+  std::vector<int> v(dim, -B);
+  while (true)
+    {
+      bool ok = true;
+      for (size_t j = 0; j < H.size(); ++j)
+        {
+          long s = 0;
+          for (int i = 0; i < dim; ++i)
+            s += static_cast<long>(H[j][i]) * static_cast<long>(v[i]);
+          if (s < rhs[j]) { ok = false; break; }
+        }
+      if (ok) out.insert(v);
+
+      // increment v lexicographically over [-B,B]^dim
+      int i = 0;
+      while (i < dim && v[i] == B) { v[i] = -B; ++i; }
+      if (i == dim) break;
+      ++v[i];
+    }
+  return out;
+}
+
+std::set<std::vector<int>> asSet(const LatticePointsResult& r)
+{
+  return std::set<std::vector<int>>(r.points.begin(), r.points.end());
+}
+
+// Generous defaults for the search caps in tests where we expect the search
+// to terminate well before either limit. 1<<24 nodes is plenty for the small
+// problems below; the largest brute-force ground truth here is (2*3+1)^3 = 343.
+constexpr long kBigN  = 1L << 20;
+constexpr long kBigNN = 1L << 24;
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Pure box enumeration (no hyperplane constraints).
+// ---------------------------------------------------------------------------
+
+TEST(LatticePoints, BoxOnly_dim2_B1)
+{
+  auto r = latticePoints(/*dim*/ 2, /*B*/ 1, {}, {}, kBigN, kBigNN);
+  EXPECT_EQ(r.points.size(), 9u);  // (2*1+1)^2
+
+  // Every lattice point in [-1,1]^2 should appear exactly once.
+  std::set<std::vector<int>> expected;
+  for (int x = -1; x <= 1; ++x)
+    for (int y = -1; y <= 1; ++y) expected.insert({x, y});
+  EXPECT_EQ(asSet(r), expected);
+}
+
+TEST(LatticePoints, BoxOnly_dim3_B2)
+{
+  auto r = latticePoints(3, 2, {}, {}, kBigN, kBigNN);
+  EXPECT_EQ(r.points.size(), 125u);  // (2*2+1)^3
+}
+
+TEST(LatticePoints, BoxOnly_dim1_B0)
+{
+  // Degenerate: only the origin.
+  auto r = latticePoints(1, 0, {}, {}, kBigN, kBigNN);
+  ASSERT_EQ(r.points.size(), 1u);
+  EXPECT_EQ(r.points[0], std::vector<int>{0});
+}
+
+// ---------------------------------------------------------------------------
+// One-hyperplane half-spaces and small simplices.
+// ---------------------------------------------------------------------------
+
+TEST(LatticePoints, HalfSpace_xPlusY_geq_0)
+{
+  // x + y >= 0 inside [-2,2]^2: count 15 by hand.
+  std::vector<std::vector<int>> H = {{1, 1}};
+  std::vector<int> rhs = {0};
+  auto r = latticePoints(2, 2, H, rhs, kBigN, kBigNN);
+  EXPECT_EQ(r.points.size(), 15u);
+  EXPECT_EQ(asSet(r), bruteForce(2, 2, H, rhs));
+}
+
+TEST(LatticePoints, Simplex_dim3_B3)
+{
+  // Standard simplex {x_i >= 0, x_1+x_2+x_3 <= 3}: count = C(6,3) = 20.
+  // In H*v >= rhs form: x_i >= 0 and -x_1-x_2-x_3 >= -3.
+  std::vector<std::vector<int>> H = {
+      {1, 0, 0}, {0, 1, 0}, {0, 0, 1}, {-1, -1, -1}};
+  std::vector<int> rhs = {0, 0, 0, -3};
+  auto r = latticePoints(3, 3, H, rhs, kBigN, kBigNN);
+  EXPECT_EQ(r.points.size(), 20u);
+  EXPECT_EQ(asSet(r), bruteForce(3, 3, H, rhs));
+}
+
+TEST(LatticePoints, MixedSignsAndRhs)
+{
+  // 2x - y >= 3 and -x + 2y >= -1 inside [-3,3]^2. No magic count -- just
+  // check the helper agrees with brute force. This pins down sign/rhs
+  // handling in set_bounds without depending on a hand-computed answer.
+  std::vector<std::vector<int>> H = {{2, -1}, {-1, 2}};
+  std::vector<int> rhs = {3, -1};
+  auto r = latticePoints(2, 3, H, rhs, kBigN, kBigNN);
+  EXPECT_EQ(asSet(r), bruteForce(2, 3, H, rhs));
+}
+
+TEST(LatticePoints, Infeasible_xGeq1_AndXLeqMinus1)
+{
+  // x >= 1 AND x <= -1: empty intersection.
+  std::vector<std::vector<int>> H = {{1}, {-1}};
+  std::vector<int> rhs = {1, 1};
+  auto r = latticePoints(1, 2, H, rhs, kBigN, kBigNN);
+  EXPECT_EQ(r.points.size(), 0u);
+  // TODO: assert r.n_nodes >= 1 here once box_enum.h is fixed upstream.
+  // Currently when set_bounds returns 0 at the root, _box_enum_c jumps
+  // straight to its end: label without ever executing `*N_nodes = 1`,
+  // so n_nodes leaks the caller's initial value (0). Issue reported
+  // to the author; one-line fix is to initialize *N_nodes at the top.
+}
+
+// ---------------------------------------------------------------------------
+// Cap behavior:
+//   max_N_out is a soft cap (return partial, no throw)
+//   max_N_nodes is a hard cap (throw runtime_error)
+// ---------------------------------------------------------------------------
+
+TEST(LatticePoints, SoftCap_MaxNOut_ReturnsPartial)
+{
+  // No hyperplanes: full box has 441 points; ask for at most 10.
+  const long cap = 10;
+  auto r = latticePoints(2, 10, {}, {}, cap, kBigNN);
+  EXPECT_EQ(r.points.size(), static_cast<size_t>(cap));
+  // No exception thrown -- if we got here, the soft-cap behavior is intact.
+}
+
+TEST(LatticePoints, SoftCap_MaxNOut_ExactlyAtBound)
+{
+  // Exactly 9 points in [-1,1]^2; cap=9 should not trigger truncation.
+  auto r = latticePoints(2, 1, {}, {}, /*max_N_out*/ 9, kBigNN);
+  EXPECT_EQ(r.points.size(), 9u);
+}
+
+TEST(LatticePoints, HardCap_MaxNNodes_Throws)
+{
+  // Tiny node budget on a problem that expands the search tree past it.
+  EXPECT_THROW(
+      latticePoints(2, 10, {}, {}, kBigN, /*max_N_nodes*/ 5),
+      std::runtime_error);
+}
+
+TEST(LatticePoints, DimTooLarge_Throws)
+{
+  // box_enum's MAX_SUPPORTED_DIM is 256.
+  EXPECT_THROW(
+      latticePoints(/*dim*/ 257, /*B*/ 0, {}, {}, kBigN, kBigNN),
+      std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
+// Input shape errors (caught in the C++ wrapper, before _box_enum_c).
+// ---------------------------------------------------------------------------
+
+TEST(LatticePoints, RhsLengthMismatch_Throws)
+{
+  std::vector<std::vector<int>> H = {{1, 0}, {0, 1}};
+  std::vector<int> rhs = {0};  // length 1, should be 2
+  EXPECT_THROW(
+      latticePoints(2, 1, H, rhs, kBigN, kBigNN),
+      std::runtime_error);
+}
+
+TEST(LatticePoints, HRowLengthMismatch_Throws)
+{
+  std::vector<std::vector<int>> H = {{1, 0, 0}};  // row length 3, dim is 2
+  std::vector<int> rhs = {0};
+  EXPECT_THROW(
+      latticePoints(2, 1, H, rhs, kBigN, kBigNN),
+      std::runtime_error);
+}
+
+// ===========================================================================
+// Engine-wrapper tests for `rawLatticePoints` (interface/cone.h):
+//   - input is two ZZ Matrix*, A (m x dim) and b (m x 1)
+//   - output is a MutableMatrix* over ZZ with dim rows, one col per point
+//   - convention is A*x <= b (the wrapper does the sign flip internally)
+// These exercise the marshaling layer that the pure-C++ tests above bypass:
+// Matrix construction, mpz extraction, ring/shape validation, MutableMatrix
+// construction with globalZZ.
+// ===========================================================================
+
+namespace {
+
+// Build a const Matrix* over globalZZ from a 2D vector of ints.
+const Matrix* makeZZ(const std::vector<std::vector<int>>& rows)
+{
+  const int nrows = static_cast<int>(rows.size());
+  const int ncols = nrows > 0 ? static_cast<int>(rows[0].size()) : 0;
+  MatrixConstructor mat(globalZZ->make_FreeModule(nrows), ncols);
+  for (int i = 0; i < nrows; ++i)
+    for (int j = 0; j < ncols; ++j)
+      mat.set_entry(i, j, globalZZ->from_long(rows[i][j]));
+  return mat.to_matrix();
+}
+
+// Read all columns of a MutableMatrix as lattice points (rows = coords).
+std::set<std::vector<int>> pointsAsSet(const MutableMatrix* M)
+{
+  std::set<std::vector<int>> out;
+  const size_t dim = M->n_rows();
+  const size_t n = M->n_cols();
+  for (size_t c = 0; c < n; ++c)
+    {
+      std::vector<int> p(dim);
+      for (size_t r = 0; r < dim; ++r)
+        {
+          ring_elem v;
+          M->get_entry(r, c, v);
+          p[r] = static_cast<int>(mpz_get_si(v.get_mpz()));
+        }
+      out.insert(std::move(p));
+    }
+  return out;
+}
+
+// Brute-force enumeration in A*x <= b form. Delegates to the H*v >= rhs
+// brute-forcer above by negating: (A,b) for Ax <= b corresponds to (-A,-b)
+// for Hv >= rhs. This keeps a single source-of-truth enumerator and also
+// documents the sign-flip the engine wrapper performs internally.
+std::set<std::vector<int>> bruteForceAxLeqB(
+    int dim, int B,
+    const std::vector<std::vector<int>>& A,
+    const std::vector<int>& b)
+{
+  std::vector<std::vector<int>> H(A.size(), std::vector<int>(dim));
+  std::vector<int> rhs(b.size());
+  for (size_t i = 0; i < A.size(); ++i)
+    {
+      for (int j = 0; j < dim; ++j) H[i][j] = -A[i][j];
+      rhs[i] = -b[i];
+    }
+  return bruteForce(dim, B, H, rhs);
+}
+
+// Read and clear the engine error flag. Returns the message that was set
+// (and "" if no error was set).
+std::string consumeEngineError()
+{
+  if (!error()) return "";
+  return std::string(error_message());  // also clears the flag
+}
+
+}  // namespace
+
+TEST(LatticePointsRaw, Simplex_dim2_B3)
+{
+  // x >= 0, y >= 0, x+y <= 3 in A*x <= b form:
+  //   -x <= 0, -y <= 0, x+y <= 3.  Count = C(5,2) = 10.
+  std::vector<std::vector<int>> A = {{-1, 0}, {0, -1}, {1, 1}};
+  std::vector<int> b = {0, 0, 3};
+  const Matrix* Am = makeZZ(A);
+  const Matrix* bm = makeZZ({{0}, {0}, {3}});
+
+  MutableMatrix* M = rawLatticePoints(Am, bm, /*B*/ 3, kBigN, kBigNN);
+  ASSERT_NE(M, nullptr);
+  EXPECT_EQ(M->n_rows(), 2u);
+  EXPECT_EQ(M->n_cols(), 10u);
+  EXPECT_EQ(pointsAsSet(M), bruteForceAxLeqB(2, 3, A, b));
+}
+
+TEST(LatticePointsRaw, HalfPlane_xPlusY_geq_0)
+{
+  // x + y >= 0 in [-2,2]^2, written A*x <= b:  -x - y <= 0.  Count = 15.
+  std::vector<std::vector<int>> A = {{-1, -1}};
+  std::vector<int> b = {0};
+  const Matrix* Am = makeZZ(A);
+  const Matrix* bm = makeZZ({{0}});
+
+  MutableMatrix* M = rawLatticePoints(Am, bm, /*B*/ 2, kBigN, kBigNN);
+  ASSERT_NE(M, nullptr);
+  EXPECT_EQ(M->n_rows(), 2u);
+  EXPECT_EQ(M->n_cols(), 15u);
+  EXPECT_EQ(pointsAsSet(M), bruteForceAxLeqB(2, 2, A, b));
+}
+
+TEST(LatticePointsRaw, MatchesSmokeExample)
+{
+  // Same shape as the M2-side smoke test: x <= 2, y <= 2, x+y >= 0 in [-5,5]^2.
+  std::vector<std::vector<int>> A = {{1, 0}, {0, 1}, {-1, -1}};
+  std::vector<int> b = {2, 2, 0};
+  const Matrix* Am = makeZZ(A);
+  const Matrix* bm = makeZZ({{2}, {2}, {0}});
+
+  MutableMatrix* M = rawLatticePoints(Am, bm, /*B*/ 5, kBigN, kBigNN);
+  ASSERT_NE(M, nullptr);
+  EXPECT_EQ(M->n_cols(), 15u);
+  EXPECT_EQ(pointsAsSet(M), bruteForceAxLeqB(2, 5, A, b));
+}
+
+TEST(LatticePointsRaw, NonZZ_b_Errors)
+{
+  // b over a finite-field ring should be rejected with a clear engine error.
+  const Matrix* Am = makeZZ({{1, 0}, {0, 1}});
+
+  Ring* Fp = Z_mod::create(101);
+  MatrixConstructor bcon(Fp->make_FreeModule(2), 1);
+  bcon.set_entry(0, 0, Fp->from_long(2));
+  bcon.set_entry(1, 0, Fp->from_long(2));
+  const Matrix* bm = bcon.to_matrix();
+
+  MutableMatrix* M = rawLatticePoints(Am, bm, 3, kBigN, kBigNN);
+  EXPECT_EQ(M, nullptr);
+  std::string msg = consumeEngineError();
+  EXPECT_NE(msg.find("over ZZ"), std::string::npos) << "msg was: " << msg;
+}
+
+TEST(LatticePointsRaw, WrongShape_b_Errors)
+{
+  // b given as a 1x2 row matrix instead of 2x1 column matrix.
+  const Matrix* Am = makeZZ({{1, 0}, {0, 1}});
+  const Matrix* bm_row = makeZZ({{2, 2}});  // 1 row, 2 cols
+
+  MutableMatrix* M = rawLatticePoints(Am, bm_row, 3, kBigN, kBigNN);
+  EXPECT_EQ(M, nullptr);
+  std::string msg = consumeEngineError();
+  EXPECT_NE(msg.find("column matrix"), std::string::npos)
+      << "msg was: " << msg;
+}
+
+TEST(LatticePointsRaw, BigInt_b_Errors)
+{
+  // b entry that doesn't fit in a C int.
+  const Matrix* Am = makeZZ({{1, 0}, {0, 1}});
+  MatrixConstructor bcon(globalZZ->make_FreeModule(2), 1);
+  mpz_t big;
+  mpz_init(big);
+  mpz_ui_pow_ui(big, 2, 40);  // 2^40, well above INT_MAX
+  bcon.set_entry(0, 0, globalZZ->from_int(big));
+  bcon.set_entry(1, 0, globalZZ->from_long(0));
+  mpz_clear(big);
+  const Matrix* bm = bcon.to_matrix();
+
+  MutableMatrix* M = rawLatticePoints(Am, bm, 3, kBigN, kBigNN);
+  EXPECT_EQ(M, nullptr);
+  std::string msg = consumeEngineError();
+  EXPECT_NE(msg.find("does not fit"), std::string::npos)
+      << "msg was: " << msg;
+}
+
+// ===========================================================================
+// Pure-C++ tests for `M2::cytools::latticePointsNormaliz` (Normaliz-backed,
+// in cytools/lattice-points-normaliz.hpp).
+//
+// Convention: A*x <= b natively (matches the engine wrapper). Inputs and
+// outputs are mpz_class so big integers are handled without overflow.
+// ===========================================================================
+
+namespace {
+
+std::vector<std::vector<mpz_class>> toMpz(
+    const std::vector<std::vector<int>>& A)
+{
+  std::vector<std::vector<mpz_class>> out(A.size());
+  for (size_t i = 0; i < A.size(); ++i)
+    out[i].assign(A[i].begin(), A[i].end());
+  return out;
+}
+
+std::vector<mpz_class> toMpz(const std::vector<int>& v)
+{
+  return std::vector<mpz_class>(v.begin(), v.end());
+}
+
+std::set<std::vector<int>> asIntSet(const LatticePointsNormalizResult& r)
+{
+  std::set<std::vector<int>> out;
+  for (const auto& p : r.points)
+    {
+      std::vector<int> q;
+      q.reserve(p.size());
+      for (const auto& x : p) q.push_back(static_cast<int>(x.get_si()));
+      out.insert(std::move(q));
+    }
+  return out;
+}
+
+// Append rows |x_i| <= B (i.e., x_i <= B and -x_i <= B) to (A, b). Used to
+// make a polytope bounded so Normaliz can enumerate.
+void addBox(int dim, int B,
+            std::vector<std::vector<int>>& A,
+            std::vector<int>& b)
+{
+  for (int i = 0; i < dim; ++i)
+    {
+      std::vector<int> rowPos(dim, 0);
+      rowPos[i] = 1;
+      A.push_back(rowPos);
+      b.push_back(B);
+      std::vector<int> rowNeg(dim, 0);
+      rowNeg[i] = -1;
+      A.push_back(rowNeg);
+      b.push_back(B);
+    }
+}
+
+}  // namespace
+
+TEST(LatticePointsNormaliz, BoxOnly_dim2_B1)
+{
+  // No "real" inequalities, just |x_i| <= 1: 9 points.
+  std::vector<std::vector<int>> A;
+  std::vector<int> b;
+  addBox(2, 1, A, b);
+
+  auto r = latticePointsNormaliz(2, toMpz(A), toMpz(b));
+  EXPECT_EQ(r.points.size(), 9u);
+  EXPECT_EQ(asIntSet(r), bruteForceAxLeqB(2, 1, A, b));
+}
+
+TEST(LatticePointsNormaliz, Simplex_dim2_B3)
+{
+  // Standard simplex {x>=0, y>=0, x+y<=3}, count = C(5,2) = 10.
+  std::vector<std::vector<int>> A = {{-1, 0}, {0, -1}, {1, 1}};
+  std::vector<int> b = {0, 0, 3};
+
+  auto r = latticePointsNormaliz(2, toMpz(A), toMpz(b));
+  EXPECT_EQ(r.points.size(), 10u);
+  EXPECT_EQ(asIntSet(r), bruteForceAxLeqB(2, 3, A, b));
+}
+
+TEST(LatticePointsNormaliz, MixedSignsAndRhs_with_box)
+{
+  // 2x - y <= 3 and -x + 2y <= 1 in [-3,3]^2. No closed-form count -- we
+  // just check agreement with brute force, locking in the sign convention.
+  std::vector<std::vector<int>> A = {{2, -1}, {-1, 2}};
+  std::vector<int> b = {3, 1};
+  addBox(2, 3, A, b);
+
+  auto r = latticePointsNormaliz(2, toMpz(A), toMpz(b));
+  EXPECT_EQ(asIntSet(r), bruteForceAxLeqB(2, 3, A, b));
+}
+
+TEST(LatticePointsNormaliz, AgreesWithBoxEnum_Simplex_dim3)
+{
+  // Cross-check: the same simplex through both helpers must give the same
+  // answer. (LatticePoints test "Simplex_dim3_B3" hits 20 points.)
+  std::vector<std::vector<int>> A = {{-1, 0, 0}, {0, -1, 0}, {0, 0, -1},
+                                     {1, 1, 1}};
+  std::vector<int> b = {0, 0, 0, 3};
+
+  auto rNm = latticePointsNormaliz(3, toMpz(A), toMpz(b));
+  auto rBox = latticePoints(3, /*B*/ 3,
+                            /*H*/ {{1, 0, 0}, {0, 1, 0}, {0, 0, 1},
+                                   {-1, -1, -1}},
+                            /*rhs*/ {0, 0, 0, -3},
+                            kBigN, kBigNN);
+
+  EXPECT_EQ(rNm.points.size(), 20u);
+  EXPECT_EQ(rBox.points.size(), 20u);
+  EXPECT_EQ(asIntSet(rNm),
+            std::set<std::vector<int>>(rBox.points.begin(), rBox.points.end()));
+}
+
+TEST(LatticePointsNormaliz, Unbounded_Throws)
+{
+  // x >= 0 in dim=1 is unbounded. libnormaliz does NOT throw for
+  // unbounded inhom_inequalities -- it silently returns just the
+  // polytope's vertex lattice points -- so latticePointsNormaliz checks
+  // RecessionRank explicitly and re-raises as runtime_error.
+  std::vector<std::vector<mpz_class>> A = {{mpz_class(-1)}};
+  std::vector<mpz_class> b = {mpz_class(0)};
+
+  try
+    {
+      latticePointsNormaliz(1, A, b);
+      FAIL() << "expected std::runtime_error for unbounded polyhedron";
+  } catch (const std::runtime_error& e)
+    {
+      std::string msg(e.what());
+      EXPECT_NE(msg.find("unbounded"), std::string::npos)
+          << "msg was: " << msg;
+  }
+}
+
+TEST(LatticePointsNormaliz, UnboundedRay_Throws)
+{
+  // 2D unbounded: x >= 0, y == 0 (via y <= 0 and -y <= 0). Recession rank 1.
+  std::vector<std::vector<mpz_class>> A = {
+      {mpz_class(-1), mpz_class(0)},
+      {mpz_class(0), mpz_class(1)},
+      {mpz_class(0), mpz_class(-1)}};
+  std::vector<mpz_class> b = {mpz_class(0), mpz_class(0), mpz_class(0)};
+
+  EXPECT_THROW(latticePointsNormaliz(2, A, b), std::runtime_error);
+}
+
+TEST(LatticePointsNormaliz, BigInt_RhsAccepted)
+{
+  // b entry of 2^40 -- box_enum would reject this (fits-in-int check),
+  // Normaliz must accept it. We use a tiny constraint set so the polytope
+  // collapses to one point at the origin via a tight box around it.
+  std::vector<std::vector<mpz_class>> A = {
+      {mpz_class(1), mpz_class(0)}, {mpz_class(-1), mpz_class(0)},
+      {mpz_class(0), mpz_class(1)}, {mpz_class(0), mpz_class(-1)}};
+  mpz_class big = mpz_class(1) << 40;  // 2^40, > INT_MAX
+  std::vector<mpz_class> b = {mpz_class(0), mpz_class(0),
+                              mpz_class(0), big};
+  // Constraints: x <= 0, x >= 0, y <= 0, y >= -2^40.
+  // Lattice points: (0, y) for y in [-2^40, 0] -- way too many to enumerate.
+  // Tighten with a finite box on y so we can count.
+  A.push_back({mpz_class(0), mpz_class(1)});  b.push_back(mpz_class(2));
+  A.push_back({mpz_class(0), mpz_class(-1)}); b.push_back(mpz_class(2));
+  // Now lattice points are (0, y) for y in [-2, 0]: 3 points.
+
+  auto r = latticePointsNormaliz(2, A, b);
+  EXPECT_EQ(r.points.size(), 3u);
+}
+
+TEST(LatticePointsNormaliz, ShapeMismatch_Throws)
+{
+  std::vector<std::vector<mpz_class>> A = {
+      {mpz_class(1), mpz_class(0)}, {mpz_class(0), mpz_class(1)}};
+  std::vector<mpz_class> b = {mpz_class(0)};  // length 1, should be 2
+  EXPECT_THROW(latticePointsNormaliz(2, A, b), std::runtime_error);
+}
+
+TEST(LatticePointsNormaliz, RowLengthMismatch_Throws)
+{
+  std::vector<std::vector<mpz_class>> A = {
+      {mpz_class(1), mpz_class(0), mpz_class(0)}};  // length 3, dim is 2
+  std::vector<mpz_class> b = {mpz_class(0)};
+  EXPECT_THROW(latticePointsNormaliz(2, A, b), std::runtime_error);
+}
+
+// ===========================================================================
+// Engine-wrapper tests for `rawLatticePointsNormaliz` (interface/cone.h).
+// Same shape as LatticePointsRaw above, exercising the marshaling layer
+// (mpz <-> mpz_class, MutableMatrix construction, ring/shape validation).
+// ===========================================================================
+
+TEST(LatticePointsNormalizRaw, Simplex_dim2_B3)
+{
+  // Standard simplex {x>=0, y>=0, x+y<=3}, count = C(5,2) = 10.
+  std::vector<std::vector<int>> A = {{-1, 0}, {0, -1}, {1, 1}};
+  std::vector<int> b = {0, 0, 3};
+  const Matrix* Am = makeZZ(A);
+  const Matrix* bm = makeZZ({{0}, {0}, {3}});
+
+  MutableMatrix* M = rawLatticePointsNormaliz(Am, bm);
+  ASSERT_NE(M, nullptr);
+  EXPECT_EQ(M->n_rows(), 2u);
+  EXPECT_EQ(M->n_cols(), 10u);
+  EXPECT_EQ(pointsAsSet(M), bruteForceAxLeqB(2, 3, A, b));
+}
+
+TEST(LatticePointsNormalizRaw, MatchesBoxEnumWrapper)
+{
+  // Same input through both engine wrappers: rawLatticePoints (with a B
+  // large enough to be non-binding) and rawLatticePointsNormaliz must
+  // produce the same set of points.
+  std::vector<std::vector<int>> A = {{1, 0}, {0, 1}, {-1, -1}};
+  std::vector<int> b = {2, 2, 0};
+  const Matrix* Am = makeZZ(A);
+  const Matrix* bm = makeZZ({{2}, {2}, {0}});
+
+  MutableMatrix* M_box = rawLatticePoints(Am, bm, /*B*/ 5, kBigN, kBigNN);
+  MutableMatrix* M_nmz = rawLatticePointsNormaliz(Am, bm);
+  ASSERT_NE(M_box, nullptr);
+  ASSERT_NE(M_nmz, nullptr);
+  EXPECT_EQ(pointsAsSet(M_box), pointsAsSet(M_nmz));
+}
+
+TEST(LatticePointsNormalizRaw, BigInt_b_Accepted)
+{
+  // rawLatticePoints would error ("entry of b does not fit") on a 2^40 in b;
+  // the Normaliz wrapper must accept it. We keep the polytope a single point
+  // by pinning x = y = 0 with the first four constraints, then add a fifth
+  // non-binding constraint that carries the 2^40 entry. Expected: 1 point.
+  const Matrix* Am = makeZZ({{1, 0}, {-1, 0}, {0, 1}, {0, -1}, {1, 0}});
+
+  MatrixConstructor bcon(globalZZ->make_FreeModule(5), 1);
+  bcon.set_entry(0, 0, globalZZ->from_long(0));   // x <=  0
+  bcon.set_entry(1, 0, globalZZ->from_long(0));   // -x <= 0
+  bcon.set_entry(2, 0, globalZZ->from_long(0));   // y <=  0
+  bcon.set_entry(3, 0, globalZZ->from_long(0));   // -y <= 0
+  mpz_t big;
+  mpz_init(big);
+  mpz_ui_pow_ui(big, 2, 40);
+  bcon.set_entry(4, 0, globalZZ->from_int(big));  // x <= 2^40 (non-binding)
+  mpz_clear(big);
+  const Matrix* bm = bcon.to_matrix();
+
+  MutableMatrix* M = rawLatticePointsNormaliz(Am, bm);
+  ASSERT_NE(M, nullptr);
+  EXPECT_EQ(M->n_cols(), 1u);
+  std::set<std::vector<int>> expected = {{0, 0}};
+  EXPECT_EQ(pointsAsSet(M), expected);
+}
+
+TEST(LatticePointsNormalizRaw, Unbounded_Errors)
+{
+  // x >= 0 in dim=1, no upper bound.
+  const Matrix* Am = makeZZ({{-1}});
+  const Matrix* bm = makeZZ({{0}});
+
+  MutableMatrix* M = rawLatticePointsNormaliz(Am, bm);
+  EXPECT_EQ(M, nullptr);
+  std::string msg = consumeEngineError();
+  EXPECT_NE(msg.find("unbounded"), std::string::npos) << "msg was: " << msg;
+}
+
+TEST(LatticePointsNormalizRaw, NonZZ_b_Errors)
+{
+  const Matrix* Am = makeZZ({{1, 0}, {0, 1}});
+
+  Ring* Fp = Z_mod::create(101);
+  MatrixConstructor bcon(Fp->make_FreeModule(2), 1);
+  bcon.set_entry(0, 0, Fp->from_long(2));
+  bcon.set_entry(1, 0, Fp->from_long(2));
+  const Matrix* bm = bcon.to_matrix();
+
+  MutableMatrix* M = rawLatticePointsNormaliz(Am, bm);
+  EXPECT_EQ(M, nullptr);
+  std::string msg = consumeEngineError();
+  EXPECT_NE(msg.find("over ZZ"), std::string::npos) << "msg was: " << msg;
+}
+
+TEST(LatticePointsNormalizRaw, WrongShape_b_Errors)
+{
+  const Matrix* Am = makeZZ({{1, 0}, {0, 1}});
+  const Matrix* bm_row = makeZZ({{2, 2}});  // 1 x 2 instead of 2 x 1
+
+  MutableMatrix* M = rawLatticePointsNormaliz(Am, bm_row);
+  EXPECT_EQ(M, nullptr);
+  std::string msg = consumeEngineError();
+  EXPECT_NE(msg.find("column matrix"), std::string::npos)
+      << "msg was: " << msg;
+}

--- a/M2/Macaulay2/e/unit-tests/Makefile.files
+++ b/M2/Macaulay2/e/unit-tests/Makefile.files
@@ -30,7 +30,8 @@ UNITTEST_CCFILES := \
     MonoidTest \
     MatrixIOTest \
     RingRRRTest \
-    RingCCCTest
+    RingCCCTest \
+    LatticePointsTest
 
 #    WeylAlgebraTest \ # TODO: add in this file
 

--- a/M2/Macaulay2/packages/Topcom.m2
+++ b/M2/Macaulay2/packages/Topcom.m2
@@ -120,6 +120,11 @@ callTopcom(String, List) := (command, inputs) -> (
 
 topcomIsRegularTriangulation = method(Options=>{Homogenize=>true})
 topcomIsRegularTriangulation(Matrix, List) := Boolean => opts -> (A, tri) -> (
+    -- Trivial case: linearly independent columns => unique single-simplex triangulation;
+    -- topcom can hang on this, so handle it here.
+    A1 := if opts.Homogenize then augment A else A;
+    if rank A1 == numColumns A1 then
+        return #tri == 1 and sort tri#0 == toList(0 .. numColumns A1 - 1);
     -- now create the output file
     (outfile, errfile) := callTopcom("checkregularity --checktriang -v", {topcomPoints(A, opts), [], tri });
     match("[Cc]hecked 1 triangulations, 0 non-regular so far", get errfile)
@@ -134,8 +139,14 @@ topcomIsRegularTriangulation(Matrix, List) := Boolean => opts -> (A, tri) -> (
 topcomRegularTriangulationWeights = method(Options => options topcomIsRegularTriangulation)
 topcomRegularTriangulationWeights(Matrix, List) := List => opts -> (A, tri) -> (
     -- returns null if the triangulation is not regular.
-    -- otherwise returns a list of rational numbers which are the 
+    -- otherwise returns a list of rational numbers which are the
     -- heights that result in the triangulation.
+    A1 := if opts.Homogenize then augment A else A;
+    if rank A1 == numColumns A1 then (
+        n := numColumns A1;
+        if #tri == 1 and sort tri#0 == toList(0 .. n - 1) then return toList(n : 0)
+        else return null;
+        );
     (outfile, errfile) := callTopcom("checkregularity --heights", {topcomPoints(A, opts), [], tri });
     output := get outfile;
     if match("non-regular", output) then return null;
@@ -149,6 +160,8 @@ topcomRegularTriangulationWeights(Matrix, List) := List => opts -> (A, tri) -> (
 
 topcomRegularFineTriangulation = method(Options => options topcomIsRegularTriangulation)
 topcomRegularFineTriangulation Matrix := List => opts -> (A) -> (
+    A1 := if opts.Homogenize then augment A else A;
+    if rank A1 == numColumns A1 then return {toList(0 .. numColumns A1 - 1)};
     (outfile,errfile) := callTopcom("points2finetriang --regular", {topcomPoints(A, opts)});
     value get outfile
     )
@@ -246,6 +259,8 @@ topcomAllTriangulations = method(Options => {
     })
 topcomAllTriangulations Matrix := List => opts -> (A) -> (
     if not opts.ConnectedToRegular and opts.RegularOnly then error "cannot have both RegularOnly=>true and ConnectedToRegular=>false";
+    A1 := if opts.Homogenize then augment A else A;
+    if rank A1 == numColumns A1 then return {{toList(0 .. numColumns A1 - 1)}};
     executable := allTriangsExecutable#(opts.Fine, opts.ConnectedToRegular);
     args := if opts.RegularOnly then " --regular" else "";
     (outfile, errfile) := callTopcom(executable | args, {topcomPoints(A, Homogenize=>opts.Homogenize)});
@@ -262,6 +277,8 @@ topcomAllTriangulations Matrix := List => opts -> (A) -> (
 topcomNumTriangulations = method(Options => {Homogenize=>true, RegularOnly => true, Fine => false, ConnectedToRegular => true})
 topcomNumTriangulations Matrix := ZZ => opts -> (A) -> (
     if not opts.ConnectedToRegular and opts.RegularOnly then error "cannot have both RegularOnly=>true and ConnectedToRegular=>false";
+    A1 := if opts.Homogenize then augment A else A;
+    if rank A1 == numColumns A1 then return 1;
     executable := numTriangsExecutable#(opts.Fine, opts.ConnectedToRegular);
     args := if opts.RegularOnly then " --regular" else "";
     (outfile, errfile) := callTopcom(executable | args, {topcomPoints(A, Homogenize=>opts.Homogenize)});
@@ -270,6 +287,8 @@ topcomNumTriangulations Matrix := ZZ => opts -> (A) -> (
 
 topcomNumFlips = method(Options => {Homogenize=>true, RegularOnly =>true})
 topcomNumFlips(Matrix, List) := ZZ => opts -> (A, tri) -> (
+    A1 := if opts.Homogenize then augment A else A;
+    if rank A1 == numColumns A1 then return 0;
     executable := "points2nflips";
     args := if opts.RegularOnly then " --regular" else "";
     (outfile, errfile) := callTopcom(executable | args, {topcomPoints(A, Homogenize=>opts.Homogenize), [], tri});
@@ -278,6 +297,8 @@ topcomNumFlips(Matrix, List) := ZZ => opts -> (A, tri) -> (
 
 topcomFlips = method(Options => {Homogenize=>true, RegularOnly =>true})
 topcomFlips(Matrix, List) := List => opts -> (A, tri) -> (
+    A1 := if opts.Homogenize then augment A else A;
+    if rank A1 == numColumns A1 then return {};
     executable := "points2flips";
     args := if opts.RegularOnly then " --regular" else "";
     (outfile, errfile) := callTopcom(executable | args, {topcomPoints(A, Homogenize=>opts.Homogenize), [], tri});
@@ -1208,6 +1229,35 @@ restart
  topcomNumTriangulations(LP)
  topcomAllTriangulations(LP);
 
+///
+
+TEST ///
+-- Trivial-config short-circuit: when the (homogenized) matrix has linearly
+-- independent columns, the unique triangulation is the single full simplex.
+-- Topcom's points2finetriangs has been observed to hang on this corner case,
+-- so the interface handles it directly.
+-*
+  restart
+  needsPackage "Topcom"
+*-
+  -- 4x4 vector configuration: columns are linearly independent
+  A = id_(ZZ^4)
+  assert(topcomRegularFineTriangulation(A, Homogenize => false) === {{0,1,2,3}})
+  assert(topcomAllTriangulations(A, Homogenize => false) === {{{0,1,2,3}}})
+  assert(topcomNumTriangulations(A, Homogenize => false) === 1)
+  assert(topcomIsRegularTriangulation(A, {{0,1,2,3}}, Homogenize => false))
+  assert(not topcomIsRegularTriangulation(A, {{0,1,2}}, Homogenize => false))
+  assert(topcomRegularTriangulationWeights(A, {{0,1,2,3}}, Homogenize => false) === {0,0,0,0})
+  assert(topcomRegularTriangulationWeights(A, {{0,1,2}}, Homogenize => false) === null)
+  assert(topcomNumFlips(A, {{0,1,2,3}}, Homogenize => false) === 0)
+  assert(topcomFlips(A, {{0,1,2,3}}, Homogenize => false) === {})
+
+  -- 3-point set forming an affinely independent simplex (point set, Homogenize => true).
+  -- After augment, the matrix is 3x3 with rank 3.
+  B = transpose matrix{{0,0},{1,0},{0,1}}
+  assert(topcomNumTriangulations B === 1)
+  assert(topcomAllTriangulations B === {{{0,1,2}}})
+  assert(topcomRegularFineTriangulation B === {{0,1,2}})
 ///
 
 end----------------------------------------------------

--- a/M2/Macaulay2/packages/undistributed-packages/GenerateD.m2
+++ b/M2/Macaulay2/packages/undistributed-packages/GenerateD.m2
@@ -35,8 +35,18 @@ celltype = new HashTable from {
         Synonym => "a small integer", 
         Suffix => "",
         Array => (
-            "isInt",
-            "toInt",
+            "isSmallInt",
+            "getSmallInt",
+            "a small integer"
+            )
+        },
+    "ints" => hashTable {
+        DType => "ZZCell",
+        Synonym => "a sequence of small integers", 
+        Suffix => "",
+        Array => (
+            "isSequenceOfSmallIntegers",
+            "getSequenceOfSmallIntegers",
             "a small integer"
             )
         },
@@ -119,6 +129,12 @@ celltype = new HashTable from {
         DType => "RawMutableMatrixCell",
         Synonym => "a raw mutable matrix", 
         Suffix => ".p"
+        },
+    "MutableMatrixOrNull" => hashTable {
+        DType => "RawMutableMatrixOrNull",
+        Synonym => "a raw mutable matrix or null", 
+        Prefix => "&",
+        Suffix => ""
         },
     "MutableComplex" => hashTable {
         DType => "RawMutableComplexCell",
@@ -220,10 +236,26 @@ genArg(ZZ,String,String) := (argnum, argtype, argname) -> (innards) -> (
             ") else WrongArgZZ("|argnum|")"
             }
         )
+    else if argtype == "ints" then (
+        {
+            "if isSequenceOfSmallIntegers(s."|argnum|") then ("|argname|" := getSequenceOfSmallIntegers(s."|argnum|");",
+            innards,
+            ") else WrongArg("|argnum|", \"a sequence of small integers\")"
+            }
+        )
     else if argtype == "ulong" then (
         {
             "when s."|argnum|" is w"|argname|":ZZcell do (", 
             "if isULong(w"|argname|") then ("|argname|" := toULong(w"|argname|");",
+            innards,
+            ") else WrongArgSmallInteger("|argnum|")",
+            ") else WrongArgZZ("|argnum|")"
+            }
+        )
+    else if argtype == "long" then (
+        {
+            "when s."|argnum|" is w"|argname|":ZZcell do (", 
+            "if isLong(w"|argname|") then ("|argname|" := toLong(w"|argname|");",
             innards,
             ") else WrongArgSmallInteger("|argnum|")",
             ") else WrongArgZZ("|argnum|")"
@@ -309,6 +341,50 @@ ans2 = ///export rawMatrixRowSwap(e:Expr):Expr := (
   ) else WrongNumArgs(3)
   );
 setupfun("rawMatrixRowSwap",rawMatrixRowSwap);
+///
+
+TEST ///
+restart
+debug needsPackage "GenerateD"
+-- note: e is not allowed as a variable name, as we use e as the input expression!
+result = str (genFunctionCall(
+        "rawGVInvariants", 
+        "MutableMatrixOrNull", 
+        ("curves"=>"ints", "lightcone"=>"ints", "grading"=>"ints", "Q"=>"ints", "nefPartition"=>"ints", "intnums"=>"ints", "settings"=>"ints")
+        ))
+///
+
+TEST ///
+restart
+debug needsPackage "GenerateD"
+-- note: e is not allowed as a variable name, as we use e as the input expression!
+result = str (genFunctionCall(
+        "rawConeInteriorPoint", 
+        "MutableMatrixOrNull",
+        toSequence {"C"=>"Matrix"}
+        ))
+///
+
+TEST ///
+restart
+debug needsPackage "GenerateD"
+-- note: e is not allowed as a variable name, as we use e as the input expression!
+result = str (genFunctionCall(
+        "rawLatticePoints",
+        "MutableMatrixOrNull",
+        ("a"=>"Matrix", "b"=>"Matrix", "c"=>"int", "d"=>"long", "f"=>"long")
+        ))
+///
+
+TEST ///
+restart
+debug needsPackage "GenerateD"
+-- note: e is not allowed as a variable name, as we use e as the input expression!
+result = str (genFunctionCall(
+        "rawLatticePointsNormaliz",
+        "MutableMatrixOrNull",
+        ("a"=>"Matrix", "b"=>"Matrix")
+        ))
 ///
 
 TEST ///

--- a/M2/Macaulay2/tests/normal/cones.m2
+++ b/M2/Macaulay2/tests/normal/cones.m2
@@ -1,0 +1,104 @@
+-- Tests for the engine cone routines in Macaulay2/e/interface/cone.h:
+--   rawFourierMotzkin, rawHilbertBasis, rawConeInteriorPoint,
+--   rawLatticePoints, rawLatticePointsNormaliz, rawGVInvariants.
+
+debug Core
+
+------------------------------------------------------------
+-- rawFourierMotzkin
+-- Input: rows of A are inequalities of the cone {x : A x <= 0}.
+-- Output: rows are the extreme rays of that cone.
+------------------------------------------------------------
+A = matrix {{1,1,1}, {-1,1,0}, {-1,0,1}, {1,2,3}}
+B = map(ZZ, rawFourierMotzkin raw A)
+assert(set entries B === set {{-1,-1,-1}, {1,-2,1}, {1,1,-2}})
+-- Sanity: every ray r satisfies A r <= 0.
+assert all(flatten entries (A * transpose B), x -> x <= 0)
+
+------------------------------------------------------------
+-- rawHilbertBasis
+-- Input: rows of C are cone rays.
+-- Output: rows are the Hilbert basis of that cone.
+------------------------------------------------------------
+C = matrix {{1,0}, {1,2}}
+HB = map(ZZ, rawHilbertBasis raw C)
+assert(set entries HB === set {{1,0}, {1,1}, {1,2}})
+
+------------------------------------------------------------
+-- rawConeInteriorPoint
+-- Output is a 1-row matrix over RR(53):
+--   full-dim:    [1, tStar, x_1, ..., x_n]
+--   not full-dim: [0, tStar, y_1, ..., y_m]  with y >= 0 and y^T A = 0.
+------------------------------------------------------------
+-- Full-dimensional: first octant in QQ^3.
+A = matrix {{-1,0,0}, {0,-1,0}, {0,0,-1}}
+cipResult = flatten entries map(RR_53, rawConeInteriorPoint raw A)
+assert(cipResult#0 == 1.0)
+assert(cipResult#1 > 0)
+interior = drop(cipResult, 2)
+assert(#interior == 3)
+-- Each row of A applied to the interior point should be strictly < 0.
+assert all(flatten entries (A * transpose matrix {interior}), v -> v < 0)
+
+-- Not full-dimensional: positive y-axis in QQ^2.
+A = matrix {{1,0}, {-1,0}, {0,-1}}
+cipResult = flatten entries map(RR_53, rawConeInteriorPoint raw A)
+assert(cipResult#0 == 0.0)
+y = drop(cipResult, 2)
+assert(#y == 3)
+assert all(y, v -> v >= 0)
+-- y^T A = 0
+assert all(flatten entries (matrix {y} * (A ** RR_53)), v -> abs v < 1e-8)
+
+------------------------------------------------------------
+-- rawLatticePoints
+-- Enumerates integer x with A x <= b and |x_i| <= B.
+------------------------------------------------------------
+A = matrix {{1,1,1}}
+b = matrix {{-2}}
+LP = map(ZZ, rawLatticePoints(raw A, raw b, 1, 100, 1000))
+assert(numrows LP == 3)
+assert(numcols LP == 4)
+assert(set entries transpose LP === set {{-1,-1,-1}, {0,-1,-1}, {-1,0,-1}, {-1,-1,0}})
+
+------------------------------------------------------------
+-- rawLatticePointsNormaliz
+-- Enumerates ALL integer x with A x <= b (polyhedron must be bounded).
+------------------------------------------------------------
+A = matrix {{1,0}, {0,1}, {-1,0}, {0,-1}}
+b = matrix {{1}, {1}, {0}, {0}}
+LP = map(ZZ, rawLatticePointsNormaliz(raw A, raw b))
+assert(numrows LP == 2)
+assert(numcols LP == 4)
+assert(set entries transpose LP === set {{0,0}, {0,1}, {1,0}, {1,1}})
+
+------------------------------------------------------------
+-- rawGVInvariants
+-- Computes Gopakumar-Vafa invariants of a Calabi-Yau threefold.
+-- M2_arrayint inputs use the length-prefix-per-row encoding.
+------------------------------------------------------------
+encodeArrayArrayInt = method()
+encodeArrayArrayInt List := List => L -> (
+    parts := flatten for i from 0 to #L - 1 list prepend(#L#i, L#i);
+    prepend(#L, parts))
+
+mori       = encodeArrayArrayInt {{-1,3,-1},{0,-2,1},{1,2,-1}}
+lightcone  = encodeArrayArrayInt {}
+gradingvec = {2, 4, 9}
+Q          = encodeArrayArrayInt {{1,0,0,0,1,0,1},{0,1,0,1,0,1,1},
+                                  {0,0,1,3,1,2,2}}
+nefpart    = encodeArrayArrayInt {}
+intnums    = encodeArrayArrayInt {{0,0,0,-1},{0,1,1,-2},{0,1,2,1},
+                                  {1,1,1,8},{1,1,2,-4},{1,2,2,2},
+                                  {2,2,2,-1}}
+settings   = {6, 150, 0, 300000}
+
+GV = transpose map(ZZ, rawGVInvariants(mori, lightcone, gradingvec, Q,
+                                       nefpart, intnums, settings))
+-- 19 (curve, GV) tuples; each row is [c_1, c_2, c_3, GV(c)].
+assert(numcols GV == 4)
+assert(numrows GV == 19)
+-- Spot-check a few specific (curve, GV) pairs.
+assert(member({1,0,0,126},   entries GV))
+assert(member({0,1,0,580},   entries GV))
+assert(member({1,1,0,20615}, entries GV))

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -10,7 +10,7 @@
 # Others, like TBB::tbb, FFI::ffi, and Boost::regex, are linked as imported libraries in those files.
 # TODO: turn all these libraries into imported libraries and find incompatibilities another way.
 set(PKGLIB_LIST    FFLAS_FFPACK GIVARO)
-set(LIBRARIES_LIST MPSOLVE FROBBY NORMALIZ FACTORY FLINT NTL MPFI MPFR GMP BDWGC LAPACK)
+set(LIBRARIES_LIST MPSOLVE FROBBY NORMALIZ FACTORY FLINT NTL MPFI MPFR GMP GLPK BDWGC LAPACK)
 set(LIBRARY_LIST   READLINE HISTORY GDBM JANSSON)
 
 message(CHECK_START " Checking for existing libraries and programs")


### PR DESCRIPTION
Add some normaliz, some cytools (lattice points, via Nate MacFadden's… box_enum.h, and Andres Rios-Tascon's computeGV), and one call to GLPK for determining if a cone is full dimensional.

This PR adds in 4 "raw" function calls that can be used: 2 different lattice point enumeration functions, one interior point function, and a function which computes Gopakumar-Vafa invariants for Calabi-Yau hypersurfaces in a toric variety.

Doxygen style comments for these and the 2 previous functions `rawFourierMotzkin` and `rawHilbertBasis` are included, as are tests in `Macaulay2/tests/normal/cones.m2`.  A first start on unit tests for these (for 2 of the 6 functions present) is included too.

Some fixes to Topcom too.  We now link with libglpk.  

This PR is in preparation for the StringTorics package (to be included soon, with new Triangulations package too).  Later, we might decide to use another linear program solver to link with, but for now, glpk which is already available, is what I used.

