### PR TITLE
Update JavaScript dependencies for .deb build

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -66,11 +66,11 @@ jobs:
 
             # don't need javascript on bullseye (just use the vendored copies)
             if test ${{ matrix.release }} != "bullseye"; then
-              apt-get install -y node-fortawesome-fontawesome-free       \
-                fonts-katex libjs-bootsidemenu libjs-bootstrap5 libjs-d3 \
-                libjs-jquery libjs-katex libjs-nouislider libjs-three    \
-                node-clipboard node-css-loader node-import-local         \
-                node-interpret node-prismjs node-prismjs-bibtex          \
+              apt-get install -y node-fortawesome-fontawesome-free                  \
+                fonts-katex node-macaulay2-boot-side-menu node-bootstrap node-d3    \
+                node-jquery libjs-katex node-nouislider libjs-three                 \
+                node-clipboard node-css-loader node-expose-loader node-import-local \
+                node-interpret node-prismjs node-prismjs-bibtex                     \
                 node-rechoir node-style-loader npm pkg-js-tools webpack
             fi
           fi


### PR DESCRIPTION
Mostly libjs-* -> node-* now that we use dh-nodejs for building the Visualize package.

I should have done this in the release branch but forgot.  After making these changes on my fork, the build-deb workflow successfully built the Debian packages now hosted on the webpage (see https://github.com/d-torrance/M2/actions/runs/27288800769).

No AI used