### PR TITLE
Bump version number to 1.26.06 in .spec file

### DIFF
--- a/M2/BUILD/rpm/Macaulay2.spec
+++ b/M2/BUILD/rpm/Macaulay2.spec
@@ -2,7 +2,7 @@
 # https://src.fedoraproject.org/rpms/Macaulay2/blob/rawhide/f/Macaulay2.spec
 
 Name:    Macaulay2
-Version: 1.26.05
+Version: 1.26.06
 
 # release convention: 0.x.m2 (so official fedora package will take precedence)
 # increment x as needed, reset to 1 with each new m2 release


### PR DESCRIPTION
Forgot to do this before this release.  Ended up not being a big deal because there are a number of other issues with the .rpm I'm having to fix anyway...
