### PR TITLE
Avoid loading packages when calling help

### DIFF
--- a/M2/Macaulay2/m2/document.m2
+++ b/M2/Macaulay2/m2/document.m2
@@ -426,8 +426,7 @@ hasDocumentation = key -> null =!= fetchAnyRawDocumentation makeDocumentTag(key,
 locate DocumentTag := tag -> new FilePosition from (
     rawdoc := fetchAnyRawDocumentation tag;
     if rawdoc =!= null then (
-	pkg := package' rawdoc.DocumentTag;
-	src := minimizeFilename(pkg#"source directory" | rawdoc#"filename");
+	src := minimizeFilename(getpkgsrcdir tag.Package | rawdoc#"filename");
 	src, rawdoc#"linenum", 0)
     else (currentFileName, currentRowNumber(), currentColumnNumber()))
 

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -226,7 +226,7 @@ getExampleOutput(String, String, String) := (prefix, pkgname, fkey) -> (
     -- TODO: only get from cache if the hash hasn't changed
     verboseLog := if notify then printerr else identity;
     output := if fileExists filename
-    then ( verboseLog("info: reading cached example results from ", filename); get filename )
+    then ( verboseLog("info: reading cached example results from ", minimizeFilename filename); get filename )
     else ( verboseLog("info: capturing example results for ", fkey); captureExamples(pkgname, fkey) );
     if output === null then {} else separateM2output output)
 

--- a/M2/Macaulay2/m2/examples.m2
+++ b/M2/Macaulay2/m2/examples.m2
@@ -208,22 +208,27 @@ captureExamples := (pkg, fkey) -> (
 	UserMode       => false,
 	PackageExports => pkg))
 
-getExampleOutputFilename := (pkg, fkey) -> (
-    if pkg#?"package prefix" and pkg#"package prefix" =!= null then (
-	packageLayout := detectCurrentLayout pkg#"package prefix";
-	if packageLayout === null then error "internal error: package layout not detected";
-	pkg#"package prefix" | replace("PKG", pkg#"pkgname", Layout#packageLayout#"packageexampleoutput") | toFilename fkey | ".out")
-    else error "internal error: package prefix is undefined")
+getExampleDirectory = (layout, pre, pkg) -> pre | replace("PKG", pkg, layout#"packageexampleoutput")
+getExampleFilename  = (layout, pre, pkg, fkey) -> getExampleDirectory(layout, pre, pkg) | toFilename fkey | ".out"
 
-getExampleOutput := (pkg, fkey) -> (
+getExampleOutput = method()
+getExampleOutput(Package, String) := (pkg, fkey) -> (
+    pkg#"example results"#fkey ??= getExampleOutput(pkg#"package prefix", pkg#"pkgname", fkey))
+getExampleOutput(String, String) := (pkgname, fkey) -> (
+    if (pkginfo := getPackageInfo pkgname) =!= null then (
+	getExampleOutput(pkginfo#"prefix", pkgname, fkey))
+    else error("could not locate package ", format pkgname, " under current prefixPath"))
+getExampleOutput(String, String, String) := (prefix, pkgname, fkey) -> (
+    filename := if (layoutID := detectCurrentLayout prefix) =!= null then (
+	getExampleFilename(Layout#layoutID, prefix, pkgname, fkey))
+    else error("could not detect layout for package ", format pkgname, " under ", prefix);
+    --
     -- TODO: only get from cache if the hash hasn't changed
-    if pkg#"example results"#?fkey then return pkg#"example results"#fkey;
-    verboseLog := if debugLevel > 1 then printerr else identity;
-    filename := getExampleOutputFilename(pkg, fkey);
+    verboseLog := if notify then printerr else identity;
     output := if fileExists filename
     then ( verboseLog("info: reading cached example results from ", filename); get filename )
-    else ( verboseLog("info: capturing example results for ", fkey); captureExamples(pkg, fkey) );
-    pkg#"example results"#fkey = if output === null then {} else separateM2output output)
+    else ( verboseLog("info: capturing example results for ", fkey); captureExamples(pkgname, fkey) );
+    if output === null then {} else separateM2output output)
 
 -- used in installPackage.m2
 -- TODO: store in a database instead

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -452,7 +452,8 @@ getDefaultOptions := (nkey, opt) -> DIV (
 getDescription := (key, tag, rawdoc) -> (
     desc := getOption(rawdoc, Description);
     if desc =!= null and #desc > 0 then (
-	desc = processExamples(package' tag, format tag, desc);
+	pkg := getpkgNoLoad tag.Package ?? tag.Package;
+	desc = processExamples(pkg, tag.Format, desc);
 	if instance(key, String) -- overview key
 	or instance(key, Package) then DIV { desc }
 	else DIV { SUBSECTION "Description", desc })

--- a/M2/Macaulay2/m2/help.m2
+++ b/M2/Macaulay2/m2/help.m2
@@ -381,11 +381,10 @@ getTechnical := (S, s) -> DIV nonnull ( "class" => "waystouse",
     getOperator S)
 
 getLocation := tag -> if tag =!= null then (
-    pkg := package tag;
     docpos := locate tag;
     linepos := ":" | docpos#1 | ":" | docpos#2;
     docfile := toAbsolutePath docpos#0;
-    filename := replace(pkg#"source directory", "", docfile);
+    filename := replace(getpkgsrcdir tag.Package, "", docfile);
     HR{},
     DIV ( "class" => "waystouse",
 	fixup PARA (

--- a/M2/Macaulay2/m2/installPackage.m2
+++ b/M2/Macaulay2/m2/installPackage.m2
@@ -320,7 +320,7 @@ makePackageIndex = method(Dispatch => Thing)
 makePackageIndex Sequence := x -> if x === () then makePackageIndex path else error "expected no arguments"
 -- this might get too many files (formerly we used packagePath)
 makePackageIndex List := path -> (
-    verboseLog := if debugLevel > 10 then printerr else identity;
+    verboseLog := if notify or debugLevel > 10 then printerr else identity;
     -- TO DO : rewrite this function to use the results of tallyInstalledPackages
     tallyInstalledPackages();
     initInstallDirectory options installPackage;

--- a/M2/Macaulay2/m2/last.m2
+++ b/M2/Macaulay2/m2/last.m2
@@ -67,9 +67,8 @@ addStartFunction( () -> (
 	  if not noinitfile and getenv "HOME" =!= "" then (
 	       prefixPath = prepend(applicationDirectory()|"local/", prefixPath);
 	       setUpApplicationDirectory();
-	       makePackageIndex())))
-
-addStartFunction( () -> tallyInstalledPackages() )
+	       makePackageIndex())
+	  else tallyInstalledPackages()))
 
 addStartFunction( () -> if not noinitfile then (
 	  -- remove empty directories and dead symbolic links from the local application directory

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -225,6 +225,9 @@ loadPackageOptions#"default" = new MutableHashTable from options loadPackage
 
 getpkg       = pkgname -> if isPackageLoaded pkgname then value PackageDictionary#pkgname else dismiss needsPackage pkgname
 getpkgNoLoad = pkgname -> if isPackageLoaded pkgname then value PackageDictionary#pkgname
+getpkgsrcdir = pkgname -> (
+    if (pkg := getpkgNoLoad pkgname ?? getPackageInfo pkgname) =!= null
+    then pkg#"source directory" else error "package not loaded or preinstalled")
 
 -----------------------------------------------------------------------------
 -- newPackage

--- a/M2/Macaulay2/m2/packages.m2
+++ b/M2/Macaulay2/m2/packages.m2
@@ -11,9 +11,6 @@ needs "system.m2"
 needs "hypertext.m2"
 
 loadedPackages = {}
-loadedDatabases = new MutableHashTable
-
-addEndFunction(() -> apply(values loadedDatabases, db -> if isOpen db then close db))
 
 rawKey   = "raw documentation"
 rawKeyDB = "raw documentation database"
@@ -112,26 +109,14 @@ checkPackageName = (title, checkdeprecated) -> (
 
 closePackage = pkg -> if pkg#?rawKeyDB then (db -> if isOpen db then close db) pkg#rawKeyDB
 
-detectPackagePrefix = () -> (
+detectPackagePrefix = pkgdir -> (
     -- Try to detect whether we are loading the package from an installed version.
     -- A better test would be to see if the raw documentation database is there...
-    m := regex("(/|^)" | Layout#2#"packages" | "$", currentFileDirectory);
-    if m#?1 then substring(currentFileDirectory, 0, m#1#0 + m#1#1) else (
-	m = regex("(/|^)" | Layout#1#"packages" | "$", currentFileDirectory);
+    m := regex("(/|^)" | Layout#2#"packages" | "$", pkgdir);
+    if m#?1 then substring(pkgdir, 0, m#1#0 + m#1#1) else (
+	m = regex("(/|^)" | Layout#1#"packages" | "$", pkgdir);
 	-- this can be useful when running from the source tree, but this is a kludge
-	if m#?1 then substring(currentFileDirectory, 0, m#1#0 + m#1#1) else prefixDirectory))
-
-openDatabaseUntilExit = dbname -> if fileExists dbname then (
-    db := loadedDatabases#dbname ??= openDatabase dbname;
-    db) else if notify then printerr("database not present: ", minimizeFilename dbname)
-
-openPackageDatabase = method()
-openPackageDatabase String := pkgname -> openPackageDatabase(detectPackagePrefix(), pkgname)
-openPackageDatabase(String, String) := (packagePrefix, pkgname) -> (
-    try ( if isOpen(pkg := getpkgNoLoad pkgname)#rawKeyDB then return pkg#rawKeyDB );
-    if (packageLayout := detectCurrentLayout packagePrefix) =!= null then (
-	openDatabaseUntilExit databaseFilename(Layout#packageLayout, packagePrefix, pkgname))
-    else if notify then printerr("package prefix null, not opening database for package ", format pkgname))
+	if m#?1 then substring(pkgdir, 0, m#1#0 + m#1#1) else prefixDirectory))
 
 -----------------------------------------------------------------------------
 -- Package type declarations and basic constructors
@@ -386,7 +371,7 @@ newPackage String := opts -> pkgname -> (
 	};
     newpkg.PackageIsLoaded = false;
     --
-    packagePrefix := detectPackagePrefix();
+    packagePrefix := detectPackagePrefix(currentFileDirectory);
     packageDatabase := openPackageDatabase(packagePrefix, pkgname);
     if packagePrefix   =!= null then newpkg#"package prefix" = packagePrefix;
     if packageDatabase =!= null then newpkg#rawKeyDB         = packageDatabase;

--- a/M2/Macaulay2/m2/system.m2
+++ b/M2/Macaulay2/m2/system.m2
@@ -219,10 +219,12 @@ getDBkeys := dbfn -> (
      dbkeys)
 
 makePackageInfo := (pkgname,prefix,dbfn,layoutIndex) -> (
+    pkgsrcdir := prefix | Layout#layoutIndex#"packages";
     new MutableHashTable from {
 	"name"             => pkgname,
 	"prefix"           => prefix,
 	"layout index"     => layoutIndex,
+	"source directory" => pkgsrcdir,
 	"doc db file name" => dbfn,
 	-- if this package is reinstalled, we can tell by checking this time stamp
 	-- (unless the package takes less than a second to install, which is unlikely)

--- a/M2/Macaulay2/m2/system.m2
+++ b/M2/Macaulay2/m2/system.m2
@@ -284,6 +284,7 @@ getPackageInfoList = () -> flatten (
 	  else {})
 
 tallyInstalledPackages = () -> for prefix in prefixPath do (
+    if notify then printerr("tallying installed packages under ", prefix);
      if not isDirectory prefix then (
 	  remove(installedPackagesByPrefix,prefix);
 	  continue;

--- a/M2/Macaulay2/m2/system.m2
+++ b/M2/Macaulay2/m2/system.m2
@@ -336,6 +336,9 @@ tallyInstalledPackages = () -> for prefix in prefixPath do (
 -- gdbm functions
 -----------------------------------------------------------------------------
 
+loadedDatabases = new MutableHashTable
+addEndFunction(() -> apply(values loadedDatabases, db -> if isOpen db then close db))
+
 -- gdbm makes architecture dependent files, so we try to distinguish them, in case
 -- they get mixed.  Yes, that's in addition to installing them in directories that
 -- are specified to be suitable for machine dependent data.
@@ -343,6 +346,20 @@ databaseSuffix := "-" | version#"endianness" | "-" | version#"pointer size" | ".
 
 databaseDirectory = (layout, pre, pkg) -> pre | replace("PKG", pkg, layout#"packagecache")
 databaseFilename  = (layout, pre, pkg) -> databaseDirectory(layout, pre, pkg) | "rawdocumentation" | databaseSuffix
+
+openDatabaseUntilExit = dbname -> if fileExists dbname then (
+    db := loadedDatabases#dbname ??= openDatabase dbname;
+    db) else if notify then printerr("database not present: ", minimizeFilename dbname)
+
+openPackageDatabase = method()
+openPackageDatabase String := pkgname -> (
+    if (pkginfo := getPackageInfo pkgname) =!= null then (
+	openDatabaseUntilExit pkginfo#"doc db file name")
+    else if notify then printerr("could not locate package ", format pkgname, " under current prefixPath"))
+openPackageDatabase(String, String) := (prefix, pkgname) -> (
+    if (layoutID := detectCurrentLayout prefix) =!= null then (
+	openDatabaseUntilExit databaseFilename(Layout#layoutID, prefix, pkgname))
+    else if notify then printerr("could not detect layout for package ", format pkgname, " under ", prefix))
 
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "


### PR DESCRIPTION
Closes #4290.
- **added notifications for makePackageIndex and tallyInstalledPackages**
- **moved and simplified openPackageDatabase**
- **added getpkgsrcdir**
- **simplified getExampleOutput to avoid loading the package**
- **minimized a logged filename**

```m2
i1 : notify = true; help "Probability :: density";
 -- opening database ../../BUILD/build/usr-dist/x86_64-Linux-Fedora-43/lib64/Macaulay2/Probability/cache/rawdocumentation-dcba-8.db
 -- info: reading cached example results from ../../BUILD/build/usr-dist/common/share/doc/Macaulay2/Probability/example-output/_density.out
```