### PR TITLE
Increase epsilon in a DeterminantalRepresentations test

### DIFF
--- a/M2/Macaulay2/packages/DeterminantalRepresentations.m2
+++ b/M2/Macaulay2/packages/DeterminantalRepresentations.m2
@@ -1516,7 +1516,7 @@ assert(isOrthogonal(O, Tolerance=>1e-5) and isDoublyStochastic A and clean(1e-8,
 ///
 
 TEST /// -- cholesky, randomPSD
-eps = 1e-15
+eps = 1e-14
 A = randomPSD 5
 E = eigenvectors(A, Hermitian => true)
 assert(clean(eps, A - E#1*diagonalMatrix(E#0)*transpose E#1) == 0)


### PR DESCRIPTION
This PR fixes #1745 on NixOS 26.05 aarch64. The failing test was discovered in NixOS/nixpkgs#520114 and is the only failing test on the platform.