### PR TITLE
Add name field for Visualize's package.json file

### DIFF
--- a/M2/Macaulay2/packages/Visualize.m2
+++ b/M2/Macaulay2/packages/Visualize.m2
@@ -18,8 +18,8 @@
 
 newPackage(
 	"Visualize",
-	Version => "1.9",
-	Date => "January 2, 2026",
+	Version => "1.10",
+	Date => "May 27, 2026",
     	Authors => {       
      	     {Name => "Brett Barwick", Email => "bbarwick@uscupstate.edu", HomePage => "http://faculty.uscupstate.edu/bbarwick/"},	     
 	     {Name => "Thomas Enkosky", Email => "tomenk@bu.edu", HomePage => "http://math.bu.edu/people/tomenk/"},	     
@@ -67,6 +67,11 @@ export {
 ---------------
 
 -*
+
+1.10 (2026-05-27, M2 1.26.06)
+* bump jquery 4.0.0
+* update my contact info
+* add name field to package.json
 
 1.9 (2026-01-02, M2 1.26.05)
 * bump three.js to 0.182.0 and update 3d ideal code

--- a/M2/Macaulay2/packages/Visualize/package.json
+++ b/M2/Macaulay2/packages/Visualize/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@macaulay2/visualize",
   "scripts": {
     "build": "webpack"
   },


### PR DESCRIPTION
This is needed to properly use Debian tools to bundle the JavaScript in the Debian package.  Also bump the version number to 1.10 while we're at it.

## AI Disclosure

Claude Chat helped me pick between various names -- it suggested `@macaulay2/visualize` as the most idiomatic in the JavaScript ecosystem.