### PR TITLE
Bump givaro to v4.2.2

### DIFF
--- a/M2/libraries/givaro/Makefile.in
+++ b/M2/libraries/givaro/Makefile.in
@@ -8,7 +8,7 @@ VLIMIT = 900000
 MLIMIT = 900000
 
 URL = https://github.com/linbox-team/givaro
-VERSION = 4.2.1
+VERSION = 4.2.2
 # PATCHFILE = @abs_srcdir@/patch-$(VERSION)
 # the patch modifies test/Makefile.am, so we must remake test/Makefile.in
 PRECONFIGURE = autoreconf -vif


### PR DESCRIPTION
A new version of givaro was just released.

Draft for now to test the builds