### PR TITLE
M2/Macaulay2/bin/main.cpp: Use interrupts-exports.h

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -4,6 +4,7 @@
 #include <M2/gc-include.h>
 
 #include "interp-exports.h"
+#include "interrupts-exports.h"
 #include <interface/m2-types.h>
 
 #include "M2mem.h"
@@ -37,10 +38,6 @@ static bool gotArg(const char* arg, char* const * argv) {
   for (; *argv; argv++) if (0 == strcmp(arg, *argv)) return true;
   return false;
 }
-
-extern "C" void interrupts_clearInterruptFlag();
-extern "C" void interrupts_clearAlarmedFlag();
-extern "C" void interrupts_determineExceptionFlag();
 
 extern int have_arg_no_int;
 


### PR DESCRIPTION
`M2/Macaulay2/bin/main.cpp` manually declares various interpreter functions.

We change it to use `#include`.

As discussed in [#Workshop: 2026 Atlanta > Python interface, Jupyter kernel via M2 callable library @ 💬](https://macaulay2.zulipchat.com/#narrow/channel/597423-Workshop.3A-2026-Atlanta/topic/Python.20interface.2C.20Jupyter.20kernel.20via.20M2.20callable.20library/near/595839666)