### PR TITLE
Use numerator when calling "roots" on element of fraction field

### DIFF
--- a/M2/Macaulay2/e/interface/polyroots.cpp
+++ b/M2/Macaulay2/e/interface/polyroots.cpp
@@ -32,11 +32,11 @@ engine_RawRingElementArrayOrNull rawRoots(const RingElement *p,
     p = RingElement::make_raw(R, frac->numerator(p->get_value()));
   }
   const PolynomialRing *P = R->cast_to_PolynomialRing();
-  const Monoid *M = P->getMonoid();
   if (P == nullptr) {
     ERROR("expected a polynomial ring");
     return nullptr;
   }
+  const Monoid *M = P->getMonoid();
   if (P->n_vars() != 1) {
     ERROR("expected a univariate polynomial ring");
     return nullptr;

--- a/M2/Macaulay2/e/interface/polyroots.cpp
+++ b/M2/Macaulay2/e/interface/polyroots.cpp
@@ -12,6 +12,7 @@
 #include "basic-rings/aring.hpp"
 #include "error.h"
 #include "monoid.hpp"
+#include "rings/frac.hpp"
 #include "rings/polyring.hpp"
 #include "ring-elements/ring-element.hpp"
 #include "rings/ring.hpp"
@@ -26,6 +27,10 @@ engine_RawRingElementArrayOrNull rawRoots(const RingElement *p,
 {
   (void) unique;
   const Ring *R = p->get_ring();
+  if (const FractionField *frac = R->cast_to_FractionField()) {
+    R = frac->get_ring();
+    p = RingElement::make_raw(R, frac->numerator(p->get_value()));
+  }
   const PolynomialRing *P = R->cast_to_PolynomialRing();
   const Monoid *M = P->getMonoid();
   if (P == nullptr) {

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/roots-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/roots-doc.m2
@@ -1,9 +1,9 @@
 document {
     Key => {(roots, RingElement), roots, [(roots,RingElement),Unique], [(roots,RingElement),Precision] },
-    Headline => "compute the roots of a polynomial",
+    Headline => "compute the roots of a polynomial or rational function",
     Usage => "roots p",
     Inputs => {
-      "p" => "a univariate polynomial over ZZ, QQ, RR or CC.",
+      "p" => "a univariate polynomial or rational function over ZZ, QQ, RR or CC.",
       Precision => { "the number of precision bits used to compute the roots.", "The default ", TO "precision", " is 53 bits for polynomials over ", TO "ZZ", " or ", TO "QQ", " and the same as the coefficient ring for ", TT "RR[x]", " or ", TT "CC[x]", "." },
       Unique => Boolean => { "whether to return multiple roots one or multiple times." },
     },
@@ -21,7 +21,14 @@ document {
       "o7#0",
     },
     PARA {
+      "If ", VAR "p", " is a rational function, then the roots of its ",
+      "numerator are returned."},
+    EXAMPLE {
+      "QQ[x]",
+      "p = (x^2 - 1)/x",
+      "roots p"
+    },
+    PARA {
       "The roots are computed using ", TO "MPSolve", ".",
     },
 }
-

--- a/M2/Macaulay2/tests/normal/roots.m2
+++ b/M2/Macaulay2/tests/normal/roots.m2
@@ -1,0 +1,7 @@
+R = QQ[x]
+f = x^5 - 1
+Z = roots f
+assert Equation(#Z, 5)
+assert all(Z, z -> abs f z < 1e-15)
+Z' = roots f_(frac R) -- used to segfault
+assert all(sort Z, sort Z', (x,y) -> abs(x - y) < 1e-15)


### PR DESCRIPTION
This used to segfault.  Also add some unit tests.

## Before

```m2
i1 : R = QQ[x];

i2 : roots((x - 1)/x)
-- SIGSEGV
-* stack trace, pid: 103461
 0# profiler_stacktrace(std::ostream&, int) at /usr/src/macaulay2-1.26.06+git202606141309-0ppa202606152342~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:128
 1# segv_handler at /usr/src/macaulay2-1.26.06+git202606141309-0ppa202606152342~ubuntu24.04.1/M2/Macaulay2/d/main.cpp:244
 2# 0x000079654F245330 in /lib/x86_64-linux-gnu/libc.so.6
 3# rawRoots at interface/polyroots.cpp:30
 4# interface_rawRoots at /usr/src/macaulay2-1.26.06+git202606141309-0ppa202606152342~ubuntu24.04.1/M2/Macaulay2/d/interface.dd:1517
 5# evaluate_evalraw at /usr/src/macaulay2-1.26.06+git202606141309-0ppa202606152342~ubuntu24.04.1/M2/Macaulay2/d/evaluate.d:1662
 6# evaluate_evalSequence at /usr/src/macaulay2-1.26.06+git202606141309-0ppa202606152342~ubuntu24.04.1/M2/Macaulay2/d/evaluate.d:457
...
```

## After

```m2
i1 : R = QQ[x];

i2 : roots((x - 1)/x)

o2 = {1}

o2 : List
```

## AI Disclosure

Claude helped with the C++ code