### PR TITLE
Fix check for GC_start_performance_measurement

### DIFF
--- a/M2/Macaulay2/bin/main.cpp
+++ b/M2/Macaulay2/bin/main.cpp
@@ -55,7 +55,7 @@ void* testFunc(ArgCell* p);
 void  M2_flint_abort(void);
 
 static void * GC_start_performance_measurement_0(void *) {
-#ifdef GC_start_performance_measurement /* added in bdwgc 8 */
+#if GC_VERSION_MAJOR >= 8 /* GC_start_performance_measurement added in bdwgc 8 */
   GC_start_performance_measurement();
 #endif
   return NULL;


### PR DESCRIPTION
It's a function, not a macro, so this block was never firing, and so `time` was always reporting "0s (gc)"

This fixes the issue discussed at this afternoon's C++ refactoring meeting

## Before
```m2
i1 : scan(10000, i -> {})

i2 : time collectGarbage()
 -- used 0.105673s (cpu); 0.0149833s (thread); 0s (gc)
```

## After
```m2
i1 : scan(10000, i -> {})

i2 : time collectGarbage()
 -- used 0.111014s (cpu); 0.0133115s (thread); 0.021s (gc)
```