### PR TITLE
A few palp updates

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -64,7 +64,7 @@ jobs:
           brew config
           brew update
           brew tap macaulay2/tap
-          brew install automake bison boost libtool tbb ccache ctags llvm make yasm libffi msolve googletest fplll eigen jansson r
+          brew install automake bison boost libtool tbb ccache ctags llvm make yasm libffi msolve googletest fplll eigen jansson r palp
           brew install texinfo || true # sometimes post-install step fails
           brew install --only-dependencies macaulay2/tap/M2
           brew link factory --force
@@ -85,7 +85,7 @@ jobs:
                   libgivaro-dev libboost-regex-dev fflas-ffpack libflint-dev libmps-dev libfrobby-dev \
                   libsingular-dev singular-data libcdd-dev cohomcalg topcom 4ti2 libnormaliz-dev normaliz coinor-csdp \
                   libnauty-dev nauty lrslib polymake pipx phcpack w3c-markup-validator libtbb-dev qepcad libomp-16-dev \
-                  msolve libfplll-dev libjansson-dev r-base
+                  msolve libfplll-dev libjansson-dev r-base palp
 
 # ----------------------
 #   Steps common to all build variants

--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -1166,7 +1166,7 @@ ExternalProject_Add(build-bertini
   )
 #_ADD_COMPONENT_DEPENDENCY(libraries bertini "gmp;mpfr" BERTINI)
 
-# http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html
+# https://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html
 set(palp_PROGRAMS
   class-11d.x  class.x    cws-6d.x    mori-5d.x  nef-4d.x  poly-11d.x  poly.x
   class-4d.x   cws-11d.x  cws.x       mori-6d.x  nef-5d.x  poly-4d.x

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1116,13 +1116,14 @@ found and $msolve_min_version is required; will build])
          [AC_MSG_RESULT([no, will build])
           BUILD_msolve=yes])])
 
-AS_IF([test $BUILD_palp = no],
-    [AC_MSG_CHECKING([whether palp is installed])
-     AS_IF([command -v poly.x > /dev/null],
-         [AC_MSG_RESULT([yes])
-          FILE_PREREQS="$FILE_PREREQS `command -v poly.x`"],
-         [AC_MSG_RESULT([no, will build])
-          BUILD_palp=yes])])
+dnl TODO: uncomment whne we require palp
+dnl AS_IF([test $BUILD_palp = no],
+dnl [AC_MSG_CHECKING([whether palp is installed])
+dnl  AS_IF([command -v poly.x > /dev/null],
+dnl      [AC_MSG_RESULT([yes])
+dnl       FILE_PREREQS="$FILE_PREREQS `command -v poly.x`"],
+dnl      [AC_MSG_RESULT([no, will build])
+dnl       BUILD_palp=yes])])
 
 AC_LANG([C++])
 AS_IF([test $BUILD_eigen = no],

--- a/M2/libraries/palp/Makefile.in
+++ b/M2/libraries/palp/Makefile.in
@@ -1,5 +1,5 @@
-HOMEPAGE = http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html
-URL = http://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/
+HOMEPAGE = https://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html
+URL = https://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/
 VERSION = 2.21
 SHA256SUM = 7e4a7bf219998a844c0bcce0a176e49d0743cb4b505a0e195329bf2ec196ddd7
 


### PR DESCRIPTION
This is a quick followup to #4400.

A few small changes:

* Don't build palp by default (autotools).  You can still build it by passing `--enable-build-libraries=palp` to `configure`, but there's no reason yet to require its presence.  (This was causing all the PPA builds to fail, as they were all trying to download the tarball but internet access isn't available during Debian package builds!)
* Use `https://` for all palp URL's. (I was using a few `http://`'s, so we were redirecting needlessly when downloading the tarball.)
* Go ahead and install palp in the GitHub builds (both in Ubuntu via `apt` and macOS via `brew` from the M2 tap) so it's there when we need it.