### PR TITLE
Some  mutableMatrix updates

### DIFF
--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -2927,7 +2927,10 @@ setupfun("rawMutableMatrixFillRandom",rawMutableMatrixFillRandom);
 export rawLinAlgRank(e:Expr):Expr := (
      when e
      is m:RawMutableMatrixCell
-     do toExpr(Ccode(long, "rawLinAlgRank(", m.p, ")" ))
+     do (
+         r := Ccode(long, "rawLinAlgRank(", m.p, ")" );
+         if r == long(-1) then engineErrorMessage()
+         else toExpr(r))
      else WrongArgMutableMatrix());
 setupfun("rawLinAlgRank",rawLinAlgRank);
 

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -22,6 +22,7 @@ expression MutableMatrix := m -> MatrixExpression append(
 texMath MutableMatrix := m -> texMath expression m
 net MutableMatrix := m -> net expression m
 toExternalString MutableMatrix := lookup(toExternalString, MutableHashTable)
+MutableMatrix.AfterPrint = Matrix.AfterPrint
 
 map(Ring,RawMutableMatrix) := opts -> (R,m) -> (
      new MutableMatrix from {

--- a/M2/Macaulay2/m2/mutablemat.m2
+++ b/M2/Macaulay2/m2/mutablemat.m2
@@ -41,6 +41,12 @@ mutableMatrix List := o -> m -> mutableMatrix(matrix m, o)
 mutableMatrix MutableMatrix := o -> (m) -> map(ring m, rawMutableMatrix(raw m, o.Dense))
 mutableMatrix(Ring,ZZ,ZZ) := o -> (R,nrows,ncols) -> map(R,rawMutableMatrix(raw R,nrows,ncols,o.Dense))
 mutableMatrix(RingFamily,ZZ,ZZ) := o -> (R,nrows,ncols) -> mutableMatrix(default R,nrows,ncols,o)
+mutableMatrix RingElement :=
+mutableMatrix Number      := o -> r -> mutableMatrix({{r}}, o)
+mutableMatrix(Ring,       Number)      :=
+mutableMatrix(Ring,       RingElement) :=
+mutableMatrix(RingFamily, Number)      :=
+mutableMatrix(RingFamily, RingElement) := o -> (R, f) -> mutableMatrix(R, {{f}}, o)
 
 matrix MutableMatrix := o -> m -> map(ring m, rawMatrix raw m)
 

--- a/M2/Macaulay2/packages/EngineTests/LinearAlgebra.Test.ZZp.m2
+++ b/M2/Macaulay2/packages/EngineTests/LinearAlgebra.Test.ZZp.m2
@@ -49,6 +49,10 @@ TEST ///
   b = transpose mutableMatrix matrix(R, {{11,9,11,3}})
   LUdecomposition M
   assert(rank M == 4)
+
+  -- used to return -1
+  assert try rank mutableMatrix(R, 1, Dense => false) then false else true
+
   assert(rawLinAlgRankProfile(raw M, false) == {1,2,3,5})
   L = solve(M, b)
   assert(M*L - b  == 0)

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc3.m2
@@ -6,64 +6,6 @@ document { Key => {(numRows, Matrix),(numRows, MutableMatrix),numRows},
 document { Key => {(numColumns, Matrix),(numColumns, MutableMatrix),numColumns},
      Headline => "number of columns in a matrix or mutable matrix",
      Usage => "numColumns m", Inputs => { "m" }, Outputs => {{ "the number of columns in ", TT "m" }}}
-document { Key => {mutableMatrix,
-	  (mutableMatrix, MutableMatrix),
-	  (mutableMatrix, Matrix),
-	  (mutableMatrix, List),
-	  (mutableMatrix, Ring, List),
-	  (mutableMatrix, RingFamily, List),
-	  [mutableMatrix, Dense]},
-     Headline => "make a mutable matrix",
-     Usage => "mutableMatrix m",
-     Inputs => { "m" => {ofClass{Matrix, MutableMatrix, List}},
-	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
-	  },
-     Outputs => {{ "a new mutable matrix whose entries are obtained from ", TT "m", ".  If ", TT "m", " is a list, it should
-	       be a doubly nested list (table) of ring elements, all from the same ring." }},
-     EXAMPLE lines ///
-     	  f = mutableMatrix {{1,2,3,4}}
-	  f_(0,2)
-	  f_(0,2) = 33
-	  f
-	  R = QQ[a..z]
-	  mutableMatrix genericMatrix(R,3,3)
-     ///
-     }
-document { Key => {(mutableMatrix, Ring, ZZ, ZZ),(mutableMatrix, RingFamily, ZZ, ZZ) },
-     Headline => "make a mutable matrix filled with zeroes",
-     Usage => "mutableMatrix(R,nrows,ncols)",
-     Inputs => { "R",
-	          "nrows",
-		  "ncols",
-	  	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
-		  },
-     Outputs => {{"an ", TT "nrows", " by ", TT "ncols", " mutable matrix filled with zeroes from the ring ", TT "R" }},
-     EXAMPLE lines ///
-         m = mutableMatrix(QQ,10,20)
-	 m_(5,5) = 11/13
-	 m
-     ///,
-     SeeAlso => {mutableIdentity, mutableMatrix}
-     }
-document { Key => {(mutableIdentity, Ring, ZZ),(mutableIdentity, RingFamily, ZZ),
-	  [mutableIdentity,Dense],
-	  mutableIdentity},
-     Headline => "make a mutable identity matrix",
-     Usage => "mutableIdentity(R,nrows)",
-     Inputs => { "R",
-	  "nrows",
-	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
-	  },
-     Outputs => {
-	  MutableMatrix => {"an ", TT "nrows", " by ", TT "nrows", " mutable identity matrix filled with elements of the ring ", TT "R" }},
-     EXAMPLE lines ///
-         m = mutableIdentity(QQ,10)
-	 m_(5,5) = 11/13
-	 m
-     ///,
-     SeeAlso => {mutableMatrix}
-     }
-
 document { Key => centerString,
      Headline => "center a string or net",
      Usage => "centerString(wid,s)",

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_mutablematrices.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_mutablematrices.m2
@@ -1,396 +1,498 @@
-document {
-     Key => "row and column operations",
-     "The usual row and column operations apply to 
-     mutable matrices.  These are:",
-     Subnodes => {
-	  TO numRows,
-	  TO rowAdd,
-	  TO rowSwap,
-	  TO rowPermute,
-	  TO rowMult,
-	  TO numColumns,
-	  TO columnAdd,
-	  TO columnSwap,
-	  TO columnPermute,
-	  TO columnMult,
-	  },
-     }
+doc ///
+  Key
+    "row and column operations"
+  Description
+    Text
+      The usual row and column operations apply to mutable matrices.
+      These are:
+  Subnodes
+    numRows
+    rowAdd
+    rowSwap
+    rowPermute
+    rowMult
+    numColumns
+    columnAdd
+    columnSwap
+    columnPermute
+    columnMult
+///
 
-document {
-     Key => "mutable matrices",
-     "To and from matrices:",
-     EXAMPLE {
-	  "m = matrix{{1,2,3},{4,5,6}}",
-	  "n = mutableMatrix m",
-	  "m2 = matrix n",
-	  "m2 - m == 0"
-	  },
-     "Modifying and accessing entries.  Remember that the upper left
-     entry is (0,0), not (1,1)!",
-     EXAMPLE {
-	  "n_(0,0) = 212314323",
-	  "n_(0,0)",
-	  "n"
-	  },
-     "Number of rows, columns, and the ring:",
-     EXAMPLE {
-	  "numrows n",
-	  "numColumns n",
-	  "numcols n",
-	  "ring n"
-	  },
-     PARA{},
-     TO "row and column operations",
-     PARA{},
-     "Some other methods for creating mutable matrices.",
-     EXAMPLE {
-	  "mutableIdentity(RR_100,5)",
-	  "mutableMatrix(QQ,3,5)",
-	  "randomMutableMatrix(4,4,.5,100)"
-	  },
-     Subnodes => {
-	 TO MutableMatrix,
-	 TO mutableMatrix,
-	 TO (mutableMatrix, Ring, ZZ, ZZ),
-	 TO mutableIdentity,
-	 TO "MutableMatrix _ Sequence = Thing",
-	 TO "row and column operations",
-	 TO fillMatrix,
-	 TO (randomMutableMatrix, ZZ, ZZ, RR, ZZ),
-	 -- TODO: move these to linear algebra node?
-	 TO nullSpace,
-	 TO reducedRowEchelonForm,
-	 TO rowRankProfile,
-	 TO columnRankProfile,
-         }
-     }
+doc ///
+  Key
+    "mutable matrices"
+  Description
+    Text
+      To and from matrices:
+    Example
+      m = matrix{{1,2,3},{4,5,6}}
+      n = mutableMatrix m
+      m2 = matrix n
+      m2 - m == 0
+    Text
+      Modifying and accessing entries.  Remember that the upper left entry is
+      (0,0), not (1,1)!
+    Example
+      n_(0,0) = 212314323
+      n_(0,0)
+      n
+    Text
+      Number of rows, columns, and the ring:
+    Example
+      numrows n
+      numColumns n
+      numcols n
+      ring n
+    Text
+      @TO "row and column operations"@
+    Text
+      Some other methods for creating mutable matrices.
+    Example
+      mutableIdentity(RR_100,5)
+      mutableMatrix(QQ,3,5)
+      randomMutableMatrix(4,4,.5,100)
+  Subnodes
+    MutableMatrix
+    mutableMatrix
+    (mutableMatrix, Ring, ZZ, ZZ)
+    mutableIdentity
+    "MutableMatrix _ Sequence = Thing"
+    "row and column operations"
+    fillMatrix
+    (randomMutableMatrix, ZZ, ZZ, RR, ZZ)
+    -- TODO: move these to linear algebra node?
+    nullSpace
+    reducedRowEchelonForm
+    rowRankProfile
+    columnRankProfile
+///
 
-document {
-     Key => MutableMatrix,
-     Headline => "the class of all mutable matrices",
-     "A mutable matrix in Macaulay2 is a rectangular array of elements
-     of a specific ring, whose entries can be modified.",
-     PARA{},
-     "A mutable matrix is different from a ", TO Matrix, " in that
-     a matrix contains degree information for the target and source of
-     the matrix, while a mutable matrix has no such information.  Also,
-     more operations are provided for matrices.",
-     PARA{},
-     "For an overview of mutable matrices, see ", TO "mutable matrices", ".",
-     PARA{},
-     "Mutable matrices can either be encoded in a sparse manner (the matrix
-     only encodes the non-zero elements), or in a dense manner (all elements
-     are stored -- even zeros).  The distinction is an option to several of
-     the routines that create mutable matrices (", TO mutableMatrix, 
-	  ", ", 
-	  TO mutableIdentity,
-     ").  
-     Certain operations over RR or CC are performed using the LAPACK library
-     and require dense encoding of matrices: ",
-     TO "LUdecomposition", ", ", TO "SVD", ", ", TO "solve", ", ", TO "eigenvalues", ", ", TO "eigenvectors", ".",
-     
-     HEADER3 "row and column operations",
-     UL {
-	  TO rowAdd,
-	  TO rowSwap,
-	  TO rowPermute,
-	  TO rowMult,
-	  TO columnAdd,
-	  TO columnSwap,
-	  TO columnPermute,
-	  TO columnMult,
-	  },
-     HEADER3 "matrix arithmetic",
-     "Many matrix arithmetic routines are only available for immutable 
-     matrices, not
-     mutable matrices.  It is necessary to use ", TO matrix, " to make
-     an immutable matrix first.",
-     }
+doc ///
+  Key
+    MutableMatrix
+  Headline
+    the class of all mutable matrices
+  Description
+    Text
+      A mutable matrix in Macaulay2 is a rectangular array of elements of a
+      specific ring, whose entries can be modified.
+    Text
+      A mutable matrix is different from a @TO Matrix@ in that a matrix
+      contains degree information for the target and source of the matrix,
+      while a mutable matrix has no such information.  Also, more operations
+      are provided for matrices.
+    Text
+      For an overview of mutable matrices, see @TO "mutable matrices"@.
+    Text
+      Mutable matrices can either be encoded in a sparse manner (the matrix
+      only encodes the non-zero elements), or in a dense manner (all elements
+      are stored -- even zeros).  The distinction is an option to several of
+      the routines that create mutable matrices (@TO mutableMatrix@,
+      @TO mutableIdentity@).  Certain operations over RR or CC are performed
+      using the LAPACK library and require dense encoding of matrices:
+      @TO "LUdecomposition"@, @TO "SVD"@, @TO "solve"@, @TO "eigenvalues"@,
+      @TO "eigenvectors"@.
+    Tree
+      :row and column operations
+        rowAdd
+        rowSwap
+        rowPermute
+        rowMult
+        columnAdd
+        columnSwap
+        columnPermute
+        columnMult
+    Text
+      @HEADER4 "matrix arithmetic"@
+    Text
+      Many matrix arithmetic routines are only available for immutable
+      matrices, not mutable matrices.  It is necessary to use @TO matrix@ to
+      make an immutable matrix first.
+///
 
 
 --- status: TODO
 --- author(s): MES
---- notes: 
+--- notes:
 
-document { 
-     Key => {rowAdd,
-	  (rowAdd,MutableMatrix,ZZ,Number,ZZ),(rowAdd,MutableMatrix,ZZ,RingElement,ZZ)},
-     Headline => "add a multiple of one row to another",
-     Usage => "rowAdd(m,i,a,j)",
-     Inputs => {
-	  "m" => MutableMatrix,
-	  "i" => ZZ,
-	  "a" => RingElement => {"in the same ring as ", TT "m"},
-	  "j" => ZZ
-          },
-     Consequences => {
-	  {"The ", TT "i", " th row of ", TT "m", 
-	  " is modified by adding ", TT "a", 
-	  " times the ", TT "j", " th 
-	  row of ", TT "m"}
-          },     
-     EXAMPLE {
-	  "R = ZZ[a..f];",
-	  "m = mutableMatrix genericMatrix(R,a,2,3)",
-	  "rowAdd(m,0,c,1)",
-	  "m"
-          },
-     SeeAlso => {"mutable matrices", "row and column operations"}
-     }
+doc ///
+  Key
+    rowAdd
+    (rowAdd, MutableMatrix, ZZ, Number, ZZ)
+    (rowAdd, MutableMatrix, ZZ, RingElement, ZZ)
+  Headline
+    add a multiple of one row to another
+  Usage
+    rowAdd(m,i,a,j)
+  Inputs
+    m:MutableMatrix
+    i:ZZ
+    a:RingElement
+      in the same ring as @TT "m"@
+    j:ZZ
+  Consequences
+    Item
+      The @TT "i"@ th row of @TT "m"@ is modified by adding @TT "a"@ times
+      the @TT "j"@ th row of @TT "m"@
+  Description
+    Example
+      R = ZZ[a..f];
+      m = mutableMatrix genericMatrix(R,a,2,3)
+      rowAdd(m,0,c,1)
+      m
+  SeeAlso
+    "mutable matrices"
+    "row and column operations"
+///
 
-document { 
-     Key => {columnAdd,(columnAdd,MutableMatrix,ZZ,Number,ZZ),
-	  (columnAdd,MutableMatrix,ZZ,RingElement,ZZ)},
-     Headline => "add a multiple of one column to another",
-     Usage => "columnAdd(m,i,a,j)",
-     Inputs => {
-	  "m" => MutableMatrix,
-	  "i" => ZZ,
-	  "a" => RingElement => {"in the same ring as ", TT "m"},
-	  "j" => ZZ
-          },
-     Consequences => {
-	  {"The ", TT "i", " th column of ", TT "m", 
-	  " is modified by adding ", TT "a", 
-	  " times the ", TT "j", " th 
-	  column of ", TT "m"}
-          },     
-     EXAMPLE {
-	  "R = ZZ[a..f];",
-	  "m = mutableMatrix genericMatrix(R,a,2,3)",
-	  "columnAdd(m,0,c,1)",
-	  "m"
-          },
-     SeeAlso => {"mutable matrices", "row and column operations"}
-     }
+doc ///
+  Key
+    columnAdd
+    (columnAdd, MutableMatrix, ZZ, Number, ZZ)
+    (columnAdd, MutableMatrix, ZZ, RingElement, ZZ)
+  Headline
+    add a multiple of one column to another
+  Usage
+    columnAdd(m,i,a,j)
+  Inputs
+    m:MutableMatrix
+    i:ZZ
+    a:RingElement
+      in the same ring as @TT "m"@
+    j:ZZ
+  Consequences
+    Item
+      The @TT "i"@ th column of @TT "m"@ is modified by adding @TT "a"@ times
+      the @TT "j"@ th column of @TT "m"@
+  Description
+    Example
+      R = ZZ[a..f];
+      m = mutableMatrix genericMatrix(R,a,2,3)
+      columnAdd(m,0,c,1)
+      m
+  SeeAlso
+    "mutable matrices"
+    "row and column operations"
+///
 
-document { 
-     Key => {rowSwap,
-	  (rowSwap,MutableMatrix,ZZ,ZZ)},
-     Headline => "interchange rows",
-     Usage => "rowSwap(m,i,j)",
-     Inputs => {
-	  "m" => MutableMatrix,
-	  "i" => ZZ,
-	  "j" => ZZ
-          },
-     Consequences => {
-	  {"Interchanges the ", TT "i", " th and ", TT "j", 
-	       " th rows of ", TT "m"}
-          },
-     EXAMPLE {
-	  "m = mutableMatrix matrix{{1,2,3},{4,5,6}}",
-	  "rowSwap(m,0,1)",
-	  "m"
-          },
-     SeeAlso => {"mutable matrices", "row and column operations"}
-     }
+doc ///
+  Key
+    rowSwap
+    (rowSwap, MutableMatrix, ZZ, ZZ)
+  Headline
+    interchange rows
+  Usage
+    rowSwap(m,i,j)
+  Inputs
+    m:MutableMatrix
+    i:ZZ
+    j:ZZ
+  Consequences
+    Item
+      Interchanges the @TT "i"@ th and @TT "j"@ th rows of @TT "m"@
+  Description
+    Example
+      m = mutableMatrix matrix{{1,2,3},{4,5,6}}
+      rowSwap(m,0,1)
+      m
+  SeeAlso
+    "mutable matrices"
+    "row and column operations"
+///
 
-document { 
-     Key => {columnSwap,
-	  (columnSwap,MutableMatrix,ZZ,ZZ)},
-     Headline => "interchange columns",
-     Usage => "columnSwap(m,i,j)",
-     Inputs => {
-	  "m" => MutableMatrix,
-	  "i" => ZZ,
-	  "j" => ZZ
-          },
-     Consequences => {
-	  {"Interchanges the ", TT "i", " th and ", TT "j", 
-	       " th columns of ", TT "m"}
-          },
-     EXAMPLE {
-	  "m = mutableMatrix matrix{{1,2,3},{4,5,6}}",
-	  "columnSwap(m,0,1)",
-	  "m"
-          },
-     SeeAlso => {"mutable matrices", "row and column operations"}
-     }
+doc ///
+  Key
+    columnSwap
+    (columnSwap, MutableMatrix, ZZ, ZZ)
+  Headline
+    interchange columns
+  Usage
+    columnSwap(m,i,j)
+  Inputs
+    m:MutableMatrix
+    i:ZZ
+    j:ZZ
+  Consequences
+    Item
+      Interchanges the @TT "i"@ th and @TT "j"@ th columns of @TT "m"@
+  Description
+    Example
+      m = mutableMatrix matrix{{1,2,3},{4,5,6}}
+      columnSwap(m,0,1)
+      m
+  SeeAlso
+    "mutable matrices"
+    "row and column operations"
+///
 
-document { 
-     Key => {rowMult,(rowMult,MutableMatrix,ZZ,Number),
-	  (rowMult,MutableMatrix,ZZ,RingElement)},
-     Headline => "multiply a row by a ring element",
-     Usage => "rowMult(m,i,a)",
-     Inputs => {
-	  "m" => MutableMatrix,
-	  "i" => ZZ,
-	  "a" => RingElement => {"in the same ring as ", TT "m"},
-          },
-     Consequences => {
-	  {"The ", TT "i", " th row of ", TT "m", 
-	  " is modified by multiplying it by ", TT "a"}
-          },     
-     EXAMPLE {
-	  "R = ZZ[a..f];",
-	  "m = mutableMatrix genericMatrix(R,a,2,3)",
-	  "rowMult(m,0,c)",
-	  "m"
-          },
-     SeeAlso => {"mutable matrices", "row and column operations"}
-     }
+doc ///
+  Key
+    rowMult
+    (rowMult, MutableMatrix, ZZ, Number)
+    (rowMult, MutableMatrix, ZZ, RingElement)
+  Headline
+    multiply a row by a ring element
+  Usage
+    rowMult(m,i,a)
+  Inputs
+    m:MutableMatrix
+    i:ZZ
+    a:RingElement
+      in the same ring as @TT "m"@
+  Consequences
+    Item
+      The @TT "i"@ th row of @TT "m"@ is modified by multiplying it by
+      @TT "a"@
+  Description
+    Example
+      R = ZZ[a..f];
+      m = mutableMatrix genericMatrix(R,a,2,3)
+      rowMult(m,0,c)
+      m
+  SeeAlso
+    "mutable matrices"
+    "row and column operations"
+///
 
-document { 
-     Key => {columnMult,(columnMult,MutableMatrix,ZZ,Number),
-	  (columnMult,MutableMatrix,ZZ,RingElement)},
-     Headline => "multiply a column by a ring element",
-     Usage => "columnMult(m,i,a)",
-     Inputs => {
-	  "m" => MutableMatrix,
-	  "i" => ZZ,
-	  "a" => RingElement => {"in the same ring as ", TT "m"},
-          },
-     Consequences => {
-	  {"The ", TT "i", " th column of ", TT "m", 
-	  " is modified by multiplying it by ", TT "a"}
-          },     
-     EXAMPLE {
-	  "R = ZZ[a..f]",
-	  "m = mutableMatrix genericMatrix(R,a,2,3)",
-	  "columnMult(m,0,c)",
-	  "m"
-          },
-     SeeAlso => {"mutable matrices", "row and column operations"}
-     }
-document { 
-     Key => {rowPermute,(rowPermute,MutableMatrix,ZZ,List)},
-     Headline => "permute some rows",
-     Usage => "rowPermute(m,i,{...})",
-     Inputs => {
-	  "m" => MutableMatrix,
-	  "i" => ZZ => "starting row",
-	  Nothing => { "a list of integers, denoting a permutation of ", TT "0..d", ", for some number ", TT "d" }
-	  },
-     Consequences => {
-	  {"If the permutation is ", TT "{p0,p1,...,pd}", ", then ", TT "m", " is modified so that
-	  the ", TT "i+j", " row becomes the ", TT "i+pj", " row of the original matrix, for ", TT "j=0..d"}
-	  },     
-     EXAMPLE {
-	  "m = mutableMatrix map(ZZ^5,ZZ^6, (i,j) -> 100*i+j)",
-	  "rowPermute(m,1,{2,0,1})"
-	  },
-     SeeAlso => {"mutable matrices", "row and column operations"}
-     }
-document { 
-     Key => {columnPermute,(columnPermute,MutableMatrix,ZZ,List)},
-     Headline => "permute some columns",
-     Usage => "columnPermute(m,i,{...})",
-     Inputs => {
-	  "m" => MutableMatrix,
-	  "i" => ZZ => "starting column",
-	  Nothing => { "a list of integers, denoting a permutation of ", TT "0..d", ", for some number ", TT "d" }
-	  },
-     Consequences => {
-	  {"If the permutation is ", TT "{p0,p1,...,pd}", ", then ", TT "m", " is modified so that
-	  the ", TT "i+j", " column becomes the ", TT "i+pj", " column of the original matrix, for ", TT "j=0..d"}
-	  },     
-     EXAMPLE {
-	  "m = mutableMatrix map(ZZ^5,ZZ^6, (i,j) -> 100*i+j)",
-	  "columnPermute(m,1,{2,0,1})"
-	  },
-     SeeAlso => {"mutable matrices", "row and column operations"} 
-     }
+doc ///
+  Key
+    columnMult
+    (columnMult, MutableMatrix, ZZ, Number)
+    (columnMult, MutableMatrix, ZZ, RingElement)
+  Headline
+    multiply a column by a ring element
+  Usage
+    columnMult(m,i,a)
+  Inputs
+    m:MutableMatrix
+    i:ZZ
+    a:RingElement
+      in the same ring as @TT "m"@
+  Consequences
+    Item
+      The @TT "i"@ th column of @TT "m"@ is modified by multiplying it by
+      @TT "a"@
+  Description
+    Example
+      R = ZZ[a..f]
+      m = mutableMatrix genericMatrix(R,a,2,3)
+      columnMult(m,0,c)
+      m
+  SeeAlso
+    "mutable matrices"
+    "row and column operations"
+///
 
-document {
-     Key => { nullSpace, (nullSpace, MutableMatrix) },
-     Headline => "find the null space of a mutable matrix",
-     Usage => "nullSpace m",
-     Inputs => {
-	  "m" => MutableMatrix => { "over ", TO "RR", " or ", TO "CC" }
-	  },
-     Outputs => {
-	  MutableMatrix => {"a mutable matrix whose columns span the null space of ", TT "m"}
-	  },
-     EXAMPLE {
-	  "m = mutableMatrix {{1.p500,1},{-2,-2}}",
-	  "nullSpace m",
-	  "precision oo"
-	  }
-     }
+doc ///
+  Key
+    rowPermute
+    (rowPermute, MutableMatrix, ZZ, List)
+  Headline
+    permute some rows
+  Usage
+    rowPermute(m,i,{...})
+  Inputs
+    m:MutableMatrix
+    i:ZZ
+      starting row
+    :List
+      a list of integers, denoting a permutation of @TT "0..d"@, for some
+      number @TT "d"@
+  Consequences
+    Item
+      If the permutation is @TT "{p0,p1,...,pd}"@, then @TT "m"@ is modified
+      so that the @TT "i+j"@ row becomes the @TT "i+pj"@ row of the original
+      matrix, for @TT "j=0..d"@
+  Description
+    Example
+      m = mutableMatrix map(ZZ^5,ZZ^6, (i,j) -> 100*i+j)
+      rowPermute(m,1,{2,0,1})
+  SeeAlso
+    "mutable matrices"
+    "row and column operations"
+///
 
-document {
-     Key => { rowRankProfile, (rowRankProfile, MutableMatrix)},
-     Headline => "find the row rank profile of a mutable matrix",
-     Usage => "rowRankProfile m",
-     Inputs => {
-	  "m" => MutableMatrix => { "over ", TO "RR", " or ", TO "CC" }
-	  },
-     Outputs => {
-	  List => {"the lexicographically smallest list of indices of linearly independent rows generating the row space of ", TT "m"}
-	  },
-     EXAMPLE "rowRankProfile mutableMatrix {{1,2,3}, {0,0,0.}, {3,4,5} }",
-     SeeAlso => { columnRankProfile }
-     }
+doc ///
+  Key
+    columnPermute
+    (columnPermute, MutableMatrix, ZZ, List)
+  Headline
+    permute some columns
+  Usage
+    columnPermute(m,i,{...})
+  Inputs
+    m:MutableMatrix
+    i:ZZ
+      starting column
+    :List
+      a list of integers, denoting a permutation of @TT "0..d"@, for some
+      number @TT "d"@
+  Consequences
+    Item
+      If the permutation is @TT "{p0,p1,...,pd}"@, then @TT "m"@ is modified
+      so that the @TT "i+j"@ column becomes the @TT "i+pj"@ column of the
+      original matrix, for @TT "j=0..d"@
+  Description
+    Example
+      m = mutableMatrix map(ZZ^5,ZZ^6, (i,j) -> 100*i+j)
+      columnPermute(m,1,{2,0,1})
+  SeeAlso
+    "mutable matrices"
+    "row and column operations"
+///
 
-document {
-     Key => { columnRankProfile, (columnRankProfile, MutableMatrix)},
-     Headline => "find the column rank profile of a mutable matrix",
-     Usage => "columnRankProfile m",
-     Inputs => {
-	  "m" => MutableMatrix => { "over ", TO "RR", " or ", TO "CC" }
-	  },
-     Outputs => {
-	  List => {"the lexicographically smallest list of indices of linearly independent columns generating the column space of ", TT "m"}
-	  },
-     EXAMPLE "columnRankProfile transpose mutableMatrix {{1,2,3}, {0,0,0.}, {3,4,5} }",
-     SeeAlso => { rowRankProfile }
-     }
+doc ///
+  Key
+    nullSpace
+    (nullSpace, MutableMatrix)
+  Headline
+    find the null space of a mutable matrix
+  Usage
+    nullSpace m
+  Inputs
+    m:MutableMatrix
+      over @TO "RR"@ or @TO "CC"@
+  Outputs
+    :MutableMatrix
+      a mutable matrix whose columns span the null space of @TT "m"@
+  Description
+    Example
+      m = mutableMatrix {{1.p500,1},{-2,-2}}
+      nullSpace m
+      precision oo
+///
 
-document { Key => {mutableMatrix,
-	  (mutableMatrix, MutableMatrix),
-	  (mutableMatrix, Matrix),
-	  (mutableMatrix, List),
-	  (mutableMatrix, Ring, List),
-	  (mutableMatrix, RingFamily, List),
-	  [mutableMatrix, Dense]},
-     Headline => "make a mutable matrix",
-     Usage => "mutableMatrix m",
-     Inputs => { "m" => {ofClass{Matrix, MutableMatrix, List}},
-	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
-	  },
-     Outputs => {{ "a new mutable matrix whose entries are obtained from ", TT "m", ".  If ", TT "m", " is a list, it should
-	       be a doubly nested list (table) of ring elements, all from the same ring." }},
-     EXAMPLE lines ///
-     	  f = mutableMatrix {{1,2,3,4}}
-	  f_(0,2)
-	  f_(0,2) = 33
-	  f
-	  R = QQ[a..z]
-	  mutableMatrix genericMatrix(R,3,3)
-     ///
-     }
-document { Key => {(mutableMatrix, Ring, ZZ, ZZ),(mutableMatrix, RingFamily, ZZ, ZZ) },
-     Headline => "make a mutable matrix filled with zeroes",
-     Usage => "mutableMatrix(R,nrows,ncols)",
-     Inputs => { "R",
-	          "nrows",
-		  "ncols",
-	  	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
-		  },
-     Outputs => {{"an ", TT "nrows", " by ", TT "ncols", " mutable matrix filled with zeroes from the ring ", TT "R" }},
-     EXAMPLE lines ///
-         m = mutableMatrix(QQ,10,20)
-	 m_(5,5) = 11/13
-	 m
-     ///,
-     SeeAlso => {mutableIdentity, mutableMatrix}
-     }
-document { Key => {(mutableIdentity, Ring, ZZ),(mutableIdentity, RingFamily, ZZ),
-	  [mutableIdentity,Dense],
-	  mutableIdentity},
-     Headline => "make a mutable identity matrix",
-     Usage => "mutableIdentity(R,nrows)",
-     Inputs => { "R",
-	  "nrows",
-	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
-	  },
-     Outputs => {
-	  MutableMatrix => {"an ", TT "nrows", " by ", TT "nrows", " mutable identity matrix filled with elements of the ring ", TT "R" }},
-     EXAMPLE lines ///
-         m = mutableIdentity(QQ,10)
-	 m_(5,5) = 11/13
-	 m
-     ///,
-     SeeAlso => {mutableMatrix}
-     }
+doc ///
+  Key
+    rowRankProfile
+    (rowRankProfile, MutableMatrix)
+  Headline
+    find the row rank profile of a mutable matrix
+  Usage
+    rowRankProfile m
+  Inputs
+    m:MutableMatrix
+      over @TO "RR"@ or @TO "CC"@
+  Outputs
+    :List
+      the lexicographically smallest list of indices of linearly independent
+      rows generating the row space of @TT "m"@
+  Description
+    Example
+      rowRankProfile mutableMatrix {{1,2,3}, {0,0,0.}, {3,4,5} }
+  SeeAlso
+    columnRankProfile
+///
+
+doc ///
+  Key
+    columnRankProfile
+    (columnRankProfile, MutableMatrix)
+  Headline
+    find the column rank profile of a mutable matrix
+  Usage
+    columnRankProfile m
+  Inputs
+    m:MutableMatrix
+      over @TO "RR"@ or @TO "CC"@
+  Outputs
+    :List
+      the lexicographically smallest list of indices of linearly independent
+      columns generating the column space of @TT "m"@
+  Description
+    Example
+      columnRankProfile transpose mutableMatrix {{1,2,3}, {0,0,0.}, {3,4,5} }
+  SeeAlso
+    rowRankProfile
+///
+
+doc ///
+  Key
+    mutableMatrix
+    (mutableMatrix, MutableMatrix)
+    (mutableMatrix, Matrix)
+    (mutableMatrix, List)
+    (mutableMatrix, Ring, List)
+    (mutableMatrix, RingFamily, List)
+    [mutableMatrix, Dense]
+  Headline
+    make a mutable matrix
+  Usage
+    mutableMatrix m
+  Inputs
+    m:{Matrix, MutableMatrix, List}
+    Dense => Boolean
+      whether the encoding of the matrix should be dense or not: see
+      @TO MutableMatrix@
+  Outputs
+    :MutableMatrix
+      a new mutable matrix whose entries are obtained from @TT "m"@.  If
+      @TT "m"@ is a list, it should be a doubly nested list (table) of ring
+      elements, all from the same ring.
+  Description
+    Example
+      f = mutableMatrix {{1,2,3,4}}
+      f_(0,2)
+      f_(0,2) = 33
+      f
+      R = QQ[a..z]
+      mutableMatrix genericMatrix(R,3,3)
+///
+
+doc ///
+  Key
+    (mutableMatrix, Ring, ZZ, ZZ)
+    (mutableMatrix, RingFamily, ZZ, ZZ)
+  Headline
+    make a mutable matrix filled with zeroes
+  Usage
+    mutableMatrix(R,nrows,ncols)
+  Inputs
+    R:{Ring, RingFamily}
+    nrows:ZZ
+    ncols:ZZ
+    Dense => Boolean
+      whether the encoding of the matrix should be dense or not: see
+      @TO MutableMatrix@
+  Outputs
+    :MutableMatrix
+      an @TT "nrows"@ by @TT "ncols"@ mutable matrix filled with zeroes from
+      the ring @TT "R"@
+  Description
+    Example
+      m = mutableMatrix(QQ,10,20)
+      m_(5,5) = 11/13
+      m
+  SeeAlso
+    mutableIdentity
+    mutableMatrix
+///
+
+doc ///
+  Key
+    mutableIdentity
+    (mutableIdentity, Ring, ZZ)
+    (mutableIdentity, RingFamily, ZZ)
+    [mutableIdentity, Dense]
+  Headline
+    make a mutable identity matrix
+  Usage
+    mutableIdentity(R,nrows)
+  Inputs
+    R:{Ring, RingFamily}
+    nrows:ZZ
+    Dense => Boolean
+      whether the encoding of the matrix should be dense or not: see
+      @TO MutableMatrix@
+  Outputs
+    :MutableMatrix
+      an @TT "nrows"@ by @TT "nrows"@ mutable identity matrix filled with
+      elements of the ring @TT "R"@
+  Description
+    Example
+      m = mutableIdentity(QQ,10)
+      m_(5,5) = 11/13
+      m
+  SeeAlso
+    mutableMatrix
+///

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_mutablematrices.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_mutablematrices.m2
@@ -412,15 +412,21 @@ doc ///
     (mutableMatrix, MutableMatrix)
     (mutableMatrix, Matrix)
     (mutableMatrix, List)
+    (mutableMatrix, Number)
+    (mutableMatrix, RingElement)
     (mutableMatrix, Ring, List)
+    (mutableMatrix, Ring, Number)
+    (mutableMatrix, Ring, RingElement)
     (mutableMatrix, RingFamily, List)
+    (mutableMatrix, RingFamily, Number)
+    (mutableMatrix, RingFamily, RingElement)
     [mutableMatrix, Dense]
   Headline
     make a mutable matrix
   Usage
     mutableMatrix m
   Inputs
-    m:{Matrix, MutableMatrix, List}
+    m:{Matrix, MutableMatrix, List, Number, RingElement}
     Dense => Boolean
       whether the encoding of the matrix should be dense or not: see
       @TO MutableMatrix@
@@ -437,6 +443,15 @@ doc ///
       f
       R = QQ[a..z]
       mutableMatrix genericMatrix(R,3,3)
+    Text
+      If the argument is a number or a ring element, then the result is a
+      $1\times 1$ mutable matrix.  The ring may be given as well, as the
+      first argument.
+    Example
+      mutableMatrix 5
+      ring oo
+      mutableMatrix(RR, 5)
+      ring oo
 ///
 
 doc ///

--- a/M2/Macaulay2/packages/Macaulay2Doc/doc_mutablematrices.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/doc_mutablematrices.m2
@@ -336,3 +336,61 @@ document {
      EXAMPLE "columnRankProfile transpose mutableMatrix {{1,2,3}, {0,0,0.}, {3,4,5} }",
      SeeAlso => { rowRankProfile }
      }
+
+document { Key => {mutableMatrix,
+	  (mutableMatrix, MutableMatrix),
+	  (mutableMatrix, Matrix),
+	  (mutableMatrix, List),
+	  (mutableMatrix, Ring, List),
+	  (mutableMatrix, RingFamily, List),
+	  [mutableMatrix, Dense]},
+     Headline => "make a mutable matrix",
+     Usage => "mutableMatrix m",
+     Inputs => { "m" => {ofClass{Matrix, MutableMatrix, List}},
+	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
+	  },
+     Outputs => {{ "a new mutable matrix whose entries are obtained from ", TT "m", ".  If ", TT "m", " is a list, it should
+	       be a doubly nested list (table) of ring elements, all from the same ring." }},
+     EXAMPLE lines ///
+     	  f = mutableMatrix {{1,2,3,4}}
+	  f_(0,2)
+	  f_(0,2) = 33
+	  f
+	  R = QQ[a..z]
+	  mutableMatrix genericMatrix(R,3,3)
+     ///
+     }
+document { Key => {(mutableMatrix, Ring, ZZ, ZZ),(mutableMatrix, RingFamily, ZZ, ZZ) },
+     Headline => "make a mutable matrix filled with zeroes",
+     Usage => "mutableMatrix(R,nrows,ncols)",
+     Inputs => { "R",
+	          "nrows",
+		  "ncols",
+	  	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
+		  },
+     Outputs => {{"an ", TT "nrows", " by ", TT "ncols", " mutable matrix filled with zeroes from the ring ", TT "R" }},
+     EXAMPLE lines ///
+         m = mutableMatrix(QQ,10,20)
+	 m_(5,5) = 11/13
+	 m
+     ///,
+     SeeAlso => {mutableIdentity, mutableMatrix}
+     }
+document { Key => {(mutableIdentity, Ring, ZZ),(mutableIdentity, RingFamily, ZZ),
+	  [mutableIdentity,Dense],
+	  mutableIdentity},
+     Headline => "make a mutable identity matrix",
+     Usage => "mutableIdentity(R,nrows)",
+     Inputs => { "R",
+	  "nrows",
+	  Dense => {"whether the encoding of the matrix should be dense or not: see ", TO MutableMatrix}
+	  },
+     Outputs => {
+	  MutableMatrix => {"an ", TT "nrows", " by ", TT "nrows", " mutable identity matrix filled with elements of the ring ", TT "R" }},
+     EXAMPLE lines ///
+         m = mutableIdentity(QQ,10)
+	 m_(5,5) = 11/13
+	 m
+     ///,
+     SeeAlso => {mutableMatrix}
+     }

--- a/M2/Macaulay2/tests/normal/mutmat.m2
+++ b/M2/Macaulay2/tests/normal/mutmat.m2
@@ -83,3 +83,11 @@ assert Equation(M^{-1}, mutableMatrix {{4, 5, 6}})
 A = mutableMatrix {{10}}
 B = submatrix(A, {0}, {0})
 assert(hash A != hash B)
+
+-- 1 by 1 constructors
+S = QQ[t]
+assert Equation(mutableMatrix 5, mutableMatrix {{5}})
+assert Equation(mutableMatrix t, mutableMatrix {{t}})
+assert Equation(mutableMatrix(QQ, 5), mutableMatrix {{5/1}})
+assert Equation(mutableMatrix(S, t), mutableMatrix {{t}})
+assert Equation(mutableMatrix(RR, 5), mutableMatrix {{5.}})


### PR DESCRIPTION
A few semi-related things that all grew out of fixing the first thing:

## Rank errors

According to `mutable-matrix.h`:

```c++
/**
   returns the rank of the matrix M.  If 'rank' is not defined on this type of
   matrix, then returns -1 (and an error message is given).
 */
long rawLinAlgRank(MutableMatrix *M);
```

However, no such error message is given, and we just get -1!

```m2
i1 : rank mutableMatrix(ZZ/101, {{1}}, Dense => false)

o1 = -1
```

So I added a little check in the interpreter -- if we get -1, return the last engine error instead, so now we have:

```m2
i1 : rank mutableMatrix(ZZ/101, {{1}}, Dense => false)
stdio:1:4:(3):[1]: error: 'rank' not implemented for this kind of matrix over this ring
```

## Constructor methods

While testing the above, I was sad that I had to type `{{` and `}}`' when constructing a $1\times 1$ mutable matrix and wanted the `Number`/`RingElement` constructors we have for immutable matrices.  So I'm proposing 6 new methods:

```m2
i1 : mutableMatrix 2 -- mutableMatrix(Number)

o1 = | 2 |

o1 : MutableMatrix

i2 : mutableMatrix(QQ, 2) -- mutableMatrix(Ring, Number)

o2 = | 2 |

o2 : MutableMatrix

i3 : mutableMatrix(RR, 2) -- mutableMatrix(RingFamily, Number)

o3 = | 2 |

o3 : MutableMatrix

i4 : R = QQ[x]; mutableMatrix x -- mutableMatrix(RingElement)

o5 = | x |

o5 : MutableMatrix

i6 : mutableMatrix(R[y], x) -- mutableMatrix(Ring, RingElement)

o6 = | x |

o6 : MutableMatrix
```

There's also `mutableMatrix(RingFamily, RingElement)`, which won't do anything now except raise errors about promoting.  But it might work in the future (e.g., after adding $p$-adics to the engine).

## Documentation updates

When I went to document the new constructor methods, I saw that a bunch of the mutable matrix docs were in the old format and in the poorly named `doc3.m2` file.  So I moved them and had Claude update them to *SimpleDoc* format.

## `AfterPrint` method

While writing this pull request description, I realized that mutable matrices don't tell us the size or what ring we're working over like we get for immutable matrices.  That's a great use for `AfterPrint` methods so we just use the `Matrix` one:

```m2
i1 : mutableMatrix(QQ[x,y,z,w], 6, 7)

o1 = 0

                                6                  7
o1 : MutableMatrix (QQ[x..z, w])  <-- (QQ[x..z, w])
```



## :robot: AI Disclosure :robot:

I wrote the actual d and m2 code, but got lazy and had Claude do the boring stuff (documentation and tests) lol.