### PR TITLE
Refactor Boost.Stacktrace detection

### DIFF
--- a/M2/CMakeLists.txt
+++ b/M2/CMakeLists.txt
@@ -14,9 +14,9 @@
 ##  6. cmake --install BUILD/cmake
 ###############################################################################
 
-## Requires CMake version 3.30 (for policy CMP0167 used in cmake/check-libraries.cmake)
-cmake_minimum_required(VERSION 3.30)
-cmake_policy(VERSION 3.30)
+## Requires CMake version 3.24 and is tested with 3.30
+cmake_minimum_required(VERSION 3.24...3.30)
+cmake_policy(VERSION 3.24)
 cmake_policy(SET CMP0096 NEW) # preserve leading zeros in version number
 
 ## Use the C++20 standard

--- a/M2/Macaulay2/bin/CMakeLists.txt
+++ b/M2/Macaulay2/bin/CMakeLists.txt
@@ -56,10 +56,7 @@ target_link_libraries(M2-binary
   ${Boost_stacktrace_lib}
   M2-supervisor M2-engine M2-interpreter ${CMAKE_DL_LIBS})
 
-#if we have a usable link time stacktrace library, force boost to use it
-if(NOT Boost_stacktrace_header_only)
-  target_compile_definitions(M2-binary PUBLIC BOOST_STACKTRACE_LINK)
-endif()
+target_compile_definitions(M2-binary PUBLIC ${Boost_stacktrace_definitions})
 
 # Set where the executable should be store and get its RPATH
 set_target_properties(M2-binary PROPERTIES

--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -1,6 +1,3 @@
-#define BOOST_STACKTRACE_USE_ADDR2LINE /* show source file and line number */
-// #define BOOST_STACKTRACE_USE_NOOP /* disable stacktrace */
-
 #include <M2/gc-include.h>
 
 #include "interp-exports.h"

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -48,21 +48,23 @@ if(STATIC_BOOST)
   message(STATUS "Using static Boost, if Boost is installed but not found, try setting STATIC_BOOST to OFF")
 endif()
 set(Boost_USE_STATIC_LIBS ${STATIC_BOOST})
-if(UNIX)
-  cmake_policy(SET CMP0167 OLD) # load CMake's FindBoost module
-  find_package(Boost	REQUIRED QUIET COMPONENTS regex OPTIONAL_COMPONENTS stacktrace_addr2line)
-else()
-  find_package(Boost	REQUIRED QUIET COMPONENTS regex OPTIONAL_COMPONENTS stacktrace_backtrace)
+find_package(Boost	REQUIRED QUIET COMPONENTS regex
+  OPTIONAL_COMPONENTS stacktrace_backtrace)
+
+# Finding a component only proves the Boost library exists, not that its backend can work.
+check_library_exists(backtrace backtrace_create_state "" LIBBACKTRACE)
+find_program(ADDR2LINE	NAMES	addr2line llvm-addr2line)
+
+if(Boost_STACKTRACE_BACKTRACE_FOUND AND LIBBACKTRACE)
+  set(Boost_stacktrace_lib Boost::stacktrace_backtrace backtrace)
+  set(Boost_stacktrace_definitions BOOST_STACKTRACE_LINK)
+elseif(ADDR2LINE)
+  # only header-only mode reads BOOST_STACKTRACE_USE_* and lets us set the addr2line path
+  set(Boost_stacktrace_definitions BOOST_STACKTRACE_USE_ADDR2LINE
+    BOOST_STACKTRACE_ADDR2LINE_LOCATION=${ADDR2LINE})
 endif()
-if(Boost_STACKTRACE_BACKTRACE_FOUND)
-  set(Boost_stacktrace_lib "Boost::stacktrace_backtrace")
-elseif(Boost_STACKTRACE_ADDR2LINE_FOUND)
-  set(Boost_stacktrace_lib "Boost::stacktrace_addr2line")
-else()
-  #fallback to header only mode
-  set(Boost_stacktrace_header_only YES)
-endif()
-set(CMAKE_REQUIRED_INCLUDES "${Boost_INCLUDE_DIR}")
+
+set(CMAKE_REQUIRED_INCLUDES "${Boost_INCLUDE_DIRS}")
 check_include_files(boost/math/tools/atomic.hpp
   HAVE_BOOST_MATH_TOOLS_ATOMIC_HPP)
 

--- a/M2/cmake/check-libraries.cmake
+++ b/M2/cmake/check-libraries.cmake
@@ -66,7 +66,7 @@ endif()
 
 set(CMAKE_REQUIRED_INCLUDES "${Boost_INCLUDE_DIRS}")
 check_include_files(boost/math/tools/atomic.hpp
-  HAVE_BOOST_MATH_TOOLS_ATOMIC_HPP)
+  HAVE_BOOST_MATH_TOOLS_ATOMIC_HPP LANGUAGE CXX) # C++ only header
 
 # TODO: replace gdbm, see https://github.com/Macaulay2/M2/issues/594
 find_package(GDBM	REQUIRED QUIET) # See FindGDBM.cmake

--- a/M2/configure.ac
+++ b/M2/configure.ac
@@ -1411,28 +1411,27 @@ AX_BOOST_BASE([1.65],,
 CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
 LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
 
-AC_MSG_CHECKING([whether the Boost::Stacktrace library is available])
 AC_LANG(C++)
+dnl the addr2line backend execs this, and boost's default of /usr/bin/addr2line is absent on macOS
+AC_PATH_PROGS([ADDR2LINE], [addr2line llvm-addr2line])
+dnl the backtrace backend needs libbacktrace, which the boost library may not carry itself
+AC_CHECK_LIB([backtrace], [backtrace_create_state])
+
+AC_MSG_CHECKING([which Boost::Stacktrace backend is usable])
 SAVECPPFLAGS=$CPPFLAGS
-CPPFLAGS="$CPPFLAGS -DBOOST_STACKTRACE_LINK"
 SAVELIBS=$LIBS
-FOUND_stacktrace_library=no
-for stacktrace_library in backtrace addr2line
-do
-    LIBS="$SAVELIBS -lboost_stacktrace_${stacktrace_library}"
-    AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM([#include <boost/stacktrace.hpp>
-         ], [boost::stacktrace::stacktrace();])],
-        [AC_MSG_RESULT([yes, boost_stacktrace_${stacktrace_library}])
-         FOUND_stacktrace_library=yes
-         break],)
-done
-if test $FOUND_stacktrace_library = no
-then
-    AC_MSG_RESULT([no, will use header-only library])
-    CPPFLAGS=$SAVECPPFLAGS
-    LIBS=$SAVELIBS
-fi
+CPPFLAGS="$CPPFLAGS -DBOOST_STACKTRACE_LINK"
+LIBS="$LIBS -lboost_stacktrace_backtrace"
+AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([#include <boost/stacktrace.hpp>
+     ], [boost::stacktrace::stacktrace();])],
+    [AC_MSG_RESULT([boost_stacktrace_backtrace])],
+    dnl only header-only mode reads BOOST_STACKTRACE_USE_* and lets us set the addr2line path
+    [AC_MSG_RESULT([header-only${ADDR2LINE:+ with $ADDR2LINE}])
+     CPPFLAGS=$SAVECPPFLAGS
+     LIBS=$SAVELIBS
+     AS_IF([test -n "$ADDR2LINE"],
+         [CPPFLAGS="$CPPFLAGS -DBOOST_STACKTRACE_USE_ADDR2LINE -DBOOST_STACKTRACE_ADDR2LINE_LOCATION=$ADDR2LINE"])])
 
 AX_BOOST_REGEX
 LIBS="$LIBS $BOOST_REGEX_LIB"


### PR DESCRIPTION
Every time I went to use the cmake build on my Ubuntu 24.04 machine, I had to go comment out that `CMP0167` line from #4146 because my cmake was too old.

Not a great workflow, so today I finally asked, "Hey Claude, what's up with this?", and it took me down a long rabbit hole about the various ways that we can use Boost.Stacktrace.  So what started out as a cmake-only branch turned into a cmake-and-autotools branch so that we end up doing the same thing in both builds.

I'll have Claude comment on the details

## :robot: AI Disclosure :robot:

Claude wrote all the code, but I asked a bunch of questions and we ended up trimming down what started out as a bunch of spaghetti code into a pretty nice little patch.