### PR TITLE
Update StatePolytope test for gfan 0.8beta

### DIFF
--- a/M2/Macaulay2/packages/StatePolytope.m2
+++ b/M2/Macaulay2/packages/StatePolytope.m2
@@ -144,7 +144,7 @@ I=ideal(a*c-b^2,a*d-b*c,b*d-c^2);
 L= {{b*d, a*d, a*c}, {a*d, b*d, b^2}, {a*d^2, b*d, b*c, b^2}, {b*d, b^2, b*c,
      c^3}, {a*d, a*c, c^2}, {a^2*d, a*c, c^2, b*c}, {a*c, c^2, b*c, b^3}, {c^2,
      b*c, b^2}};
-assert(set initialIdeals(I) === set L)
+assert(set(set \ initialIdeals(I)) === set(set \ L))
 ///
      
 document {


### PR DESCRIPTION
The orders of the elements of the output of `initialIdeals` has changed, so we compare them as sets.

This commit is cherry-picked from #4268.  I just backported the new version of gfan for the PPA, so now the Ubuntu GitHub builds are using it, and so the tests are failing, e.g., from https://github.com/Macaulay2/M2/actions/runs/26850868422/job/79182360697?pr=4401:

```m2
/home/runner/work/M2/M2/M2/BUILD/build/usr-dist/x86_64-Linux-Ubuntu-24.04/bin/M2 -q --no-preload --stop --silent -e "needsPackage(\"StatePolytope\",LoadDocumentation=>true,DebuggingMode=>true)" -e "debug Core; argumentMode = defaultMode" -e "check(StatePolytope,UserMode=>false,Verbose=>false); exit 0"
 -- capturing check(0, "StatePolytope") -- capture failed; retrying ...
 -- running   check(0, "StatePolytope") -- running failed
 -- error log:  /tmp/M2-97656-0/2.tmp:0:1:(3):[13]: stdio:8:6:(3):[1]: error: assertion failed
 -- 
 -- input code: ../../../../Macaulay2/packages/StatePolytope.m2:141:5-148:3
*** error: M2 exited with status code 1 -- 1.25146s elapsed
 -- capturing check(1, "StatePolytope") -- 2.77179s elapsed
 -- capturing check(2, "StatePolytope") -- 10.4525s elapsed

 -- Summary: 1 test(s) failed in package StatePolytope:
 -- Test #0.  ../../../../Macaulay2/packages/StatePolytope.m2:141:5-148:3
../../../../Macaulay2/m2/testing.m2:130:13:(1):[8]: error: repeat failed tests with:
  check({0}, "StatePolytope")
```