### PR TITLE
ConnectionMatrices: v1.1

### DIFF
--- a/M2/Macaulay2/packages/ConnectionMatrices.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices.m2
@@ -1,7 +1,7 @@
 newPackage(
     "ConnectionMatrices",
-    Version => "1.0",
-    Date => "March 2025",
+    Version => "1.1",
+    Date => "May 2026",
     Authors => {
 	{ Name => "Paul Goerlach",           Email => "paul.goerlach@ovgu.de",              HomePage => "" },
 	{ Name => "Joris Koefler",           Email => "joris.koefler@mis.mpg.de",           HomePage => "" },

--- a/M2/Macaulay2/packages/ConnectionMatrices.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices.m2
@@ -25,7 +25,8 @@ export {
     -- see ConnectionMatrices.m2
     "standardMonomials",
     "connectionMatrices" => "pfaffianSystem",
-    "connectionMatrix",
+    "connectionForm",
+    "connectionMatrix" => "connectionForm",
     "pfaffianSystem",
     -- see ConnectionMatrices/integrabilityCheck.m2
     "isIntegrable",
@@ -96,20 +97,20 @@ pfaffianSystem(Ideal, List) := (I, B)->(
 )
 
 ----------------------------------------------------
--- connectionMatrix: computes connection matrix of I
+-- connectionForm: computes connection matrix of I
 ----------------------------------------------------
 
-connectionMatrix = method()
+connectionForm = method()
 
 -- D-ideal as an input
-connectionMatrix Ideal := Net => I -> (
+connectionForm Ideal := Net => I -> (
     P := pfaffianSystem I;
     R := rationalWeylAlgebra ring I;
     net sum(P, gens R, (Px, dx) -> Px * dx)
 )
 
 -- a system of connection matrices as input
-connectionMatrix List := Net => P -> (
+connectionForm List := Net => P -> (
     F := ring P#0;
     D := inferWeylAlgebra F;
     R := rationalWeylAlgebra D;

--- a/M2/Macaulay2/packages/ConnectionMatrices.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices.m2
@@ -22,10 +22,11 @@ export {
     -- see ConnectionMatrices/reduce.m2
     "normalForm",
     "baseFractionField",
-    -- see ConnectionMatrices/connectionMatrices.m2
+    -- see ConnectionMatrices.m2
     "standardMonomials",
-    "connectionMatrices",
+    "connectionMatrices" => "pfaffianSystem",
     "connectionMatrix",
+    "pfaffianSystem",
     -- see ConnectionMatrices/integrabilityCheck.m2
     "isIntegrable",
     -- see ConnectionMatrices/gaugeMatrix.m2
@@ -51,7 +52,7 @@ load "./ConnectionMatrices/holonomic.m2"
 load "./ConnectionMatrices/normalForm.m2"
 
 -------------------------------------------------------------
--- connectionMatrices: computes system of connection matrices
+-- pfaffianSystem: computes system of connection matrices
 -------------------------------------------------------------
 
 -- borrowed from Varieties: twists don't make sense on connection matrices, so we remove them
@@ -60,11 +61,11 @@ dehomogenizeMatrix = f -> (R := ring f; map(R^(numRows f), R^(numColumns f), f))
 -- to access private methods from Core
 importFrom_Core { "concatCols" }
 
-connectionMatrices = method()
+pfaffianSystem = method()
 
 -- gives connection matrices for a D-ideal
 -- c.f. [Theorem 1.4.22, SST]
-connectionMatrices Ideal := List => I -> I.cache.connectionMatrices ??= (
+pfaffianSystem Ideal := List => I -> I.cache.pfaffianSystem ??= (
     D := ring I;
     if not isWeylAlgebra D then error "expected left ideal in a Weyl algebra";
     -- TODO: Change holonomic Rank, so it only takes ideal and infers the order from it.
@@ -88,9 +89,9 @@ connectionMatrices Ideal := List => I -> I.cache.connectionMatrices ??= (
 )
 
 -- gives the system of connection matrices with respect to a new basis B
-connectionMatrices(Ideal, List) := (I, B)->(
+pfaffianSystem(Ideal, List) := (I, B)->(
     g := gaugeMatrix(I,B);
-    A := connectionMatrices I;
+    A := pfaffianSystem I;
     gaugeTransform(g, A)
 )
 
@@ -102,7 +103,7 @@ connectionMatrix = method()
 
 -- D-ideal as an input
 connectionMatrix Ideal := Net => I -> (
-    P := connectionMatrices I;
+    P := pfaffianSystem I;
     R := rationalWeylAlgebra ring I;
     net sum(P, gens R, (Px, dx) -> Px * dx)
 )

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -22,7 +22,7 @@ Node
 	standardMonomials
 	baseFractionField
       :Computing and displaying $D$-ideals in connection form
-        connectionMatrices
+        pfaffianSystem
         connectionMatrix
       :Changing basis of a system of connection matrices
         gaugeMatrix
@@ -47,7 +47,7 @@ Node
     normalForm
     standardMonomials
     baseFractionField
-    connectionMatrices
+    pfaffianSystem
     connectionMatrix
     gaugeMatrix
     gaugeTransform
@@ -159,14 +159,14 @@ SeeAlso
 
 doc ///
 Key
-    connectionMatrices
-    (connectionMatrices, Ideal)
-    (connectionMatrices, Ideal, List)
+     pfaffianSystem
+    (pfaffianSystem, Ideal)
+    (pfaffianSystem, Ideal, List)
 Headline
     computes the connection matrices of a $D_n$-ideal $I$ for a chosen basis
 Usage
-    connectionMatrices I
-    connectionMatrices(I, B)
+    pfaffianSystem I
+    pfaffianSystem(I, B)
 Inputs
     I:Ideal
       $D_n$-ideal
@@ -185,7 +185,7 @@ Description
   Example
     D = makeWeylAlgebra(QQ[x,y], {2, 1})
     I = ideal (x*dx^2-y*dy^2+2*dx-2*dy, x*dx+y*dy+1)
-    A = connectionMatrices I
+    A = pfaffianSystem I
 References
   For more details, see [@HREF("https://link.springer.com/book/10.1007/978-3-662-04112-3","SST")@, pp. 37-40].
 ///
@@ -216,7 +216,7 @@ Description
   Example
     D = makeWeylAlgebra(QQ[x,y]);
     I = ideal(x*dx^2-y*dy^2+2*dx-2*dy, x*dx+y*dy+1);
-    A = connectionMatrices I;
+    A = pfaffianSystem I;
     M = matrix {{x,0}, {0,y}};
     gaugeTransform(M, A, D)
   Text
@@ -255,7 +255,7 @@ Description
 Caveat
   The output is purely for visualizing purposes.
 SeeAlso
-  connectionMatrices
+  pfaffianSystem
 ///
 
 doc ///
@@ -318,7 +318,7 @@ Description
   Example
     D = makeWeylAlgebra(frac(QQ[ϵ])[x]);
     I = ideal(x*(1-x)*dx^2 - ϵ*(1-x)*dx);
-    A = connectionMatrices(I, {1_D, 1/ϵ*dx})
+    A = pfaffianSystem(I, {1_D, 1/ϵ*dx})
     isEpsilonFactorized(A, ϵ)
 SeeAlso
   isIntegrable
@@ -351,12 +351,12 @@ Description
   Example
     D = makeWeylAlgebra(QQ[x,y], {1, 2});
     I = ideal(x*dx^2 - y*dy^2 + dx-dy, x*dx+y*dy+1);
-    A = connectionMatrices I;
+    A = pfaffianSystem I;
     assert isIntegrable(D, A)
     assert isIntegrable A
 Caveat
   The matrices need to be defined over the @TO2{baseFractionField, "base fraction field"}@ of $D_n$.
 SeeAlso
-  connectionMatrices
+  pfaffianSystem
   isEpsilonFactorized
 ///

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -222,6 +222,7 @@ Description
     gaugeTransform(M, A, D)
   Text
     It is also possible to compute the gauge transform of a system of connection matrices containing parameters.
+    See line i15 of @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
 SeeAlso
   gaugeMatrix
   "Cosmological correlator for the 2-site chain"

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -15,7 +15,8 @@ Node
       The systematic computation of connection matrices requires Gröbner basis computations in the rational Weyl algebra
       $$ R_n=\CC(x_1,\ldots,x_n)\langle \partial_1,\ldots,\partial_n \rangle. $$
 
-      The theoretical foundations of our algorithms is described the companion paper to this package, available at @arXiv "2504.01362"@.
+      The theoretical foundations of our algorithms are described in the companion paper to this package, available at @arXiv "2504.01362"@.
+      The package is available with Macaulay2, version 1.25.05 and newer.
     Tree
       :Working with the rational Weyl algebra
         normalForm

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -84,7 +84,7 @@ Description
     This method computes the normal form of an element $P$ in the Weyl algebra $D_n$ with respect to another element in the Weyl algebra, or a whole list of such elements.
     The reduction step is carried out over the rational Weyl algebra $R_n$.
   Example
-    D = makeWA(QQ[x,y], {1,1});
+    D = makeWeylAlgebra(QQ[x,y], {1,1});
     P = dx^2 ; Q = x*dx+1;
     normalForm(P, Q)
 References
@@ -114,7 +114,7 @@ Description
     Several functions in this package return an object over the fraction field of the base
     polynomial ring of a Weyl algebra. This function extracts that ring.
   Example
-    D = makeWA(frac(QQ[e])[a,b,c, DegreeRank => 0][x,y]);
+    D = makeWeylAlgebra(frac(QQ[e])[a,b,c, DegreeRank => 0][x,y]);
     baseFractionField D
     gens oo
 ///
@@ -154,7 +154,13 @@ Description
     gaugeMatrix(I, SM2)
   Text
     It is also possible to compute the gauge matrix of a system of connection matrices containing parameters.
-    See line i14 of @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
+  Example
+    D = makeWeylAlgebra(frac(QQ[a])[x]);
+    I = ideal(x^2*dx^2 + x*dx + (x^2-a^2))
+    standardMonomials I
+    gaugeMatrix(I,{dx,x^2*dx^2+x*dx+x^2})
+  Text
+    See also line i14 of @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
 SeeAlso
   standardMonomials
   gaugeTransform
@@ -241,7 +247,14 @@ Description
     gaugeTransform(M, A, D)
   Text
     It is also possible to compute the gauge transform of a system of connection matrices containing parameters.
-    See line i15 of @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
+  Example
+    D = makeWeylAlgebra(frac(QQ[a])[x]);
+    I = ideal(x^2*dx^2 + x*dx + (x^2-a^2))
+    A = pfaffianSystem I
+    M = gaugeMatrix(I,{dx,x^2*dx^2+x*dx+x^2});
+    gaugeTransform(M,A)
+  Text
+    See also line i15 of @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
 SeeAlso
   gaugeMatrix
   "Cosmological correlator for the 2-site chain"

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -311,6 +311,12 @@ Description
     I = ideal(x*dx^2-y*dy^2+2*dx-2*dy, x*dx+y*dy+1);
     standardMonomials I
     holonomicRank I
+  Text
+    Changing the order on the Weyl algebra might change the
+    standard monomials of $I$.
+  Example
+    D2 = makeWeylAlgebra(QQ[x,y],{1,10});
+    standardMonomials(sub(I,D2))
 SeeAlso
   "Dmodules::holonomicRank"
   gaugeMatrix

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -152,6 +152,9 @@ Description
     D2 = makeWeylAlgebra(QQ[x, y], w2 = {1, 2});
     SM2 = standardMonomials sub(I, D2)
     gaugeMatrix(I, SM2)
+  Text
+    It is also possible to compute the gauge matrix of a system of connection matrices containing parameters.
+    See line i14 of @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
 SeeAlso
   standardMonomials
   gaugeTransform

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -87,6 +87,14 @@ Description
     D = makeWeylAlgebra(QQ[x,y], {1,1});
     P = dx^2 ; Q = x*dx+1;
     normalForm(P, Q)
+  Text
+    We can compute the normal form with respect to the Gröbner basis of a $D$-ideal.
+  Example
+    D = makeWeylAlgebra(QQ[x, y]);
+    I = ideal(x*dx^2-y*dy^2+2*dx-2*dy, x*dx+y*dy+1);
+    G = first entries mingens gb I;
+    P = dx;
+    normalForm(P,G)
 References
   See [@HREF("https://link.springer.com/book/10.1007/978-3-662-04112-3","SST")@, Theorem 1.1.7].
 Caveat

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -24,7 +24,7 @@ Node
 	baseFractionField
       :Computing and displaying $D$-ideals in connection form
         pfaffianSystem
-        connectionMatrix
+        connectionForm
       :Changing basis of a system of connection matrices
         gaugeMatrix
         gaugeTransform
@@ -49,7 +49,7 @@ Node
     standardMonomials
     baseFractionField
     pfaffianSystem
-    connectionMatrix
+    connectionForm
     gaugeMatrix
     gaugeTransform
     isEpsilonFactorized
@@ -164,7 +164,7 @@ Key
     (pfaffianSystem, Ideal)
     (pfaffianSystem, Ideal, List)
 Headline
-    computes the connection matrices of a $D_n$-ideal $I$ for a chosen basis
+    computes the Pfaffian system of a $D_n$-ideal $I$ for a chosen basis
 Usage
     pfaffianSystem I
     pfaffianSystem(I, B)
@@ -175,18 +175,34 @@ Inputs
       a basis of $R_n/R_nI$
 Outputs
     A:List
-      the system of connection matrices of $I$ over the @TO2{baseFractionField, "base fraction field"}@ of $D_n$
+      Pfaffian system of $I$ over the @TO2{baseFractionField, "base fraction field"}@ of $D_n$
 Description
   Text
     Let $I$ be an ideal in the Weyl algebra $D_n$ and $B$ a basis for $R_n/R_nI$ over the
     @TO2{baseFractionField, "base fraction field"}@ of $D_n$. If no basis is provided by the user,
     the basis is chosen to be the set of standard monomials of a Gröbner basis on $R_nI$ with
     regards to the weighted Lex order $(\partial_1 > \cdots > \partial_n > x_1 > \cdots > x_n)$
-    on the Weyl algebra.
+    on the Weyl algebra. The following example computes the Pfaffian system for the $D$-ideal
+    annihilating $1/x$ and $1/y$.
   Example
     D = makeWeylAlgebra(QQ[x,y], {2, 1})
     I = ideal (x*dx^2-y*dy^2+2*dx-2*dy, x*dx+y*dy+1)
     A = pfaffianSystem I
+  Text
+    The following example computes the Pfaffian system for the $D$-ideal annihilating $sin(xy)$
+    and $cos(xy)$, with respect to the basis $\{1,dx\}$.
+  Example
+    D = makeWeylAlgebra(QQ[x,y]);
+    I = ideal (dx^2-y^2, dy^2-x^2);
+    A = pfaffianSystem(I,{1_D,dx})
+  Text
+    The command @TT "pfaffianSystem(I,B)"@ computes the Pfaffian system of $I$ with
+    respect to the basis of standard monomials of $I$ and then performs a
+    @TO2{"gaugeTransform", "gauge transformation"}@ to the provided basis $B$.
+  Example
+    B = pfaffianSystem(I)
+    M = gaugeMatrix(I,{1_D,dx})
+    A2 = gaugeTransform(M,B)
 References
   For more details, see [@HREF("https://link.springer.com/book/10.1007/978-3-662-04112-3","SST")@, pp. 37-40].
 ///
@@ -230,14 +246,14 @@ SeeAlso
 
 doc ///
 Key
-    connectionMatrix
-    (connectionMatrix, Ideal)
-    (connectionMatrix, List)
+    connectionForm
+    (connectionForm, Ideal)
+    (connectionForm, List)
 Headline
     computes the connection matrix
 Usage
-    connectionMatrix I
-    connectionMatrix A
+    connectionForm I
+    connectionForm A
 Inputs
     I:Ideal
       of the Weyl algebra
@@ -253,7 +269,15 @@ Description
   Example
     D = makeWeylAlgebra(QQ[x,y]);
     I = ideal(x*dx^2-y*dy^2+2*dx-2*dy, x*dx+y*dy+1);
-    connectionMatrix I
+    connectionForm I
+  Text
+    The following example computes the connection matrix of the $D$-ideal annihilating $sin(xy)$
+    and $cos(xy)$
+  Example
+    D = makeWeylAlgebra(QQ[x,y]);
+    I = ideal (dx^2-y^2, dy^2-x^2);
+    A = pfaffianSystem(I,{1_D,dx});
+    connectionForm A
 Caveat
   The output is purely for visualizing purposes.
 SeeAlso

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -168,7 +168,7 @@ Description
     standardMonomials I
     gaugeMatrix(I,{dx,x^2*dx^2+x*dx+x^2})
   Text
-    See also line i14 of @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
+    See @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
 SeeAlso
   standardMonomials
   gaugeTransform
@@ -262,7 +262,7 @@ Description
     M = gaugeMatrix(I,{dx,x^2*dx^2+x*dx+x^2});
     gaugeTransform(M,A)
   Text
-    See also line i15 of @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
+    See @TO2{"Cosmological correlator for the 2-site chain", "Cosmological correlator for the 2-site chain"}@ for an example.
 SeeAlso
   gaugeMatrix
   "Cosmological correlator for the 2-site chain"

--- a/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/docs.m2
@@ -320,6 +320,11 @@ Description
   Example
     D = makeWeylAlgebra(frac(QQ[ϵ])[x]);
     I = ideal(x*(1-x)*dx^2 - ϵ*(1-x)*dx);
+    A = pfaffianSystem(I)
+    isEpsilonFactorized(A, ϵ)
+  Text
+    The property of being epsilon factorizable depends on a choice of basis.
+  Example
     A = pfaffianSystem(I, {1_D, 1/ϵ*dx})
     isEpsilonFactorized(A, ϵ)
 SeeAlso
@@ -356,6 +361,12 @@ Description
     A = pfaffianSystem I;
     assert isIntegrable(D, A)
     assert isIntegrable A
+  Text
+    A trivial example of a non integrable system comes from non-commuting constant matrices.
+  Example
+    R = baseFractionField(D);
+    A = {sub(matrix{{1,1},{1,1}},R),sub(matrix{{1,0},{0,-1}},R)};
+    isIntegrable(D,A)
 Caveat
   The matrices need to be defined over the @TO2{baseFractionField, "base fraction field"}@ of $D_n$.
 SeeAlso

--- a/M2/Macaulay2/packages/ConnectionMatrices/examples.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/examples.m2
@@ -29,7 +29,7 @@ Description
   Text
     Then, we compute the system in connection form and verify that it meets the integrability conditions.
   Example
-    elapsedTime A = connectionMatrices I;
+    elapsedTime A = pfaffianSystem I;
     elapsedTime assert isIntegrable A
     netList A
   Text
@@ -88,7 +88,7 @@ Description
   Text
     Finally, we can compute the connection matrices.
   Example
-    elapsedTime A = connectionMatrices I;
+    elapsedTime A = pfaffianSystem I;
     elapsedTime assert isIntegrable A
     netList A
 References
@@ -112,10 +112,10 @@ Description
     standardMonomials I
   Text
     [@HREF("https://link.springer.com/book/10.1007/978-3-662-04112-3","SST")@, Example 1.4.23] computes the connection matrices
-    for this system with constants $a=1/2,b=1/2,c=1$. Using the @TO connectionMatrices@ function,
+    for this system with constants $a=1/2,b=1/2,c=1$. Using the @TO pfaffianSystem@ function,
     we can find the system for arbitrary constants.
   Example
-    A = connectionMatrices I;
+    A = pfaffianSystem I;
     isIntegrable A
     netList(Boxes => false, VerticalSpace => 1, apply(4, i -> i+1 => A#i))
   Text
@@ -130,7 +130,7 @@ Description
 	  x_1*dx_1 - x_4*dx_4 + 1 - c,
 	  x_2*dx_2 + x_4*dx_4 + a,
 	  x_3*dx_3 + x_4*dx_4 + b);
-      A := connectionMatrices I;
+      A := pfaffianSystem I;
       UL apply(4, i -> concatenate_("$A_"|i+1|"=") substring_1 tex sub(A#i, {a => 1/2, b => 1/2, c => 1}))
 References
   [@HREF("https://link.springer.com/book/10.1007/978-3-662-04112-3","SST")@] M. Saito, B. Sturmfels, and N. Takayama. {\em Gröbner Deformations of Hypergeometric Differential Equations}. Volume 6 of {\em Algorithms and Computation in Mathematics}. Springer, 2000.

--- a/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
@@ -10,6 +10,13 @@ WeightThenEliminationOrder = w -> join( { Weights => w },
 --D = QQ[x,y,dx,dy, WeylAlgebra => {x=>dx, y=>dy}, MonomialOrder => WeightThenLexicographicOrder {0,0,1,1}]
 --1 + dx + dy + dx^2 + dx*dy + dy^2 + x*(1 + dx + dy + dx^2 + dx*dy + dy^2)
 
+-- retrieve the weight vectors of a WeylAlgebra (or any polynomial ring)
+weights = D -> (
+    mo := D.monoid.Options.MonomialOrder;
+    last \ select(mo, opt ->
+	instance(opt, Option)
+	and opt#0 === Weights))
+
 -- Weyl Algebra with monomial order given by the weighted lexicographic elimination order
 makeWeylAlgebra(PolynomialRing, List) := opts -> (R, v) -> (
     n := numgens R;
@@ -25,7 +32,6 @@ makeWeylAlgebra(PolynomialRing, List) := opts -> (R, v) -> (
     if opts.SetVariables then use W;
     W)
 
--- This causes a crash
 -- Weyl Algebra with non-weighted lexicographic elimination order
 makeWeylAlgebra(PolynomialRing) := opts -> R -> (
     n := length(gens R);
@@ -75,7 +81,7 @@ inferWeylAlgebra = F -> (
 -- Used for bookkeeping elements in R
 rationalWeylAlgebra = memoize((D) -> (
     createDpairs D;
-    w := (((options(D)).MonomialOrder)#1)#1;
+    w := first weights D;
     R := baseFractionField(D);
     (R)(monoid[D.dpairVars#1,
 	    MonomialOrder => WeightThenLexicographicOrder last pack_(#w//2) w ]))
@@ -86,7 +92,7 @@ reduceOneStep = method()
 reduceOneStep(RingElement, RingElement) := (f, g) -> (
     if f == 0 then return f;
     D := ring g;
-    w := (((options(D)).MonomialOrder)#1)#1;
+    w := first weights D;
     n := numgens D // 2;
     F := baseFractionField D;
     R := rationalWeylAlgebra(D);

--- a/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
@@ -129,7 +129,7 @@ normalForm(RingElement, RingElement) := (f, g) -> (
     R := rationalWeylAlgebra(D);
     if R =!= ring f then f = sub(f, R);
     f0 := leadTerm(f);
-    g0 := leadTerm(g);
+    g0 := leadTerm(sub(g,R));
     --fexp := unique exponents f0;
     --gexp := unique apply(exponents g0, e -> last pack_n e);
     fexp := (exponents f0)#0;

--- a/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
@@ -120,44 +120,46 @@ reduceOneStep(RingElement, RingElement) := (f, g) -> (
 -- Normal form with respect to single element g.
 normalForm = method()
 -- f in D, g in D, SST page 7
-normalForm(RingElement, RingElement) := (f, g) -> (
-    if f == 0 then return f;
-    D := ring g;
-    w := (((options(D)).MonomialOrder)#1)#1;
-    n := numgens D // 2;
-    F := baseFractionField D;
-    R := rationalWeylAlgebra(D);
-    if R =!= ring f then f = sub(f, R);
-    f0 := leadTerm(f);
-    g0 := leadTerm(sub(g,R));
-    --fexp := unique exponents f0;
-    --gexp := unique apply(exponents g0, e -> last pack_n e);
-    fexp := (exponents f0)#0;
-    gexp := (last pack_n (exponents g0)#0);
-    -- as long as we refine with elimination lexicographic order, we don't need generic weights
-    -- if #fexp > 1 or #gexp > 1 then error "expected generic weight order";
-    -- RECURSION: if g0 does not divide f0, no reduction is necessary
-    if not (gexp << fexp) then (return f0 + normalForm(f-f0, g));
-    -- compare weights of leading monomials
-    -- scalar product of exponent vector with the weight of the d's
-    fwt := sum(fexp, last pack_n w, times);
-    gwt := sum(gexp, last pack_n w, times);
-    if fwt < gwt then return f;
-    -- find the coefficient to divide by
-    fcoef := lift(f0 // R_(fexp), F);
-    gcoef := lift(sub(g0, R) // R_(gexp), F);
-    -- this must be in D to perform the derivative
-    ddexp := fexp - gexp;
-    ddmon := D_(toList(n:0) | ddexp);
-    -- exponents on the x's are zeroes and exponents of the d's are ddexp
-    -- recurse to normalize the lower order terms
---     -- FIXME: this should work, but doesn't:
---     -- f - fcoef / gcoef * sub(ddmon * g, R)
---     --    print netList {f, g, sub(ddmon * g, R), f % sub(ddmon * g, R)};
---     --    error 0;
-    normalForm(f % sub(ddmon * g, R), g)
-    -- eliminates leading term of f and restarts with the remainder
-    )
+normalForm(RingElement, RingElement) := (f, g) -> normalForm(f,{g})
+
+-- normalForm(RingElement, RingElement) := (f, g) -> (
+--     if f == 0 then return f;
+--     D := ring g;
+--     w := (((options(D)).MonomialOrder)#1)#1;
+--     n := numgens D // 2;
+--     F := baseFractionField D;
+--     R := rationalWeylAlgebra(D);
+--     if R =!= ring f then f = sub(f, R);
+--     f0 := leadTerm(f);
+--     g0 := leadTerm(sub(g,R));
+--     --fexp := unique exponents f0;
+--     --gexp := unique apply(exponents g0, e -> last pack_n e);
+--     fexp := (exponents f0)#0;
+--     gexp := (last pack_n (exponents g0)#0);
+--     -- as long as we refine with elimination lexicographic order, we don't need generic weights
+--     -- if #fexp > 1 or #gexp > 1 then error "expected generic weight order";
+--     -- RECURSION: if g0 does not divide f0, no reduction is necessary
+--     if not (gexp << fexp) then (return f0 + normalForm(f-f0, g));
+--     -- compare weights of leading monomials
+--     -- scalar product of exponent vector with the weight of the d's
+--     fwt := sum(fexp, last pack_n w, times);
+--     gwt := sum(gexp, last pack_n w, times);
+--     if fwt < gwt then return f;
+--     -- find the coefficient to divide by
+--     fcoef := lift(f0 // R_(fexp), F);
+--     gcoef := lift(sub(g0, R) // R_(gexp), F);
+--     -- this must be in D to perform the derivative
+--     ddexp := fexp - gexp;
+--     ddmon := D_(toList(n:0) | ddexp);
+--     -- exponents on the x's are zeroes and exponents of the d's are ddexp
+--     -- recurse to normalize the lower order terms
+-- --     -- FIXME: this should work, but doesn't:
+-- --     -- f - fcoef / gcoef * sub(ddmon * g, R)
+-- --     --    print netList {f, g, sub(ddmon * g, R), f % sub(ddmon * g, R)};
+-- --     --    error 0;
+--     normalForm(f % sub(ddmon * g, R), g)
+--     -- eliminates leading term of f and restarts with the remainder
+--     )
 
 -- use this for lifting from R to D
 -- c.f. https://github.com/Macaulay2/M2/issues/3613
@@ -188,7 +190,7 @@ restart
 needs "reduce.m2"
 -- Examples for testing with connection matrices
 -- Example 1.3: w = (0,0,2,1)
-D = makeWeylAlgebra(QQ[x,y], w = {0,0,2,1});
+D = makeWeylAlgebra(QQ[x,y], w = {2,1});
 I = ideal(x*dx^2-y*dy^2+dx-dy,x*dx+y*dy+1)
 leadTerm(I)
 R = rationalWeylAlgebra D
@@ -208,7 +210,7 @@ normalForm(dy_R^2,flatten entries gens G)
 
 
 -- Example 1.3: w = (0,0,1,2)
-D = makeWeylAlgebra(QQ[x,y], w = {0,0,1,2});
+D = makeWeylAlgebra(QQ[x,y], w = {1,2});
 I = ideal(x*dx^2-y*dy^2+dx-dy,x*dx+y*dy+1)
 leadTerm(I)
 R = rationalWeylAlgebra D
@@ -227,7 +229,7 @@ normalForm(dy_R,flatten entries gens G)
 normalForm(dx_R*dy_R,flatten entries gens G)
 
 -- Example 1.4: w = (0,0,2,1)
-D = makeWeylAlgebra(QQ[x,y], w = {0,0,2,1});
+D = makeWeylAlgebra(QQ[x,y], w = {2,1});
 I = ideal(x*dx^2-y*dy^2+2*dx-2*dy,x*dx+y*dy+1)
 leadTerm(I)
 R = rationalWeylAlgebra D
@@ -245,7 +247,7 @@ normalForm(dy_R,flatten entries gens G)
 normalForm(dy_R^2,flatten entries gens G)
 
 -- w=(0,0,1,2)
-D = makeWeylAlgebra(QQ[x,y], w = {0,0,1,2});
+D = makeWeylAlgebra(QQ[x,y], w = {1,2});
 I = ideal(x*dx^2-y*dy^2+2*dx-2*dy,x*dx+y*dy+1)
 leadTerm(I)
 R = rationalWeylAlgebra D

--- a/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
@@ -87,9 +87,17 @@ rationalWeylAlgebra = memoize((D) -> (
 	    MonomialOrder => WeightThenLexicographicOrder last pack_(#w//2) w ]))
 )
 
--- reduce the lead term in rational Weyl algebra R
-reduceOneStep = method()
-reduceOneStep(RingElement, RingElement) := (f, g) -> (
+-- use this for lifting from R to D
+-- c.f. https://github.com/Macaulay2/M2/issues/3613
+sub' = (g, D) -> if instance(g, D) then g else sum(listForm g,
+    (e, c) -> sub(c, D) * sub((ring g)_e, D))
+
+clearDenominators = (G, D) -> apply(G, g -> if instance(g, D) then g
+    else sub'(g * lcm(denominator \ last \ listForm g), D))
+
+normalForm = method()
+-- Normal form of f with respect to a single element g.
+normalForm(RingElement, RingElement) := (f, g) -> (
     if f == 0 then return f;
     D := ring g;
     w := first weights D;
@@ -105,7 +113,8 @@ reduceOneStep(RingElement, RingElement) := (f, g) -> (
     gexp := (last pack_n (exponents g0)#0);
     -- as long as we refine with elimination lexicographic order, we don't need generic weights
     -- if #fexp > 1 or #gexp > 1 then error "expected generic weight order";
-    if not (gexp << fexp) then return f;
+    -- RECURSION: if g0 does not divide f0, no reduction is necessary
+    if not (gexp << fexp) then return f0 + normalForm(f-f0, g);
     -- compare weights of leading monomials
     -- scalar product of exponent vector with the weight of the d's
     fwt := sum(fexp, last pack_n w, times);
@@ -118,25 +127,20 @@ reduceOneStep(RingElement, RingElement) := (f, g) -> (
     ddexp := fexp - gexp;
     ddmon := D_(toList(n:0) | ddexp);
     -- exponents on the x's are zeroes and exponents of the d's are ddexp
-    -- recurse to normalize the lower order terms
-    -- Computing S-pair
-    f - fcoef / gcoef * sub(ddmon * g, R)
-    )
+    -- the remainder is f % sub(ddmon * g, R), but we can get it directly as
+    r := f - fcoef / gcoef * sub(ddmon * g, R);
+    -- now we recurse to normalize the lower order terms
+    normalForm(r, g))
 
--- use this for lifting from R to D
--- c.f. https://github.com/Macaulay2/M2/issues/3613
-sub' = (g, D) -> if instance(g, D) then g else sum(listForm g,
-    (e, c) -> sub(c, D) * sub((ring g)_e, D))
+-- Reduces only the lead term of f w.r.t g in the rational Weyl algebra R
+reduceLeadTerm = method()
+reduceLeadTerm(RingElement, RingElement) := (f, g) -> (
+    normalForm(f0 := leadTerm f, g) + (f - f0))
 
-clearDenominators = (G, D) -> apply(G, g -> if instance(g, D) then g
-    else sub'(g * lcm(denominator \ last \ listForm g), D))
-
-normalForm = method()
--- Normal form with respect to single element g.
-normalForm(RingElement, RingElement) := (f, g) -> normalForm(f,{g})
--- Normal form with respect to a Groebner basis G.
-normalForm(RingElement, List) := (f, G) -> (
-    -- f in D, G in D, SST page 7
+-- Normal form of f with respect to a Groebner basis G.
+normalForm(RingElement, GroebnerBasis) := (f, G) -> normalForm(f, flatten entries gens G)
+normalForm(RingElement, List)          := (f, G) -> (
+    -- f and G are in Weyl algebra D, see SST page 7.
     if f == 0 then return f;
     D := ring(G#0);
     w := first weights D;
@@ -144,67 +148,18 @@ normalForm(RingElement, List) := (f, G) -> (
     G = clearDenominators(G, D);
     f = sub(f, R);
     f0 := 0_R;
-    -- iterate as long as going through G does not give any change
-    while f0 != f do (
-	f0 = f; scan(G, g -> f = reduceOneStep(f, g)));
-    -- recurse to normalize the lower order terms
+    -- iteratively reduce the lead term w.r.t G until it does not change
+    while f0 != f do ( f0 = f; scan(G, g -> f = reduceLeadTerm(f, g)) );
+    -- now recurse to normalize the lower order terms
     f = leadTerm f + normalForm(f - leadTerm f, G);
+    -- Alternatively, we can reduce all of f repeatedly, but this may be slower.
+    -- while f0 != f do ( f0 = f; scan(G, g -> f = normalForm(f, g)) );
     f)
-
--- Suppose G = {g1, g2}, then this version works with the assumption
--- that reducing once against g1 and once against g2 is enough,
--- but we think it might be possible that after reducing against g2,
--- the element f can be again reduced with respect to g1.
--- TODO: find an explicit example where this occurs.
--- normalForm(RingElement, List) := (f, G) -> (
---     if f == 0 then return f;
---     D := ring(G#0);
---     G = clearDenominators(G, D);
---     scan(G, g -> f = normalForm(f, g));
---     f)
--- normalForm(RingElement, RingElement) := (f, g) -> (
---     if f == 0 then return f;
---     D := ring g;
---     w := first weights D;
---     n := numgens D // 2;
---     F := baseFractionField D;
---     R := rationalWeylAlgebra(D);
---     if R =!= ring f then f = sub(f, R);
---     f0 := leadTerm(f);
---     g0 := leadTerm(sub(g,R));
---     --fexp := unique exponents f0;
---     --gexp := unique apply(exponents g0, e -> last pack_n e);
---     fexp := (exponents f0)#0;
---     gexp := (last pack_n (exponents g0)#0);
---     -- as long as we refine with elimination lexicographic order, we don't need generic weights
---     -- if #fexp > 1 or #gexp > 1 then error "expected generic weight order";
---     -- RECURSION: if g0 does not divide f0, no reduction is necessary
---     if not (gexp << fexp) then (return f0 + normalForm(f-f0, g));
---     -- compare weights of leading monomials
---     -- scalar product of exponent vector with the weight of the d's
---     fwt := sum(fexp, last pack_n w, times);
---     gwt := sum(gexp, last pack_n w, times);
---     if fwt < gwt then return f;
---     -- find the coefficient to divide by
---     fcoef := lift(f0 // R_(fexp), F);
---     gcoef := lift(sub(g0, R) // R_(gexp), F);
---     -- this must be in D to perform the derivative
---     ddexp := fexp - gexp;
---     ddmon := D_(toList(n:0) | ddexp);
---     -- exponents on the x's are zeroes and exponents of the d's are ddexp
---     -- recurse to normalize the lower order terms
--- --     -- FIXME: this should work, but doesn't:
--- --     -- f - fcoef / gcoef * sub(ddmon * g, R)
--- --     --    print netList {f, g, sub(ddmon * g, R), f % sub(ddmon * g, R)};
--- --     --    error 0;
---     normalForm(f % sub(ddmon * g, R), g)
---     -- eliminates leading term of f and restarts with the remainder
---     )
 
 end--
 restart
 
-needs "reduce.m2"
+debug needsPackage "ConnectionMatrices"
 -- Examples for testing with connection matrices
 -- Example 1.3: w = (0,0,2,1)
 D = makeWeylAlgebra(QQ[x,y], w = {2,1});

--- a/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/normalForm.m2
@@ -123,15 +123,49 @@ reduceOneStep(RingElement, RingElement) := (f, g) -> (
     f - fcoef / gcoef * sub(ddmon * g, R)
     )
 
--- Normal form with respect to single element g.
-normalForm = method()
--- f in D, g in D, SST page 7
-normalForm(RingElement, RingElement) := (f, g) -> normalForm(f,{g})
+-- use this for lifting from R to D
+-- c.f. https://github.com/Macaulay2/M2/issues/3613
+sub' = (g, D) -> if instance(g, D) then g else sum(listForm g,
+    (e, c) -> sub(c, D) * sub((ring g)_e, D))
 
+clearDenominators = (G, D) -> apply(G, g -> if instance(g, D) then g
+    else sub'(g * lcm(denominator \ last \ listForm g), D))
+
+normalForm = method()
+-- Normal form with respect to single element g.
+normalForm(RingElement, RingElement) := (f, g) -> normalForm(f,{g})
+-- Normal form with respect to a Groebner basis G.
+normalForm(RingElement, List) := (f, G) -> (
+    -- f in D, G in D, SST page 7
+    if f == 0 then return f;
+    D := ring(G#0);
+    w := first weights D;
+    R := rationalWeylAlgebra D;
+    G = clearDenominators(G, D);
+    f = sub(f, R);
+    f0 := 0_R;
+    -- iterate as long as going through G does not give any change
+    while f0 != f do (
+	f0 = f; scan(G, g -> f = reduceOneStep(f, g)));
+    -- recurse to normalize the lower order terms
+    f = leadTerm f + normalForm(f - leadTerm f, G);
+    f)
+
+-- Suppose G = {g1, g2}, then this version works with the assumption
+-- that reducing once against g1 and once against g2 is enough,
+-- but we think it might be possible that after reducing against g2,
+-- the element f can be again reduced with respect to g1.
+-- TODO: find an explicit example where this occurs.
+-- normalForm(RingElement, List) := (f, G) -> (
+--     if f == 0 then return f;
+--     D := ring(G#0);
+--     G = clearDenominators(G, D);
+--     scan(G, g -> f = normalForm(f, g));
+--     f)
 -- normalForm(RingElement, RingElement) := (f, g) -> (
 --     if f == 0 then return f;
 --     D := ring g;
---     w := (((options(D)).MonomialOrder)#1)#1;
+--     w := first weights D;
 --     n := numgens D // 2;
 --     F := baseFractionField D;
 --     R := rationalWeylAlgebra(D);
@@ -166,29 +200,6 @@ normalForm(RingElement, RingElement) := (f, g) -> normalForm(f,{g})
 --     normalForm(f % sub(ddmon * g, R), g)
 --     -- eliminates leading term of f and restarts with the remainder
 --     )
-
--- use this for lifting from R to D
--- c.f. https://github.com/Macaulay2/M2/issues/3613
-sub' = (g, D) -> if instance(g, D) then g else sum(listForm g,
-    (e, c) -> sub(c, D) * sub((ring g)_e, D))
-
-clearDenominators = (G, D) -> apply(G, g -> if instance(g, D) then g else sub'(g * lcm(denominator \ last \ listForm g), D))
-
--- Normal Form w.r.t. a Groebner Basis
-normalForm(RingElement, List) := (f, G) -> (
-    if f == 0 then return f;
-    D := ring(G#0);
-    w := (((options(D)).MonomialOrder)#1)#1;
-    G = clearDenominators(G, D);
-    haschanged := true;
-    -- iterate as long as going through G does not give any change
-    while haschanged do(
-        fstart := sub(f, rationalWeylAlgebra(D));
-        scan(G, g -> f = reduceOneStep(f, g));
-        haschanged = not(fstart == f);
-        );
-    f = leadTerm(f) + normalForm(f-leadTerm(f), G);
-    f)
 
 end--
 restart

--- a/M2/Macaulay2/packages/ConnectionMatrices/tests.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/tests.m2
@@ -26,7 +26,7 @@ TEST /// -- course notes, Example 7.16 (1)
   assert(G == {y*dy+x*dx+1, x^2*dx^2-x*y*dx^2+3*x*dx-y*dx+1, x*dx*dy+x*dx^2+dy+dx });
 
   R = baseFractionField D
-  A = connectionMatrices I;
+  A = pfaffianSystem I;
   assert(A_0 == map(R^2, R^2, {{0, 1}, {(-1)/(x^2-x*y), (-3*x+y)/(x^2-x*y)}}))
   assert(A_1 == map(R^2, R^2, {{(-1)/y, (-x)/y}, {1/(x*y-y^2), (x+y)/(x*y-y^2)}}))
 
@@ -46,7 +46,7 @@ TEST /// -- course notes, Example 7.16 (2)
   assert(holonomicRank(w, comodule I) == 2);
 
   R = baseFractionField D;
-  A = connectionMatrices I;
+  A = pfaffianSystem I;
   G = flatten entries gens gb I;
 
   SM = standardMonomials I;
@@ -70,7 +70,7 @@ TEST /// -- course notes, Example 7.16 (3)
   assert(holonomicRank(w, comodule I) == 2);
 
   R = baseFractionField D;
-  A = connectionMatrices I;
+  A = pfaffianSystem I;
   G = flatten entries gens gb I;
 
   SM = standardMonomials I;
@@ -102,11 +102,11 @@ TEST /// -- Example from Overleaf
   assert(holonomicRank I == 2)
 
   -- Computing the system of connection matrices w.r.t. weight vector w1
-  C1 = connectionMatrices I;
+  C1 = pfaffianSystem I;
   SM1 = standardMonomials I;
 
   -- Computing the system of connection matrices w.r.t. weight vector w2
-  C2 = connectionMatrices sub(I, D2);
+  C2 = pfaffianSystem sub(I, D2);
   SM2 = standardMonomials sub(I, D2);
 
   R = baseFractionField D2
@@ -163,7 +163,7 @@ TEST /// -- isIntegrable
   -- A connection coming from a D-ideal is integrable:
   D = makeWeylAlgebra(QQ[x,y], w = {1,2});
   I = ideal(x*dx^2 - y*dy^2 + dx-dy, x*dx+y*dy+1);
-  A = connectionMatrices I;
+  A = pfaffianSystem I;
   assert(isIntegrable(D,A));
 
   -- Constant coefficient matrices that don't commute can't come from an integrable system.

--- a/M2/Macaulay2/packages/ConnectionMatrices/tests.m2
+++ b/M2/Macaulay2/packages/ConnectionMatrices/tests.m2
@@ -37,6 +37,27 @@ TEST /// -- course notes, Example 7.16 (1)
   -- Grobner basis:
   -- | ydy+xdx+1 xdxdy+xdx^2+dy+dx x2dx^2-xydx^2+3xdx-ydx+1 |
 
+  -- Note: this example also shows that reducing with respect to each
+  -- element of G only once in order doesn't suffice, because after
+  -- reducing by an element, the result may become further reducible
+  -- by an earlier element in the list.
+  debug needsPackage "ConnectionMatrices"
+  D = makeWeylAlgebra(QQ[x,y], w = {2,1});
+  I = ideal(x*dx^2 - y*dy^2 + dx-dy, x*dx+y*dy+1)
+  R = rationalWeylAlgebra D
+  G = flatten entries gens gb I
+  f0 = dx_R*dy_R
+  -- first pass
+  f1 = normalForm(f0, G#0) -- does not reduce wrt G#0
+  f2 = normalForm(f1, G#1) -- reduces
+  f3 = normalForm(f2, G#2)
+  assert same {f0, f1, dx_R*dy_R}
+  assert same {f2, f3, -(y_R*x_R^-1)*dy_R^2 - (2*x_R^-1)*dy_R}
+  -- second pass
+  f4 = normalForm(f3, G#0) -- now it reduces wrt G#0!
+  f5 = normalForm(f4, G#1)
+  f6 = normalForm(f5, G#2)
+  assert same {f4, f5, f6, (-x_R-y_R)*(x_R^2-x_R*y_R)^-1*dy_R - (x_R^2-x_R*y_R)^-1}
 ///
 
 TEST /// -- course notes, Example 7.16 (2)


### PR DESCRIPTION
This PR implements changes from JSAG's technical review.

- **renamed connectionMatrices => pfaffianSystem**
- **added available date m2**
- **example gauge**
- **more examples**
- **examples and renaming**
- **standard monomials example**
- **connectionMatrix example**
- **gauge examples**
- **normal form example**
- **removed hardcoded line numbers**
- **added helper weights**
- **simplified normalForm and added comment for the old version**
- **rename reduceOneStep to reduceLeadTerm and combine with normalForm**

AI disclosure: none.