### PR TITLE
Fix realpath handling for URL fragments

### DIFF
--- a/M2/Macaulay2/d/scclib.c
+++ b/M2/Macaulay2/d/scclib.c
@@ -343,9 +343,15 @@ M2_string system_realpath(M2_string filename) {
   char *fn = M2_tocharstar(filename);
   char buf[PATH_MAX+1];
   char *r = realpath(*fn ? fn : ".",buf);
+  if (r == NULL) {
+    int err = errno;
+    freemem(fn);
+    errno = err;
+    return NULL;
+  }
   if (isDirectory(r) && r[1] != 0) strcat(r,"/");
   freemem(fn);
-  return r == NULL ? NULL : M2_tostring(buf);
+  return M2_tostring(buf);
  #else
   return filename;
  #endif

--- a/M2/Macaulay2/m2/hypertext.m2
+++ b/M2/Macaulay2/m2/hypertext.m2
@@ -45,19 +45,22 @@ new URL from String := (URL, str) -> { str }
 -- relative URLs and filenames
 isAbsoluteURL = url -> match( "^(#|mailto:|[a-z]+://)", url )
 
-fileExists' = pth -> (
-    if match("#",pth) then pth = substring(0,lastMatch#0#0,pth);
-    fileExists pth
-)
+splitURLFragment = pth -> (
+    if match("#", pth) then (
+	i := lastMatch#0#0;
+	(substring(0, i, pth), substring(i, pth)))
+    else (pth, ""))
 
 -- TODO: phase this one out eventually
 toURL = method()
 toURL String := pth -> (
-     urlEncode if isAbsolutePath pth then concatenate(rootURI,
-	  if fileExists' pth then realpath pth
-	  else (
-	       stderr << "-- *** warning: file needed for URL not found: " << pth << endl;
-	       pth))
+     urlEncode if isAbsolutePath pth then (
+	  (filename, fragment) := splitURLFragment pth;
+	  concatenate(rootURI,
+	       if fileExists filename then realpath filename | fragment
+	       else (
+		    stderr << "-- *** warning: file needed for URL not found: " << pth << endl;
+		    pth)))
      else if isAbsoluteURL pth then pth
      else (
 	  r := if htmlDirectory === null then pth else relativizeFilename(htmlDirectory, pth);

--- a/M2/Macaulay2/tests/normal/files.m2
+++ b/M2/Macaulay2/tests/normal/files.m2
@@ -17,3 +17,15 @@ assert(baseFilename "foo////" == "foo")
 assert(baseFilename "" == "")
 assert(baseFilename "/" == "/")
 assert(baseFilename "////" == "/")
+
+missing = temporaryFileName()
+(err, out) = capture("realpath " | toExternalString missing)
+assert(err and match("realpath failed: No such file or directory", out))
+
+filename = temporaryFileName()
+filename << "" << close
+filename = realpath filename
+fragment = "#L1:C1-L2:C2_L1:C1"
+toURL' = value Core#"private dictionary"#"toURL"
+assert(toURL' (filename | fragment) == rootURI | urlEncode filename | fragment)
+removeFile filename


### PR DESCRIPTION
This fixes two bugs:
- one is #4442 -- now `toURL` correctly splits the `#` part before feeding it to `realpath`
- the other one, also mentioned in #4442, is that the error code of `realpath` wasn't correctly sent back to M2.
- I've added a couple of tests as well -- I hope they're not too specific, if they fail I can relax/remove them.