### PR TITLE
Add .gitmodules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .DS_Store
 .#*
 .*.swp
+.gitmodules

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /M2/Macaulay2/m2/TAGS.doc
 /M2/build-vscode
 /M2/BUILD/*/builds.tmp
+/M2/BUILD/build
 /.vscode
 /M2/BUILD/frank
 /M2/autom4te.cache


### PR DESCRIPTION
Add `.gitmodules` to `.gitignore` so that users can put submodules (for example https://github.com/Macaulay2/vscode-Macaulay2 or https://github.com/Macaulay2/Workshop-2026-Atlanta) inside of their `M2` directory.

Of course, this does mean that when a new git submodule really should be added one must manually add `.gitmodules` but this doesn't seem like a large burden or a frequent occurance.