### PR TITLE
Increase virtual memory limit for test failure in ComputationsBook::v…

### DIFF
--- a/M2/Macaulay2/tests/ComputationsBook/Makefile.chapter.in
+++ b/M2/Macaulay2/tests/ComputationsBook/Makefile.chapter.in
@@ -18,7 +18,7 @@ ifeq (@ULIMIT_T@,yes)
 LIMIT += ulimit -t 1200 ;
 endif
 ifeq (@ULIMIT_V@,yes)
-LIMIT += ulimit -v 1600000 ;
+LIMIT += ulimit -v 3200000 ;
 endif
 ifeq (@ULIMIT_M@,yes)
 LIMIT += ulimit -m 800000 ;


### PR DESCRIPTION
When compiled on a host with many number of processors, the test for `ComputationsBook::varieties` may fail with:

```
testing: ComputationsBook::varieties
make[6]: *** [../Makefile.chapter:46: test.out] Error 134
make[5]: *** [Makefile:10: check] Error 2
```

and the content in the corresponding `test.out.tmp` is:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  pthread_create has failed: Resource temporarily unavailable
Aborted
```

Increasing the limit of the virtual memory would solve the problem.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
