### PR TITLE
Bug processing example in docs

### DIFF
--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/wedgeProduct-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/wedgeProduct-doc.m2
@@ -2,22 +2,31 @@
 --- author(s): 
 --- notes: 
 
-document { 
-     Key => {(wedgeProduct,ZZ,ZZ,Module),wedgeProduct},
-     Headline => "the exterior multiplication map",
-     Usage => "wedgeProduct(p,q,F)",
-     Inputs => {
-	  "p", "q", "F" => "a free module"
-	  },
-     Outputs => {
-	  Matrix => {"representing the multiplication map
-	  from ", TT "exteriorPower(p,M) ** exteriorPower(q,M)", "
-     	  to ", TT "exteriorPower(p+q,M)"}
-	  },
-     EXAMPLE lines ///
+doc ///
+Key
+     (wedgeProduct, ZZ, ZZ, Module)
+     wedgeProduct     
+Headline
+     the exterior multiplication map
+Usage
+     wedgeProduct(p, q, F)
+Inputs
+     p:ZZ
+     q:ZZ
+     F:Module
+          must be free
+Outputs
+     :Matrix
+          representing the multiplication map from @TT "exteriorPower(p, F) **
+          exteriorPower(q, F)"@ to @TT "exteriorPower(p+q, F)"@
+Description
+     Example
           F = QQ^4
-          wedgeProduct(1,1,F)
-	  ///,
-     SeeAlso => {exteriorPower}
-     }
-
+          wp = wedgeProduct(1, 1, F)
+          L = exteriorPower(1, F)
+          R = exteriorPower(1, F)
+          wp * (L_0 ** R_0)
+          wp * (L_0 ** R_1)
+SeeAlso
+     exteriorPower
+///


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
I am seeing some funny behavior in rendering examples in docs. If I comment out all but the first two lines I see the doc nodes that I expect (which are the ones that already existed prior to this change). If I add in a third line, The example renders as having one more empty input regardless of what the line was - and no output. If I add in a fourth line the example rendering breaks.


This example works locally for me as in :

```
i1 :     F = QQ^4
          wp = wedgeProduct(1, 1, F)
          L = exteriorPower(1, F)
          R = exteriorPower(1, F)
          wp * (L_0 ** R_0)
          wp * (L_0 ** R_1)

       4
o1 = QQ

o1 : QQ-module, free

o2 = | 0 1 0 0 -1 0 0 0 0  0  0 0 0  0  0  0 |
     | 0 0 1 0 0  0 0 0 -1 0  0 0 0  0  0  0 |
     | 0 0 0 0 0  0 1 0 0  -1 0 0 0  0  0  0 |
     | 0 0 0 1 0  0 0 0 0  0  0 0 -1 0  0  0 |
     | 0 0 0 0 0  0 0 1 0  0  0 0 0  -1 0  0 |
     | 0 0 0 0 0  0 0 0 0  0  0 1 0  0  -1 0 |

              6       16
o2 : Matrix QQ  <-- QQ

       4
o3 = QQ

o3 : QQ-module, free

       4
o4 = QQ

o4 : QQ-module, free

o5 = 0

       6
o5 : QQ

o6 = | 1 |
     | 0 |
     | 0 |
     | 0 |
     | 0 |
     | 0 |

       6
o6 : QQ
```