### PR TITLE
Install Bertini in GitHub workflows

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -79,13 +79,13 @@ jobs:
         run: |
           sudo add-apt-repository -y -n ppa:macaulay2/macaulay2
           sudo apt-get update
-          sudo apt-get install -y -q --no-install-recommends clang-16 gfortran libtool-bin ninja-build yasm ccache
+          sudo apt-get install -y -q --no-install-recommends libtool-bin ninja-build yasm ccache
           sudo apt-get install -y -q --no-install-recommends liblzma-dev libboost-stacktrace-dev \
-                  libncurses-dev libncurses5-dev libreadline-dev libeigen3-dev libopenblas-dev libxml2-dev \
+                  libreadline-dev libeigen3-dev libopenblas-dev \
                   libgc-dev libgdbm-dev libglpk-dev libgmp3-dev libgtest-dev libmpfr-dev libmpfi-dev libntl-dev gfan \
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
                   libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 libnormaliz-dev normaliz coinor-csdp \
-                  libnauty-dev nauty lrslib polymake pipx phcpack w3c-markup-validator libtbb-dev qepcad libomp-16-dev \
+                  libnauty-dev nauty lrslib polymake pipx phcpack libtbb-dev qepcad \
                   msolve libfplll-dev libjansson-dev r-base palp
 
 # ----------------------

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -65,7 +65,9 @@ jobs:
           brew update
           brew trust macaulay2/tap
           brew tap macaulay2/tap
-          brew install automake bison boost libtool tbb ccache ctags llvm make yasm libffi msolve googletest fplll eigen jansson r palp
+          brew trust apaffenholz/polymake
+          brew tap apaffenholz/polymake
+          brew install automake bison boost libtool tbb ccache ctags llvm make yasm libffi msolve googletest fplll eigen jansson r palp polymake
           brew install texinfo || true # sometimes post-install step fails
           brew install --only-dependencies macaulay2/tap/M2
           brew link factory --force
@@ -86,7 +88,7 @@ jobs:
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
                   libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 libnormaliz-dev normaliz coinor-csdp \
                   libnauty-dev nauty lrslib polymake pipx phcpack libtbb-dev qepcad \
-                  msolve libfplll-dev libjansson-dev r-base palp
+                  msolve libfplll-dev libjansson-dev r-base palp bergman
 
 # ----------------------
 #   Install Bertini

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -89,6 +89,27 @@ jobs:
                   msolve libfplll-dev libjansson-dev r-base palp
 
 # ----------------------
+#   Install Bertini
+# ----------------------
+
+      - name: Cache Bertini
+        id: cache-bertini
+        uses: actions/cache@v5
+        with:
+          path: ~/bertini
+          key: bertini-${{ runner.os }}-v1.7
+
+      - name: Download Bertini
+        if: steps.cache-bertini.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/bertini
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            curl -fL https://bertini.nd.edu/BertiniLinux64_v1.7.tar.gz | tar xz --strip-components=1 -C ~/bertini
+          else
+            curl -fL https://bertini.nd.edu/BertiniApple_v1.7.tar.gz | tar xz --strip-components=1 -C ~/bertini
+          fi
+
+# ----------------------
 #   Steps common to all build variants
 # ----------------------
 
@@ -122,6 +143,7 @@ jobs:
                echo "CPPFLAGS=-I$(brew --prefix)/include -I$(brew --prefix libomp)/include -I$(brew --prefix readline)/include" >> $GITHUB_ENV
                echo "LDFLAGS= -L$(brew --prefix)/lib     -L$(brew --prefix libomp)/lib     -L$(brew --prefix readline)/lib"     >> $GITHUB_ENV
           fi
+          echo "$HOME/bertini" >> $GITHUB_PATH
 
       - uses: actions/cache@v5
         if: matrix.build-system == 'cmake'

--- a/M2/Macaulay2/packages/Bertini.m2
+++ b/M2/Macaulay2/packages/Bertini.m2
@@ -1643,7 +1643,7 @@ makeB'InputFile(String) := o ->(IFD)->(
        openedInputFile << toString(thePathVariable_(-1)) << " ; "<< endl);
      openedInputFile <<endl;
 --If userdefined homotopy then we write the parameters and in terms of the path variable.
-     if #o.PathVariable=!=0 then(
+     if #o.PathVariable=!=0 and #o.SetParameterGroup=!=0 then(
      if #o.SetParameterGroup=!=0 and not member( class((o.SetParameterGroup)_0 ),pairTypes) then error"Parameters should be set in terms of the pathvariable, e.g., x=>t,y=>t^2. ";
      oneGroupNames:=for i in o.SetParameterGroup list if class i ===List then first i else if class i===Option then first toList i;
      writeNamedListToB'InputFile("parameter",oneGroupNames,openedInputFile);

--- a/M2/Macaulay2/packages/NumericalAlgebraicGeometry/Bertini/Bertini.interface.m2
+++ b/M2/Macaulay2/packages/NumericalAlgebraicGeometry/Bertini/Bertini.interface.m2
@@ -62,10 +62,21 @@ trackBertini (List,List,List,OptionTable) := List => (S,T,solS,o) -> (
 trackBertini (PolySystem,PolySystem,List,OptionTable) := List => (S,T,solS,o) -> trackBertini (equations S, equations T, solS, o)
 
 refineBertini = method()
-refineBertini (PolySystem,AbstractPoint,OptionTable) := List => (F,x,o) -> (              
-    -- bits to decimals 
+refineBertini (PolySystem,AbstractPoint,OptionTable) := List => (F,x,o) -> (
+    -- bits to decimals
     decimals := if o.Bits =!= infinity then ceiling(o.Bits * log 2 / log 10) else log_10 o.ErrorTolerance;
-    first bertiniRefineSols(decimals, equations F, {x}) -*toBertiniOptions o*-
+    -- bertiniRefineSols only accepts points that came from a Bertini run, i.e.,
+    -- that carry cache.MainDataDirectory and cache.PathNumber (set by importMainDataFile).
+    -- If x lacks this, run a trivial (constant) user homotopy starting at x to bring
+    -- it into a Bertini session before sharpening. Bertini's UserHomotopy:2 requires
+    -- at least one parameter to be defined, so we declare a dummy one (unused in F)
+    -- and set it equal to the path variable.
+    y := if x.cache.?MainDataDirectory then x else (
+	t := local bertiniRefineSolsPathVariable;
+	s := local bertiniRefineSolsDummyParameter;
+	first bertiniUserHomotopy(t, {s=>t}, equations F, {x})
+	);
+    first bertiniRefineSols(decimals, {y})
     -- bertiniRefineSols may reorder points!!!
     )
 toBertiniOptions'numericalIrreducibleDecomposition = o -> new OptionTable from {Verbose=>false,BertiniInputConfiguration=>{Bertini$RandomSeed=>0}}


### PR DESCRIPTION
This way, we can properly test packages that use it (e.g., #4353).  The download should be cached so we don't overload the Notre Dame servers.

I also took the opportunity to simplify the `apt-get install` step a bit -- there were a few packages we aren't using or are already installed on the GitHub Ubuntu runners.

Partially addresses #1955

Draft for now, as the tests will fail until #4368 is fixed.

## AI Disclosure

Claude Code wrote the code to download and cache Bertini.

