### PR TITLE
Bump googletest to v1.18.0

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -415,10 +415,17 @@ ExternalProject_Add(build-factory
   TEST_EXCLUDE_FROM_MAIN ON
   STEP_TARGETS      install test
   )
-if(GFTABLESDIR AND NOT EXISTS ${M2_DIST_PREFIX}/${M2_INSTALL_DATADIR}/Core/factory/gftables)
+# Copy again when GFTABLESDIR moves, so that building factory ourselves replaces
+# the tables copied from the version already on the system.
+set(GFTABLES_DEST ${M2_DIST_PREFIX}/${M2_INSTALL_DATADIR}/Core/factory)
+if(GFTABLESDIR AND (NOT EXISTS ${GFTABLES_DEST}/gftables
+    OR NOT "${GFTABLESDIR}" STREQUAL "${GFTABLES_COPIED_FROM}"))
   message(STATUS "Copying gftables from ${GFTABLESDIR}/gftables")
-  file(COPY ${GFTABLESDIR}/gftables
-    DESTINATION ${M2_DIST_PREFIX}/${M2_INSTALL_DATADIR}/Core/factory FOLLOW_SYMLINK_CHAIN)
+  # clear the previous copy first; file(COPY) skips files whose timestamps match
+  file(REMOVE_RECURSE ${GFTABLES_DEST}/gftables)
+  file(COPY ${GFTABLESDIR}/gftables DESTINATION ${GFTABLES_DEST} FOLLOW_SYMLINK_CHAIN)
+  set(GFTABLES_COPIED_FROM "${GFTABLESDIR}"
+    CACHE INTERNAL "directory the distributed gftables were copied from")
 endif()
 _ADD_COMPONENT_DEPENDENCY(libraries factory "gmp;ntl;flint" FACTORY_FOUND)
 

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -142,6 +142,20 @@ find_package(GMP	6.0.0 REQUIRED)
 #   givaro	prime field and algebraic computations	(needs gmp)
 #  fflas_ffpack	Finite Field Linear Algebra Routines	(needs gmp, givaro + LAPACK)
 
+set(LIBRARY_OPTIONS
+  Eigen3 BDWGC MPFR MPFI NTL Flint Factory Frobby cddlib MPSolve
+  GTest GLPK Givaro FFLAS_FFPACK Normaliz)
+
+# A cached <Package>_DIR outranks CMAKE_PREFIX_PATH, so drop it for anything we
+# intend to build ourselves before searching for it below.
+string(TOUPPER "${BUILD_LIBRARIES}" BUILD_LIBRARIES)
+foreach(_library IN LISTS LIBRARY_OPTIONS)
+  string(TOUPPER "${_library}" _name)
+  if(BUILD_LIBRARIES MATCHES "(ALL|ON)" OR "${_name}" IN_LIST BUILD_LIBRARIES)
+    unset(${_library}_DIR CACHE)
+  endif()
+endforeach()
+
 # Prior to 3.4.1, find_package for Eigen3 doesn't support version ranges
 # but Ubuntu only has 3.4.0 right now, so we should support it
 # For Eigen 5.0 and later, the way the version checking is setup, specifying
@@ -179,10 +193,6 @@ find_package(GLPK      4.59.0)
 pkg_search_module(FFLAS_FFPACK	IMPORTED_TARGET	fflas-ffpack>=2.4.3)
 pkg_search_module(GIVARO	IMPORTED_TARGET	givaro>=4.1.1)
 # TODO: add FindModules for these two as well
-
-set(LIBRARY_OPTIONS
-  Eigen3 BDWGC MPFR MPFI NTL Flint Factory Frobby cddlib MPSolve
-  GTest GLPK Givaro FFLAS_FFPACK Normaliz)
 
 ###############################################################################
 ## Optional libraries:

--- a/M2/libraries/gtest/Makefile.in
+++ b/M2/libraries/gtest/Makefile.in
@@ -1,7 +1,7 @@
 SUBMODULE = true
 LIBNAME = googletest
 URL = https://github.com/google/googletest
-VERSION = 1.16.0
+VERSION = 1.18.0
 CONFIGURECMD = cmake . -DCMAKE_INSTALL_PREFIX=$(PREFIX) -DBUILD_GMOCK=OFF \
 	-DCMAKE_INSTALL_LIBDIR=lib
 


### PR DESCRIPTION
[Googletest 1.18.0 ](https://github.com/google/googletest/releases/tag/v1.18.0)was just released.

Draft for now to test the builds.

~~*No AI used*~~ I asked Claude to diagnose why the macOS cmake build was failing, and it added a couple commits.  See below.