### PR TITLE
Improvements to Ring_List

### DIFF
--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -16,6 +16,7 @@ header "// TODO: break apart this file so each piece includes only one:
 #include <interface/freemodule.h>
 #include <interface/groebner.h>
 #include <interface/matrix.h>
+#include <interface/monomial.h>
 #include <interface/monomial-ideal.h>
 #include <interface/mutable-matrix.h>
 #include <interface/random.h>
@@ -150,15 +151,6 @@ export rawSparseListFormMonomial(e:Expr):Expr := (
      );
 setupfun("rawSparseListFormMonomial",rawSparseListFormMonomial);
 
--- rawMakeMonomial(m:array(int)):RawMonomialOrNull := Ccode(returns,"
---      try { return EngineMonomial::make(m); }
---      catch (const exc::engine_error& e) { ERROR(e.what()); return NULL; }
---      "
---      -- /* Takes an array of the form [n, v1, e1, v2, e2, ..., vn, en]
---      --    and returns the monomial v1^e1*v2^e2*...vn^en.
---      --    ASSUMPTION: v1 > v2 > ... > vn >= 0, each en is not 0. */
---      );
-
 export rawMakeMonomial(e:Expr):Expr := (
      -- accepts a list of pairs : {(2, 1), (3, 7), (5, 4)}
      -- we reverse the list before giving it to the engine
@@ -166,12 +158,10 @@ export rawMakeMonomial(e:Expr):Expr := (
      is l:List do (
 	  when isSequenceOfPairsOfSmallIntegers(l.v) 
 	  is s:string do WrongArg(s) 
-	  else (
-	       ret := RawMonomialOrNull(null());
-	       Ccode(void, "
-		    try { ",ret," = EngineMonomial::make(",getReverseSequenceOfPairsOfSmallIntegers(l.v),"); }
-     		    catch (const exc::engine_error& e) { ERROR(e.what()); }");
-	       toExpr(ret)))
+	  else toExpr(Ccode(RawMonomialOrNull,
+                            "rawMakeMonomial(",
+                            getReverseSequenceOfPairsOfSmallIntegers(l.v),
+                            ")")))
      else WrongArg("a list of pairs of integers"));
 setupfun("rawMakeMonomial",rawMakeMonomial);
 

--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -1474,6 +1474,15 @@ export rawFraction(e:Expr):Expr := (
      else WrongNumArgs(3));
 setupfun("rawFraction",rawFraction);
 
+export rawSum(e:Expr):Expr := (
+    if isSequenceOfRingElements(e)
+    then toExpr(Ccode(RawRingElementOrNull,
+                      "rawSum(",
+                      getSequenceOfRingElements(e),
+                      ")"))
+    else WrongArg("a sequence of ring elements"));
+setupfun("rawSum", rawSum);
+
 export rawFactor(e:Expr):Expr := (
      when e
      is x:RawRingElementCell do (

--- a/M2/Macaulay2/d/interface.dd
+++ b/M2/Macaulay2/d/interface.dd
@@ -165,6 +165,19 @@ export rawMakeMonomial(e:Expr):Expr := (
      else WrongArg("a list of pairs of integers"));
 setupfun("rawMakeMonomial",rawMakeMonomial);
 
+export rawMakeMonomialFromExponents(e:Expr):Expr := (
+    -- accepts a list of exponents, e.g., {3,4,5} for x^3*y^4*z^5
+    when e
+    is l:List do (
+        if isSequenceOfSmallIntegers(l.v)
+        then toExpr(Ccode(RawMonomialOrNull,
+                          "rawMakeMonomialFromExponents(",
+                          getSequenceOfSmallIntegers(l.v),
+                          ")"))
+        else WrongArg("a list of small integers"))
+    else WrongArg("a list of small integers"));
+setupfun("rawMakeMonomialFromExponents", rawMakeMonomialFromExponents);
+
 export rawMonomialIsOne(e:Expr):Expr := (
      when e is s:Sequence 
      do if length(s) == 2 

--- a/M2/Macaulay2/e/CMakeLists.txt
+++ b/M2/Macaulay2/e/CMakeLists.txt
@@ -134,6 +134,8 @@ set(CPPONLYFILES
   interface/matrix.h
   interface/monoid.cpp
   interface/monoid.h
+  interface/monomial.cpp
+  interface/monomial.h
   interface/monomial-ideal.cpp
   interface/monomial-ideal.h
   interface/monomial-ordering.cpp

--- a/M2/Macaulay2/e/M2FreeAlgebra.cpp
+++ b/M2/Macaulay2/e/M2FreeAlgebra.cpp
@@ -319,8 +319,12 @@ void M2FreeAlgebra::makeTerm(Poly& result, const ring_elem a, const_varpower mon
   monoid().fromMonomial(monom, result.getMonomInserter());
 }
 
-ring_elem M2FreeAlgebra::makeTerm(const ring_elem a, const_varpower monom) const
+ring_elem M2FreeAlgebra::makeTerm(const Ring *coeffR,
+                                  const ring_elem a,
+                                  const_varpower monom) const
 {
+  if (coefficientRing() != coeffR)
+    throw exc::engine_error("wrong coefficient ring");
   auto result = new Poly;
   makeTerm(*result, a, monom);
   return reinterpret_cast<Nterm*>(result);

--- a/M2/Macaulay2/e/M2FreeAlgebra.hpp
+++ b/M2/Macaulay2/e/M2FreeAlgebra.hpp
@@ -44,8 +44,6 @@ public:
 
   virtual ring_elem from_coefficient(const ring_elem a) const = 0;
 
-  virtual ring_elem makeTerm(const ring_elem a, const_varpower monom) const = 0;
-
   // casting functions
   virtual const M2FreeAlgebraOrQuotient * cast_to_M2FreeAlgebraOrQuotient()  const { return this; }
   virtual       M2FreeAlgebraOrQuotient * cast_to_M2FreeAlgebraOrQuotient()        { return this; }
@@ -165,8 +163,9 @@ public:
   void debug_display(const Poly* f) const;
   void debug_display(const ring_elem ff) const;
 
-  ring_elem makeTerm(const ring_elem a, const_varpower monom) const;
-
+  ring_elem makeTerm(const Ring *coeffR,
+                     const ring_elem a,
+                     const_varpower monom) const override;
   void makeTerm(Poly& result, const ring_elem a, const_varpower monom) const;
 };
 

--- a/M2/Macaulay2/e/M2FreeAlgebraQuotient.cpp
+++ b/M2/Macaulay2/e/M2FreeAlgebraQuotient.cpp
@@ -299,8 +299,12 @@ void M2FreeAlgebraQuotient::makeTerm(Poly& result, const ring_elem a, const_varp
   freeAlgebraQuotient().normalizeInPlace(result);
 }
 
-ring_elem M2FreeAlgebraQuotient::makeTerm(const ring_elem a, const_varpower monom) const
+ring_elem M2FreeAlgebraQuotient::makeTerm(const Ring *coeffR,
+                                          const ring_elem a,
+                                          const_varpower monom) const
 {
+  if (coefficientRing() != coeffR)
+    throw exc::engine_error("wrong coefficient ring");
   Poly* f = new Poly;
   makeTerm(*f, a, monom);
   return ring_elem(reinterpret_cast<void*>(f));

--- a/M2/Macaulay2/e/M2FreeAlgebraQuotient.hpp
+++ b/M2/Macaulay2/e/M2FreeAlgebraQuotient.hpp
@@ -130,9 +130,11 @@ public:
   void debug_display(const Poly* f) const;
   void debug_display(const ring_elem ff) const;
 
-  void makeTerm(Poly& result, const ring_elem a, const int* monom) const;
-  
-  ring_elem makeTerm(const ring_elem a, const int* monom) const;
+  void makeTerm(Poly& result, const ring_elem a, const_varpower monom) const;
+  ring_elem makeTerm(const Ring *coeffR,
+                     const ring_elem a,
+                     const_varpower monom) const override;
+
   // 'monom' is in 'varpower' format
   // [2n+1 v1 e1 v2 e2 ... vn en], where each ei > 0, (in 'varpower' format)
 };

--- a/M2/Macaulay2/e/Makefile.files.in
+++ b/M2/Macaulay2/e/Makefile.files.in
@@ -200,6 +200,7 @@ COMMANDS = \
 	interface/m2-types \
 	interface/matrix \
 	interface/monoid \
+	interface/monomial \
 	interface/monomial-ideal \
 	interface/monomial-ordering \
 	interface/mutable-matrix \

--- a/M2/Macaulay2/e/interface/monomial.cpp
+++ b/M2/Macaulay2/e/interface/monomial.cpp
@@ -1,0 +1,14 @@
+#include "interface/monomial.h"
+
+#include "error.h"
+#include "exceptions.hpp"
+
+EngineMonomial *rawMakeMonomial(M2_arrayint m)
+{
+  try {
+    return EngineMonomial::make(m);
+  } catch (const exc::engine_error& e) {
+    ERROR(e.what());
+    return nullptr;
+  }
+}

--- a/M2/Macaulay2/e/interface/monomial.cpp
+++ b/M2/Macaulay2/e/interface/monomial.cpp
@@ -12,3 +12,15 @@ EngineMonomial *rawMakeMonomial(M2_arrayint m)
     return nullptr;
   }
 }
+
+EngineMonomial *rawMakeMonomialFromExponents(M2_arrayint exp)
+{
+  try {
+    varpower::Vector vp;
+    varpower::from_expvector(exp->len, exp->array, vp);
+    return EngineMonomial::make(vp.data());
+  } catch (const exc::engine_error &e) {
+    ERROR(e.what());
+    return nullptr;
+  }
+}

--- a/M2/Macaulay2/e/interface/monomial.h
+++ b/M2/Macaulay2/e/interface/monomial.h
@@ -4,5 +4,6 @@
 #include "monomials/monomial.hpp"
 
 EngineMonomial *rawMakeMonomial(M2_arrayint m);
+EngineMonomial *rawMakeMonomialFromExponents(M2_arrayint m);
 
 #endif /* M2_INTERFACE_MONOMIAL_H_ */

--- a/M2/Macaulay2/e/interface/monomial.h
+++ b/M2/Macaulay2/e/interface/monomial.h
@@ -1,0 +1,8 @@
+#ifndef M2_INTERFACE_MONOMIAL_H_
+#define M2_INTERFACE_MONOMIAL_H_
+
+#include "monomials/monomial.hpp"
+
+EngineMonomial *rawMakeMonomial(M2_arrayint m);
+
+#endif /* M2_INTERFACE_MONOMIAL_H_ */

--- a/M2/Macaulay2/e/interface/ring.cpp
+++ b/M2/Macaulay2/e/interface/ring.cpp
@@ -511,7 +511,13 @@ const Ring *rawSchurSnRing(const Ring *A, int n)
 
 const Ring /* or null */ *rawTowerRing1(long charac, M2_ArrayString names)
 {
-  return Tower::create(static_cast<int>(charac), names);
+  try {
+    return Tower::create(static_cast<int>(charac), names);
+  }
+  catch (const exc::engine_error& e) {
+    ERROR(e.what());
+    return nullptr;
+  }
 }
 
 const Ring /* or null */ *rawTowerRing2(const Ring *R1,

--- a/M2/Macaulay2/e/interface/ringelement.cpp
+++ b/M2/Macaulay2/e/interface/ringelement.cpp
@@ -918,6 +918,36 @@ const RingElement /* or null */ *IM2_RingElement_fraction(const Ring *R,
   }
 }
 
+const RingElement /* or null */ *rawSum(const engine_RawRingElementArray terms)
+{
+  try {
+    if (terms->len > 0) {
+      const Ring *R = terms->array[0]->get_ring();
+
+      for (int i = 1; i < terms->len; ++i) {
+        if (terms->array[i]->get_ring() != R) {
+          ERROR("expected terms from the same ring");
+          return nullptr;
+        }
+      }
+
+      SumCollector *H = R->make_SumCollector();
+      for (int i = 0; i < terms->len; ++i)
+          H->add(terms->array[i]->get_value());
+
+      RingElement *result = RingElement::make_raw(R, H->getValue());
+      delete H;
+      return result;
+    } else {
+      ERROR("expected at least one ring element");
+      return nullptr;
+    }
+  } catch (const exc::engine_error& e) {
+    ERROR(e.what());
+    return nullptr;
+  }
+}
+
 gmp_ZZorNull rawSchurDimension(const RingElement *f)
 {
   try

--- a/M2/Macaulay2/e/interface/ringelement.cpp
+++ b/M2/Macaulay2/e/interface/ringelement.cpp
@@ -529,36 +529,14 @@ IM2_RingElement_homogenize(const RingElement *a, int v, M2_arrayint wts)
 const RingElement /* or null */ *IM2_RingElement_term(const Ring *R,
                                                       const RingElement *a,
                                                       const EngineMonomial *m)
-/* R must be a polynomial ring, and 'a' an element of the
-   coefficient ring of R.  Returns a*m, if this is a valid
-   element of R.  Returns NULL if not (with an error message). */
+/* 'a' an element of the coefficient ring of R.  Returns a*m, if this is a
+   valid element of R.  Returns NULL if not (with an error message).
+*/
 {
   try {
-    const PolynomialRing *P = R->cast_to_PolynomialRing();
-    if (P != nullptr)
-      {
-        int nvars0 = P->n_vars();
-        const PolynomialRing *K = a->get_ring()->cast_to_PolynomialRing();
-        if (K != nullptr && K != P->getCoefficients()) nvars0 -= K->n_vars();
-        exponents_t exp = newarray_atomic(int, nvars0);
-        varpower::to_expvector(nvars0, m->ints(), exp);
-        ring_elem val = P->make_logical_term(a->get_ring(), a->get_value(), exp);
-        return RingElement::make_raw(R,val);
-      }
-    auto Q = dynamic_cast<const M2FreeAlgebraOrQuotient *>(R);
-    if (Q != nullptr)
-      {
-        if (Q->coefficientRing() != a->get_ring())
-          {
-            ERROR("wrong coefficient ring");
-            return nullptr;
-          }
-        return RingElement::make_raw(Q,
-                                     Q->makeTerm(a->get_value(),
-                                                 m->ints()));
-      }
-    ERROR("requires a polynomial ring");
-    return nullptr;
+    return RingElement::make_raw(R, R->makeTerm(a->get_ring(),
+                                                a->get_value(),
+                                                m->ints()));
   }
   catch (exc::engine_error& e) {
     ERROR(e.what());

--- a/M2/Macaulay2/e/interface/ringelement.h
+++ b/M2/Macaulay2/e/interface/ringelement.h
@@ -430,6 +430,8 @@ const RingElement /* or null */ *IM2_RingElement_fraction(
     const RingElement *a,
     const RingElement *b); /* drg: connected rawFraction*/
 
+const RingElement /* or null */ *rawSum(const engine_RawRingElementArray terms);
+
 gmp_ZZ /* or null */ rawSchurDimension(
     const RingElement *f); /* connected rawSchurDimension */
 /* f should be a polynomial whose base ring was created using rawSchurRing

--- a/M2/Macaulay2/e/interface/ringelement.h
+++ b/M2/Macaulay2/e/interface/ringelement.h
@@ -118,9 +118,9 @@ IM2_RingElement_homogenize(const RingElement *a, int v, M2_arrayint wts);
 const RingElement /* or null */ *IM2_RingElement_term(const Ring *R,
                                                       const RingElement *a,
                                                       const EngineMonomial *m);
-/* R must be a polynomial ring, and 'a' an element of the
-   coefficient ring of R.  Returns a*m, if this is a valid
-   element of R.  Returns NULL if not (with an error message). */
+/* 'a' an element of the coefficient ring of R.  Returns a*m, if this is a
+   valid element of R.  Returns NULL if not (with an error message).
+*/
 
 const RingElement /* or null */ *IM2_RingElement_get_terms(
     int nvars, /* n variables in an outermost monoid */
@@ -293,9 +293,8 @@ const RingElement /* or null */ *IM2_RingElement_term(
     const Ring *R,
     const RingElement *a,
     const EngineMonomial *m); /* drg: connected rawTerm*/
-/* R must be a polynomial ring, and 'a' an element of the
-   coefficient ring of R.  Returns a*m, if this is a valid
-   element of R.  Returns NULL if not (with an error message).
+/* 'a' an element of the coefficient ring of R.  Returns a*m, if this is a
+   valid element of R.  Returns NULL if not (with an error message).
 */
 
 const RingElement /* or null */ *IM2_RingElement_get_terms(

--- a/M2/Macaulay2/e/monomials/ExponentList.cpp
+++ b/M2/Macaulay2/e/monomials/ExponentList.cpp
@@ -449,6 +449,38 @@ void varpower::radical(ConstExponents a, Vector& result)
     }
 }
 
+template <>
+void varpower::split_signs(ConstExponents a, Vector& num, Vector& den)
+{
+  Exponents num_vp, orig_num_vp, den_vp, orig_den_vp;
+  int newlen;
+
+  num.resize(length(a));
+  num_vp = num.data();
+  orig_num_vp = num_vp;
+  num_vp++;
+
+  den.resize(length(a));
+  den_vp = den.data();
+  orig_den_vp = den_vp;
+  den_vp++;
+
+  for (index_varpower i = a; i.valid(); ++i) {
+    if (i.exponent() > 0) {
+      *num_vp++ = i.var();
+      *num_vp++ = i.exponent();
+    } else if (i.exponent() < 0) {
+      *den_vp++ = i.var();
+      *den_vp++ = -i.exponent();
+    }
+  }
+
+  newlen = static_cast<int>(num_vp - orig_num_vp);
+  *orig_num_vp = newlen;
+  newlen = static_cast<int>(den_vp - orig_den_vp);
+  *orig_den_vp = newlen;
+}
+
 // Local Variables:
 // compile-command: "make -C $M2BUILDDIR/Macaulay2/e "
 // indent-tabs-mode: nil

--- a/M2/Macaulay2/e/monomials/ExponentList.hpp
+++ b/M2/Macaulay2/e/monomials/ExponentList.hpp
@@ -175,6 +175,10 @@ class ExponentList
     return true;
   }
 
+  // split positive & negative exponents into two vectors w/ positive exponents
+  // e.g., {(0,2),(1,-3)} -> {(0,2)}, {(1,3)}
+  static void split_signs(ConstExponents a, Vector& num, Vector& den);
+
   /* These should satisfy: lcm(p,q) == pq
      returns 0 if the pair (p,q) should be REMOVED
      Returns 1 iff either (a) m does not divide pq, or

--- a/M2/Macaulay2/e/rings/frac.cpp
+++ b/M2/Macaulay2/e/rings/frac.cpp
@@ -397,6 +397,26 @@ ring_elem FractionField::copy(const ring_elem a) const
   return FRAC_RINGELEM(g);
 }
 
+ring_elem FractionField::makeTerm(const Ring* coeffR,
+                                  const ring_elem a,
+                                  const_varpower monom) const
+{
+  varpower::Vector num, den;
+  ring_elem num_elem, den_elem, result;
+
+  varpower::split_signs(monom, num, den);
+
+  num_elem = R_->makeTerm(coeffR, a, num.data());
+  den_elem = R_->makeTerm(coeffR, coeffR->one(), den.data());
+
+  if (varpower::is_one(den.data()))
+    promote(R_, num_elem, result);
+  else
+    result = fraction(num_elem, den_elem);
+
+  return result;
+}
+
 void FractionField::remove(ring_elem &a) const { (void) a; }
 void FractionField::internal_negate_to(ring_elem &a) const
 {

--- a/M2/Macaulay2/e/rings/frac.hpp
+++ b/M2/Macaulay2/e/rings/frac.hpp
@@ -88,6 +88,10 @@ class FractionField : public Ring
   virtual ring_elem copy(const ring_elem f) const;
   virtual void remove(ring_elem &f) const;
 
+  ring_elem makeTerm(const Ring* coeffR,
+                     const ring_elem a,
+                     const_varpower monom) const override;
+
   void internal_negate_to(ring_elem &f) const;
   void internal_add_to(ring_elem &f, ring_elem &g) const;
   void internal_subtract_to(ring_elem &f, ring_elem &g) const;

--- a/M2/Macaulay2/e/rings/localring.cpp
+++ b/M2/Macaulay2/e/rings/localring.cpp
@@ -475,6 +475,29 @@ ring_elem LocalRing::copy(const ring_elem a) const
 
 void LocalRing::remove(ring_elem &a) const { (void) a; }
 
+ring_elem LocalRing::makeTerm(const Ring* coeffR,
+                              const ring_elem a,
+                              const_varpower monom) const
+{
+  varpower::Vector num, den;
+  ring_elem num_elem, den_elem, result;
+
+  varpower::split_signs(monom, num, den);
+
+  den_elem = get_ring()->makeTerm(coeffR, coeffR->one(), den.data());
+  if (!varpower::is_one(den.data()) && is_in_prime(den_elem))
+    throw exc::engine_error("attempt to divide by a non-unit");
+
+  num_elem = get_ring()->makeTerm(coeffR, a, num.data());
+
+  if (varpower::is_one(den.data()))
+    promote(get_ring(), num_elem, result);
+  else
+    result = fraction(num_elem, den_elem);
+
+  return result;
+}
+
 ring_elem LocalRing::negate(const ring_elem a) const
 {
   const local_elem *f = a.get_local_elem();

--- a/M2/Macaulay2/e/rings/localring.hpp
+++ b/M2/Macaulay2/e/rings/localring.hpp
@@ -90,6 +90,10 @@ class LocalRing : public Ring
   virtual ring_elem copy(const ring_elem f) const;
   virtual void remove(ring_elem &f) const;
 
+  ring_elem makeTerm(const Ring* coeffR,
+                     const ring_elem a,
+                     const_varpower monom) const override;
+
   virtual ring_elem negate(const ring_elem f) const;
   virtual ring_elem add(const ring_elem f, const ring_elem g) const;
   virtual ring_elem subtract(const ring_elem f, const ring_elem g) const;

--- a/M2/Macaulay2/e/rings/poly.cpp
+++ b/M2/Macaulay2/e/rings/poly.cpp
@@ -1893,10 +1893,7 @@ ring_elem PolyRing::make_logical_term(const Ring *coeffR,
       return make_flat_term(a, m);
     }
   if (logicalK == nullptr)
-    {
-      ERROR("expected actual coefficient ring");
-      return from_long(0);
-    }
+      throw exc::engine_error("expected actual coefficient ring");
   nvars0 -= logicalK->n_vars();
 
   Nterm head;

--- a/M2/Macaulay2/e/rings/polyring.cpp
+++ b/M2/Macaulay2/e/rings/polyring.cpp
@@ -182,6 +182,18 @@ Matrix *PolynomialRing::getPresentation() const
   return mat.to_matrix();
 }
 
+ring_elem PolynomialRing::makeTerm(const Ring *coeffR,
+                                   const ring_elem a,
+                                   const_varpower monom) const
+{
+  int nvars0 = n_vars();
+  const PolynomialRing *K = coeffR->cast_to_PolynomialRing();
+  if (K != nullptr && K != getCoefficients()) nvars0 -= K->n_vars();
+  exponents_t exp = newarray_atomic(int, nvars0);
+  varpower::to_expvector(nvars0, monom, exp);
+  return make_logical_term(coeffR, a, exp);
+}
+
 class SumCollectorPolyHeap : public SumCollector
 {
   polyheap H;

--- a/M2/Macaulay2/e/rings/polyring.cpp
+++ b/M2/Macaulay2/e/rings/polyring.cpp
@@ -187,8 +187,17 @@ ring_elem PolynomialRing::makeTerm(const Ring *coeffR,
                                    const_varpower monom) const
 {
   int nvars0 = n_vars();
+  for (index_varpower i = monom; i.valid(); ++i) {
+    if (i.exponent() < 0 && !getMonoid()->isLaurentVariable(i.var()))
+      throw exc::engine_error("expected a nonnegative exponent");
+  }
+
   const PolynomialRing *K = coeffR->cast_to_PolynomialRing();
   if (K != nullptr && K != getCoefficients()) nvars0 -= K->n_vars();
+
+  if (!varpower::is_one(monom) && varpower::topvar(monom) >= nvars0)
+    throw exc::engine_error("too many variables in monomial");
+
   exponents_t exp = newarray_atomic(int, nvars0);
   varpower::to_expvector(nvars0, monom, exp);
   return make_logical_term(coeffR, a, exp);

--- a/M2/Macaulay2/e/rings/polyring.cpp
+++ b/M2/Macaulay2/e/rings/polyring.cpp
@@ -200,6 +200,10 @@ ring_elem PolynomialRing::makeTerm(const Ring *coeffR,
 
   exponents_t exp = newarray_atomic(int, nvars0);
   varpower::to_expvector(nvars0, monom, exp);
+
+  if (is_skew_commutative() && getSkewInfo().exp_is_zero(exp, nvars0))
+    return from_long(0);
+
   return make_logical_term(coeffR, a, exp);
 }
 

--- a/M2/Macaulay2/e/rings/polyring.hpp
+++ b/M2/Macaulay2/e/rings/polyring.hpp
@@ -303,6 +303,9 @@ class PolynomialRing : public Ring
   int n_terms(const ring_elem f) const { return n_flat_terms(f); }
   // This is here mainly because geopoly requires n_terms.
 
+  ring_elem makeTerm(const Ring *coeffR,
+                     const ring_elem a,
+                     const_varpower monom) const override;
   virtual ring_elem make_flat_term(const ring_elem a, const_monomial m) const = 0;
   virtual ring_elem make_logical_term(const Ring *coeffR,
                                       const ring_elem a,

--- a/M2/Macaulay2/e/rings/ring.cpp
+++ b/M2/Macaulay2/e/rings/ring.cpp
@@ -9,6 +9,7 @@
 #include "monoid.hpp"      // for Monoid
 #include "rings/poly.hpp"        // for PolyRing
 #include "rings/polyring.hpp"    // for PolynomialRing
+#include "ring-elements/ring-element.hpp" // for get_value
 
 const Monoid *Ring::degree_monoid() const { return degree_ring->getMonoid(); }
 #if 1
@@ -279,6 +280,48 @@ bool Ring::from_complex_double(double re, double im, ring_elem &result) const
   (void) im;
   result = from_long(0);
   return false;
+}
+
+ring_elem Ring::makeTerm(const Ring *coeffR,
+                         const ring_elem a,
+                         const_varpower monom) const
+{
+  if (isGaloisField()) {
+    const RingElement *gen;
+    ring_elem c;
+
+    if (!coeffR->isFinitePrimeField() ||
+        coeffR->characteristic() != characteristic())
+      throw exc::engine_error("wrong coefficient ring");
+
+    auto [ok, n] = coeffR->coerceToLongInteger(a);
+    if (ok)
+      c = from_long(n);
+    else // shouldn't happen
+      throw exc::engine_error("could not coerce coefficient to integer");
+
+    switch (varpower::npairs(monom)) {
+    case 0:
+      return c;
+
+    case 1:
+      gen = getGenerator();
+
+      if (gen == nullptr) {
+        throw exc::engine_error("no generator for Galois field");
+      } else {
+        if (monom[1] == 0)
+          return mult(c, power(gen->get_value(), monom[2]));
+        else
+          throw exc::engine_error("unknown variable");
+      }
+
+    default:
+      throw exc::engine_error("expected at most 1 exponent");
+    }
+  } else {
+    throw exc::engine_error("not implemented for this ring");
+  }
 }
 
 ring_elem Ring::random() const

--- a/M2/Macaulay2/e/rings/ring.hpp
+++ b/M2/Macaulay2/e/rings/ring.hpp
@@ -283,14 +283,7 @@ class Ring : public MutableEngineObject
 
   virtual ring_elem makeTerm(const Ring* coeffR,
                              const ring_elem a,
-                             const_varpower monom) const
-  {
-    (void) coeffR;
-    (void) a;
-    (void) monom;
-
-    throw exc::engine_error("not implemented for this ring");
-  }
+                             const_varpower monom) const;
 
   // Returns the element in the polynomial ring A corresponding to the element
   // a.

--- a/M2/Macaulay2/e/rings/ring.hpp
+++ b/M2/Macaulay2/e/rings/ring.hpp
@@ -281,6 +281,17 @@ class Ring : public MutableEngineObject
     throw exc::engine_error("cannot compute discrete logarithm in this ring");
   }
 
+  virtual ring_elem makeTerm(const Ring* coeffR,
+                             const ring_elem a,
+                             const_varpower monom) const
+  {
+    (void) coeffR;
+    (void) a;
+    (void) monom;
+
+    throw exc::engine_error("not implemented for this ring");
+  }
+
   // Returns the element in the polynomial ring A corresponding to the element
   // a.
   // Returns NULL if not a GF field.

--- a/M2/Macaulay2/e/rings/skew.cpp
+++ b/M2/Macaulay2/e/rings/skew.cpp
@@ -146,10 +146,16 @@ int SkewMultiplication::divide(const int *exp1,
 bool SkewMultiplication::exp_is_zero(const int *exp) const
 // Return whether any skew variable in the exponent vector has exponent >= 2
 {
+  return exp_is_zero(exp, _n_vars);
+}
+
+bool SkewMultiplication::exp_is_zero(const int *exp, int n) const
+// As above, but exp has only n entries, so larger skew indices are skipped
+{
   for (int i = 0; i < _n_skew; i++)
     {
       int v = _skew_list[i];
-      if (exp[v] >= 2) return true;
+      if (v < n && exp[v] >= 2) return true;
     }
   return false;
 }

--- a/M2/Macaulay2/e/rings/skew.hpp
+++ b/M2/Macaulay2/e/rings/skew.hpp
@@ -35,6 +35,7 @@ class SkewMultiplication
   int diff(const int *exp1, const int *exp2, int *result) const;
   int divide(const int *exp1, const int *exp2, int *result) const;
   bool exp_is_zero(const int *exp) const;
+  bool exp_is_zero(const int *exp, int n) const;
 };
 
 #endif

--- a/M2/Macaulay2/e/rings/tower.cpp
+++ b/M2/Macaulay2/e/rings/tower.cpp
@@ -1,5 +1,7 @@
 // Copyright 2010 Michael E. Stillman
 
+#include <algorithm>
+
 #include "rings/tower.hpp"
 
 #include "monomials/ExponentList.hpp"
@@ -467,6 +469,7 @@ ring_elem Tower::translate(const PolynomialRing *R, ring_elem fR) const
   for (Nterm& t : fR)
     {
       M->to_expvector(t.monom, exp);
+      std::reverse(exp, exp + nvars); // variables are in reverse order
       std::pair<bool, long> res = K->coerceToLongInteger(t.coeff);
       assert(res.first);
       int c1 = static_cast<int>(res.second);

--- a/M2/Macaulay2/e/rings/tower.cpp
+++ b/M2/Macaulay2/e/rings/tower.cpp
@@ -18,6 +18,9 @@ bool Tower::initialize(long charac0,
                        M2_ArrayString names0,
                        const VECTOR(ring_elem) & extensions)
 {
+  if (charac0 == 0)
+    throw exc::engine_error("expected coefficient ring with characteristic p > 0");
+
   initialize_ring(charac0);
   declare_field();
 

--- a/M2/Macaulay2/e/rings/tower.cpp
+++ b/M2/Macaulay2/e/rings/tower.cpp
@@ -175,6 +175,35 @@ void Tower::remove(ring_elem &) const
   // nothing needed to remove?  Or should we remove it?
 }
 
+ring_elem Tower::makeTerm(const Ring* coeffR,
+                          const ring_elem a,
+                          const_varpower monom) const
+{
+  if (!coeffR->isFinitePrimeField() ||
+      coeffR->characteristic() != characteristic())
+    throw exc::engine_error("wrong coefficient ring");
+
+  for (index_varpower i = monom; i.valid(); ++i) {
+    if (i.exponent() < 0)
+      throw exc::engine_error("expected nonnegative exponents");
+    if (i.var() >= n_vars())
+      throw exc::engine_error("unknown variable");
+  }
+
+  auto [ok, n] = coeffR->coerceToLongInteger(a);
+  if (ok) {
+    exponents_t exp = new int[n_vars()];
+    varpower::to_expvector(n_vars(), monom, exp);
+    std::reverse(exp, exp + n_vars()); // variables are in reverse order
+    TowerPolynomial result = nullptr;
+    D->add_term(result, n, exp);
+    delete[] exp;
+    return TOWER_RINGELEM(result);
+  } else {
+    throw exc::engine_error("could not coerce coefficient to integer");
+  }
+}
+
 ring_elem Tower::negate(const ring_elem g) const
 {
   TowerPolynomial f1;

--- a/M2/Macaulay2/e/rings/tower.hpp
+++ b/M2/Macaulay2/e/rings/tower.hpp
@@ -62,6 +62,10 @@ class Tower : public Ring
   virtual ring_elem copy(const ring_elem f) const;
   virtual void remove(ring_elem &f) const;
 
+  ring_elem makeTerm(const Ring* coeffR,
+                     const ring_elem a,
+                     const_varpower monom) const override;
+
   virtual ring_elem negate(const ring_elem f) const;
   virtual ring_elem add(const ring_elem f, const ring_elem g) const;
   virtual ring_elem subtract(const ring_elem f, const ring_elem g) const;

--- a/M2/Macaulay2/e/unit-tests/PolyRingTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/PolyRingTest.cpp
@@ -17,6 +17,10 @@
 #include "interface/aring.h"
 
 #include "unit-tests/util-polyring-creation.hpp"
+#include "interface/ringelement.h"
+#include "monomials/monomial.hpp"
+#include "ring-elements/ring-element.hpp"
+#include "exceptions.hpp"
 
 TEST(PolyRing, createDegreesRing)
 {
@@ -84,4 +88,70 @@ TEST(PolyRing, createSimple)
   buffer o;
   R->text_out(o);
   std::cout << "ring is " << o.str() << std::endl;
+}
+
+// makeTerm builds a*monom directly, without going through ring arithmetic.
+TEST(PolyRing, makeTerm)
+{
+  const PolynomialRing* R = simplePolynomialRing(101, {"x", "y", "z"});
+  const Ring* kk = R->getCoefficients();
+
+  // x^2*z^3; a varpower lists variables in decreasing order
+  std::vector<int> vp = varpowerOf({{2, 3}, {0, 2}});
+  ring_elem t = R->makeTerm(kk, kk->from_long(1), vp.data());
+  EXPECT_TRUE(R->is_equal(t, monomialOf(R, {{0, 2}, {2, 3}})));
+
+  // the coefficient is carried, not dropped
+  ring_elem u = R->makeTerm(kk, kk->from_long(7), vp.data());
+  EXPECT_TRUE(R->is_equal(u, R->mult(R->from_long(7), t)));
+
+  // the empty monomial gives back the coefficient
+  std::vector<int> one = varpowerOf({});
+  EXPECT_TRUE(R->is_equal(R->makeTerm(kk, kk->from_long(5), one.data()),
+                          R->from_long(5)));
+}
+
+TEST(PolyRing, makeTermRejectsBadInput)
+{
+  const PolynomialRing* R = simplePolynomialRing(101, {"x", "y", "z"});
+  const Ring* kk = R->getCoefficients();
+  ring_elem one = kk->from_long(1);
+
+  // a variable the ring does not have
+  std::vector<int> tooMany = varpowerOf({{3, 1}});
+  EXPECT_THROW(R->makeTerm(kk, one, tooMany.data()), exc::engine_error);
+
+  // a negative exponent, in a ring with no Laurent variables
+  std::vector<int> negative = varpowerOf({{1, -1}, {0, 2}});
+  EXPECT_THROW(R->makeTerm(kk, one, negative.data()), exc::engine_error);
+
+  // a coefficient from an unrelated ring
+  const Ring* wrong = IM2_Ring_ZZp(2);
+  std::vector<int> vp = varpowerOf({{0, 1}});
+  EXPECT_THROW(R->makeTerm(wrong, wrong->from_long(1), vp.data()),
+               exc::engine_error);
+}
+
+// An interface function that fails must return null *and* set the error flag.
+// Returning a value with the flag set leaves a pending error that surfaces
+// later, at an unrelated call.
+TEST(PolyRing, termInterfaceReportsFailure)
+{
+  const PolynomialRing* R = simplePolynomialRing(0, {"x", "y"});
+  const Ring* wrong = IM2_Ring_ZZp(2);
+  (void)error_message();  // clears the flag
+
+  const RingElement* a = RingElement::make_raw(wrong, wrong->from_long(1));
+  std::vector<int> vp = varpowerOf({{0, 1}});
+  EngineMonomial* m = EngineMonomial::make(vp.data());
+
+  EXPECT_TRUE(IM2_RingElement_term(R, a, m) == nullptr);
+  EXPECT_TRUE(error());
+  (void)error_message();
+
+  const Ring* kk = R->getCoefficients();
+  const RingElement* b = RingElement::make_raw(kk, kk->from_long(3));
+  const RingElement* ok = IM2_RingElement_term(R, b, m);
+  EXPECT_TRUE(ok != nullptr);
+  EXPECT_FALSE(error());
 }

--- a/M2/Macaulay2/e/unit-tests/PolyRingTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/PolyRingTest.cpp
@@ -11,6 +11,7 @@
 #include "util.hpp"
 #include "rings/ring.hpp"
 #include "rings/polyring.hpp"
+#include "rings/skew.hpp"
 #include "interface/monomial-ordering.h"
 #include "interface/monoid.h"
 #include "interface/ring.h"
@@ -109,6 +110,89 @@ TEST(PolyRing, makeTerm)
   std::vector<int> one = varpowerOf({});
   EXPECT_TRUE(R->is_equal(R->makeTerm(kk, kk->from_long(5), one.data()),
                           R->from_long(5)));
+}
+
+// The square of a skew commutative variable is zero, so a monomial with any
+// such exponent >= 2 makes the whole term zero.  Note that the engine has no
+// way to represent e^2, so failing to check this yields a bogus ring element
+// rather than an error.
+TEST(PolyRing, makeTermSkew)
+{
+  const PolynomialRing* E =
+      simpleSkewPolynomialRing(101, {"e0", "e1", "e2"}, {0, 1, 2});
+  ASSERT_NE(E, nullptr);
+  const Ring* kk = E->getCoefficients();
+  ring_elem one = kk->from_long(1);
+
+  // a squarefree monomial is untouched
+  std::vector<int> squarefree = varpowerOf({{2, 1}, {0, 1}});
+  EXPECT_TRUE(E->is_equal(E->makeTerm(kk, one, squarefree.data()),
+                          monomialOf(E, {{0, 1}, {2, 1}})));
+
+  // e2^2 is zero, and so is any monomial divisible by it
+  std::vector<int> square = varpowerOf({{2, 2}});
+  EXPECT_TRUE(E->is_zero(E->makeTerm(kk, one, square.data())));
+
+  std::vector<int> mixed = varpowerOf({{2, 2}, {0, 1}});
+  EXPECT_TRUE(E->is_zero(E->makeTerm(kk, one, mixed.data())));
+
+  // a nonzero coefficient does not rescue it
+  EXPECT_TRUE(E->is_zero(E->makeTerm(kk, kk->from_long(7), square.data())));
+}
+
+// Only the skew variables square to zero; the commuting ones are unaffected.
+TEST(PolyRing, makeTermPartiallySkew)
+{
+  const PolynomialRing* R =
+      simpleSkewPolynomialRing(101, {"x", "y", "a", "b"}, {2, 3});
+  ASSERT_NE(R, nullptr);
+  const Ring* kk = R->getCoefficients();
+  ring_elem one = kk->from_long(1);
+
+  std::vector<int> xSquared = varpowerOf({{0, 2}});
+  EXPECT_TRUE(R->is_equal(R->makeTerm(kk, one, xSquared.data()),
+                          monomialOf(R, {{0, 2}})));
+
+  std::vector<int> aSquared = varpowerOf({{2, 2}});
+  EXPECT_TRUE(R->is_zero(R->makeTerm(kk, one, aSquared.data())));
+}
+
+// exp_is_zero, in both forms.  The 1-argument form covers every variable of
+// the ring; the 2-argument form is for an exponent vector with only n entries.
+TEST(PolyRing, skewExpIsZero)
+{
+  std::vector<int> skewvars {1, 3};
+  SkewMultiplication skew(4, static_cast<int>(skewvars.size()), skewvars.data());
+
+  int squarefree[4] {2, 1, 5, 1};  // skew variables appear at most once
+  EXPECT_FALSE(skew.exp_is_zero(squarefree));
+
+  int skewSquared[4] {1, 2, 0, 0};
+  EXPECT_TRUE(skew.exp_is_zero(skewSquared));
+
+  int lastVarCubed[4] {0, 0, 0, 3};
+  EXPECT_TRUE(skew.exp_is_zero(lastVarCubed));
+}
+
+TEST(PolyRing, skewExpIsZeroBounded)
+{
+  std::vector<int> skewvars {1, 3};
+  SkewMultiplication skew(4, static_cast<int>(skewvars.size()), skewvars.data());
+
+  int exp[4] {1, 2, 0, 2};  // both e1 and e3 are squared
+
+  EXPECT_TRUE(skew.exp_is_zero(exp, 4));
+  EXPECT_TRUE(skew.exp_is_zero(exp, 2));   // e1 is still in range
+  EXPECT_FALSE(skew.exp_is_zero(exp, 1));  // neither skew variable is in range
+  EXPECT_FALSE(skew.exp_is_zero(exp, 0));
+
+  // the unbounded form agrees with n = number of variables
+  EXPECT_EQ(skew.exp_is_zero(exp), skew.exp_is_zero(exp, 4));
+
+  // a vector with only 2 entries must not be read past the end; under a
+  // sanitizer this catches the bound being ignored
+  std::vector<int> shortExp {0, 1};
+  EXPECT_FALSE(skew.exp_is_zero(shortExp.data(), 2));
 }
 
 TEST(PolyRing, makeTermRejectsBadInput)

--- a/M2/Macaulay2/e/unit-tests/QuotientRingTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/QuotientRingTest.cpp
@@ -60,6 +60,20 @@ TEST(QuotientRing, sphere)
   EXPECT_EQ(lhs, rhs);
 }
 
+// makeTerm reduces the term modulo the quotient ideal.
+TEST(QuotientRing, makeTerm)
+{
+  const PolynomialRing* A = simplePolynomialRing(101, {"x", "y"});
+  const Ring* R = simpleQuotientRing(A, {"x^2-y"});
+  ASSERT_NE(R, nullptr);
+  const Ring* kk = R->cast_to_PolynomialRing()->getCoefficients();
+
+  // x^3*y reduces to x*y^2 modulo x^2-y
+  std::vector<int> vp = varpowerOf({{1, 1}, {0, 3}});
+  ring_elem t = R->makeTerm(kk, kk->from_long(1), vp.data());
+  EXPECT_TRUE(R->is_equal(t, monomialOf(R, {{0, 1}, {1, 2}})));
+}
+
 // Local Variables:
 // indent-tabs-mode: nil
 // End:

--- a/M2/Macaulay2/e/unit-tests/QuotientRingTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/QuotientRingTest.cpp
@@ -74,6 +74,27 @@ TEST(QuotientRing, makeTerm)
   EXPECT_TRUE(R->is_equal(t, monomialOf(R, {{0, 1}, {1, 2}})));
 }
 
+// A quotient of a skew commutative ring is a PolyRingQuotient rather than a
+// SkewPolynomialRing, but it still carries the skew information, so makeTerm
+// must zero out squares of skew variables there too.
+TEST(QuotientRing, makeTermSkew)
+{
+  const PolynomialRing* E =
+      simpleSkewPolynomialRing(101, {"e0", "e1", "e2"}, {0, 1, 2});
+  ASSERT_NE(E, nullptr);
+  const Ring* R = simpleQuotientRing(E, {"e0*e1"});
+  ASSERT_NE(R, nullptr);
+  const Ring* kk = R->cast_to_PolynomialRing()->getCoefficients();
+  ring_elem one = kk->from_long(1);
+
+  std::vector<int> square = varpowerOf({{2, 2}});
+  EXPECT_TRUE(R->is_zero(R->makeTerm(kk, one, square.data())));
+
+  // a variable not involved in the quotient ideal still behaves
+  std::vector<int> squarefree = varpowerOf({{2, 1}});
+  EXPECT_FALSE(R->is_zero(R->makeTerm(kk, one, squarefree.data())));
+}
+
 // Local Variables:
 // indent-tabs-mode: nil
 // End:

--- a/M2/Macaulay2/e/unit-tests/RingTowerTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/RingTowerTest.cpp
@@ -11,6 +11,9 @@
 #include "unit-tests/RingTest.hpp"
 #include "rings/tower.hpp"
 #include "util.hpp"
+#include "interface/ring.h"
+#include "exceptions.hpp"
+#include "unit-tests/util-polyring-creation.hpp"
 
 // First: we need a routine to read a polynomial from a string.
 // Format:  variables are a..zA..Z, and then [1], [2], ...
@@ -69,6 +72,57 @@ TEST(RingTower, elems)
   o << newline;
 
   std::cout << o.str();
+}
+
+// DPoly::add_term takes the outermost variable at index 0, the reverse of the
+// variable-indexed order varpower::to_expvector produces, so makeTerm has to
+// reverse.  x^2*y^3 must not come back as x^3*y^2.
+TEST(RingTower, makeTerm)
+{
+  std::vector<std::string> vars = {"x", "y"};
+  M2_ArrayString varnames = stdvector_to_M2_ArrayString(vars);
+  const Tower* R = Tower::create(101, varnames);
+  ASSERT_NE(R, nullptr);
+  const Ring* kk = IM2_Ring_ZZp(101);
+  ring_elem one = kk->from_long(1);
+
+  std::vector<int> vp = varpowerOf({{1, 3}, {0, 2}});
+  EXPECT_TRUE(R->is_equal(R->makeTerm(kk, one, vp.data()),
+                          monomialOf(R, {{0, 2}, {1, 3}})));
+
+  // one variable at a time, to pin down which is which
+  std::vector<int> justX = varpowerOf({{0, 1}});
+  EXPECT_TRUE(R->is_equal(R->makeTerm(kk, one, justX.data()), R->var(0)));
+  std::vector<int> justY = varpowerOf({{1, 1}});
+  EXPECT_TRUE(R->is_equal(R->makeTerm(kk, one, justY.data()), R->var(1)));
+
+  // the coefficient is carried
+  EXPECT_TRUE(R->is_equal(R->makeTerm(kk, kk->from_long(5), justX.data()),
+                          R->mult(R->from_long(5), R->var(0))));
+}
+
+TEST(RingTower, makeTermRejectsBadInput)
+{
+  std::vector<std::string> vars = {"x", "y"};
+  M2_ArrayString varnames = stdvector_to_M2_ArrayString(vars);
+  const Tower* R = Tower::create(101, varnames);
+  ASSERT_NE(R, nullptr);
+  const Ring* kk = IM2_Ring_ZZp(101);
+  ring_elem one = kk->from_long(1);
+
+  // exponents index a dense array, so negatives are never legal here
+  std::vector<int> negative = varpowerOf({{0, -1}});
+  EXPECT_THROW(R->makeTerm(kk, one, negative.data()), exc::engine_error);
+
+  // a variable the ring does not have
+  std::vector<int> tooMany = varpowerOf({{2, 1}});
+  EXPECT_THROW(R->makeTerm(kk, one, tooMany.data()), exc::engine_error);
+
+  // the coefficient ring must be the prime field of the same characteristic
+  const Ring* wrong = IM2_Ring_ZZp(7);
+  std::vector<int> vp = varpowerOf({{0, 1}});
+  EXPECT_THROW(R->makeTerm(wrong, wrong->from_long(1), vp.data()),
+               exc::engine_error);
 }
 
 // Local Variables:

--- a/M2/Macaulay2/e/unit-tests/WeylAlgebraTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/WeylAlgebraTest.cpp
@@ -206,3 +206,17 @@ TEST(PolyRingFromString, basic)
   auto g_expected = x.power(3) + x * y * z * 2 - y * y + z;
   EXPECT_EQ(g, g_expected);
 }
+
+TEST(WeylAlgebra, makeTerm)
+{
+  const WeylAlgebra* R = simpleWeylAlgebra(101, {"x", "dx"}, {0}, {1});
+  ASSERT_NE(R, nullptr);
+  const Ring* kk = R->getCoefficients();
+
+  std::vector<int> vp = varpowerOf({{1, 2}, {0, 1}});
+  ring_elem t = R->makeTerm(kk, kk->from_long(1), vp.data());
+  EXPECT_TRUE(R->is_equal(t, monomialOf(R, {{0, 1}, {1, 2}})));
+
+  ring_elem u = R->makeTerm(kk, kk->from_long(3), vp.data());
+  EXPECT_TRUE(R->is_equal(u, R->mult(R->from_long(3), t)));
+}

--- a/M2/Macaulay2/e/unit-tests/util-polyring-creation.cpp
+++ b/M2/Macaulay2/e/unit-tests/util-polyring-creation.cpp
@@ -198,6 +198,26 @@ const Ring* simpleQuotientRing(const PolynomialRing* R,
   return PolynomialRing::create_quotient(R, gb);
 }
 
+std::vector<int> varpowerOf(const std::vector<std::pair<int, int>>& pairs)
+{
+  std::vector<int> vp;
+  vp.push_back(static_cast<int>(2 * pairs.size() + 1));
+  for (const auto& p : pairs)
+    {
+      vp.push_back(p.first);
+      vp.push_back(p.second);
+    }
+  return vp;
+}
+
+ring_elem monomialOf(const Ring* R, const std::vector<std::pair<int, int>>& pairs)
+{
+  ring_elem result = R->one();
+  for (const auto& p : pairs)
+    result = R->mult(result, R->power(R->var(p.first), p.second));
+  return result;
+}
+
 // Local Variables:
 // indent-tabs-mode: nil
 // End:

--- a/M2/Macaulay2/e/unit-tests/util-polyring-creation.cpp
+++ b/M2/Macaulay2/e/unit-tests/util-polyring-creation.cpp
@@ -2,6 +2,7 @@
 
 #include "util.hpp"
 #include "unit-tests/util-polyring-creation.hpp"
+#include "rings/skewpoly.hpp"
 #include "rings/weylalg.hpp"
 #include "interface/ring.h"
 #include "interface/aring.h"
@@ -117,6 +118,31 @@ const PolynomialRing* simplePolynomialRing(int p, const std::vector<std::string>
     });
 
   return simplePolynomialRing(kk, names, monorder);
+}
+
+const PolynomialRing* simpleSkewPolynomialRing(int p,
+                                               const std::vector<std::string>& names,
+                                               const std::vector<int>& skewvars)
+{
+  // if p is 0, use QQ.
+  // degrees are all set to 1. (degree ring has one variable)
+  // heft is 1.
+  // monomial order is grevlex.
+
+  const Ring *kk = (p > 0 ? rawARingZZpFlint(p) : IM2_Ring_QQ());
+  if (kk == nullptr) return nullptr; // one of these routines would have made an error.
+
+  MonomialOrdering* monorder = MonomialOrderings::join
+    ({
+      MonomialOrderings::GRevLex(names.size()),
+      MonomialOrderings::PositionUp()
+    });
+
+  std::vector<int> degs(names.size(), 1);
+  const Monoid* M = Monoid::create(monorder, degreeRing(1), names, degs, {1});
+  if (M == nullptr) return nullptr;
+
+  return SkewPolynomialRing::create(kk, M, stdvector_to_M2_arrayint(skewvars));
 }
 
 const WeylAlgebra* simpleWeylAlgebra(long p,

--- a/M2/Macaulay2/e/unit-tests/util-polyring-creation.hpp
+++ b/M2/Macaulay2/e/unit-tests/util-polyring-creation.hpp
@@ -29,6 +29,12 @@ const PolynomialRing* simplePolynomialRing(const Ring* kk,
 // This create a polynomial ring with all degrees 1, and with GRevLex order
 const PolynomialRing* simplePolynomialRing(int p, const std::vector<std::string>& names);
 
+// Creates a skew commutative ring, with degree rank one, GRevLex monomial
+// order.  skewvars lists the indices of the anti-commuting variables.
+const PolynomialRing* simpleSkewPolynomialRing(int p,
+                                               const std::vector<std::string>& names,
+                                               const std::vector<int>& skewvars);
+
 // Creates a Weyl algebra, with degree rank one, GRevLex monomial order.
 const WeylAlgebra* simpleWeylAlgebra(long p,
                                      const std::vector<std::string> varnames,

--- a/M2/Macaulay2/e/unit-tests/util-polyring-creation.hpp
+++ b/M2/Macaulay2/e/unit-tests/util-polyring-creation.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <memory>
 #include <gtest/gtest.h>
+#include <utility>
 #include <vector>
 
 #include "interface/monomial-ordering.h"
@@ -35,6 +36,16 @@ const WeylAlgebra* simpleWeylAlgebra(long p,
                                      const std::vector<int> derivs);
 
 class Matrix;
+
+// Helpers for testing Ring::makeTerm.
+
+// Build a varpower [2n+1, v1, e1, ..., vn, en] from (variable, exponent)
+// pairs.  The pairs must be in decreasing order of variable.
+std::vector<int> varpowerOf(const std::vector<std::pair<int, int>>& pairs);
+
+// The same monomial, built with the ring's own arithmetic, so that the result
+// of makeTerm can be compared against something built a different way.
+ring_elem monomialOf(const Ring* R, const std::vector<std::pair<int, int>>& pairs);
 
 // Create a 1-row matrix (ideal generators) from polynomial strings.
 // Each string is a polynomial like "x^2+3*x*y-1".

--- a/M2/Macaulay2/m2/enginering.m2
+++ b/M2/Macaulay2/m2/enginering.m2
@@ -305,6 +305,7 @@ frac Ring := R -> (
      )
 
            frac FractionField := identity
+        ambient FractionField := F -> last F.baseRings
 coefficientRing FractionField := F -> coefficientRing last F.baseRings
    degreeLength FractionField := F -> degreeLength last F.baseRings
         degrees FractionField := F -> degrees last F.baseRings

--- a/M2/Macaulay2/m2/intervals.m2
+++ b/M2/Macaulay2/m2/intervals.m2
@@ -132,7 +132,7 @@ midpoint Ring := R -> (
 intervalPolyHelper := (func, f) -> (
     R := midpoint ring f;
     if R === ring f then f
-    else sum(listForm f, (m, c) -> func c * product(#m, i -> R_i^(m#i))))
+    else sum(listForm f, (m, c) -> func c * R_m))
 
 midpoint   RingElement := f -> intervalPolyHelper(midpoint,   f)
 left       RingElement := f -> intervalPolyHelper(left,       f)

--- a/M2/Macaulay2/m2/intervals.m2
+++ b/M2/Macaulay2/m2/intervals.m2
@@ -132,7 +132,7 @@ midpoint Ring := R -> (
 intervalPolyHelper := (func, f) -> (
     R := midpoint ring f;
     if R === ring f then f
-    else sum(listForm f, (m, c) -> func c * R_m))
+    else (apply(listForm f, (m, c) -> (m, func c)))_R)
 
 midpoint   RingElement := f -> intervalPolyHelper(midpoint,   f)
 left       RingElement := f -> intervalPolyHelper(left,       f)

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -22,7 +22,7 @@ madeTrivialMonoid := false
 
 dotprod = (c,d) -> sum( min(#c, #d), i -> c#i * d#i )
 
-makeSparse := v -> select(pairs v, (k, v) -> v != 0)
+makeSparse = v -> select(pairs v, (k, v) -> v != 0)
 
 listSplice := L -> deepSplice flatten sequence L
 
@@ -212,8 +212,11 @@ Monoid _*     := List => M -> vars M
 -- this implementation is for sparse monomials, but it might
 -- make sense to have a dense implementation
 Monoid _ ZZ   := MonoidElement => (M, i) -> (vars M)#i
-Monoid _ List := MonoidElement => (M, v) -> if #v === 0 then M#1 else product(
-    take(vars M, #v), v, (x, i) -> x^i)
+Monoid _ List := MonoidElement => (M, v) -> (
+    if #v > (n := numgens M)
+    then error("expected at most ", n, " exponent",
+               if n == 1 then "" else "s");
+    new M from rawMakeMonomial makeSparse v)
 
 ZZ            _ Monoid := MonoidElement => (i, M) -> if i === 1 then M#1 else error "expected integer to be 1"
 RingElement   _ Monoid :=

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -77,6 +77,8 @@ degree MonoidElement := m -> (
 baseName MonoidElement := m -> if #(s := rawSparseListFormMonomial raw m) == 1 and s#0#1 == 1
     then (class m).generatorSymbols#(s#0#0) else error "expected a generator"
 
+rawOne = R -> R.rawOne ??= raw 1_R
+
 promote(IndexedVariable, RingElement) := RingElement => (m, R) -> promote(value m, R)
 promote(MonoidElement, RingElement) := RingElement => (m, R) -> (
     k := coefficientRing first flattenRing R;
@@ -85,7 +87,7 @@ promote(MonoidElement, RingElement) := RingElement => (m, R) -> (
     or instance(m, monoid R)
     or instance(m, R.FlatMonoid)
     -- TODO: what does rawTerm expect?
-    then new R from rawTerm(R.RawRing, raw 1_k, m.RawMonomial)
+    then new R from rawTerm(R.RawRing, rawOne k, m.RawMonomial)
     else "expected monomial from same ring")
 
 lift(IndexedVariable, MonoidElement) := MonoidElement => (m, M) -> lift(value m, M)
@@ -120,7 +122,7 @@ leadMonomial RingElement := RingElement => f -> (
      R := ring f;
      k := coefficientRing R;
      n := numgens monoid R;
-     leadMonomial R := f -> new R from rawTerm(raw R, raw 1_k, rawLeadMonomial(n, raw f)); -- quicker the second time
+     leadMonomial R := f -> new R from rawTerm(raw R, rawOne k, rawLeadMonomial(n, raw f)); -- quicker the second time
      leadMonomial f)
 
 listForm = method()

--- a/M2/Macaulay2/m2/monoids.m2
+++ b/M2/Macaulay2/m2/monoids.m2
@@ -22,8 +22,6 @@ madeTrivialMonoid := false
 
 dotprod = (c,d) -> sum( min(#c, #d), i -> c#i * d#i )
 
-makeSparse = v -> select(pairs v, (k, v) -> v != 0)
-
 listSplice := L -> deepSplice flatten sequence L
 
 baseName' = var -> baseName if instance(var, String) and match("[[:alnum:]$]+", var) then getSymbol var else var
@@ -216,7 +214,7 @@ Monoid _ List := MonoidElement => (M, v) -> (
     if #v > (n := numgens M)
     then error("expected at most ", n, " exponent",
                if n == 1 then "" else "s");
-    new M from rawMakeMonomial makeSparse v)
+    new M from rawMakeMonomialFromExponents v)
 
 ZZ            _ Monoid := MonoidElement => (i, M) -> if i === 1 then M#1 else error "expected integer to be 1"
 RingElement   _ Monoid :=

--- a/M2/Macaulay2/m2/polyrings.m2
+++ b/M2/Macaulay2/m2/polyrings.m2
@@ -32,15 +32,21 @@ isSkewCommutative PolynomialRing := R -> isSkewCommutative coefficientRing R or 
     R.?SkewCommutative and 0 < #R.SkewCommutative)
 
 Ring _ List := RingElement => (R, v) -> (
-    if #v == 0 then 1_R
-    else if #v > (m := R.numallvars ?? numgens R)
+    if #v == 0 then return 1_R;
+    n := numgens R;
+    if #v > (m := R.numallvars ?? n)
     then error("expected at most ", m, " exponent",
                if m == 1 then "" else "s")
     else (
         kk := coefficientRing ambient R;
-        n := numgens R;
-        new R from rawTerm(raw R, raw kk_(drop(v, n)),
-                           rawMakeMonomialFromExponents take(v, n))))
+        new R from (
+            if #v > n
+            then rawTerm(raw R,
+                         raw kk_(drop(v, n)),
+                         rawMakeMonomialFromExponents take(v, n))
+            else rawTerm(raw R,
+                         rawOne kk,
+                         rawMakeMonomialFromExponents v))))
 RingFamily _ List := RingElement => (R, v) -> (default R)_v
 
 coefficientRing PolynomialRing := R -> last R.baseRings

--- a/M2/Macaulay2/m2/polyrings.m2
+++ b/M2/Macaulay2/m2/polyrings.m2
@@ -56,7 +56,7 @@ generators PolynomialRing := opts -> R -> (
 
 char      PolynomialRing :=      char @@ coefficientRing
 precision PolynomialRing := precision @@ coefficientRing
-numgens   PolynomialRing := numgens @@ monoid
+numgens   PolynomialRing := R -> R.cache.numgens ??= numgens monoid R
 options   PolynomialRing := options @@ monoid
 dim       PolynomialRing := R -> dim coefficientRing R + #generators R - (
     if R.?SkewCommutative then #R.SkewCommutative else 0)

--- a/M2/Macaulay2/m2/polyrings.m2
+++ b/M2/Macaulay2/m2/polyrings.m2
@@ -40,7 +40,7 @@ Ring _ List := RingElement => (R, v) -> (
         kk := coefficientRing ambient R;
         n := numgens R;
         new R from rawTerm(raw R, raw kk_(drop(v, n)),
-                           rawMakeMonomial makeSparse take(v, n))))
+                           rawMakeMonomialFromExponents take(v, n))))
 RingFamily _ List := RingElement => (R, v) -> (default R)_v
 
 coefficientRing PolynomialRing := R -> last R.baseRings

--- a/M2/Macaulay2/m2/polyrings.m2
+++ b/M2/Macaulay2/m2/polyrings.m2
@@ -31,9 +31,17 @@ isWeylAlgebra PolynomialRing := R -> isWeylAlgebra coefficientRing R or ( o := o
 isSkewCommutative PolynomialRing := R -> isSkewCommutative coefficientRing R or (
     R.?SkewCommutative and 0 < #R.SkewCommutative)
 
--- TODO: is the second one needed?
-Ring _ List :=
-PolynomialRing _ List := RingElement => (R, v) -> if #v === 0 then 1_R else product ( #v , i -> R_i^(v#i) )
+Ring _ List := RingElement => (R, v) -> (
+    if #v == 0 then 1_R
+    else if #v > (m := R.numallvars ?? numgens R)
+    then error("expected at most ", m, " exponent",
+               if m == 1 then "" else "s")
+    else (
+        kk := coefficientRing ambient R;
+        n := numgens R;
+        new R from rawTerm(raw R, raw kk_(drop(v, n)),
+                           rawMakeMonomial makeSparse take(v, n))))
+RingFamily _ List := RingElement => (R, v) -> (default R)_v
 
 coefficientRing PolynomialRing := R -> last R.baseRings
 ambient PolynomialRing := identity

--- a/M2/Macaulay2/m2/polyrings.m2
+++ b/M2/Macaulay2/m2/polyrings.m2
@@ -49,6 +49,18 @@ Ring _ List := RingElement => (R, v) -> (
                          rawMakeMonomialFromExponents v))))
 RingFamily _ List := RingElement => (R, v) -> (default R)_v
 
+List _ Ring := RingElement => (v, R) -> (
+    if #v == 0 then 0_R
+    else (
+        kk := coefficientRing ambient R;
+        new R from rawSum apply(toSequence v, mc -> (
+            if not instance(mc, Sequence)
+            then error "expected a list of sequences";
+            if #mc =!= 2
+            then error "expected a list of pairs";
+            rawTerm(raw R, raw mc#1_kk, rawMakeMonomialFromExponents mc#0)))))
+List _ RingFamily := RingElement => (v, R) -> v_(default R)
+
 coefficientRing PolynomialRing := R -> last R.baseRings
 ambient PolynomialRing := identity
 monoid PolynomialRing := o -> R -> R.monoid

--- a/M2/Macaulay2/m2/rings.m2
+++ b/M2/Macaulay2/m2/rings.m2
@@ -37,10 +37,12 @@ generators Ring := opts -> R -> (
      if opts.CoefficientRing === null or opts.CoefficientRing === R then {}
      else if opts.CoefficientRing === ZZ and R === QQ then {} -- where should we really stash this special case? (QQ is not in the class FractionField)
      else errorGenCoeff())
+generators RingFamily := opts -> R -> generators(default R, opts)
 
 Ring_* := R -> generators R
 
-numgens Ring := R -> #generators R
+numgens Ring       :=
+numgens RingFamily := R -> #generators R
 
 ring = method(TypicalValue => Ring)
 

--- a/M2/Macaulay2/packages/AssociativeAlgebras/tests.m2
+++ b/M2/Macaulay2/packages/AssociativeAlgebras/tests.m2
@@ -2243,3 +2243,15 @@ A_1 ** A_3 <--> 4
 C_4 <--> 2
 A_4 <--> 2 diml
 ///
+
+TEST ///
+  R = QQ<|a,b|>
+  assert Equation(R_{1,2}, a*b^2)
+  assert Equation(R_{0,1}, b)
+  assert Equation(R_{2,0}, a^2)
+  assert Equation(R_{}, 1)
+  assert try R_{1,1,1} then false else true
+  S = R/ideal(a*b - b*a)
+  assert Equation(S_{1,2}, b^2*a)
+  assert Equation(S_{}, 1)
+///

--- a/M2/Macaulay2/packages/LocalRings/doc.m2
+++ b/M2/Macaulay2/packages/LocalRings/doc.m2
@@ -367,7 +367,7 @@ SeeAlso
 ///
 
 importFrom_Core { "headline" }
-scan({ baseRing, char, coefficientRing, degreeLength, degrees, dim, frac, generators, isCommutative, numgens },
+scan({ ambient, baseRing, char, coefficientRing, degreeLength, degrees, dim, frac, generators, isCommutative, numgens },
     m -> document { Key => (m, LocalRing), Headline => headline makeDocumentTag (m, Ring), PARA {"See ", TO (m, Ring)} })
 
 undocumented apply({describe, expression, precision, presentation}, m -> (m, LocalRing))

--- a/M2/Macaulay2/packages/LocalRings/localring.m2
+++ b/M2/Macaulay2/packages/LocalRings/localring.m2
@@ -38,6 +38,7 @@ LocalRing#{Standard,AfterPrint} = RP -> (
 localRing = method(TypicalValue => LocalRing)
        describe LocalRing := RP -> Describe (expression localRing) (expression last RP.baseRings, expression RP.maxIdeal)
      expression LocalRing := RP -> if hasAttribute(RP, ReverseDictionary) then expression getAttribute(RP, ReverseDictionary) else new FunctionApplication from unhold describe RP
+        ambient LocalRing := RP -> ring RP.maxIdeal
 coefficientRing LocalRing := RP -> coefficientRing ring RP.maxIdeal
   isWellDefined LocalRing := RP -> isPrime RP.maxIdeal
   isCommutative LocalRing := RP -> isCommutative ring RP.maxIdeal -- FIXME make sure this is correct

--- a/M2/Macaulay2/packages/LocalRings/tests.m2
+++ b/M2/Macaulay2/packages/LocalRings/tests.m2
@@ -872,6 +872,30 @@ TEST /// -- dim and char of a LocalRing reflect the underlying prime
   assert(degreeLength Rmax == 1)
 ///
 
+TEST ///
+  R = QQ[x,y]
+  I = ideal x
+  J = ideal(x-y)
+  RP = localRing(R, I)
+  assert Equation(RP_{1,2}, x*y^2)
+  assert Equation(RP_{2,0}, x^2)
+  assert Equation(RP_{}, 1)
+  assert Equation(RP_{1,-2}, x/y^2)                 -- y is a unit
+  assert Equation(RP_{0,-1}, 1/y)
+  assert Equation(RP_{2,-3}, x^2/y^3)
+  assert try RP_{-1,2} then false else true         -- x is not a unit
+  assert try RP_{-1,-1} then false else true
+  RP = localRing(R, J)                              -- here x and y are units
+  assert Equation(RP_{1,-1}, x/y)
+  assert Equation(RP_{-1,1}, y/x)
+  assert Equation(RP_{-1,-1}, 1/(x*y))
+  R = QQ[x,y,z]
+  RP = localRing(R, ideal(x,y))
+  assert Equation(RP_{0,0,-1}, 1/z)
+  assert Equation(RP_{1,1,-2}, x*y/z^2)
+  assert try RP_{-1,0,0} then false else true
+///
+
 end--
 
 --============================ Tests Under Development ===================================--

--- a/M2/Macaulay2/packages/MRDI.m2
+++ b/M2/Macaulay2/packages/MRDI.m2
@@ -20,8 +20,8 @@
 
 newPackage(
     "MRDI",
-    Version => "0.1",
-    Date => "April 25, 2026",
+    Version => "0.2",
+    Date => "September 5, 2026",
     Headline => "serializing algebraic data with .mrdi files",
     Authors => {
 	{
@@ -31,6 +31,23 @@ newPackage(
 	    }},
     PackageImports => {"JSON"},
     Keywords => {"System"})
+
+---------------
+-- ChangeLog --
+---------------
+
+-*
+
+0.2 (2026-09-05, M2 1.26.11)
+* use new List_Ring method for deserializing polynomials
+* update documentation and tests (thanks Keller and the Atlanta workshop
+  participants!)
+* update my contact info
+
+0.1 (2026-04-25, M2 1.26.05)
+* initial release
+
+*-
 
 export {
     -- methods
@@ -293,9 +310,9 @@ mrdiToCoefficient QQ := R -> a -> value a#0 / value a#1
 
 mrdiToPolynomial = (R, f) -> (
     if #f == 0 then 0_R
-    else sum(f, term -> times(
-	    (mrdiToCoefficient coefficientRing R) term#1,
-	    R_(value \ toList term#0))))
+    else (apply(f, term -> (
+        value \ toList term#0,
+        (mrdiToCoefficient coefficientRing R) term#1)))_R)
 addLoadMethod("RingElement", (params, data) -> (
 	mrdiToPolynomial(params, data)))
 addLoadMethod("Ideal", (params, data) -> (

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/ambient-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/ambient-doc.m2
@@ -15,28 +15,50 @@ document {
      PARA{},
      SeeAlso => {GF,cover,super}
      }
-document { 
-     Key => {(ambient,Ring),(ambient,PolynomialRing),(ambient,QuotientRing)},
-     Headline => "ambient polynomial ring",
-     Usage => "ambient R",
-     Inputs => {
-	  "R" => {"a polynomial ring or a quotient of a polynomial ring"}
-	  },
-     Outputs => {
-	  Ring => {"the polynomial ring of which this ring is a quotient"}
-	  },
-     EXAMPLE {
-	  "A = ZZ[a..d];",
-     	  "B = A/(3*a^2-1);",
-	  "C = B/(a*b-3);",
-	  "describe C",
-	  "ambient C"
-	  },
-     "If R is not a quotient of a polynomial ring, an error is given.",
-     Caveat => {"If the ring is a ", TO GaloisField, ", then the meaning is
-	  different.  See ", TO (ambient,GaloisField), "."},
-     SeeAlso => {}
-     }
+
+doc ///
+  Key
+    (ambient, Ring)
+    (ambient, PolynomialRing)
+    (ambient, QuotientRing)
+    (ambient, FractionField)
+  Headline
+    ambient ring
+  Usage
+    ambient R
+  Inputs
+    R:Ring
+  Outputs
+    :Ring
+  Description
+    Text
+      The ambient ring of a polynomial ring is itself.
+    Example
+      A = ZZ[a..d];
+      ambient A
+    Text
+      The ambient ring of a quotient ring is the ring of which it is a quotient.
+    Example
+      B = A/(3*a^2-1);
+      ambient B
+      C = B/(a*b-3);
+      ambient C
+    Text
+      The ring used to create a fraction field is the ambient ring of the
+      resulting fraction field.
+    Example
+      F = frac A
+      ambient F
+    Text
+      If @VAR "R"@ is not a polynomial ring, quotient ring, fraction field, or
+      Galois field, then an error is given.
+    Example
+      trap ambient ZZ
+  Caveat
+    If the ring is a @TO GaloisField@, then the meaning is different.  See
+    @TO (ambient, GaloisField)@.
+///
+
 document { 
      Key => (ambient,GaloisField),
      Headline => "corresponding quotient ring",

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/generators-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/generators-doc.m2
@@ -140,6 +140,7 @@ document {
      }
 document { 
      Key => {(generators,Ring),
+             (generators,RingFamily),
 	  [generators,CoefficientRing]
 	  },
      Headline => "the list of generators of a ring",

--- a/M2/Macaulay2/packages/Macaulay2Doc/functions/numgens-doc.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/functions/numgens-doc.m2
@@ -80,7 +80,7 @@ document {
      SeeAlso => {mingens, trim, generators}
      }
 document { 
-     Key => {(numgens,Ring),(numgens, EngineRing),(numgens, FractionField),(numgens, MonomialIdeal),(numgens, PolynomialRing),(numgens, QuotientRing)},
+     Key => {(numgens,Ring),(numgens, EngineRing),(numgens, FractionField),(numgens, MonomialIdeal),(numgens, PolynomialRing),(numgens, QuotientRing),(numgens, RingFamily)},
      Headline => "number of generators of a polynomial ring",
      Usage => "numgens R",
      Inputs => {

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators/underscore.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators/underscore.m2
@@ -17,7 +17,6 @@ undocumented {
      (symbol _, MonoidElement, Thing),
      (symbol _, MonoidElement, Monoid),
      (symbol _, RingElement, MonoidElement),
-     (symbol _, PolynomialRing, List),
      (symbol _, RingElement, RingElement), --coeff of monomials in polynomial -- deprecate or obsolete
      (symbol _, Ring, String), -- these three are kept for backwards compatibility
      (symbol _, Ring, Symbol), -- maybe should be deprecated?
@@ -249,6 +248,7 @@ document {
      Key => {
 	 "get a monomial by exponent vector",
 	 (symbol _, Ring, List),
+	 (symbol _, RingFamily, List),
      },
      Headline => "make a monomial from a list of exponents",
      Usage => "R_w",

--- a/M2/Macaulay2/packages/Macaulay2Doc/operators/underscore.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/operators/underscore.m2
@@ -268,7 +268,48 @@ document {
 	  S_{1,1,1}
 	  S_{1,1,1,4}
 	  ///,
+     SeeAlso => {(symbol _, List, Ring)}
      }
+
+doc ///
+  Key
+    (symbol _, List, Ring)
+    (symbol _, List, RingFamily)
+  Headline
+    make a polynomial from a list of terms
+  Usage
+    L_R
+  Inputs
+    L:List
+      of pairs @CODE "(m, c)"@, where @VAR "m"@ is a list of exponents and
+      @VAR "c"@ is a coefficient
+    R:Ring
+  Outputs
+    :RingElement
+      the polynomial of @VAR "R"@ with the given terms
+  Description
+    Text
+      This is the inverse of @TO listForm@.
+    Example
+      R = QQ[x,y,z]
+      {({2,0,3}, 1/2), ({0,1,0}, -1)}_R
+      f = x^2*z^3 - 1/2*y + 7
+      (listForm f)_R
+    Text
+      The terms need not be given in order, monomials may be repeated, and
+      each coefficient is promoted into the coefficient ring of @VAR "R"@.
+    Example
+      {({0,1,0}, 3), ({1,0,0}, 1), ({1,0,0}, 2)}_R
+    Text
+      The empty list gives zero, the empty sum.
+    Example
+      {}_R
+  SeeAlso
+    listForm
+    standardForm
+    (symbol _, Ring, List)
+///
+
 document { 
      Key => (symbol _, IndexedVariable, Ring), -- ring variable by name
      Headline => "get a ring variable by name",

--- a/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
+++ b/M2/Macaulay2/packages/Macaulay2Doc/ov_rings.m2
@@ -811,6 +811,7 @@ document {
 	 TO "get a ring variable by index",
 	 TO "get a ring variable by name",
 	 TO "get a monomial by exponent vector",
+	 TO (symbol _, List, Ring),
 	 TO "graded and multigraded polynomial rings",
 	 TO "monomial orderings",
          }
@@ -1094,6 +1095,9 @@ document {
      a list of exponents in a monomial, and the second member is the corresponding
      coefficient.  Standard list operations can be used to manipulate the result.",
      EXAMPLE "S / print;",
+     "Such a list can be turned back into a polynomial by subscripting it with
+     the ring, see ", TO (symbol _, List, Ring), ".",
+     EXAMPLE "S_(ring g)",
      "The structure of a polynomial can also be provided in a form
      based on hash tables with ", TO "standardForm", ".",
      EXAMPLE {

--- a/M2/Macaulay2/tests/normal/terms.m2
+++ b/M2/Macaulay2/tests/normal/terms.m2
@@ -17,3 +17,131 @@ debug Core
 R = QQ[x,y]
 assert try rawTerm(raw R, raw 1_(ZZ/2), rawMakeMonomial {(0,1)}) then false else true
 ideal vars R
+
+---------------
+-- Ring_List --
+---------------
+
+R = QQ[x,y,z]
+assert Equation(R_{2,0,3}, x^2*z^3)
+assert Equation(R_{0,0,0}, 1)
+assert Equation(R_{}, 1)
+assert Equation(R_{2}, x^2)
+assert try R_{1,1,1,1} then false else true -- too many exponents
+assert try R_{2,-1,3} then false else true  -- negative, but not Laurent
+
+R = QQ[x,y, Inverses => true, MonomialOrder => Lex]
+assert Equation(R_{-2,3}, x^(-2)*y^3)
+assert Equation(R_{-2,-3}, x^(-2)*y^(-3))
+assert Equation(R_{-2,0}, x^(-2))
+assert Equation(R_{3,2}, x^3*y^2)
+
+R = QQ[x,y]/ideal(x^2-y)
+assert Equation(R_{3,1}, x*y^2)
+R = QQ[x,dx, WeylAlgebra => {x => dx}]
+assert Equation(R_{1,2}, x*dx^2)
+R = QQ[x,y,z, SkewCommutative => true]
+assert Equation(R_{1,0,1}, x*z)
+
+R = QQ[a][x,y]
+assert Equation(R_{2,1}, x^2*y)
+assert Equation(R_{1,1,1}, a*x*y)
+assert Equation(R_{0,0,1}, a)
+assert try R_{1,1,1,1} then false else true
+R = QQ[a,b][c][x,y]
+assert Equation(R_{1,1}, x*y)
+assert Equation(R_{1,1,1,1,1}, a*b*c*x*y)
+
+F = frac(QQ[x,y])
+assert Equation(F_{1,2}, x*y^2)
+assert Equation(F_{-1,2}, y^2/x)
+assert Equation(F_{-1,-1}, 1/(x*y))
+assert Equation(F_{0,-3}, 1/y^3)
+assert Equation(F_{}, 1)
+F = frac(QQ[x,y]/ideal(x^2-y-1))
+assert Equation(F_{1,1}, x*y)
+assert Equation(F_{-2,-2}, 1/(y^3+y^2))
+F = frac((QQ[a])[x,y])
+assert Equation(F_{1,1,1}, a*x*y)
+
+F = GF 8
+assert Equation(F_{2}, a^2)
+assert Equation(F_{-1}, a^2+1)
+assert Equation(F_{0}, 1)
+assert Equation(F_{}, 1)
+assert try F_{1,1} then false else true
+F = GF 9
+assert Equation(F_{2}, a+1)
+assert Equation(F_{3}, -a+1)
+F = GF 2^20
+assert Equation(F_{3}, a^3)
+
+R = (ZZ/101)[x,y, Constants => true]
+assert Equation(R_{2,3}, x^2*y^3)
+assert Equation(R_{1}, x)
+assert Equation(R_{5,0}, x^5)
+assert Equation(R_{0,7}, y^7)
+assert Equation(R_{0,0}, 1)
+assert Equation(R_{}, 1)
+assert try R_{1,1,1} then false else true
+assert try R_{-1,2} then false else true
+R = (ZZ/7)[x,y,z, Constants => true]
+assert Equation(R_{1,2,3}, x*y^2*z^3)
+assert Equation(R_{2,0,0}, x^2)
+
+assert Equation(ZZ_{}, 1)
+assert Equation(QQ_{}, 1)
+assert Equation((ZZ/7)_{}, 1)
+assert Equation(RR_{}, 1)
+assert try (ZZ/7)_{1} then false else true
+
+M = monoid[x,y,z]
+assert Equation(M_{2,0,3}, x^2*z^3)
+assert Equation(M_{}, 1)
+assert try M_{1,1,1,1} then false else true
+assert Equation(M_{2,1,0} / M_{0,1,0}, x^2)
+
+-- Ring _ List always passes a coefficient of 1 and screens the exponent
+-- vector first, so call rawTerm directly to reach the engine's own checks.
+
+-- coefficients other than 1
+R = QQ[x,y]
+m = rawMakeMonomial {(0,2)}
+assert Equation(new R from rawTerm(raw R, raw(3/2), m), 3/2*x^2)
+F = GF 9
+m = rawMakeMonomial {(0,1)}
+assert Equation(new F from rawTerm(raw F, raw 2_(ZZ/3), m), 2*a)
+R = (ZZ/101)[x,y, Constants => true]
+m = rawMakeMonomial {(0,2)}
+assert Equation(new R from rawTerm(raw R, raw 5_(ZZ/101), m), 5*x^2)
+
+-- the coefficient must come from the ring's own coefficient ring
+R = QQ[x,y]
+m = rawMakeMonomial {(0,1)}
+assert try rawTerm(raw R, raw 1_(ZZ/2), m) then false else true
+F = GF 8
+assert try rawTerm(raw F, raw 1_(ZZ/3), m) then false else true  -- wrong char
+assert try rawTerm(raw F, raw 1_QQ, m) then false else true
+assert try rawTerm(raw F, raw 1_F, m) then false else true  -- not a prime field
+R = (ZZ/101)[x,y, Constants => true]
+assert try rawTerm(raw R, raw 1_(ZZ/7), m) then false else true
+assert try rawTerm(raw R, raw 1_QQ, m) then false else true
+
+-- an exponent vector naming a variable the ring does not have
+R = QQ[x,y,z]
+m = rawMakeMonomial {(3,1)}
+assert try rawTerm(raw R, raw 1_QQ, m) then false else true
+R = (ZZ/101)[x,y, Constants => true]
+m = rawMakeMonomial {(2,1)}
+assert try rawTerm(raw R, raw 1_(ZZ/101), m) then false else true
+
+-- a tower takes the coefficient ring's variables in the coefficient
+R = QQ[a][x,y]
+m = rawMakeMonomial {(0,1),(1,1)}
+assert Equation(new R from rawTerm(raw R, raw(a^4), m), a^4*x*y)
+
+-- every Galois field representation agrees
+m = rawMakeMonomial {(0,1)}
+scan({"Flint", "FlintBig", "New", "Old"}, s -> (
+    F := GF(9, Strategy => s);
+    assert Equation(new F from rawTerm(raw F, raw 2_(ZZ/3), m), 2*F_0)))

--- a/M2/Macaulay2/tests/normal/terms.m2
+++ b/M2/Macaulay2/tests/normal/terms.m2
@@ -145,3 +145,85 @@ m = rawMakeMonomial {(0,1)}
 scan({"Flint", "FlintBig", "New", "Old"}, s -> (
     F := GF(9, Strategy => s);
     assert Equation(new F from rawTerm(raw F, raw 2_(ZZ/3), m), 2*F_0)))
+
+---------------
+-- List_Ring --
+---------------
+
+R = QQ[x,y,z]
+assert Equation({({2,0,3}, 1/2)}_R, 1/2*x^2*z^3)
+assert Equation({({0,0,0}, 3/4)}_R, 3/4)
+assert Equation({({2}, 1)}_R, x^2)  -- short exponent vectors pad with zeros
+assert Equation({({}, 5)}_R, 5)
+assert Equation({}_R, 0)            -- the empty sum, not the empty product
+assert(ring {}_R === R)
+
+-- coefficients are promoted
+assert Equation({({1,0,0}, 3)}_R, 3*x)
+
+-- the terms need not be sorted, repeated monomials are collected
+assert Equation({({0,1,0}, 1), ({2,0,0}, 1)}_R, x^2+y)
+assert Equation({({1,0,0}, 1), ({1,0,0}, 2)}_R, 3*x)
+assert Equation({({1,0,0}, 1), ({1,0,0}, -1)}_R, 0)
+assert Equation({({1,0,0}, 0)}_R, 0)
+
+f = x^2*z^3 - 1/2*y + 7
+assert Equation((listForm f)_R, f)
+
+assert try {{1,1,1}}_R then false else true       -- pairs, not lists
+assert try {({1,1,1}, 1, 1)}_R then false else true
+assert try {(1, 2)}_R then false else true        -- exponents must be a list
+assert try {({1/2,0,0}, 1)}_R then false else true
+assert try {({1,1,1,1}, 1)}_R then false else true -- too many exponents
+assert try {({-1,0,0}, 1)}_R then false else true  -- negative, not Laurent
+assert try {({1,0,0}, 1_(ZZ/2))}_R then false else true -- no promotion
+
+R = ZZ/101[x,y]
+assert Equation({({1,1}, 3)}_R, 3*x*y)
+f = 3*x*y + 5
+assert Equation((listForm f)_R, f)
+
+R = QQ[x,y, Inverses => true, MonomialOrder => Lex]
+assert Equation({({-2,3}, 1)}_R, x^(-2)*y^3)
+assert Equation({({-2,-3}, 1/2)}_R, 1/2*x^(-2)*y^(-3))
+f = x^(-2)*y^3 + x*y^(-1)
+assert Equation((listForm f)_R, f)
+
+R = QQ[x,y]/ideal(x^2-y)
+assert Equation({({3,1}, 1)}_R, x*y^2)  -- reduced modulo the ideal
+f = x*y^2 + 1
+assert Equation((listForm f)_R, f)
+
+R = QQ[x,dx, WeylAlgebra => {x => dx}]
+assert Equation({({1,2}, 1)}_R, x*dx^2)
+f = x*dx^2 + dx
+assert Equation((listForm f)_R, f)
+
+R = QQ[x,y,z, SkewCommutative => true]
+assert Equation({({1,0,1}, 1)}_R, x*z)
+f = x*z - y*z
+assert Equation((listForm f)_R, f)
+
+R = QQ[a][x,y]
+assert Equation({({1,1}, 1)}_R, x*y)
+assert Equation({({1,1}, a^3)}_R, a^3*x*y)
+f = (a^2+1)*x*y + a
+assert Equation((listForm f)_R, f)
+
+F = GF 9
+R = F[x,y]
+assert Equation({({1,0}, F_0)}_R, F_0*x)
+f = F_0*x + 1
+assert Equation((listForm f)_R, f)
+
+R = frac(QQ[x,y])
+assert Equation({({1,-2}, 1)}_R, x/y^2)
+assert Equation({({1,0}, 1), ({0,-1}, 1)}_R, x + 1/y)
+
+R = (ZZ/101)[x,y, Constants => true]
+assert Equation({({2,3}, 1)}_R, x^2*y^3)
+assert Equation({({2,3}, 1), ({1,0}, 5)}_R, x^2*y^3 + 5*x)
+
+-- List _ RingFamily
+assert Equation({}_RR, 0)
+assert(ring {}_RR === RR_53)

--- a/M2/Macaulay2/tests/normal/terms.m2
+++ b/M2/Macaulay2/tests/normal/terms.m2
@@ -42,6 +42,17 @@ R = QQ[x,dx, WeylAlgebra => {x => dx}]
 assert Equation(R_{1,2}, x*dx^2)
 R = QQ[x,y,z, SkewCommutative => true]
 assert Equation(R_{1,0,1}, x*z)
+-- the square of a skew commutative variable is zero
+assert Equation(R_{2,0,0}, 0)
+assert Equation(R_{1,0,2}, 0)
+assert Equation(R_{0,3,0}, 0)
+S = R/ideal(x*y)
+assert Equation(S_{1,0,1}, x*z)
+assert Equation(S_{0,0,2}, 0)
+R = QQ[x,y,a,b, SkewCommutative => {2,3}]
+-- only the skew commutative variables square to zero
+assert Equation(R_{2,0,0,0}, x^2)
+assert Equation(R_{0,0,2,0}, 0)
 
 R = QQ[a][x,y]
 assert Equation(R_{2,1}, x^2*y)
@@ -203,6 +214,8 @@ R = QQ[x,y,z, SkewCommutative => true]
 assert Equation({({1,0,1}, 1)}_R, x*z)
 f = x*z - y*z
 assert Equation((listForm f)_R, f)
+assert Equation({({2,0,0}, 1)}_R, 0)
+assert Equation({({2,0,0}, 1), ({1,0,1}, 1)}_R, x*z)
 
 R = QQ[a][x,y]
 assert Equation({({1,1}, 1)}_R, x*y)

--- a/M2/Macaulay2/tests/normal/terms.m2
+++ b/M2/Macaulay2/tests/normal/terms.m2
@@ -11,3 +11,9 @@ K = toField kk
 R = K[x, y]
 G = a*x^28+x^28 + a*x^2*y^5
 assert(terms G === {(a+1)*x^28, a*x^2*y^5})
+
+-- previously, rawTerm returned 0 and then we'd segfault creating the ideal
+debug Core
+R = QQ[x,y]
+assert try rawTerm(raw R, raw 1_(ZZ/2), rawMakeMonomial {(0,1)}) then false else true
+ideal vars R

--- a/M2/Macaulay2/tests/normal/tower3.m2
+++ b/M2/Macaulay2/tests/normal/tower3.m2
@@ -66,3 +66,10 @@ rawGCD(x3-x,F)
 rawGCD(x4-x,F)
 rawGCD(x5-x,F)
 
+x = symbol x
+y = symbol y
+-- used to be reversed, e.g., x*y^2*z^3 -> x^3*y^2*z
+R = ZZ/101[x,y,z, Constants => true]
+S = ZZ/101[x,y,z]
+f = new R from rawTowerTranslatePoly(raw R, raw(x*y^2*z^3))
+assert Equation(f, R_0 * R_1^2 * R_2^3)


### PR DESCRIPTION
Previously, the `Ring_List` method, which takes a list of exponents and returns the corresponding monomial in that ring, was implemented entirely at top level using top-level arithmetic.  However, we already had `rawTerm` in the engine that accomplishes the same thing without doing any multiplication or raising any powers, so we use that instead.

However, `rawTerm` was only implemented for a few rings, so we add support for all the others for which it makes sense.

Here's a quick rundown of the changes:
* Add `numgens` and `generators` methods for `FieldFamily` (basically so `RR_{}` and `CC_{}` would work).
* Add a `makeTerm` method to the `Ring` class in the engine and implement it in a bunch of different ring types (previously it only existed in `M2FreeAlgebra` and `M2FreAlgebraQuotient`, and it basically existed for `PolynomialRing`, but it was implemented in `interface/ringelement.cpp`)
* Fix a few bugs that were found along the way (e.g., `QQ[x, Constants => true]` crashed M2 lol)
* Refactor `rawMakeMonomial` so it calls a function in the `interface` directory rather than low-level engine code, matching most of the rest of the `raw*` functions.
* Add `rawMakeMonomialFromExponents` so we can pass a dense exponent vector to the engine directly rather than sparsifying it first at top-level.
* Cache `numgens(PolynomialRing)` for moderate speedup.
* Add `ambient(FractionField)` and `ambient(LocalRing)`, which do the obvious thing (e.g., if `R` is a polynomial ring, then `ambient frac R` is just `R`).

In the end, `Ring_List` is about twice as fast.  This should be helpful for deserializing polynomials, e.g., the *MRDI* package uses this method to convert a JSON string to a polynomial.

### Before
```m2
i1 : R = QQ[x,y,z,w];

i2 : elapsedTime scan(10000, i -> R_(apply(4, i -> random(0, 10))))
 -- .490082s elapsed
```

### After
```m2
i1 : R = QQ[x,y,z,w];

i2 : elapsedTime scan(10000, i -> R_(apply(4, i -> random(0, 10))))
 -- .237976s elapsed
```


## :robot: AI Disclosure :robot:

I used Claude extensively for brainstorming, but I wrote every line of code myself except for the two commits of unit tests.