### PR TITLE
Remove some unused code from Core

### DIFF
--- a/M2/Macaulay2/m2/methods.m2
+++ b/M2/Macaulay2/m2/methods.m2
@@ -281,8 +281,7 @@ setupMethods((), {
 	  presentation, dismiss, precision, 
 	  norm, clean, fraction, part,
 	  hasEngineLinearAlgebra, nullSpace,
-      isBasicMatrix, basicDet, basicInverse, basicKernel, basicRank, basicSolve, basicRankProfile,
-      minimize
+	  isBasicMatrix, basicDet, basicInverse, basicRank, minimize
 	  })
 
 gradedModule = method(Dispatch => Thing)

--- a/M2/Macaulay2/m2/quotring.m2
+++ b/M2/Macaulay2/m2/quotring.m2
@@ -109,31 +109,7 @@ ZZp Ideal := opts -> (I) -> (
 	  S))
 
 initializeEngineLinearAlgebra = method()
-initializeEngineLinearAlgebra Ring := (R) -> (
-    R#"EngineLinearAlgebra" = true;
-    R.determinant = (f) -> (
-        -- The following information 
-        -- f is a Matrix in the ring R
-        -- f should be a square matrix, with free modules for both source and target
-         m := mutableMatrix(f, Dense=>true);
-         new R from rawLinAlgDeterminant raw m
-         );
-    R.inverse = (f) -> (
-        A := mutableMatrix(f, Dense=>true);
-        R := ring A;
-        if numRows A =!= numColumns A then error "expected square matrix";
-        matrix map(R,rawLinAlgInverse(raw A))
-        );
-    R#"solveLinear" = (f,g) -> (
-        -- solve f*X = g
-        if ring f =!= ring g then error "expected same base rings";
-        A := mutableMatrix(f, Dense=>true);
-        B := mutableMatrix(g, Dense=>true);
-        R := ring A;
-        result := map(R,rawLinAlgSolve(raw A,raw B));
-        matrix result
-        );
-    )
+initializeEngineLinearAlgebra Ring := (R) -> R#"EngineLinearAlgebra" = true
 
 isBasicMatrix Matrix := (f) -> isFreeModule source f and isFreeModule target f
 basicDet Matrix := (f) -> (


### PR DESCRIPTION
We remove a few unused method functions that aren't exported and never had any methods installed, as well as some unused key/value pairs in ring types that are created in `initializeEngineLinearAlgebra`.

## :robot: AI Disclosure :robot:

Claude pointed these out while I was looking at a slightly related issue, but I did all the removing myself.