### PR TITLE
Prevent race condition in makeMonomialOrdering

### DIFF
--- a/M2/Macaulay2/m2/engine.m2
+++ b/M2/Macaulay2/m2/engine.m2
@@ -187,6 +187,7 @@ processWeights = (nvars,weights) -> (
 	       then error("Weights: expected weight vector of length ",toString nvars," but got ",toString (#wt))));
      weights);
 
+makeMonomialOrderingMutex := new Mutex
 makeMonomialOrdering = (monsize,inverses,nvars,degs,weights,ordering) -> (
      -- 'monsize' is the old MonomialSize option, usually 8 or 16, or 'null' if unset
      -- 'inverses' is true or false, and tells whether the old "Inverses => true" option was used.
@@ -197,10 +198,10 @@ makeMonomialOrdering = (monsize,inverses,nvars,degs,weights,ordering) -> (
      --    the *separate* Weights option.  Could be an empty list.
      -- 'ordering' is a list of ordering options, e.g., { Lex => 4, GRevLex => 4 }
      --    If it's not a list, we'll make a list of one element from it.
-     if monsize === null then monsize = null;
+     if not isListOfIntegers degs then error "expected a list of integers";
+     lock makeMonomialOrderingMutex;
      ordering = {MonomialSize => monsize, ordering};
      invert = inverses;
-     if not isListOfIntegers degs then error "expected a list of integers";
      deglist = degs;
      varcount = 0;
      MonSize = 0;
@@ -214,7 +215,9 @@ makeMonomialOrdering = (monsize,inverses,nvars,degs,weights,ordering) -> (
      varcount = 0;
      t := toList nonnull fixup2 t';
      logmo := new FunctionApplication from {rawMonomialOrdering,t};
-     (t,t',value logmo, logmo))
+     ret := (t,t',value logmo, logmo);
+     unlock makeMonomialOrderingMutex;
+     ret)
 
 RawMonomialOrdering ** RawMonomialOrdering := RawMonomialOrdering => rawProductMonomialOrdering
 


### PR DESCRIPTION
A number of the variables used in this function are global, so we lock while modifying them so we can construct monomial orders in parallel.

This also gives us a chance to use the new `Mutex` class!

### Before

```m2
i1 : unique \\ class \ taskResult \ apply(20, i -> schedule(() -> ZZ[x]))
/usr/share/Macaulay2/Core/engine.m2:103:47:(1):[18]: error: Inverses => true not compatible with GRevLex
/usr/share/Macaulay2/Core/engine.m2:113:15:(1):[17]: --back trace--
/usr/share/Macaulay2/Core/engine.m2:152:45:(1):[16]: --back trace--
/usr/share/Macaulay2/Core/engine.m2:211:51:(1):[14]: --back trace--
/usr/share/Macaulay2/Core/monoids.m2:565:61:(1):[13]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:130:48:(1):[12]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:146:20:(1):[11]: --back trace--
/usr/share/Macaulay2/Core/option.m2:17:14:(1):[10]: --back trace--
/usr/share/Macaulay2/Core/monoids.m2:589:17:(1):[6]: error: degree list should be of length 0
/usr/share/Macaulay2/Core/remember.m2:11:24:(1):[8]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:130:48:(1):[5]: --back trace--
/usr/share/Macaulay2/Core/polyrings.m2:90:31:(1):[7]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:146:20:(1):[4]: --back trace--
/usr/share/Macaulay2/Core/remember.m2:11:24:(1):[7]: --back trace--
/usr/share/Macaulay2/Core/polyrings.m2:138:55:(1):[2]: --back trace--
/usr/share/Macaulay2/Core/monoids.m2:587:62:(1):[6]: --back trace--
/usr/share/Macaulay2/Core/monoids.m2:589:17:(1):[6]: error: degree list should be of length 0
/usr/share/Macaulay2/Core/methods.m2:130:48:(1):[5]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:130:48:(1):[5]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:146:20:(1):[4]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:146:20:(1):/usr/share/Macaulay2/Core/polyrings.m2:138:55:(1):[2]: --back trace--
[4]: --back trace--
/usr/share/Macaulay2/Core/polyrings.m2:138:55:(1):[2]: --back trace--
/usr/share/Macaulay2/Core/monoids.m2:589:17:(1):[6]: error: degree list should be of length 0
/usr/share/Macaulay2/Core/methods.m2:130:48:(1):[5]: --back trace--
/usr/share/Macaulay2/Core/methods.m2:146:20:(1):[4]: --back trace--
/usr/share/Macaulay2/Core/polyrings.m2:138:55:(1):[2]: --back trace--

o1 = {Nothing, PolynomialRing}

o1 : List

```

### After

```m2
i1 : unique \\ class \ taskResult \ apply(20, i -> schedule(() -> ZZ[x]))

o1 = {PolynomialRing}

o1 : List
```

Closes: #3239 (one of our greatest hits of GitHub workflow build failures!)

## AI Disclosure

Claude Code zeroed in on what was causing `check(6, "NumericalImplicitization")` to fail frequently and wrote an early draft of this commit.