### PR TITLE
Fix F4 GB algorithm on 32-bit ARM; add MonomialInfo tests

### DIFF
--- a/M2/Macaulay2/e/buffer.cpp
+++ b/M2/Macaulay2/e/buffer.cpp
@@ -57,6 +57,14 @@ void buffer::put(long n)
   put(s, strlen(s));
 }
 
+void buffer::put(long long n)
+{
+  const int N = 100;
+  char s[N];
+  snprintf(s, N, "%lld", n);
+  put(s, strlen(s));
+}
+
 void buffer::put(double n)
 {
   const int N = 100;

--- a/M2/Macaulay2/e/buffer.hpp
+++ b/M2/Macaulay2/e/buffer.hpp
@@ -59,6 +59,7 @@ class buffer : public our_new_delete
   void put(int n);              // Format the integer, place into buffer
   void put(int n, int width);   // Format the integer, with given width field.
   void put(long n);             // Format the integer, place into buffer
+  void put(long long n);        // Format the integer, place into buffer
   void put(double n);             // Format the double, place into buffer
   void put(long n, int width);  // Format the integer, with given width field.
   void put(unsigned int n);     // Format the integer, place into buffer
@@ -100,6 +101,11 @@ class buffer : public our_new_delete
     return *this;
   }
   buffer &operator<<(long n)
+  {
+    put(n);
+    return *this;
+  }
+  buffer &operator<<(long long n)
   {
     put(n);
     return *this;

--- a/M2/Macaulay2/e/f4/f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/f4/f4-m2-interface.cpp
@@ -93,7 +93,7 @@ vec F4toM2Interface::to_M2_vec(const VectorArithmetic* VA,
   const monomial_word *w = f.monoms;
   for (int i = 0; i < f.len; i++)
     {
-      long comp;
+      monomial_word comp;
       MI->to_expvector(w, lexp, comp);
       w = w + MI->monomial_size(w);
       for (int a = 0; a < M->n_vars(); a++) exp[a] = static_cast<int>(lexp[a]);

--- a/M2/Macaulay2/e/f4/f4-monlookup.cpp
+++ b/M2/Macaulay2/e/f4/f4-monlookup.cpp
@@ -261,7 +261,7 @@ void F4MonomialLookupTableT<Key>::reset_expvector(
 }
 
 template <typename Key>
-bool F4MonomialLookupTableT<Key>::find_one_divisor_vp(long comp,
+bool F4MonomialLookupTableT<Key>::find_one_divisor_vp(monomial_word comp,
                                                       const_varpower_monomial m,
                                                       Key &result_k) const
 {
@@ -278,7 +278,7 @@ bool F4MonomialLookupTableT<Key>::find_one_divisor_vp(long comp,
 
 template <typename Key>
 void F4MonomialLookupTableT<Key>::find_all_divisors_vp(
-    long comp,
+    monomial_word comp,
     const_varpower_monomial m,
     std::vector<Key> & result_k) const
 {
@@ -299,7 +299,7 @@ bool F4MonomialLookupTableT<Key>::find_one_divisor_packed(
     Key &result_k) const
 // mi is the top: where to start looking
 {
-  long comp = M->get_component(m);
+  monomial_word comp = M->get_component(m);
   if (comp >= mis.size()) return false;
   mi_node *mi = mis[comp];
   if (mi == nullptr) return false;
@@ -313,7 +313,7 @@ void F4MonomialLookupTableT<Key>::find_all_divisors_packed(
     const_packed_monomial m,
     std::vector<Key> & result_k) const
 {
-  long comp = M->get_component(m);
+  monomial_word comp = M->get_component(m);
   if (comp >= mis.size()) return;
   mi_node *mi = mis[comp];
   if (mi == nullptr) return;
@@ -322,7 +322,7 @@ void F4MonomialLookupTableT<Key>::find_all_divisors_packed(
 }
 
 template <typename Key>
-void F4MonomialLookupTableT<Key>::insert_minimal_vp(long comp,
+void F4MonomialLookupTableT<Key>::insert_minimal_vp(monomial_word comp,
                                                     const_varpower_monomial m,
                                                     Key k)
 {
@@ -335,7 +335,7 @@ void F4MonomialLookupTableT<Key>::insert_minimal_vp(long comp,
 }
 
 template <typename Key>
-bool F4MonomialLookupTableT<Key>::insert_vp(long comp,
+bool F4MonomialLookupTableT<Key>::insert_vp(monomial_word comp,
                                             const_varpower_monomial m,
                                             Key &k)
 // Insert the monomial 'm' with key 'k', if it

--- a/M2/Macaulay2/e/f4/f4-monlookup.hpp
+++ b/M2/Macaulay2/e/f4/f4-monlookup.hpp
@@ -79,11 +79,11 @@ class F4MonomialLookupTableT
   //        // to be the key of that element.
   //        // If m is not divisible, then insert (m,k), and return true.
 
-  void insert_minimal_vp(long comp, const_varpower_monomial m, Key k);
+  void insert_minimal_vp(monomial_word comp, const_varpower_monomial m, Key k);
 
-  bool insert_vp(long comp, const_varpower_monomial m, Key &k);
+  bool insert_vp(monomial_word comp, const_varpower_monomial m, Key &k);
 
-  bool find_one_divisor_vp(long comp,
+  bool find_one_divisor_vp(monomial_word comp,
                            const_varpower_monomial m,
                            Key &result_k) const;
 
@@ -93,7 +93,7 @@ class F4MonomialLookupTableT
   // Search.  Return whether a monomial which divides 'm' is
   // found.  If so, return true, set the key.
 
-  void find_all_divisors_vp(long comp,
+  void find_all_divisors_vp(monomial_word comp,
                             const_varpower_monomial m,
                             std::vector<Key> & result_k) const;
 

--- a/M2/Macaulay2/e/f4/monhashtable.cpp
+++ b/M2/Macaulay2/e/f4/monhashtable.cpp
@@ -36,7 +36,7 @@ void MonomialHashTable<ValueType>::initialize(int logsize0)
 template <typename ValueType>
 void MonomialHashTable<ValueType>::insert(value m)
 {
-  long hashval = HASHVALUE(m) & hashmask;
+  auto hashval = HASHVALUE(m) & hashmask;
   while (hashtab[hashval])
     {
       hashval++;

--- a/M2/Macaulay2/e/f4/monhashtable.hpp
+++ b/M2/Macaulay2/e/f4/monhashtable.hpp
@@ -12,7 +12,7 @@ class MonomialsWithComponent
 {
  public:
   typedef packed_monomial value;
-  long hash_value(value m) const { return m[0] + m[1]; }
+  uint64_t hash_value(value m) const { return static_cast<uint64_t>(m[0] + m[1]); }
   bool is_equal(value m, value n) const { return mMonoid.is_equal(m, n); }
   void show(value m) const { mMonoid.show(m); }
   MonomialsWithComponent(const MonomialInfo& MI) : mMonoid(MI) {}
@@ -24,7 +24,7 @@ class MonomialsIgnoringComponent
 {
  public:
   typedef packed_monomial value;
-  long hash_value(value m) const { return m[0]; }
+  uint64_t hash_value(value m) const { return static_cast<uint64_t>(m[0]); }
   bool is_equal(value m, value n) const
   {
     return mMonoid.monomial_part_is_equal(m, n);
@@ -68,7 +68,7 @@ class ResMonomialsIgnoringComponent
 // ValueType must implement the following:
 // values should have computed hash values stored with them
 //  typename ValueType::value
-//  long ValueType::hash_value(value m)
+//  uint64_t ValueType::hash_value(value m)
 //  bool ValueType::is_equal(value m, value n)
 //  void ValueType::show(value m) -- prints to stderr
 

--- a/M2/Macaulay2/e/f4/moninfo.cpp
+++ b/M2/Macaulay2/e/f4/moninfo.cpp
@@ -4,6 +4,7 @@
 #include "monomials/monordering.hpp"                // for monomialOrderingToMatrix
 #include "newdelete.hpp"                  // for freemem, newarray_atomic
 
+#include <cinttypes>                      // for PRId64
 #include <cstdio>                         // for fprintf, stderr, stdout
 #include <cstdlib>                        // for rand
 #include <iostream>
@@ -116,24 +117,24 @@ void MonomialInfo::show(const_packed_monomial m) const
   for (int v = 1; v < monomial_size(m); v++)
     {
       if (v > 1) fprintf(stderr, " ");
-      fprintf(stderr, "%ld", m[v]);
+      fprintf(stderr, "%" PRId64, m[v]);
     }
   fprintf(stderr, "]");
 }
 
 void MonomialInfo::showAlpha(const_packed_monomial m) const
 {
-  long comp = get_component(m);
+  monomial_word comp = get_component(m);
 
   m += 2 + mNumWeights;  // get by: hashcode, component, weightvals
   for (int i = 0; i < nvars; i++)
     {
-      long e = *m++;
+      monomial_word e = *m++;
       if (e == 0) continue;
       fprintf(stdout, "%c", 'a' + i);
-      if (e > 1) fprintf(stdout, "%ld", e);
+      if (e > 1) fprintf(stdout, "%" PRId64, e);
     }
-  fprintf(stdout, "<%ld>", comp);
+  fprintf(stdout, "<%" PRId64 ">", comp);
 }
 
 // Local Variables:

--- a/M2/Macaulay2/e/f4/moninfo.hpp
+++ b/M2/Macaulay2/e/f4/moninfo.hpp
@@ -4,12 +4,14 @@
 #define M2_F4_MONINFO_HPP_
 
 #include "interface/m2-types.h"           // for M2_arrayint, M2_arrayint_st...
+#include "f4/monomial-word.hpp"           // for monomial_word, packed_monomial
 #include "f4/ntuple-monomial.hpp"         // for ntuple_word, const_ntuple_m...
 #include "f4/varpower-monomial.hpp"       // for varpower_word, index_varpow...
 #include "interface/monomial-ordering.h"  // for MonomialOrdering
 #include "newdelete.hpp"                  // for our_new_delete
 #include "rings/skew.hpp"                       // for SkewMultiplication
 
+#include <cinttypes>
 #include <iostream>
 
 #if 0
@@ -26,11 +28,6 @@
 
 #endif
 
-// typedef int64_t monomial_word; // Used for all types of monomials.  Is this
-// OK?
-typedef long monomial_word;  // Used for all types of monomials.  Is this OK?
-typedef monomial_word *packed_monomial;
-typedef const monomial_word *const_packed_monomial;
 // format: [hash,component,e1,...,envars],
 // where [e1,...,envars] is packed.
 // OR: [hash,component,weight,e1,...,envars]
@@ -107,7 +104,7 @@ class MonomialInfo : public our_new_delete
   int componentLocation() const { return mComponentLoc; }
   int positionUp() { return mPositionUp; }
   
-  long hash_value(const_packed_monomial m) const { return *m; }
+  uint64_t hash_value(const_packed_monomial m) const { return static_cast<uint64_t>(*m); }
   // This hash value is an ADDITIVE hash (trick due to A. Steel)
 
   void copy(const_packed_monomial src, packed_monomial target) const
@@ -115,20 +112,20 @@ class MonomialInfo : public our_new_delete
     for (int i = 0; i < nslots; i++) *target++ = *src++;
   }
 
-  long last_exponent(const_packed_monomial m) const { return m[nslots - 1]; }
-  void set_component(long component, packed_monomial m) const
+  monomial_word last_exponent(const_packed_monomial m) const { return m[nslots - 1]; }
+  void set_component(monomial_word component, packed_monomial m) const
   {
     m[1] = component;
   }
 
-  long get_component(const_packed_monomial m) const
+  monomial_word get_component(const_packed_monomial m) const
   {
     ncalls_get_component++;
     return m[1];
   }
 
   bool from_expvector(const_ntuple_monomial e,
-                            long comp,
+                            monomial_word comp,
                             packed_monomial result) const
   {
     // Pack the vector e[0]..e[nvars-1],comp.  Create the hash value at the same
@@ -146,10 +143,10 @@ class MonomialInfo : public our_new_delete
     const int *wt = mWeightVectors.data();
     for (int j = 0; j < mNumWeights; j++, wt += nvars)
       {
-        long val = 0;
+        monomial_word val = 0;
         for (int i = 0; i < nvars; i++)
           {
-            long a = e[i];
+            monomial_word a = e[i];
             if (a > 0) val += a * wt[i];
           }
         result[2 + j] = val;
@@ -171,7 +168,7 @@ class MonomialInfo : public our_new_delete
     return skew->mult_sign(m + 2 + mNumWeights, n + 2 + mNumWeights);
   }
 
-  bool one(long comp, packed_monomial result) const
+  bool one(monomial_word comp, packed_monomial result) const
   {
     // Pack the vector (0,...,0,comp) with nvars zeroes.
     // Hash value = 0. ??? Should the hash-function take component into account
@@ -184,7 +181,7 @@ class MonomialInfo : public our_new_delete
 
   bool to_expvector(const_packed_monomial m,
                           ntuple_monomial result,
-                          long &result_comp) const
+                          monomial_word &result_comp) const
   {
     // Unpack the monomial m.
     ncalls_to_expvector++;
@@ -229,7 +226,7 @@ class MonomialInfo : public our_new_delete
   }
 
   void from_varpower_monomial(const_varpower_monomial m,
-                              long comp,
+                              monomial_word comp,
                               packed_monomial result) const
   {
     // 'result' must have enough space allocated
@@ -254,12 +251,12 @@ class MonomialInfo : public our_new_delete
     const int *wt = mWeightVectors.data();
     for (int j = 0; j < mNumWeights; j++, wt += nvars)
       {
-        long val = 0;
+        monomial_word val = 0;
         for (index_varpower_monomial i = m; i.valid(); ++i)
           {
             varpower_word v = i.var();
             varpower_word e = i.exponent();
-            long w = wt[v];
+            monomial_word w = wt[v];
             if (e == 1)
               val += w;
             else
@@ -362,7 +359,7 @@ class MonomialInfo : public our_new_delete
     const_packed_monomial n1 = n + nslots;
     for (int i = nslots - 2; i > 0; i--)
       {
-        varpower_word cmp = *--m1 - *--n1;
+        monomial_word cmp = *--m1 - *--n1;
         if (cmp < 0) return -1;
         if (cmp > 0) return 1;
       }
@@ -376,21 +373,21 @@ class MonomialInfo : public our_new_delete
                        const_packed_monomial n,
                        const_packed_monomial m0,
                        const_packed_monomial n0,
-                       long tie1,
-                       long tie2) const
+                       int tie1,
+                       int tie2) const
   {
     ncalls_compare++;
 #if 0
     printf("compare_schreyer: ");
     printf("  m=");
     showAlpha(m);
-    printf("  n=");    
+    printf("  n=");
     showAlpha(n);
-    printf("  m0=");    
+    printf("  m0=");
     showAlpha(m0);
-    printf("  n0=");    
+    printf("  n0=");
     showAlpha(n0);
-    printf("  tiebreakers: %ld %ld\n", tie1, tie2);
+    printf("  tiebreakers: %d %d\n", tie1, tie2);
 #endif
     const_packed_monomial m1 = m + nslots;
     const_packed_monomial n1 = n + nslots;
@@ -398,7 +395,7 @@ class MonomialInfo : public our_new_delete
     const_packed_monomial n2 = n0 + nslots;
     for (int i = nslots - 2; i > 0; i--)
       {
-        varpower_word cmp = *--m1 - *--n1 + *--m2 - *--n2;
+        monomial_word cmp = *--m1 - *--n1 + *--m2 - *--n2;
         if (cmp < 0) return -1;
         if (cmp > 0) return 1;
       }
@@ -415,7 +412,7 @@ class MonomialInfo : public our_new_delete
     const_packed_monomial n1 = n + 2;
     for (int i = nslots - 2; i > 0; i--)
       {
-        varpower_word cmp = *m1++ - *n1++;
+        monomial_word cmp = *m1++ - *n1++;
         if (cmp > 0) return -1;
         if (cmp < 0) return 1;
       }
@@ -433,7 +430,7 @@ class MonomialInfo : public our_new_delete
     const_packed_monomial n1 = n + 2;
     for (int i = 0; i < mNumWeights; i++)
       {
-        varpower_word cmp = *m1++ - *n1++;
+        monomial_word cmp = *m1++ - *n1++;
         if (cmp > 0) return -1;
         if (cmp < 0) return 1;
       }
@@ -441,7 +438,7 @@ class MonomialInfo : public our_new_delete
     n1 = n + nslots;
     for (int i = nvars - 1; i > 0; i--)
       {
-        varpower_word cmp = *--m1 - *--n1;
+        monomial_word cmp = *--m1 - *--n1;
         if (cmp < 0) return -1;
         if (cmp > 0) return 1;
       }
@@ -464,7 +461,7 @@ class MonomialInfo : public our_new_delete
     const_packed_monomial n1 = n + 2;
     for (int i = 0; i < mNumWeights; i++)
       {
-        varpower_word cmp = *m1++ - *n1++;
+        monomial_word cmp = *m1++ - *n1++;
         if (cmp > 0) return GT;
         if (cmp < 0) return LT;
       }
@@ -474,7 +471,7 @@ class MonomialInfo : public our_new_delete
         n1 = n + nslots;
         for (int i = nvars - 1; i >= 0; i--)
           {
-            varpower_word cmp = *--m1 - *--n1;
+            monomial_word cmp = *--m1 - *--n1;
             if (cmp < 0) return GT;
             if (cmp > 0) return LT;
           }
@@ -483,7 +480,7 @@ class MonomialInfo : public our_new_delete
           n1 = n + firstvar;
           for (int i = 0; i < nvars; ++i)
             {
-              varpower_word cmp = *m1++ - *n1++;
+              monomial_word cmp = *m1++ - *n1++;
               if (cmp > 0) return GT;
               if (cmp < 0) return LT;
             }
@@ -638,7 +635,7 @@ class MonomialInfo : public our_new_delete
     for (int i = nvars - 1; i >= 0; --i)
       {
         if (a[i] != 0 && b[i] != 0) are_disjoint = false;
-        long c = a[i] - b[i];
+        monomial_word c = a[i] - b[i];
         if (c > 0)
           {
             *r++ = i;

--- a/M2/Macaulay2/e/f4/monomial-word.hpp
+++ b/M2/Macaulay2/e/f4/monomial-word.hpp
@@ -1,0 +1,10 @@
+#ifndef MONOMIAL_WORD_HPP
+#define MONOMIAL_WORD_HPP
+
+#include <cstdint>
+
+typedef int64_t monomial_word;
+typedef monomial_word *packed_monomial;
+typedef const monomial_word *const_packed_monomial;
+
+#endif /* MONOMIAL_WORD_HPP */

--- a/M2/Macaulay2/e/f4/varpower-monomial.hpp
+++ b/M2/Macaulay2/e/f4/varpower-monomial.hpp
@@ -3,10 +3,11 @@
 #define M2_F4_VARPOWER_MONOMIAL_HPP
 
 #include "monomials/ExponentList.hpp"
+#include "f4/monomial-word.hpp"  // for monomial_word
 
 // Legacy specialization
-using varpower_monomials = ExponentList<long, false>;
-using index_varpower_monomial = ExponentListIterator<long, false>;
+using varpower_monomials = ExponentList<monomial_word, false>;
+using index_varpower_monomial = ExponentListIterator<monomial_word, false>;
 
 typedef varpower_monomials::Exponent varpower_word;
 typedef varpower_word *varpower_monomial;

--- a/M2/Macaulay2/e/rings/skew.cpp
+++ b/M2/Macaulay2/e/rings/skew.cpp
@@ -73,7 +73,7 @@ int SkewMultiplication::skew_vars(const int *exp, int *result) const
   return next;
 }
 
-int SkewMultiplication::skew_vars(const long *exp, int *result) const
+int SkewMultiplication::skew_vars(const int64_t *exp, int *result) const
 // The number s of skew variables in 'exp' is returned, and their
 // indices are placed in result[0], ..., result[s-1].
 // The space that 'result' points to MUST hold at least n_skew ints
@@ -97,7 +97,7 @@ int SkewMultiplication::mult_sign(const int *exp1, const int *exp2) const
   return sort_sign(a, SKEW1, b, SKEW2);
 }
 
-int SkewMultiplication::mult_sign(const long *exp1, const long *exp2) const
+int SkewMultiplication::mult_sign(const int64_t *exp1, const int64_t *exp2) const
 {
   exponents_t SKEW1 = ALLOCATE_EXPONENTS(skew_byte_size);
   exponents_t SKEW2 = ALLOCATE_EXPONENTS(skew_byte_size);

--- a/M2/Macaulay2/e/rings/skew.hpp
+++ b/M2/Macaulay2/e/rings/skew.hpp
@@ -3,6 +3,8 @@
 #ifndef M2_RINGS_SKEW_HPP_
 #define M2_RINGS_SKEW_HPP_
 
+#include <cstdint>
+
 class SkewMultiplication
 {
  public:
@@ -24,13 +26,13 @@ class SkewMultiplication
   int skew_degree(const int *exp) const;
 
   int skew_vars(const int *exp, int *result) const;
-  int skew_vars(const long *exp, int *result) const;
+  int skew_vars(const int64_t *exp, int *result) const;
   // The number s of skew variables in 'exp' is returned, and their
   // indices are placed in result[0], ..., result[s-1].
   // The space that 'result' points to MUST hold at least 'nskew' ints.
 
   int mult_sign(const int *exp1, const int *exp2) const;
-  int mult_sign(const long *exp1, const long *exp2) const;
+  int mult_sign(const int64_t *exp1, const int64_t *exp2) const;
 
   int diff(const int *exp1, const int *exp2, int *result) const;
   int divide(const int *exp1, const int *exp2, int *result) const;

--- a/M2/Macaulay2/e/schreyer-resolutions/res-poly-ring.cpp
+++ b/M2/Macaulay2/e/schreyer-resolutions/res-poly-ring.cpp
@@ -39,8 +39,8 @@ bool check_poly(const ResPolyRing& R,
       else
         {
           // Now compare to previous monomial
-          long comp1 = M.get_component(prev);
-          long comp2 = M.get_component(i.monomial());
+          auto comp1 = M.get_component(prev);
+          auto comp2 = M.get_component(i.monomial());
           int result = M.compare_schreyer(prev,
                                           i.monomial(),
                                           ord.mTotalMonom[comp1],

--- a/M2/Macaulay2/e/unit-tests/Makefile.files
+++ b/M2/Macaulay2/e/unit-tests/Makefile.files
@@ -29,6 +29,7 @@ UNITTEST_CCFILES := \
     PolyRingTest \
     NewF4Test \
     MonoidTest \
+    MonomialInfoTest \
     MatrixIOTest \
     WeylAlgebraTest \
     QuotientRingTest \

--- a/M2/Macaulay2/e/unit-tests/MonomialInfoTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/MonomialInfoTest.cpp
@@ -1,0 +1,429 @@
+// Tests for the MonomialInfo packed-monomial format used by the F4 GB algorithm.
+//
+// Run with: ./M2-unit-tests --gtest_filter="MonomialInfo*"
+//
+// These tests verify the core arithmetic and comparison invariants of
+// MonomialInfo.  They are particularly important on 32-bit platforms where
+// the previous 'long'-based monomial_word was only 32 bits wide.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include "f4/moninfo.hpp"
+#include "monomials/monordering.hpp"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Build a MonomialInfo for an n-variable ring with the given monomial order.
+// heft degrees are all 1 (standard grading), no module component (rank-1).
+static std::unique_ptr<MonomialInfo> makeMonomialInfo(int nvars,
+                                                      MonomialOrdering* mo)
+{
+  std::vector<int> heft(nvars, 1);
+  return std::make_unique<MonomialInfo>(nvars, mo, heft, std::vector<int>{0});
+}
+
+static std::unique_ptr<MonomialInfo> makeGRevLex(int nvars)
+{
+  return makeMonomialInfo(nvars, MonomialOrderings::join({
+    MonomialOrderings::GRevLex(nvars),
+    MonomialOrderings::PositionUp()
+  }));
+}
+
+// GRevLex4 corresponds to MonomialSize=>8 in M2 (4 exponents per 32-bit word).
+static std::unique_ptr<MonomialInfo> makeGRevLex4(int nvars)
+{
+  return makeMonomialInfo(nvars, MonomialOrderings::join({
+    MonomialOrderings::GRevLex4(nvars),
+    MonomialOrderings::PositionUp()
+  }));
+}
+
+// GRevLex2 corresponds to MonomialSize=>16.
+static std::unique_ptr<MonomialInfo> makeGRevLex2(int nvars)
+{
+  return makeMonomialInfo(nvars, MonomialOrderings::join({
+    MonomialOrderings::GRevLex2(nvars),
+    MonomialOrderings::PositionUp()
+  }));
+}
+
+static std::unique_ptr<MonomialInfo> makeLex(int nvars)
+{
+  return makeMonomialInfo(nvars, MonomialOrderings::join({
+    MonomialOrderings::Lex(nvars),
+    MonomialOrderings::PositionUp()
+  }));
+}
+
+// Pack an exponent vector into a fresh monomial buffer.
+static std::vector<monomial_word> packExpvector(const MonomialInfo& MI,
+                                                const std::vector<int64_t>& e,
+                                                int comp = 0)
+{
+  std::vector<monomial_word> m(MI.max_monomial_size());
+  MI.from_expvector(e.data(), comp, m.data());
+  return m;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture for 4-variable grevlex tests
+// ---------------------------------------------------------------------------
+
+class MonomialInfoGRevLex4Var : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    srand(12345);
+    MI = makeGRevLex(4);
+  }
+  std::unique_ptr<MonomialInfo> MI;
+};
+
+// ---------------------------------------------------------------------------
+// Round-trip: from_expvector / to_expvector
+// ---------------------------------------------------------------------------
+
+TEST_F(MonomialInfoGRevLex4Var, RoundTripNonzero)
+{
+  std::vector<int64_t> e = {3, 1, 4, 1};
+  auto m = packExpvector(*MI, e);
+  std::vector<int64_t> result(4);
+  monomial_word comp;
+  MI->to_expvector(m.data(), result.data(), comp);
+  EXPECT_EQ(comp, 0);
+  for (int i = 0; i < 4; i++) EXPECT_EQ(result[i], e[i]) << "var " << i;
+}
+
+TEST_F(MonomialInfoGRevLex4Var, RoundTripZeroExponents)
+{
+  std::vector<int64_t> e = {0, 0, 0, 0};
+  auto m = packExpvector(*MI, e);
+  std::vector<int64_t> result(4);
+  monomial_word comp;
+  MI->to_expvector(m.data(), result.data(), comp);
+  EXPECT_EQ(comp, 0);
+  for (int i = 0; i < 4; i++) EXPECT_EQ(result[i], 0) << "var " << i;
+}
+
+TEST_F(MonomialInfoGRevLex4Var, RoundTripComponent)
+{
+  std::vector<int64_t> e = {2, 0, 1, 3};
+  auto m = packExpvector(*MI, e, 7);
+  std::vector<int64_t> result(4);
+  monomial_word comp;
+  MI->to_expvector(m.data(), result.data(), comp);
+  EXPECT_EQ(comp, 7);
+  for (int i = 0; i < 4; i++) EXPECT_EQ(result[i], e[i]) << "var " << i;
+}
+
+// ---------------------------------------------------------------------------
+// Multiplication: unchecked_mult
+// ---------------------------------------------------------------------------
+
+TEST_F(MonomialInfoGRevLex4Var, MultiplyExponentsAdd)
+{
+  std::vector<int64_t> e1 = {1, 2, 0, 3};
+  std::vector<int64_t> e2 = {2, 0, 4, 1};
+  auto m1 = packExpvector(*MI, e1);
+  auto m2 = packExpvector(*MI, e2);
+  std::vector<monomial_word> prod(MI->max_monomial_size());
+  MI->unchecked_mult(m1.data(), m2.data(), prod.data());
+
+  std::vector<int64_t> result(4);
+  monomial_word comp;
+  MI->to_expvector(prod.data(), result.data(), comp);
+  for (int i = 0; i < 4; i++) EXPECT_EQ(result[i], e1[i] + e2[i]) << "var " << i;
+}
+
+TEST_F(MonomialInfoGRevLex4Var, MultiplyMatchesDirectPack)
+{
+  // unchecked_mult(m(e1), m(e2)) == m(e1+e2) for all fields including hash
+  std::vector<int64_t> e1 = {3, 0, 2, 1};
+  std::vector<int64_t> e2 = {1, 4, 0, 2};
+  std::vector<int64_t> esum = {4, 4, 2, 3};
+  auto m1   = packExpvector(*MI, e1);
+  auto m2   = packExpvector(*MI, e2);
+  auto msum = packExpvector(*MI, esum);
+  std::vector<monomial_word> prod(MI->max_monomial_size());
+  MI->unchecked_mult(m1.data(), m2.data(), prod.data());
+  EXPECT_TRUE(MI->is_equal(prod.data(), msum.data()));
+}
+
+TEST_F(MonomialInfoGRevLex4Var, HashIsAdditive)
+{
+  // The core property of the additive hash: hash(m*n) == hash(m) + hash(n).
+  // This is the property that would fail if monomial_word were too narrow to
+  // hold the hash without truncation.
+  std::vector<int64_t> e1 = {2, 1, 3, 0};
+  std::vector<int64_t> e2 = {0, 3, 1, 2};
+  auto m1 = packExpvector(*MI, e1);
+  auto m2 = packExpvector(*MI, e2);
+  std::vector<monomial_word> prod(MI->max_monomial_size());
+  MI->unchecked_mult(m1.data(), m2.data(), prod.data());
+  EXPECT_EQ(MI->hash_value(prod.data()),
+            MI->hash_value(m1.data()) + MI->hash_value(m2.data()));
+}
+
+// ---------------------------------------------------------------------------
+// Division: unchecked_divide
+// ---------------------------------------------------------------------------
+
+TEST_F(MonomialInfoGRevLex4Var, DivideExponentsSubtract)
+{
+  std::vector<int64_t> e1 = {4, 3, 2, 5};
+  std::vector<int64_t> e2 = {1, 1, 2, 3};
+  auto m1 = packExpvector(*MI, e1);
+  auto m2 = packExpvector(*MI, e2);
+  std::vector<monomial_word> quot(MI->max_monomial_size());
+  MI->unchecked_divide(m1.data(), m2.data(), quot.data());
+
+  std::vector<int64_t> result(4);
+  monomial_word comp;
+  MI->to_expvector(quot.data(), result.data(), comp);
+  for (int i = 0; i < 4; i++) EXPECT_EQ(result[i], e1[i] - e2[i]) << "var " << i;
+}
+
+TEST_F(MonomialInfoGRevLex4Var, MultThenDivideIsIdentity)
+{
+  std::vector<int64_t> e1 = {2, 0, 3, 1};
+  std::vector<int64_t> e2 = {1, 2, 0, 1};
+  auto m1 = packExpvector(*MI, e1);
+  auto m2 = packExpvector(*MI, e2);
+  std::vector<monomial_word> prod(MI->max_monomial_size());
+  std::vector<monomial_word> quot(MI->max_monomial_size());
+  MI->unchecked_mult(m1.data(), m2.data(), prod.data());
+  MI->unchecked_divide(prod.data(), m2.data(), quot.data());
+  EXPECT_TRUE(MI->is_equal(quot.data(), m1.data()));
+}
+
+// ---------------------------------------------------------------------------
+// Equality
+// ---------------------------------------------------------------------------
+
+TEST_F(MonomialInfoGRevLex4Var, EqualSameMonomial)
+{
+  auto m1 = packExpvector(*MI, {1, 2, 3, 4});
+  auto m2 = packExpvector(*MI, {1, 2, 3, 4});
+  EXPECT_TRUE(MI->is_equal(m1.data(), m2.data()));
+}
+
+TEST_F(MonomialInfoGRevLex4Var, NotEqualDifferentExponent)
+{
+  auto m1 = packExpvector(*MI, {1, 2, 3, 4});
+  auto m2 = packExpvector(*MI, {1, 2, 3, 5});
+  EXPECT_FALSE(MI->is_equal(m1.data(), m2.data()));
+}
+
+TEST_F(MonomialInfoGRevLex4Var, NotEqualDifferentComponent)
+{
+  auto m1 = packExpvector(*MI, {1, 2, 0, 0}, 0);
+  auto m2 = packExpvector(*MI, {1, 2, 0, 0}, 1);
+  EXPECT_FALSE(MI->is_equal(m1.data(), m2.data()));
+}
+
+// ---------------------------------------------------------------------------
+// Comparison: grevlex order
+// ---------------------------------------------------------------------------
+
+TEST_F(MonomialInfoGRevLex4Var, CompareHigherDegreeIsGreater)
+{
+  auto hi = packExpvector(*MI, {2, 1, 0, 0}); // degree 3
+  auto lo = packExpvector(*MI, {1, 0, 0, 0}); // degree 1
+  EXPECT_EQ(MI->compare(hi.data(), lo.data()), GT);
+  EXPECT_EQ(MI->compare(lo.data(), hi.data()), LT);
+}
+
+TEST_F(MonomialInfoGRevLex4Var, CompareEqualMonomials)
+{
+  auto m1 = packExpvector(*MI, {1, 2, 0, 3});
+  auto m2 = packExpvector(*MI, {1, 2, 0, 3});
+  EXPECT_EQ(MI->compare(m1.data(), m2.data()), EQ);
+}
+
+TEST_F(MonomialInfoGRevLex4Var, CompareGRevLexTieBreakLastVar)
+{
+  // Equal degree; grevlex prefers the monomial with smaller exponent for the
+  // last (highest-index) variable: x0^2 > x1^2 > x2^2 > x3^2.
+  auto m0 = packExpvector(*MI, {2, 0, 0, 0}); // degree 2
+  auto m1 = packExpvector(*MI, {0, 2, 0, 0});
+  auto m2 = packExpvector(*MI, {0, 0, 2, 0});
+  auto m3 = packExpvector(*MI, {0, 0, 0, 2});
+  EXPECT_EQ(MI->compare(m0.data(), m1.data()), GT);
+  EXPECT_EQ(MI->compare(m1.data(), m2.data()), GT);
+  EXPECT_EQ(MI->compare(m2.data(), m3.data()), GT);
+}
+
+TEST_F(MonomialInfoGRevLex4Var, CompareAntisymmetric)
+{
+  auto m1 = packExpvector(*MI, {3, 0, 1, 0});
+  auto m2 = packExpvector(*MI, {0, 2, 0, 2});
+  int r12 = MI->compare(m1.data(), m2.data());
+  int r21 = MI->compare(m2.data(), m1.data());
+  if      (r12 == GT) EXPECT_EQ(r21, LT);
+  else if (r12 == LT) EXPECT_EQ(r21, GT);
+  else                EXPECT_EQ(r21, EQ);
+}
+
+TEST_F(MonomialInfoGRevLex4Var, CompareTransitive)
+{
+  auto a = packExpvector(*MI, {3, 0, 0, 0}); // degree 3
+  auto b = packExpvector(*MI, {1, 1, 0, 0}); // degree 2
+  auto c = packExpvector(*MI, {0, 0, 0, 1}); // degree 1
+  EXPECT_EQ(MI->compare(a.data(), b.data()), GT);
+  EXPECT_EQ(MI->compare(b.data(), c.data()), GT);
+  EXPECT_EQ(MI->compare(a.data(), c.data()), GT);
+}
+
+// ---------------------------------------------------------------------------
+// Lex order
+// ---------------------------------------------------------------------------
+
+TEST(MonomialInfoLex, CompareFirstVarDominates)
+{
+  srand(77777);
+  auto MI = makeLex(3);
+  // Lex: x0^2 > x0*x1 > x1^2 regardless of total degree
+  auto x0sq = packExpvector(*MI, {2, 0, 0});
+  auto x0x1 = packExpvector(*MI, {1, 1, 0});
+  auto x1sq = packExpvector(*MI, {0, 2, 0});
+  EXPECT_EQ(MI->compare(x0sq.data(), x0x1.data()), GT);
+  EXPECT_EQ(MI->compare(x0x1.data(), x1sq.data()), GT);
+  EXPECT_EQ(MI->compare(x0sq.data(), x1sq.data()), GT);
+}
+
+TEST(MonomialInfoLex, RoundTrip)
+{
+  srand(88888);
+  auto MI = makeLex(3);
+  std::vector<int64_t> e = {5, 0, 3};
+  auto m = packExpvector(*MI, e);
+  std::vector<int64_t> result(3);
+  monomial_word comp;
+  MI->to_expvector(m.data(), result.data(), comp);
+  for (int i = 0; i < 3; i++) EXPECT_EQ(result[i], e[i]) << "var " << i;
+}
+
+// ---------------------------------------------------------------------------
+// GRevLex4 (MonomialSize=>8): the order used in the originally-failing test
+// ---------------------------------------------------------------------------
+
+TEST(MonomialInfoGRevLex4, RoundTrip7Vars)
+{
+  srand(42);
+  auto MI = makeGRevLex4(7);
+  std::vector<int64_t> e = {3, 0, 1, 4, 0, 2, 1};
+  auto m = packExpvector(*MI, e);
+  std::vector<int64_t> result(7);
+  monomial_word comp;
+  MI->to_expvector(m.data(), result.data(), comp);
+  for (int i = 0; i < 7; i++) EXPECT_EQ(result[i], e[i]) << "var " << i;
+}
+
+TEST(MonomialInfoGRevLex4, HashAdditive7Vars)
+{
+  srand(42);
+  auto MI = makeGRevLex4(7);
+  std::vector<int64_t> e1 = {1, 2, 0, 3, 1, 0, 2};
+  std::vector<int64_t> e2 = {2, 0, 3, 0, 1, 2, 1};
+  auto m1 = packExpvector(*MI, e1);
+  auto m2 = packExpvector(*MI, e2);
+  std::vector<monomial_word> prod(MI->max_monomial_size());
+  MI->unchecked_mult(m1.data(), m2.data(), prod.data());
+  EXPECT_EQ(MI->hash_value(prod.data()),
+            MI->hash_value(m1.data()) + MI->hash_value(m2.data()));
+}
+
+TEST(MonomialInfoGRevLex4, CompareCorrect7Vars)
+{
+  srand(42);
+  auto MI = makeGRevLex4(7);
+  // x0^2 (degree 2) > x6^2 (degree 2) in grevlex: x0^2 has smaller x6 exponent
+  auto x0sq = packExpvector(*MI, {2, 0, 0, 0, 0, 0, 0});
+  auto x6sq = packExpvector(*MI, {0, 0, 0, 0, 0, 0, 2});
+  EXPECT_EQ(MI->compare(x0sq.data(), x6sq.data()), GT);
+  EXPECT_EQ(MI->compare(x6sq.data(), x0sq.data()), LT);
+}
+
+// ---------------------------------------------------------------------------
+// GRevLex2 (MonomialSize=>16)
+// ---------------------------------------------------------------------------
+
+TEST(MonomialInfoGRevLex2, RoundTrip5Vars)
+{
+  srand(55555);
+  auto MI = makeGRevLex2(5);
+  std::vector<int64_t> e = {0, 5, 2, 0, 3};
+  auto m = packExpvector(*MI, e);
+  std::vector<int64_t> result(5);
+  monomial_word comp;
+  MI->to_expvector(m.data(), result.data(), comp);
+  for (int i = 0; i < 5; i++) EXPECT_EQ(result[i], e[i]) << "var " << i;
+}
+
+TEST(MonomialInfoGRevLex2, HashAdditive5Vars)
+{
+  srand(55555);
+  auto MI = makeGRevLex2(5);
+  std::vector<int64_t> e1 = {1, 0, 3, 2, 0};
+  std::vector<int64_t> e2 = {0, 2, 1, 0, 4};
+  auto m1 = packExpvector(*MI, e1);
+  auto m2 = packExpvector(*MI, e2);
+  std::vector<monomial_word> prod(MI->max_monomial_size());
+  MI->unchecked_mult(m1.data(), m2.data(), prod.data());
+  EXPECT_EQ(MI->hash_value(prod.data()),
+            MI->hash_value(m1.data()) + MI->hash_value(m2.data()));
+}
+
+// ---------------------------------------------------------------------------
+// Many variables: stress all monomial slots and the hash accumulator
+// ---------------------------------------------------------------------------
+
+TEST(MonomialInfoManyVars, RoundTrip10Vars)
+{
+  srand(33333);
+  auto MI = makeGRevLex(10);
+  std::vector<int64_t> e = {1, 2, 3, 4, 5, 0, 1, 0, 2, 1};
+  auto m = packExpvector(*MI, e);
+  std::vector<int64_t> result(10);
+  monomial_word comp;
+  MI->to_expvector(m.data(), result.data(), comp);
+  for (int i = 0; i < 10; i++) EXPECT_EQ(result[i], e[i]) << "var " << i;
+}
+
+TEST(MonomialInfoManyVars, MultiplyMatchesDirectPack10Vars)
+{
+  srand(33333);
+  const int n = 10;
+  auto MI = makeGRevLex(n);
+  std::vector<int64_t> e1(n), e2(n), esum(n);
+  for (int i = 0; i < n; i++) { e1[i] = i; e2[i] = n - i; esum[i] = n; }
+  auto m1   = packExpvector(*MI, e1);
+  auto m2   = packExpvector(*MI, e2);
+  auto msum = packExpvector(*MI, esum);
+  std::vector<monomial_word> prod(MI->max_monomial_size());
+  MI->unchecked_mult(m1.data(), m2.data(), prod.data());
+  EXPECT_TRUE(MI->is_equal(prod.data(), msum.data()));
+}
+
+TEST(MonomialInfoManyVars, HashAdditive10Vars)
+{
+  srand(33333);
+  const int n = 10;
+  auto MI = makeGRevLex(n);
+  std::vector<int64_t> e1(n), e2(n);
+  for (int i = 0; i < n; i++) { e1[i] = i % 4; e2[i] = (i + 2) % 3; }
+  auto m1 = packExpvector(*MI, e1);
+  auto m2 = packExpvector(*MI, e2);
+  std::vector<monomial_word> prod(MI->max_monomial_size());
+  MI->unchecked_mult(m1.data(), m2.data(), prod.data());
+  EXPECT_EQ(MI->hash_value(prod.data()),
+            MI->hash_value(m1.data()) + MI->hash_value(m2.data()));
+}

--- a/M2/Macaulay2/packages/EngineTests/GB.Test.LinearAlgebra.m2
+++ b/M2/Macaulay2/packages/EngineTests/GB.Test.LinearAlgebra.m2
@@ -371,6 +371,91 @@ TEST /// -- multigradings
   assert(gbA == gbC)
 ///
 
+-- Tests added to cover the monomial_word int64_t fix (was 'long', which is
+-- 32-bit on armhf).  The original failing case was GF(125) with MonomialSize=>8.
+-- These tests exercise other extension fields, more variables, and MonomialSize=>16
+-- to give broader coverage on 32-bit platforms.
+
+-*
+  restart
+*-
+TEST /// -- F4 over GF(4) = GF(2^2) with MonomialSize=>8
+  kk = GF 4;
+  R1 = kk[a..f, MonomialSize=>8];
+  setRandomSeed 42
+  J1 = ideal random(R1^1, R1^{-3,-3,-4,-4});
+  elapsedTime gbC = flatten entries gens gb(ideal J1_*, DegreeLimit => 8);
+  elapsedTime gbB = flatten entries gens gb(ideal J1_*, Algorithm => LinearAlgebra, DegreeLimit => 8);
+  assert(gbC == gbB)
+///
+
+-*
+  restart
+*-
+TEST /// -- F4 over GF(9) = GF(3^2) with MonomialSize=>8
+  kk = GF 9;
+  R1 = kk[a..f, MonomialSize=>8];
+  setRandomSeed 42
+  J1 = ideal random(R1^1, R1^{-3,-3,-4,-4});
+  elapsedTime gbC = flatten entries gens gb(ideal J1_*, DegreeLimit => 8);
+  elapsedTime gbB = flatten entries gens gb(ideal J1_*, Algorithm => LinearAlgebra, DegreeLimit => 8);
+  assert(gbC == gbB)
+///
+
+-*
+  restart
+*-
+TEST /// -- F4 over GF(27) = GF(3^3) with MonomialSize=>8
+  kk = GF 27;
+  R1 = kk[a..f, MonomialSize=>8];
+  setRandomSeed 42
+  J1 = ideal random(R1^1, R1^{-3,-3,-4,-4});
+  elapsedTime gbC = flatten entries gens gb(ideal J1_*, DegreeLimit => 8);
+  elapsedTime gbB = flatten entries gens gb(ideal J1_*, Algorithm => LinearAlgebra, DegreeLimit => 8);
+  assert(gbC == gbB)
+///
+
+-*
+  restart
+*-
+TEST /// -- F4 over GF(125) with MonomialSize=>16 (GRevLex2 packing path)
+  kk = GF 125;
+  R1 = kk[a..g, MonomialSize=>16];
+  setRandomSeed 42
+  J1 = ideal random(R1^1, R1^{-4,-4,-5,-5});
+  elapsedTime gbC = flatten entries gens gb(ideal J1_*, DegreeLimit => 10);
+  elapsedTime gbB = flatten entries gens gb(ideal J1_*, Algorithm => LinearAlgebra, DegreeLimit => 10);
+  assert(gbC == gbB)
+///
+
+-*
+  restart
+*-
+TEST /// -- F4 over ZZ/101 with MonomialSize=>8 and more variables (10)
+  -- More variables stress more monomial slots and the hash accumulator.
+  kk = ZZ/101;
+  R1 = kk[a..j, MonomialSize=>8];
+  setRandomSeed 42
+  J1 = ideal random(R1^1, R1^{-3,-3,-3,-3});
+  elapsedTime gbC = flatten entries gens gb(ideal J1_*, DegreeLimit => 6);
+  elapsedTime gbB = flatten entries gens gb(ideal J1_*, Algorithm => LinearAlgebra, DegreeLimit => 6);
+  assert(gbC == gbB)
+///
+
+-*
+  restart
+*-
+TEST /// -- F4 over GF(125) with 10 variables and MonomialSize=>8
+  -- Combines non-prime field with more variables than the original failing test.
+  kk = GF 125;
+  R1 = kk[a..j, MonomialSize=>8];
+  setRandomSeed 42
+  J1 = ideal random(R1^1, R1^{-3,-3,-3,-3});
+  elapsedTime gbC = flatten entries gens gb(ideal J1_*, DegreeLimit => 6);
+  elapsedTime gbB = flatten entries gens gb(ideal J1_*, Algorithm => LinearAlgebra, DegreeLimit => 6);
+  assert(gbC == gbB)
+///
+
 -- todo:
 --  error for quotient rings (for LinearAlgebra)
 --  error for exterior algebra


### PR DESCRIPTION
### Summary

Replace `long` with `int64_t` for `monomial_word` in the F4 Gröbner basis engine, fixing test failures on 32-bit ARM (armhf). Add C++ unit tests for `MonomialInfo` and extend the `EngineTests` suite with additional F4 GB tests over extension fields and wider variable/packing configurations.

### Background

The F4 Gröbner basis algorithm stores packed monomials as arrays of `monomial_word`, which was `typedef long monomial_word`. On 64-bit platforms `long` is 64 bits, but on 32-bit ARM (armhf) it is only 32 bits. The original code even carried a comment acknowledging the uncertainty: `// Is this OK?`

The test `EngineTests/GB.Test.LinearAlgebra.m2` (test 75), which computes a Gröbner basis over `GF(125)` in a ring with `MonomialSize=>8`, was failing on Ubuntu 18.04 armhf with:

```
-- Internal error: array out of order   (6 times)
-- i7 :   assert(gbC == gbB)
-- error: assertion failed
```

The "array out of order" message comes from a consistency check in `F4GB::reorder_columns` (`f4.cpp`): after sorting the F4 matrix columns by monomial order, it verifies that each row's component array is strictly increasing. When this fires, the subsequent Gaussian elimination uses the wrong pivot columns and produces an incorrect Gröbner basis.

The test was added in commit fa31ec2ba7 after the F4 algorithm was extended (in 37fda3a6b6) to support non-default monomial orders by storing a total-degree weight slot inside each packed monomial. Both commits were written and validated on 64-bit only.

### Changes

**`M2/Macaulay2/e/f4/monomial-word.hpp`** (new file) — extracts the `monomial_word` typedef into a standalone header so that both `moninfo.hpp` and `varpower-monomial.hpp` can include it without a circular dependency.

**`M2/Macaulay2/e/f4/moninfo.hpp` / `moninfo.cpp`** — `monomial_word` changed from `long` to `int64_t` via the new header; all function parameters and return types that hold monomial slot values updated accordingly; comparison temporaries changed from `varpower_word` to `monomial_word` to avoid narrowing; `compare_schreyer` tiebreaker parameters use `int` since they are component indices; `hash_value` return type changed to `uint64_t`, consistent with the Macaulay2 interpreter's convention for hash values; `printf` format specifiers updated to `PRId64`.

**`M2/Macaulay2/e/f4/varpower-monomial.hpp`** — `ExponentList<long, false>` → `ExponentList<monomial_word, false>`, so `varpower_word` stays in sync with `monomial_word` automatically.

**`M2/Macaulay2/e/f4/f4-monlookup.hpp` / `.cpp`**, **`f4-m2-interface.cpp`**, **`monhashtable.hpp`** / **`.cpp`**, **`schreyer-resolution/res-poly-ring.cpp`** — callers updated to use `monomial_word` (or `auto`) where they previously used `long` to store values originating from `monomial_word` slots.

**Behavior on 64-bit is completely unchanged.** On all mainstream 64-bit Unix platforms (Linux, macOS) `long` and `int64_t` are the same type, so the generated code is identical.

### Tests

**`M2/Macaulay2/e/unit-tests/MonomialInfoTest.cpp`** (new file, registered in `Makefile.files`) — direct C++ unit tests for `MonomialInfo`, exercising the properties that would be silently broken by a too-narrow `monomial_word`: round-trip correctness of `from_expvector`/`to_expvector`; exponent arithmetic under `unchecked_mult` and `unchecked_divide`; the additive hash property `hash(m·n) == hash(m) + hash(n)` (the invariant that breaks on 32-bit if the hash accumulator truncates); and comparison correctness for GRevLex, GRevLex4 (`MonomialSize=>8`), GRevLex2 (`MonomialSize=>16`), and Lex orderings with 4, 5, 7, and 10 variables.

**`M2/Macaulay2/packages/EngineTests/GB.Test.LinearAlgebra.m2`** — six new `TEST` blocks verifying that `Algorithm => LinearAlgebra` produces the same GB as the default algorithm, covering: GF(4), GF(9), GF(27) with MonomialSize=>8; GF(125) with MonomialSize=>16 (the GRevLex2 packing path); ZZ/101 with 10 variables and MonomialSize=>8; and GF(125) with 10 variables and MonomialSize=>8.

### Test plan

Run the new C++ unit tests with `./M2-unit-tests --gtest_filter="MonomialInfo*"`. Confirm the original armhf failure (test 75 over GF(125) with MonomialSize=>8) is resolved on a 32-bit ARM build. Verify no regressions on 64-bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Disclosure

This was all Claude, baby!

*Draft for now pending the "great sort"*