### PR TITLE
Remove references to INSTALL file

### DIFF
--- a/M2/BUILD/build/README
+++ b/M2/BUILD/build/README
@@ -1,2 +1,4 @@
-This build directory is kept empty, for use with the build instructions in the file
-../../INSTALL.
+This build directory is kept empty, for use with the build instructions at
+https://github.com/Macaulay2/M2/wiki/Building-M2-from-source-using-Autotools
+and
+https://github.com/Macaulay2/M2/wiki/Building-M2-from-source-using-CMake

--- a/M2/submodules/README
+++ b/M2/submodules/README
@@ -1,8 +1,6 @@
 In this directory are the various git submodules corresponding to the git
 repositories of the various third party libraries we link with and of the third
-party programs we include.  We hope to convert all of the entries in
-../libraries to submodules eventually, maintaining our own git repositories for
-those libraries and programs, if necessary.
+party programs we include.
 
 Not all of these submodules get initialized when building Macaulay2, because
 some of them may be present already in the OS and detected by ../configure, but

--- a/M2/submodules/README
+++ b/M2/submodules/README
@@ -8,7 +8,10 @@ Not all of these submodules get initialized when building Macaulay2, because
 some of them may be present already in the OS and detected by ../configure, but
 if you wish to have a complete source tree that needs no network access or
 downloading during configuration and compilation, then just add "--recursive" to
-the "git clone" command line in ../INSTALL.
+the "git clone" command line in
+https://github.com/Macaulay2/M2/wiki/Building-M2-from-source-using-Autotools
+and
+https://github.com/Macaulay2/M2/wiki/Building-M2-from-source-using-CMake
 
 For instructions about adding a new submodule, follow the same instructions as
 presented in the file ../libraries/README.


### PR DESCRIPTION
Closes: #4475 (thanks @dimpase for catching this!)

I also removed a note in the `submodules` directory `README` file suggesting that we'd be moving other dependencies to submodules.  I'm not aware of a plan to do this.

Skipping the builds since we're just editing some text files.