### PR TITLE
fix code() failing with "line number not found in file stdio" on pasted input

### DIFF
--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -175,7 +175,24 @@ static int read_via_readline(char *buf,int len,char *prompt) {
     if (p == NULL) return 0;	/* EOF */
     i = 0;
     plen = strlen(p);
-    add_history(p);
+    /* readline 8+ with bracketed paste mode can return a multi-line string
+       when the user pastes text containing newlines.  add_history on such a
+       string would store one entry for the whole paste, but M2's line counter
+       increments for every '\n' it sees, breaking the 1:1 correspondence that
+       code.m2 relies on when fetching history by line number.  Split at each
+       embedded newline so every logical line gets its own history entry. */
+    {
+      char *s = p;
+      char *nl;
+      while ((nl = strchr(s, '\n')) != NULL) {
+	char saved = *nl;
+	*nl = '\0';
+	add_history(s);
+	*nl = saved;
+	s = nl + 1;
+      }
+      add_history(s);
+    }
   }
   r = plen - i;
   if (r > len) r = len;


### PR DESCRIPTION
readline 8+ enables bracketed paste mode by default.  When the user pastes multiple lines at once, readline() can return a single string containing embedded newlines (e.g. "expr1\nexpr2") rather than one line per readline() call.

The old code called add_history() on the entire returned string, so the whole paste was stored as one history entry.  Meanwhile M2's parser incremented lineNumber for every '\n' it saw, creating a mismatch: after a two-line paste the session line counter was 2 but only one new history entry existed.

code.m2 maps M2 line numbers to history entries via
    getHistory(lineNumber + historyOffset)
so getHistory(2 + historyOffset) would call history_get() with an out-of-range index, return NULL, and ultimately produce:

    error: line number 1 not found in file stdio

Fix: instead of a single add_history(p), split p at each embedded '\n' and add each segment as its own history entry (save/restore the '\n' in-place).  For single-line input (the common case) this is identical to the previous behaviour.

Fixes: #4356 

## AI Disclosure

This was 100% Claude Code
