### PR TITLE
Clean up compiler warnings in the d directory

### DIFF
--- a/M2/Macaulay2/c/chk.c
+++ b/M2/Macaulay2/c/chk.c
@@ -2402,8 +2402,10 @@ node chk(node e, scope v){
 	       node sym = lookupword(e);
 	       if (sym == NULL)
 		    sym = newsymbol(e,deferred__T,v,intern_F);
-	       else if (sym->body.symbol.flags & macro_variable_F) {
-		    sym = chk(sym->body.symbol.body,v);
+	       else {
+		    sym->body.symbol.flags |= used_F; /* track usage for unused parameter detection */
+		    if (sym->body.symbol.flags & macro_variable_F)
+			 sym = chk(sym->body.symbol.body,v);
 		    }
 	       return repos(e,sym);
 	       }

--- a/M2/Macaulay2/c/cprint.c
+++ b/M2/Macaulay2/c/cprint.c
@@ -527,6 +527,7 @@ static void cprintdefun(node g) {
      node args = CDAR(g);
      node funtype = type(fun);
      node rettype = functionrettype(funtype);
+     node parm;
      assert(issym(fun));
      locn(g);
      /* printpos(); */
@@ -548,6 +549,15 @@ static void cprintdefun(node g) {
      put(")");
      put("{");
      put("\n");
+     /* suppress unused parameter warnings for parameters not referenced in scc source */
+     for (parm = CDAR(g); parm != NULL; parm = CDR(parm)) {
+	  node w = CAR(parm);
+	  if (issym(w) && !(w->body.symbol.flags & used_F)) {
+	       put("(void)");
+	       cprint(w);
+	       put(";\n");
+	       }
+	  }
      cprintsemi(CDDR(g));
      printpos();
      put("}");

--- a/M2/Macaulay2/c/scc.h
+++ b/M2/Macaulay2/c/scc.h
@@ -90,6 +90,7 @@ struct NODE {
 #define macro_variable_F 0x100000
 #define errmsg_given_F   0x200000
 #define package_active_F 0x400000
+#define used_F           0x800000
 #define none_F	   	0
 	       } symbol;
 	  struct TYPE {

--- a/M2/Macaulay2/d/CMakeLists.txt
+++ b/M2/Macaulay2/d/CMakeLists.txt
@@ -214,8 +214,6 @@ target_compile_options(M2-interpreter PRIVATE
   -Wno-sign-compare
   -Wno-uninitialized
   -Wno-unused
-  -Wno-array-bounds   # FIXME: caused by scc1's implementation of arrays
-
   # FIXME: mismatched-tags and parentheses-equality errors are caused by scc1
   $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang>:-Wno-parentheses-equality>
   $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-mismatched-tags -Wno-parentheses-equality>

--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -124,6 +124,7 @@ static char *M2_completion_generator(const char *text, int state) {
 }
 
 static char **M2_completion(const char *text, int start, int end) {
+  (void)start; (void)end;
   rl_attempted_completion_over = TRUE;
   /* if (start > 0 && rl_line_buffer[start-1] == '"') ... filename completion ... */
   return rl_completion_matches(text, M2_completion_generator);

--- a/M2/Macaulay2/d/M2mem.c
+++ b/M2/Macaulay2/d/M2mem.c
@@ -50,6 +50,7 @@ char *getmem_malloc(size_t n)
 
 char *getmoremem (char *s, size_t old, size_t new) {
      void *p;
+     (void)old;
      enter_getmem();
      p = GC_REALLOC(s,new);
      if (p == NULL) outofmem2(new);

--- a/M2/Macaulay2/d/Makefile.in
+++ b/M2/Macaulay2/d/Makefile.in
@@ -212,7 +212,7 @@ M2lib.o scclib.o gdbm_interface.o gc_cpp.o : ../../include/M2/config.h
 M2.o : ../../include/M2/config.h @srcdir@/../c/scc-core.h
 
 clean::; rm -f startup.c
-SSTRING := -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/\(.*\)/"\1\\n"/'
+SSTRING := -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/??/?\\\?/g' -e 's/\(.*\)/"\1\\n"/'
 BSTRING := -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/\(.*\)/"\1"/'
 ../m2/startup.m2: ../m2/startup.m2.in ; cd ../.. ; ./config.status Macaulay2/m2/startup.m2
 startup.c: startup-header.h ../m2/startup.m2 @srcdir@/../m2/basictests/*.m2 Makefile

--- a/M2/Macaulay2/d/actors.d
+++ b/M2/Macaulay2/d/actors.d
@@ -1368,6 +1368,7 @@ isInfinite(e:Expr):Expr := (
 setupfun("isInfinite",isInfinite).Protected=false;
 
 gcIsVisible(e:Expr):Expr := (
+     Ccode(void, "(void)", e);
      Ccode(void, "assert(GC_is_visible(",e,"))");
      nullE);
 setupfun("gcIsVisible",gcIsVisible);

--- a/M2/Macaulay2/d/actors4.d
+++ b/M2/Macaulay2/d/actors4.d
@@ -939,13 +939,15 @@ substrfun(e:Expr):Expr := (
      else WrongNumArgs(2,3));
 setupfun("substring",substrfun);
 
-tostring(n:MysqlConnection):string := tostring(Ccode(constcharstarOrNull, "
+tostring(n:MysqlConnection):string := (
+    Ccode(void, "(void)", n);
+    tostring(Ccode(constcharstarOrNull, "
      #if WITH_MYSQL
        mysql_get_host_info(", n, ")
      #else
        \"not present\"
      #endif
-"));
+")));
 
 tostring(m:MysqlConnectionWrapper):string := (
      "<<MysqlConnection : " + ( when m.mysql is null do "closed" is n:MysqlConnection do tostring(n) ) + ">>"

--- a/M2/Macaulay2/d/ffi.d
+++ b/M2/Macaulay2/d/ffi.d
@@ -91,7 +91,7 @@ dlsym0(e:Expr):Expr :=
 setupfun("dlsym", dlsym0);
 
 ffiTypeVoid := Ccode(voidPointer, "&ffi_type_void");
-ffiOk := Ccode(int, "FFI_OK");
+ffiOk := Ccode(uint, "FFI_OK");
 
 ffiTypeSize(e:Expr):Expr := (
     when e
@@ -99,12 +99,12 @@ ffiTypeSize(e:Expr):Expr := (
     else WrongArgPointer());
 setupfun("ffiTypeSize", ffiTypeSize);
 
-ffiError(r:int):Expr:=
-    if r == Ccode(int, "FFI_BAD_TYPEDEF")
+ffiError(r:uint):Expr:=
+    if r == Ccode(uint, "FFI_BAD_TYPEDEF")
     then buildErrorPacket("libffi: bad typedef")
-    else if r == Ccode(int, "FFI_BAD_ABI")
+    else if r == Ccode(uint, "FFI_BAD_ABI")
     then buildErrorPacket("libffi: bad ABI")
-    else if r == Ccode(int, "FFI_BAD_ARGTYPE")
+    else if r == Ccode(uint, "FFI_BAD_ARGTYPE")
     then buildErrorPacket("libffi: bad argtype")
     else buildErrorPacket("libffi: unknown");
 
@@ -119,7 +119,7 @@ ffiPrepCif(e:Expr):Expr :=
 			do provide when y.v.i is z:pointerCell do z.v
 			    else ffiTypeVoid;
 		    cif := Ccode(voidPointer, "getmem(sizeof(ffi_cif))");
-		    r := Ccode(int, "ffi_prep_cif((ffi_cif *)", cif,
+		    r := Ccode(uint, "ffi_prep_cif((ffi_cif *)", cif,
 			", FFI_DEFAULT_ABI, ",
 			argtypes, "->len, ",
 			"(ffi_type *) ", x.v, ", ",
@@ -143,7 +143,7 @@ ffiPrepCifVar(e:Expr):Expr :=
 				do provide when y.v.i is z:pointerCell do z.v
 				else ffiTypeVoid;
 			cif := Ccode(voidPointer, "getmem(sizeof(ffi_cif))");
-			r := Ccode(int, "ffi_prep_cif_var((ffi_cif *)", cif,
+			r := Ccode(uint, "ffi_prep_cif_var((ffi_cif *)", cif,
 			    ", FFI_DEFAULT_ABI, ",
 			    toInt(n), ", ",
 			    argtypes, "->len, ",
@@ -560,7 +560,7 @@ ffiGetStructOffsets(e:Expr):Expr :=
 	while Ccode(voidPointer, "(((ffi_type *)", x.v, ")->elements)[", n,
 	    "]") != nullPointer() do n = n + 1;
 	offsets := Ccode(voidPointer, "getmem((", n , ") * sizeof(size_t))");
-	r := Ccode(int, "ffi_get_struct_offsets(FFI_DEFAULT_ABI, ",
+	r := Ccode(uint, "ffi_get_struct_offsets(FFI_DEFAULT_ABI, ",
 	    "(ffi_type *)", x.v, ", (size_t *)", offsets, ")");
 	if r != ffiOk then return ffiError(r);
 	Expr(list(new Sequence len n at i do provide
@@ -580,7 +580,7 @@ ffiStructAddress(e:Expr):Expr := (
 			")->elements)[", n, "]") != nullPointer() do n = n + 1;
 		    offsets := Ccode(voidPointer, "getmem((", n ,
 			") * sizeof(size_t))");
-		    r := Ccode(int, "ffi_get_struct_offsets(FFI_DEFAULT_ABI, ",
+		    r := Ccode(uint, "ffi_get_struct_offsets(FFI_DEFAULT_ABI, ",
 			"(ffi_type *)", x.v, ", (size_t *)", offsets, ")");
 		    if r != ffiOk then return ffiError(r);
 		    result := getMem(Ccode(int, "((ffi_type *)", x.v,
@@ -621,7 +621,7 @@ ffiUnionType(e:Expr):Expr := (
 	for i from 0 to length(a.v) - 1 do (
 	    when a.v.i
 	    is p:pointerCell do (
-		if Ccode(int, "ffi_prep_cif((ffi_cif *)", cif,
+		if Ccode(uint, "ffi_prep_cif((ffi_cif *)", cif,
 		    ", FFI_DEFAULT_ABI, 0, ", p.v, ", NULL)") == ffiOk then (
 		    if Ccode(int, "((ffi_type *)", p.v , ")->size"
 			) > Ccode(int, "((ffi_type *)", x, ")->size"
@@ -672,7 +672,7 @@ ffiFunctionPointerAddress(e:Expr):Expr := (
 		    "ffi_closure_alloc(sizeof(ffi_closure), &", code, ")");
 		if closure == nullPointer() then return buildErrorPacket(
 		    "ffi_closure_alloc() returned NULL");
-		r := Ccode(int, "ffi_prep_closure_loc(", closure, ", ", cif.v,
+		r := Ccode(uint, "ffi_prep_closure_loc(", closure, ", ", cif.v,
 		    ", ", ffiClosureFunction, ", ", f, ", ", code, ")");
 		if r != ffiOk then return ffiError(r);
 		ptr := getMem(pointerSize);

--- a/M2/Macaulay2/d/gmp1.d
+++ b/M2/Macaulay2/d/gmp1.d
@@ -145,7 +145,19 @@ export format(
 	  concatenate(
 	       array(string)(
 		    if pt == 0 then "." else "",
-		    if l == 0 then "" else new string len l do provide '0',
+		    -- GCC incorrectly infers a zero-size region from the "" branch of
+		    -- this if-else and spuriously warns about the new string allocation.
+		    if l == 0 then "" else (
+			Ccode(void, "
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored \"-Warray-bounds\"
+#pragma GCC diagnostic ignored \"-Wstringop-overflow\"
+(void)0");
+			r := new string len l do provide '0';
+			Ccode(void, "
+#pragma GCC diagnostic pop
+(void)0");
+			r),
 		    substr(mantissa,0,pt),
 		    if pt > 0 && pt < manlen then "." else "",
 		    substr(mantissa,pt,manlen-pt),

--- a/M2/Macaulay2/d/python-c.c
+++ b/M2/Macaulay2/d/python-c.c
@@ -63,6 +63,7 @@ int python_Main() {
 /* see http://docs.python.org/extending/extending.html for this example */
 
 static PyObject * spam_system(PyObject *self, PyObject *args) {
+  (void)self;
   const char *command;
   int sts;
   if (!PyArg_ParseTuple(args, "s", &command)) return NULL;

--- a/M2/Macaulay2/d/python-c.c
+++ b/M2/Macaulay2/d/python-c.c
@@ -1,6 +1,8 @@
 #include <Python.h>
 #include "python-exports.h"
-/* pythoncapi_compat.h is a vendored header; suppress warnings we can't fix */
+
+/* vendored from https://github.com/python/pythoncapi-compat
+ * suppress warnings we can't fix */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #include "pythoncapi_compat.h"

--- a/M2/Macaulay2/d/python-c.c
+++ b/M2/Macaulay2/d/python-c.c
@@ -1,6 +1,10 @@
 #include <Python.h>
 #include "python-exports.h"
+/* pythoncapi_compat.h is a vendored header; suppress warnings we can't fix */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 #include "pythoncapi_compat.h"
+#pragma GCC diagnostic pop
 
 #include <gmp.h>
 

--- a/M2/Macaulay2/d/pythoncapi_compat.h
+++ b/M2/Macaulay2/d/pythoncapi_compat.h
@@ -1425,6 +1425,11 @@ PyUnicodeWriter_WriteStr(PyUnicodeWriter *writer, PyObject *obj)
 static inline int
 PyUnicodeWriter_WriteRepr(PyUnicodeWriter *writer, PyObject *obj)
 {
+    if (obj == NULL) {
+        return _PyUnicodeWriter_WriteASCIIString((_PyUnicodeWriter*)writer,
+                                                 "<NULL>", 6);
+    }
+
     PyObject *str = PyObject_Repr(obj);
     if (str == NULL) {
         return -1;
@@ -1569,6 +1574,11 @@ static inline int PyLong_IsZero(PyObject *obj)
 
 // gh-124502 added PyUnicode_Equal() to Python 3.14.0a0
 #if PY_VERSION_HEX < 0x030E00A0
+
+#if PY_VERSION_HEX >= 0x030d0000 && !defined(PYPY_VERSION)
+PyAPI_FUNC(int) _PyUnicode_Equal(PyObject *str1, PyObject *str2);
+#endif
+
 static inline int PyUnicode_Equal(PyObject *str1, PyObject *str2)
 {
     if (!PyUnicode_Check(str1)) {
@@ -1583,8 +1593,6 @@ static inline int PyUnicode_Equal(PyObject *str1, PyObject *str2)
     }
 
 #if PY_VERSION_HEX >= 0x030d0000 && !defined(PYPY_VERSION)
-    PyAPI_FUNC(int) _PyUnicode_Equal(PyObject *str1, PyObject *str2);
-
     return _PyUnicode_Equal(str1, str2);
 #elif PY_VERSION_HEX >= 0x03060000 && !defined(PYPY_VERSION)
     return _PyUnicode_EQ(str1, str2);
@@ -1607,11 +1615,14 @@ static inline PyObject* PyBytes_Join(PyObject *sep, PyObject *iterable)
 
 
 #if PY_VERSION_HEX < 0x030E00A0
+
+#if PY_VERSION_HEX >= 0x03000000 && !defined(PYPY_VERSION)
+PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void *src, Py_ssize_t len);
+#endif
+
 static inline Py_hash_t Py_HashBuffer(const void *ptr, Py_ssize_t len)
 {
 #if PY_VERSION_HEX >= 0x03000000 && !defined(PYPY_VERSION)
-    PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void *src, Py_ssize_t len);
-
     return _Py_HashBytes(ptr, len);
 #else
     Py_hash_t hash;
@@ -1948,11 +1959,14 @@ PyLongWriter_Finish(PyLongWriter *writer)
 
 // gh-127350 added Py_fopen() and Py_fclose() to Python 3.14a4
 #if PY_VERSION_HEX < 0x030E00A4
+
+#if 0x030400A2 <= PY_VERSION_HEX && !defined(PYPY_VERSION)
+PyAPI_FUNC(FILE*) _Py_fopen_obj(PyObject *path, const char *mode);
+#endif
+
 static inline FILE* Py_fopen(PyObject *path, const char *mode)
 {
 #if 0x030400A2 <= PY_VERSION_HEX && !defined(PYPY_VERSION)
-    PyAPI_FUNC(FILE*) _Py_fopen_obj(PyObject *path, const char *mode);
-
     return _Py_fopen_obj(path, mode);
 #else
     FILE *f;
@@ -2659,6 +2673,40 @@ PyUnstable_Unicode_GET_CACHED_HASH(PyObject *op)
 }
 #endif
 
+#if 0x030D0000 <= PY_VERSION_HEX && PY_VERSION_HEX < 0x030F00A7 && !defined(PYPY_VERSION)
+// Immortal objects were implemented in Python 3.12, however there is no easy API
+// to make objects immortal until 3.14 which has _Py_SetImmortal(). Since
+// immortal objects are primarily needed for free-threading, this API is implemented
+// for 3.14 using _Py_SetImmortal() and uses private macros on 3.13.
+#if 0x030E0000 <= PY_VERSION_HEX
+PyAPI_FUNC(void) _Py_SetImmortal(PyObject *op);
+#endif
+
+static inline int
+PyUnstable_SetImmortal(PyObject *op)
+{
+    assert(op != NULL);
+    if (!PyUnstable_Object_IsUniquelyReferenced(op) || PyUnicode_Check(op)) {
+        return 0;
+    }
+#if 0x030E0000 <= PY_VERSION_HEX
+    _Py_SetImmortal(op);
+#else
+    // Python 3.13 doesn't export _Py_SetImmortal() function
+    if (PyObject_GC_IsTracked(op)) {
+        PyObject_GC_UnTrack(op);
+    }
+#ifdef Py_GIL_DISABLED
+    op->ob_tid = _Py_UNOWNED_TID;
+    op->ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL;
+    op->ob_ref_shared = 0;
+#else
+    op->ob_refcnt = _Py_IMMORTAL_REFCNT;
+#endif
+#endif
+    return 1;
+}
+#endif
 
 #ifdef __cplusplus
 }

--- a/M2/Macaulay2/d/scclib.c
+++ b/M2/Macaulay2/d/scclib.c
@@ -411,13 +411,13 @@ int system_fileMode(M2_string name) {
   struct stat buf;
   int r = stat(cname,&buf);
   freemem(cname);
-  return r == ERROR ? -1 : buf.st_mode & ~S_IFMT;
+  return r == ERROR ? -1 : (int)(buf.st_mode & ~S_IFMT);
 }
 
 int system_fileModeFD(int fd) {
   struct stat buf;
   int r = fstat(fd,&buf);
-  return r == ERROR ? -1 : buf.st_mode & ~S_IFMT;
+  return r == ERROR ? -1 : (int)(buf.st_mode & ~S_IFMT);
 }
 
 int system_chmod(M2_string name,int mode) {

--- a/M2/Macaulay2/d/scclib.c
+++ b/M2/Macaulay2/d/scclib.c
@@ -448,7 +448,7 @@ int system_isRegularFile(M2_string name) {
   return r == ERROR ? -1 : S_ISREG(buf.st_mode);
 }
 
-int always(const struct dirent *p) { return 1; }
+int always(const struct dirent *p) { (void)p; return 1; }
 
 M2_ArrayString system_readDirectory(M2_string name) {
   int n=0, i=0;

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -106,7 +106,21 @@ export clearFileError(o:file):void := (
      );
 export fileErrorMessage(o:file):string := o.errorMessage;
 export noprompt():string := "";
-newbuffer():string := new string len bufsize do provide ' ';
+-- When newbuffer() is inlined, GCC cannot tell that GC_MALLOC_ATOMIC allocated
+-- bufsize bytes for the flexible array, so it spuriously warns that the
+-- memset writing bufsize bytes overflows a region of size 0.
+newbuffer():string := (
+    Ccode(void, "
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored \"-Warray-bounds\"
+#pragma GCC diagnostic ignored \"-Wstringop-overflow\"
+(void)0");
+    result := new string len bufsize do provide ' ';
+    Ccode(void, "
+#pragma GCC diagnostic pop
+(void)0");
+    result
+    );
 export stdError := newFile(
      -- contrast with stderr, defined in errio.d
      -- intended just for top level use where nets might be printed

--- a/M2/Macaulay2/d/system.d
+++ b/M2/Macaulay2/d/system.d
@@ -184,7 +184,12 @@ import historyLength():int;
 import chdir(name:string):int;
 import initReadlineVariables():void;
 import handleInterruptsSetup(handleInterrupts:bool):void;
-export segmentationFault():void := Ccode(void, "*((int*)1)=0"); -- for debugging our handling of segmentation faults
+export segmentationFault():void := Ccode(void, "
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored \"-Warray-bounds\"
+*((int*)1)=0;
+#pragma GCC diagnostic pop
+(void)0"); -- for debugging our handling of segmentation faults
 import isReady(fd:int):int;
 import hasException(fd:int):int;
 

--- a/M2/cmake/startup.cmake
+++ b/M2/cmake/startup.cmake
@@ -12,6 +12,7 @@ MACRO (_STARTUP_REGEX input retval with_newline)
   STRING (STRIP "${input}" _output)
   string(      REPLACE "\\" "\\\\"    _output "${_output}") # sed -e 's/\\/\\\\/g'
   string(REGEX REPLACE "\"" "\\\\\""  _output "${_output}") # set -e 's/"/\\"/g'
+  string(      REPLACE "??" "?\\?"    _output "${_output}") # sed -e 's/??/?\\\?/g'
   # Note: we could use s/(.*)\n/.../g but for now string(REGEX REPLACE) behave differently than `sed -e`
   # See https://gitlab.kitware.com/cmake/cmake/issues/16899
   string(PREPEND _output "\"")

--- a/M2/include/config.Makefile.in
+++ b/M2/include/config.Makefile.in
@@ -223,8 +223,12 @@ HIDE := $(if $(VERBOSE),,@)
 	$(SHOW)CC $*.c
 	$(HIDE)$(COMPILE.c) $< $(OUTPUT_OPTION)
 
-%.o: %.cc %.cpp
-	$(SHOW)CXX $<
+%.o: %.cc
+	$(SHOW)CXX $*.cc
+	$(HIDE)$(COMPILE.cc) $< $(OUTPUT_OPTION)
+
+%.o: %.cpp
+	$(SHOW)CXX $*.cpp
 	$(HIDE)$(COMPILE.cc) $< $(OUTPUT_OPTION)
 
 # Local Variables:


### PR DESCRIPTION
We clean up a bunch of compiler warnings in the d directory, such as the trigraph warning from startup.m2.in mentioned in https://github.com/Macaulay2/M2/pull/4017#issuecomment-3924010667

## AI Disclosure

Claude Code did all the hard work.  It took some hand-holding -- it kept missing unused parameters and I had to tell it to do more.  :)