### PR TITLE
Update pushForward routine in Core to handle towers better

### DIFF
--- a/M2/Macaulay2/m2/pushforward.m2
+++ b/M2/Macaulay2/m2/pushforward.m2
@@ -118,26 +118,26 @@ pushNonLinear := (opts, f, M) -> (
     -- returns R-presentation matrix for the pushforward of M
     -- written by Mike Stillman and David Eisenbud
 
-    -- first flatten R, S so that this computation works for towers.
+    -- first flatten source and target of f so that this computation works for towers.
     -- note this forces us to unflatten the return value when we are done.
-    (S, phiS) := flattenRing target f;
-    (R, phiR) := flattenRing source f;
-    m := phiS presentation M;
-    f = phiS * f * phiR^-1;
+    (R, phiR) := flattenRing target f;
+    (S, phiS) := flattenRing source f;
+    m := phiR presentation M;
+    f = phiR * f * phiS^-1;
 
     -- set up some variables that are used throughout
-    deglenR := degreeLength R;
-    numgensR := numgens R;
+    deglenS := degreeLength S;
     numgensS := numgens S;
+    numgensR := numgens R;
 
     monorder := opts.MonomialOrder;
-    monorder  = if ordertab#?monorder then (ordertab#monorder)(numgensS, numgensR)
+    monorder  = if ordertab#?monorder then (ordertab#monorder)(numgensR, numgensS)
     else error("pushForward: MonomialOrder option expected one of ",
 	demark_", " \\ toString \ keys ordertab);
 
     J := graphIdeal(f, MonomialOrder => monorder, VariableBaseName => local X);
     G := ring J;
-    xvars := map(G, S, submatrix(vars G, toList(0..numgensS - 1)));
+    xvars := map(G, R, submatrix(vars G, toList(0..numgensR - 1)));
     m1 := presentation (cokernel xvars m  **  cokernel generators J);
 
     if opts.UseHilbertFunction and all({f, m}, isHomogeneous) then (
@@ -148,15 +148,15 @@ pushNonLinear := (opts, f, M) -> (
 	-- cache poincare
 	poincare cokernel m1 = hf);
 
-    mapbackdeg := d -> take(d, -deglenR);
+    mapbackdeg := d -> take(d, -deglenS);
     -- that choice of degree map was chosen to make the symmetricPower functor homogeneous, but it doesn't have much
     -- else to recommend it.
-    -- we should really be *lifting* the result to R along the natural map R ---> G
-    mapback := map(R, G, map(R^1, R^numgensS, 0) | vars R, DegreeMap => mapbackdeg );
+    -- we should really be *lifting* the result to S along the natural map S ---> G
+    mapback := map(S, G, map(S^1, S^numgensR, 0) | vars S, DegreeMap => mapbackdeg );
 
     -- let's at least check it splits f's degree map:
-    for i from 0 to deglenR-1 do (
-	e := for j from 0 to deglenR-1 list if i === j then 1 else 0;
+    for i from 0 to deglenS-1 do (
+	e := for j from 0 to deglenS-1 list if i === j then 1 else 0;
 	if mapbackdeg f.cache.DegreeMap e =!= e
 	then error "not implemented yet: unexpected degree map of ring map");
 
@@ -164,8 +164,8 @@ pushNonLinear := (opts, f, M) -> (
 	StopBeforeComputation => opts.StopBeforeComputation,
 	DegreeLimit           => opts.DegreeLimit,
 	PairLimit             => opts.PairLimit);
-    -- MES: check if the monomial order restricts to S.  If so, then do `` forceGB result ''
-    phiR^-1 mapback selectInSubring(if numgensS > 0 then 1 else 0, generators g))
+    -- MES: check if the monomial order restricts to R.  If so, then do `` forceGB result ''
+    phiS^-1 mapback selectInSubring(if numgensR > 0 then 1 else 0, generators g))
 
 -*
 pushLinear := opts -> (f,M) -> (

--- a/M2/Macaulay2/m2/pushforward.m2
+++ b/M2/Macaulay2/m2/pushforward.m2
@@ -117,19 +117,19 @@ pushNonLinear := (opts, f, M) -> (
     -- given f: R --> S, and M an S-module, finite over R,
     -- returns R-presentation matrix for the pushforward of M
     -- written by Mike Stillman and David Eisenbud
-    (R, S) := (target f, source f);
-    deglen := degreeLength S;
-    n1 := numgens R; -- TODO: what if R is a tower?
+    (S, R) := (target f, source f);
+    deglen := degreeLength R;
+    n1 := numgens S; -- TODO: what if S is a tower?
 
     monorder := opts.MonomialOrder;
-    monorder  = if ordertab#?monorder then (ordertab#monorder)(numgens R, numgens S)
+    monorder  = if ordertab#?monorder then (ordertab#monorder)(numgens S, numgens R)
     else error("pushForward: MonomialOrder option expected one of ",
 	demark_", " \\ toString \ keys ordertab);
 
     J := graphIdeal(f, MonomialOrder => monorder, VariableBaseName => local X);
     G := ring J;
     m := presentation M;
-    xvars := map(G, R, submatrix(vars G, toList(0..n1-1)));
+    xvars := map(G, S, submatrix(vars G, toList(0..n1-1)));
     m1 := presentation (cokernel xvars m  **  cokernel generators J);
 
     if opts.UseHilbertFunction and all({f, m}, isHomogeneous) then (
@@ -143,8 +143,8 @@ pushNonLinear := (opts, f, M) -> (
     mapbackdeg := d -> take(d, -deglen);
     -- that choice of degree map was chosen to make the symmetricPower functor homogeneous, but it doesn't have much
     -- else to recommend it.
-    -- we should really be *lifting* the result to S along the natural map S ---> G
-    mapback := map(S, G, map(S^1, S^n1, 0) | vars S, DegreeMap => mapbackdeg );
+    -- we should really be *lifting* the result to R along the natural map R ---> G
+    mapback := map(R, G, map(R^1, R^n1, 0) | vars R, DegreeMap => mapbackdeg );
 
     -- let's at least check it splits f's degree map:
     for i from 0 to deglen-1 do (
@@ -157,7 +157,7 @@ pushNonLinear := (opts, f, M) -> (
 	DegreeLimit           => opts.DegreeLimit,
 	PairLimit             => opts.PairLimit);
     -- MES: check if the monomial order restricts to S.  If so, then do `` forceGB result ''
-    mapback selectInSubring(if numgens target f > 0 then 1 else 0, generators g))
+    mapback selectInSubring(if numgens S > 0 then 1 else 0, generators g))
 
 -*
 pushLinear := opts -> (f,M) -> (

--- a/M2/Macaulay2/m2/pushforward.m2
+++ b/M2/Macaulay2/m2/pushforward.m2
@@ -113,17 +113,21 @@ ordertab := new HashTable from {
     Lex          => (nR, nS) -> Lex,
     }
 
-pushNonLinear := (opts, f, M) -> (
+pushNonLinear := (opts, f0, M) -> (
     -- given f: R --> S, and M an S-module, finite over R,
     -- returns R-presentation matrix for the pushforward of M
     -- written by Mike Stillman and David Eisenbud
 
     -- first flatten source and target of f so that this computation works for towers.
     -- note this forces us to unflatten the return value when we are done.
-    (R, phiR) := flattenRing target f;
-    (S, phiS) := flattenRing source f;
+    (R, phiR) := flattenRing target f0;
+    (S, phiS) := flattenRing source f0;
     m := phiR presentation M;
-    f = phiR * f * phiS^-1;
+    f := phiR * f0 * phiS^-1;
+
+    -- making sure that homogeneity isn't broken
+    if isHomogeneous M  then assert isHomogeneous m;
+    if isHomogeneous f0 then assert isHomogeneous f;
 
     -- set up some variables that are used throughout
     deglenS := degreeLength S;

--- a/M2/Macaulay2/m2/pushforward.m2
+++ b/M2/Macaulay2/m2/pushforward.m2
@@ -117,29 +117,27 @@ pushNonLinear := (opts, f, M) -> (
     -- given f: R --> S, and M an S-module, finite over R,
     -- returns R-presentation matrix for the pushforward of M
     -- written by Mike Stillman and David Eisenbud
-    (S, R) := (target f, source f);
 
-    -- nudge source, target to have same coefficient ring for graphIdeal
-    (S', phiS) := try(flattenRing S) else (S, id_S);
-    (R', phiR) := try(flattenRing R) else (R, id_R);
-    if (S' =!= S) or (R' =!= R) then (
-	f' := phiS * f * phiR^-1;
-	M' := cokernel phiS presentation M;
-	return phiR^-1 pushNonLinear(opts, f', M');
-    );
+    -- first flatten R, S so that this computation works for towers.
+    -- note this forces us to unflatten the return value when we are done.
+    (S, phiS) := flattenRing target f;
+    (R, phiR) := flattenRing source f;
+    m := phiS presentation M;
+    f = phiS * f * phiR^-1;
 
-    deglen := degreeLength R;
-    n1 := numgens S; -- TODO: what if S is a tower?
+    -- set up some variables that are used throughout
+    deglenR := degreeLength R;
+    numgensR := numgens R;
+    numgensS := numgens S;
 
     monorder := opts.MonomialOrder;
-    monorder  = if ordertab#?monorder then (ordertab#monorder)(numgens S, numgens R)
+    monorder  = if ordertab#?monorder then (ordertab#monorder)(numgensS, numgensR)
     else error("pushForward: MonomialOrder option expected one of ",
 	demark_", " \\ toString \ keys ordertab);
 
     J := graphIdeal(f, MonomialOrder => monorder, VariableBaseName => local X);
     G := ring J;
-    m := presentation M;
-    xvars := map(G, S, submatrix(vars G, toList(0..n1-1)));
+    xvars := map(G, S, submatrix(vars G, toList(0..numgensS - 1)));
     m1 := presentation (cokernel xvars m  **  cokernel generators J);
 
     if opts.UseHilbertFunction and all({f, m}, isHomogeneous) then (
@@ -150,15 +148,15 @@ pushNonLinear := (opts, f, M) -> (
 	-- cache poincare
 	poincare cokernel m1 = hf);
 
-    mapbackdeg := d -> take(d, -deglen);
+    mapbackdeg := d -> take(d, -deglenR);
     -- that choice of degree map was chosen to make the symmetricPower functor homogeneous, but it doesn't have much
     -- else to recommend it.
     -- we should really be *lifting* the result to R along the natural map R ---> G
-    mapback := map(R, G, map(R^1, R^n1, 0) | vars R, DegreeMap => mapbackdeg );
+    mapback := map(R, G, map(R^1, R^numgensS, 0) | vars R, DegreeMap => mapbackdeg );
 
     -- let's at least check it splits f's degree map:
-    for i from 0 to deglen-1 do (
-	e := for j from 0 to deglen-1 list if i === j then 1 else 0;
+    for i from 0 to deglenR-1 do (
+	e := for j from 0 to deglenR-1 list if i === j then 1 else 0;
 	if mapbackdeg f.cache.DegreeMap e =!= e
 	then error "not implemented yet: unexpected degree map of ring map");
 
@@ -167,7 +165,7 @@ pushNonLinear := (opts, f, M) -> (
 	DegreeLimit           => opts.DegreeLimit,
 	PairLimit             => opts.PairLimit);
     -- MES: check if the monomial order restricts to S.  If so, then do `` forceGB result ''
-    mapback selectInSubring(if numgens S > 0 then 1 else 0, generators g))
+    phiR^-1 mapback selectInSubring(if numgensS > 0 then 1 else 0, generators g))
 
 -*
 pushLinear := opts -> (f,M) -> (

--- a/M2/Macaulay2/m2/pushforward.m2
+++ b/M2/Macaulay2/m2/pushforward.m2
@@ -118,6 +118,16 @@ pushNonLinear := (opts, f, M) -> (
     -- returns R-presentation matrix for the pushforward of M
     -- written by Mike Stillman and David Eisenbud
     (S, R) := (target f, source f);
+
+    -- nudge source, target to have same coefficient ring for graphIdeal
+    (S', phiS) := try(flattenRing S) else (S, id_S);
+    (R', phiR) := try(flattenRing R) else (R, id_R);
+    if (S' =!= S) or (R' =!= R) then (
+	f' := phiS * f * phiR^-1;
+	M' := cokernel phiS presentation M;
+	return phiR^-1 pushNonLinear(opts, f', M');
+    );
+
     deglen := degreeLength R;
     n1 := numgens S; -- TODO: what if S is a tower?
 

--- a/M2/Macaulay2/tests/normal/pushforward5.m2
+++ b/M2/Macaulay2/tests/normal/pushforward5.m2
@@ -1,14 +1,16 @@
+kk = ZZ/101
+
+-- source and target have different coefficient rings
 R = kk[a]
 S = R[b, Join => false] / {a^2, b^2}
 T = kk[t]
 f = map(S, T, {a})
-
 M = pushForward(f, S^1)
 assert(t^2 * M == 0)
 
+-- map from coefficient ring is not an inclusion
 R = kk[a]
 S = R[b]/{a^2, b^2}
 f = map(S, R)
-
 M = pushForward(f, S^1)
 assert(a^2 * M == 0)

--- a/M2/Macaulay2/tests/normal/pushforward5.m2
+++ b/M2/Macaulay2/tests/normal/pushforward5.m2
@@ -1,0 +1,14 @@
+R = kk[a]
+S = R[b, Join => false] / {a^2, b^2}
+T = kk[t]
+f = map(S, T, {a})
+
+M = pushForward(f, S^1)
+assert(t^2 * M == 0)
+
+R = kk[a]
+S = R[b]/{a^2, b^2}
+f = map(S, R)
+
+M = pushForward(f, S^1)
+assert(a^2 * M == 0)


### PR DESCRIPTION
<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
Some issues arise when computing `graphIdeal f`:
* when `source f` and `target f` have different coefficient rings. 
* when `f` is the inclusion of a coefficient ring and `target f` includes relations on the generators of `source f`.

Here are some examples that have improved behavior after this patch:

```
i1 : R = kk[a];
S = R[b, Join => false] / {a^2, b^2};
T = kk[t];
f = map(S, T, {a});
graphIdeal f

o4 : RingMap S <-- T
stdio:5:10:(3):[1]: error: expected polynomial rings over the same ring
```

```
i1 : R = kk[a];
S = R[b]/{a^2, b^2};
f = map(S, R);
graphIdeal f

o3 : RingMap S <-- R
o4 = ideal ()
o4 : Ideal of S
```

Also switches variable names `(R, S)` <> `(S, R)` in code to match direction of comments. I changed variables instead of comment since I agree with the comment direction in wanting my ring maps to go from R --> S.