### PR TITLE
Update copyright years for pygments lexer

### DIFF
--- a/M2/Macaulay2/editors/pygments/macaulay2.py.in
+++ b/M2/Macaulay2/editors/pygments/macaulay2.py.in
@@ -4,7 +4,7 @@
 
     Lexer for Macaulay2.
 
-    :copyright: Copyright 2006-2025 by the Pygments team, see AUTHORS.
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
 


### PR DESCRIPTION
This way, we match the file in the pygments repo.  Rather than updating each year, they've just made the last year "present".
