### PR TITLE
Set default `gbTrace` value for CMake build-system

### DIFF
--- a/M2/Macaulay2/packages/CMakeLists.txt
+++ b/M2/Macaulay2/packages/CMakeLists.txt
@@ -33,6 +33,7 @@ set(PACKAGES_DEVEL       "EngineTests" CACHE INTERNAL "the list of packages to o
 ## Arguments to M2
 set(errorDepth                  "1" CACHE STRING "set the error printing depth")
 set(debugLevel                  "0" CACHE STRING "set the debugging level")
+set(gbTrace                     "0" CACHE STRING "set the Groebner basis trace level")
 ## Options to installPackage
 set(CheckDocumentation       "true" CACHE STRING "check documentation for completeness")
 set(IgnoreExampleErrors     "false" CACHE STRING "ignore errors in example code")


### PR DESCRIPTION
If `gbTrace` is not passed either as an environment variable or using `-DgbTrace=foo` then the command line produced by `ctest` for most tests is incorrect, e.g. as seen here: https://github.com/Macaulay2/M2/issues/3421#issuecomment-4453102652

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
