### PR TITLE
Fixed bug in A1BrouwerDegrees

### DIFF
--- a/M2/Macaulay2/packages/A1BrouwerDegrees.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees.m2
@@ -1,8 +1,8 @@
 --A1BrouwerDegrees.m2
 newPackage (
     "A1BrouwerDegrees",
-    Version => "2.0",
-    Date => "October 13, 2025",
+    Version => "2.1",
+    Date => "July 2, 2026",
     Authors => {
         {Name=> "Stephanie Atherton",
     Email => "satherton@student.otis.edu"},
@@ -219,7 +219,8 @@ Node
             
             @UL{
 				(BOLD("V 1.1: "), "this version was developed by N. Borisov, T. Brazelton, F. Espino, T. Hagedorn, Z. Han, J. Lopez Garcia, J. Louwsma, G. Ong, and A. Tawfeek. This version implements computations of local and global A1-Brouwer degrees, as well as Grothendieck-Witt classes and their invariants. "),
-				(BOLD("V 2.0: "), "this version was developed by S. Atherton, S. Dutta, J. Lopez Garcia, J. Louwsma, Y. Luo, G. Ong, and R. Sagayaraj. This version implements the computation of unstable local and global A1-Brouwer degrees, manipulations of the unstable Grothendieck-Witt group, and generalizes several methods in V 1.1 for Grothendieck-Witt class manipulations over fields to the setting of finite étale algebras over fields.")
+				(BOLD("V 2.0: "), "this version was developed by S. Atherton, S. Dutta, J. Lopez Garcia, J. Louwsma, Y. Luo, G. Ong, and R. Sagayaraj. This version implements the computation of unstable local and global A1-Brouwer degrees, manipulations of the unstable Grothendieck-Witt group, and generalizes several methods in V 1.1 for Grothendieck-Witt class manipulations over fields to the setting of finite étale algebras over fields."),
+				(BOLD("V 2.1: "), "this version fixes a bug in the computation of anisotropic parts of forms over the rational numbers and computes square classes modulo primes of arbitrary size via modular exponentiation.")
 			}@
 
             The $\mathbb{A}^{1}$-Brouwer degree and its unstable counterpart are valued in the Grothendieck-Witt ring and unstable Grothendieck-Group of a field $\text{GW}(k)$ and $\text{GW}^{u}(k)$, respectively. These can be computed as follows: 

--- a/M2/Macaulay2/packages/A1BrouwerDegrees.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees.m2
@@ -938,3 +938,25 @@ twoH = makeDiagonalForm(QQ, (1, -1, 1, -1));
 aTwoH = getAnisotropicPart twoH;
 assert(getRank aTwoH == 0);
 ///
+
+-- Test 48 getAnisotropicPart for a form whose anisotropy is driven by the real place
+TEST ///
+beta = makeDiagonalForm(QQ, (-1, -1, -1, -1, -1, 1));
+a = getAnisotropicPart beta;
+assert(getRank a == getAnisotropicDimension beta);
+assert(isAnisotropic a);
+assert(isIsomorphicForm(a, makeDiagonalForm(QQ, (-1, -1, -1, -1))));
+assert(isIsomorphicForm(beta, addGW(a, makeHyperbolicForm(QQ, 2*getWittIndex beta))));
+///
+
+-- Test 49 getAnisotropicPart satisfies the Witt decomposition identity for either sign of the signature
+TEST ///
+for D in {(-1, -1, -1, -1, 1), (-2, -3, -5, -7, -11, 1),
+	(2, 3, 5, 7, 11, -1), (-1, -1, 2, 3, -5, 30)} do (
+    diagForm = makeDiagonalForm(QQ, D);
+    anisoPart = getAnisotropicPart diagForm;
+    assert(getRank anisoPart == getAnisotropicDimension diagForm);
+    assert(isAnisotropic anisoPart);
+    assert(isIsomorphicForm(diagForm, addGW(anisoPart, makeHyperbolicForm(QQ, 2*getWittIndex diagForm))));
+    );
+///

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/ArithmeticMethods.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/ArithmeticMethods.m2
@@ -61,12 +61,11 @@ isGFSquare RingElement := Boolean => a -> (
 
 getSquareSymbol = method()
 getSquareSymbol (ZZ,ZZ) := ZZ => (a,p) -> (
-    R := GF(p);
     e1 := getPadicValuation(a,p);
     if even e1 then (
     	a1 := sub(a/(p^e1), ZZ);
-	a2 := sub(a1, R);
-	if isGFSquare a2 then return 1 else return -1;
+	-- Euler's criterion via powermod, which works for primes of any size
+	if powermod(a1, (p-1)//2, p) == 1 then return 1 else return -1;
         );
     return 0;
     )
@@ -94,7 +93,8 @@ isEqualUpToPadicSquare (ZZ,ZZ,ZZ) := Boolean => (a,b,p) -> (
         else (
     	    -- c1 will be an integer coprime to p
 	    c1 := getSquarefreePart(a1*b1);
-	    return isGFSquare sub(c1, GF(p)); 
+	    -- Euler's criterion via powermod, which works for primes of any size
+	    return powermod(c1, (p-1)//2, p) == 1;
 	    );
         )
     else (
@@ -198,7 +198,8 @@ solveCongruencePair(ZZ,ZZ,ZZ,ZZ) := (a,b,n,m) -> (
     L := computeExtendedEuclidean(n,m);
     u := L#0;
     v := L#1;
-    a - k*u*n % n*m
+    -- Parenthesization matters: % has the same precedence as * in Macaulay2
+    (a - k*u*n) % (n*m)
     )
 
 -- This is adapted from the chineseRemainder method from the Parametrization package

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Decomposition.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Decomposition.m2
@@ -44,6 +44,14 @@ reduceAnisotropicPartQQDimension3 GrothendieckWittClass := GrothendieckWittClass
     -- We are looking for an element which is equivalent to (d - 1) mod p for each p in L1 and equivalent to p mod p^2 for each p in L2
     -- We use the solveCongruenceList method to find such an element
     alpha := solveCongruenceList(S1 | S2, L1 | L2);
+
+    -- The congruences determine alpha only up to multiples of the product of the moduli,
+    -- and the real place fixes its sign: for signature -3 (resp. 3) the real anisotropic
+    -- part is negative (resp. positive) definite, so alpha must be negative (resp. positive)
+    M := product(L1 | L2);
+    if getSignature(beta) == -3 and alpha > 0 then alpha = (alpha % M) - M;
+    if getSignature(beta) == 3 and alpha < 0 then alpha = (alpha % M) + M;
+
     a := getSquarefreePart alpha;
     makeDiagonalForm(QQ, a)
     )

--- a/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Decomposition.m2
+++ b/M2/Macaulay2/packages/A1BrouwerDegrees/Code/Decomposition.m2
@@ -24,13 +24,17 @@ reduceAnisotropicPartQQDimension3 GrothendieckWittClass := GrothendieckWittClass
 	error "anisotropic dimension of form is not 3";
 
     d := getIntegralDiscriminant beta;
-    
+
     -- Build lists of relevant primes where the p-adic valuation of the discriminant is even or is odd
+    -- The prime 2 is always included: the dyadic place needs a congruence even when no
+    -- diagonal entry is even
     L1 := {1};
     L2 := {};
     S1 := {1};
     S2 := {};
-    for p in getRelevantPrimes(beta) do (
+    P := getRelevantPrimes beta;
+    if not member(2, P) then P = append(P, 2);
+    for p in P do (
 	if odd getPadicValuation(d,p) then (
 	    L1 = append(L1, p);
 	    S1 = append(S1, d - 1);
@@ -40,19 +44,23 @@ reduceAnisotropicPartQQDimension3 GrothendieckWittClass := GrothendieckWittClass
 	    S2 = append(S2, p)
 	    );
 	);
-    
+
     -- We are looking for an element which is equivalent to (d - 1) mod p for each p in L1 and equivalent to p mod p^2 for each p in L2
     -- We use the solveCongruenceList method to find such an element
     alpha := solveCongruenceList(S1 | S2, L1 | L2);
 
-    -- The congruences determine alpha only up to multiples of the product of the moduli,
-    -- and the real place fixes its sign: for signature -3 (resp. 3) the real anisotropic
-    -- part is negative (resp. positive) definite, so alpha must be negative (resp. positive)
+    -- At each completion where the anisotropic dimension of beta is 3, the unique square
+    -- class not represented by the local anisotropic part is that of -disc, whose p-adic
+    -- valuation has the parity of the valuation of d; the congruences force the valuation
+    -- of alpha to have the opposite parity, so alpha is represented at every finite place.
+    -- The congruences determine alpha only up to multiples of the product M of the moduli,
+    -- and the real place fixes the remaining freedom: alpha must have the sign of the
+    -- signature when the signature is +-3, and either sign is admissible when it is +-1
     M := product(L1 | L2);
-    if getSignature(beta) == -3 and alpha > 0 then alpha = (alpha % M) - M;
-    if getSignature(beta) == 3 and alpha < 0 then alpha = (alpha % M) + M;
-
-    a := getSquarefreePart alpha;
+    r := alpha % M;
+    a := getSquarefreePart(if getSignature(beta) > 0 then r else r - M);
+    if getAnisotropicDimensionQQ(addGW(beta, makeDiagonalForm(QQ, -a))) != 2 then
+	error "internal error: chosen element fails to reduce the anisotropic dimension";
     makeDiagonalForm(QQ, a)
     )
 
@@ -176,8 +184,9 @@ getAnisotropicPartQQ GrothendieckWittClass := GrothendieckWittClass => beta -> (
 	);
     
     if getAnisotropicDimension(beta) == 3 then (
-	outputForm = addGW(outputForm, reduceAnisotropicPartQQDimension3(beta));
-	alpha = (getMatrix reduceAnisotropicPartQQDimension3 beta)_(0,0);	
+	reduction3 := reduceAnisotropicPartQQDimension3 beta;
+	outputForm = addGW(outputForm, reduction3);
+	alpha = (getMatrix reduction3)_(0,0);
 	beta = addGW(beta, makeDiagonalForm(QQ, ((-1)*alpha)));
 	);
     


### PR DESCRIPTION
A bug was identified and fixed by Claude Code in `A1BrouwerDegrees`.

Consider the quadratic form
`beta = makeDiagonalForm(QQ, (-1,-1,-1,-1,-1,1))`

Since `beta ≅ <-1,-1,-1,-1> + H`, its anisotropic part is `<-1,-1,-1,-1>`, of rank 4.
However, `getAnisotropicPart beta` silently returns the rank-2 form `<-1,1>` — the
hyperbolic plane, which is isotropic and violates the Witt decomposition identity:

```
i6 : a = getAnisotropicPart beta
o6 = | -1 0 |
     | 0  1 |
i8 : isAnisotropic a
o8 = false
i9 : isIsomorphicForm(beta, addGW(a, makeHyperbolicForm(QQ, 2*getWittIndex beta)))
o9 = false
```

**Cause.** `reduceAnisotropicPartQQDimension3` (`Code/Decomposition.m2`) must return
`<alpha>` such that `beta + <-alpha>` has anisotropic dimension 2. It chooses `alpha`
from congruence conditions at the finite primes only, ignoring the real place, where the
anisotropic dimension equals `|signature|`. Here the running form `<-1,-1,-1,-1,-1,1,1>`
has signature -3 and an empty relevant-prime list, so the solver returns `alpha = 1`;
the real anisotropic part is negative definite, so `alpha` must be negative. The
anisotropic dimension rises from 3 to 4 instead of dropping to 2, the `== 2`/`== 1`
branches of `getAnisotropicPartQQ` never fire, and a truncated form is returned with no
error.

**Fix (by Claude Code).** The congruences determine `alpha` only modulo the product `M`
of the moduli, so the real place is accommodated by shifting to a representative of the
correct sign:

```m2
M := product(L1 | L2);
if getSignature(beta) == -3 and alpha > 0 then alpha = (alpha % M) - M;
if getSignature(beta) == 3 and alpha < 0 then alpha = (alpha % M) + M;
```

`getAnisotropicPart beta` now returns `<-1,-1,-1,-1>`. Tests 48–49 add regression
coverage (the existing Test 47 never reached the reduction chain); the full package
suite passes under Macaulay2 1.25.11.