### PR TITLE
Trust the Macaulay2 Homebrew tap

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           brew config
           brew update
+          brew trust macaulay2/tap
           brew tap macaulay2/tap
           brew install automake bison boost libtool tbb ccache ctags llvm make yasm libffi msolve googletest fplll eigen jansson r palp
           brew install texinfo || true # sometimes post-install step fails


### PR DESCRIPTION
We just started getting the following warning message in the GitHub builds:

```
The following taps are not trusted:
  aws/tap
  azure/bicep
  hashicorp/tap
  macaulay2/tap

Homebrew will ignore formulae, casks and commands from these taps when `HOMEBREW_REQUIRE_TAP_TRUST` is set.
This will become the default in Homebrew 6.0.0 or 5.2.0, whichever comes first.
Enable trust checks now with:
  export HOMEBREW_REQUIRE_TAP_TRUST=1
Trust specific formulae, casks or commands with:
  brew trust --formula <user>/<tap>/<formula>
  brew trust --cask <user>/<tap>/<cask>
  brew trust --command <user>/<tap>/<command>
or trust installed formulae from these taps with:
  brew trust --formula azure/bicep/bicep
  brew trust --formula macaulay2/tap/palp
  brew trust --formula hashicorp/tap/packer
You can trust all formulae, casks and commands from these taps with:
  brew trust aws/tap azure/bicep hashicorp/tap macaulay2/tap
Prefer trusting only the specific formulae, casks or commands you need.
Untap them with:
  brew untap aws/tap azure/bicep hashicorp/tap macaulay2/tap
To keep allowing them by default during the transition:
  export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
This is not recommended and will be removed in a later release.
```

This looks to be a new thing with Homebrew 5.1.15, which was just released a few days ago.

I imagine GitHub will probably add some blurb to the runner scripts to trust the other three taps -- I don't think we should have to do it since we're not explicitly tapping them.