### PR TITLE
Add completion control requests

### DIFF
--- a/M2/Macaulay2/d/expr.d
+++ b/M2/Macaulay2/d/expr.d
@@ -108,6 +108,48 @@ export completions(s:string):array(string) := (
 	  unlock(d.symboltable.mutex);
 	  d != d.outerDictionary) do d = d.outerDictionary;
      extract(v));
+
+-- This assumes x is a valid symbol name; arbitrary strings would need format from stdio.d.
+completionJSONQuote(x:string):string := "\"" + x + "\"";
+
+completionKind(e:Expr):string := when e
+     is FunctionClosure do "function"
+     is CompiledFunction do "function"
+     is CompiledFunctionClosure do "function"
+     is List do "list"
+     is Sequence do "sequence"
+     is h:HashTable do if h.Mutable then "mutable-hash-table" else "hash-table"
+     is stringCell do "string"
+     is Net do "net"
+     is NetFile do "net"
+     is SymbolClosure do "symbol"
+     is SymbolBody do "symbol"
+     is s:SpecialExpr do completionKind(s.e)
+     else "other";
+
+export completionInfoJSON(s:string):string := (
+     n := length(s);
+     if n == 0 then return "[]";
+     ret := "[";
+     first := true;
+     d := globalDictionary;
+     while (
+	  lockRead(d.symboltable.mutex);
+	  foreach bucket in d.symboltable.buckets do (
+	       b := bucket;
+	       while true do when b
+	       is null do break
+	       is q:SymbolListCell do (
+		    t := q.word.name;
+		    if isalnum(t.0) && n <= length(t) && 0 == strncmp(s,t,n) then (
+			 if first then first = false else ret = ret + ",";
+			 ret = ret + "{\"name\":" + completionJSONQuote(t)
+			      + ",\"kind\":" + completionJSONQuote(completionKind(getGlobalVariable(q.entry))) + "}";
+			 );
+		    b = q.next; ));
+	  unlock(d.symboltable.mutex);
+	  d != d.outerDictionary) do d = d.outerDictionary;
+     ret + "]");
 export DictionaryList := {
      dictionary:Dictionary,
      next:DictionaryList				    -- pointer to self indicates end

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -726,7 +726,6 @@ completionControlPartialRequest(o:file):bool := (
      true);
 
 completionControlInputInProgress(o:file):bool := (
-     if o != stdIO then return false;
      if o.insize > 0 && completionControlPartialRequest(o) then return true;
      o.inbuffer.(o.insize) == completionControlRequestStart.0);
 
@@ -798,7 +797,7 @@ export filbuf(o:file):int := (
 		    then 0 -- take care of "string files" made by stringTokenFile in interp.d
 		    else (
 			ret := read(o.infd,o.inbuffer,n,o.insize);
-			if ret > 0 && !completionControlInputInProgress(o)
+			if ret > 0 && o == stdIO && !completionControlInputInProgress(o)
 			then addHistory(tocharstarn(o.inbuffer, ret - 1));
 			ret)));
 	  if r == ERROR then (

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -699,6 +699,59 @@ export present(x:string):string := (
 
 export format(s:string):string := "\"" + present(s) + "\"";
 
+completionControlRequestStart := char(27) + "]M2-COMPLETE-REQUEST;";
+completionControlResponseStart := char(27) + "]M2-COMPLETE-RESPONSE;";
+completionControlEnd := char(7);
+
+completionControlPrefixOK(s:string):bool := (
+     if length(s) == 0 || length(s) > 128 then return false;
+     foreach c in s do if !isalnum(c) then return false;
+     true);
+
+sendCompletionControlResponse(requestID:string,prefix:string):void := (
+     resp := completionControlResponseStart + requestID;
+     if completionControlPrefixOK(prefix) then (
+	  foreach s in completions(prefix) do resp = resp + "\t" + s;
+	  );
+     resp = resp + string(completionControlEnd);
+     write(STDOUT,resp);
+     );
+
+completionControlPartialRequest(o:file):bool := (
+     n := if o.insize < length(completionControlRequestStart)
+	  then o.insize
+	  else length(completionControlRequestStart);
+     for i from 0 to n-1 do
+	  if o.inbuffer.i != completionControlRequestStart.i then return false;
+     true);
+
+completionControlInputInProgress(o:file):bool := (
+     if o != stdIO then return false;
+     if o.insize > 0 && completionControlPartialRequest(o) then return true;
+     o.inbuffer.(o.insize) == completionControlRequestStart.0);
+
+processCompletionControlRequests(o:file):bool := (
+     if o != stdIO then return false;
+     while o.insize > 0 && completionControlPartialRequest(o) do (
+	  if o.insize < length(completionControlRequestStart) then return true;
+	  fin := length(completionControlRequestStart);
+	  while fin < o.insize && o.inbuffer.fin != completionControlEnd do fin = fin + 1;
+	  if fin == o.insize then return true;
+	  payload := substr(o.inbuffer,length(completionControlRequestStart),fin-length(completionControlRequestStart));
+	  tab := index(payload,0,'\t');
+	  if tab > 0 then (
+	       requestID := substr(payload,0,tab);
+	       prefix := substr(payload,tab+1,length(payload)-tab-1);
+	       sendCompletionControlResponse(requestID,prefix);
+	       );
+	  rest := o.insize - fin - 1;
+	  for i from 0 to rest-1 do o.inbuffer.i = o.inbuffer.(fin+1+i);
+	  o.insize = rest;
+	  o.inindex = 0;
+	  o.echoindex = 0;
+	  );
+     o.insize == 0);
+
 export filbuf(o:file):int := (
 --      if o.fulllines then (
 -- 	  stdIO << flush;
@@ -745,7 +798,7 @@ export filbuf(o:file):int := (
 		    then 0 -- take care of "string files" made by stringTokenFile in interp.d
 		    else (
 			ret := read(o.infd,o.inbuffer,n,o.insize);
-			if ret > 0 && o == stdIO
+			if ret > 0 && !completionControlInputInProgress(o)
 			then addHistory(tocharstarn(o.inbuffer, ret - 1));
 			ret)));
 	  if r == ERROR then (
@@ -765,7 +818,8 @@ export filbuf(o:file):int := (
 	       oldsize := o.insize;
 	       newsize := o.insize + r;
 	       o.insize = newsize;
-	       if o.fulllines then (
+	       if !o.readline && processCompletionControlRequests(o) then r = 0
+	       else if o.fulllines then (
 		    for i from newsize-1 to oldsize by -1 do if o.inbuffer.i == '\n' then (
 			 if o.promptq then (
 			      o << o.reward();

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -709,10 +709,8 @@ completionControlPrefixOK(s:string):bool := (
      true);
 
 sendCompletionControlResponse(requestID:string,prefix:string):void := (
-     resp := completionControlResponseStart + requestID;
-     if completionControlPrefixOK(prefix) then (
-	  foreach s in completions(prefix) do resp = resp + "\t" + s;
-	  );
+     resp := completionControlResponseStart + requestID + "\t";
+     resp = resp + if completionControlPrefixOK(prefix) then completionInfoJSON(prefix) else "[]";
      resp = resp + string(completionControlEnd);
      write(STDOUT,resp);
      );


### PR DESCRIPTION
This is a first attempt at getting dynamic autocomplete even when `readline` is not used (e.g., in emacs or in the WebApp). cf discussion in #3330.