### PR TITLE
Add lock(Function) method for thread-safe functions

### DIFF
--- a/M2/Macaulay2/d/pthread.d
+++ b/M2/Macaulay2/d/pthread.d
@@ -279,6 +279,32 @@ unlock(e:Expr):Expr := (
     else WrongArgMutex());
 setupfun("unlock0", unlock);
 
+-- env.0 = the mutex to lock/unlock
+-- env.1 = the function to call
+lockedFunction(e:Expr, env:Sequence):Expr := (
+    if length(env) == 2 then (
+	l := lock(env.0);
+	when l is Error do return l else nothing;
+	r := applyEE(env.1, e);
+	u := unlock(env.0);
+	when u is Error do u else r)
+    else buildErrorPacket("internal error: expected 2 values in environment"));
+
+lockFunction(e:Expr):Expr := (
+    when e
+    is a:Sequence do (
+	if length(a) == 2 then (
+	    when a.0
+	    is mutexCell do (
+		if isFunction(a.1)
+		then Expr(CompiledFunctionClosure(
+			lockedFunction, nextHash(), a))
+		else WrongArg(2, "a function"))
+	    else WrongArg(1, "a mutex"))
+	else WrongNumArgs(2))
+    else WrongNumArgs(2));
+setupfun("lockFunction", lockFunction);
+
 -- Local Variables:
 -- compile-command: "echo \"make: Entering directory \\`$M2BUILDDIR/Macaulay2/d'\" && make -C $M2BUILDDIR/Macaulay2/d pthread.o "
 -- End:

--- a/M2/Macaulay2/m2/engine.m2
+++ b/M2/Macaulay2/m2/engine.m2
@@ -187,7 +187,7 @@ processWeights = (nvars,weights) -> (
 	       then error("Weights: expected weight vector of length ",toString nvars," but got ",toString (#wt))));
      weights);
 
-makeMonomialOrdering = (monsize,inverses,nvars,degs,weights,ordering) -> (
+makeMonomialOrdering = lock((monsize,inverses,nvars,degs,weights,ordering) -> (
      -- 'monsize' is the old MonomialSize option, usually 8 or 16, or 'null' if unset
      -- 'inverses' is true or false, and tells whether the old "Inverses => true" option was used.
      -- 'nvars' tells the total number of variables.  Any extra variables will be ordered with GRevLex or GroupLex.
@@ -214,7 +214,7 @@ makeMonomialOrdering = (monsize,inverses,nvars,degs,weights,ordering) -> (
      varcount = 0;
      t := toList nonnull fixup2 t';
      logmo := new FunctionApplication from {rawMonomialOrdering,t};
-     (t,t',value logmo, logmo))
+     (t,t',value logmo, logmo)))
 
 RawMonomialOrdering ** RawMonomialOrdering := RawMonomialOrdering => rawProductMonomialOrdering
 

--- a/M2/Macaulay2/m2/threads.m2
+++ b/M2/Macaulay2/m2/threads.m2
@@ -29,6 +29,8 @@ net Mutex := x -> toString (
 
 lock = method()
 lock Mutex := lock0
+lock(Mutex, Function) := lockFunction -- defined in pthread.d
+lock Function := f -> lockFunction(new Mutex, f)
 
 tryLock = method()
 tryLock Mutex := tryLock0

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_mutex.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_mutex.m2
@@ -87,6 +87,53 @@ doc ///
   SeeAlso
     (tryLock, Mutex)
     (unlock, Mutex)
+  Subnodes
+    (lock, Mutex, Function)
+///
+
+doc ///
+  Key
+    (lock, Mutex, Function)
+    (lock, Function)
+  Headline
+    make a function thread-safe
+  Usage
+    lock(mutex, f)
+    lock f
+  Inputs
+    mutex:Mutex
+    f:Function
+  Outputs
+    :Function
+  Description
+    Text
+      This function creates a thread-safe version of @VAR "f"@.  In particular,
+      it takes @ofClass Mutex@ and returns a new function that locks it when
+      the function is called and unlocks it when complete, even if there is an
+      error.
+
+      If @VAR "mutex"@ is omitted, then a mutex is created behind the scenes.
+      Therefore, it's only necessary to define @VAR "mutex"@ before calling
+      @M2CODE "lock"@ if you plan on sharing it between multiple functions.
+
+      Consider the following example.
+    Example
+      x = 0
+      f = i -> x += 1;
+      parallelApply(1..1000, f);
+      x
+    Text
+      You likely see that @VAR "x"@ ended up less than the expected value of
+      1000.  This is an example of a @EM "race condition"@, as multiple
+      threads were trying to modify the global variable @VAR "x"@ at the same
+      time.
+
+      Let's try again using @M2CODE "lock"@.
+    Example
+      x = 0
+      f = lock f;
+      parallelApply(1..1000, f);
+      x
 ///
 
 doc ///

--- a/M2/Macaulay2/tests/normal/threads.m2
+++ b/M2/Macaulay2/tests/normal/threads.m2
@@ -101,6 +101,15 @@ assert try tryLock m then true else false
 assert try tryLock m then false else true
 unlock m
 
+x = 0
+f = lock(i -> x += 1)
+parallelApply(1..1000, f)
+assert Equation(x, 1000)
+g = lock(m, () -> x += 1)
+h = lock(m, () -> x += 1)
+parallelApply(1..1000, i -> if i % 2 == 0 then g() else h())
+assert Equation(x, 2000)
+
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test threads.out"
 -- End:


### PR DESCRIPTION
This is a simpler alternative to #4367 for providing a `lock(Function)` method without adding a new type of statement to the Macaulay2 language.

For example:

```m2
i1 : x = 0

o1 = 0

i2 : f = i -> x += 1;

i3 : parallelApply(1..1000, f);

i4 : x

o4 = 345

i5 : x = 0

o5 = 0

i6 : parallelApply(1..1000, lock f);

i7 : x

o7 = 1000
```

## AI Disclosure

No AI used!