### PR TITLE
Fix discriminant error with polynomials with identically vanishing derivatives (issue #4449)

### DIFF
--- a/M2/Macaulay2/packages/Elimination.m2
+++ b/M2/Macaulay2/packages/Elimination.m2
@@ -332,6 +332,13 @@ assert(isHomogeneous J)
 
 assert(eliminate(x,eliminate(y,I)) == eliminate(y,eliminate(x,I)))
 ///
+
+-- Resultant of a polynomial whose derivative is identically zero should return zero
+TEST ///
+R=ZZ/2[x]
+F=x^24+x^22+x^20+x^14+x^12+x^8+x^4
+assert(discriminant(F,x) == 0)
+///
 end
 loadPackage "Elimination"
 installPackage Elimination

--- a/M2/Macaulay2/packages/Elimination.m2
+++ b/M2/Macaulay2/packages/Elimination.m2
@@ -125,8 +125,10 @@ resultant(RingElement, RingElement, RingElement) := o -> (f,g,x) ->
      det sylvesterMatrix(f,g,x)
 
 discriminant = method(Options => { Algorithm => null })
-discriminant(RingElement, RingElement) := RingElement => o -> (f,x) -> resultant(f, diff(x,f), x, o)
-
+discriminant(RingElement, RingElement) := RingElement => o -> (f,x) -> (
+     if diff(f,x) == 0 then return 0;
+     resultant(f, diff(x,f), x, o)
+)
 -----------------------------------------------
 -- documentation and tests
 -----------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/Macaulay2/M2/issues/4449

Given a univariate polynomial whose derivative is identically zero (e.g. over a finite field), its discriminant should return the zero polynomial, rather than an error.