### PR TITLE
Add withLock keyword for locking/unlocking mutexes around code

### DIFF
--- a/M2/Macaulay2/d/binding.d
+++ b/M2/Macaulay2/d/binding.d
@@ -321,6 +321,7 @@ bumpPrecedence();
      export profileS       := special("profile",       unaryop, precSpace, wide);
      export shieldS        := special("shield",        unaryop, precSpace, wide);
      export trapS          := special("trap",          unaryop, precSpace, wide);
+     export withLockS      := special("withLock",      unaryop, precSpace, wide);
      export throwS         := special("throw",        nunaryop, precSpace, wide);
      export returnS        := special("return",       nunaryop, precSpace, wide);
      export breakS         := special("break",        nunaryop, precSpace, wide);

--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -279,6 +279,20 @@ unlock(e:Expr):Expr := (
     else WrongArgMutex());
 setupfun("unlock0", unlock);
 
+withLock(c:Code):Expr := (
+    when c
+    is a:sequenceCode do (
+	if length(a.x) == 2 then (
+	    e := eval(a.x.0);
+	    l := lock(e);
+	    when l is Error do return l else nothing;
+	    r := eval(a.x.1);
+	    u := unlock(e);
+	    when u is Error do u else r)
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+setupop(withLockS, withLock);
+
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d pthread.o "
 -- End:

--- a/M2/Macaulay2/m2/exports.m2
+++ b/M2/Macaulay2/m2/exports.m2
@@ -1278,6 +1278,7 @@ export {
 	"when",
 	"while",
 	"width",
+	"withLock",
 	"wrap",
 	"xor",
 	"youngest",

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_mutex.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_mutex.m2
@@ -47,6 +47,7 @@ doc ///
     (lock, Mutex)
     (tryLock, Mutex)
     (unlock, Mutex)
+    symbol withLock
 ///
 
 doc ///
@@ -135,4 +136,30 @@ doc ///
   SeeAlso
     (lock, Mutex)
     (tryLock, Mutex)
+///
+
+doc ///
+  Key
+    symbol withLock
+  Headline
+    evaluate an expression while holding a mutex lock
+  Usage
+    withLock(m, c)
+  Inputs
+    m:Mutex
+    c: -- code to evaluate
+  Description
+    Text
+      @M2CODE "withLock"@ is a keyword that locks the mutex @VAR "m"@, evaluates
+      the code @VAR "c"@, unlocks the mutex, and returns the result of
+      evaluating @VAR "c"@.
+
+      Using @M2CODE "withLock"@ is equivalent to surrounding the code with
+      calls to @TO lock@ and @TO unlock@, but with the added guarantee that the
+      mutex is unlocked even if the code raises an error.
+    Example
+      m = new Mutex
+      last trap withLock(m, (print last trap tryLock m; 1/0))
+      tryLock m
+      unlock m
 ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_threads.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_threads.m2
@@ -27,6 +27,8 @@ Node
  SeeAlso
   "parallelism in engine computations"
   "elapsedTime"
+  AtomicInt
+  Mutex
  Description
   Text
     The simplest way to run computations in parallel is to use @ TO parallelApply @. This works

--- a/M2/Macaulay2/tests/normal/threads.m2
+++ b/M2/Macaulay2/tests/normal/threads.m2
@@ -101,6 +101,10 @@ assert try tryLock m then true else false
 assert try tryLock m then false else true
 unlock m
 
+withLock(m, assert try tryLock m then false else true)
+assert try tryLock m then true else false
+unlock m
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test threads.out"
 -- End:


### PR DESCRIPTION
As suggested by @jkyang92 in https://github.com/Macaulay2/M2/pull/4299#discussion_r3284283364.  This way, we have a way to not worry about getting stuck with a locked mutex if something happens before we have a chance to unlock it.

```m2
i1 : m = new Mutex

o1 = m

o1 : Mutex

i2 : last trap withLock(m, (print last trap tryLock m; 1/0))
pthread_mutex_trylock: Device or resource busy

o2 = division by zero

o2 : Error

i3 : tryLock m

i4 : unlock m

i5 : withLock(m, sleep 60)
  C-c C-cstdio:5:0:(3):[1]: error: interrupted

i6 : tryLock m

i7 : unlock m
```

## AI Disclosure

Claude Code wrote the first draft of the documentation for `withLock` (but I ended up rewriting most of it...)