### PR TITLE
Reject zero substitutions in Laurent denominators

### DIFF
--- a/M2/Macaulay2/e/ringmap.cpp
+++ b/M2/Macaulay2/e/ringmap.cpp
@@ -5,6 +5,7 @@
 #include "matrices/matrix-con.hpp"
 #include "rings/polyring.hpp"
 #include "ring-elements/ring-element.hpp"
+#include "exceptions.hpp"
 
 #include <iostream>
 RingMap::RingMap(const Matrix *m) : R(m->get_ring())
@@ -143,12 +144,17 @@ ring_elem RingMap::eval_term(const Ring *sourceK,  // source coeff ring
                              int first_var,
                              int nvars_in_source) const
 {
+  bool result_is_zero = false;
   for (index_varpower i = vp; i.valid(); ++i)
     {
       int v = first_var + i.var();
       if (v >= nvars || _elem[v].is_zero)
-        return R->from_long(0);  // The result is zero.
+        {
+          if (i.exponent() < 0) throw exc::division_by_zero_error();
+          result_is_zero = true;
+        }
     }
+  if (result_is_zero) return R->from_long(0);
 
   // If K is a coeff ring of R, AND map is an identity on K,
   // then don't recurse: use this value directly.

--- a/M2/Macaulay2/tests/normal/subst.m2
+++ b/M2/Macaulay2/tests/normal/subst.m2
@@ -4,6 +4,17 @@ I = matrix{{x^2,y^2}}
 P=matrix({{2,3,4}})
 substitute(f,P)
 substitute(I,P)
+
+S = QQ[t,Inverses=>true,MonomialOrder=>Lex]
+g = matrix{{t^-1,1/2}}
+assert(try (sub(g,t=>0); false) else true)
+assert(sub(matrix{{t,1/2}}, t=>0) == matrix{{0_QQ,1/2}})
+assert(sub(t^-1, t=>2) == 1/2)
+
+T = QQ[x,y,Inverses=>true,MonomialOrder=>Lex]
+assert(try (sub(x^(-1)*y, {x => 0, y => 0}); false) else true)
+assert(sub(x*y, {x => 0, y => 0}) == 0)
+
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test subst.out"


### PR DESCRIPTION
I forget if I ever submitted an issue:
```
   R=QQ[x,Inverses=>true,MonomialOrder=>Lex]
   f=matrix{{x^-1,1/2}}
   sub(f,x=>0)
```
will happily produce `matrix{{0,1/2}}` instead of throwing an error. Fixed with test.

# AI Disclosure

codex helped me diagnose this.