### PR TITLE
Correctly pad url encodings of characters with < 2 hex digits

### DIFF
--- a/M2/Macaulay2/m2/html.m2
+++ b/M2/Macaulay2/m2/html.m2
@@ -232,4 +232,7 @@ urlEncode = method()
 urlEncode Nothing := identity
 urlEncode String := s -> concatenate apply(s, c -> (
 	if percentEncoding#?c then percentEncoding#c
-	else percentEncoding#c = "%" | toUpper changeBase(first ascii c, 16)))
+	else (
+	    a := first ascii c;
+	    percentEncoding#c = concatenate("%", if a < 0x10 then "0" else "",
+		toUpper changeBase(a, 16)))))

--- a/M2/Macaulay2/tests/normal/formatting.m2
+++ b/M2/Macaulay2/tests/normal/formatting.m2
@@ -16,3 +16,4 @@ assert(///A<i><b>B</b><span class="tt">C<a href="D">D</a><em>E</em></span>F</i>G
 assert(///<span class="tt">A<em>B</em>C</span>/// === html TEX{"{\\tt A", EM{"B"}, "C}"})
 assert Equation(urlEncode "https://en.wikipedia.org/wiki/Gröbner basis",
     "https://en.wikipedia.org/wiki/Gr%C3%B6bner%20basis")
+assert Equation(urlEncode newline, "%0A")


### PR DESCRIPTION
This fixes a small bug I found:

### Before
```m2
i1 : urlEncode newline

o1 = %A
```

### After
```m2
i1 : urlEncode newline

o1 = %0A
```

According to [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1), percent encodings should have two hex digits.

## AI Disclosure

I wrote all the code, but it was Claude that pointed out to me that %0A was the correct encoding while brainstorming something else in a forthcoming PR.