### PR TITLE
fix comment syntax highlighting

### DIFF
--- a/M2/Macaulay2/editors/prism/macaulay2.js.in
+++ b/M2/Macaulay2/editors/prism/macaulay2.js.in
@@ -4,11 +4,11 @@ Prism.languages.m2 =
 Prism.languages.macaulay2 = {
     'comment': [
 	{
-	    pattern: /(^|[^\\])\-\*[\s\S]*?(?:\*\-|$)/,
+	    pattern: /(^|[^\\<|])\-\*[\s\S]*?(?:\*\-|$)/,
 	    lookbehind: true
 	},
 	{
-	    pattern: /(^|[^\\:])\-\-.*/,
+	    pattern: /(^|[^\\<|])\-\-.*/,
 	    lookbehind: true,
 	    greedy: true
 	}


### PR DESCRIPTION
This fixes prism's handling of comments. silly examples of noncomments:
```m2
Symbol * Symbol := toString; symbol <-*symbol a
ZZ |- ZZ := plus; 3 |--1
```
I also removed not highlighting `:--` : I can't think of any circumstance where this would occur, but in any case I think this is a valid comment?
someone should check my regex...