### PR TITLE
A few autotools updates for the packages directory

### DIFF
--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -46,7 +46,7 @@ m2-need-template = "needsPackage(\"$(1)\",LoadDocumentation=>true,DebuggingMode=
 m2-check-template = "check($(1),UserMode=>false,Verbose=>$(Verbose)); exit 0"
 $(foreach i,\
 	$(sort $(ALL_PACKAGES)),\
-	$(eval check::check-$i)\
+	$(eval check: check-$i)\
 	$(eval check-$i:; \
 		@pre_bindir@/M2 -q --no-preload $(STOP)                 \
 			-e $(call m2-need-template,$i)                  \
@@ -116,7 +116,7 @@ all: @pre_bindir@/M2-language-server
 	cp $< $@
 
 # the Info-validate function doesn't work well enough to be useful:
-# check::check-info
+# check: check-info
 
 clean::; rm -rf tmp
 big-check:

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -9,9 +9,6 @@ ALL_PACKAGES = $(shell cat @srcdir@/=distributed-packages)
 # this one can be overridden by the user:
 PACKAGES = $(ALL_PACKAGES)
 
-# packages under development that should be checked but not installed:
-DEVEL = EngineTests
-
 MakeDocumentation ?= $(if @DOCUMENTATION@,true,false)
 MakeHTML ?= $(if $(filter html, @DOCUMENTATION@),true,false)
 MakeInfo ?= $(if $(filter info, @DOCUMENTATION@),true,false)
@@ -48,7 +45,7 @@ ArgumentMode = defaultMode
 m2-need-template = "needsPackage(\"$(1)\",LoadDocumentation=>true,DebuggingMode=>true)"
 m2-check-template = "check($(1),UserMode=>false,Verbose=>$(Verbose)); exit 0"
 $(foreach i,\
-	$(sort $(ALL_PACKAGES) $(DEVEL)),\
+	$(sort $(ALL_PACKAGES)),\
 	$(eval check::check-$i)\
 	$(eval check-$i:; \
 		@pre_bindir@/M2 -q --no-preload $(STOP)                 \

--- a/M2/Macaulay2/packages/Makefile.in
+++ b/M2/Macaulay2/packages/Makefile.in
@@ -46,7 +46,6 @@ m2-need-template = "needsPackage(\"$(1)\",LoadDocumentation=>true,DebuggingMode=
 m2-check-template = "check($(1),UserMode=>false,Verbose=>$(Verbose)); exit 0"
 $(foreach i,\
 	$(sort $(ALL_PACKAGES)),\
-	$(eval check: check-$i)\
 	$(eval check-$i:; \
 		@pre_bindir@/M2 -q --no-preload $(STOP)                 \
 			-e $(call m2-need-template,$i)                  \
@@ -102,7 +101,7 @@ $(foreach i, $(ALL_PACKAGES), $(eval $(call bld,$i)))
 ifeq "$(ReinstallPackages)" "true"
 $(foreach i, $(PACKAGES), $(eval all: unmark-$i))
 endif
-$(foreach i, $(PACKAGES), $(eval all: all-$i) $(eval install: install-$i))
+$(foreach i, $(PACKAGES), $(eval all: all-$i) $(eval install: install-$i) $(eval check: check-$i))
 
 # make packages Style, FirstPackage, and Macaulay2Doc get installed
 # before the others:


### PR DESCRIPTION
Some related changes:

* Scrap the redundant `DEVEL` variable, which was used for `EngineTests` when it wasn't distributed.  But now it is.
* Use `:` instead of `::` for the `check` target.  This enables us to run the package tests in parallel, which should speed up the `autotools-ubuntu` build considerably.
* Only run tests for packages in the `PACKAGES` variable, e.g., `make check PACKAGES=Foo` now only runs the checks for the *Foo* package, where it used to run *all* the tests.  This brings it in line with `make PACKAGES=Foo`, which already only built the documentation for *Foo*.

## :robot: AI Disclosure :robot:

I wrote all the code, but the recommendations were all from Claude after it did a review of our GitHub workflow.