### PR TITLE
Add problem matchers for annotations during GitHub builds

### DIFF
--- a/.github/problem-matchers.json
+++ b/.github/problem-matchers.json
@@ -1,0 +1,29 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "cpptools",
+      "pattern": [
+        {
+          "regexp": "^(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    },
+    {
+      "owner": "macaulay2",
+      "pattern": [
+        {
+          "regexp": "^(\\S+):(\\d+):(\\d+):\\(\\d+\\):\\[\\d\\]: error: (.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -131,6 +131,8 @@ jobs:
             ~/work/M2/M2/M2/BUILD/build/usr-host
           key: build-cache-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build-system }}-${{ hashFiles('**/cmake/*-libraries.cmake', '.github/workflows/test_build.yml') }}
 
+      - name: Register problem matcher
+        run: echo "::add-matcher::.github/problem-matchers.json"
 
 # ----------------------
 #   Configure and build M2 using CMake


### PR DESCRIPTION
The cpptools regex is from https://github.com/microsoft/vscode-cpptools

Closes: #3533 

## AI Disclosure

Some brainstorming with Claude Chat.  It wrote the first draft of some of the regexes, but honestly did a less than stellar job.