### PR TITLE
cmake: force factory to use M2-built FLINT when system FLINT is too old

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -243,7 +243,7 @@ ExternalProject_Add(build-mpfr
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
-if(NOT MPFR_ROOT)
+if(NOT MPFR_FOUND)
   set(MPFR_ROOT ${M2_HOST_PREFIX})
 endif()
 set(MPFR_INCLUDE_DIR ${MPFR_INCLUDE_DIRS}) # TODO: make this unnecessary in d/CMakeLists.txt
@@ -330,7 +330,7 @@ ExternalProject_Add_Step(build-ntl wizard
   EXCLUDE_FROM_MAIN ON
   USES_TERMINAL ON
   )
-if(NOT NTL_ROOT)
+if(NOT NTL_FOUND)
   set(NTL_ROOT ${M2_HOST_PREFIX})
 endif()
 if(AUTOTUNE)
@@ -367,7 +367,7 @@ ExternalProject_Add(build-flint
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
-if(NOT FLINT_ROOT)
+if(NOT FLINT_FOUND)
   set(FLINT_ROOT ${M2_HOST_PREFIX})
 endif()
 _ADD_COMPONENT_DEPENDENCY(libraries flint "gmp;mpfr;ntl" FLINT_FOUND)
@@ -475,7 +475,7 @@ ExternalProject_Add(build-cddlib
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
-if(NOT CDDLIB_ROOT)
+if(NOT CDDLIB_FOUND)
   set(CDDLIB_ROOT ${M2_HOST_PREFIX})
   set(CDDLIB_LIBRARY_DIR ${CDDLIB_ROOT}/lib)
   set(CDDLIB_INCLUDE_DIR ${CDDLIB_ROOT}/include/cddlib)
@@ -672,7 +672,7 @@ ExternalProject_Add(build-glpk
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
-if(NOT GLPK_ROOT)
+if(NOT GLPK_FOUND)
   set(GLPK_ROOT ${M2_HOST_PREFIX})
 endif()
 _ADD_COMPONENT_DEPENDENCY(libraries glpk gmp GLPK_FOUND)


### PR DESCRIPTION
Small follow-up to #4216 (Bump FLINT to v3.5.0).

These issues related to FLINT came up as I was working on different arithmetic-related optimizations for Macaulay2. I spun up a Google Cloud server and began working and these issues came up (Claude assisting with PR body below):

---

On systems with `libflint-dev` installed but too old for our 3.0.0+ requirement (e.g., Debian 12 ships FLINT 2.9.0), a fresh build of `M2-unit-tests` currently fails at the final link with a bunch of `undefined reference to fq_nmod_poly_divrem_divconquer` (and friends) plus a `multiple definition of fq_nmod_set_nmod_poly`. CI doesn't see it because the build hosts don't have an old libflint-dev sitting around.

The root cause is that `find_package(FLINT 3.0.0)` finds the system FLINT, fails the version check (`FLINT_FOUND=FALSE`), and along the way still populates `FLINT_ROOT=/usr` from where it found the rejected library. The existing guard

```cmake
if(NOT FLINT_ROOT)
  set(FLINT_ROOT ${M2_HOST_PREFIX})
endif()
```

is therefore a no-op, and factory's configure ends up with `--with-flint=/usr`. Factory then compiles against the system FLINT 2.x headers — where `fq_nmod_poly_divrem` is a macro that expands to `fq_nmod_poly_divrem_divconquer` — but the M2-built FLINT 3.5 we link against doesn't have those (they were removed in 3.5). And under FLINT 2.x's `__FLINT_RELEASE` Factory's source also defines its own `fq_nmod_set_nmod_poly`, which then collides with FLINT 3.5's native one.

The fix is a one-line change: trigger the override on `FLINT_FOUND` instead of `FLINT_ROOT`, so whenever M2 is building its own FLINT we force `FLINT_ROOT` to the M2 prefix regardless of what `find_package` left behind:

```diff
-if(NOT FLINT_ROOT)
+if(NOT FLINT_FOUND)
   set(FLINT_ROOT ${M2_HOST_PREFIX})
 endif()
```

That single change fixes both link errors at once — factory now compiles against M2's FLINT 3.5 headers, so `fq_nmod_poly_divrem` is a plain function (no macro expansion), and Factory's `#if __FLINT_RELEASE < 30000` guards correctly skip its own `fq_nmod_set_nmod_poly` definition.

Tested locally on Debian 12 with `libflint-dev 2.9.0` installed alongside the M2-built FLINT 3.5: build now completes, and `./M2-unit-tests --gtest_filter='ARingRR*'` runs 21/21 PASSED.