### PR TITLE
Mark M2_flint_abort as FLINT_NORETURN

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -52,7 +52,7 @@ bool interrupts_interruptShield;
 void* interpFunc(ArgCell* vargs);
 void* profFunc(ArgCell* p);
 void* testFunc(ArgCell* p);
-void  M2_flint_abort(void);
+FLINT_NORETURN void  M2_flint_abort(void);
 
 static void * GC_start_performance_measurement_0(void *) {
 #ifdef GC_start_performance_measurement /* added in bdwgc 8 */
@@ -130,7 +130,7 @@ void profiler_stacktrace(std::ostream &stream, int traceDepth) {
   }
 }
 
-void M2_flint_abort(void) {
+FLINT_NORETURN void M2_flint_abort(void) {
   profiler_stacktrace(std::cerr, 0);
   abort();
 }


### PR DESCRIPTION
Otherwise, compilation can fail w/:

    ../../../../Macaulay2/d/main.cpp:92:3: fatal error: no matching function for call to 'flint_set_abort'
       92 |   flint_set_abort(M2_flint_abort);
          |   ^~~~~~~~~~~~~~~
    /usr/include/flint/flint.h:222:6: note: candidate function not viable: no known conversion from 'void ()' to 'void (*)() __attribute__((noreturn))' for 1st argument
      222 | void flint_set_abort(FLINT_NORETURN void (*func)(void));
          |      ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

I ran into this problem compiling M2 with clang 18.1.3 in Ubuntu 24.04.