### PR TITLE
Don't redefine cblas/lapack routines from MKL

### DIFF
--- a/M2/Macaulay2/e/basic-mutable-matrices/lapack.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/lapack.hpp
@@ -18,6 +18,7 @@ typedef DMat<M2::ARingCC> DMatCC;
 /* MES, On my mac, 10.12.4, lapack include file is at
   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/Headers/clapack.h
 */
+#ifndef _MKL_LAPACK_H_
 extern "C" {
 int dgesv_(int *n,      // number of rows in A
            int *nrhs,   // number of right hand sides
@@ -204,6 +205,7 @@ int zungqr_(int *m,      // #rows m >= 0
                            // nb, where nb is optimal block size.
             int *lwork,    // dimension of 'work'
             int *info);
+#endif /* _MKL_LAPACK_H_ */
 
 #if 0  
   int dormqr_(char *__side,
@@ -221,6 +223,7 @@ int zungqr_(int *m,      // #rows m >= 0
               __CLPK_integer *__info);
 #endif
 
+#ifndef __MKL_CBLAS_H__
 #ifndef __FFLASFFPACK_config_blas_H
 /* cblas routines */
 // computes "ax + y"
@@ -256,7 +259,9 @@ void cblas_dscal(const int n,      // length of vectors
                  const double a,   // scalar alpha
                  double *x,        // vector x
                  const int incx);  // increment of x
+#endif /* __MKL_CBLAS_H__ */
 
+#ifndef _MKL_LAPACK_H_
 int zgesv_(int *n,      // number of rows in A
            int *nrhs,   // number of right hand sides
            double *a,   // n by n matrix A, on exit L&U from A=PLU
@@ -357,7 +362,9 @@ int zgelss_(int *rows,      // rows
             int *lwork,     // size of workspace
             double *rwork,  // workspace
             int *info);     // error info
+#endif /* _MKL_LAPACK_ */
 
+#ifndef __MKL_CBLAS_H__
 #ifndef __FFLASFFPACK_config_blas_H
 /* cblas routines */
 // computes "ax + y"
@@ -395,6 +402,7 @@ void cblas_zgemm(
     const int ldc);     // rows of C
 };
 
+#endif /* __MKL_CBLAS_H__ */
 
 class Lapack
 {

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp-ffpack.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp-ffpack.hpp
@@ -17,6 +17,7 @@
 #ifdef _OPENMP
 #define __FFLASFFPACK_USE_OPENMP
 #endif
+#define MKL_Complex16 double /* issue #3372 */
 #define bool_constant givaro_bool_constant
 #include <fflas-ffpack/ffpack/ffpack.h>
 #undef bool_constant


### PR DESCRIPTION
Also define `MKL_Complex16` as `double` before including `ffpack.h`.  If it was built with MKL support, then compilation will fail with a bunch of `cannot convert 'double*' to 'MKL_Complex16*'` errors.

After these changes, I was able to build M2 and FFLAS-FFPACK using MKL as their BLAS/LAPACK implementation.

Here are the steps to reproduce the issue.  In particular, we need FFLAS-FFPACK to pull in the MKL headers.  This is on Ubuntu 24.04 with `intel-mkl` installed:

```sh
sudo update-alternatives --config libblas.so-x86_64-linux-gnu
# select /usr/lib/x86_64-linux-gnu/libmkl_rt.so
cd M2/M2/BUILD/build
../../autogen.sh
../../configure CPPFLAGS="$(pkg-config --cflags blas)"
# need fflas-ffpack built w/ MKL support, and it only detects it using CBLAS_LIBS
make -C libraries/fflas_ffpack CBLAS_LIBS="$(pkg-config --libs blas)"
make
```

Closes: #3372

## :robot: AI Disclosure :robot:

I did a bit of brainstorming with Claude, but the code is all mine.
