### PR TITLE
Raise runtime_error's instead of engine_error's for TBB

### DIFF
--- a/M2/Macaulay2/e/interface/groebner.cpp
+++ b/M2/Macaulay2/e/interface/groebner.cpp
@@ -114,7 +114,7 @@ Computation /* or null */ *IM2_GB_make(
                                       strategy,
                                       numThreads,
                                       max_reduction_count);
-  } catch (const exc::engine_error& e)
+  } catch (const std::runtime_error& e)
     {
       ERROR(e.what());
       return nullptr;
@@ -151,7 +151,7 @@ Computation /* or null */ *IM2_res_make(const Matrix *m,
                                                strategy,
                                                numThreads,
                                                parallelizeByDegree);
-  } catch (const exc::engine_error& e)
+  } catch (const std::runtime_error& e)
     {
       ERROR(e.what());
       return nullptr;
@@ -307,7 +307,7 @@ Computation /* or null */ *rawStartComputation(Computation *C)
         }
 
       return error() ? nullptr : C;
-  } catch (const exc::engine_error& e)
+  } catch (const std::runtime_error& e)
     {
       ERROR(e.what());
       return nullptr;
@@ -932,33 +932,40 @@ const Matrix* polyListToMatrix(const M2FreeAlgebraOrQuotient* A,
 
 const Matrix* rawNCGroebnerBasisTwoSided(const Matrix* input, int maxdeg, int strategy)
 {
-  const Ring* R = input->get_ring();
-  const M2FreeAlgebra* A = R->cast_to_M2FreeAlgebra();
-  if (A != nullptr and input->n_rows() == 1)
+  try
     {
-      auto elems = matrixToPolyList(A, input);
-      bool isF4 = strategy & 16;
-      bool isParallel = strategy & 32;
-      if (isF4)
+      const Ring* R = input->get_ring();
+      const M2FreeAlgebra* A = R->cast_to_M2FreeAlgebra();
+      if (A != nullptr and input->n_rows() == 1)
         {
-          int numthreads = M2_numTBBThreads; // settable from front end.
-          // std::cout << "Using numthreads = " << numthreads << std::endl;
-          NCF4 G(A->freeAlgebra(), elems, maxdeg, strategy, (isParallel ? numthreads : 1));
-          G.compute(maxdeg); // this argument is actually the soft degree limit
-          auto result = copyPolyVector(A, G.currentValue());
-          return polyListToMatrix(A, result, 1, result.size()); // consumes the Poly's in result
-        }
-      else
-        {
-          NCGroebner G(A->freeAlgebra(), elems, maxdeg, strategy);
-          G.compute(maxdeg); // this argument is actually the soft degree limit
-          auto result = copyPolyVector(A, G.currentValue());
-          return polyListToMatrix(A, result, 1, result.size()); // consumes the Poly's in result
-        }
+          auto elems = matrixToPolyList(A, input);
+          bool isF4 = strategy & 16;
+          bool isParallel = strategy & 32;
+          if (isF4)
+            {
+              int numthreads = M2_numTBBThreads; // settable from front end.
+              // std::cout << "Using numthreads = " << numthreads << std::endl;
+              NCF4 G(A->freeAlgebra(), elems, maxdeg, strategy, (isParallel ? numthreads : 1));
+              G.compute(maxdeg); // this argument is actually the soft degree limit
+              auto result = copyPolyVector(A, G.currentValue());
+              return polyListToMatrix(A, result, 1, result.size()); // consumes the Poly's in result
+            }
+          else
+            {
+              NCGroebner G(A->freeAlgebra(), elems, maxdeg, strategy);
+              G.compute(maxdeg); // this argument is actually the soft degree limit
+              auto result = copyPolyVector(A, G.currentValue());
+              return polyListToMatrix(A, result, 1, result.size()); // consumes the Poly's in result
+            }
 
-    }
-  ERROR("expected a one row matrix over a noncommutative algebra");
-  return nullptr;
+        }
+      ERROR("expected a one row matrix over a noncommutative algebra");
+      return nullptr;
+  } catch (const std::runtime_error& e)
+    {
+      ERROR(e.what());
+      return nullptr;
+  }
 }
 
 const Matrix* rawNCReductionTwoSided(const Matrix* toBeReduced, const Matrix* reducerMatrix)

--- a/M2/Macaulay2/e/schreyer-resolutions/res-f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/schreyer-resolutions/res-f4-m2-interface.cpp
@@ -716,7 +716,7 @@ M2_arrayint rawMinimalBetti(Computation* C,
                                 length_limit);  // Computes it if needed
       ERROR("expected resolution computed via res(...,FastNonminimal=>true)");
       return nullptr;
-  } catch (const exc::engine_error& e)
+  } catch (const std::runtime_error& e)
     {
       ERROR(e.what());
       return nullptr;


### PR DESCRIPTION
Otherwise, M2 crashes rather than raising a top-level error.

### Before

(After loading M2 with a little shim that Claude wrote to force a TBB error:

```m2
i1 : R = ZZ/32003[x,y,z,w]; I = monomialCurveIdeal(R, {1,2,3});

o2 : Ideal of R

i3 : res(I, Strategy => Nonminimal)
[failthread] denying pthread_create #9
terminate called after throwing an instance of 'std::runtime_error'
  what():  pthread_create has failed: Resource temporarily unavailable
Aborted (core dumped)
```

### After

```m2
i1 : R = ZZ/32003[x,y,z,w]; I = monomialCurveIdeal(R, {1,2,3});

o2 : Ideal of R

i3 : res(I, Strategy => Nonminimal)
[failthread] denying pthread_create #9
stdio:2:3:(3):[1]: error: pthread_create has failed: Resource temporarily unavailable
```

## :robot: AI Disclosure :robot:

Claude diagnosed the issue and wrote the code.