### PR TITLE
Raise an error when attempting to close stdio or stderr

### DIFF
--- a/M2/Macaulay2/d/stdio.d
+++ b/M2/Macaulay2/d/stdio.d
@@ -518,6 +518,7 @@ export closeListener(o:file):(errmsg or null) := (
      null());
 
 export closeIn(o:file):(errmsg or null) := (
+     if o == stdIO then return errmsg("can't close stdio");
      stat := 0;
      if o.infd == NOFD then return errmsg("close: file not open");
      if o == stdIO then return null();			    -- silently refuse to close stdIO
@@ -538,6 +539,8 @@ export closeIn(o:file):(errmsg or null) := (
      null());
 
 export closeOut(o:file):(errmsg or null) := (
+     if o == stdIO then return errmsg("can't close stdio");
+     if o == stdError then return errmsg("can't close stderr");
      stat := 0;
      if o.outfd == NOFD then return errmsg("close: file not open");
      haderror := false;

--- a/M2/Macaulay2/tests/normal/files.m2
+++ b/M2/Macaulay2/tests/normal/files.m2
@@ -17,3 +17,7 @@ assert(baseFilename "foo////" == "foo")
 assert(baseFilename "" == "")
 assert(baseFilename "/" == "/")
 assert(baseFilename "////" == "/")
+
+-- issue #4392
+assert try stdio << close then false else true
+assert try stderr << close then false else true


### PR DESCRIPTION
`stdio` supports both input and output, so we check in both `closeIn` and `closeOut`

`stderr` only supports output, so we only check in `closeOut` (`stderr << closeIn` already raises an error since it's not open for input)

Closes: #4392 

No AI used!

### Before

```m2
i1 : stdio << close
stdio:1:6:(3):[1]: error: at print: expected an output file
stdio:1:6:(3):[1]: error: after print: expected an output file
```

```m2
i1 : stderr << close

o1 = stderr

o1 : File

i2 : 1/0

i3 : -- where's the error message?
```

### After

```m2
i1 : stdio << close
stdio:1:6:(3):[1]: error: can't close stdio

i2 : stderr << close
stdio:2:7:(3):[1]: error: can't close stderr
```