### PR TITLE
 Bump minimum normaliz version to 3.6.3 (autotools)

### DIFF
--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1019,7 +1019,7 @@ AS_IF([test $BUILD_normaliz = no],
     [AC_MSG_CHECKING(whether the package normaliz is installed)
      AS_IF([command -v normaliz > /dev/null],
 	 [normaliz_version=`normaliz --version | head -1 | cut -d " " -f 2`
-	  AX_COMPARE_VERSION([$normaliz_version], [ge], [2.11],
+	  AX_COMPARE_VERSION([$normaliz_version], [ge], [3.6.3],
 	      [AC_MSG_RESULT([yes])
 	       AC_MSG_CHECKING([for libnormaliz])
 	       AC_LANG(C++)
@@ -1038,7 +1038,7 @@ AS_IF([test $BUILD_normaliz = no],
 		   [AC_MSG_RESULT([no, will build])
 		    BUILD_normaliz=yes
 		    LIBS=$SAVELIBS])],
-	      [AC_MSG_RESULT([yes, but < 2.11, will build])
+	      [AC_MSG_RESULT([yes, but < 3.6.3, will build])
 	       BUILD_normaliz=yes])],
         [AC_MSG_RESULT([no, will build])
          BUILD_normaliz=yes])])


### PR DESCRIPTION
This is when `getLatticePoints()` was added.

The build fails before this, e.g., in Ubuntu 18.04 (which has normaliz 3.5.1):

```c++
cytools/lattice-points-normaliz.cpp: In function ‘M2::cytools::LatticePointsNormalizResult M2::cytools::latticePointsNormaliz(int, const std::vector<std::vector<__gmp_expr<__mpz_struct [1], __mpz_struct [1]> > >&, const std::vector<__gmp_expr<__mpz_struct [1], __mpz_struct [1]> >&)’:
cytools/lattice-points-normaliz.cpp:41:47: error: ‘LatticePoints’ is not a member of ‘libnormaliz::ConeProperty’
       cone.compute(libnormaliz::ConeProperty::LatticePoints);
                                               ^~~~~~~~~~~~~
cytools/lattice-points-normaliz.cpp:52:30: error: ‘class libnormaliz::Cone<__gmp_expr<__mpz_struct [1], __mpz_struct [1]> >’ has no member named ‘getLatticePoints’
       const auto& lps = cone.getLatticePoints();
                              ^~~~~~~~~~~~~~~~
cytools/lattice-points-normaliz.cpp:55:30: error: unable to deduce ‘auto&&’ from ‘lps’
       for (const auto& row : lps)
                              ^~~
```