### PR TITLE
Install language server in .rpm packages

### DIFF
--- a/M2/BUILD/rpm/Macaulay2.spec
+++ b/M2/BUILD/rpm/Macaulay2.spec
@@ -141,6 +141,7 @@ rm -fv %{buildroot}%{_infodir}/dir
 %files
 %{_bindir}/M2
 %{_bindir}/M2-binary
+%{_bindir}/M2-language-server
 %{_prefix}/lib/Macaulay2/
 %{_libexecdir}/Macaulay2/
 %{_datadir}/emacs/site-lisp/macaulay2/


### PR DESCRIPTION
Quick followup to #3655.  The .rpm package builds are failing because we weren't installing the new `M2-language-server` script:

```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/macaulay/rpmbuild/BUILDROOT/Macaulay2-1.26.05-0.1.m2.el10.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/bin/M2-language-server

    Installed (but unpackaged) file(s) found:
RPM build errors:
   /usr/bin/M2-language-server
make: *** [Makefile:20: rpm] Error 1
```

Full log: https://github.com/d-torrance/M2-workflows/actions/runs/26945142267/job/79496126798