### PR TITLE
Add workflow to prevent PR's against stable

### DIFF
--- a/.github/workflows/no-stable-pr.yml
+++ b/.github/workflows/no-stable-pr.yml
@@ -1,0 +1,15 @@
+name: Block PRs targeting stable
+
+on:
+  pull_request:
+    branches: [ stable ]
+
+jobs:
+  block:
+    if: github.repository == 'Macaulay2/M2'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail
+        run: |
+          echo "::error::Pull requests targeting the 'stable' branch are not accepted. Please target 'development' instead."
+          exit 1


### PR DESCRIPTION
To hopefully keep us (well, me) from doing things like merging #4287 into the wrong branch again....

Opening this against `stable` for now to test it out.  (*Edit:* It [worked](https://github.com/Macaulay2/M2/actions/runs/26475742560/job/77960721576?pr=4373)!)

## AI Disclosure

Claude wrote pretty much everything