### PR TITLE
Added exception for Darwin builds that aren't using Homebrew

### DIFF
--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -607,9 +607,9 @@ toExternalString SharedLibrary := toExternalFormat @@ describe
 -- homebrew, so we try there if the first call to dlopen fails
 importFrom_Core {"isAbsolutePath"}
 if version#"operating system" == "Darwin" then (
-    brewPrefix := replace("\\s+$", "", get "!brew --prefix");
+    brewPrefix := replace("\\s+$", "", try get "!brew --prefix" else "");
     dlopen' = filename -> (
-	if isAbsolutePath filename then dlopen filename
+	if isAbsolutePath filename or brewPrefix == "" then dlopen filename
 	else (
 	    try dlopen filename
 	    else (


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
If a Darwin build wasn't built with Homebrew, the `dlopen'` function might lead to undesirable behavior.  If Homebrew is innstalled, it might call the wrong libraries, and if it isn't, it would lead to an error (from trying to call `!brew --prefix` without error handling).

This is to address one of the issues from [#519802](https://github.com/NixOS/nixpkgs/pull/519802#discussion_r3266523386) in Nixpkgs.  I was originally going to carve out an exception for Nix builds, but thought that this is better as a general fix.