### PR TITLE
e/interface/cone.cpp: avoid pulling in fflas-ffpack via mutablemat.hpp

### DIFF
--- a/M2/Macaulay2/e/interface/cone.cpp
+++ b/M2/Macaulay2/e/interface/cone.cpp
@@ -13,7 +13,7 @@
 #include "matrices/matrix-con.hpp"
 #include "matrices/matrix.hpp"
 #include "interface/mutable-matrix.h"
-#include "mutable-matrices/mutablemat.hpp"
+#include "basic-mutable-matrices/mat.hpp"
 #include "util.hpp"
 
 #include "cytools/lattice_points.hpp"


### PR DESCRIPTION
While building the Fedora packages for the new release, I ran into an issue.

We use both fflas-ffpack and normaliz (and in particular, we use even more normaliz features in the new release).  In Fedora, normaliz is built with cocoa support, and cocoa depends on gsl.  So we end up pulling in both fflas-ffpack and gsl headers, giving us the following compilation error since both define some cblas enums:

```c
CXX interface/cone.cpp
In file included from /usr/include/gsl/gsl_blas_types.h:28,
                 from /usr/include/gsl/gsl_matrix_complex_long_double.h:29,
                 from /usr/include/gsl/gsl_matrix.h:4,
                 from /usr/include/gsl/gsl_blas.h:27,
                 from /usr/include/CoCoA/ExternalLibs-GSL.H:29,
                 from /usr/include/CoCoA/library.H:29,
                 from /usr/include/libnormaliz/nmz_polynomial.h:39,
                 from /usr/include/libnormaliz/cone.h:41,
                 from interface/cone.cpp:23:
/usr/include/gsl/gsl_cblas.h:46:6: error: multiple definition of ‘enum CBLAS_ORDER’
   46 | enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102};
      |      ^~~~~~~~~~~
In file included from /usr/include/fflas-ffpack/fflas/fflas.h:38,
                 from /usr/include/fflas-ffpack/ffpack/ffpack.h:45,
                 from ./basic-rings/aring-ZZp-ffpack.hpp:21,
                 from ./basic-mutable-matrices/mat-linalg.hpp:24,
                 from ./mutable-matrices/mutablemat-defs.hpp:88,
                 from ./mutable-matrices/mutablemat.hpp:6,
                 from interface/cone.cpp:16:
/usr/include/fflas-ffpack/config-blas.h:72:6: note: previous definition here
   72 | enum CBLAS_ORDER {CblasRowMajor=101, CblasColMajor=102 };
      |      ^~~~~~~~~~~
/usr/include/gsl/gsl_cblas.h:47:6: error: multiple definition of ‘enum CBLAS_TRANSPOSE’
   47 | enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
      |      ^~~~~~~~~~~~~~~
/usr/include/fflas-ffpack/config-blas.h:73:6: note: previous definition here
   73 | enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113, AtlasConj=114};
      |      ^~~~~~~~~~~~~~~
/usr/include/gsl/gsl_cblas.h:48:6: error: multiple definition of ‘enum CBLAS_UPLO’
   48 | enum CBLAS_UPLO {CblasUpper=121, CblasLower=122};
      |      ^~~~~~~~~~
/usr/include/fflas-ffpack/config-blas.h:74:6: note: previous definition here
   74 | enum CBLAS_UPLO  {CblasUpper=121, CblasLower=122};
      |      ^~~~~~~~~~
/usr/include/gsl/gsl_cblas.h:49:6: error: multiple definition of ‘enum CBLAS_DIAG’
   49 | enum CBLAS_DIAG {CblasNonUnit=131, CblasUnit=132};
      |      ^~~~~~~~~~
/usr/include/fflas-ffpack/config-blas.h:75:6: note: previous definition here
   75 | enum CBLAS_DIAG  {CblasNonUnit=131, CblasUnit=132};
      |      ^~~~~~~~~~
/usr/include/gsl/gsl_cblas.h:50:6: error: multiple definition of ‘enum CBLAS_SIDE’
   50 | enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
      |      ^~~~~~~~~~
/usr/include/fflas-ffpack/config-blas.h:76:6: note: previous definition here
   76 | enum CBLAS_SIDE  {CblasLeft=141, CblasRight=142};
      |      ^~~~~~~~~~
/usr/include/gsl/gsl_cblas.h:100:13: error: conflicting declaration of C function ‘size_t cblas_idamax(int, const double*, int)’
  100 | CBLAS_INDEX cblas_idamax(const int N, const double *X, const int incX);
      |             ^~~~~~~~~~~~
/usr/include/fflas-ffpack/config-blas.h:331:12: note: previous declaration ‘int cblas_idamax(int, const double*, int)’
  331 |     int    cblas_idamax(const int N, const double *X, const int incX);
      |            ^~~~~~~~~~~~
/usr/include/gsl/gsl_cblas.h:538:6: error: conflicting declaration of C function ‘void cblas_zgemm(CBLAS_ORDER, CBLAS_TRANSPOSE, CBLAS_TRANSPOSE, int, int, int, const void*, const void*, int, const void*, int, const void*, void*, int)’
  538 | void cblas_zgemm(const enum CBLAS_ORDER Order, const enum CBLAS_TRANSPOSE TransA,
      |      ^~~~~~~~~~~
In file included from ./basic-mutable-matrices/mat-linalg.hpp:48:
./basic-mutable-matrices/lapack.hpp:381:6: note: previous declaration ‘void cblas_zgemm(int, int, int, int, int, int, const void*, const void*, int, const void*, int, const void*, void*, int)’
  381 | void cblas_zgemm(
      |      ^~~~~~~~~~~
```

## AI Disclosure

Claude found the problem and suggested the solution.   The rpm builds have all now successfully passed this part of the build after applying the fix.

Here's the commit message it wrote:

> libnormaliz/cone.h transitively includes CoCoA -> GSL, whose gsl_cblas.h unconditionally defines enum CBLAS_ORDER and friends. mutablemat.hpp transitively includes fflas-ffpack's config-blas.h, which defines the same enums. Neither header guards against the other, so including both in cone.cpp causes "multiple definition" errors for the CBLAS enums and declarations.
> 
> cone.cpp only needs MutableMatrix::zero_matrix and set_entry, which are declared on the abstract MutableMatrix base class in basic-mutable-matrices/mat.hpp. That header doesn't pull in fflas-ffpack, so swapping the include avoids the conflict entirely.
> 

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
