### PR TITLE
factor.m2 minor fixes

### DIFF
--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -142,7 +142,7 @@ algorithms#(factor, RingElement) = new MutableHashTable from {
 	R := coefficientRing(RM := ring f);
 	if not instance(R, FractionField)
 	then return null;
-	RM' := (baseRing R) RM.monoid;
+	RM' := (baseRing R) monoid RM;
 	toRM := map(RM, RM', generators RM);
 	toRM' := map(RM', RM, generators RM');
 	denom := lcm apply(listForm f, t -> denominator t_1);

--- a/M2/Macaulay2/m2/factor.m2
+++ b/M2/Macaulay2/m2/factor.m2
@@ -224,9 +224,17 @@ topCoefficients RingElement := f -> (
      	  (monoms_(0,0), coeffs_(0,0))))
 
 roots = method(Options => true);
-roots RingElement := {Precision => -1, Unique => false} >> o -> p ->
-  toList apply(rawRoots(raw p, o.Precision, o.Unique), r -> new CC from r)
-
+roots RingElement := {Precision => -1, Unique => false} >> o -> p -> (
+    (R,f) := flattenRing ring p;
+    if numgens R > 1 then (
+	p = f p;
+	exps := positions(transpose exponents p, x -> any(x,y->y=!=0));
+        if #exps == 0 then return {}
+	else if #exps > 1 then error "expected a univariate polynomial ring";
+	p = substitute(p,(baseRing R)(monoid[R_(exps#0)]));
+	);
+    toList apply(rawRoots(raw p, o.Precision, o.Unique), r -> new CC from r)
+  )
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/m2 "
 -- End:

--- a/M2/Macaulay2/tests/normal/factor.m2
+++ b/M2/Macaulay2/tests/normal/factor.m2
@@ -111,3 +111,14 @@ assert(#factor(x^2+y^2)==2);
 F=frac(QQ[a]);
 R=F[x,y];
 assert(#factor(x^2-a^-2*y^2)==3);
+
+-- issue #4445
+F=frac(QQ[x]); R=F[y]/(y^6); factor(x^2-y^2)
+
+-- roots in multivariable ring
+R=QQ[x,y]
+assert(#(roots(x^2-1))==2)
+assert(try(roots(x+y)) else true)
+R=QQ[x][y]
+assert(#(roots(x^2-1))==2)
+assert(#(roots(y^2-1))==2)


### PR DESCRIPTION
- fixes #4445
- allows the use of `roots` in a multivariate polynomial ring, as long as the actual polynomial is univariate