### PR TITLE
Bump GitHub macOS runners to Tahoe

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -39,17 +39,17 @@ jobs:
           - cmake
         os:
           - ubuntu-24.04
-          - macos-15
+          - macos-26
         compiler:
           - default
         include:
           # This build tests Clang rather than AppleClang (keep)
           - build-system: cmake
-            os: macos-15
+            os: macos-26
             compiler: brew-clang
         exclude:
           - build-system: cmake
-            os: macos-15
+            os: macos-26
             compiler: default
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
GitHub is currently migrating the `macos-latest` runner to `macos-26` (see https://github.com/actions/runner-images/issues/14167), so we follow suit.

Draft for now to make sure the builds pass.