### PR TITLE
Minor output routine updates

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -20,13 +20,16 @@ needs "nets.m2"
 -- Common utilities for formatting documentation nodes
 -----------------------------------------------------------------------------
 
+-- skip Options; TODO: define parser Option := null instead
+nooptsnull := x -> select(x,e -> class e =!= Option and class e =!= OptionTable and class e =!= Nothing)
+
 -- Macro for setting default parsing of type T
 -- When writing a new formatting tool, call setupRenderer to create the default
 -- parsing for Hypertext, then use the examples provided below to test rendering
 -- of individual subtypes.
 setupRenderer = (parser, joiner, T) -> (
-    parser T := node -> joiner apply(node,
-	subnode -> if class subnode =!= Option and class subnode =!= OptionTable then parser subnode))
+    parser T := node -> joiner apply(nooptsnull node,
+	parser))
 
 -- Default joiners: (TODO: move to string.m2?)
 -- concatenate
@@ -46,8 +49,6 @@ wrapHorizontalJoin := x -> wrap horizontalJoin' x
 -- Hypertext  > HypertextParagraph, HypertextContainer
 -- MarkUpType > IntermediateMarkUpType
 
--- skip Options; TODO: define parser Option := null instead
-noopts := x -> select(x,e -> class e =!= Option and class e =!= OptionTable)
 
 -----------------------------------------------------------------------------
 -- Setup uniform rendering
@@ -171,7 +172,7 @@ scan({net, info},
 	))
 
 Hop := (op,filler) -> x -> (
-     r := horizontalJoin apply(noopts x,op);
+     r := horizontalJoin apply(nooptsnull x,op);
      if width r === 1 then r = horizontalJoin(r," ");
      r || concatenate( width r : filler ) )
 net  HEADER1 := Hop(net, "*")
@@ -187,20 +188,20 @@ net CODE  :=
 net SAMP  :=
 info TT   :=
 info SAMP :=
-info CODE :=  x -> horizontalJoin' apply(noopts x,net)
+info CODE :=  x -> horizontalJoin' apply(nooptsnull x,net)
 
 net  KBD :=
-info KBD := x -> formatNoEscaping toString horizontalJoin' apply(noopts x,net)
+info KBD := x -> formatNoEscaping toString horizontalJoin' apply(nooptsnull x,net)
 
 info PRE  := x ->
-    wrap(printWidth, "-", concatenate apply(noopts x,toString @@ info))
+    wrap(printWidth, "-", concatenate apply(nooptsnull x,toString @@ info))
 
 net TH := Hop(net, "-")
 
 ULop := op -> x -> (
      s := "  * ";
      printWidth = printWidth - #s;
-     r := stack apply(toList noopts x, i -> s | op i);
+     r := stack apply(toList nooptsnull x, i -> s | op i);
      printWidth = printWidth + #s;
      r)
 info UL := ULop info
@@ -217,13 +218,13 @@ OLop := op -> x -> (
 info OL := OLop info
 net  OL := OLop net
 
-info DL := x -> stack apply(noopts x, info)
-net  DL := x -> stack apply(noopts x, net)
+info DL := x -> stack apply(nooptsnull x, info)
+net  DL := x -> stack apply(nooptsnull x, net)
 
-info DD := x -> "    " | horizontalJoin apply(noopts x, info)
-net  DD := x -> "    " | horizontalJoin apply(noopts x, net)
+info DD := x -> "    " | horizontalJoin apply(nooptsnull x, info)
+net  DD := x -> "    " | horizontalJoin apply(nooptsnull x, net)
 
-opSU := (op,n) -> x -> (horizontalJoin apply(noopts x, op))^n
+opSU := (op,n) -> x -> (horizontalJoin apply(nooptsnull x, op))^n
 net  SUP := opSU(net, 1)
 info SUP := opSU(info,1)
 net  SUB := opSU(net, -1)
@@ -250,13 +251,13 @@ net TABLE :=  x -> (
      (op,ag) := override(options TABLE, toSequence x);
      save := printWidth;
      printWidth = printWidth - 2;
-     r := netList(Boxes => op#"class" === "examples", HorizontalSpace => 2, noopts \ toList \ toList sequence ag);
+     r := netList(Boxes => op#"class" === "examples", HorizontalSpace => 2, nooptsnull \ toList \ toList sequence ag);
      printWidth = save;
      r)
 info TABLE := x -> (
      s := printWidth;
      if printWidth > 2 then printWidth = printWidth - 2;
-     ret := netList(Boxes=>true, applyTable(noopts \ toList \ noopts \\ toList x,info));
+     ret := netList(Boxes=>true, applyTable(nooptsnull \ toList \ nooptsnull \\ toList x,info));
      printWidth = s;
      ret)
 

--- a/M2/Macaulay2/m2/latex.m2
+++ b/M2/Macaulay2/m2/latex.m2
@@ -80,6 +80,9 @@ sectionType = sectionNumber -> (
 
 -----------------------------------------------------------------------------
 keywordTexMath = applyKeys(hashTable { -- both unary and binary keywords
+	symbol ==   => "=\\!=",
+	symbol ===  => "=\\!=\\!=",
+	symbol =!=  => "=\\!\\ne\\!=",
 	symbol |-   => "\\vdash ",
 	symbol ..   => "\\,{.}{.}\\,",
 	symbol ..<  => "\\,{.}{.}{<}\\,",
@@ -124,10 +127,11 @@ keywordTexMath = applyKeys(hashTable { -- both unary and binary keywords
 	symbol |>  => "\\rangle ",
 	symbol |   => "\\mid",
 	symbol ||  => "\\mid\\mid",
-	symbol ^** => "{}^{\\otimes}", -- temporary solution to KaTeX issue https://github.com/KaTeX/KaTeX/issues/3576
-	symbol _*  => "{}_*", -- temporary solution to KaTeX issue https://github.com/KaTeX/KaTeX/issues/3576
-	symbol ^*  => "{}^*", -- temporary solution to KaTeX issue https://github.com/KaTeX/KaTeX/issues/3576
+	symbol ^** => "^{\\otimes}",
+	symbol _*  => "_*",
+	symbol ^*  => "^*",
 	symbol ·   => "\\cdot",
+	symbol ⊠  => "\\boxtimes"
 	},symbolBody)
 
 bbLetters := set characters "kABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -147,14 +151,14 @@ texMathLiteralTable := merge(texLiteralTable,
 	},last)
 texMathLiteral = texLiteral1 texMathLiteralTable
 -- TODO: expand and document this behavior
-suffixes := {"bar","tilde","hat","vec","dot","ddot","check","acute","grave","breve"};
-suffixesRegExp := "\\w("|demark("|",suffixes)|")$";
-texVariable := x -> (
+suffixes := {"bar","tilde","hat","vec","ddot","dot","check","acute","grave","breve"};
+suffixesRegExp := "(\\S+?)\\s*("|demark("|",suffixes)|")$";
+texVariable = x -> (
     if x === "" then return "";
     if #x === 2 and x#0 === x#1 and bbLetters#?(x#0) then return "{\\mathbb " | x#0 | "}";
     if last x === "'" then return texVariable substring(x, 0, #x-1) | "'";
     if (r := regex(suffixesRegExp, x)) =!= null then return (
-	r = r#1; "\\" | substring(r, x) | "{" | texVariable substring(x, 0, r#0) | "}");
+	"\\" | substring(r#2, x) | "{" | texVariable substring(r#1,x) | "}");
     if #x === 1 or regex("[^[:alnum:]]", x) =!= null then x else "\\mathit{" | x | "}")
 texMathSymbol :=
 texMath Symbol := texVariable @@ texMathLiteral @@ toString

--- a/M2/Macaulay2/m2/reals.m2
+++ b/M2/Macaulay2/m2/reals.m2
@@ -537,6 +537,8 @@ texMath RR := x -> (
 	)
     )
 texMath RRi := x -> concatenate("\\big[",texMath left x,",",texMath right x,"\\big]",if isEmpty x then "\\text{ (an empty interval)}")
+texMath CCi := x -> texMath realPart x | "+" | texMath imaginaryPart x | texMath ii
+
 withFullPrecision = f -> (
      prec := printingPrecision;
      acc := printingAccuracy;

--- a/M2/Macaulay2/tests/normal/nets.m2
+++ b/M2/Macaulay2/tests/normal/nets.m2
@@ -21,6 +21,13 @@ assert ( toString net x === x )
 -- https://github.com/Macaulay2/M2/issues/1763
 assert(value toExternalString horizontalJoin() == horizontalJoin())
 
+-- net Hypertext
+needsPackage "Text"
+scan({SPAN,DIV,PRE}, h -> (
+	assert(net h {"a",BR{},"b"} == "a"||"b");
+	assert(net h null == stack());
+	))
+
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test nets.out"

--- a/M2/Macaulay2/tests/normal/texmath.m2
+++ b/M2/Macaulay2/tests/normal/texmath.m2
@@ -1,3 +1,40 @@
-assert Equation(
-    texMath new HashTable,
-    ///\texttt{HashTable}\left\{\,\right\}///)
+stripTexMathSpaces = s -> concatenate for i to #s-1 list (
+    if s#i === " " and (i === 0 or s#(i-1) =!= "\\") then "" else s#i)
+stripTexMathBraces = s -> (
+    while #s >= 2 and s#0 === "{" and s#(#s-1) === "}" do s = substring(s, 1, #s-2);
+    s)
+normalizeTexMath = stripTexMathBraces @@ stripTexMathSpaces
+assertTexMath = (x, s) -> assert Equation(normalizeTexMath texMath x, normalizeTexMath s)
+
+assertTexMath(0, ///0///)
+assertTexMath(-7, ///-7///)
+assertTexMath(3/5, ///\frac{3}{5}///)
+assertTexMath(2.5, ///{2.5}///)
+assertTexMath(true, ///\texttt{true}///)
+assertTexMath(infinity, ///\infty///)
+assertTexMath(-infinity, ///{-\infty}///)
+
+assertTexMath("alpha_beta", ///\texttt{alpha\char95 beta}///)
+assertTexMath(symbol alpha, ///\mathit{alpha}///)
+assertTexMath(ZZ, ///{\mathbb Z}///)
+assertTexMath(QQ, ///{\mathbb Q}///)
+
+assertTexMath((1,2,3), ///\left(1,\,2,\,3\right)///)
+assertTexMath({1,2,3}, ///\left\{1,\:2,\:3\right\}///)
+assertTexMath([1,2,3], ///\left[1,\,2,\,3\right]///)
+assertTexMath(new Option from (a=>1), ///a\ \Rightarrow \ 1///)
+assertTexMath(new HashTable, ///\texttt{HashTable}\left\{\,\right\}///)
+assertTexMath(new HashTable from {a=>1,b=>{2,3}}, ///\texttt{HashTable}\left\{a\ \Rightarrow \ 1,\:b\ \Rightarrow \ \left\{2,\:3\right\}\right\}///)
+assertTexMath(new MutableList from {1,2}, ///\texttt{MutableList}\left\{\ldots 2\ldots\right\}///)
+
+R = QQ[x,y,z]
+assertTexMath(R, ///R///)
+assertTexMath(x*y^2, ///x\,y^{2}///)
+assertTexMath(x^2 + y*z - 3, ///x^{2}+y\,z-3///)
+assertTexMath(ideal(x^2,y*z), ///\texttt{ideal}{}\left(x^{2},\,y\,z\right)///)
+assertTexMath(R/ideal(x^2-y), ///\frac{R}{x^{2}-y}///)
+assertTexMath(R^2, ///R^{2}///)
+assertTexMath(map(R,R,{x+y,y,z}), ///\texttt{map}{}\left(R,\,R,\,\left\{x+y,\:y,\:z\right\}\right)///)
+
+assertTexMath(αbar_1, ///\bar{\alpha}_{1}///)
+assertTexMath(addot, ///\ddot{a}///)


### PR DESCRIPTION
This is a minor update to `latex.m2`:
- a workaround for a bug in KaTeX is no longer needed since the bug was fixed
- added a couple of new `texMath` for certain keywords
- there was a bug in a regex for parsing variable names that I fixed
- I added `texMath CCi`

Also a small addendum to #4272 -- missed `net` of a `null` inside a `Hypertext`