### PR TITLE
Fix #732

### DIFF
--- a/M2/Macaulay2/e/groebner-computations/gb-default.cpp
+++ b/M2/Macaulay2/e/groebner-computations/gb-default.cpp
@@ -2671,8 +2671,6 @@ Computation /* or null */ *gbA::set_hilbert_function(const RingElement *hf)
 {
   // TODO Problems here:
   //  -- check that the ring is correct
-  //  -- if the computation has already been started, this will fail
-  //     So probably an error should be given, and 0 returned in this case.
 
   // We may only use the Hilbert function if syzygies are not being collected
   // since otherwise we will miss syzygies
@@ -2690,7 +2688,10 @@ Computation /* or null */ *gbA::set_hilbert_function(const RingElement *hf)
       hf_diff = RingElement::make_raw(hf->get_ring(), ZERO_RINGELEM);
       use_hilb = true;
       hilb_new_elems = true;
-      state = STATE_HILB;
+      // A computation stopped mid-degree must first finish auto-reduction and
+      // create pairs for its new elements.  Those phases naturally lead to
+      // STATE_HILB; only a computation at a degree boundary must be redirected.
+      if (state == STATE_NEWDEGREE) state = STATE_HILB;
     }
 
   return this;

--- a/M2/Macaulay2/tests/normal/gb-hilbert.m2
+++ b/M2/Macaulay2/tests/normal/gb-hilbert.m2
@@ -48,3 +48,11 @@ f = x^4 + y^4 + z^4;
 R = S / ideal(f);
 I = ideal(x^3, x^2+y^2);
 integralClosure(I) -- crashed, now ok.
+
+-- git issue #732: resume a min-gens computation with a Hilbert hint
+R = QQ[a..k]
+I = trim ideal(a*b+c*d, a*e+b*f+c*g+d*h)
+M = cokernel gens I
+use degreesRing R
+M.cache.poincare = 1-2*T^2+T^4
+assert(dim I == 9)

--- a/M2/Macaulay2/tests/normal/gb-hilbert.m2
+++ b/M2/Macaulay2/tests/normal/gb-hilbert.m2
@@ -1,5 +1,4 @@
 -- test of canUseHilbertHint, Hilbert hint code with M2.
-restart
 R1 = ZZ/101[x,y,z, Degrees => {1,2,3}];
 assert canUseHilbertHint R1
 R2 = ZZ[x,y,z];
@@ -22,7 +21,7 @@ assert not canUseHilbertHint I
 Rlex = ZZ/101[a,b,c,d, Degrees => {2:{1,0}, 2:{0,1}}, MonomialOrder => Lex]
 Ilex = sub(I, Rlex)
 gblex = gens gb(Ilex, Hilbert => hf) -- gives warning, but no error
-assert(numgens ideal gblex == 37) -- happens with given random seed, at least....
+assert(ideal gblex == Ilex)
 
 -- git issue # 3937
 p = 32003
@@ -37,7 +36,7 @@ S = R/(x^3 - y^2*z)
 T = S/(y*w^2 - z*x^2)
 f = map(T, S)
 assert not isWellDefined inverse f -- kernel of a non-welldefined ring map is undefined behavior, but should not crash.
-(ans, err) = trap kernel inverse f -- internal error: incorrect Hilbert function given, aborting, crashses.
+(ans, err) = trap kernel inverse f -- used to abort when given an incorrect Hilbert function
 assert(ans === null)
 -- now it doesn't crash, but the error message is not so good either...
 assert(toString err === "incorrect Hilbert function given")


### PR DESCRIPTION
The recent Claude comments prompted me to revisit #732. The fix is actually quite easy, it's one line in the c++ code that makes sure the GB computation remains in the correct state.
That being said, adding a test in `gb-hilbert.m2` and trying to run it led to a massive headache that only codex could help me out of: first `gb-hilbert.m2` started with `restart` which means `ctest` never actually ran it; second, after removing `restart`, a test failed because it was based on some given value of a random seed (and when I run it with `ctest` I get 36 rather than 37...) I replaced it with a more reasonable test. Finally, a test had the comment `internal error` which is a no no for `ctest`, so that needed rewriting as well. Phew.
### AI DISCLOSURE
see above
