### PR TITLE
Patch gfan to build on most systems

### DIFF
--- a/M2/cmake/build-libraries.cmake
+++ b/M2/cmake/build-libraries.cmake
@@ -837,8 +837,7 @@ _ADD_COMPONENT_DEPENDENCY(programs cohomcalg "" COHOMCALG)
 # https://users-math.au.dk/~jensen/software/gfan/gfan.html
 # gfan needs cddlib and is used by the packages gfanInterface and StatePolytopes
 # TODO: would gfan benefit from enabling the USEFACTORY option?
-# gfan 0.8beta's Makefile hardcodes gcc-15/g++-15 on macOS (clang doesn't work),
-# and uses plain gcc/g++ on Linux. We pass the cddlib lib path via CDD_LINKOPTIONS.
+# We pass the cddlib lib path via CDD_LINKOPTIONS.
 ExternalProject_Add(build-gfan
   URL               https://users-math.au.dk/~jensen/software/gfan/gfan0.8beta.tar.gz
   URL_HASH          SHA256=fa7884e5f317c50f8fb4f37bcf5d419f0fd5f7b90d6037349d1957ea73cebbee
@@ -846,6 +845,7 @@ ExternalProject_Add(build-gfan
   SOURCE_DIR        libraries/gfan/build
   DOWNLOAD_DIR      ${CMAKE_SOURCE_DIR}/BUILD/tarfiles
   BUILD_IN_SOURCE   ON
+  PATCH_COMMAND     patch --batch -p1 < ${CMAKE_SOURCE_DIR}/libraries/gfan/patch-0.8beta
   CONFIGURE_COMMAND true
   BUILD_COMMAND     ${MAKE} -j${PARALLEL_JOBS}
                       cddnoprefix=yes

--- a/M2/libraries/gfan/Makefile.in
+++ b/M2/libraries/gfan/Makefile.in
@@ -1,14 +1,13 @@
 GFAN_VERSION = 0.8beta
 VERSION = $(GFAN_VERSION)
 SHA256SUM = fa7884e5f317c50f8fb4f37bcf5d419f0fd5f7b90d6037349d1957ea73cebbee
-# PATCHFILE = @abs_srcdir@/patch-$(GFAN_VERSION)
+PATCHFILE = @abs_srcdir@/patch-$(GFAN_VERSION)
 URL = https://users-math.au.dk/jensen/software/gfan
 TARFILE = gfan$(VERSION).tar.gz
 TARDIR = gfan$(VERSION)
 CONFIGURECMD = true
 # adding cddnoprefix=yes here ensures that we include "cdd.h" instead of "cdd/cdd.h", which is necessary when trying to use cddlib as installed by homebrew on the Mac:
 CPPFLAGS += -I$(BUILTLIBPATH)/include/cddlib -DGMPRATIONAL
-# gfan's Makefile uses gcc-15/g++-15 on macOS by default, plain gcc/g++ elsewhere.
 # Inject LDFLAGS via CDD_LINKOPTIONS so the linker can find cddlib (homebrew on macOS,
 # system or M2-built elsewhere).
 BUILDOPTIONS = OPTFLAGS="$(CXXFLAGS) $(CPPFLAGS) -ffast-math"  \
@@ -16,6 +15,7 @@ BUILDOPTIONS = OPTFLAGS="$(CXXFLAGS) $(CPPFLAGS) -ffast-math"  \
 	cddnoprefix=yes
 INSTALLOPTIONS = PREFIX=$(LIBRARIESDIR)
 CHECKTARGET = check
+VLIMIT = unlimited
 STRIPFILES = gfan@EXEEXT@
 LICENSEFILES = LICENSE COPYING
 include ../Makefile.library

--- a/M2/libraries/gfan/patch-0.8beta
+++ b/M2/libraries/gfan/patch-0.8beta
@@ -1,0 +1,647 @@
+Description: Build gfan on a wider variety of systems
+ Gfan 0.8beta builds only on a fairly narrow set of toolchains.  This patch
+ collects the changes needed to build it with the system compiler on macOS,
+ with clang, and with the compilers shipped by older distributions, back to
+ GCC 7.5 on Ubuntu 18.04 and GCC 8.5 on RHEL 8.  It adds no dependency:
+ gfan already links TBB unconditionally, and the memory_resource fallback
+ uses what libstdc++ has shipped since GCC 6.
+ .
+ Parallelism: gfan drove its parallel loops through std::for_each with
+ std::execution::par.  libc++ has no <execution> at all and libstdc++ only
+ gained it in GCC 9; where it does exist it is implemented on top of TBB.
+ Call TBB directly.  That also removes the reason for the include-ordering
+ workaround at the top of log.h, which pulled <execution> into all 110
+ translation units that include it, and it exposes two files that had been
+ getting <atomic> through that include.  Two loops are deliberately left
+ sequential: they walk a std::set, so libstdc++ never parallelised them,
+ and their body writes to std::cout unlocked and names output files after
+ an index that is not unique across threads.
+ .
+ Library features that are too new: <semaphore> (GCC 11, Xcode 14) was
+ needed only by unreachable scratch code, which is removed; std::erase_if
+ and std::filesystem each had one call site and are replaced with older
+ equivalents; and std::pmr, which is threaded through the core matrix and
+ vector types, falls back to <experimental/memory_resource>, the Library
+ Fundamentals TS version that std::pmr came from.
+ .
+ Language features that are too new: operator!= was left to the C++20
+ rewritten candidate for operator==, which GCC 9 does not synthesise, and a
+ multimap was left to default construct a lambda comparator, which is only
+ possible from C++20.  With those gone, gfan compiles as C++17, so the
+ hardcoded -std=c++20 becomes -std=c++17; GCC 9 spells that standard c++2a
+ and GCC 7 does not have it at all.
+ .
+ Makefile: the macOS pin to gcc-15/g++-15 is gone, so macOS uses its own
+ compiler; a -fno-guess-branch-probability workaround for a gcc 4.7.2 bug
+ goes with it, since clang rejects the option; and -march=native is no
+ longer passed unconditionally, which clang rejects outright on arm64 and
+ which otherwise leaves a binary tuned for whichever machine compiled it.
+ The existing vectorize= switch, which previously set the same value in
+ both of its branches, now turns it back on.
+ .
+ One change is not a build fix but was made along the way: virtual
+ destructors for EnumerationTarget and EnumerationAlgorithm, which are
+ deleted through base class pointers.
+ .
+ Verified by building and running the gfan test suite (50/50) on Ubuntu
+ 18.04, 20.04, 22.04, 24.04 and 25.04 (GCC 7.5 through 14.2), Rocky Linux
+ 8 (GCC 8.5), macOS 26 on arm64, and with clang.
+Author: Doug Torrance <dtorrance9@gatech.edu>, Claude Opus 5 <noreply@anthropic.com>
+Last-Update: 2026-08-13
+diff --git gfan0.8beta/Makefile gfan0.8beta/Makefile
+index 1d5fad9..e64e65d 100644
+--- gfan0.8beta/Makefile
++++ gfan0.8beta/Makefile
+@@ -95,7 +95,7 @@ SOPLEX_OBJECTS = lp_soplexcdd.o
+ endif
+ 
+ ifeq ($(vectorize),)
+-VECTORISE = -march=native
++VECTORISE =
+ else
+ VECTORISE = -march=native
+ #-mavx -msse2
+@@ -152,17 +152,10 @@ CCLINKER    = $(CXX)
+ #CXX         = $(PREFIX)g++-8.1
+ #CCLINKER    = $(CXX)
+ 
+-# macOS: use Homebrew GCC (supports std::execution::par via TBB backend)
+ ifeq ($(UNAME_S),Darwin)
+-CC       = gcc-15
+-CXX      = g++-15
+-CLINKER  = $(CC)
+-CCLINKER = $(CXX)
+-SYMMETRICTRAVERSAL_FLAGS = -fno-guess-branch-probability
+ # -rdynamic is Linux-only; use TBB for parallel execution support
+ PLATFORM_LINKOPTIONS = -L$(HOMEBREW_PREFIX)/opt/tbb/lib -ltbb
+ else
+-SYMMETRICTRAVERSAL_FLAGS = -fno-guess-branch-probability
+ PLATFORM_LINKOPTIONS = -rdynamic -ltbb
+ endif
+ 
+@@ -172,8 +165,6 @@ endif
+ OPTFLAGS    =  -DGMPRATIONAL -Wuninitialized -O3   $(VECTORISE)  -finline-limit=1000 -ffast-math -fno-omit-frame-pointer  -fdelete-null-pointer-checks #-D_GLIBCXX_DEBUG #-fno-inline-functions -fno-inline-small-functions#-fno-common  #-fno-inline-functions #-D_GLIBCXX_DEBUG #-O2	 #-O3 -fno-guess-branch-probability #-DNDEBUG
+ #OPTFLAGS    =  -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O3 -mavx -msse2  -finline-limit=1000 -ffast-math -Wuninitialized # -fno-guess-branch-probability #-DNDEBUG
+ 
+-# macOS uses GCC-15 which supports all the same flags as Linux GCC
+-# Add TBB include path so <execution> finds the TBB PSTL backend
+ ifeq ($(UNAME_S),Darwin)
+ TBB_INCLUDEOPTIONS = -I $(HOMEBREW_PREFIX)/opt/tbb/include
+ endif
+@@ -184,7 +175,7 @@ endif
+ #OPTFLAGS    =  -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O3 -msse2 -ftree-vectorizer-verbose=2 -ffast-math #-DNDEBUG
+ #OPTFLAGS    =  -DGMPRATIONAL -Wuninitialized -fno-omit-frame-pointer -O3 -mavx -msse2 -ftree-vectorizer-verbose=2 -ffast-math #-DNDEBUG
+ 
+-CFLAGS	  = $(OPTFLAGS) $(GPROFFLAG) $(STACTDUMP_OPTIONS) $(ADDITIONALINCLUDEOPTIONS) -g $(CDDDEFINE_PREFIX) -std=c++20 $(TBB_INCLUDEOPTIONS) #-pedantic
++CFLAGS	  = $(OPTFLAGS) $(GPROFFLAG) $(STACTDUMP_OPTIONS) $(ADDITIONALINCLUDEOPTIONS) -g $(CDDDEFINE_PREFIX) -std=c++17 $(TBB_INCLUDEOPTIONS) #-pedantic
+ #CFLAGS	  = $(OPTFLAGS) $(GPROFFLAG) $(STACTDUMP_OPTIONS) $(ADDITIONALINCLUDEOPTIONS) -std=c++0x -g $(CDDDEFINE_PREFIX) #-pedantic
+ #CFLAGS	  = $(OPTFLAGS) $(GPROFFLAG) $(STACTDUMP_OPTIONS) $(ADDITIONALINCLUDEOPTIONS) -D_GLIBCXX_DEBUG -g $(CDDDEFINE_PREFIX) #-pedantic
+ CCFLAGS	  = $(CFLAGS)
+@@ -475,13 +466,6 @@ GFANLIBFILES= 	gfanlib.h \
+ 
+ EXECS	  = $(MAIN)
+ 
+-# When compiling symmetrictraversal.cpp as any other file, it causes the program to crash in certain situations.
+-# (compiling with gcc version 4.7.2 and running gfan _tropicaltraverse on a starting cone for Grassmann3_7)
+-# Either this is a bug in the code or in the compiler. The bug disappears by compiling with -fno-guess-branch-probability
+-# SYMMETRICTRAVERSAL_FLAGS is set to -fno-guess-branch-probability on Linux/gcc and empty on macOS/clang.
+-src/symmetrictraversal.o: src/symmetrictraversal.cpp
+-	$(CXX) $(CFLAGS) $(SYMMETRICTRAVERSAL_FLAGS) -c src/symmetrictraversal.cpp -o src/symmetrictraversal.o
+-
+ # Define suffixes to make the program compile on legolas.imf.au.dk :
+ .SUFFIXES: .o .cpp .c
+ 
+diff --git gfan0.8beta/src/app_components.cpp gfan0.8beta/src/app_components.cpp
+index 407c23e..a42efea 100644
+--- gfan0.8beta/src/app_components.cpp
++++ gfan0.8beta/src/app_components.cpp
+@@ -6,10 +6,9 @@
+  */
+ 
+ #include <thread>
+-#include <execution>
+ #include <iostream>
+ #include <fstream>
+-#include <filesystem>
++#include <sys/stat.h>
+ #include "app_anton.h"
+ //#include <algorithm>
+ 
+@@ -162,14 +161,13 @@ void connectedComponentsOfSlices(PostComplex<mvtyp>& pc, bool saveNoncomets, boo
+   */
+   if (potentialsOutputAndStop) {
+     std::for_each(
+-		  std::execution::seq, 
+ 		  potentials.begin(),
+ 		  potentials.end(),
+ 		  [](Rational p)
+ 		  {
+ 		    auto nd = p.numeratorDenominator();
+ 		    int n(nd.first.toInt()), d(nd.second.toInt());
+-		    std::filesystem::create_directory("POTENTIALS");
++		    mkdir("POTENTIALS",0777);
+ 		    std::stringstream filename;		    
+ 		    filename << "POTENTIALS/" << n << "over" << d;
+ 		    std::ofstream of(filename.str());
+@@ -180,7 +178,6 @@ void connectedComponentsOfSlices(PostComplex<mvtyp>& pc, bool saveNoncomets, boo
+ 		  });
+   } else {
+     std::for_each(
+-		  std::execution::par,//fails to trigger parallelism
+ 		  potentials.begin(),
+ 		  potentials.end(),
+ 		  [pc,minConePotential,maxConePotential,saveNoncomets](Rational p)
+diff --git gfan0.8beta/src/app_halfopenconecomponents.cpp gfan0.8beta/src/app_halfopenconecomponents.cpp
+index 4b14062..66c26e1 100644
+--- gfan0.8beta/src/app_halfopenconecomponents.cpp
++++ gfan0.8beta/src/app_halfopenconecomponents.cpp
+@@ -13,6 +13,8 @@
+ 
+ #include <mutex>
+ #include <thread>
++#include <atomic>
++#include <tbb/parallel_for_each.h>
+ 
+ #include "gfanlib_tableau.h"
+ #include "gfanapplication.h"
+@@ -90,7 +92,7 @@ public:
+ 		  atomic_int64_t numberOfNonEmptyCones=0;
+ 		  ThreadSafeSequenceStreamIterator i(inputFileOption.getFreshStreamReference());
+ 		  vector<int> dummy(100);
+-		  std::for_each(std::execution::par, dummy.begin(),dummy.end(),[&i,&numberOfNonEmptyCones,&allowedVertices,&mtx,&connectivityThroughEdges](size_t t)
++		  tbb::parallel_for_each(dummy.begin(),dummy.end(),[&i,&numberOfNonEmptyCones,&allowedVertices,&mtx,&connectivityThroughEdges](size_t t)
+ 				  {
+ 			  std::cerr<<t<<"\n";
+ 			  while(auto s1=i.getNextString())
+@@ -136,7 +138,7 @@ public:
+ 			  ThreadSafeSequenceStreamIterator i(inputFileOption.getFreshStreamReference());
+ 			  std::mutex mtx;
+ 			  vector<int> dummy(100);
+-			  std::for_each(std::execution::par, dummy.begin(),dummy.end(),[&i,&allowedVertices,&classes,&mtx,&connectivityThroughEdges](size_t t)
++			  tbb::parallel_for_each(dummy.begin(),dummy.end(),[&i,&allowedVertices,&classes,&mtx,&connectivityThroughEdges](size_t t)
+ 					  {
+ 				  std::cerr<<t<<"\n";
+ 				  while(auto s1=i.getNextString())
+@@ -185,7 +187,7 @@ public:
+ 		  ThreadSafeSequenceStreamIterator i(inputFileOption.getFreshStreamReference());
+ 		  std::mutex mtx;
+ 		  vector<int> dummy(100);
+-		  std::for_each(std::execution::par, dummy.begin(),dummy.end(),[&i,&I,&classToIndex,&allowedVertices,&classes,&mtx](size_t t)
++		  tbb::parallel_for_each(dummy.begin(),dummy.end(),[&i,&I,&classToIndex,&allowedVertices,&classes,&mtx](size_t t)
+ 				  {
+ 			  std::cerr<<t<<"\n";
+ 			  while(auto s1=i.getNextString())
+diff --git gfan0.8beta/src/app_hashemikapur.cpp gfan0.8beta/src/app_hashemikapur.cpp
+index 149e523..8d20837 100644
+--- gfan0.8beta/src/app_hashemikapur.cpp
++++ gfan0.8beta/src/app_hashemikapur.cpp
+@@ -53,7 +53,7 @@ public:
+ 	  	  		  	  	  if(B<A)return false;
+ 	  	  		  	  	  return a<b;
+ 	  	  			  };
+-	  	  	  multimap<IntegerVector,pair<int,int>,decltype(cmp)> P;
++	  	  	  multimap<IntegerVector,pair<int,int>,decltype(cmp)> P(cmp);
+ #else
+ 	  	  	  multimap<IntegerVector,pair<int,int>> P;
+ #endif
+diff --git gfan0.8beta/src/app_processcomplex.cpp gfan0.8beta/src/app_processcomplex.cpp
+index 6503535..16d5bc9 100644
+--- gfan0.8beta/src/app_processcomplex.cpp
++++ gfan0.8beta/src/app_processcomplex.cpp
+@@ -14,7 +14,7 @@
+ #include <sstream>
+ #include <mutex>
+ #include <thread>
+-#include <execution>
++#include <tbb/parallel_for_each.h>
+ #include "parser.h"
+ #include "printer.h"
+ #include "polynomial.h"
+@@ -225,7 +225,7 @@ if(0)	  {
+ 			ThreadSafeSequenceStreamIterator i(inputFileOption.getFreshStreamReference(),true);
+ 			  std::mutex mtx;
+ 			  vector<int> dummy(100);
+-			  std::for_each(std::execution::par, dummy.begin(),dummy.end(),[&](size_t t)
++			  tbb::parallel_for_each(dummy.begin(),dummy.end(),[&](size_t t)
+ 					  {
+ 			while(auto s1=i.getNextString())
+ 			{
+diff --git gfan0.8beta/src/app_tropicalprevariety.cpp gfan0.8beta/src/app_tropicalprevariety.cpp
+index 53d7553..0519614 100644
+--- gfan0.8beta/src/app_tropicalprevariety.cpp
++++ gfan0.8beta/src/app_tropicalprevariety.cpp
+@@ -11,6 +11,8 @@
+ #include <iostream>
+ #include <fstream>
+ #include <stdlib.h>
++#include <atomic>
++#include <tbb/parallel_for_each.h>
+ #include "parser.h"
+ #include "printer.h"
+ #include "polynomial.h"
+@@ -219,7 +221,7 @@ if(optionRestrictToHalfOpenCones.getValue())
+ 	  std::mutex mtx;
+ 	  vector<int> dummy(100);
+ 	  std::atomic<int> c2=count;
+-	  std::for_each(std::execution::par, dummy.begin(),dummy.end(),[this,&useValuation,&n,&ret,&c2,&mtx](size_t t)
++	  tbb::parallel_for_each(dummy.begin(),dummy.end(),[this,&useValuation,&n,&ret,&c2,&mtx](size_t t)
+ 			  {
+ 		  	  while(c2>0 && !ssi->eof())
+ 		  		  {
+diff --git gfan0.8beta/src/enumeration.h gfan0.8beta/src/enumeration.h
+index b0bd187..650b74a 100644
+--- gfan0.8beta/src/enumeration.h
++++ gfan0.8beta/src/enumeration.h
+@@ -6,6 +6,7 @@
+ class EnumerationTarget
+ {
+  public:
++  virtual ~EnumerationTarget(){}
+   virtual void beginEnumeration(const PolynomialSet &groebnerBasis)=0;
+   virtual void endEnumeration()=0;
+   virtual bool basis(const PolynomialSet &groebnerBasis)=0; /* return false to break enumaration */
+@@ -61,6 +62,7 @@ class EnumerationAlgorithm
+   bool targetBasis(const PolynomialSet &groebnerBasis){bool ret=true;if(target)ret=target->basis(groebnerBasis);printProgress();return ret;}
+  public:
+   EnumerationAlgorithm(){target=0;progressCounter=0;}
++  virtual ~EnumerationAlgorithm(){}
+   void setEnumerationTarget(EnumerationTarget *target){this->target=target;}
+   virtual void enumerate(const PolynomialSet &groebnerBasis){}
+ };
+diff --git gfan0.8beta/src/gfanlib_circuittableint.h gfan0.8beta/src/gfanlib_circuittableint.h
+index 6078a36..9698a3a 100644
+--- gfan0.8beta/src/gfanlib_circuittableint.h
++++ gfan0.8beta/src/gfanlib_circuittableint.h
+@@ -318,6 +318,7 @@ public:
+ 	friend bool operator<(CircuitTableIntPOD const &a, CircuitTableIntPOD const &b){return a.v<b.v;}
+ 	friend bool operator<=(CircuitTableIntPOD const &a, CircuitTableIntPOD const &b){return a.v<=b.v;}
+ 	friend bool operator==(CircuitTableIntPOD const &a, CircuitTableIntPOD const &b){return a.v==b.v;}
++	friend bool operator!=(CircuitTableIntPOD const &a, CircuitTableIntPOD const &b){return a.v!=b.v;}
+ 	bool isZero()const{return v==0;}
+ 	bool isOne()const{return v==1;}
+ 	bool isNonZero()const{return v!=0;}
+diff --git gfan0.8beta/src/gfanlib_circuittableinteger.h gfan0.8beta/src/gfanlib_circuittableinteger.h
+index b0f5613..42564e1 100644
+--- gfan0.8beta/src/gfanlib_circuittableinteger.h
++++ gfan0.8beta/src/gfanlib_circuittableinteger.h
+@@ -111,6 +111,7 @@ public:
+ 	friend bool operator<(CircuitTableInteger const &a, CircuitTableInteger const &b){return a.v<b.v;}
+ 	friend bool operator<=(CircuitTableInteger const &a, CircuitTableInteger const &b){return (a.v<b.v)||(a.v==b.v);}
+ 	friend bool operator==(CircuitTableInteger const &a, CircuitTableInteger const &b){return a.v==b.v;}
++	friend bool operator!=(CircuitTableInteger const &a, CircuitTableInteger const &b){return a.v!=b.v;}
+ 	bool isZero()const{return v.sign()==0;}
+ 	bool isOne()const{return v==1;}
+ 	bool isNonZero()const{return v.sign()!=0;}
+diff --git gfan0.8beta/src/gfanlib_hypersurfaceintersection.cpp gfan0.8beta/src/gfanlib_hypersurfaceintersection.cpp
+index b63e891..60e8198 100644
+--- gfan0.8beta/src/gfanlib_hypersurfaceintersection.cpp
++++ gfan0.8beta/src/gfanlib_hypersurfaceintersection.cpp
+@@ -7,7 +7,7 @@
+ 
+ #include <mutex>
+ #include <thread>
+-#include <execution>
++#include <tbb/parallel_for_each.h>
+ #include "gfanlib_hypersurfaceintersection.h"
+ #include "gfanlib_paralleltraverser.h"
+ #include "gfanlib_memoryresource.h"
+@@ -435,7 +435,7 @@ namespace gfan{
+ 
+ 		vector<int> dummy(100);
+ 		mutex mtx;
+-		std::for_each(std::execution::par, dummy.begin(),dummy.end(),[&](size_t t)
++		tbb::parallel_for_each(dummy.begin(),dummy.end(),[&](size_t t)
+ 			{
+ 			StackResource localStackResource1(20160000);
+ 			StackResource localStackResource2(20160000);
+diff --git gfan0.8beta/src/gfanlib_memoryresource.cpp gfan0.8beta/src/gfanlib_memoryresource.cpp
+index 1cc1ad0..dffee16 100644
+--- gfan0.8beta/src/gfanlib_memoryresource.cpp
++++ gfan0.8beta/src/gfanlib_memoryresource.cpp
+@@ -10,7 +10,7 @@
+ StackResource globalStackResource1(20160000);
+ StackResource globalStackResource2(20160000);
+ 
+-std::string memoryResourceToString(const std::pmr::memory_resource *mr)
++std::string memoryResourceToString(const gfanpmr::memory_resource *mr)
+ {
+ 	if(get_default_resource()==mr)
+ 	{
+diff --git gfan0.8beta/src/gfanlib_memoryresource.h gfan0.8beta/src/gfanlib_memoryresource.h
+index f54d7aa..8d5f29a 100644
+--- gfan0.8beta/src/gfanlib_memoryresource.h
++++ gfan0.8beta/src/gfanlib_memoryresource.h
+@@ -6,7 +6,13 @@
+  *      Author: anders
+  */
+ 
++#if __has_include(<memory_resource>) && !defined(GFAN_USE_EXPERIMENTAL_MEMORY_RESOURCE)
+ #include <memory_resource>
++namespace gfanpmr = std::pmr;
++#else
++#include <experimental/memory_resource>
++namespace gfanpmr = std::experimental::pmr;
++#endif
+ #include <iostream>
+ #include <vector>
+ #include <assert.h>
+@@ -42,9 +48,9 @@ void test() {
+ 
+ template<typename a>
+ //using std::experimental::pmr pmr;
+-using pmrvector=std::pmr::vector<a>;
+-typedef std::pmr::memory_resource MR; //Maybe this should be polymorphic_allocator<byte> instead - at least for the constructors using these
+-using std::pmr::get_default_resource;
++using pmrvector=std::vector<a,gfanpmr::polymorphic_allocator<a> >;//that is std::pmr::vector<a>
++typedef gfanpmr::memory_resource MR; //Maybe this should be polymorphic_allocator<byte> instead - at least for the constructors using these
++using gfanpmr::get_default_resource;
+ 
+ //DELETE
+ class ResourceWrapper: public MR{
+@@ -76,7 +82,7 @@ public:
+ 	}
+ };
+ 
+-class StackResource: public std::pmr::memory_resource{
++class StackResource: public gfanpmr::memory_resource{
+   /*
+    *
+    * Layout of memory
+@@ -98,7 +104,7 @@ class StackResource: public std::pmr::memory_resource{
+ 	The header is 4 byte aligned, while the alignment of each block is specified at allocation.
+    */
+ public:
+-  std::pmr::vector<char> mem;
++  pmrvector<char> mem;
+   int topHeader;
+   int nbytes;
+   memory_resource* parentResource;
+@@ -124,8 +130,8 @@ public:
+ 	  return (firstPossible+((align-1)|(minimumAlignment-1)))& ~((align-1)|(minimumAlignment-1));
+   }
+   StackResource(int nbytes_,
+-		memory_resource* parentResource_=std::pmr::new_delete_resource(),
+-		memory_resource* fallBackResource_=std::pmr::null_memory_resource()):
++		memory_resource* parentResource_=gfanpmr::new_delete_resource(),
++		memory_resource* fallBackResource_=gfanpmr::null_memory_resource()):
+ 	topHeader(0),
+     nbytes(nbytes_),
+     mem(nbytes_,parentResource_),
+@@ -254,7 +260,7 @@ public:
+ };
+ 
+ 
+-std::string memoryResourceToString(const std::pmr::memory_resource *mr);
++std::string memoryResourceToString(const gfanpmr::memory_resource *mr);
+ 
+ // DELETE?
+ class ResourceInvariant
+diff --git gfan0.8beta/src/log.h gfan0.8beta/src/log.h
+index 008b020..2a197f4 100644
+--- gfan0.8beta/src/log.h
++++ gfan0.8beta/src/log.h
+@@ -1,4 +1,3 @@
+-#include <execution> // This header does not like the macros below.
+ #ifndef LOG_H_INCLUDED
+ #define LOG_H_INCLUDED
+ 
+diff --git gfan0.8beta/src/paralleltraversal.cpp gfan0.8beta/src/paralleltraversal.cpp
+index 4bae95c..f170d7d 100644
+--- gfan0.8beta/src/paralleltraversal.cpp
++++ gfan0.8beta/src/paralleltraversal.cpp
+@@ -11,7 +11,6 @@
+ #include <algorithm>
+ #include <unistd.h>
+ #include <mutex>
+-#include <semaphore>
+ #include <thread>
+ #include <optional>
+ #include <string_view>
+@@ -213,7 +212,9 @@ public:
+ 		scoped_lock<mutex> lock(theMutex);
+ 		for(auto &a:L)
+ 		{
+-			auto erased=std::erase_if(theSet,[a](StoredArc &A){return (a.ray==A.ray && a.ridge==A.ridge);});
++			auto j=std::remove_if(theSet.begin(),theSet.end(),[a](StoredArc &A){return (a.ray==A.ray && a.ridge==A.ridge);});
++			auto erased=std::distance(j,theSet.end());
++			theSet.erase(j,theSet.end());
+ 			if(!erased)
+ 			{
+ 				theSet.push_back(StoredArc(a.ridge,a.ray,a.facetTag,!a.fromFacetToRidge));
+@@ -518,216 +519,6 @@ static ParallelTraverseApplication theApplication;
+ 
+ 
+ 
+-std::counting_semaphore<0> S(0);
+-
+-namespace parallelplayground{
+-using VertexName=string;
+-
+-list<VertexName> computeNeighbours(VertexName v)
+-{
+-	list<VertexName> ret;
+-	for(int i=1;i<v.size();i++)
+-	{
+-		swap(v[i-1],v[i]);
+-		ret.push_back(v);
+-		swap(v[i-1],v[i]);
+-	}
+-	return ret;
+-}
+-
+-class Boundary
+-	{
+-		class BoundaryEntry
+-		{
+-		public:
+-			VertexName name;
+-			list<VertexName> neighbours;//parents
+-			bool beingProcessed;
+-			BoundaryEntry(VertexName name_):
+-				name(name_),
+-				beingProcessed(false)
+-			{
+-
+-			}
+-		};
+-		vector<BoundaryEntry> b;
+-		mutex M;
+-		int numberBeingProcessed;
+-		bool terminate;
+-public:
+-		Boundary():
+-			numberBeingProcessed(1),
+-			terminate(false)
+-		{
+-
+-		}
+-		int boundarySize()
+-		{
+-			int ret=0;
+-			for(auto &v:b)
+-				ret+=v.neighbours.size();
+-			return ret;
+-		}
+-		void print()
+-		{
+-			cout<<"Size"<<b.size()<<"\n";
+-			for(int i=0;i<b.size();i++)
+-			{
+-				cout<<i<<":"<<b[i].name<<"\n";
+-				for(auto n:b[i].neighbours)
+-					cout<<n;
+-				cout<<"\n";
+-			}
+-		}
+-		unique_ptr<VertexName> getJob()
+-		{
+-			S.acquire();
+-//			std::cerr<<"\tACQUIRED\n";
+-			{
+-				scoped_lock<mutex> s(M);
+-
+-				if(terminate)return 0;
+-
+-				//HER skal vi lede efter ledig kant, markere, free mutex og returnere
+-				if(b.size())
+-				{
+-					numberBeingProcessed++;
+-					for(auto &a:b)
+-						if(!a.beingProcessed)
+-						{
+-							a.beingProcessed=true;
+-							return make_unique<VertexName>(a.name);
+-						}
+-				}
+-				assert(0);
+-			}
+-			return 0;
+-			// If there are jobs available, then return a job
+-			// If there are no more jobs and no entries being processed, then return false
+-			// If there are no more jobs and entries being processed, then block
+-		}
+-		void markStar(VertexName name, list<VertexName> neighbours)
+-		{
+-			int increase=0;
+-			{
+-			scoped_lock<mutex> s(M);
+-//			cout<<"markStar"<<name<<"\n";
+-			int j=-1;
+-			for(int i=0;i<b.size();i++)
+-				if(name==b[i].name)j=i;
+-			if(j==-1)
+-				b.emplace_back(name);
+-			for(int i=0;i<b.size();i++)
+-				if(name==b[i].name)j=i;
+-			assert(j!=-1);
+-
+-//			cout<<"J:"<<j<<"\n";
+-			for(auto &neighbour:neighbours)
+-			{
+-				bool found=false;
+-		//		cout<<"nsize"<<b[j].neighbours.size()<<"\n";
+-				for(auto &a:b[j].neighbours)
+-					if(neighbour==a)
+-						found=true;
+-				if(!found)
+-				{
+-//					cout<<"NOT FOUND:"<<neighbour<<"\n";
+-					bool found2=false;
+-					for(auto &c:b)
+-						if(c.name==neighbour)
+-							found2=true;
+-					if(!found2)
+-					{
+-						b.emplace_back(neighbour);
+-						increase++;
+-					}
+-					for(auto &c:b)
+-						if(c.name==neighbour)
+-							c.neighbours.push_back(name);
+-//					print();
+-				}
+-				else
+-				{
+-//					cout<<"FOUND:"<<neighbour<<"\n";
+-			//		cout<<"looking up"<<neighbour<<"\n";
+-					for(auto &a:b)
+-						if(neighbour==a.name)
+-						{
+-							remove_if(a.neighbours.begin(),a.neighbours.end(),[name](auto x){return name==x;});
+-							increase--;
+-						}
+-//					print();
+-
+-				}
+-			}
+-
+-//			print();
+-			vector<BoundaryEntry> b2;
+-			for(auto &a:b)if(a.name!=name)b2.push_back(a);
+-			b=b2;
+-
+-
+-			numberBeingProcessed--;//We are done with this vertex
+-//			std::cerr<<"NumberBeingProcessed"<<numberBeingProcessed<<"boundarySize"<<boundarySize()<<"\n";
+-			if(numberBeingProcessed==0)
+-			{
+-				if(boundarySize()==0)
+-				{
+-					std::cerr<<"TERMINATE\n";
+-					terminate=true;
+-					S.release(10000); //this should be enough for everyone to terminate
+-				}
+-			}
+-
+-			}//scoped lock
+-//			std::cerr<<"\tINCREASE:"<<increase<<"\n";
+-			S.release(increase);
+-		}
+-	};
+-void program(Boundary *B)
+-{
+-	unique_ptr<VertexName> job;
+-	int count=0;
+-	while((job=B->getJob()))
+-		{
+-			sleep(1);
+-//			b.print();
+-//			std::cout<<*job<<"\n";
+-			count++;
+-			B->markStar(*job,computeNeighbours(*job));
+-		}
+-	{
+-	std::cerr<<count<<"\n";
+-	}
+-}
+-	void computeComponent(VertexName root)
+-	{
+-		Boundary b;
+-		std::cout<<root<<"\n";
+-//		b.numberBeingProcessed=1;
+-		b.markStar(root,computeNeighbours(root));
+-//		b.print();
+-//		pardo
+-
+-		if(1)
+-		{
+-			int N=16;
+-			std::vector<std::thread> threads;
+-			threads.reserve(N);
+-			for(int i=0;i<N;i++)threads.emplace_back(std::thread(program,&b));
+-			for(auto &t:threads){t.join();}
+-		}
+-		else
+-			program(&b);
+-	}
+-}
+-
+-/*int main()
+-{
+-	std::cerr<<"test\n";
+-	parallelplayground::computeComponent("ABCDE");
+-	return 0;
+-}*/
+ 
+ #if 0
+ namespace gfan{


### PR DESCRIPTION
In #4268, we started requiring gfan 0.8, with the idea that eventually we'll need some of its new features (and bug fixes!) in the *gfanInterface* package.  Currently, the package still works just fine with older gfan releases like 0.6.2 and 0.7 if you comment out the check.  We've had to do this in multiple places like [Debian/Ubuntu](https://salsa.debian.org/math-team/macaulay2/-/blob/ppa/bionic-stable/debian/patches/allow-older-gfan.patch?ref_type=heads), [spack](https://github.com/spack/spack-packages/blob/b7471690b804c195ce3b3bd2c259db24f0b18ded/repos/spack_repo/builtin/packages/macaulay2/allow-older-gfan.patch#L24), [RHEL](https://github.com/d-torrance/M2/commit/60a1cbd1908fb96106c7f531c2adfb4d566331a2), and [nix](https://github.com/NixOS/nixpkgs/pull/530398) because currently, 0.8 only compiles on modern systems and only when compiling with GCC.

At the Macaulay2 workshop at Warwick this summer, the package was updated so that we actually will need 0.8 for several features (see https://github.com/Macaulay2/M2/pull/4466), so patching out the version requirement won't work once those changes are merged.

Claude and I worked on a series of patches (also submitted upstream) that enable us to build gfan on most systems using either GCC 7+ or Clang.  They're squashed into a single patch to fit our `M2/libraries` patch convention.

## AI Disclosure

Most code was written by Claude after lots of discussion.  I'll have it comment below with a summary of changes.

~~*Draft for now to test the builds*~~ Builds passed!