### PR TITLE
Remove slow EnumerationCurves test

### DIFF
--- a/M2/Macaulay2/packages/EnumerationCurves.m2
+++ b/M2/Macaulay2/packages/EnumerationCurves.m2
@@ -1051,15 +1051,6 @@ TEST ///
     assert(rationalCurve(4) == 15517926796875/64)
 ///
 
--- Slower test: rationalCurve(5) takes ~12s on a current laptop, which
--- is why it was originally commented out.  The value
--- 229305888887648 is Katz's classical enumeration of degree-5
--- rational curves on a general quintic threefold; without this
--- assertion the degree-5 code path has zero direct coverage.
-TEST ///
-    assert(rationalCurve(5) == 229305888887648)
-///
-
 -- rationalCurve(1, D) for the five complete-intersection Calabi-Yau
 -- threefold types.  Previously only D = {5} was tested via
 -- rationalCurve(1).


### PR DESCRIPTION
Runs out of memory on 32-bit systems and takes a long time (~25 s on my system) otherwise.

I asked Claude if we'd be losing anything by removing it, and this was its response (TL;DR: no):

# Coverage Analysis: Removing EnumerationCurves TEST 1

## Question

If TEST 1 (`rationalCurve(5)`) is removed, does any functionality of the package
lose test coverage?

## Answer

No. All code paths exercised by TEST 1 are already covered by other tests,
primarily TEST 4.

## What TEST 1 Uniquely Exercises

`rationalCurve(5)` triggers the `d == 5` branch in `fixedPoints`
(`EnumerationCurves.m2:122–179`), which is the only place the helper functions
`graph51`–`graph56` are called. Those six helpers are never reached by any
degree ≤ 4 computation.

## Why TEST 4 Already Covers That Code Path

`multipleCover(d)` calls `fixedPoints(1, d)` internally.  TEST 4 asserts
`multipleCover(5) == 1/125`, which calls `fixedPoints(1, 5)` and therefore
enters the `d == 5` branch.  With `r = 1` (two torus weights, 0 and 1), the
inequality guards (`k != h`, `h != m`, `m != n`, etc.) are all satisfiable, so
`graph51`–`graph56` are genuinely called and their results feed into the
asserted value.

## Coverage Map After Removing TEST 1

| Code path | Still covered by |
|---|---|
| `rationalCurve` (general) | TEST 0 — degrees 1–4 |
| `d == 5` branch in `fixedPoints` | TEST 4 via `multipleCover(5)` |
| `graph51`–`graph56` helpers | TEST 4 via `multipleCover(5)` |
| `contributionBundle`, `normalBundle` | TESTSs 4–6 |
| `linesHypersurface` | TEST 5 |
| Internal helpers (`torusList`, `fixedPoints` directly) | TEST 6 |

## What Is Lost

The only thing removed is the end-to-end verification of the value
229305888887648 (Katz's count of degree-5 rational curves on the general quintic
threefold).  The algorithm producing it remains fully exercised through other
tests; only this specific published constant loses its direct assertion.


Closes: #4413 