### PR TITLE
Add Jansson to dependencies for make-dist workflow

### DIFF
--- a/.github/workflows/make-dist.yml
+++ b/.github/workflows/make-dist.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo add-apt-repository -y ppa:macaulay2/macaulay2
-          sudo apt-get install -y 4ti2 autoconf automake bison ca-certificates cohomcalg coinor-csdp fflas-ffpack flex g++ gdbmtool gfan gfortran git install-info libboost-dev libboost-regex-dev libboost-stacktrace-dev libcdd-dev libeigen3-dev libffi-dev libflint-dev libfplll-dev libfrobby-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp-dev libgtest-dev liblzma-dev libmathic-dev libmathicgb-dev libmemtailor-dev libmpfi-dev libmpfr-dev libmps-dev libnauty-dev libncurses-dev libnormaliz-dev libntl-dev libopenblas-dev libpython3-dev libreadline-dev libsingular-dev libtbb-dev libtool-bin libxml2-dev lrslib make msolve nauty normaliz patch pkgconf python3 r-base singular-data time topcom wget zlib1g-dev
+          sudo apt-get install -y 4ti2 autoconf automake bison ca-certificates cohomcalg coinor-csdp fflas-ffpack flex g++ gdbmtool gfan gfortran git install-info libboost-dev libboost-regex-dev libboost-stacktrace-dev libcdd-dev libeigen3-dev libffi-dev libflint-dev libfplll-dev libfrobby-dev libgc-dev libgdbm-dev libgivaro-dev libglpk-dev libgmp-dev libgtest-dev libjansson-dev liblzma-dev libmathic-dev libmathicgb-dev libmemtailor-dev libmpfi-dev libmpfr-dev libmps-dev libnauty-dev libncurses-dev libnormaliz-dev libntl-dev libopenblas-dev libpython3-dev libreadline-dev libsingular-dev libtbb-dev libtool-bin libxml2-dev lrslib make msolve nauty normaliz patch pkgconf python3 r-base singular-data time topcom wget zlib1g-dev
       - name: Build Macaulay2
         run: |
           cd M2/BUILD/build


### PR DESCRIPTION
I completely forgot to do this before tagging the release, so my first attempt at building the distribution tarballs failed.  I ran it successfully from my fork (https://github.com/d-torrance/M2/actions/runs/25625809714) after making this change.