### PR TITLE
Update Debian package workflow

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -80,14 +80,20 @@ jobs:
           cd macaulay2
           git checkout debian/${{ matrix.release }}
       - name: Generate tarball
-        run: uscan --verbose --rename --force-download
-      - name: Build package
         run: |
           cd macaulay2
-          git submodule update --init M2/Macaulay2/editors/emacs
+          uscan --verbose --rename --force-download
+      - name: Build source package
+        run: |
+          cd macaulay2
+          dpkg-buildpackage --build=source
+      - name: Build binary package
+        run: |
+          dpkg-source -x macaulay2_*.dsc
+          cd macaulay2-*
           if test ${{ matrix.os }} = "ubuntu-latest"; \
-          then dpkg-buildpackage; \
-          else dpkg-buildpackage -B; \
+          then dpkg-buildpackage --build=binary;      \
+          else dpkg-buildpackage --build=any;         \
           fi
       - name: Upload build logs
         if: always()


### PR DESCRIPTION
Build a source package first and use that.  Also don't do a full build for the x86 package -- we just need the binary packages, and the .changes file was expecting there to be source package files to sign that weren't included in the artifacts.

Basically, I didn't actually check to see if I'd be able to upload the Debian packages this workflow created until after the release ... and I wasn't!  This fixes that, and there are now nice fresh 1.26.05 .deb files on macaulay2.com after running this updated workflow on my fork (https://github.com/d-torrance/M2/actions/runs/25637548581).