### PR TITLE
Improve lifting from RR to QQ

### DIFF
--- a/M2/Macaulay2/e/basic-rings/aring-QQ-gmp.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-QQ-gmp.hpp
@@ -9,6 +9,7 @@
 #include "basic-rings/aring.hpp"
 #include "buffer.hpp"
 #include "rings/ringelem.hpp"
+#include <cmath>
 #include <iosfwd>
 #include "exceptions.hpp"
 
@@ -133,6 +134,78 @@ class ARingQQGMP : public SimpleARing<ARingQQGMP>
   // negative, which means both n0 and d0 can come out with the same
   // negative sign.  We negate both before storing into the mpq_t,
   // which requires a positive denominator.
+  bool set_from_double(ElementType& result, double a) const
+  {
+    bool negative, success;
+    double q, r;
+    mpz_t c, d0, d1, n0, n1, p2, tmp;
+
+    if (std::isnan(a) || std::isinf(a)) return false;
+    if (a == 0.0) {
+      mpq_set_si(&result, 0, 1);
+      return true;
+    }
+
+    negative = (a < 0.0);
+
+    mpz_init(p2);
+    mpz_setbit(p2, 53);
+
+    mpz_init_set_ui(n0, 1);
+    mpz_init_set_ui(n1, 0);
+    mpz_init_set_ui(d0, 0);
+    mpz_init_set_ui(d1, 1);
+
+    r = std::fabs(a);
+
+    mpz_init(c);
+    mpz_init(tmp);
+
+    success = false;
+
+    while (true) {
+      mpz_set_d(c, std::round(r));
+
+      mpz_swap(n0, n1);
+      mpz_swap(d0, d1);
+
+      mpz_mul(tmp, c, n1);
+      mpz_add(n0, n0, tmp);
+      mpz_mul(tmp, c, d1);
+      mpz_add(d0, d0, tmp);
+
+      r -= mpz_get_d(c);
+
+      // return the first convergent that rounds back to a
+      q = mpz_get_d(n0) / mpz_get_d(d0);
+      if (q == std::fabs(a)) {
+        if (mpz_sgn(d0) < 0) {
+          mpz_neg(n0, n0);
+          mpz_neg(d0, d0);
+        }
+        mpz_set(mpq_numref(&result), n0);
+        mpz_set(mpq_denref(&result), d0);
+        if (negative) mpq_neg(&result, &result);
+        success = true;
+        break;
+      }
+
+      mpz_mul(tmp, n0, d0);
+      mpz_abs(tmp, tmp);
+      if (r == 0.0 || mpz_cmp(tmp, p2) > 0) {
+        mpq_set_d(&result, a);
+        success = true;
+        break;
+      }
+
+      r = 1.0 / r;
+    }
+
+    mpz_clears(c, d0, d1, n0, n1, p2, tmp, nullptr);
+
+    return success;
+  }
+
   bool set_from_BigReal(ElementType& result, gmp_RR a) const
   {
     bool negative, success;

--- a/M2/Macaulay2/e/basic-rings/aring-QQ-gmp.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-QQ-gmp.hpp
@@ -119,11 +119,98 @@ class ARingQQGMP : public SimpleARing<ARingQQGMP>
     return true;
   }
 
+  // Use nearest-integer continued fraction approximation to find the
+  // simplest rational that rounds back to a at its precision.  The
+  // nearest-integer variant (rounding each remainder rather than taking
+  // the floor) keeps remainders in (-1/2, 1/2], so convergents grow
+  // faster than with the standard floor-based algorithm.  At each step
+  // we compute the next convergent n0/d0 and check whether it
+  // round-trips to a; if so, we return it.  Otherwise, once the
+  // convergents grow as large as the exact bit representation of a, we
+  // fall back to returning that exact representation.
+  //
+  // Because remainders can be negative, partial quotients can be
+  // negative, which means both n0 and d0 can come out with the same
+  // negative sign.  We negate both before storing into the mpq_t,
+  // which requires a positive denominator.
   bool set_from_BigReal(ElementType& result, gmp_RR a) const
   {
-    (void) result;
-    (void) a;
-    return false;
+    bool negative, success;
+    mpfr_prec_t prec;
+    mpfr_t q, r;
+    mpz_t c, d0, d1, n0, n1, p2, tmp;
+
+    if (!mpfr_number_p(a)) return false;
+    if (mpfr_zero_p(a)) {
+      mpq_set_si(&result, 0, 1);
+      return true;
+    }
+
+    negative = mpfr_sgn(a) < 0;
+    prec = mpfr_get_prec(a);
+
+    // p2 = 2^prec, the bound used to detect when convergents are large enough
+    mpz_init(p2);
+    mpz_setbit(p2, (mp_bitcnt_t)prec);
+
+    mpz_init_set_ui(n0, 1);
+    mpz_init_set_ui(n1, 0);
+    mpz_init_set_ui(d0, 0);
+    mpz_init_set_ui(d1, 1);
+
+    mpfr_init2(r, prec);
+    mpfr_abs(r, a, MPFR_RNDN);
+
+    mpz_init(c);
+    mpz_init(tmp);
+
+    mpfr_init2(q, prec);
+
+    success = false;
+
+    while (true) {
+      mpfr_get_z(c, r, MPFR_RNDN);
+
+      mpz_swap(n0, n1);
+      mpz_swap(d0, d1);
+
+      mpz_mul(tmp, c, n1);
+      mpz_add(n0, n0, tmp);
+      mpz_mul(tmp, c, d1);
+      mpz_add(d0, d0, tmp);
+
+      mpfr_sub_z(r, r, c, MPFR_RNDN);
+
+      // return the first convergent that rounds back to a
+      mpfr_set_z(q, n0, MPFR_RNDN);
+      mpfr_div_z(q, q, d0, MPFR_RNDN);
+      if (mpfr_cmpabs(a, q) == 0) {
+        if (mpz_sgn(d0) < 0) {
+          mpz_neg(n0, n0);
+          mpz_neg(d0, d0);
+        }
+        mpz_set(mpq_numref(&result), n0);
+        mpz_set(mpq_denref(&result), d0);
+        if (negative) mpq_neg(&result, &result);
+        success = true;
+        break;
+      }
+
+      mpz_mul(tmp, n0, d0);
+      mpz_abs(tmp, tmp);
+      if (mpfr_zero_p(r) || mpz_cmp(tmp, p2) > 0) {
+        mpfr_get_q(&result, a);
+        success = true;
+        break;
+      }
+
+      mpfr_ui_div(r, 1, r, MPFR_RNDN);  // r = 1/r
+    }
+
+    mpz_clears(c, d0, d1, n0, n1, p2, tmp, nullptr);
+    mpfr_clears(q, r, nullptr);
+
+    return success;
   }
 
   void set_var(ElementType& result, int v) const

--- a/M2/Macaulay2/e/basic-rings/aring-glue.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-glue.hpp
@@ -768,9 +768,8 @@ bool ConcreteRing<RingType>::lift(const Ring *R,
     }
   if (R == globalZZ)
     {
-      printf("error!! lift called with no ZZ lifting method\n");
       // MES:TODO!! WRITE ME
-      return true;
+      return false;
     }
   switch (R->ringID())
     {

--- a/M2/Macaulay2/e/basic-rings/aring-glue.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-glue.hpp
@@ -796,6 +796,14 @@ bool ConcreteRing<RingType>::lift(const Ring *R,
             default:
               return false;
           }
+      case M2::ring_QQ:
+        switch (S->ringID())
+          {
+            case M2::ring_RRR:
+              return RP::lifter<ARingQQ, ARingRRR>(R, S, result_gR, gS);
+            default:
+              return false;
+          }
       case M2::ring_RR:
         switch (S->ringID())
           {

--- a/M2/Macaulay2/e/basic-rings/aring-glue.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-glue.hpp
@@ -799,6 +799,8 @@ bool ConcreteRing<RingType>::lift(const Ring *R,
       case M2::ring_QQ:
         switch (S->ringID())
           {
+            case M2::ring_RR:
+              return RP::lifter<ARingQQ, ARingRR>(R, S, result_gR, gS);
             case M2::ring_RRR:
               return RP::lifter<ARingQQ, ARingRRR>(R, S, result_gR, gS);
             default:

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -80,6 +80,13 @@ bool get_from_complex_double(const RT& R,
   return false;
 }
 
+inline bool get_from_BigReal(const ARingQQ& R,
+                             ARingQQ::ElementType& a,
+                             gmp_RR b)
+{
+  return R.set_from_BigReal(a, b);
+}
+
 inline bool get_from_BigReal(const ARingRR& R,
                              ARingRR::ElementType& a,
                              gmp_RR b)
@@ -634,6 +641,15 @@ inline bool mylift(const ARingRRR& R,
     bool liftstep = mylift(R,T,result_gR,gT);
     S.diameter(gT,gS1);
     return liftstep && T.is_zero(gT);
+}
+
+inline bool mylift(const ARingQQ& R,
+                   const ARingRRR& S,
+                   ARingQQ::ElementType& fR,
+                   const ARingRRR::ElementType& fS)
+{
+  (void) S;
+  return R.set_from_BigReal(fR, &fS);
 }
 
 inline bool mylift(const ARingQQ& R,

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -644,6 +644,15 @@ inline bool mylift(const ARingRRR& R,
 }
 
 inline bool mylift(const ARingQQ& R,
+                   const ARingRR& S,
+                   ARingQQ::ElementType& fR,
+                   const ARingRR::ElementType& fS)
+{
+  (void) S;
+  return R.set_from_double(fR, fS);
+}
+
+inline bool mylift(const ARingQQ& R,
                    const ARingRRR& S,
                    ARingQQ::ElementType& fR,
                    const ARingRRR::ElementType& fS)

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -225,24 +225,7 @@ internalRepresentation = z -> if z === 0. then 0/1 else if isFinite z then (
      (prec,sgn,expt,m,numbits) := partsRR z;
      sgn * m / 2^(numbits - expt)
      )
-lift(RR,QQ) := opts -> (r,QQ) -> (
-     if r == 0 then return 0/1;
-     r' := r;
-     p := precision r;
-     p2 := 2^p;
-     m := mutableIdentity(ZZ,2);
-     while true do (
-	  a := round r';
-	  columnSwap(m,0,1);
-	  columnAdd(m,0,a,1);
-	  r' = r' - a;
-	  n := m_(0,0);
-	  d := m_(1,0);
-	  q := n / d;
-	  if r === numeric(p,q) then return q;
-	  if r' == 0 or abs(n*d) > p2 then return internalRepresentation r;
-	  r' = 1/r' ;
-	  ))
+lift(RR,QQ) := opts -> (r, K) -> rawToRational rawFromNumber(raw K, r)
 lift(RR,ZZ) := opts -> (r,ZZ) -> (
      i := floor r; 
      if r == i then i 

--- a/M2/Macaulay2/tests/normal/lift.m2
+++ b/M2/Macaulay2/tests/normal/lift.m2
@@ -118,9 +118,23 @@ x = symbol x
 assert(lift(1_(ZZ[x]), ZZ) === 1)
 assert(lift(1_(QQ[x]), QQ) === 1/1)
 assert(lift(1_(RR[x]), RR) === 1.0)
+assert(lift(1_(RR[x]), QQ) === 1/1)
+assert(lift(1_(RR[x]), ZZ) === 1)
+assert(lift(1_(RR_100[x]), QQ) === 1/1)
+assert(lift(1_(RR_100[x]), ZZ) === 1)
 assert(lift(1_(RRi[x]), RRi) === toRRi 1)
+assert(lift(1_(RRi[x]), QQ) === 1/1)
+assert(lift(1_(RRi[x]), ZZ) === 1)
 assert(lift(1_(CC[x]), CC) === toCC 1)
+assert(lift(1_(CC[x]), QQ) === 1/1)
+assert(lift(1_(CC[x]), ZZ) === 1)
+assert(lift(1_(CC_100[x]), QQ) === 1/1)
+assert(lift(1_(CC_100[x]), ZZ) === 1)
 assert(lift(1_(CCi[x]), CCi) === toCCi 1)
+
+try lift(matrix(RR, 1), ZZ) -- #2509 (used to segfault)
+assert(lift(matrix(RR, 1), QQ) === matrix(QQ, 1))
+assert(lift(matrix(RR_100, 1), QQ) === matrix(QQ, 1))
 
 end
 -- Local Variables:

--- a/M2/Macaulay2/tests/normal/subst7.m2
+++ b/M2/Macaulay2/tests/normal/subst7.m2
@@ -12,11 +12,8 @@ assert try (sub(matrix{{1.0}},QQ);false) else true -- used to crash (<= 1.9.2)
 f = map(QQ,RR_53)
 assert try (f (matrix{{1.0}}); false) else true  -- used to crash (<= 1.9.2)
 
-assert try (lift(matrix{{1.0}}, QQ); false) else true
-
 C = matrix {{1_CC}}
 assert(ring lift(C,RR) === RR_53) -- works
-assert try(lift(C,QQ); false) else true 
 assert try (sub(C,QQ); false) else true -- used to crash (<= 1.9.2)
 
 kk = ZZ/101


### PR DESCRIPTION
Currently, we implement lifting `RR` from `QQ` using continued fraction approximation.  It works only for lifting `RR` objects to `QQ` -- no matrices or polynomials, and it's slow because it's written at top-level.

We move this code to the engine, speeding things up and giving us lifting of polynomials and matrices for free.  We also get lifting to `ZZ` for free for most things (not matrices...), and lifting from `RRi` and `CC` to `QQ` for free.  (Not `CCi` though ... not sure why.)

Lifting matrices to `ZZ` used to segfault.  It still doesn't work, but now it doesn't segfault!

### Before

```m2
i1 : lift(1_(RR[x]), QQ)
stdio:1:4:(3):[1]: error: cannot lift given ring element

i2 : lift(1_(CC[x]), ZZ)
stdio:2:4:(3):[1]: error: cannot lift given ring element

i3 : lift(matrix(RR, 1), QQ)
stdio:3:4:(3):[1]: error: cannot lift given matrix

i4 : lift(matrix(RR, 1), ZZ)
error!! lift called with no ZZ lifting method
-- SIGSEGV
-* stack trace, pid: 23779
 0# profiler_stacktrace(std::ostream&, int) at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:132
 1# segv_handler at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:248
 2# 0x0000749623045330 in /lib/x86_64-linux-gnu/libc.so.6
 3# RingZZ::is_zero(ring_elem) const at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/e/ZZ.cpp:158
 4# Ring::set_entry(vecterm*&, int, ring_elem) const at /usr/src/macaulay2-1.25.11+git202604300057-0ppa202604290114~ubuntu24.04.1/M2/Macaulay2/e/ring-vecs.cpp:606
 5# IM2_Matrix_lift at interface/matrix.cpp:804
```

### After

```m2
i1 : lift(1_(RR[x]), QQ)

o1 = 1

o1 : QQ

i2 : lift(1_(CC[x]), ZZ)

o2 = 1

i3 : lift(matrix(RR, 1), QQ)

o3 = | 1 |

              1       1
o3 : Matrix QQ  <-- QQ

i4 : lift(matrix(RR, 1), ZZ)
stdio:4:4:(3):[1]: error: cannot lift given matrix
```

Closes: #921, #1812

Partial band-aid fix for #2509

### AI Disclosure

Most of the code was written by Claude Code, with significant hand-holding from me.