### PR TITLE
Use markdown for links when possible

### DIFF
--- a/M2/Macaulay2/m2/format.m2
+++ b/M2/Macaulay2/m2/format.m2
@@ -289,7 +289,7 @@ infoTagConvert DocumentTag := tag -> (
 
 -- TODO: can this be simplified?
 -- checking if doc is missing can be very slow if node is from another package
-info TO  := x -> info TO2{x#0, format x#0 | if x#?1 then x#1 else ""}
+info TO  := x -> info TO2 x
 info TO2 := x -> (
      tag := fixup x#0;
      if isMissingDoc tag or isUndocumented tag then concatenate(x#1, " (missing documentation)")

--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -170,7 +170,7 @@ html MENU := x -> html redoMENU x
 
 html INDENT := x -> html DIV append(toList x, "class"=>"indent")
 
-html TO   := x -> html TO2{tag := x#0, format tag | if x#?1 then x#1 else ""}
+html TO   := x -> html TO2 x
 html TO2  := x -> (
     (tag, name) := (x#0, x#1);
     -- TODO: add this to htmlLiteral? what is it even for?

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -262,6 +262,7 @@ new TOH  from Thing     := (TO, x) -> new TO from {x}
 new TO   from List      := (TO, x) -> if x#?1 then { makeDocumentTag x#0, concatenate drop(toSequence x,1) } else { makeDocumentTag x#0 }
 new TO2  from List      :=
 new TO2  from Sequence  := (TO2, x) -> { makeDocumentTag x#0, concatenate drop(toSequence x,1) }
+new TO2  from TO        := (TO2, x) -> TO2 {x#0, format x#0 | (x#1 ?? "")}
 new TOH  from List      := (TOH, x) -> { makeDocumentTag x#0 }
 new HREF from List      := (HREF, x) -> (
     url := if x#?0 and (instance(x#0, String) or instance(x#0, Sequence) and #x#0 === 2 and all(x#0, y -> instance(y, String)))

--- a/M2/Macaulay2/m2/markdown.m2
+++ b/M2/Macaulay2/m2/markdown.m2
@@ -104,9 +104,28 @@ markdown DD := x -> shorten concatenate(lvl:"   ", ": ", apply(x, markdown))
 
 -- Links
 -- (markdown, TOH) defined in format.m2
-markdown TO     :=
-markdown TO2    :=
-markdown ANCHOR := html
+markdown TO     := x -> markdown TO2 x
+markdown TO2    := x -> (
+    -- TODO: essentially the same as html(TO2) -- de-duplicate?
+    (tag, name) := (x#0, x#1);
+    if tag.Format != tag.Package then tag = getPrimaryTag fixup tag;
+    if (isUndocumented or isMissingDoc) tag
+    then concatenate(markdown TT name, " (missing documentation)")
+    else markdown ANCHOR {
+	"title" => headline tag,
+	"href"  => toURL htmlFilename tag, name})
+markdown ANCHOR := x -> (
+    elems := partition(a -> instance(a, Option), toList x, {true, false});
+    attrs := hashTable elems#true;
+    -- if we have "href" and possibly "title" attributes, then use markdown
+    if (
+	#attrs == 1 and attrs#?"href" or
+	#attrs == 2 and attrs#?"href" and attrs#?"title")
+    then concatenate("[", markdown \ elems#false, "](",
+	attrs#"href",
+	(1, format attrs#"title") ?? "", ")")
+    -- otherwise fall back to html
+    else html x)
 markdown HREF   := x -> concatenate("[", markdown last x, "](", toURL first x, ")")
 
 -- Images

--- a/M2/Macaulay2/m2/markdown.m2
+++ b/M2/Macaulay2/m2/markdown.m2
@@ -46,7 +46,7 @@ markdown TITLE := x -> concatenate("title: ", apply(x, markdown), newline)
 
 markdown BODY  := x -> concatenate(
     "{% raw %}", shorten apply(x, markdown), "{% endraw %}")
-markdown SPAN  := x -> concatenate(apply(x, markdown), newline) -- TODO: should this have a newline?
+markdown SPAN  := x -> concatenate apply(x, markdown)
 markdown PARA  := x -> concatenate(apply(x, markdown), 2:newline)
 markdown DIV   := x -> (
     c := (parseAttr(DIV, x))#"class";


### PR DESCRIPTION
When an `ANCHOR` object contains only "href" and possibly "title" attributes, then it's possible to use pure markdown to render the link, e.g.:

* `<a href="foo">bar</a>` ⟶ `[bar](foo)`
* `<a href="foo" title="baz">bar</a>` ⟶ `[bar](foo "baz")`

We do this when possible in the (unexported) `markdown(ANCHOR)` method and update `markdown(TO)` and `markdown(TO2)` accordingly.  (We also add a helper function for converting `TO` ⟶ `TO2` since we do the same thing in several places.)

This significantly improves the appearance of the "signature help" feature in the latest draft of the language server when using Eglot in Emacs.  

### Before

```m2
i1 : debug Core

i2 : markdown TO rank

o2 = <a title="compute the rank" href="/usr/share/doc/Macaulay2/Macaulay2Doc/html/_rank.html">rank</a>
```

#### Using the language server in Emacs

<img width="988" height="222" alt="image" src="https://github.com/user-attachments/assets/78f03b4c-2a07-4703-858d-c190260fd01a" />


### After

```m2
i1 : debug Core

i2 : markdown TO rank

o2 = [rank](/usr/share/doc/Macaulay2/Macaulay2Doc/html/_rank.html "compute the rank")
```

#### Using the language server in Emacs

<img width="217" height="219" alt="image" src="https://github.com/user-attachments/assets/33955b34-1ccb-4f80-973d-fb664ea4942d" />

## AI Disclosure

This one was pretty much all me.  I did have Claude Code review my code.  It suggested a few changes, but I disagreed with them and it was convinced after I stated my case.