### PR TITLE
Memoize ZZ/n for non-prime n too

### DIFF
--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -81,7 +81,7 @@ ZZp Ideal := opts -> (I) -> (
          savedQuotients#(typ, n)
      else (
 	  if not isPrime n or n > 2^64
-	  then return ZZ[DegreeRank => 0]/n;
+	  then return savedQuotients#(typ, n) = ZZ[DegreeRank => 0]/n;
 	  S := new QuotientRing from 
       if typ === "Ffpack" then rawARingGaloisField(n,1)  
         else if typ === "Flint" then rawARingZZpFlint n

--- a/M2/Macaulay2/tests/normal/quotientring.m2
+++ b/M2/Macaulay2/tests/normal/quotientring.m2
@@ -17,6 +17,10 @@ assert( a_R^2 == 0 )
 R = ZZ/41
 assert(sqrt(5_R)^2 == 5_R)
 
+-- issue #4486
+assert Equation(#unique apply(20,i->promote(i,ZZ/4)), 4)
+assert Equation(#unique apply(20,i->promote(i,ZZ/5)), 5)
+
 end
 -- Local Variables:
 -- compile-command: "make -C $M2BUILDDIR/Macaulay2/packages/Macaulay2Doc/test quotientring.out"


### PR DESCRIPTION
We currently memoize `ZZ/n` in the `savedQuotients` hash table when `n` is prime, but we don't when it isn't (or is large), causing #4486.

### Before
```m2
i1 : unique apply(20,i->promote(i,ZZ/4))

o1 = {0, 1, 2, -1, 0, 1, 2, -1, 0, 1, 2, -1, 0, 1, 2, -1, 0, 1, 2, -1}

o1 : List
```

Every element of this list belongs to a distinct ring!

### After
```m2
i1 : unique apply(20,i->promote(i,ZZ/4))

o1 = {0, 1, 2, -1}

o1 : List
```

## AI Disclosure

No AI used