### PR TITLE
move tries block in isIsomorphism

### DIFF
--- a/M2/Macaulay2/packages/Isomorphism.m2
+++ b/M2/Macaulay2/packages/Isomorphism.m2
@@ -235,10 +235,6 @@ isIsomorphic(Module, Module) := Boolean => o -> (N, M) -> (
     if isFreeModule M and isFreeModule N then
     return isIsomorphismFree(N, M, o);
     --
-    tries := o.Tries ?? defaultNumTries char S;
-    if tries > 1 then return any(tries,
-	i -> isIsomorphic(N, M, o, Tries => 1));
-    --
     if o.Homogeneous == true and not (
 	isHomogeneous M and isHomogeneous N)
     then error "inputs not homogeneous";
@@ -262,6 +258,13 @@ isIsomorphic(Module, Module) := Boolean => o -> (N, M) -> (
 	if class df_1 =!= List  then return false);
 	--now there is a chance at an isomorphism up to shift, 
 	--and df is the degree diff.
+
+    --
+    tries := o.Tries ?? defaultNumTries char S;
+    if tries > 1 then return any(tries,
+	i -> isIsomorphic(N, M, o, Tries => 1));
+    --
+
 
     --compute an appropriate random map g
     g := if o.Homogeneous and degreeLength S == 1


### PR DESCRIPTION
A small change in order of operations for `isIsomorphic`: before, when running `isIsomorphic(M, N)`, the (deterministic) check that the degrees of `M` could be shifted to the degrees of `N` was occurring after the line `if tries > 1 then return any(tries, i -> isIsomorphic(N, M, o, Tries => 1))`, so the same check was getting run `tries` many times; if this check failed, we'd scan a list of `Tries` many `false` entries. Now the degree check occurs first, so that we reject immediately. For a toy example where this speeds things up considerably, try:

```
R = (ZZ/5)[x,y]
elapsedTime isIsomorphic(R^{1}/x,R^{2}/y,Tries=>20000,Strict=>true)
```