### PR TITLE
Added check for getconf

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -231,6 +231,8 @@ then DOCUMENTATION="html info"
 elif test "$DOCUMENTATION" = download
 then DOCUMENTATION=""
      BUILDLIST="$BUILDLIST Macaulay2-docs"
+     AC_CHECK_PROGS(GETCONF,getconf,false)
+     AS_IF([test $GETCONF = false], AC_MSG_ERROR([getconf is required]))
 else for DOCTYPE in $DOCUMENTATION
     do case $DOCTYPE in
             html|pdf)


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
This is the cause of a subtle problem @wegank encountered while drafting [#519802](https://github.com/NixOS/nixpkgs/pull/519802) in nixpkgs.  Surprisingly, if `getconf` isn't on `$PATH`, Core check `#261` can fail, for reasons detailed in [this comment](https://github.com/NixOS/nixpkgs/pull/519802#issuecomment-4472656747) (also included below).  This is a bit of a nitpick because `getconf` can be found on any system that uses `glibc`, and some that don't, but is not a coreutil, so a check before the rest of the build couldn't hurt.  It certainly would've saved me a day's worth of going through log files.
>I think [this line](https://github.com/coolcuber/nixpkgs-review-gha/actions/runs/25978294393/job/76362348774#step:6:2146) reveals the issue.  Because `getconf` couldn't be found, the documentation database files went to `/lib/share/Macaulay2/*/cache/rawdocumentation-dcba-.db` and `check_261` tries to load them from `/lib/share/Macaulay2/*/cache/rawdocumentation-dcba-8.db` (the correct path), but it didn't find them there, so it ran out of memory trying to load `Macaulay2Doc` without them (see [this comment](https://salsa.debian.org/math-team/macaulay2/-/blob/debian/latest/debian/patches/skip-failing-core-tests.patch?ref_type=heads#L35) in the Debian package).  I think we missed this because there isn't a check for `getconf` in the configuration script and on Linux `getconf` is in `glibc-bin`.