### PR TITLE
Add texMath and mathML methods for PadicFieldFamily

### DIFF
--- a/M2/Macaulay2/packages/ForeignFunctions.m2
+++ b/M2/Macaulay2/packages/ForeignFunctions.m2
@@ -16,8 +16,8 @@
 
 newPackage("ForeignFunctions",
     Headline => "foreign function interface",
-    Version => "0.8",
-    Date => "June 5, 2026",
+    Version => "0.9",
+    Date => "July 21, 2026",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance9@gatech.edu",
@@ -43,6 +43,9 @@ newPackage("ForeignFunctions",
 ---------------
 
 -*
+
+0.9 (2026-07-21, M2 1.26.11)
+* allow null as first argument to foreignFunction/foreignSymbol
 
 0.8 (2026-06-05, M2 1.26.06)
 * update my contact info
@@ -648,6 +651,10 @@ foreignFunction(String, ForeignType, ForeignType) := o -> (
 foreignFunction(String, ForeignType, VisibleList) := o -> (
     symb, rtype, argtypes) -> foreignFunction(
 	dlsym symb, symb, rtype, argtypes, o)
+foreignFunction(Nothing, String, ForeignType, ForeignType) := o -> (
+    nothing, symb, rtype, argtype) -> foreignFunction(symb, rtype, argtype, o)
+foreignFunction(Nothing, String, ForeignType, VisibleList) := o -> (
+    nothing, symb, rtype, argtypes) -> foreignFunction(symb, rtype, argtypes, o)
 foreignFunction(SharedLibrary, String, ForeignType, ForeignType) := o -> (
     lib, symb, rtype, argtype) -> foreignFunction(
     lib, symb, rtype, {argtype}, o)
@@ -693,6 +700,8 @@ foreignSymbol = method(TypicalValue => ForeignObject)
 foreignSymbol(SharedLibrary, String, ForeignType) := (
     lib, symb, T) -> dereference_T dlsym(lib#0, symb)
 foreignSymbol(String, ForeignType) := (symb, T) -> dereference_T dlsym symb
+foreignSymbol(Nothing, String, ForeignType) := (nothing, symb, T) -> (
+    foreignSymbol(symb, T))
 
 ---------------------------
 -- working with pointers --
@@ -1874,6 +1883,8 @@ doc ///
     (foreignFunction, SharedLibrary, String, ForeignType, ForeignType)
     (foreignFunction, String, ForeignType, VisibleList)
     (foreignFunction, String, ForeignType, ForeignType)
+    (foreignFunction, Nothing, String, ForeignType, VisibleList)
+    (foreignFunction, Nothing, String, ForeignType, ForeignType)
     (foreignFunction, Pointer, String, ForeignType, VisibleList)
     [foreignFunction, Variadic]
     Variadic
@@ -1895,9 +1906,9 @@ doc ///
     Text
       Load a function contained in a shared library using the C function
       @TT "dlsym"@ and declare its signature.
-      The library may be omitted if it is already loaded, e.g., for functions
-      in the C standard library or libraries that Macaulay2 is already linked
-      against.
+      The library may be omitted (or @TO null@ passed instead) if it is already
+      loaded, e.g., for functions in the C standard library or libraries that
+      Macaulay2 is already linked against.
     Example
       mycos = foreignFunction("cos", double, double)
       mycos pi
@@ -2519,7 +2530,11 @@ TEST ///
 ---------------------
 cCos = foreignFunction("cos", double, double)
 assert Equation(value cCos pi, -1)
+cCos = foreignFunction(,"cos", double, double)
+assert Equation(value cCos pi, -1)
 cAbs = foreignFunction("abs", int, int)
+assert Equation(value cAbs(-2), 2)
+cAbs = foreignFunction(,"abs", int, int)
 assert Equation(value cAbs(-2), 2)
 ///
 
@@ -2528,6 +2543,11 @@ TEST ///
 -- foreignFunction (variadic) --
 --------------------------------
 sprintf = foreignFunction("sprintf", int, {charstar, charstar},
+    Variadic => true)
+foo = charstar "foo"
+assert Equation(value sprintf(foo, "%s", "bar"), 3)
+assert Equation(value foo, "bar")
+sprintf = foreignFunction(,"sprintf", int, {charstar, charstar},
     Variadic => true)
 foo = charstar "foo"
 assert Equation(value sprintf(foo, "%s", "bar"), 3)
@@ -2561,6 +2581,8 @@ TEST ///
 -- foreignSymbol --
 -------------------
 environ = foreignSymbol("environ", charstarstar)
+assert all(value environ, x -> instance(x, String))
+environ = foreignSymbol(,"environ", charstarstar)
 assert all(value environ, x -> instance(x, String))
 ///
 

--- a/M2/Macaulay2/packages/Padic.m2
+++ b/M2/Macaulay2/packages/Padic.m2
@@ -56,7 +56,10 @@ endpkg = msg -> (
 if not ForeignFunctions#"private dictionary"#?"foreignFunction"
 then endpkg "foreign function interface is not available"
 
-flint = try openSharedLibrary "flint" else endpkg "flint is not available"
+flint = (
+    try openSharedLibrary "flint"
+    else try foreignFunction("fmpz_init", void, voidstar) then null
+    else endpkg "flint is not available")
 
 export {
     -- methods

--- a/M2/Macaulay2/packages/Padic.m2
+++ b/M2/Macaulay2/packages/Padic.m2
@@ -16,8 +16,8 @@
 
 newPackage("Padic",
     Headline => "p-adic numbers",
-    Version => "0.2",
-    Date => "June 5, 2026",
+    Version => "0.3",
+    Date => "July 19, 2026",
     Authors => {{
 	    Name => "Doug Torrance",
 	    Email => "dtorrance9@gatech.edu",
@@ -32,6 +32,9 @@ newPackage("Padic",
 ---------------
 
 -*
+
+0.3 (2026-07-19, M2 1.26.11)
+* add texMath and mathML methods
 
 0.2 (2026-06-05, M2 1.26.06)
 * update my contact info
@@ -216,6 +219,8 @@ PadicFieldFamily.synonym = "p-adic field family"
 expression PadicFieldFamily := kk -> Subscript(QQ, prime kk)
 net PadicFieldFamily := net @@ expression
 toString PadicFieldFamily := toString @@ expression
+texMath PadicFieldFamily := texMath @@ expression
+mathML PadicFieldFamily := mathML @@ expression
 
 PadicNumber = new Type of Number
 PadicNumber.synonym = "p-adic number"
@@ -497,6 +502,8 @@ undocumented {
     (expression, PadicFieldFamily),
     (net, PadicFieldFamily),
     (toString, PadicFieldFamily),
+    (texMath, PadicFieldFamily),
+    (mathML, PadicFieldFamily),
     (toString, PadicNumber),
     (peek', ZZ, PadicNumber),
     (describe, PadicNumber)}

--- a/M2/Macaulay2/packages/Padic.m2
+++ b/M2/Macaulay2/packages/Padic.m2
@@ -247,6 +247,18 @@ toString PadicNumber := x -> (
     -- from src/padic/get_str.c
     n := (N - v) * (2 * numdigits p + numdigits max(abs v, abs N) + 5) + 1;
     value padicGetStr(concatenate(n:"\0"), x.number, x.context))
+expression PadicNumber := x -> (
+    s := toString x;
+    Sum apply(separate(" \\+ ", s), term -> (
+            factors := separate("\\*", term);
+            if #factors == 1 then value factors#0
+            else if #factors == 2
+            then Product(
+                value factors#0,
+                Power(value \ separate("\\^", factors#1))))))
+texMath PadicNumber := texMath @@ expression
+mathML PadicNumber := mathML @@ expression
+
 
 PadicNumber.AfterPrint = lookup(AfterPrint, InexactNumber)
 
@@ -505,6 +517,9 @@ undocumented {
     (texMath, PadicFieldFamily),
     (mathML, PadicFieldFamily),
     (toString, PadicNumber),
+    (expression, PadicNumber),
+    (texMath, PadicNumber),
+    (mathML, PadicNumber),
     (peek', ZZ, PadicNumber),
     (describe, PadicNumber)}
 


### PR DESCRIPTION
Also bump package version to 0.3

As I was preparing my talk on this package for ICMS, I realized that $p$-adic fields look awful in webapp mode!

### Before

<img width="982" height="706" alt="image" src="https://github.com/user-attachments/assets/3eb9194a-5df0-4cbf-88b9-c57e3c1d0b10" />

### After
<img width="696" height="688" alt="image" src="https://github.com/user-attachments/assets/65a7da70-7fc3-445c-abb7-4542e8f7b65f" />

## AI Disclosure

No AI used