### PR TITLE
Allow gcd in fields that are also quotient rings

### DIFF
--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -15,28 +15,36 @@ monic := t -> (
 gcd(ZZ,RingElement) := (r,s) -> gcd(promote(r,ring s),s)
 gcd(RingElement,ZZ) := (r,s) -> gcd(promote(s,ring r),r)
 
-gcd(RingElement,RingElement) := RingElement => (r,s) -> (
-     R := ring r;
-     if ring s =!= R then error "gcd: expected elements in the same ring";
-     if instance(R,QuotientRing) then error "gcd: unimplemented for this ring";
-     if isField R then if r == 0 and s == 0 then 0_R else 1_R
-     else if factoryAlmostGood R then (
-	  if (options R).Inverses then (r,s) = (numerator r, numerator s);
- 	  new ring r from rawGCD(raw r, raw s))
-     else (
-	 (R1,f,g) := flattenRing(R,Result=>3);
-	 if factoryAlmostGood R1 then g gcd(f r,f s)
-     else if instance(R,PolynomialRing) and numgens R == 1 and isField coefficientRing R then monic (
-	  -- does this depend on the monomial order in R, too?
-	  -- would this code work for more than one variable?
-	  if gbTrace >= 3 then << "gcd via syzygies" << endl;
-	  if r == 0 then s
-	  else if s == 0 then r
-	  else (
-	       a := (syz( matrix{{r,s}}, SyzygyLimit => 1 ))_(0,0);
-	       if s%a != 0 then error "can't find gcd in this ring";
-	       s // a))
-     else notImplemented()))
+gcd(RingElement, RingElement) := RingElement => (r, s) -> (
+    R := ring r;
+    if ring s =!= R then error "gcd: expected elements in the same ring";
+
+    -- GaloisFields are QuotientRings so this line has to go before the
+    -- QuotientRing check
+    if isField R then return if r == 0 and s == 0 then 0_R else 1_R;
+    if instance(R, QuotientRing) then error "gcd: unimplemented for this ring";
+
+    if factoryAlmostGood R then (
+        if (options R).Inverses then (r, s) = (numerator r, numerator s);
+        new ring r from rawGCD(raw r, raw s)
+    ) else (
+        (R1, f, g) := flattenRing(R, Result => 3);
+        if factoryAlmostGood R1 then g gcd(f r,f s)
+        else if instance(R, PolynomialRing) and numgens R == 1 and isField coefficientRing R then monic (
+            -- does this depend on the monomial order in R, too?
+            -- would this code work for more than one variable?
+            if gbTrace >= 3 then << "gcd via syzygies" << endl;
+            if r == 0 then s
+            else if s == 0 then r
+            else (
+                a := (syz(matrix{{r, s}}, SyzygyLimit => 1))_(0,0);
+                if s % a != 0 then error "can't find gcd in this ring";
+                s // a
+            )
+        )
+        else notImplemented()
+    )
+)
 gcd RingElement := identity
 
 gcdCoefficients(ZZ, RingElement) := (r, s) -> gcdCoefficients(r_(ring s), s)

--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -21,7 +21,7 @@ gcd(RingElement, RingElement) := RingElement => (r, s) -> (
 
     -- GaloisFields are QuotientRings so this line has to go before the QuotientRing check
     if isField R then return if r == 0 and s == 0 then 0_R else 1_R;
-    if instance(R, QuotientRing) then notImplemented("gcd for quotient rings is")
+    if instance(R, QuotientRing) then notImplemented("gcd for quotient rings is");
 
     if factoryAlmostGood R then (
         if (options R).Inverses then (r, s) = (numerator r, numerator s);
@@ -46,11 +46,18 @@ gcd(RingElement, RingElement) := RingElement => (r, s) -> (
 )
 gcd RingElement := identity
 
+gcdCoefficientsField := (R, r, s) -> (
+    if (r == 0 and s == 0) then (0_R, 0_R, 0_R)
+        else if r == 0 then (1_R, 0_R, 1/s)
+        else (1_R, 1/r, 0_R)
+)
+
 gcdCoefficients(ZZ, RingElement) := (r, s) -> gcdCoefficients(r_(ring s), s)
 gcdCoefficients(RingElement, ZZ) := (r, s) -> gcdCoefficients(r, s_(ring r))
 gcdCoefficients(RingElement,RingElement) := (f,g) -> (	    -- ??
      R := ring f;
      if R =!= ring g then error "expected elements of the same ring";
+     if isField R then return gcdCoefficientsField(R, f, g);
      if not isPolynomialRing R then error "expected a polynomial ring";
      if not isField coefficientRing R then error "expected a polynomial ring over a field";
      if numgens R > 1 then error "expected a polynomial ring in at most one variable";

--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -19,10 +19,9 @@ gcd(RingElement, RingElement) := RingElement => (r, s) -> (
     R := ring r;
     if ring s =!= R then error "gcd: expected elements in the same ring";
 
-    -- GaloisFields are QuotientRings so this line has to go before the
-    -- QuotientRing check
+    -- GaloisFields are QuotientRings so this line has to go before the QuotientRing check
     if isField R then return if r == 0 and s == 0 then 0_R else 1_R;
-    if instance(R, QuotientRing) then error "gcd: unimplemented for this ring";
+    if instance(R, QuotientRing) then notImplemented("gcd for quotient rings is")
 
     if factoryAlmostGood R then (
         if (options R).Inverses then (r, s) = (numerator r, numerator s);

--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -21,7 +21,7 @@ gcd(RingElement, RingElement) := RingElement => (r, s) -> (
 
     -- GaloisFields are QuotientRings so this line has to go before the QuotientRing check
     if isField R then return if r == 0 and s == 0 then 0_R else 1_R;
-    if instance(R, QuotientRing) then notImplemented("gcd for quotient rings is")
+    if instance(R, QuotientRing) then notImplemented("gcd for quotient rings is");
 
     if factoryAlmostGood R then (
         if (options R).Inverses then (r, s) = (numerator r, numerator s);

--- a/M2/Macaulay2/tests/normal/gcd.m2
+++ b/M2/Macaulay2/tests/normal/gcd.m2
@@ -82,8 +82,13 @@ R = QQ[x]; R2=R[t];
 assert ( gcd(t^2-x^2,t^3-x^3) == t-x )
 
 R = GF(9);
-for i = 0 to 8 assert(gcd(R_0, R_0^i) == 1_R and gcd(R_0^i, 0_R) == 0_R)
-S = R[x];
+for i from 0 to 8 do assert(gcd(R_0, R_0^i) == 1_R and gcd(R_0^i, 0_R) == 1_R);
+assert(gcd(0_R, 0_R) == 0_R)
+assert(gcdCoefficients(0_R, 0_R) == (0_R, 0_R, 0_R))
+assert(gcdCoefficients(R_0, 0_R) == (1_R, 1/R_0, 0_R))
+assert(gcdCoefficients(0_R, R_0) == (1_R, 0_R, 1/R_0))
+assert(gcdCoefficients(R_0, R_0 + 1) == (1_R, 1/R_0, 0_R))
+
 
 debug Core
 R = QQ[x,y]

--- a/M2/Macaulay2/tests/normal/gcd.m2
+++ b/M2/Macaulay2/tests/normal/gcd.m2
@@ -81,6 +81,10 @@ assert( d % w#0 == 0 ) -- actually, we'd like w#0 == d.  I wonder why factory do
 R = QQ[x]; R2=R[t];
 assert ( gcd(t^2-x^2,t^3-x^3) == t-x )
 
+R = GF(9);
+for i = 0 to 8 assert(gcd(R_0, R_0^i) == 1_R and gcd(R_0^i, 0_R) == 0_R)
+S = R[x];
+
 debug Core
 R = QQ[x,y]
 f = 1+x^2


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->

I ran into this bug when computing pushFwd along some ring maps. The logic change seems crisp and clear enough so I am pushing the bare change as a PR but would be happy to reproduce an example that led to me noticing this and capturing it in a test case if requested.

This is in effect just a swap of L24 <> L25 so that the early return comes before the QuotientRing error check. Everything else is just standardized formatting so I could read the code to make sure I understood it while making this change. 