### PR TITLE
Record stdio source independently of readline history

### DIFF
--- a/M2/Macaulay2/d/M2lib.c
+++ b/M2/Macaulay2/d/M2lib.c
@@ -136,14 +136,6 @@ int system_appendHistory(int n, char *filename)
   return append_history(n, filename);
 }
 
-void system_addHistory(char *buf) { add_history(buf); }
-char *system_getHistory(const int n)
-{
-  HIST_ENTRY *entry = history_get(n);
-  if (entry != NULL) return entry->line;
-  return NULL;
-}
-
 int system_historyLength() { return history_length; }
 
 void system_initReadlineVariables(void) {

--- a/M2/Macaulay2/d/interp.dd
+++ b/M2/Macaulay2/d/interp.dd
@@ -717,12 +717,12 @@ runBasicTests(e:Expr):Expr := (
      else WrongNumArgs(0));
 setupfun("runBasicTests",runBasicTests);
 
-getHistory(e:Expr):Expr := (
-    when e is n:ZZcell do if isInt(n)
-    then toExpr(tostring(getHistory(toInt(n))))
-    else WrongArgSmallInteger()
-    else WrongArgZZ());
-setupfun("getHistory", getHistory);
+getStdioSource(e:Expr):Expr := (
+    when e is s:Sequence do
+    if length(s) == 0 then toExpr(getStdioSource())
+    else WrongNumArgs(0)
+    else WrongNumArgs(0));
+setupfun("getStdioSource", getStdioSource);
 
 readHistory(e:Expr):Expr := (
     when e is filename:stringCell

--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -5,6 +5,7 @@ use errio;
 use gmp;
 use expr;
 use stdio0;
+use varstrin;
 
 header "#include \"../system/m2fileinterface.h\"
 	#include <assert.h>";
@@ -143,6 +144,8 @@ export stdIO  := newFile("stdio",  0,
 
 export interpreterDepth := 0;
 export lineNumber := 0;
+stdioSource := newvarstring(bufsize);
+export getStdioSource():string := tostring(stdioSource);
 texmacsprompt():string := (
      s := "";
      for i from 1 to interpreterDepth do s = s + "i";
@@ -757,11 +760,7 @@ export filbuf(o:file):int := (
 	       r = (
 		    if o.infd == NOFD 
 		    then 0 -- take care of "string files" made by stringTokenFile in interp.d
-		    else (
-			ret := read(o.infd,o.inbuffer,n,o.insize);
-			if ret > 0 && o == stdIO
-			then addHistory(tocharstarn(o.inbuffer, ret - 1));
-			ret)));
+		    else read(o.infd,o.inbuffer,n,o.insize)));
 	  if r == ERROR then (
 	       fileErrorMessage(o,"read");
 	       return r;
@@ -854,6 +853,7 @@ export getc(o:file):int := (
      else if o.bol && !o.readline then maybeprompt(o);
      c := o.inbuffer.(o.inindex);
      o.inindex = o.inindex + 1;
+     if o == stdIO then stdioSource << c;
      if o.echo && o.echoindex < o.inindex then (
 	  while o.echoindex < o.insize && (
 	       e := o.inbuffer.(o.echoindex);

--- a/M2/Macaulay2/d/system.d
+++ b/M2/Macaulay2/d/system.d
@@ -176,8 +176,6 @@ import realpath(filename:string):(null or string);
 import readDirectory(name:string):(null or array(string));
 import strncmp(s:string,t:string,n:int):int;
 import history():array(string);
-import getHistory(n:int):charstar;
-import addHistory(s:charstar):void;
 import appendHistory(n:int,f:charstar):int;
 import readHistory(f:charstar):int;
 import historyLength():int;

--- a/M2/Macaulay2/m2/Core.m2
+++ b/M2/Macaulay2/m2/Core.m2
@@ -151,11 +151,9 @@ needs = filename -> (loadPath(path, filename, simpleNeeds, notify);)
 -- Setup persistent history
 -----------------------------------------------------------------------------
 historyFilename = "history.m2"
-historyOffset = 0;
 
 if not noinitfile and not gotarg "--no-readline" then (
     readHistory(applicationDirectory() | historyFilename);
-    historyOffset = historyLength();
     -- TODO: find a better alternative to addEndFunction, because
     -- exiting with Ctrl+D duplicates the last line of history file,
     -- but if we use lineNumber-1, then exit and restart miss the first

--- a/M2/Macaulay2/m2/code.m2
+++ b/M2/Macaulay2/m2/code.m2
@@ -62,11 +62,7 @@ code FilePosition := x -> (
 		    if currentString === null
 		    then error "code no longer available"
 		    else currentString)
-	       else if filename === "stdio" then (
-		    start = 1;
-		    stop += 1 - x#1;
-		    toString stack apply(x#1..x#1+stop-1,
-			i -> getHistory(i + historyOffset)))
+	       else if filename === "stdio" then getStdioSource()
 	       else (
 		    if not fileExists filename then error ("couldn't find file ", filename);
 		    get filename


### PR DESCRIPTION
This is my solution to #4356: simply stop using readline and use our own, more reliable, source code for stdio.
Simpler, less fragile.