### PR TITLE
Fix segfault/error in Nonminimal res over QQ on 32-bit/older systems

### DIFF
--- a/M2/Macaulay2/e/resolution/comp-res.cpp
+++ b/M2/Macaulay2/e/resolution/comp-res.cpp
@@ -134,6 +134,11 @@ ResolutionComputation *ResolutionComputation::choose_res(
                 "polynomial rings");
             return nullptr;
           }
+        if (K->is_QQ())
+          {
+            ERROR("Nonminimal resolution strategy not available over QQ");
+            return nullptr;
+          }
         if (M2_gbTrace > 0) emit_line("resolution Strategy=>4 (res-f4)");
         C = createF4Res(m, max_level, strategy, numThreads, parallelizeByDegree);
         if (C == nullptr) return nullptr;

--- a/M2/Macaulay2/e/schreyer-resolutions/res-f4-computation.cpp
+++ b/M2/Macaulay2/e/schreyer-resolutions/res-f4-computation.cpp
@@ -237,12 +237,6 @@ void F4ResComputation::text_out(buffer& o) const
 
 const Matrix /* or null */* F4ResComputation::get_matrix(int level)
 {
-  if (mOriginalRing.getCoefficientRing()->is_QQ())
-    {
-      std::cout << "setting error message, returning null" << std::endl;
-      ERROR("cannot create differential over this ring");
-      return nullptr;
-    }
   const FreeModule* tar = get_free(level - 1);
   const FreeModule* src = get_free(level);
   return ResF4toM2Interface::to_M2_matrix(*mComp, level, tar, src);
@@ -250,11 +244,6 @@ const Matrix /* or null */* F4ResComputation::get_matrix(int level)
 
 MutableMatrix /* or null */* F4ResComputation::get_matrix(int level, int degree)
 {
-  if (mOriginalRing.getCoefficientRing()->is_QQ())
-    {
-      ERROR("cannot create differential over this ring");
-      return nullptr;
-    }
   return ResF4toM2Interface::to_M2_MutableMatrix(
       *mComp, mOriginalRing.getCoefficientRing(), level, degree);
 }


### PR DESCRIPTION
When res(I, Strategy => Nonminimal) is called over QQ, the computation should immediately raise an error: the strategy relies on rank computation over a finite field (rankUsingDenseMatrix constructs an ARingZZpFFPACK or ARingZZpFlint from the ring's characteristic), and characteristic 0 is invalid for that purpose.

Previously, the error was caught lazily in F4ResComputation::get_matrix, which meant res() itself would succeed and only fail when the caller tried to access a differential.  On 32-bit and older 64-bit systems (e.g. Ubuntu 18.04), a segfault in from_M2_vec fired even earlier: from_ring_elem for ARingQQGMP called mpq_set with an mpz_srcptr disguised as mpq_srcptr, causing mpq_set to read the denominator field past the end of the mpz_t object and crash.

Move the QQ check to choose_res, before createF4Res is called, so that res() raises the error immediately on all platforms.  Remove the now- unreachable guards from get_matrix, including a stray debug std::cout.

Closes: #4286 

## AI Disclosure

This one was all Claude.  I even let it write the commit message
