### PR TITLE
Return rhs in parallel assignment even when lhs is null

### DIFF
--- a/M2/Macaulay2/d/evaluate.d
+++ b/M2/Macaulay2/d/evaluate.d
@@ -1282,7 +1282,7 @@ parallelAssignmentFun(x:parallelAssignmentCode):Expr := (
 			then AssignNewOfFromFun(CodeSequence(
 				y.newClause, y.ofClause, y.fromClause, c))
 			else ParallelAssignmentErrorAt(i + 1))
-		    is nullCode do nullE
+		    is nullCode do values.i
 		    else ParallelAssignmentErrorAt(i + 1);
 		    when r
 		    is Error do (
@@ -1532,7 +1532,7 @@ augmentedAssignmentFun(x:augmentedAssignmentCode):Expr := (
 		    convertGlobalOperator(AdjacentS.symbol), y.lhs, y.rhs, c)))
 	is y:unaryCode do (
 	    UnaryInstallValueFun(convertGlobalOperator(y.oper), y.rhs, c))
-	is nullCode do nullE -- for use w/ parallel assignment
+	is nullCode do eval(c) -- for use w/ parallel assignment
 	else buildErrorPacket(
 	    "augmented assignment not implemented for this code")));
 

--- a/M2/Macaulay2/tests/normal/parallel.m2
+++ b/M2/Macaulay2/tests/normal/parallel.m2
@@ -91,9 +91,10 @@ assert Equation(g, 7)
 assert Equation(h, 8)
 
 -- null
-(a, , , b) = (9, 10, 11, 12)
+assert Equation((a, , , b) = (9, 10, 11, 12), (9, 10, 11, 12))
 assert Equation(a, 9)
 assert Equation(b, 12)
+assert Equation((a,) ??= (13, 14), (9, 14))
 
 -- augmented
 (x, y, z) = (1, 2, 3)


### PR DESCRIPTION
Suggested by @mahrud during my "new features" presentation in Atlanta.

### Before

```m2
i1 : (x,,z) = (1,2,3)

o1 = (1, , 3)

o1 : Sequence
```

### After
```m2
i1 : (x,,z) = (1,2,3)

o1 = (1, 2, 3)

o1 : Sequence
```

## AI Disclosure

Just old school, human-written code.